### PR TITLE
Ling nerfs, ear protection cleanup, and ling bugfixes.

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -58,6 +58,7 @@ attacked_by() will handle hitting/missing/logging as it does now, and will call 
 
 	// TODO: needs to be refactored into a mob/living level attacked_by() proc. ~Z
 	user.do_attack_animation(M)
+	user.break_cloak()
 	if(istype(M, /mob/living/carbon/human))
 		var/mob/living/carbon/human/H = M
 

--- a/code/game/gamemodes/changeling/powers/shriek.dm
+++ b/code/game/gamemodes/changeling/powers/shriek.dm
@@ -22,8 +22,18 @@
 
 	var/datum/changeling/changeling = changeling_power(20,0,100,CONSCIOUS)
 	if(!changeling)	return 0
-	changeling.chem_charges -= 20
 
+	if(is_muzzled())
+		src << "<span class='danger'>Mmmf mrrfff!</span>"
+		return 0
+
+	if(ishuman(src))
+		var/mob/living/carbon/human/H = src
+		if(H.silent)
+			src << "<span class='danger'>You can't speak!</span>"
+			return 0
+
+	changeling.chem_charges -= 20
 	var/range = 4
 	if(src.mind.changeling.recursive_enhancement)
 		range = range * 2
@@ -33,13 +43,21 @@
 	for(var/mob/living/M in range(range, src))
 		if(iscarbon(M))
 			if(!M.mind || !M.mind.changeling)
+				if(M.get_ear_protection() >= 2)
+					continue
+				M << "<span class='danger'>You hear an extremely loud screeching sound!  It \
+				[pick("confuses","confounds","perturbs","befuddles","dazes","unsettles","disorients")] you.</span>"
 				M.adjustEarDamage(0,30)
 				M.confused += 20
+				M << sound('sound/effects/screech.ogg')
 			else
+				if(M != src)
+					M << "<span class='notice'>You hear a familiar screech from nearby.  It has no effect on you.</span>"
 				M << sound('sound/effects/screech.ogg')
 
 		if(issilicon(M))
 			M << sound('sound/weapons/flash.ogg')
+			M << "<span class='notice'>Auditory input overloaded.  Reinitializing...</span>"
 			M.Weaken(rand(5,10))
 
 	for(var/obj/machinery/light/L in range(range, src))
@@ -57,6 +75,17 @@
 
 	var/datum/changeling/changeling = changeling_power(20,0,100,CONSCIOUS)
 	if(!changeling)	return 0
+
+	if(is_muzzled())
+		src << "<span class='danger'>Mmmf mrrfff!</span>"
+		return 0
+
+	if(ishuman(src))
+		var/mob/living/carbon/human/H = src
+		if(H.silent)
+			src << "<span class='danger'>You can't speak!</span>"
+			return 0
+
 	changeling.chem_charges -= 20
 
 	var/range_heavy = 2

--- a/code/game/gamemodes/changeling/powers/visible_camouflage.dm
+++ b/code/game/gamemodes/changeling/powers/visible_camouflage.dm
@@ -26,7 +26,7 @@
 
 		if(!changeling)
 			return 0
-
+		changeling.chem_charges -= 10
 		var/old_regen_rate = H.mind.changeling.chem_recharge_rate
 
 		H << "<span class='notice'>We vanish from sight, and will remain hidden, so long as we move carefully.</span>"
@@ -40,7 +40,7 @@
 			src << "<span class='notice'>We are now truly invisible.</span>"
 			src.mind.changeling.recursive_enhancement = 0
 
-		while(H.m_intent == "walk" && H.mind.changeling.cloaked) //This loop will keep going until the player uncloaks.
+		while(H.m_intent == "walk" && H.mind.changeling.cloaked && !H.stat) //This loop will keep going until the player uncloaks.
 			if(mind.changeling.chem_recharge_rate != 0) //Without this, there is an exploit that can be done, if one buys engorged chem sacks while cloaked.
 				old_regen_rate += mind.changeling.chem_recharge_rate //Unfortunately, it has to occupy this part of the proc.  This fixes it while at the same time
 				mind.changeling.chem_recharge_rate = 0 //making sure nobody loses out on their bonus regeneration after they're done hiding.

--- a/code/game/machinery/jukebox.dm
+++ b/code/game/machinery/jukebox.dm
@@ -89,10 +89,8 @@ datum/track/New(var/title_name, var/audio)
 		if(emagged)
 			playsound(src.loc, 'sound/items/AirHorn.ogg', 100, 1)
 			for(var/mob/living/carbon/M in ohearers(6, src))
-				if(istype(M, /mob/living/carbon/human))
-					var/mob/living/carbon/human/H = M
-					if(istype(H.l_ear, /obj/item/clothing/ears/earmuffs) || istype(H.r_ear, /obj/item/clothing/ears/earmuffs))
-						continue
+				if(M.get_ear_protection() >= 2)
+					continue
 				M.sleeping = 0
 				M.stuttering += 20
 				M.ear_deaf += 30

--- a/code/game/objects/items/weapons/grenades/flashbang.dm
+++ b/code/game/objects/items/weapons/grenades/flashbang.dm
@@ -36,13 +36,7 @@
 		var/ear_safety = 0
 		if(iscarbon(M))
 			eye_safety = M.eyecheck()
-			if(ishuman(M))
-				if(istype(M:l_ear, /obj/item/clothing/ears/earmuffs) || istype(M:r_ear, /obj/item/clothing/ears/earmuffs))
-					ear_safety += 2
-				if(HULK in M.mutations)
-					ear_safety += 1
-				if(istype(M:head, /obj/item/clothing/head/helmet))
-					ear_safety += 1
+			ear_safety = M.get_ear_protection()
 
 //Flashing everyone
 		if(eye_safety < 1)

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -11,6 +11,7 @@
 		while sprite_sheets should be used for "flexible" clothing items that do not need to be refitted (e.g. vox wearing jumpsuits).
 	*/
 	var/list/sprite_sheets_refit = null
+	var/ear_protection = 0
 
 //Updates the icons of the mob wearing the clothing item, if any.
 /obj/item/clothing/proc/update_clothing_icon()
@@ -162,6 +163,7 @@
 	icon_state = "earmuffs"
 	item_state = "earmuffs"
 	slot_flags = SLOT_EARS | SLOT_TWOEARS
+	ear_protection = 2
 
 /obj/item/clothing/ears/earmuffs/headphones
 	name = "headphones"

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -15,6 +15,7 @@
 	max_heat_protection_temperature = HELMET_MAX_HEAT_PROTECTION_TEMPERATURE
 	siemens_coefficient = 0.7
 	w_class = 3
+	ear_protection = 1
 
 /obj/item/clothing/head/helmet/riot
 	name = "riot helmet"

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -116,7 +116,7 @@
 				b_loss = b_loss/1.5
 				f_loss = f_loss/1.5
 
-			if (!istype(l_ear, /obj/item/clothing/ears/earmuffs) && !istype(r_ear, /obj/item/clothing/ears/earmuffs))
+			if (!get_ear_protection() >= 2)
 				ear_damage += 30
 				ear_deaf += 120
 			if (prob(70) && !shielded)
@@ -126,7 +126,7 @@
 			b_loss += 30
 			if (prob(getarmor(null, "bomb")))
 				b_loss = b_loss/2
-			if (!istype(l_ear, /obj/item/clothing/ears/earmuffs) && !istype(r_ear, /obj/item/clothing/ears/earmuffs))
+			if (!get_ear_protection() >= 2)
 				ear_damage += 15
 				ear_deaf += 60
 			if (prob(50) && !shielded)

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -18,7 +18,7 @@
 		if(!temp || !temp.is_usable())
 			H << "\red You can't use your hand."
 			return
-
+	break_cloak()
 	..()
 
 	// Should this all be in Touch()?

--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -32,6 +32,30 @@
 		return list(HUMAN_EATING_BLOCKED_MOUTH, blocked)
 	return list(HUMAN_EATING_NO_ISSUE)
 
+//This is called when we want different types of 'cloaks' to stop working, e.g. when attacking.
+/mob/living/carbon/human/break_cloak()
+	if(mind && mind.changeling) //Changeling visible camo
+		mind.changeling.cloaked = 0
+	if(istype(back, /obj/item/weapon/rig)) //Ninja cloak
+		var/obj/item/weapon/rig/suit = back
+		for(var/obj/item/rig_module/stealth_field/cloaker in suit.installed_modules)
+			if(cloaker.active)
+				cloaker.deactivate()
+
+/mob/living/carbon/human/get_ear_protection()
+	var/sum = 0
+	if(istype(l_ear, /obj/item/clothing/ears))
+		var/obj/item/clothing/ears/L = l_ear
+		sum += L.ear_protection
+	if(istype(r_ear, /obj/item/clothing/ears))
+		var/obj/item/clothing/ears/R = r_ear
+		sum += R.ear_protection
+	if(istype(head, /obj/item/clothing/head))
+		var/obj/item/clothing/head/H = head
+		sum += H.ear_protection
+	return sum
+
+
 #undef HUMAN_EATING_NO_ISSUE
 #undef HUMAN_EATING_NO_MOUTH
 #undef HUMAN_EATING_BLOCKED_MOUTH

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -1041,7 +1041,7 @@
 			ear_deaf = max(ear_deaf, 1)
 		else if(ear_deaf)			//deafness, heals slowly over time
 			ear_deaf = max(ear_deaf-1, 0)
-		else if(istype(l_ear, /obj/item/clothing/ears/earmuffs) || istype(r_ear, /obj/item/clothing/ears/earmuffs))	//resting your ears with earmuffs heals ear damage faster
+		else if(get_ear_protection() >= 2)	//resting your ears with earmuffs heals ear damage faster
 			ear_damage = max(ear_damage-0.15, 0)
 			ear_deaf = max(ear_deaf, 1)
 		else if(ear_damage < 25)	//ear damage heals slowly under this threshold. otherwise you'll need earmuffs

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -37,6 +37,12 @@ proc/isdeaf(A)
 		return (M.sdisabilities & DEAF) || M.ear_deaf
 	return 0
 
+/mob/proc/get_ear_protection()
+	return 0
+
+/mob/proc/break_cloak()
+	return
+
 proc/hasorgans(A) // Fucking really??
 	return ishuman(A)
 


### PR DESCRIPTION
Changeling shrieks (both kinds) now require the ling to not be muzzled or silenced in some form.
Sufficient ear protection (earmuffs-tier) will protect people from the confusing shriek.
A message is produced to any victims of the disorienting shriek.
Ear protection checks are now generalized in a ```get_ear_protection()``` proc, which returns the sum of ear protection from both ears and helmet slot.
Clothing now has an ```ear_protection``` variable.  Earmuffs get 2, while helmets get 1, to be the same as how flashbangs worked previously.
Attacking while cloaked as a ninja or changeling will uncloak them.
Dead or unconscious changelings will now uncloak.
Cloaking as a changeling will now correctly deduct chemicals.