### PR TITLE
Makes stasis bags better

### DIFF
--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -456,7 +456,7 @@ var/list/all_supply_groups = list("Operations","Security","Hospitality","Enginee
 	group = "Medical"
 
 /datum/supply_packs/cryobag
-	name = "Statis bag crate"
+	name = "Stasis bag crate"
 	contains = list(/obj/item/bodybag/cryobag,
 				    /obj/item/bodybag/cryobag,
 	    			/obj/item/bodybag/cryobag)

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -225,6 +225,7 @@
 
 	var/obj/machinery/computer/cryopod/control_computer
 	var/last_no_computer_message = 0
+	var/applies_stasis = 1
 
 	// These items are preserved when the process() despawn proc occurs.
 	var/list/preserve_items = list(
@@ -254,6 +255,7 @@
 	on_enter_occupant_message = "The storage unit broadcasts a sleep signal to you. Your systems start to shut down, and you enter low-power mode."
 	allow_occupant_types = list(/mob/living/silicon/robot)
 	disallow_occupant_types = list(/mob/living/silicon/robot/drone)
+	applies_stasis = 0
 
 /obj/machinery/cryopod/robot/door
 	//This inherits from the robot cryo, so synths can be properly cryo'd.  If a non-synth enters and is cryo'd, ..() is called and it'll still work.
@@ -524,6 +526,9 @@
 			M << "<span class='notice'><b>If you ghost, log out or close your client now, your character will shortly be permanently removed from the round.</b></span>"
 			set_occupant(M)
 			time_entered = world.time
+			if(ishuman(M) && applies_stasis)
+				var/mob/living/carbon/human/H = M
+				H.in_stasis = 1
 
 			// Book keeping!
 			var/turf/location = get_turf(src)
@@ -589,6 +594,9 @@
 		usr.client.eye = src
 		usr.forceMove(src)
 		set_occupant(usr)
+		if(ishuman(usr) && applies_stasis)
+			var/mob/living/carbon/human/H = occupant
+			H.in_stasis = 1
 
 		icon_state = occupied_icon_state
 
@@ -622,6 +630,9 @@
 		occupant.client.perspective = MOB_PERSPECTIVE
 
 	occupant.forceMove(get_turf(src))
+	if(ishuman(occupant) && applies_stasis)
+		var/mob/living/carbon/human/H = occupant
+		H.in_stasis = 0
 	set_occupant(null)
 
 	icon_state = base_icon_state

--- a/code/game/objects/items/bodybag.dm
+++ b/code/game/objects/items/bodybag.dm
@@ -98,25 +98,36 @@
 
 /obj/item/bodybag/cryobag
 	name = "stasis bag"
-	desc = "A folded, non-reusable bag designed to prevent additional damage to an occupant at the cost of genetic damage."
+	desc = "A folded, non-reusable bag designed to prevent additional damage to an occupant, especially useful if short on time or in \
+	a hostile enviroment."
 	icon = 'icons/obj/cryobag.dmi'
 	icon_state = "bodybag_folded"
+	origin_tech = list(TECH_BIO = 4)
 
-	attack_self(mob/user)
-		var/obj/structure/closet/body_bag/cryobag/R = new /obj/structure/closet/body_bag/cryobag(user.loc)
-		R.add_fingerprint(user)
-		qdel(src)
-
-
+/obj/item/bodybag/cryobag/attack_self(mob/user)
+	var/obj/structure/closet/body_bag/cryobag/R = new /obj/structure/closet/body_bag/cryobag(user.loc)
+	R.add_fingerprint(user)
+	qdel(src)
 
 /obj/structure/closet/body_bag/cryobag
 	name = "stasis bag"
-	desc = "A non-reusable plastic bag designed to prevent additional damage to an occupant at the cost of genetic damage."
+	desc = "A non-reusable plastic bag designed to prevent additional damage to an occupant, especially useful if short on time or in \
+	a hostile enviroment."
 	icon = 'icons/obj/cryobag.dmi'
 	item_path = /obj/item/bodybag/cryobag
 	store_misc = 0
 	store_items = 0
 	var/used = 0
+	var/obj/item/weapon/tank/tank = null
+
+/obj/structure/closet/body_bag/cryobag/New()
+	tank = new /obj/item/weapon/tank/emergency_oxygen(null) //It's in nullspace to prevent ejection when the bag is opened.
+	..()
+
+/obj/structure/closet/body_bag/cryobag/Destroy()
+	qdel(tank)
+	tank = null
+	..()
 
 /obj/structure/closet/body_bag/cryobag/open()
 	. = ..()
@@ -128,8 +139,38 @@
 		O.desc = "Pretty useless now.."
 		qdel(src)
 
-/obj/structure/closet/body_bag/cryobag/MouseDrop(over_object, src_location, over_location)
-	if((over_object == usr && (in_range(src, usr) || usr.contents.Find(src))))
-		if(!ishuman(usr))	return
-		usr << "<span class='warning'>You can't fold that up anymore..</span>"
+/obj/structure/closet/body_bag/cryobag/Entered(atom/movable/AM)
+	if(ishuman(AM))
+		var/mob/living/carbon/human/H = AM
+		H.in_stasis = 1
+		src.used = 1
 	..()
+
+/obj/structure/closet/body_bag/cryobag/Exited(atom/movable/AM)
+	if(ishuman(AM))
+		var/mob/living/carbon/human/H = AM
+		H.in_stasis = 0
+	..()
+
+/obj/structure/closet/body_bag/cryobag/return_air() //Used to make stasis bags protect from vacuum.
+	if(tank)
+		return tank.air_contents
+	..()
+
+/obj/structure/closet/body_bag/cryobag/examine(mob/user)
+	..()
+	if(Adjacent(user)) //The bag's rather thick and opaque from a distance.
+		user << "<span class='info'>You peer into \the [src].</span>"
+		for(var/mob/living/L in contents)
+			L.examine(user)
+
+/obj/structure/closet/body_bag/cryobag/attackby(obj/item/W, mob/user)
+	if(opened)
+		..()
+	else //Allows the bag to respond to a health analyzer by analyzing the mob inside without needing to open it.
+		if(istype(W,/obj/item/device/healthanalyzer))
+			var/obj/item/device/healthanalyzer/analyzer = W
+			for(var/mob/living/L in contents)
+				analyzer.attack(L,user)
+		else
+			..()

--- a/code/modules/examine/descriptions/medical.dm
+++ b/code/modules/examine/descriptions/medical.dm
@@ -40,3 +40,25 @@
 	<br>\
 	Right-click the cell and click 'Eject Occupant' to remove them.  You can enter the cell yourself by right clicking and selecting 'Enter Sleeper'. \
 	Note that you cannot control the sleeper while inside of it."
+
+/obj/item/bodybag/cryobag
+	description_info = "This stasis bag will preserve the occupant, stopping most forms of harm from occuring, such as from oxygen \
+	deprivation, irradiation, shock, and chemicals inside the occupant, at least until the bag is opened again.<br>\
+	<br>\
+	Stasis bags can only be used once, and are rather costly, so use them well.  They are ideal for situations where someone may die \
+	before being able to bring them back to safety, or if they are in a hostile enviroment, such as in vacuum or in a phoron leak, as \
+	the bag will protect the occupant from most outside enviromental hazards.  If you open a bag by mistake, closing the bag with no \
+	occupant will not use up the bag, and you can pick it back up.<br>\
+	<br>\
+	You can use a health analyzer to scan the occupant's vitals without opening the bag by clicking the occupied bag with the analyzer."
+
+/obj/structure/closet/body_bag/cryobag
+	description_info = "This stasis bag will preserve the occupant, stopping most forms of harm from occuring, such as from oxygen \
+	deprivation, irradiation, shock, and chemicals inside the occupant, at least until the bag is opened again.<br>\
+	<br>\
+	Stasis bags can only be used once, and are rather costly, so use them well.  They are ideal for situations where someone may die \
+	before being able to bring them back to safety, or if they are in a hostile enviroment, such as in vacuum or in a phoron leak, as \
+	the bag will protect the occupant from most outside enviromental hazards.  If you open a bag by mistake, closing the bag with no \
+	occupant will not use up the bag, and you can pick it back up.<br>\
+	<br>\
+	You can use a health analyzer to scan the occupant's vitals without opening the bag by clicking the occupied bag with the analyzer."

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -56,9 +56,6 @@
 	if(wearing_rig && wearing_rig.offline)
 		wearing_rig = null
 
-	in_stasis = istype(loc, /obj/structure/closet/body_bag/cryobag) && loc:opened == 0
-	if(in_stasis) loc:used++
-
 	..()
 
 	if(life_tick%30==15)
@@ -1303,7 +1300,7 @@
 				var/base_temperature = species.body_temperature
 				if(base_temperature == null) //some species don't have a set metabolic temperature
 					base_temperature = (species.heat_level_1 + species.cold_level_1)/2
-				
+
 				var/temp_step
 				if (bodytemperature >= base_temperature)
 					temp_step = (species.heat_level_1 - base_temperature)/4

--- a/html/changelogs/Neerti-StasisBags.yml
+++ b/html/changelogs/Neerti-StasisBags.yml
@@ -1,0 +1,37 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Neerti
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Stasis bags will protect the occupant from the outside enviroment's atmosphere."
+  - rscadd: "Stasis bags can be hit with a health analyzer to analyze the occupant."


### PR DESCRIPTION
**``Life()`` no longer checks if the mob's inside a stasis bag and if so, sets the bag to used every life tick.  The bag itself does this now, and this allows for alternate sources of the stasis effect.**
Cryo (the log-out kind) applies the stasis effect.  Robot cryo, gateway, elevator, etc, do not apply this effect.
Stasis bags now have a tech level.
Stasis bags protect the occupant from hostile environments such as vacuum.  This is to attempt to fit the stasis bag in a specific niche, where an EMT may have to rescue someone who's in a breach or other horrible thing but can't bring them out in a timely manner, as pressure damage is quite high and crits you in under a minute.
Stasis bags can be examined to examine the occupant if you are next to them.
Stasis bags can be hit with a health analyzer to analyze the occupant.
Stasis bags can be picked up if unrolled, if they were not already used.
Examine tab ``description_info`` filled for both stasis bag types.