### PR TITLE
Camera Hotfix

### DIFF
--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -141,7 +141,6 @@
 				assembly.camera_network = english_list(network, NETWORK_EXODUS, ",", ",")
 				assembly.update_icon()
 				assembly.dir = src.dir
-				assembly = null //so qdel doesn't eat it.
 				if(stat & BROKEN)
 					assembly.state = 2
 					user << "<span class='notice'>You repaired \the [src] frame.</span>"
@@ -149,6 +148,7 @@
 					assembly.state = 1
 					user << "<span class='notice'>You cut \the [src] free from the wall.</span>"
 					new /obj/item/stack/cable_coil(src.loc, length=2)
+				assembly = null //so qdel doesn't eat it.
 			qdel(src)
 
 	// OTHER


### PR DESCRIPTION
assembly.state wasn't set due to the variable not existing anymore. Fixed.