### PR TITLE
Fixing the 'Succumb' verb for all species across the board

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -149,9 +149,9 @@ default behaviour is:
 
 /mob/living/verb/succumb()
 	set hidden = 1
-	if ((src.health < 0 && src.health > -95.0))
-		src.adjustOxyLoss(src.health + 200)
-		src.health = 100 - src.getOxyLoss() - src.getToxLoss() - src.getFireLoss() - src.getBruteLoss()
+	if ((src.health < 0 && src.health > (5-src.maxHealth))) // Health below Zero but above 5-away-from-death, as before, but variable
+		src.adjustOxyLoss(src.health + src.maxHealth * 2) // Deal 2x health in OxyLoss damage, as before but variable.
+		src.health = src.maxHealth - src.getOxyLoss() - src.getToxLoss() - src.getFireLoss() - src.getBruteLoss()
 		src << "\blue You have given up life and succumbed to death."
 
 


### PR DESCRIPTION
This will need review, but may repair the succumb feature for all races, regardless of health levels.  I'm still learning this, and my syntax may be wrong.

Currently, succumb works off of the default health of 100.  This will adjust it to call the maxHealth variable of the mob and allow/deny succumb accordingly.  I think this is right(?)

This should fix #1013 