### PR TITLE
Fixes #984

### DIFF
--- a/code/game/gamemodes/changeling/powers/fake_death.dm
+++ b/code/game/gamemodes/changeling/powers/fake_death.dm
@@ -29,6 +29,9 @@
 	C.update_canmove()
 	C.remove_changeling_powers()
 
+	if(C.suiciding)
+		C.suiciding = 0
+
 	if(C.stat != DEAD)
 		C.emote("deathgasp")
 		C.tod = worldtime2text()


### PR DESCRIPTION
Fixes the issue where lings suiciding and regenerating would keep taking oxyloss. They'll take oxyloss through the regen process, but once they revive themselves, the oxyloss will stop and everything will be grand again.