### PR TITLE
Two minor edits to ERT equipment

### DIFF
--- a/code/game/machinery/computer/specops_shuttle.dm
+++ b/code/game/machinery/computer/specops_shuttle.dm
@@ -2,7 +2,7 @@
 #define SPECOPS_MOVETIME 600	//Time to station is milliseconds. 60 seconds, enough time for everyone to be on the shuttle before it leaves.
 #define SPECOPS_STATION_AREATYPE "/area/shuttle/specops/station" //Type of the spec ops shuttle area for station
 #define SPECOPS_DOCK_AREATYPE "/area/shuttle/specops/centcom"	//Type of the spec ops shuttle area for dock
-#define SPECOPS_RETURN_DELAY 6000 //Time between the shuttle is capable of moving.
+#define SPECOPS_RETURN_DELAY 600 //Time between the shuttle is capable of moving.
 
 var/specops_shuttle_moving_to_station = 0
 var/specops_shuttle_moving_to_centcom = 0

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -149,7 +149,7 @@ var/global/list/obj/item/device/pda/PDAs = list()
 	default_cartridge = /obj/item/weapon/cartridge/captain
 	icon_state = "pda-h"
 	detonate = 0
-	hidden = 1
+//	hidden = 1
 
 /obj/item/device/pda/cargo
 	default_cartridge = /obj/item/weapon/cartridge/quartermaster


### PR DESCRIPTION
Shortens the delay for returning to CentCom.
Comments out the ERT PDA being hidden, which prevented them from receiving messages.