### PR TITLE
Uplink NanoUI patch.

### DIFF
--- a/code/game/objects/items/devices/uplink.dm
+++ b/code/game/objects/items/devices/uplink.dm
@@ -98,6 +98,7 @@ A list of items and costs is stored under the datum of every game mode, alongsid
 	ui = nanomanager.try_update_ui(user, src, ui_key, ui, data, force_open)
 	if (!ui)	// No auto-refresh
 		ui = new(user, src, ui_key, "uplink.tmpl", title, 450, 600, state = inventory_state)
+		data["menu"] = 0
 		ui.set_initial_data(data)
 		ui.open()
 


### PR DESCRIPTION
Forces new uplink NanoUIs to start at category menu, avoids grayed out options. (#576)

May also resolve other outstanding issues, such as menu displaying only one item. (https://github.com/PolarisSS13/Polaris/issues/576#issuecomment-164813250)

Issue will be left open for some time to allow for any unusual runtime errors such as the second case to resurface.