### PR TITLE
Makes map merger clean colony maps.  Band-aid fix for now.

### DIFF
--- a/tools/mapmerge/1prepare_map.bat
+++ b/tools/mapmerge/1prepare_map.bat
@@ -3,6 +3,7 @@ cd ../../maps
 
 FOR /L %%i IN (1,1,%z_levels%) DO (
   copy exodus-%%i.dmm exodus-%%i.dmm.backup
+  copy colony-%%i.dmm colony-%%i.dmm.backup
 )
 
 pause

--- a/tools/mapmerge/1prepare_map.bat
+++ b/tools/mapmerge/1prepare_map.bat
@@ -1,9 +1,7 @@
-SET z_levels=6
 cd ../../maps
 
-FOR /L %%i IN (1,1,%z_levels%) DO (
-  copy exodus-%%i.dmm exodus-%%i.dmm.backup
-  copy colony-%%i.dmm colony-%%i.dmm.backup
+FOR %%f IN (*.dmm) DO (
+  copy %%f %%f.backup
 )
 
 pause

--- a/tools/mapmerge/2clean_map.bat
+++ b/tools/mapmerge/2clean_map.bat
@@ -3,6 +3,7 @@ cd
 
 FOR /L %%i IN (1,1,%z_levels%) DO (
   java -jar MapPatcher.jar -clean ../../maps/exodus-%%i.dmm.backup ../../maps/exodus-%%i.dmm ../../maps/exodus-%%i.dmm
+  java -jar MapPatcher.jar -clean ../../maps/colony-%%i.dmm.backup ../../maps/colony-%%i.dmm ../../maps/colony-%%i.dmm
 )
 
 pause

--- a/tools/mapmerge/2clean_map.bat
+++ b/tools/mapmerge/2clean_map.bat
@@ -1,9 +1,8 @@
 SET z_levels=6
 cd 
 
-FOR /L %%i IN (1,1,%z_levels%) DO (
-  java -jar MapPatcher.jar -clean ../../maps/exodus-%%i.dmm.backup ../../maps/exodus-%%i.dmm ../../maps/exodus-%%i.dmm
-  java -jar MapPatcher.jar -clean ../../maps/colony-%%i.dmm.backup ../../maps/colony-%%i.dmm ../../maps/colony-%%i.dmm
+FOR %%f IN (../../maps/*.dmm) DO (
+  java -jar MapPatcher.jar -clean ../../maps/%%f.backup ../../maps/%%f ../../maps/%%f
 )
 
 pause


### PR DESCRIPTION
Hopefully we can steal /tg/'s at a later point, which doesn't make assumptions about the map name or how many z-levels exist.

Also you'll get a few errors about how it can't find a few files, that's because the maps for those don't exist yet, so it's nothing to worry about.

-edit-
Bay's KP's map merge is apparently superior to their normal one, sooooo I stole it.