### PR TITLE
Fixes the canUnEquip() proc.

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -206,7 +206,7 @@
 					else if(success)
 						user << "<span class='notice'>You put some things in [S].</span>"
 					else
-						user << "<span class='notice'>You fail to pick anything up with [S].</span>"
+						user << "<span class='notice'>You fail to pick anything up with \the [S].</span>"
 
 			else if(S.can_be_inserted(src))
 				S.handle_item_insertion(src)

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -227,7 +227,7 @@
 /obj/item/weapon/storage/proc/can_be_inserted(obj/item/W as obj, stop_messages = 0)
 	if(!istype(W)) return //Not an item
 
-	if(!usr.canUnEquip(W))
+	if(usr.isEquipped(W) && !usr.canUnEquip(W))
 		return 0
 
 	if(src.loc == W)

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -216,19 +216,20 @@ var/list/slot_equipment_priority = list( \
 		wear_mask = null
 		update_inv_wear_mask(0)
 	return
+    
+/mob/proc/isEquipped(obj/item/I)
+	if(!I)
+		return 0
+	return get_inventory_slot(I) != 0
 
 /mob/proc/canUnEquip(obj/item/I)
 	if(!I) //If there's nothing to drop, the drop is automatically successful.
 		return 1
 	var/slot = get_inventory_slot(I)
-	if(slot && !I.mob_can_unequip(src, slot))
-		return 0
-
-	drop_from_inventory(I)
-	return 1
+	return slot && I.mob_can_unequip(src, slot)
 
 /mob/proc/get_inventory_slot(obj/item/I)
-	var/slot
+	var/slot = 0
 	for(var/s in slot_back to slot_tie) //kind of worries me
 		if(get_equipped_item(s) == I)
 			slot = s


### PR DESCRIPTION
It now only checks state, it doesn't change it. Fixes a number of odd putting items into bags interactions.
Partial port of https://github.com/Baystation12/Baystation12/pull/11823.