### PR TITLE
[FIX] Makes Deckard's Gun Usable

### DIFF
--- a/code/modules/projectiles/guns/projectile/revolver.dm
+++ b/code/modules/projectiles/guns/projectile/revolver.dm
@@ -48,7 +48,11 @@
 	name = "Deckard .44"
 	desc = "A custom-built revolver, based off the semi-popular Detective Special model."
 	icon_state = "deckard-empty"
-	ammo_type = /obj/item/ammo_magazine/c38/rubber
+	max_shells = 6
+	caliber = "38"
+	origin_tech = list(TECH_COMBAT = 3, TECH_MATERIAL = 3)
+	fire_sound = 'sound/weapons/Gunshot_light.ogg'
+	ammo_type = /obj/item/ammo_casing/c38
 
 /obj/item/weapon/gun/projectile/revolver/deckard/update_icon()
 	..()


### PR DESCRIPTION
Prior to fix, Deckard's gun was not usable.
Woodrat told me that it was someone's custom item's sprite, but if they don't play any more on Bay, we might as well have it available for anyone that's interested.