### PR TITLE
Telecrystal Refactoring

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -54,6 +54,7 @@
 	var/datum/changeling/changeling		//changeling holder
 
 	var/rev_cooldown = 0
+	var/tcrystals = 0
 
 	// the world.time since the mob has been brigged, or -1 if not at all
 	var/brigged_since = -1
@@ -375,14 +376,12 @@
 				memory = null//Remove any memory they may have had.
 			if("crystals")
 				if (usr.client.holder.rights & R_FUN)
-					var/obj/item/device/uplink/hidden/suplink = find_syndicate_uplink()
+				//	var/obj/item/device/uplink/hidden/suplink = find_syndicate_uplink() No longer needed, uses stored in mind
 					var/crystals
-					if (suplink)
-						crystals = suplink.uses
-					crystals = input("Amount of telecrystals for [key]","Operative uplink", crystals) as null|num
+					crystals = tcrystals
+					crystals = input("Amount of telecrystals for [key]", crystals) as null|num
 					if (!isnull(crystals))
-						if (suplink)
-							suplink.uses = crystals
+						tcrystals = crystals
 
 	else if (href_list["obj_announce"])
 		var/obj_count = 1

--- a/code/game/antagonist/outsider/mercenary.dm
+++ b/code/game/antagonist/outsider/mercenary.dm
@@ -43,6 +43,7 @@ var/datum/antagonist/mercenary/mercs
 	if(player.backbag == 4) player.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/satchel(player), slot_back)
 	player.equip_to_slot_or_del(new /obj/item/weapon/storage/box/engineer(player.back), slot_in_backpack)
 	player.equip_to_slot_or_del(new /obj/item/weapon/reagent_containers/pill/cyanide(player), slot_in_backpack)
+	player.mind.tcrystals = DEFAULT_TELECRYSTAL_AMOUNT
 
 	if (player.mind == leader)
 		var/obj/item/device/radio/uplink/U = new(player.loc, player.mind, 40)

--- a/code/game/antagonist/station/traitor.dm
+++ b/code/game/antagonist/station/traitor.dm
@@ -81,6 +81,7 @@ var/datum/antagonist/traitor/traitors
 		return 0
 
 	spawn_uplink(traitor_mob)
+	traitor_mob.mind.tcrystals = DEFAULT_TELECRYSTAL_AMOUNT
 	// Tell them about people they might want to contact.
 	var/mob/living/carbon/human/M = get_nt_opposed()
 	if(M && M != traitor_mob)

--- a/code/game/objects/items/devices/uplink.dm
+++ b/code/game/objects/items/devices/uplink.dm
@@ -27,7 +27,7 @@ A list of items and costs is stored under the datum of every game mode, alongsid
 	src.uplink_owner = owner
 	purchase_log = list()
 	world_uplinks += src
-	uses = telecrystals
+	uses = owner.tcrystals
 
 /obj/item/device/uplink/Destroy()
 	world_uplinks -= src
@@ -87,6 +87,7 @@ A list of items and costs is stored under the datum of every game mode, alongsid
 /obj/item/device/uplink/hidden/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1)
 	var/title = "Remote Uplink"
 	var/data[0]
+	uses = user.mind.tcrystals
 
 	data["welcome"] = welcome
 	data["crystals"] = uses

--- a/code/game/objects/items/devices/uplink_items.dm
+++ b/code/game/objects/items/devices/uplink_items.dm
@@ -56,7 +56,7 @@ var/datum/uplink/uplink = new()
 		return
 
 	purchase_log(U)
-	U.uses -= cost
+	user.mind.tcrystals -= cost
 	U.used_TC += cost
 	return goods
 
@@ -408,8 +408,8 @@ datum/uplink_item/dd_SortValue()
 	path = /obj/item/weapon/storage/box/syndie_kit/imp_explosive
 
 /datum/uplink_item/item/implants/imp_uplink
-	name = "Uplink Implant (Contains 5 Telecrystals)"
-	item_cost = 10
+	name = "Uplink Implant" //Original name: "Uplink Implant (Contains 5 Telecrystals)"
+	item_cost = 5 //Original cost: 10
 	path = /obj/item/weapon/storage/box/syndie_kit/imp_uplink
 
 /**********

--- a/code/game/objects/items/weapons/implants/implantuplink.dm
+++ b/code/game/objects/items/weapons/implants/implantuplink.dm
@@ -6,7 +6,8 @@
 /obj/item/weapon/implant/uplink/New()
 	activation_emote = pick("blink", "blink_r", "eyebrow", "chuckle", "twitch_s", "frown", "nod", "blush", "giggle", "grin", "groan", "shrug", "smile", "pale", "sniff", "whimper", "wink")
 	hidden_uplink = new(src)
-	hidden_uplink.uses = 5
+	//hidden_uplink.uses = 5
+	//Code currently uses a mind var for telecrystals, balancing is currently an issue. Will investigate.
 	..()
 	return
 

--- a/code/game/objects/structures/crates_lockers/closets/syndicate.dm
+++ b/code/game/objects/structures/crates_lockers/closets/syndicate.dm
@@ -60,8 +60,8 @@
 	new /obj/item/weapon/pinpointer/nukeop(src)
 	new /obj/item/weapon/pinpointer/nukeop(src)
 	new /obj/item/device/pda/syndicate(src)
-	var/obj/item/device/radio/uplink/U = new(src)
-	U.hidden_uplink.uses = 40
+	new /obj/item/device/radio/uplink(src)
+	//U.hidden_uplink.uses = 40
 	return
 
 /obj/structure/closet/syndicate/resources/

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -1326,3 +1326,19 @@ proc/admin_notice(var/message, var/rights)
 	message_admins("[key_name(usr)] attempting to force mode latespawn.")
 	ticker.mode.next_spawn = 0
 	ticker.mode.try_latespawn()
+	
+/datum/admins/proc/set_tcrystals(mob/living/carbon/human/H as mob)
+	set category = "Debug"
+	set name = "Set Telecrystals"
+	set desc = "Allows admins to change telecrystals of a user."
+	
+	var/crystals
+	
+	if(R_ADMIN)
+		crystals = input("Amount of telecrystals for [H.ckey]", crystals) as null|num
+		if (!isnull(crystals))
+			H.mind.tcrystals = crystals
+			var/msg = "[key_name(usr)] has modified [H.ckey]'s telecrystals to [crystals]."
+			message_admins(msg)
+	else
+		usr << "You do not have access to this command."

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -13,7 +13,8 @@ var/list/admin_verbs_default = list(
 //	/client/proc/deadchat				/*toggles deadchat on/off*/
 	)
 var/list/admin_verbs_admin = list(
-	/client/proc/player_panel_new,		/*shows an interface for all players, with links to various panels*/
+	/client/proc/player_panel_new, /*shows an interface for all players, with links to various panels*/
+	/datum/admins/proc/set_tcrystals,
 	/client/proc/invisimin,				/*allows our mob to go invisible/visible*/
 //	/datum/admins/proc/show_traitor_panel,	/*interface which shows a mob's mind*/ -Removed due to rare practical use. Moved to debug verbs ~Errorage
 	/datum/admins/proc/show_game_mode,  /*Configuration window for the current game mode.*/


### PR DESCRIPTION
Refactors Telecrystals into individual pools, adds a new command to allow for admins to modify telecrystal levels.

Things that don't work:
Uplink Implant does NOT have a separate pool. Will look into another time. Price adjusted down and noted.

EDIT: Oh, and the command is logged and sent to all admins/mods.