### PR TITLE
Allows you to define a base turf for an area

### DIFF
--- a/code/_helpers/unsorted.dm
+++ b/code/_helpers/unsorted.dm
@@ -229,14 +229,14 @@ Turf and target are seperate in case you want to teleport some distance from a t
 #define LOCATE_COORDS(X, Y, Z) locate(between(1, X, world.maxx), between(1, Y, world.maxy), Z)
 /proc/getcircle(turf/center, var/radius) //Uses a fast Bresenham rasterization algorithm to return the turfs in a thin circle.
 	if(!radius) return list(center)
-	
+
 	var/x = 0
 	var/y = radius
 	var/p = 3 - 2 * radius
-	
+
 	. = list()
 	while(y >= x) // only formulate 1/8 of circle
-		
+
 		. += LOCATE_COORDS(center.x - x, center.y - y, center.z) //upper left left
 		. += LOCATE_COORDS(center.x - y, center.y - x, center.z) //upper upper left
 		. += LOCATE_COORDS(center.x + y, center.y - x, center.z) //upper upper right
@@ -247,7 +247,7 @@ Turf and target are seperate in case you want to teleport some distance from a t
 		. += LOCATE_COORDS(center.x + x, center.y + y, center.z) //lower right right
 
 		if(p < 0)
-			p += 4*x++ + 6; 
+			p += 4*x++ + 6;
 		else
 			p += 4*(x++ - y--) + 10;
 
@@ -875,7 +875,7 @@ proc/GaussRandRound(var/sigma,var/roundto)
 					if(turftoleave)
 						fromupdate += T.ChangeTurf(turftoleave)
 					else
-						T.ChangeTurf(get_base_turf(T.z))
+						T.ChangeTurf(get_base_turf_by_area(T))
 
 					refined_src -= T
 					refined_trg -= B

--- a/code/game/area/Space Station 13 areas.dm
+++ b/code/game/area/Space Station 13 areas.dm
@@ -53,6 +53,8 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	var/list/ambience = list('sound/ambience/ambigen1.ogg','sound/ambience/ambigen3.ogg','sound/ambience/ambigen4.ogg','sound/ambience/ambigen5.ogg','sound/ambience/ambigen6.ogg','sound/ambience/ambigen7.ogg','sound/ambience/ambigen8.ogg','sound/ambience/ambigen9.ogg','sound/ambience/ambigen10.ogg','sound/ambience/ambigen11.ogg','sound/ambience/ambigen12.ogg','sound/ambience/ambigen14.ogg')
 	var/list/forced_ambience = null
 	var/sound_env = STANDARD_STATION
+	var/turf/base_turf //The base turf type of the area, which can be used to override the z-level's base turf
+
 /*Adding a wizard area teleport list because motherfucking lag -- Urist*/
 /*I am far too lazy to make it a proper list of areas so I'll just make it run the usual telepot routine at the start of the game*/
 var/list/teleportlocs = list()

--- a/code/game/base_turf.dm
+++ b/code/game/base_turf.dm
@@ -1,4 +1,4 @@
-// Returns the lowest turf available on a given Z-level, defaults to space.
+// Returns the lowest turf available on a given Z-level, defaults to asteroid for Polaris.
 var/global/list/base_turf_by_z = list(
 	"1" = /turf/simulated/floor/asteroid,
 	"4" = /turf/simulated/floor/asteroid,
@@ -9,6 +9,13 @@ proc/get_base_turf(var/z)
 	if(!base_turf_by_z["[z]"])
 		base_turf_by_z["[z]"] = /turf/space
 	return base_turf_by_z["[z]"]
+
+//An area can override the z-level base turf, so our solar array areas etc. can be space-based.
+proc/get_base_turf_by_area(var/turf/T)
+	var/area/A = T.loc
+	if(A.base_turf)
+		return A.base_turf
+	return get_base_turf(T.z)
 
 /client/proc/set_base_turf()
 	set category = "Debug"


### PR DESCRIPTION
Overrides the z-level's base turf in unsorted.dm.

It will first check to see if the turf is set, and if not it will still use the z-level default.
This means we can mark areas as having a base of space to override the z-level base of asteroid that we're using.
As a result, we can ensure the bombs, shuttles moving, etc. leave behind an space turf by defining shuttles, solars/"external" areas as using space as a base.
Areas will need to be updated to check with base_turf = /turf/space and references to the old get_base_turf proc updated so all calls (bombs, Nar'Sie, deconstruction, etc.) have the correct effect, but it's tired and I want to commit this now so I'm committed to finishing it tomorrow.