### PR TITLE
Changes to Confused Moving

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -123,22 +123,26 @@ default behaviour is:
 		now_pushing = 0
 		spawn(0)
 			..()
-			if (!istype(AM, /atom/movable))
+			if (!istype(AM, /atom/movable) || AM.anchored)
+				if(confused && prob(50) && m_intent=="run")
+					Paralyse(1)
+					playsound(loc, "punch", 25, 1, -1)
+					visible_message("<span class='warning'>[src] [pick("ran", "slammed")] into \the [AM]!</span>")
+					src.take_organ_damage(5)
 				return
 			if (!now_pushing)
 				now_pushing = 1
 
-				if (!AM.anchored)
-					var/t = get_dir(src, AM)
-					if (istype(AM, /obj/structure/window))
-						for(var/obj/structure/window/win in get_step(AM,t))
-							now_pushing = 0
-							return
-					step(AM, t)
-					if(ishuman(AM) && AM:grabbed_by)
-						for(var/obj/item/weapon/grab/G in AM:grabbed_by)
-							step(G:assailant, get_dir(G:assailant, AM))
-							G.adjust_position()
+				var/t = get_dir(src, AM)
+				if (istype(AM, /obj/structure/window))
+					for(var/obj/structure/window/win in get_step(AM,t))
+						now_pushing = 0
+						return
+				step(AM, t)
+				if(ishuman(AM) && AM:grabbed_by)
+					for(var/obj/item/weapon/grab/G in AM:grabbed_by)
+						step(G:assailant, get_dir(G:assailant, AM))
+						G.adjust_position()
 				now_pushing = 0
 			return
 	return

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -11,7 +11,7 @@
 	return
 
 /mob/proc/setMoveCooldown(var/timeout)
-	if(client) 
+	if(client)
 		client.move_delay = max(world.time + timeout, client.move_delay)
 
 /client/North()
@@ -286,7 +286,7 @@
 			//specific vehicle move delays are set in code\modules\vehicles\vehicle.dm
 			move_delay = world.time + tickcomp
 			//drunk driving
-			if(mob.confused)
+			if(mob.confused && prob(75))
 				direct = pick(cardinal)
 			return mob.buckled.relaymove(mob,direct)
 
@@ -307,8 +307,12 @@
 					if((!l_hand || (l_hand.status & ORGAN_DESTROYED)) && (!r_hand || (r_hand.status & ORGAN_DESTROYED)))
 						return // No hands to drive your chair? Tough luck!
 				//drunk wheelchair driving
-				if(mob.confused)
-					direct = pick(cardinal)
+				else if(mob.confused)
+					switch(mob.m_intent)
+						if("run")
+							if(prob(75))	direct = pick(cardinal)
+						if("walk")
+							if(prob(25))	direct = pick(cardinal)
 				move_delay += 2
 				return mob.buckled.relaymove(mob,direct)
 
@@ -348,7 +352,11 @@
 							return
 
 		else if(mob.confused)
-			step(mob, pick(cardinal))
+			switch(mob.m_intent)
+				if("run")
+					if(prob(75))	step(mob, pick(cardinal))
+				if("walk")
+					if(prob(25))	step(mob, pick(cardinal))
 		else
 			. = mob.SelfMove(n, direct)
 


### PR DESCRIPTION
Instead of complete random cardinal movements while confused, the chance of the direction being randomly picked is now at 75% for running (and driving) and 25% for walking. This is to ensure people have a chance of getting into the general direction they want to.
Bumping into an immobile object while confused and running has a 50% chance of making you visibly run into the obstacle. Induces minor (5 points of) damage.