### PR TITLE
Flares now spawn in sec lockers

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -192,6 +192,7 @@
 		new /obj/item/clothing/glasses/sunglasses/sechud(src)
 		new /obj/item/taperoll/police(src)
 		new /obj/item/device/hailer(src)
+		new /obj/item/device/flashlight/flare(src)
 		new /obj/item/clothing/accessory/storage/black_vest(src)
 		new /obj/item/clothing/head/soft/sec/corp(src)
 		new /obj/item/clothing/under/rank/security/corp(src)


### PR DESCRIPTION
Previously, flares were mapped in to spawn inside security officer lockers(they still do however, I'm just waiting for the /tg/ clothing port to be merged).