### PR TITLE
Traitor synth lockdown changes

### DIFF
--- a/code/game/machinery/computer/robot.dm
+++ b/code/game/machinery/computer/robot.dm
@@ -91,15 +91,23 @@
 		if(!target || !istype(target))
 			return
 
-		message_admins("<span class='notice'>[key_name_admin(usr)] [target.canmove ? "locked down" : "released"] [target.name]!</span>")
-		log_game("[key_name(usr)] [target.canmove ? "locked down" : "released"] [target.name]!")
-		target.canmove = !target.canmove
-		if (target.lockcharge)
+		var/istraitor = target.mind.special_role == "Traitor"
+		if (istraitor)
 			target.lockcharge = !target.lockcharge
-			target << "Your lockdown has been lifted!"
+			if (target.lockcharge)
+				target << "Someone tried to lock you down!"
+			else
+				target << "Someone tried to lift your lockdown!"
 		else
-			target.lockcharge = !target.lockcharge
-			target << "You have been locked down!"
+			target.canmove = !target.canmove
+			target.lockcharge = !target.canmove //when canmove is 1, lockcharge should be 0
+			if (target.lockcharge)
+				target << "You have been locked down!"
+			else
+				target << "Your lockdown has been lifted!"
+		message_admins("<span class='notice'>[key_name_admin(usr)] [istraitor ? "failed (target is traitor) " : ""][target.lockcharge ? "lockdown" : "release"] on [target.name]!</span>")
+		log_game("[key_name(usr)] attempted to [target.lockcharge ? "lockdown" : "release"] [target.name] on the robotics console!")
+
 
 	// Remotely hacks the cyborg. Only antag AIs can do this and only to linked cyborgs.
 	else if (href_list["hack"])

--- a/code/game/machinery/computer/robot.dm
+++ b/code/game/machinery/computer/robot.dm
@@ -91,7 +91,7 @@
 		if(!target || !istype(target))
 			return
 
-		var/istraitor = target.mind.special_role == "Traitor"
+		var/istraitor = traitors.is_antagonist(target.mind)
 		if (istraitor)
 			target.lockcharge = !target.lockcharge
 			if (target.lockcharge)

--- a/html/changelogs/EmperorJon-PR-904.yml
+++ b/html/changelogs/EmperorJon-PR-904.yml
@@ -1,0 +1,4 @@
+author: EmperorJon
+delete-after: True
+changes: 
+  - tweak: "Traitor synths can no longer be locked down from the robotics console. Attempting to lock them down (or release the lockdown) notifies the synth of the attempt and updates the console's UI as normal."


### PR DESCRIPTION
Prevents traitor synthetics from being locked down on the robotics console.
Reports that they have been locked down on the UI to whoever attempted it.
Notifies the synth that an attempt was made.