### PR TITLE
Fixes people spawning in space.

### DIFF
--- a/code/modules/client/preferences_gear.dm
+++ b/code/modules/client/preferences_gear.dm
@@ -934,6 +934,7 @@ var/global/list/gear_datums = list()
 
 /datum/gear/scarf_orange
 	display_name = "scarf, orange"
+	path = /obj/item/clothing/accessory/scarf/orange
 	slot = slot_tie
 	cost = 1
 


### PR DESCRIPTION
People were spawning in space due to a runtime error that occured when they choose the orange scarf, because the loadout entry lacked a path variable.

Fixes #376 