### PR TITLE
Fixes window 'bang' typo

### DIFF
--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -186,7 +186,7 @@
 		playsound(src.loc, 'sound/effects/glassknock.ogg', 80, 1)
 		user.do_attack_animation(src)
 		usr.visible_message("<span class='danger'>[usr.name] bangs against the [src.name]!</span>",
-							"<<span class='danger'>You bang against the [src.name]!</span>",
+							"<span class='danger'>You bang against the [src.name]!</span>",
 							"You hear a banging sound.")
 	else
 		playsound(src.loc, 'sound/effects/glassknock.ogg', 80, 1)


### PR DESCRIPTION
Fixes the typo when harm-intent clicking a window with your bare hand:

<You bang against the window!

to:

You bang against the window!