### PR TITLE
Fixes lack of asteroid on the asteroid colony.

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -141,6 +141,8 @@ var/list/gamemode_cache = list()
 	var/welder_vision = 1
 	var/generate_asteroid = 0
 
+	var/asteroid_z_levels = list()
+
 	//Used for modifying movement speed for mobs.
 	//Unversal modifiers
 	var/run_speed = 0
@@ -328,6 +330,12 @@ var/list/gamemode_cache = list()
 
 				if ("generate_asteroid")
 					config.generate_asteroid = 1
+
+				if ("asteroid_z_levels")
+					config.asteroid_z_levels = text2list(value, ";")
+					//Numbers get stored as strings, so we'll fix that right now.
+					for(var/z_level in config.asteroid_z_levels)
+						z_level = text2num(z_level)
 
 				if("allow_admin_ooccolor")
 					config.allow_admin_ooccolor = 1

--- a/code/world.dm
+++ b/code/world.dm
@@ -81,7 +81,7 @@ var/global/datum/global_init/init = new ()
 				z_level = text2num(z_level)
 				if(!isnum(z_level))
 					// If it's still not a number, we probably got fed some nonsense string.
-					admin_notice("<span class='danger'>Error: ASTEROID_Z_LEVELS config wasn't given a number.</span>"
+					admin_notice("<span class='danger'>Error: ASTEROID_Z_LEVELS config wasn't given a number.</span>")
 				// Now for the actual map generating.  This occurs for every z-level defined in the config.
 				new /datum/random_map/automata/cave_system(null,1,1,z_level,300,300)
 				// Let's add ore too.

--- a/code/world.dm
+++ b/code/world.dm
@@ -74,12 +74,20 @@ var/global/datum/global_init/init = new ()
 
 	if(config.generate_asteroid)
 		// These values determine the specific area that the map is applied to.
-		// If you do not use the official Baycode moonbase map, you will need to change them.
-		//Create the mining Z-level.
-		new /datum/random_map/automata/cave_system(null,1,1,5,255,255)
-		//new /datum/random_map/noise/volcanism(null,1,1,5,255,255) // Not done yet! Pretty, though.
-		// Create the mining ore distribution map.
-		new /datum/random_map/noise/ore(null, 1, 1, 5, 64, 64)
+		// Because we do not use Bay's default map, we check the config file to see if custom parameters are needed, so we need to avoid hardcoding.
+		if(config.asteroid_z_levels)
+			for(var/z_level in config.asteroid_z_levels)
+				// In case we got fed a string instead of a number...
+				z_level = text2num(z_level)
+				if(!isnum(z_level))
+					// If it's still not a number, we probably got fed some nonsense string.
+					admin_notice("<span class='danger'>Error: ASTEROID_Z_LEVELS config wasn't given a number.</span>"
+				// Now for the actual map generating.  This occurs for every z-level defined in the config.
+				new /datum/random_map/automata/cave_system(null,1,1,z_level,300,300)
+				// Let's add ore too.
+				new /datum/random_map/noise/ore(null, 1, 1, z_level, 64, 64)
+		else
+			admin_notice("<span class='danger'>Error: No asteroid z-levels defined in config!</span>")
 		// Update all turfs to ensure everything looks good post-generation. Yes,
 		// it's brute-forcey, but frankly the alternative is a mine turf rewrite.
 		for(var/turf/simulated/mineral/M in world) // Ugh.

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -361,6 +361,12 @@ STARLIGHT 0
 ## Enable asteroid tunnel/cave generation. Will behave strangely if turned off with a map that expects it on.
 # GENERATE_ASTEROID
 
+
+
+## If you've enabled asteroid generation, you need to supply which z-levels to apply it to, in integer form, and seperated using ;
+## An example: 1;4;5
+# ASTEROID_Z_LEVELS 1;4;5
+
 ## Uncomment to enable organ decay outside of a body or storage item.
 #ORGANS_CAN_DECAY
 


### PR DESCRIPTION
The issue was that the game assumed that the fifth z-level was the only z-level to generate.
The game will now check for mining z-levels by using a new config option.
For the Northern Star, 1;4;5 will be sufficient.  Remember to uncomment it out when going live!