### PR TITLE
No verbose cantouch check when not climbable

### DIFF
--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -56,7 +56,8 @@
 		user << "<span class='warning'>You can't buckle anyone in before the game starts.</span>"
 	if(!user.Adjacent(M) || user.restrained() || user.lying || user.stat || istype(user, /mob/living/silicon/pai))
 		return
-
+	if(M == buckled_mob)
+		return
 	if(istype(M, /mob/living/carbon/slime))
 		user << "<span class='warning'>The [M] is too squishy to buckle in.</span>"
 		return

--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -69,7 +69,7 @@
 		return ..()
 
 /obj/structure/proc/can_climb(var/mob/living/user, post_climb_check=0)
-	if (!can_touch(user) || !climbable || (!post_climb_check && (user in climbers)))
+	if (!climbable || !can_touch(user) || (!post_climb_check && (user in climbers)))
 		return 0
 
 	if (!user.Adjacent(src))


### PR DESCRIPTION
Used to get "You need your hands and legs free to do this" when buckling to chairs - the game mistakingly thinking you are trying to climb it.
Also makes buckled mobs unable to be buckled again.