### PR TITLE
Fixes #685.

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -988,7 +988,13 @@ mob/proc/yank_out_object()
 		if (ishuman(U))
 			var/mob/living/carbon/human/human_user = U
 			human_user.bloody_hands(H)
-
+			
+	else if(issilicon(src))
+		var/mob/living/silicon/robot/R = src
+		R.embedded -= selection
+		R.adjustBruteLoss(5)
+		R.adjustFireLoss(10)
+	
 	selection.forceMove(get_turf(src))
 	if(!(U.l_hand && U.r_hand))
 		U.put_in_hands(selection)

--- a/html/changelogs/Datraen-YankFix.yml
+++ b/html/changelogs/Datraen-YankFix.yml
@@ -1,0 +1,4 @@
+author: Datraen
+delete-after: True
+changes: 
+  - bugfix: "Objects can now be yanked out of synthetics."


### PR DESCRIPTION
Objects are now properly removed from the embedded and pinned lists for synthetics.*