### PR TITLE
Space heater buff

### DIFF
--- a/code/game/machinery/spaceheater.dm
+++ b/code/game/machinery/spaceheater.dm
@@ -6,6 +6,7 @@
 	name = "space heater"
 	desc = "Made by Space Amish using traditional space techniques, this heater is guaranteed not to set the station on fire."
 	var/obj/item/weapon/cell/cell
+	var/cell_type = /obj/item/weapon/cell/apc
 	var/on = 0
 	var/set_temperature = T0C + 50	//K
 	var/heating_power = 40000
@@ -13,7 +14,8 @@
 
 /obj/machinery/space_heater/New()
 	..()
-	cell = new(src)
+	if (cell_type)
+		src.cell = new cell_type(src)
 	update_icon()
 
 /obj/machinery/space_heater/update_icon()


### PR DESCRIPTION
Defines a default cell type for space heaters as a var and sets it to heavy duty cell, granting much more power than before. By suggestion of a certain sparkletron.