### PR TITLE
Object access check fix.

### DIFF
--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -39,7 +39,8 @@
 	return STATUS_CLOSE
 
 /mob/living/silicon/CanUseObjTopic(var/obj/O)
-	return O.allowed(src)
+	var/id = src.GetIdCard()
+	return O.check_access(id)
 
 /mob/proc/CanUseObjTopic()
 	return 1


### PR DESCRIPTION
Objects now only check synth access as intended, instead of the more restrictive allowance.
Fixes https://github.com/PolarisSS13/Polaris/issues/409, but will leave it open as there's still a related issue lying around.