### PR TITLE
Space's default turf is space. 

### DIFF
--- a/code/game/area/Space Station 13 areas.dm
+++ b/code/game/area/Space Station 13 areas.dm
@@ -105,6 +105,7 @@ var/list/ghostteleportlocs = list()
 	power_equip = 0
 	power_environ = 0
 	ambience = list('sound/ambience/ambispace.ogg','sound/music/title2.ogg','sound/music/space.ogg','sound/music/main.ogg','sound/music/traitor.ogg')
+	base_turf = /turf/space
 
 area/space/atmosalert()
 	return


### PR DESCRIPTION
We'll no longer get sand when we place down lattices. You'd think that was pretty clear and easy to remember to do, right?

Wrong. Apparently.