### PR TITLE
Fixes #36

### DIFF
--- a/code/modules/mining/machine_processing.dm
+++ b/code/modules/mining/machine_processing.dm
@@ -8,16 +8,18 @@
 	anchored = 1
 
 	var/obj/machinery/mineral/processing_unit/machine = null
-	var/machinedir = EAST
+	//var/machinedir = EAST //Dumb
 	var/show_all_ores = 0
 
 /obj/machinery/mineral/processing_unit_console/New()
 	..()
 	spawn(7)
-		src.machine = locate(/obj/machinery/mineral/processing_unit, get_step(src, machinedir))
+		//src.machine = locate(/obj/machinery/mineral/processing_unit, get_step(src, machinedir))
+		src.machine = locate(/obj/machinery/mineral/processing_unit) in range(5,src)
 		if (machine)
 			machine.console = src
 		else
+			world << "<span class='danger'>Warning: Ore processing machine console at [src.x], [src.y], [src.z] could not find its machine!</span>"
 			qdel(src)
 
 /obj/machinery/mineral/processing_unit_console/attack_hand(mob/user)

--- a/code/modules/mining/machine_stacking.dm
+++ b/code/modules/mining/machine_stacking.dm
@@ -7,17 +7,20 @@
 	density = 1
 	anchored = 1
 	var/obj/machinery/mineral/stacking_machine/machine = null
-	var/machinedir = SOUTHEAST
+	//var/machinedir = SOUTHEAST //This is really dumb, so lets burn it with fire.
 
 /obj/machinery/mineral/stacking_unit_console/New()
 
 	..()
 
 	spawn(7)
-		src.machine = locate(/obj/machinery/mineral/stacking_machine, get_step(src, machinedir))
+		//src.machine = locate(/obj/machinery/mineral/stacking_machine, get_step(src, machinedir)) //No.
+		src.machine = locate(/obj/machinery/mineral/stacking_machine) in range(5,src)
 		if (machine)
 			machine.console = src
 		else
+			//Silently failing and causing mappers to scratch their heads while runtiming isn't ideal.
+			world << "<span class='danger'>Warning: Stacking machine console at [src.x], [src.y], [src.z] could not find its machine!</span>"
 			qdel(src)
 
 /obj/machinery/mineral/stacking_unit_console/attack_hand(mob/user)

--- a/polaris.dme
+++ b/polaris.dme
@@ -1761,4 +1761,5 @@
 #include "maps\colony-1.dmm"
 #include "maps\colony-2.dmm"
 #include "maps\colony-4.dmm"
+#include "maps\colony-7.dmm"
 // END_INCLUDE


### PR DESCRIPTION
Removes machinedir on in machine_processing.dm and machine_stacking.dm, because they're dumb.
Instead, it searches in a range of five tiles, and gives a message if it still can't find one.
Also checks the mining z-level in the .dme

Fixes #36 