### PR TITLE
Comments out the Geneticist job so that it doesn't appear in the preferences.

### DIFF
--- a/code/game/jobs/job/medical.dm
+++ b/code/game/jobs/job/medical.dm
@@ -128,7 +128,7 @@
 		return 1
 
 
-
+/* I'm commenting out Geneticist so you can't actually see it in the job menu, given that you can't play as one - Jon.
 /datum/job/geneticist
 	title = "Geneticist"
 	flag = GENETICIST
@@ -156,6 +156,7 @@
 		H.equip_to_slot_or_del(new /obj/item/clothing/suit/storage/toggle/labcoat/genetics(H), slot_wear_suit)
 		H.equip_to_slot_or_del(new /obj/item/device/flashlight/pen(H), slot_s_store)
 		return 1
+*/
 
 /datum/job/psychiatrist
 	title = "Psychiatrist"


### PR DESCRIPTION
Given that it doesn't work in any way, has 0 slots, and nobody's overhauling it any time soon (probably), I don't see the point in having it available in the preferences screen - that's just confusing.