### PR TITLE
Fixes #166 | Softcaps preventing glasses

### DIFF
--- a/code/modules/clothing/head/soft_caps.dm
+++ b/code/modules/clothing/head/soft_caps.dm
@@ -2,7 +2,6 @@
 	name = "cargo cap"
 	desc = "It's a peaked cap in a tasteless yellow color."
 	icon_state = "cargosoft"
-	flags = HEADCOVERSEYES
 	item_state_slots = list(
 		slot_l_hand_str = "helmet", //probably a placeholder
 		slot_r_hand_str = "helmet",


### PR DESCRIPTION
Removes the HEADCOVERSEYES flag from softcaps.