### PR TITLE
Fix for disposal pipes not vanishing under floors.

### DIFF
--- a/code/modules/recycling/disposal-construction.dm
+++ b/code/modules/recycling/disposal-construction.dm
@@ -91,6 +91,9 @@
 
 		if(invisibility)				// if invisible, fade icon
 			alpha = 128
+		else
+			alpha = 255
+			//otherwise burying half-finished pipes under floors causes them to half-fade
 
 	// hide called by levelupdate if turf intact status changes
 	// change visibility status and force update of icon
@@ -318,3 +321,9 @@
 			else
 				user << "You need to attach it to the plating first!"
 				return
+
+/obj/structure/disposalconstruct/hides_under_flooring()
+	if(anchored)
+		return 1
+	else
+		return 0

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -940,6 +940,9 @@
 			expel(H, T, 0)
 	..()
 
+/obj/structure/disposalpipe/hides_under_flooring()
+	return 1
+
 // *** TEST verb
 //client/verb/dispstop()
 //	for(var/obj/structure/disposalholder/H in world)

--- a/html/changelogs/magmaram-disposalfix.yml
+++ b/html/changelogs/magmaram-disposalfix.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: MagmaRam
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Fixed a bug where disposals pipes would show up above floors despite being installed under them."


### PR DESCRIPTION
This is a fix for issue #291. Disposals pipes should now properly stop
displaying when a floor is placed on top of them.