### PR TITLE
Applying Harpy's prosthetic limb damage fix.

### DIFF
--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -8,8 +8,8 @@
 	var/total_burn  = 0
 	var/total_brute = 0
 	for(var/obj/item/organ/external/O in organs)	//hardcoded to streamline things a bit
-		if(O.status & ORGAN_ROBOT)
-			continue //robot limbs don't count towards shock and crit
+		if((O.status & ORGAN_ROBOT) && !O.vital)
+			continue // Non-vital robot limbs don't count towards shock and crit
 		total_brute += O.brute_dam
 		total_burn  += O.burn_dam
 


### PR DESCRIPTION
This may mean that synthetics need several general buffs as four egun shots to the chest will kill them.