### PR TITLE
Properly cleans up the mmi_holder Destroy() proc.

### DIFF
--- a/code/modules/organs/subtypes/machine.dm
+++ b/code/modules/organs/subtypes/machine.dm
@@ -27,7 +27,9 @@
 	var/obj/item/device/mmi/stored_mmi
 
 /obj/item/organ/internal/mmi_holder/Destroy()
-	stored_mmi = null
+	if(stored_mmi)
+		qdel(stored_mmi)
+		stored_mmi = null
 	return ..()
 
 /obj/item/organ/internal/mmi_holder/New(var/mob/living/carbon/human/new_owner, var/internal)


### PR DESCRIPTION
This fixes the MMI-brain-in-elevator bug.