### PR TITLE
Removing Cryo bag damage

### DIFF
--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -86,7 +86,6 @@
 		if(!client)
 			species.handle_npc(src)
 
-	handle_stasis_bag()
 
 	if(!handle_some_updates())
 		return											//We go ahead and process them 5 times for HUD images and other stuff though.
@@ -224,15 +223,7 @@
 					src << "<span class='danger'>Your legs won't respond properly, you fall down!</span>"
 					Weaken(10)
 
-/mob/living/carbon/human/proc/handle_stasis_bag()
-	// Handle side effects from stasis bag
-	if(in_stasis)
-		// First off, there's no oxygen supply, so the mob will slowly take brain damage
-		adjustBrainLoss(0.1)
 
-		// Next, the method to induce stasis has some adverse side-effects, manifesting
-		// as cloneloss
-		adjustCloneLoss(0.1)
 
 /mob/living/carbon/human/handle_mutations_and_radiation()
 	if(in_stasis)


### PR DESCRIPTION
This appears to cover everything?  It should only remove the damage-over-time effect of stasis bags.  Please review this code as I am not an expert.

Stasis bags are currently less than useless.  A simple shot of inapprovalin and a little hustle easily does more than they do.  As well, they cause genetic AND brain damage while in use!  This requires a trip to cryo to repair, and maybe more.  My suggestion is that we remove the damage so that stasis bags can be properly used without fear.