### PR TITLE
Adds the missing cargo department to the world Topic() manifest request.

### DIFF
--- a/code/world.dm
+++ b/code/world.dm
@@ -191,6 +191,7 @@ var/world_topic_spam_protect_time = world.timeofday
 				"eng" = engineering_positions,
 				"med" = medical_positions,
 				"sci" = science_positions,
+				"car" = cargo_positions,
 				"civ" = civilian_positions,
 				"bot" = nonhuman_positions
 			)


### PR DESCRIPTION
Using the !manifest command in IRC will (should) now list cargo personnel under the Cargo department instead of Misc./Civilian, same as the manifest does in game.