### PR TITLE
Tweaks Filtering and Toxic Gases

### DIFF
--- a/code/__defines/machinery.dm
+++ b/code/__defines/machinery.dm
@@ -91,7 +91,7 @@ var/list/restricted_camera_networks = list(NETWORK_ERT,NETWORK_MERCENARY,"Secret
 
 // Will not bother pumping or filtering if the gas source as fewer than this amount of moles, to help with performance.
 #define MINIMUM_MOLES_TO_PUMP   0.01
-#define MINIMUM_MOLES_TO_FILTER 0.1
+#define MINIMUM_MOLES_TO_FILTER 0.04
 
 // The flow rate/effectiveness of various atmos devices is limited by their internal volume,
 // so for many atmos devices these will control maximum flow rates in L/s.

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -375,7 +375,7 @@
 			safe_pressure_min *= 1.25
 
 	var/safe_exhaled_max = 10
-	var/safe_toxins_max = 0.005
+	var/safe_toxins_max = 0.2
 	var/SA_para_min = 1
 	var/SA_sleep_min = 5
 	var/inhaled_gas_used = 0


### PR DESCRIPTION
 * Scrubbers will filter gases down to 0.04 resident moles per turf (opposed to 0.1)
 * Toxic gas has no negative effect when beneath 0.2 kPa partial pressure (as the sensor settings on air alarms would suggest)

Resolves #522