### PR TITLE
NanoUI interaction for ghosts on APCs/Atmos

### DIFF
--- a/code/ATMOSPHERICS/atmospherics.dm
+++ b/code/ATMOSPHERICS/atmospherics.dm
@@ -123,3 +123,8 @@ obj/machinery/atmospherics/proc/check_connect_types(obj/machinery/atmospherics/a
 
 /obj/machinery/atmospherics/update_icon()
 	return null
+
+/obj/machinery/atmospherics/attack_ghost(user as mob)
+	if(stat & (BROKEN|MAINT))
+		return
+	return ui_interact(user)

--- a/code/ATMOSPHERICS/atmospherics.dm
+++ b/code/ATMOSPHERICS/atmospherics.dm
@@ -123,8 +123,3 @@ obj/machinery/atmospherics/proc/check_connect_types(obj/machinery/atmospherics/a
 
 /obj/machinery/atmospherics/update_icon()
 	return null
-
-/obj/machinery/atmospherics/attack_ghost(user as mob)
-	if(stat & (BROKEN|MAINT))
-		return
-	return ui_interact(user)

--- a/code/game/machinery/computer/computer.dm
+++ b/code/game/machinery/computer/computer.dm
@@ -96,15 +96,6 @@
 	text = replacetext(text, "\n", "<BR>")
 	return text
 
-
-/obj/machinery/computer/attack_ghost(user as mob)
-	return src.attack_hand(user)
-
-/obj/machinery/computer/attack_hand(user as mob)
-	/* Observers can view computers, but not actually use them via Topic*/
-	if(istype(user, /mob/dead/observer)) return 0
-	return ..()
-
 /obj/machinery/computer/attackby(I as obj, user as mob)
 	if(istype(I, /obj/item/weapon/screwdriver) && circuit)
 		playsound(src.loc, 'sound/items/Screwdriver.ogg', 50, 1)

--- a/code/game/machinery/teleporter.dm
+++ b/code/game/machinery/teleporter.dm
@@ -10,10 +10,6 @@
 	var/one_time_use = 0 //Used for one-time-use teleport cards (such as clown planet coordinates.)
 						 //Setting this to 1 will set src.locked to null after a player enters the portal and will not allow hand-teles to open portals to that location.
 
-/* Ghosts can't use this */
-/obj/machinery/computer/teleporter/attack_ghost(user as mob)
-	return 1
-
 /obj/machinery/computer/teleporter/New()
 	src.id = "[rand(1000, 9999)]"
 	..()

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -82,9 +82,6 @@ var/global/list/default_medbay_channels = list(
 	for (var/ch_name in channels)
 		secure_radio_connections[ch_name] = radio_controller.add_object(src, radiochannels[ch_name],  RADIO_CHAT)
 
-/obj/item/device/radio/attack_ghost(mob/user)
-	return ui_interact(user)
-
 /obj/item/device/radio/attack_self(mob/user as mob)
 	user.set_machine(src)
 	interact(user)

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -114,6 +114,9 @@
 		if(!ai_in_use && !is_in_use)
 			in_use = 0
 
+/obj/attack_ghost(mob/user)
+	ui_interact(user)
+
 /obj/proc/interact(mob/user)
 	return
 

--- a/code/modules/nano/interaction/default.dm
+++ b/code/modules/nano/interaction/default.dm
@@ -9,10 +9,12 @@
 /mob/proc/default_can_use_topic(var/src_object)
 	return STATUS_CLOSE // By default no mob can do anything with NanoUI
 
-/mob/dead/observer/default_can_use_topic()
+/mob/dead/observer/default_can_use_topic(var/src_object)
 	if(can_admin_interact())
-		return STATUS_INTERACTIVE				// Admins are more equal
-	return STATUS_UPDATE						// Ghosts can view updates
+		return STATUS_INTERACTIVE							// Admins are more equal
+	if(!client || get_dist(src_object, src)	> client.view)	// Preventing ghosts from having a million windows open by limiting to objects in range
+		return STATUS_CLOSE
+	return STATUS_UPDATE									// Ghosts can view updates
 
 /mob/living/silicon/pai/default_can_use_topic(var/src_object)
 	if((src_object == src || src_object == radio) && !stat)

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -720,11 +720,6 @@
 	// do APC interaction
 	src.interact(user)
 
-/obj/machinery/power/apc/attack_ghost(user as mob)
-	if(stat & (BROKEN|MAINT))
-		return
-	return ui_interact(user)
-
 /obj/machinery/power/apc/interact(mob/user)
 	if(!user)
 		return

--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -223,10 +223,7 @@
 
 
 /obj/machinery/power/smes/attack_ai(mob/user)
-	add_fingerprint(user)
-	ui_interact(user)
-
-/obj/machinery/power/smes/attack_ghost(mob/user)
+	add_hiddenprint(user)
 	ui_interact(user)
 
 /obj/machinery/power/smes/attack_hand(mob/user)


### PR DESCRIPTION
Adds attack_ghost() to base atmospherics object and APC to allow ghosts to see the nanoUI, and for admins to modify the objects from the interface.

-edit-  I was wondering why attack_ghost() wasn't defined higher up the tree and as it turns out, it was, on bay.  Thank you GinjaNinja32 for pointing that out, and Psi for allowing me to be lazy.