### PR TITLE
Increased wiki integration with better wiki verb.

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -95,6 +95,7 @@ var/list/gamemode_cache = list()
 	var/banappeals
 	var/wikiurl
 	var/forumurl
+	var/rulesurl
 
 	//Alert level description
 	var/alert_desc_green = "All threats to the station have passed. Security may not have weapons visible, privacy laws are once again fully enforced."
@@ -387,6 +388,9 @@ var/list/gamemode_cache = list()
 
 				if ("forumurl")
 					config.forumurl = value
+
+				if ("rulesurl")
+					config.rulesurl = value
 
 				if ("guest_jobban")
 					config.guest_jobban = 1

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -177,6 +177,9 @@ GUEST_BAN
 ## Wiki address
 # WIKIURL http://example.com
 
+## Rules address - where the rules button sends you.
+# RULESURL http://example.com
+
 ## Ban appeals URL - usually for a forum or wherever people should go to contact your admins.
 # BANAPPEALS http://example.com
 

--- a/interface/interface.dm
+++ b/interface/interface.dm
@@ -1,14 +1,16 @@
 //Please use mob or src (not usr) in these procs. This way they can be called in the same fashion as procs.
-/client/verb/wiki()
+/client/verb/wiki(query as text)
 	set name = "wiki"
-	set desc = "Visit the wiki."
-	set hidden = 1
-	if( config.wikiurl )
-		if(alert("This will open the wiki in your browser. Are you sure?",,"Yes","No")=="No")
-			return
-		src << link(config.wikiurl)
+	set desc = "Type what you want to know about.  This will open the wiki on your web browser."
+	set category = "OOC"
+	if(config.wikiurl)
+		if(query)
+			var/output = config.wikiurl + "/index.php?title=Special%3ASearch&profile=default&search=" + query
+			src << link(output)
+		else
+			src << link(config.wikiurl)
 	else
-		src << "\red The wiki URL is not set in the server configuration."
+		src << "<span class='danger'>The wiki URL is not set in the server configuration.</span>"
 	return
 
 /client/verb/forum()
@@ -20,16 +22,21 @@
 			return
 		src << link(config.forumurl)
 	else
-		src << "\red The forum URL is not set in the server configuration."
+		src << "<span class='danger'>The forum URL is not set in the server configuration.</span>"
 	return
 
-#define RULES_FILE "config/rules.html"
 /client/verb/rules()
 	set name = "Rules"
 	set desc = "Show Server Rules."
 	set hidden = 1
-	src << browse(file(RULES_FILE), "window=rules;size=480x320")
-#undef RULES_FILE
+
+	if(config.rulesurl)
+		if(alert("This will open the rules in your browser. Are you sure?",,"Yes","No")=="No")
+			return
+		src << link(config.rulesurl)
+	else
+		src << "<span class='danger'>The rules URL is not set in the server configuration.</span>"
+	return
 
 /client/verb/hotkeys_help()
 	set name = "hotkeys-help"


### PR DESCRIPTION
Changes client/verb/wiki() to be more useful.
You can now type 'wiki [query]' to look something up quickly. For example, 'wiki cult' brings up the cult guide in your web browser.

The wiki button on the top right will also do this, but it will ask you for the thing you want. If you input nothing, it brings you to the front page.