### PR TITLE
Changes types of ghosts and eyes

### DIFF
--- a/code/ZAS/Airflow.dm
+++ b/code/ZAS/Airflow.dm
@@ -43,7 +43,7 @@ mob/check_airflow_movable(n)
 		return 0
 	return 1
 
-mob/dead/observer/check_airflow_movable()
+mob/observer/check_airflow_movable()
 	return 0
 
 mob/living/silicon/check_airflow_movable()
@@ -247,6 +247,6 @@ zone/proc/movables()
 	. = list()
 	for(var/turf/T in contents)
 		for(var/atom/movable/A in T)
-			if(!A.simulated || A.anchored || istype(A, /obj/effect) || istype(A, /mob/eye))
+			if(!A.simulated || A.anchored || istype(A, /obj/effect) || istype(A, /mob/observer))
 				continue
 			. += A

--- a/code/_helpers/game.dm
+++ b/code/_helpers/game.dm
@@ -244,7 +244,7 @@
 			var/turf/ear = get_turf(M)
 			if(ear)
 				// Ghostship is magic: Ghosts can hear radio chatter from anywhere
-				if(speaker_coverage[ear] || (istype(M, /mob/dead/observer) && (M.client) && (M.client.prefs.toggles & CHAT_GHOSTRADIO)))
+				if(speaker_coverage[ear] || (istype(M, /mob/observer/dead) && (M.client) && (M.client.prefs.toggles & CHAT_GHOSTRADIO)))
 					. |= M		// Since we're already looping through mobs, why bother using |= ? This only slows things down.
 	return .
 
@@ -323,7 +323,7 @@ proc/isInSight(var/atom/A, var/atom/B)
 	var/list/candidates = list() //List of candidate KEYS to assume control of the new larva ~Carn
 	var/i = 0
 	while(candidates.len <= 0 && i < 5)
-		for(var/mob/dead/observer/G in player_list)
+		for(var/mob/observer/dead/G in player_list)
 			if(((G.client.inactivity/10)/60) <= buffer + i) // the most active players are more likely to become an alien
 				if(!(G.mind && G.mind.current && G.mind.current.stat != DEAD))
 					candidates += G.key
@@ -337,7 +337,7 @@ proc/isInSight(var/atom/A, var/atom/B)
 	var/list/candidates = list() //List of candidate KEYS to assume control of the new larva ~Carn
 	var/i = 0
 	while(candidates.len <= 0 && i < 5)
-		for(var/mob/dead/observer/G in player_list)
+		for(var/mob/observer/dead/G in player_list)
 			if(G.client.prefs.be_special & BE_ALIEN)
 				if(((G.client.inactivity/10)/60) <= ALIEN_SELECT_AFK_BUFFER + i) // the most active players are more likely to become an alien
 					if(!(G.mind && G.mind.current && G.mind.current.stat != DEAD))

--- a/code/_helpers/unsorted.dm
+++ b/code/_helpers/unsorted.dm
@@ -462,7 +462,7 @@ Turf and target are seperate in case you want to teleport some distance from a t
 		if (M.real_name && M.real_name != M.name)
 			name += " \[[M.real_name]\]"
 		if (M.stat == 2)
-			if(istype(M, /mob/dead/observer/))
+			if(istype(M, /mob/observer/dead/))
 				name += " \[ghost\]"
 			else
 				name += " \[dead\]"
@@ -474,7 +474,7 @@ Turf and target are seperate in case you want to teleport some distance from a t
 /proc/sortmobs()
 	var/list/moblist = list()
 	var/list/sortmob = sortAtom(mob_list)
-	for(var/mob/eye/M in sortmob)
+	for(var/mob/observer/eye/M in sortmob)
 		moblist.Add(M)
 	for(var/mob/living/silicon/ai/M in sortmob)
 		moblist.Add(M)
@@ -488,7 +488,7 @@ Turf and target are seperate in case you want to teleport some distance from a t
 		moblist.Add(M)
 	for(var/mob/living/carbon/alien/M in sortmob)
 		moblist.Add(M)
-	for(var/mob/dead/observer/M in sortmob)
+	for(var/mob/observer/dead/M in sortmob)
 		moblist.Add(M)
 	for(var/mob/new_player/M in sortmob)
 		moblist.Add(M)
@@ -861,7 +861,7 @@ proc/GaussRandRound(var/sigma,var/roundto)
 						if(!istype(O,/obj)) continue
 						O.loc = X
 					for(var/mob/M in T)
-						if(!istype(M,/mob) || istype(M, /mob/eye)) continue // If we need to check for more mobs, I'll add a variable
+						if(!istype(M,/mob) || istype(M, /mob/observer/eye)) continue // If we need to check for more mobs, I'll add a variable
 						M.loc = X
 
 //					var/area/AR = X.loc
@@ -995,7 +995,7 @@ proc/DuplicateObject(obj/original, var/perfectcopy = 0 , var/sameloc = 0)
 
 					for(var/mob/M in T)
 
-						if(!istype(M,/mob) || istype(M, /mob/eye)) continue // If we need to check for more mobs, I'll add a variable
+						if(!istype(M,/mob) || istype(M, /mob/observer/eye)) continue // If we need to check for more mobs, I'll add a variable
 						mobs += M
 
 					for(var/mob/M in mobs)

--- a/code/_macros.dm
+++ b/code/_macros.dm
@@ -13,7 +13,7 @@
 
 #define iscorgi(A) istype(A, /mob/living/simple_animal/corgi)
 
-#define isEye(A) istype(A, /mob/eye)
+#define isEye(A) istype(A, /mob/observer/eye)
 
 #define ishuman(A) istype(A, /mob/living/carbon/human)
 
@@ -23,7 +23,7 @@
 
 #define isnewplayer(A) istype(A, /mob/new_player)
 
-#define isobserver(A) istype(A, /mob/dead/observer)
+#define isobserver(A) istype(A, /mob/observer/dead)
 
 #define isorgan(A) istype(A, /obj/item/organ/external)
 

--- a/code/_onclick/observer.dm
+++ b/code/_onclick/observer.dm
@@ -1,5 +1,5 @@
 /client/var/inquisitive_ghost = 1
-/mob/dead/observer/verb/toggle_inquisition() // warning: unexpected inquisition
+/mob/observer/dead/verb/toggle_inquisition() // warning: unexpected inquisition
 	set name = "Toggle Inquisitiveness"
 	set desc = "Sets whether your ghost examines everything on click by default"
 	set category = "Ghost"
@@ -10,7 +10,7 @@
 	else
 		src << "<span class='notice'>You will no longer examine things you click on.</span>"
 
-/mob/dead/observer/DblClickOn(var/atom/A, var/params)
+/mob/observer/dead/DblClickOn(var/atom/A, var/params)
 	if(client.buildmode)
 		build_click(src, client.buildmode, params, A)
 		return
@@ -28,7 +28,7 @@
 		following = null
 		forceMove(get_turf(A))
 
-/mob/dead/observer/ClickOn(var/atom/A, var/params)
+/mob/observer/dead/ClickOn(var/atom/A, var/params)
 	if(client.buildmode)
 		build_click(src, client.buildmode, params, A)
 		return
@@ -39,7 +39,7 @@
 	A.attack_ghost(src)
 
 // Oh by the way this didn't work with old click code which is why clicking shit didn't spam you
-/atom/proc/attack_ghost(mob/dead/observer/user as mob)
+/atom/proc/attack_ghost(mob/observer/dead/user as mob)
 	if(user.client && user.client.inquisitive_ghost)
 		user.examinate(src)
 	return

--- a/code/controllers/Processes/inactivity.dm
+++ b/code/controllers/Processes/inactivity.dm
@@ -6,7 +6,7 @@
 	if(config.kick_inactive)
 		for(var/client/C in clients)
 			if(!C.holder && C.is_afk(config.kick_inactive MINUTES))
-				if(!istype(C.mob, /mob/dead))
+				if(!istype(C.mob, /mob/observer/dead))
 					log_access("AFK: [key_name(C)]")
 					C << "<SPAN CLASS='warning'>You have been inactive for more than [config.kick_inactive] minute\s and have been disconnected.</SPAN>"
 					del(C)	// Don't qdel, cannot override finalize_qdel behaviour for clients.

--- a/code/defines/procs/hud.dm
+++ b/code/defines/procs/hud.dm
@@ -72,7 +72,7 @@ mob/proc/handle_regular_hud_updates() //Used in the life.dm of mobs that can use
 mob/proc/in_view(var/turf/T)
 	return view(T)
 
-/mob/eye/in_view(var/turf/T)
+/mob/observer/eye/in_view(var/turf/T)
 	var/list/viewed = new
 	for(var/mob/living/carbon/human/H in mob_list)
 		if(get_dist(H, T) <= 7)

--- a/code/game/antagonist/antagonist.dm
+++ b/code/game/antagonist/antagonist.dm
@@ -92,7 +92,7 @@
 	// Prune restricted status. Broke it up for readability.
 	// Note that this is done before jobs are handed out.
 	for(var/datum/mind/player in ticker.mode.get_players_for_role(role_type, id))
-		if(ghosts_only && !istype(player.current, /mob/dead))
+		if(ghosts_only && !istype(player.current, /mob/observer/dead))
 			log_debug("[key_name(player)] is not eligible to become a [role_text]: Only ghosts may join as this role!")
 		else if(player.special_role)
 			log_debug("[key_name(player)] is not eligible to become a [role_text]: They already have a special role ([player.special_role])!")
@@ -124,7 +124,7 @@
 		return 0
 	player.current << "<span class='danger'><i>You have been selected this round as an antagonist!</i></span>"
 	message_admins("[uppertext(ticker.mode.name)]: Selected [player] as a [role_text].")
-	if(istype(player.current, /mob/dead))
+	if(istype(player.current, /mob/observer/dead))
 		create_default(player.current)
 	else
 		add_antagonist(player,0,0,0,1,1)

--- a/code/game/antagonist/antagonist_add.dm
+++ b/code/game/antagonist/antagonist_add.dm
@@ -8,7 +8,7 @@
 		player.assigned_role = role_text
 	player.special_role = role_text
 
-	if(istype(player.current, /mob/dead))
+	if(istype(player.current, /mob/observer/dead))
 		create_default(player.current)
 	else
 		create_antagonist(player, move_to_spawn, do_not_announce, preserve_appearance)

--- a/code/game/dna/dna_modifier.dm
+++ b/code/game/dna/dna_modifier.dm
@@ -159,7 +159,7 @@
 		|| locate(/obj/machinery/computer/cloning, get_step(src, WEST)))
 
 		if(!M.client && M.mind)
-			for(var/mob/dead/observer/ghost in player_list)
+			for(var/mob/observer/dead/ghost in player_list)
 				if(ghost.mind == M.mind)
 					ghost << "<b><font color = #330033><font size = 3>Your corpse has been placed into a cloning scanner. Return to your body if you want to be resurrected/cloned!</b> (Verbs -> Ghost -> Re-enter corpse)</font></font>"
 					break

--- a/code/game/gamemodes/cult/cultify/mob.dm
+++ b/code/game/gamemodes/cult/cultify/mob.dm
@@ -6,7 +6,7 @@
 /mob/proc/cultify()
 	return
 
-/mob/dead/cultify()
+/mob/observer/dead/cultify()
 	if(icon_state != "ghost-narsie")
 		icon = 'icons/mob/mob.dmi'
 		icon_state = "ghost-narsie"
@@ -21,7 +21,7 @@
 		C << "<span class='sinister'>The Geometer of Blood is overjoyed to be reunited with its followers, and accepts your body in sacrifice. As reward, you have been gifted with the shell of an Harvester.<br>Your tendrils can use and draw runes without need for a tome, your eyes can see beings through walls, and your mind can open any door. Use these assets to serve Nar-Sie and bring him any remaining living human in the world.<br>You can teleport yourself back to Nar-Sie along with any being under yourself at any time using your \"Harvest\" spell.</span>"
 		dust()
 	else if(client)
-		var/mob/dead/G = (ghostize())
+		var/mob/observer/dead/G = (ghostize())
 		G.icon = 'icons/mob/mob.dmi'
 		G.icon_state = "ghost-narsie"
 		G.overlays = 0

--- a/code/game/gamemodes/cult/narsie.dm
+++ b/code/game/gamemodes/cult/narsie.dm
@@ -298,7 +298,7 @@ var/global/list/narsie_list = list()
 		acquire(pick(cultists))
 		return
 		//no living cultists, pick a living human instead.
-	for(var/mob/dead/observer/ghost in player_list)
+	for(var/mob/observer/dead/ghost in player_list)
 		if(!ghost.client)
 			continue
 		var/turf/pos = get_turf(ghost)

--- a/code/game/gamemodes/cult/ritual.dm
+++ b/code/game/gamemodes/cult/ritual.dm
@@ -343,8 +343,8 @@ var/global/list/rnwords = list("ire","ego","nahlizet","certum","veri","jatkaa","
 		user.attack_log += text("\[[time_stamp()]\] <font color='red'>Used [name] on [M.name] ([M.ckey])</font>")
 		msg_admin_attack("[user.name] ([user.ckey]) used [name] on [M.name] ([M.ckey]) (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[user.x];Y=[user.y];Z=[user.z]'>JMP</a>)")
 
-		if(istype(M,/mob/dead))
-			var/mob/dead/D = M
+		if(istype(M,/mob/observer/dead))
+			var/mob/observer/dead/D = M
 			D.manifest(user)
 			return
 		if(!istype(M))

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -342,8 +342,8 @@ var/list/sacrificed = list()
 					usr << "<span class='warning'>The sacrifical corpse is not dead. You must free it from this world of illusions before it may be used.</span>"
 				return fizzle()
 
-			var/mob/dead/observer/ghost
-			for(var/mob/dead/observer/O in loc)
+			var/mob/observer/dead/ghost
+			for(var/mob/observer/dead/O in loc)
 				if(!O.client)	continue
 				if(O.mind && O.mind.current && O.mind.current.stat != DEAD)	continue
 				ghost = O
@@ -437,8 +437,8 @@ var/list/sacrificed = list()
 			src = null
 			if(usr.loc!=this_rune.loc)
 				return this_rune.fizzle()
-			var/mob/dead/observer/ghost
-			for(var/mob/dead/observer/O in this_rune.loc)
+			var/mob/observer/dead/ghost
+			for(var/mob/observer/dead/O in this_rune.loc)
 				if(!O.client)	continue
 				if(!O.MayRespawn()) continue
 				if(O.mind && O.mind.current && O.mind.current.stat != DEAD)	continue

--- a/code/game/gamemodes/endgame/supermatter_cascade/blob.dm
+++ b/code/game/gamemodes/endgame/supermatter_cascade/blob.dm
@@ -112,7 +112,7 @@
 
 
 /turf/unsimulated/wall/supermatter/proc/Consume(var/mob/living/user)
-	if(istype(user,/mob/dead/observer))
+	if(istype(user,/mob/observer))
 		return
 
 	qdel(user)

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -537,7 +537,7 @@ proc/display_roundstart_logout_report()
 					continue //Dead
 
 			continue //Happy connected client
-		for(var/mob/dead/observer/D in mob_list)
+		for(var/mob/observer/dead/D in mob_list)
 			if(D.mind && (D.mind.original == L || D.mind.current == L))
 				if(L.stat == DEAD)
 					if(L.suiciding)	//Suicider

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -387,8 +387,8 @@ var/global/datum/controller/gameticker/ticker
 				else
 					Player << "<font color='blue'><b>You missed the crew transfer after the events on [station_name()] as [Player.real_name].</b></font>"
 			else
-				if(istype(Player,/mob/dead/observer))
-					var/mob/dead/observer/O = Player
+				if(istype(Player,/mob/observer/dead))
+					var/mob/observer/dead/O = Player
 					if(!O.started_as_observer)
 						Player << "<font color='red'><b>You did not survive the events on [station_name()]...</b></font>"
 				else

--- a/code/game/machinery/atmoalter/meter.dm
+++ b/code/game/machinery/atmoalter/meter.dm
@@ -68,7 +68,7 @@
 /obj/machinery/meter/examine(mob/user)
 	var/t = "A gas flow meter. "
 	
-	if(get_dist(user, src) > 3 && !(istype(user, /mob/living/silicon/ai) || istype(user, /mob/dead)))
+	if(get_dist(user, src) > 3 && !(istype(user, /mob/living/silicon/ai) || istype(user, /mob/observer/dead)))
 		t += "<span class='warning'>You are too far away to read it.</span>"
 	
 	else if(stat & (NOPOWER|BROKEN))

--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -87,7 +87,7 @@
 		if(ckey(clonemind.key) != R.ckey)
 			return 0
 	else
-		for(var/mob/dead/observer/G in player_list)
+		for(var/mob/observer/dead/G in player_list)
 			if(G.ckey == R.ckey)
 				if(G.can_reenter_corpse)
 					break

--- a/code/game/machinery/telecomms/broadcaster.dm
+++ b/code/game/machinery/telecomms/broadcaster.dm
@@ -298,7 +298,7 @@ var/message_delay = 0 // To make sure restarting the recentmessages list is kept
 			continue
 
 		// Ghosts hearing all radio chat don't want to hear syndicate intercepts, they're duplicates
-		if(data == 3 && istype(R, /mob/dead/observer) && R.client && R.client.prefs && (R.client.prefs.toggles & CHAT_GHOSTRADIO))
+		if(data == 3 && istype(R, /mob/observer/dead) && R.client && R.client.prefs && (R.client.prefs.toggles & CHAT_GHOSTRADIO))
 			continue
 
 		// --- Check for compression ---

--- a/code/game/machinery/teleporter.dm
+++ b/code/game/machinery/teleporter.dm
@@ -85,7 +85,7 @@
 	if(..()) return
 
 	/* Ghosts can't use this one because it's a direct selection */
-	if(istype(user, /mob/dead/observer)) return
+	if(istype(user, /mob/observer/dead)) return
 
 	var/list/L = list()
 	var/list/areaindex = list()

--- a/code/game/objects/effects/step_triggers.dm
+++ b/code/game/objects/effects/step_triggers.dm
@@ -13,7 +13,7 @@
 	..()
 	if(!H)
 		return
-	if(istype(H, /mob/dead/observer) && !affect_ghosts)
+	if(istype(H, /mob/observer) && !affect_ghosts)
 		return
 	Trigger(H)
 

--- a/code/game/objects/items/devices/communicator/communicator.dm
+++ b/code/game/objects/items/devices/communicator/communicator.dm
@@ -109,7 +109,7 @@ var/global/list/obj/item/device/communicator/all_communicators = list()
 		if(!comm || !comm.exonet || !comm.exonet.address || comm.exonet.address == src.exonet.address) //Don't add addressless devices, and don't add ourselves.
 			continue
 		src.known_devices |= comm
-	for(var/mob/dead/observer/O in dead_mob_list)
+	for(var/mob/observer/dead/O in dead_mob_list)
 		if(!O.client || O.client.prefs.communicator_visibility == 0)
 			continue
 		src.known_devices |= O
@@ -157,13 +157,13 @@ var/global/list/obj/item/device/communicator/all_communicators = list()
 	populate_known_devices() //Update the devices so ghosts can see the list on NanoUI.
 	..()
 
-/mob/dead/observer
+/mob/observer/dead
 	var/datum/exonet_protocol/exonet = null
 
 // Proc: New()
 // Parameters: None
 // Description: Gives ghosts an exonet address based on their key and ghost name.
-/mob/dead/observer/New()
+/mob/observer/dead/New()
 	. = ..()
 	spawn(20)
 		exonet = new(src)
@@ -175,7 +175,7 @@ var/global/list/obj/item/device/communicator/all_communicators = list()
 // Proc: Destroy()
 // Parameters: None
 // Description: Removes the ghost's address and nulls the exonet datum, to allow qdel()ing.
-/mob/dead/observer/Destroy()
+/mob/observer/dead/Destroy()
 	. = ..()
 	if(exonet)
 		exonet.remove_address()
@@ -200,7 +200,7 @@ var/global/list/obj/item/device/communicator/all_communicators = list()
 			communicators[++communicators.len] = list("name" = sanitize(comm.name), "address" = comm.exonet.address)
 
 	//Now for ghosts who we pretend have communicators.
-	for(var/mob/dead/observer/O in known_devices)
+	for(var/mob/observer/dead/O in known_devices)
 		if(O.client && O.client.prefs.communicator_visibility == 1 && O.exonet)
 			communicators[++communicators.len] = list("name" = sanitize("[O.client.prefs.real_name]'s communicator"), "address" = O.exonet.address)
 
@@ -210,7 +210,7 @@ var/global/list/obj/item/device/communicator/all_communicators = list()
 			invites[++invites.len] = list("name" = sanitize(comm.name), "address" = comm.exonet.address)
 
 	//Ghosts we invited.
-	for(var/mob/dead/observer/O in voice_invites)
+	for(var/mob/observer/dead/O in voice_invites)
 		if(O.exonet && O.client)
 			invites[++invites.len] = list("name" = sanitize("[O.client.prefs.real_name]'s communicator"), "address" = O.exonet.address)
 
@@ -220,7 +220,7 @@ var/global/list/obj/item/device/communicator/all_communicators = list()
 			requests[++requests.len] = list("name" = sanitize(comm.name), "address" = comm.exonet.address)
 
 	//Ghosts that want to talk to us.
-	for(var/mob/dead/observer/O in voice_requests)
+	for(var/mob/observer/dead/O in voice_requests)
 		if(O.exonet && O.client)
 			requests[++requests.len] = list("name" = sanitize("[O.client.prefs.real_name]'s communicator"), "address" = O.exonet.address)
 
@@ -342,7 +342,7 @@ var/global/list/obj/item/device/communicator/all_communicators = list()
 // Proc: receive_exonet_message()
 // Parameters: 3 (origin atom - the source of the message's holder, origin_address - where the message came from, message - the message received)
 // Description: Handles voice requests and invite messages originating from both real communicators and ghosts.  Also includes a ping response.
-/mob/dead/observer/receive_exonet_message(origin_atom, origin_address, message)
+/mob/observer/dead/receive_exonet_message(origin_atom, origin_address, message)
 	if(message == "voice")
 		if(istype(origin_atom, /obj/item/device/communicator))
 			var/obj/item/device/communicator/comm = origin_atom
@@ -600,7 +600,7 @@ var/global/list/obj/item/device/communicator/all_communicators = list()
 // Verb: join_as_voice()
 // Parameters: None
 // Description: Allows ghosts to call communicators, if they meet all the requirements.
-/mob/dead/verb/join_as_voice()
+/mob/observer/dead/verb/join_as_voice()
 	set category = "Ghost"
 	set name = "Call Communicator"
 	set desc = "If there is a communicator available, send a request to speak through it.  This will reset your respawn timer, if someone picks up."
@@ -643,7 +643,7 @@ var/global/list/obj/item/device/communicator/all_communicators = list()
 	var/choice = input(src,"Send a voice request to whom?") as null|anything in choices
 	if(choice)
 		var/obj/item/device/communicator/chosen_communicator = choice
-		var/mob/dead/observer/O = src
+		var/mob/observer/dead/O = src
 		if(O.exonet)
 			O.exonet.send_message(chosen_communicator.exonet.address, "voice")
 

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -156,7 +156,7 @@ var/global/list/default_medbay_channels = list(
 	var/obj/item/weapon/card/id/I = GetIdCard()
 	return has_access(list(), req_one_accesses, I ? I.GetAccess() : list())
 
-/mob/dead/observer/has_internal_radio_channel_access(var/list/req_one_accesses)
+/mob/observer/dead/has_internal_radio_channel_access(var/list/req_one_accesses)
 	return can_admin_interact()
 
 /obj/item/device/radio/proc/text_wires()

--- a/code/game/objects/items/robot/robot_parts.dm
+++ b/code/game/objects/items/robot/robot_parts.dm
@@ -185,7 +185,7 @@
 			if(!M.brainmob.key)
 				var/ghost_can_reenter = 0
 				if(M.brainmob.mind)
-					for(var/mob/dead/observer/G in player_list)
+					for(var/mob/observer/dead/G in player_list)
 						if(G.can_reenter_corpse && G.mind == M.brainmob.mind)
 							ghost_can_reenter = 1
 							break

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -67,7 +67,7 @@
 		return 0
 
 	if(!R.key)
-		for(var/mob/dead/observer/ghost in player_list)
+		for(var/mob/observer/dead/ghost in player_list)
 			if(ghost.mind && ghost.mind.current == R)
 				R.key = ghost.key
 

--- a/code/game/response_team.dm
+++ b/code/game/response_team.dm
@@ -46,7 +46,7 @@ client/verb/JoinResponseTeam()
 		usr << "<span class='warning'>You cannot join the response team at this time.</span>"
 		return
 
-	if(istype(usr,/mob/dead/observer) || istype(usr,/mob/new_player))
+	if(istype(usr,/mob/observer/dead) || istype(usr,/mob/new_player))
 		if(!send_emergency_team)
 			usr << "No emergency response team is currently being sent."
 			return

--- a/code/game/verbs/who.dm
+++ b/code/game/verbs/who.dm
@@ -18,7 +18,7 @@
 					entry += " - <font color='darkgray'><b>Unconscious</b></font>"
 				if(DEAD)
 					if(isobserver(C.mob))
-						var/mob/dead/observer/O = C.mob
+						var/mob/observer/dead/O = C.mob
 						if(O.started_as_observer)
 							entry += " - <font color='gray'>Observing</font>"
 						else

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -1257,7 +1257,7 @@ proc/admin_notice(var/message, var/rights)
 
 //Returns 1 to let the dragdrop code know we are trapping this event
 //Returns 0 if we don't plan to trap the event
-/datum/admins/proc/cmd_ghost_drag(var/mob/dead/observer/frommob, var/mob/living/tomob)
+/datum/admins/proc/cmd_ghost_drag(var/mob/observer/dead/frommob, var/mob/living/tomob)
 	if(!istype(frommob))
 		return //Extra sanity check to make sure only observers are shoved into things
 

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -399,9 +399,9 @@ var/list/admin_verbs_mentor = list(
 	set category = "Admin"
 	set name = "Aghost"
 	if(!holder)	return
-	if(istype(mob,/mob/dead/observer))
+	if(istype(mob,/mob/observer/dead))
 		//re-enter
-		var/mob/dead/observer/ghost = mob
+		var/mob/observer/dead/ghost = mob
 		if(!is_mentor(usr.client))
 			ghost.can_reenter_corpse = 1
 		if(ghost.can_reenter_corpse)
@@ -417,7 +417,7 @@ var/list/admin_verbs_mentor = list(
 	else
 		//ghostize
 		var/mob/body = mob
-		var/mob/dead/observer/ghost = body.ghostize(1)
+		var/mob/observer/dead/ghost = body.ghostize(1)
 		ghost.admin_ghosted = 1
 		if(body)
 			body.teleop = ghost

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -262,7 +262,7 @@
 		message_admins("\blue [key_name_admin(usr)] has used rudimentary transformation on [key_name_admin(M)]. Transforming to [href_list["simplemake"]]; deletemob=[delmob]", 1)
 
 		switch(href_list["simplemake"])
-			if("observer")			M.change_mob_type( /mob/dead/observer , null, null, delmob )
+			if("observer")			M.change_mob_type( /mob/observer/dead , null, null, delmob )
 			if("larva")				M.change_mob_type( /mob/living/carbon/alien/larva , null, null, delmob )
 			if("nymph")				M.change_mob_type( /mob/living/carbon/alien/diona , null, null, delmob )
 			if("human")				M.change_mob_type( /mob/living/carbon/human , null, null, delmob, href_list["species"])
@@ -1927,7 +1927,7 @@ mob/living/silicon/ai/can_centcom_reply()
 	if(client && eyeobj)
 		return "|<A HREF='?[source];adminplayerobservejump=\ref[eyeobj]'>EYE</A>"
 
-/mob/dead/observer/extra_admin_link(var/source)
+/mob/observer/dead/extra_admin_link(var/source)
 	if(mind && mind.current)
 		return "|<A HREF='?[source];adminplayerobservejump=\ref[mind.current]'>BDY</A>"
 

--- a/code/modules/admin/verbs/adminjump.dm
+++ b/code/modules/admin/verbs/adminjump.dm
@@ -1,7 +1,7 @@
 /mob/proc/on_mob_jump()
 	return
 
-/mob/dead/observer/on_mob_jump()
+/mob/observer/dead/on_mob_jump()
 	following = null
 
 /client/proc/Jump(var/area/A in return_sorted_areas())

--- a/code/modules/admin/verbs/adminpm.dm
+++ b/code/modules/admin/verbs/adminpm.dm
@@ -21,7 +21,7 @@
 		if(T.mob)
 			if(istype(T.mob, /mob/new_player))
 				targets["(New Player) - [T]"] = T
-			else if(istype(T.mob, /mob/dead/observer))
+			else if(istype(T.mob, /mob/observer/dead))
 				targets["[T.mob.name](Ghost) - [T]"] = T
 			else
 				targets["[T.mob.real_name](as [T.mob.name]) - [T]"] = T

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -85,7 +85,7 @@
 	var/mob/choice = input("Choose a player to play the pAI", "Spawn pAI") in available
 	if(!choice)
 		return 0
-	if(!istype(choice, /mob/dead/observer))
+	if(!istype(choice, /mob/observer/dead))
 		var/confirm = input("[choice.key] isn't ghosting right now. Are you sure you want to yank them out of them out of their body and place them in this pAI?", "Spawn pAI Confirmation", "No") in list("Yes", "No")
 		if(confirm != "Yes")
 			return 0
@@ -231,7 +231,7 @@
 	set name = "Del-All"
 
 	// to prevent REALLY stupid deletions
-	var/blocked = list(/obj, /mob, /mob/living, /mob/living/carbon, /mob/living/carbon/human, /mob/dead, /mob/dead/observer, /mob/living/silicon, /mob/living/silicon/robot, /mob/living/silicon/ai)
+	var/blocked = list(/obj, /mob, /mob/living, /mob/living/carbon, /mob/living/carbon/human, /mob/observer/dead, /mob/living/silicon, /mob/living/silicon/robot, /mob/living/silicon/ai)
 	var/hsbitem = input(usr, "Choose an object to delete.", "Delete:") as null|anything in typesof(/obj) + typesof(/mob) - blocked
 	if(hsbitem)
 		for(var/atom/O in world)
@@ -299,7 +299,7 @@
 		if(alert("This mob is being controlled by [M.ckey]. Are you sure you wish to assume control of it? [M.ckey] will be made a ghost.",,"Yes","No") != "Yes")
 			return
 		else
-			var/mob/dead/observer/ghost = new/mob/dead/observer(M,1)
+			var/mob/observer/dead/ghost = new/mob/observer/dead(M,1)
 			ghost.ckey = M.ckey
 	message_admins("\blue [key_name_admin(usr)] assumed direct control of [M].", 1)
 	log_admin("[key_name(usr)] assumed direct control of [M].")

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -236,7 +236,7 @@ Ccomp's first proc.
 	var/list/ghosts = list()
 	var/list/sortmob = sortAtom(mob_list)                           // get the mob list.
 	/var/any=0
-	for(var/mob/dead/observer/M in sortmob)
+	for(var/mob/observer/dead/M in sortmob)
 		mobs.Add(M)                                             //filter it where it's only ghosts
 		any = 1                                                 //if no ghosts show up, any will just be 0
 	if(!any)
@@ -266,7 +266,7 @@ Ccomp's first proc.
 		src << "Hrm, appears you didn't select a ghost"		// Sanity check, if no ghosts in the list we don't want to edit a null variable and cause a runtime error.
 		return
 
-	var/mob/dead/observer/G = ghosts[target]
+	var/mob/observer/dead/G = ghosts[target]
 	if(G.has_enabled_antagHUD && config.antag_hud_restricted)
 		var/response = alert(src, "Are you sure you wish to allow this individual to play?","Ghost has used AntagHUD","Yes","No")
 		if(response == "No") return
@@ -291,9 +291,9 @@ Ccomp's first proc.
 		src << "Only administrators may use this command."
 	var/action=""
 	if(config.antag_hud_allowed)
-		for(var/mob/dead/observer/g in get_ghosts())
+		for(var/mob/observer/dead/g in get_ghosts())
 			if(!g.client.holder)						//Remove the verb from non-admin ghosts
-				g.verbs -= /mob/dead/observer/verb/toggle_antagHUD
+				g.verbs -= /mob/observer/dead/verb/toggle_antagHUD
 			if(g.antagHUD)
 				g.antagHUD = 0						// Disable it on those that have it enabled
 				g.has_enabled_antagHUD = 2				// We'll allow them to respawn
@@ -302,9 +302,9 @@ Ccomp's first proc.
 		src << "\red <B>AntagHUD usage has been disabled</B>"
 		action = "disabled"
 	else
-		for(var/mob/dead/observer/g in get_ghosts())
+		for(var/mob/observer/dead/g in get_ghosts())
 			if(!g.client.holder)						// Add the verb back for all non-admin ghosts
-				g.verbs += /mob/dead/observer/verb/toggle_antagHUD
+				g.verbs += /mob/observer/dead/verb/toggle_antagHUD
 			g << "\blue <B>The Administrator has enabled AntagHUD </B>"	// Notify all observers they can now use AntagHUD
 		config.antag_hud_allowed = 1
 		action = "enabled"
@@ -324,13 +324,13 @@ Ccomp's first proc.
 		src << "Only administrators may use this command."
 	var/action=""
 	if(config.antag_hud_restricted)
-		for(var/mob/dead/observer/g in get_ghosts())
+		for(var/mob/observer/dead/g in get_ghosts())
 			g << "\blue <B>The administrator has lifted restrictions on joining the round if you use AntagHUD</B>"
 		action = "lifted restrictions"
 		config.antag_hud_restricted = 0
 		src << "\blue <B>AntagHUD restrictions have been lifted</B>"
 	else
-		for(var/mob/dead/observer/g in get_ghosts())
+		for(var/mob/observer/dead/g in get_ghosts())
 			g << "\red <B>The administrator has placed restrictions on joining the round if you use AntagHUD</B>"
 			g << "\red <B>Your AntagHUD has been disabled, you may choose to re-enabled it but will be under restrictions </B>"
 			g.antagHUD = 0
@@ -358,8 +358,8 @@ Traitors and the like can also be revived with the previous role mostly intact.
 	if(!input)
 		return
 
-	var/mob/dead/observer/G_found
-	for(var/mob/dead/observer/G in player_list)
+	var/mob/observer/dead/G_found
+	for(var/mob/observer/dead/G in player_list)
 		if(G.ckey == input)
 			G_found = G
 			break
@@ -627,7 +627,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 	log_admin("[key_name(usr)] has gibbed [key_name(M)]")
 	message_admins("[key_name_admin(usr)] has gibbed [key_name_admin(M)]", 1)
 
-	if(istype(M, /mob/dead/observer))
+	if(istype(M, /mob/observer/dead))
 		gibs(M.loc)
 		return
 
@@ -640,7 +640,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 
 	var/confirm = alert(src, "You sure?", "Confirm", "Yes", "No")
 	if(confirm == "Yes")
-		if (istype(mob, /mob/dead/observer)) // so they don't spam gibs everywhere
+		if (istype(mob, /mob/observer/dead)) // so they don't spam gibs everywhere
 			return
 		else
 			mob.gib()

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -663,7 +663,7 @@
 
 /obj/item/clothing/under/proc/set_sensors(mob/usr as mob)
 	var/mob/M = usr
-	if (istype(M, /mob/dead/)) return
+	if (istype(M, /mob/observer)) return
 	if (usr.stat || usr.restrained()) return
 	if(has_sensor >= 2)
 		usr << "The controls are locked."

--- a/code/modules/clothing/masks/miscellaneous.dm
+++ b/code/modules/clothing/masks/miscellaneous.dm
@@ -129,7 +129,7 @@
 	item_state = "s-ninja"
 	flags_inv = HIDEFACE
 	body_parts_covered = 0
-	var/mob/eye/aiEye/eye
+	var/mob/observer/eye/aiEye/eye
 
 /obj/item/clothing/mask/ai/New()
 	eye = new(src)

--- a/code/modules/ghosttrap/trap.dm
+++ b/code/modules/ghosttrap/trap.dm
@@ -22,7 +22,7 @@ proc/populate_ghost_traps()
 	var/ghost_trap_role = "Positronic Brain"
 
 // Check for bans, proper atom types, etc.
-/datum/ghosttrap/proc/assess_candidate(var/mob/dead/observer/candidate)
+/datum/ghosttrap/proc/assess_candidate(var/mob/observer/dead/candidate)
 	if(!istype(candidate) || !candidate.client || !candidate.ckey)
 		return 0
 	if(!candidate.MayRespawn())
@@ -39,7 +39,7 @@ proc/populate_ghost_traps()
 /datum/ghosttrap/proc/request_player(var/mob/target, var/request_string)
 	if(!target)
 		return
-	for(var/mob/dead/observer/O in player_list)
+	for(var/mob/observer/dead/O in player_list)
 		if(!O.MayRespawn())
 			continue
 		if(islist(ban_checks))
@@ -56,7 +56,7 @@ proc/populate_ghost_traps()
 	if(..())
 		return 1
 	if(href_list["candidate"] && href_list["target"])
-		var/mob/dead/observer/candidate = locate(href_list["candidate"]) // BYOND magic.
+		var/mob/observer/dead/candidate = locate(href_list["candidate"]) // BYOND magic.
 		var/mob/target = locate(href_list["target"])                     // So much BYOND magic.
 		if(!target || !candidate)
 			return

--- a/code/modules/hydroponics/trays/tray.dm
+++ b/code/modules/hydroponics/trays/tray.dm
@@ -129,7 +129,7 @@
 		return 1
 	return ..()
 
-/obj/machinery/portable_atmospherics/hydroponics/attack_ghost(var/mob/dead/observer/user)
+/obj/machinery/portable_atmospherics/hydroponics/attack_ghost(var/mob/observer/dead/user)
 
 	if(!(harvest && seed && seed.has_mob_product))
 		return

--- a/code/modules/mob/dead/death.dm
+++ b/code/modules/mob/dead/death.dm
@@ -1,5 +1,5 @@
-/mob/dead/dust()	//ghosts can't be vaporised.
+/mob/observer/dust()	//ghosts can't be vaporised.
 	return
 
-/mob/dead/gib()		//ghosts can't be gibbed.
+/mob/observer/gib()		//ghosts can't be gibbed.
 	return

--- a/code/modules/mob/dead/observer/login.dm
+++ b/code/modules/mob/dead/observer/login.dm
@@ -1,4 +1,4 @@
-/mob/dead/observer/Login()
+/mob/observer/dead/Login()
 	..()
 	if (ghostimage)
 		ghostimage.icon_state = src.icon_state

--- a/code/modules/mob/dead/observer/logout.dm
+++ b/code/modules/mob/dead/observer/logout.dm
@@ -1,4 +1,4 @@
-/mob/dead/observer/Logout()
+/mob/observer/dead/Logout()
 	..()
 	spawn(0)
 		if(src && !key)	//we've transferred to another mob. This ghost should be deleted.

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -1,14 +1,18 @@
 var/global/list/image/ghost_darkness_images = list() //this is a list of images for things ghosts should still be able to see when they toggle darkness
 var/global/list/image/ghost_sightless_images = list() //this is a list of images for things ghosts should still be able to see even without ghost sight
 
-/mob/dead/observer
+/mob/observer
+	name = "observer"
+	desc = "This shouldn't appear"
+	density = 0
+
+/mob/observer/dead
 	name = "ghost"
 	desc = "It's a g-g-g-g-ghooooost!" //jinkies!
 	icon = 'icons/mob/mob.dmi'
 	icon_state = "ghost"
 	layer = 4
 	stat = DEAD
-	density = 0
 	canmove = 0
 	blinded = 0
 	anchored = 1	//  don't get pushed around
@@ -31,11 +35,11 @@ var/global/list/image/ghost_sightless_images = list() //this is a list of images
 	var/seedarkness = 1
 	incorporeal_move = 1
 
-/mob/dead/observer/New(mob/body)
+/mob/observer/dead/New(mob/body)
 	sight |= SEE_TURFS | SEE_MOBS | SEE_OBJS | SEE_SELF
 	see_invisible = SEE_INVISIBLE_OBSERVER
 	see_in_dark = 100
-	verbs += /mob/dead/observer/proc/dead_tele
+	verbs += /mob/observer/dead/proc/dead_tele
 
 	stat = DEAD
 
@@ -81,7 +85,7 @@ var/global/list/image/ghost_sightless_images = list() //this is a list of images
 	real_name = name
 	..()
 
-/mob/dead/observer/Destroy()
+/mob/observer/dead/Destroy()
 	if (ghostimage)
 		ghost_darkness_images -= ghostimage
 		qdel(ghostimage)
@@ -89,7 +93,7 @@ var/global/list/image/ghost_sightless_images = list() //this is a list of images
 		updateallghostimages()
 	..()
 
-/mob/dead/observer/Topic(href, href_list)
+/mob/observer/dead/Topic(href, href_list)
 	if (href_list["track"])
 		var/mob/target = locate(href_list["track"]) in mob_list
 		if(target)
@@ -97,19 +101,19 @@ var/global/list/image/ghost_sightless_images = list() //this is a list of images
 
 
 
-/mob/dead/attackby(obj/item/W, mob/user)
+/mob/observer/dead/attackby(obj/item/W, mob/user)
 	if(istype(W,/obj/item/weapon/book/tome))
-		var/mob/dead/M = src
+		var/mob/observer/dead/M = src
 		M.manifest(user)
 
-/mob/dead/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
+/mob/observer/dead/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
 	return 1
 /*
 Transfer_mind is there to check if mob is being deleted/not going to have a body.
 Works together with spawning an observer, noted above.
 */
 
-/mob/dead/observer/Life()
+/mob/observer/dead/Life()
 	..()
 	if(!loc) return
 	if(!client) return 0
@@ -131,13 +135,13 @@ Works together with spawning an observer, noted above.
 		process_medHUD(src)
 
 
-/mob/dead/proc/process_medHUD(var/mob/M)
+/mob/observer/dead/proc/process_medHUD(var/mob/M)
 	var/client/C = M.client
 	for(var/mob/living/carbon/human/patient in oview(M, 14))
 		C.images += patient.hud_list[HEALTH_HUD]
 		C.images += patient.hud_list[STATUS_HUD_OOC]
 
-/mob/dead/proc/assess_targets(list/target_list, mob/dead/observer/U)
+/mob/observer/dead/proc/assess_targets(list/target_list, mob/observer/dead/U)
 	var/client/C = U.client
 	for(var/mob/living/carbon/human/target in target_list)
 		C.images += target.hud_list[SPECIALROLE_HUD]
@@ -147,14 +151,14 @@ Works together with spawning an observer, noted above.
 
 /mob/proc/ghostize(var/can_reenter_corpse = 1)
 	if(key)
-		var/mob/dead/observer/ghost = new(src)	//Transfer safety to observer spawning proc.
+		var/mob/observer/dead/ghost = new(src)	//Transfer safety to observer spawning proc.
 		ghost.can_reenter_corpse = can_reenter_corpse
 		ghost.timeofdeath = src.timeofdeath //BS12 EDIT
 		ghost.key = key
 		if(ghost.client)
 			ghost.client.time_died_as_mouse = ghost.timeofdeath
 		if(ghost.client && !ghost.client.holder && !config.antag_hud_allowed)		// For new ghosts we remove the verb from even showing up if it's not allowed.
-			ghost.verbs -= /mob/dead/observer/verb/toggle_antagHUD	// Poor guys, don't know what they are missing!
+			ghost.verbs -= /mob/observer/dead/verb/toggle_antagHUD	// Poor guys, don't know what they are missing!
 		return ghost
 
 /*
@@ -183,14 +187,14 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		var/turf/location = get_turf(src)
 		message_admins("[key_name_admin(usr)] has ghosted. (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[location.x];Y=[location.y];Z=[location.z]'>JMP</a>)")
 		log_game("[key_name_admin(usr)] has ghosted.")
-		var/mob/dead/observer/ghost = ghostize(0)	//0 parameter is so we can never re-enter our body, "Charlie, you can never come baaaack~" :3
+		var/mob/observer/dead/ghost = ghostize(0)	//0 parameter is so we can never re-enter our body, "Charlie, you can never come baaaack~" :3
 		ghost.timeofdeath = world.time // Because the living mob won't have a time of death and we want the respawn timer to work properly.
 		announce_ghost_joinleave(ghost)
 
-/mob/dead/observer/can_use_hands()	return 0
-/mob/dead/observer/is_active()		return 0
+/mob/observer/dead/can_use_hands()	return 0
+/mob/observer/dead/is_active()		return 0
 
-/mob/dead/observer/Stat()
+/mob/observer/dead/Stat()
 	..()
 	if(statpanel("Status"))
 		if(emergency_shuttle)
@@ -198,7 +202,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 			if(eta_status)
 				stat(null, eta_status)
 
-/mob/dead/observer/verb/reenter_corpse()
+/mob/observer/dead/verb/reenter_corpse()
 	set category = "Ghost"
 	set name = "Re-enter Corpse"
 	if(!client)	return
@@ -224,7 +228,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		announce_ghost_joinleave(mind, 0, "They now occupy their body again.")
 	return 1
 
-/mob/dead/observer/verb/toggle_medHUD()
+/mob/observer/dead/verb/toggle_medHUD()
 	set category = "Ghost"
 	set name = "Toggle MedicHUD"
 	set desc = "Toggles Medical HUD allowing you to see how everyone is doing"
@@ -237,7 +241,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		medHUD = 1
 		src << "\blue <B>Medical HUD Enabled</B>"
 
-/mob/dead/observer/verb/toggle_antagHUD()
+/mob/observer/dead/verb/toggle_antagHUD()
 	set category = "Ghost"
 	set name = "Toggle AntagHUD"
 	set desc = "Toggles AntagHUD allowing you to see who is the antagonist"
@@ -248,7 +252,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	if(!config.antag_hud_allowed && (!client.holder || mentor))
 		src << "\red Admins have disabled this for this round."
 		return
-	var/mob/dead/observer/M = src
+	var/mob/observer/dead/M = src
 	if(jobban_isbanned(M, "AntagHUD"))
 		src << "\red <B>You have been banned from using this feature</B>"
 		return
@@ -265,16 +269,16 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		M.antagHUD = 1
 		src << "\blue <B>AntagHUD Enabled</B>"
 
-/mob/dead/observer/proc/dead_tele(A in ghostteleportlocs)
+/mob/observer/dead/proc/dead_tele(A in ghostteleportlocs)
 	set category = "Ghost"
 	set name = "Teleport"
 	set desc= "Teleport to a location"
-	if(!istype(usr, /mob/dead/observer))
+	if(!istype(usr, /mob/observer/dead))
 		usr << "Not when you're not dead!"
 		return
-	usr.verbs -= /mob/dead/observer/proc/dead_tele
+	usr.verbs -= /mob/observer/dead/proc/dead_tele
 	spawn(30)
-		usr.verbs += /mob/dead/observer/proc/dead_tele
+		usr.verbs += /mob/observer/dead/proc/dead_tele
 	var/area/thearea = ghostteleportlocs[A]
 	if(!thearea)	return
 
@@ -300,7 +304,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	usr.forceMove(pick(L))
 	following = null
 
-/mob/dead/observer/verb/follow(input in getmobs())
+/mob/observer/dead/verb/follow(input in getmobs())
 	set category = "Ghost"
 	set name = "Follow" // "Haunt"
 	set desc = "Follow and haunt a mob."
@@ -310,7 +314,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	ManualFollow(target)
 
 // This is the ghost's follow verb with an argument
-/mob/dead/observer/proc/ManualFollow(var/atom/movable/target)
+/mob/observer/dead/proc/ManualFollow(var/atom/movable/target)
 	if(!target)
 		return
 
@@ -340,7 +344,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 
 /mob/proc/update_following()
 	. = get_turf(src)
-	for(var/mob/dead/observer/M in following_mobs)
+	for(var/mob/observer/dead/M in following_mobs)
 		if(M.following != src)
 			following_mobs -= M
 		else
@@ -351,12 +355,12 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	var/list/following_mobs = list()
 
 /mob/Destroy()
-	for(var/mob/dead/observer/M in following_mobs)
+	for(var/mob/observer/dead/M in following_mobs)
 		M.following = null
 	following_mobs = null
 	return ..()
 
-/mob/dead/observer/Destroy()
+/mob/observer/dead/Destroy()
 	if(ismob(following))
 		var/mob/M = following
 		M.following_mobs -= src
@@ -376,18 +380,18 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 /mob/proc/check_holy(var/turf/T)
 	return 0
 
-/mob/dead/observer/check_holy(var/turf/T)
+/mob/observer/dead/check_holy(var/turf/T)
 	if(check_rights(R_ADMIN|R_FUN, 0, src))
 		return 0
 
 	return (T && T.holy) && (invisibility <= SEE_INVISIBLE_LIVING || (mind in cult.current_antagonists))
 
-/mob/dead/observer/verb/jumptomob(target in getmobs()) //Moves the ghost instead of just changing the ghosts's eye -Nodrak
+/mob/observer/dead/verb/jumptomob(target in getmobs()) //Moves the ghost instead of just changing the ghosts's eye -Nodrak
 	set category = "Ghost"
 	set name = "Jump to Mob"
 	set desc = "Teleport to a mob"
 
-	if(istype(usr, /mob/dead/observer)) //Make sure they're an observer!
+	if(istype(usr, /mob/observer/dead)) //Make sure they're an observer!
 
 		if (!target)//Make sure we actually have a target
 			return
@@ -401,7 +405,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 			else
 				src << "This mob is not located in the game world."
 /*
-/mob/dead/observer/verb/boo()
+/mob/observer/dead/verb/boo()
 	set category = "Ghost"
 	set name = "Boo!"
 	set desc= "Scare your crew members because of boredom!"
@@ -416,22 +420,22 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	return
 */
 
-/mob/dead/observer/memory()
+/mob/observer/dead/memory()
 	set hidden = 1
 	src << "\red You are dead! You have no mind to store memory!"
 
-/mob/dead/observer/add_memory()
+/mob/observer/dead/add_memory()
 	set hidden = 1
 	src << "\red You are dead! You have no mind to store memory!"
 
-/mob/dead/observer/Post_Incorpmove()
+/mob/observer/dead/Post_Incorpmove()
 	following = null
 
-/mob/dead/observer/verb/analyze_air()
+/mob/observer/dead/verb/analyze_air()
 	set name = "Analyze Air"
 	set category = "Ghost"
 
-	if(!istype(usr, /mob/dead/observer)) return
+	if(!istype(usr, /mob/observer/dead)) return
 
 	// Shamelessly copied from the Gas Analyzers
 	if (!( istype(usr.loc, /turf) ))
@@ -453,7 +457,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		src << "\blue Temperature: [round(environment.temperature-T0C,0.1)]&deg;C ([round(environment.temperature,0.1)]K)"
 		src << "\blue Heat Capacity: [round(environment.heat_capacity(),0.1)]"
 
-/mob/dead/observer/verb/become_mouse()
+/mob/observer/dead/verb/become_mouse()
 	set name = "Become mouse"
 	set category = "Ghost"
 
@@ -500,7 +504,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		host.ckey = src.ckey
 		host << "<span class='info'>You are now a mouse. Try to avoid interaction with players, and do not give hints away that you are more than a simple rodent.</span>"
 
-/mob/dead/observer/verb/view_manfiest()
+/mob/observer/dead/verb/view_manfiest()
 	set name = "Show Crew Manifest"
 	set category = "Ghost"
 
@@ -511,7 +515,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	src << browse(dat, "window=manifest;size=370x420;can_close=1")
 
 //This is called when a ghost is drag clicked to something.
-/mob/dead/observer/MouseDrop(atom/over)
+/mob/observer/dead/MouseDrop(atom/over)
 	if(!usr || !over) return
 	if (isobserver(usr) && usr.client && usr.client.holder && isliving(over))
 		if (usr.client.holder.cmd_ghost_drag(src,over))
@@ -520,7 +524,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	return ..()
 
 //Used for drawing on walls with blood puddles as a spooky ghost.
-/mob/dead/verb/bloody_doodle()
+/mob/observer/dead/verb/bloody_doodle()
 
 	set category = "Ghost"
 	set name = "Write in blood"
@@ -594,17 +598,17 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		W.add_hiddenprint(src)
 		W.visible_message("\red Invisible fingers crudely paint something in blood on [T]...")
 
-/mob/dead/observer/pointed(atom/A as mob|obj|turf in view())
+/mob/observer/dead/pointed(atom/A as mob|obj|turf in view())
 	if(!..())
 		return 0
 	usr.visible_message("<span class='deadsay'><b>[src]</b> points to [A]</span>")
 	return 1
 
-/mob/dead/proc/manifest(mob/user)
+/mob/observer/dead/proc/manifest(mob/user)
 	var/is_manifest = 0
 	if(!is_manifest)
 		is_manifest = 1
-		verbs += /mob/dead/proc/toggle_visibility
+		verbs += /mob/observer/dead/proc/toggle_visibility
 
 	if(src.invisibility != 0)
 		user.visible_message( \
@@ -618,7 +622,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 			"<span class='warning'>You get the feeling that the ghost can't become any more visible.</span>" \
 		)
 
-/mob/dead/proc/toggle_icon(var/icon)
+/mob/observer/dead/proc/toggle_icon(var/icon)
 	if(!client)
 		return
 
@@ -632,7 +636,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		var/image/J = image('icons/mob/mob.dmi', loc = src, icon_state = icon)
 		client.images += J
 
-/mob/dead/proc/toggle_visibility(var/forced = 0)
+/mob/observer/dead/proc/toggle_visibility(var/forced = 0)
 	set category = "Ghost"
 	set name = "Toggle Visibility"
 	set desc = "Allows you to turn (in)visible (almost) at will."
@@ -652,7 +656,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	// Give the ghost a cult icon which should be visible only to itself
 	toggle_icon("cult")
 
-/mob/dead/observer/verb/toggle_anonsay()
+/mob/observer/dead/verb/toggle_anonsay()
 	set category = "Ghost"
 	set name = "Toggle Anonymous Chat"
 	set desc = "Toggles showing your key in dead chat."
@@ -663,13 +667,13 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	else
 		src << "<span class='info'>Your key will be publicly visible again.</span>"
 
-/mob/dead/observer/canface()
+/mob/observer/dead/canface()
 	return 1
 
-/mob/dead/observer/proc/can_admin_interact()
+/mob/observer/dead/proc/can_admin_interact()
 	return check_rights(R_ADMIN, 0, src)
 
-/mob/dead/observer/verb/toggle_ghostsee()
+/mob/observer/dead/verb/toggle_ghostsee()
 	set name = "Toggle Ghost Vision"
 	set desc = "Toggles your ability to see things only ghosts can see, like other ghosts"
 	set category = "Ghost"
@@ -677,13 +681,13 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	updateghostsight()
 	usr << "You [(ghostvision?"now":"no longer")] have ghost vision."
 
-/mob/dead/observer/verb/toggle_darkness()
+/mob/observer/dead/verb/toggle_darkness()
 	set name = "Toggle Darkness"
 	set category = "Ghost"
 	seedarkness = !(seedarkness)
 	updateghostsight()
 
-/mob/dead/observer/proc/updateghostsight()
+/mob/observer/dead/proc/updateghostsight()
 	if (!seedarkness)
 		see_invisible = SEE_INVISIBLE_NOLIGHTING
 	else
@@ -693,10 +697,10 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	updateghostimages()
 
 /proc/updateallghostimages()
-	for (var/mob/dead/observer/O in player_list)
+	for (var/mob/observer/dead/O in player_list)
 		O.updateghostimages()
 
-/mob/dead/observer/proc/updateghostimages()
+/mob/observer/dead/proc/updateghostimages()
 	if (!client)
 		return
 	if (seedarkness || !ghostvision)
@@ -709,7 +713,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		if (ghostimage)
 			client.images -= ghostimage //remove ourself
 
-mob/dead/observer/MayRespawn(var/feedback = 0)
+mob/observer/dead/MayRespawn(var/feedback = 0)
 	if(!client)
 		return 0
 	if(mind && mind.current && mind.current.stat != DEAD && can_reenter_corpse)
@@ -729,7 +733,7 @@ mob/dead/observer/MayRespawn(var/feedback = 0)
 	if(client && eyeobj)
 		return "|<a href='byond://?src=\ref[ghost];track=\ref[eyeobj]'>eye</a>"
 
-/mob/dead/observer/extra_ghost_link(var/atom/ghost)
+/mob/observer/dead/extra_ghost_link(var/atom/ghost)
 	if(mind && mind.current)
 		return "|<a href='byond://?src=\ref[ghost];track=\ref[mind.current]'>body</a>"
 

--- a/code/modules/mob/dead/observer/say.dm
+++ b/code/modules/mob/dead/observer/say.dm
@@ -1,4 +1,4 @@
-/mob/dead/observer/say(var/message)
+/mob/observer/dead/say(var/message)
 	message = sanitize(message)
 
 	if (!message)
@@ -17,7 +17,7 @@
 	. = src.say_dead(message)
 
 
-/mob/dead/observer/emote(var/act, var/type, var/message)
+/mob/observer/dead/emote(var/act, var/type, var/message)
 	//message = sanitize(message) - already sanitized in verb/me_verb()
 
 	if(!message)

--- a/code/modules/mob/freelook/ai/eye.dm
+++ b/code/modules/mob/freelook/ai/eye.dm
@@ -3,15 +3,15 @@
 // A mob that the AI controls to look around the station with.
 // It streams chunks as it moves around, which will show it what the AI can and cannot see.
 
-/mob/eye/aiEye
+/mob/observer/eye/aiEye
 	name = "Inactive AI Eye"
 	icon_state = "AI-eye"
 
-/mob/eye/aiEye/New()
+/mob/observer/eye/aiEye/New()
 	..()
 	visualnet = cameranet
 
-/mob/eye/aiEye/setLoc(var/T, var/cancel_tracking = 1)
+/mob/observer/eye/aiEye/setLoc(var/T, var/cancel_tracking = 1)
 	if(..())
 		var/mob/living/silicon/ai/ai = owner
 		if(cancel_tracking)
@@ -43,7 +43,7 @@
 /mob/living/silicon/ai/proc/create_eyeobj(var/newloc)
 	if(eyeobj) destroy_eyeobj()
 	if(!newloc) newloc = src.loc
-	eyeobj = PoolOrNew(/mob/eye/aiEye, newloc)
+	eyeobj = PoolOrNew(/mob/observer/eye/aiEye, newloc)
 	eyeobj.owner = src
 	eyeobj.name = "[src.name] (AI Eye)" // Give it a name
 	if(client) client.eye = eyeobj

--- a/code/modules/mob/freelook/chunk.dm
+++ b/code/modules/mob/freelook/chunk.dm
@@ -25,7 +25,7 @@
 
 // Add an eye to the chunk, then update if changed.
 
-/datum/chunk/proc/add(mob/eye/eye)
+/datum/chunk/proc/add(mob/observer/eye/eye)
 	if(!eye.owner)
 		return
 	eye.visibleChunks += src
@@ -38,7 +38,7 @@
 
 // Remove an eye from the chunk, then update if changed.
 
-/datum/chunk/proc/remove(mob/eye/eye)
+/datum/chunk/proc/remove(mob/observer/eye/eye)
 	if(!eye.owner)
 		return
 	eye.visibleChunks -= src
@@ -91,7 +91,7 @@
 		if(t.obfuscations[obfuscation.type])
 			obscured -= t.obfuscations[obfuscation.type]
 			for(var/eye in seenby)
-				var/mob/eye/m = eye
+				var/mob/observer/eye/m = eye
 				if(!m || !m.owner)
 					continue
 				if(m.owner.client)
@@ -105,7 +105,7 @@
 
 			obscured += t.obfuscations[obfuscation.type]
 			for(var/eye in seenby)
-				var/mob/eye/m = eye
+				var/mob/observer/eye/m = eye
 				if(!m || !m.owner)
 					seenby -= m
 					continue

--- a/code/modules/mob/freelook/eye.dm
+++ b/code/modules/mob/freelook/eye.dm
@@ -3,12 +3,11 @@
 // A mob that another mob controls to look around the station with.
 // It streams chunks as it moves around, which will show it what the controller can and cannot see.
 
-/mob/eye
+/mob/observer/eye
 	name = "Eye"
 	icon = 'icons/mob/eye.dmi'
 	icon_state = "default-eye"
 	alpha = 127
-	density = 0
 
 	var/sprint = 10
 	var/cooldown = 0
@@ -25,14 +24,14 @@
 	var/ghostimage = null
 	var/datum/visualnet/visualnet
 
-/mob/eye/New()
+/mob/observer/eye/New()
 	ghostimage = image(src.icon,src,src.icon_state)
 	ghost_darkness_images |= ghostimage //so ghosts can see the eye when they disable darkness
 	ghost_sightless_images |= ghostimage //so ghosts can see the eye when they disable ghost sight
 	updateallghostimages()
 	..()
 
-mob/eye/Destroy()
+mob/observer/eye/Destroy()
 	if (ghostimage)
 		ghost_darkness_images -= ghostimage
 		ghost_sightless_images -= ghostimage
@@ -41,30 +40,30 @@ mob/eye/Destroy()
 		updateallghostimages()
 	..()
 
-/mob/eye/Move(n, direct)
+/mob/observer/eye/Move(n, direct)
 	if(owner == src)
 		return EyeMove(n, direct)
 	return 0
 
-/mob/eye/airflow_hit(atom/A)
+/mob/observer/eye/airflow_hit(atom/A)
 	airflow_speed = 0
 	airflow_dest = null
 
-/mob/eye/examinate()
+/mob/observer/eye/examinate()
 	set popup_menu = 0
 	set src = usr.contents
 	return 0
 
-/mob/eye/pointed()
+/mob/observer/eye/pointed()
 	set popup_menu = 0
 	set src = usr.contents
 	return 0
 
-/mob/eye/examine(mob/user)
+/mob/observer/eye/examine(mob/user)
 
 // Use this when setting the eye's location.
 // It will also stream the chunk that the new loc is in.
-/mob/eye/proc/setLoc(var/T)
+/mob/observer/eye/proc/setLoc(var/T)
 	if(owner)
 		T = get_turf(T)
 		if(T != loc)
@@ -82,13 +81,13 @@ mob/eye/Destroy()
 			return 1
 	return 0
 
-/mob/eye/proc/getLoc()
+/mob/observer/eye/proc/getLoc()
 	if(owner)
 		if(!isturf(owner.loc) || !owner.client)
 			return
 		return loc
 /mob
-	var/mob/eye/eyeobj
+	var/mob/observer/eye/eyeobj
 
 /mob/proc/EyeMove(n, direct)
 	if(!eyeobj)
@@ -96,7 +95,7 @@ mob/eye/Destroy()
 
 	return eyeobj.EyeMove(n, direct)
 
-/mob/eye/EyeMove(n, direct)
+/mob/observer/eye/EyeMove(n, direct)
 	var/initial = initial(sprint)
 	var/max_sprint = 50
 

--- a/code/modules/mob/freelook/life.dm
+++ b/code/modules/mob/freelook/life.dm
@@ -1,4 +1,4 @@
-/mob/eye/Life()
+/mob/observer/eye/Life()
 	..()
 	// If we lost our client, reset the list of visible chunks so they update properly on return
 	if(owner == src && !client)

--- a/code/modules/mob/freelook/mask/eye.dm
+++ b/code/modules/mob/freelook/mask/eye.dm
@@ -3,11 +3,11 @@
 // A mob that a cultists controls to look around the station with.
 // It streams chunks as it moves around, which will show it what the cultist can and cannot see.
 
-/mob/eye/maskEye
+/mob/observer/eye/maskEye
 	name = "Eye of Nar-Sie"
 	acceleration = 0
 	owner_follows_eye = 1
 
-/mob/eye/maskEye/New()
+/mob/observer/eye/maskEye/New()
 	..()
 	visualnet = cultnet

--- a/code/modules/mob/freelook/visualnet.dm
+++ b/code/modules/mob/freelook/visualnet.dm
@@ -36,7 +36,7 @@
 
 // Updates what the aiEye can see. It is recommended you use this when the aiEye moves or it's location is set.
 
-/datum/visualnet/proc/visibility(mob/eye/eye)
+/datum/visualnet/proc/visibility(mob/observer/eye/eye)
 	// 0xf = 15
 	var/x1 = max(0, eye.x - 16) & ~0xf
 	var/y1 = max(0, eye.y - 16) & ~0xf

--- a/code/modules/mob/hear_say.dm
+++ b/code/modules/mob/hear_say.dm
@@ -4,14 +4,14 @@
 	if(!client)
 		return
 
-	if(speaker && !speaker.client && istype(src,/mob/dead/observer) && client.prefs.toggles & CHAT_GHOSTEARS && !speaker in view(src))
+	if(speaker && !speaker.client && istype(src,/mob/observer/dead) && client.prefs.toggles & CHAT_GHOSTEARS && !speaker in view(src))
 			//Does the speaker have a client?  It's either random stuff that observers won't care about (Experiment 97B says, 'EHEHEHEHEHEHEHE')
 			//Or someone snoring.  So we make it where they won't hear it.
 		return
 
 	//make sure the air can transmit speech - hearer's side
 	var/turf/T = get_turf(src)
-	if ((T) && (!(istype(src, /mob/dead/observer)))) //Ghosts can hear even in vacuum.
+	if ((T) && (!(istype(src, /mob/observer/dead)))) //Ghosts can hear even in vacuum.
 		var/datum/gas_mixture/environment = T.return_air()
 		var/pressure = (environment)? environment.return_pressure() : 0
 		if(pressure < SOUND_MINIMUM_PRESSURE && get_dist(speaker, src) > 1)
@@ -50,7 +50,7 @@
 		message = "<i>[message]</i>"
 
 	var/track = null
-	if(istype(src, /mob/dead/observer))
+	if(istype(src, /mob/observer/dead))
 		if(italics && client.prefs.toggles & CHAT_GHOSTRADIO)
 			return
 		if(speaker_name != speaker.real_name && speaker.real_name)
@@ -177,7 +177,7 @@
 		else
 			track = "<a href='byond://?src=\ref[src];trackname=[html_encode(speaker_name)];track=\ref[speaker]'>[speaker_name] ([jobname])</a>"
 
-	if(istype(src, /mob/dead/observer))
+	if(istype(src, /mob/observer/dead))
 		if(speaker_name != speaker.real_name && !isAI(speaker)) //Announce computer and various stuff that broadcasts doesn't use it's real name but AI's can't pretend to be other mobs.
 			speaker_name = "[speaker.real_name] ([speaker_name])"
 		track = "[speaker_name] ([ghost_follow_link(speaker, src)])"
@@ -199,7 +199,7 @@
 /mob/proc/on_hear_radio(part_a, speaker_name, track, part_b, formatted)
 	src << "[part_a][speaker_name][part_b][formatted]"
 
-/mob/dead/observer/on_hear_radio(part_a, speaker_name, track, part_b, formatted)
+/mob/observer/dead/on_hear_radio(part_a, speaker_name, track, part_b, formatted)
 	src << "[part_a][track][part_b][formatted]"
 
 /mob/living/silicon/on_hear_radio(part_a, speaker_name, track, part_b, formatted)

--- a/code/modules/mob/language/language.dm
+++ b/code/modules/mob/language/language.dm
@@ -114,7 +114,7 @@
 /mob/new_player/hear_broadcast(var/datum/language/language, var/mob/speaker, var/speaker_name, var/message)
 	return
 
-/mob/dead/observer/hear_broadcast(var/datum/language/language, var/mob/speaker, var/speaker_name, var/message)
+/mob/observer/dead/hear_broadcast(var/datum/language/language, var/mob/speaker, var/speaker_name, var/message)
 	if(speaker.name == speaker_name || antagHUD)
 		src << "<i><span class='game say'>[language.name], <span class='name'>[speaker_name]</span> ([ghost_follow_link(speaker, src)]) [message]</span></i>"
 	else

--- a/code/modules/mob/living/carbon/brain/posibrain.dm
+++ b/code/modules/mob/living/carbon/brain/posibrain.dm
@@ -23,7 +23,7 @@
 		spawn(600) reset_search()
 
 /obj/item/device/mmi/digital/posibrain/proc/request_player()
-	for(var/mob/dead/observer/O in player_list)
+	for(var/mob/observer/dead/O in player_list)
 		if(!O.MayRespawn())
 			continue
 		if(jobban_isbanned(O, "AI") && jobban_isbanned(O, "Cyborg"))

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -210,7 +210,7 @@
 		msg += "[T.He] [T.is] small halfling!\n"
 
 	var/distance = get_dist(usr,src)
-	if(istype(usr, /mob/dead/observer) || usr.stat == 2) // ghosts can see anything
+	if(istype(usr, /mob/observer/dead) || usr.stat == 2) // ghosts can see anything
 		distance = 1
 	if (src.stat)
 		msg += "<span class='warning'>[T.He] [T.is]n't responding to anything around [T.him] and seems to be asleep.</span>\n"

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -841,7 +841,7 @@
 		target.show_message("\blue You hear a voice that seems to echo around the room: [say]")
 	usr.show_message("\blue You project your mind into [target.real_name]: [say]")
 	log_say("[key_name(usr)] sent a telepathic message to [key_name(target)]: [say]")
-	for(var/mob/dead/observer/G in world)
+	for(var/mob/observer/dead/G in world)
 		G.show_message("<i>Telepathic message from <b>[src]</b> to <b>[target]</b>: [say]</i>")
 
 /mob/living/carbon/human/proc/remoteobserve()

--- a/code/modules/mob/living/carbon/human/human_powers.dm
+++ b/code/modules/mob/living/carbon/human/human_powers.dm
@@ -181,7 +181,7 @@
 
 	var/mob/M = targets[target]
 
-	if(istype(M, /mob/dead/observer) || M.stat == DEAD)
+	if(istype(M, /mob/observer/dead) || M.stat == DEAD)
 		src << "Not even a [src.species.name] can speak to the dead."
 		return
 

--- a/code/modules/mob/living/carbon/metroid/items.dm
+++ b/code/modules/mob/living/carbon/metroid/items.dm
@@ -244,8 +244,8 @@
 		processing_objects.Add(src)
 
 	process()
-		var/mob/dead/observer/ghost
-		for(var/mob/dead/observer/O in src.loc)
+		var/mob/observer/dead/ghost
+		for(var/mob/observer/dead/O in src.loc)
 			if(!O.client)	continue
 			if(O.mind && O.mind.current && O.mind.current.stat != DEAD)	continue
 			ghost = O
@@ -256,8 +256,8 @@
 			icon_state = "golem"
 
 	attack_hand(mob/living/user as mob)
-		var/mob/dead/observer/ghost
-		for(var/mob/dead/observer/O in src.loc)
+		var/mob/observer/dead/ghost
+		for(var/mob/observer/dead/O in src.loc)
 			if(!O.client)	continue
 			if(O.mind && O.mind.current && O.mind.current.stat != DEAD)	continue
 			ghost = O
@@ -273,7 +273,7 @@
 
 
 	proc/announce_to_ghosts()
-		for(var/mob/dead/observer/G in player_list)
+		for(var/mob/observer/dead/G in player_list)
 			if(G.client)
 				var/area/A = get_area(src)
 				if(A)

--- a/code/modules/mob/living/silicon/ai/examine.dm
+++ b/code/modules/mob/living/silicon/ai/examine.dm
@@ -39,6 +39,6 @@
 /mob/proc/showLaws(var/mob/living/silicon/S)
 	return
 
-/mob/dead/observer/showLaws(var/mob/living/silicon/S)
+/mob/observer/dead/showLaws(var/mob/living/silicon/S)
 	if(antagHUD || is_admin(src))
 		S.laws.show_laws(src)

--- a/code/modules/mob/living/silicon/pai/recruit.dm
+++ b/code/modules/mob/living/silicon/pai/recruit.dm
@@ -233,7 +233,7 @@ var/datum/paiController/paiController			// Global handler for pAI candidates
 	for(var/datum/paiCandidate/c in paiController.pai_candidates)
 		if(c.ready)
 			var/found = 0
-			for(var/mob/dead/observer/o in player_list)
+			for(var/mob/observer/dead/o in player_list)
 				if(o.key == c.key && o.MayRespawn())
 					found = 1
 			if(found)
@@ -346,7 +346,7 @@ var/datum/paiController/paiController			// Global handler for pAI candidates
 
 /datum/paiController/proc/requestRecruits(var/mob/user)
 	inquirer = user
-	for(var/mob/dead/observer/O in player_list)
+	for(var/mob/observer/dead/O in player_list)
 		if(!O.MayRespawn())
 			continue
 		if(jobban_isbanned(O, "pAI"))

--- a/code/modules/mob/living/silicon/robot/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone.dm
@@ -278,7 +278,7 @@ var/list/mob_hat_cache = list()
 //Reboot procs.
 
 /mob/living/silicon/robot/drone/proc/request_player()
-	for(var/mob/dead/observer/O in player_list)
+	for(var/mob/observer/dead/O in player_list)
 		if(jobban_isbanned(O, "Cyborg"))
 			continue
 		if(O.client)

--- a/code/modules/mob/living/silicon/robot/drone/drone_manufacturer.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_manufacturer.dm
@@ -59,7 +59,7 @@
 
 /obj/machinery/drone_fabricator/examine(mob/user)
 	..(user)
-	if(produce_drones && drone_progress >= 100 && istype(user,/mob/dead) && config.allow_drone_spawn && count_drones() < config.max_maint_drones)
+	if(produce_drones && drone_progress >= 100 && istype(user,/mob/observer/dead) && config.allow_drone_spawn && count_drones() < config.max_maint_drones)
 		user << "<BR><B>A drone is prepared. Select 'Join As Drone' from the Ghost tab to spawn as a maintenance drone.</B>"
 
 /obj/machinery/drone_fabricator/proc/create_drone(var/client/player)
@@ -70,7 +70,7 @@
 	if(!produce_drones || !config.allow_drone_spawn || count_drones() >= config.max_maint_drones)
 		return
 
-	if(!player || !istype(player.mob,/mob/dead))
+	if(!player || !istype(player.mob,/mob/observer/dead))
 		return
 
 	announce_ghost_joinleave(player, 0, "They have taken control over a maintenance drone.")
@@ -85,7 +85,7 @@
 
 	drone_progress = 0
 
-/mob/dead/verb/join_as_drone()
+/mob/observer/dead/verb/join_as_drone()
 
 	set category = "Ghost"
 	set name = "Join As Drone"

--- a/code/modules/mob/living/simple_animal/borer/borer.dm
+++ b/code/modules/mob/living/simple_animal/borer/borer.dm
@@ -173,7 +173,7 @@
 
 //Procs for grabbing players.
 /mob/living/simple_animal/borer/proc/request_player()
-	for(var/mob/dead/observer/O in player_list)
+	for(var/mob/observer/dead/O in player_list)
 		if(jobban_isbanned(O, "Borer"))
 			continue
 		if(O.client)

--- a/code/modules/mob/living/simple_animal/friendly/cat.dm
+++ b/code/modules/mob/living/simple_animal/friendly/cat.dm
@@ -57,7 +57,7 @@
 				handle_movement_target()
 
 	if(prob(2)) //spooky
-		var/mob/dead/observer/spook = locate() in range(src,5)
+		var/mob/observer/dead/spook = locate() in range(src,5)
 		if(spook)
 			var/turf/T = spook.loc
 			var/list/visible = list()

--- a/code/modules/mob/living/simple_animal/friendly/spiderbot.dm
+++ b/code/modules/mob/living/simple_animal/friendly/spiderbot.dm
@@ -61,7 +61,7 @@
 		if(!B.brainmob.key)
 			var/ghost_can_reenter = 0
 			if(B.brainmob.mind)
-				for(var/mob/dead/observer/G in player_list)
+				for(var/mob/observer/dead/G in player_list)
 					if(G.can_reenter_corpse && G.mind == B.brainmob.mind)
 						ghost_can_reenter = 1
 						break

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -388,8 +388,8 @@
 		return
 	else
 		var/deathtime = world.time - src.timeofdeath
-		if(istype(src,/mob/dead/observer))
-			var/mob/dead/observer/G = src
+		if(istype(src,/mob/observer/dead))
+			var/mob/observer/dead/G = src
 			if(G.has_enabled_antagHUD == 1 && config.antag_hud_restricted)
 				usr << "\blue <B>Upon using the antagHUD you forfeighted the ability to join the round.</B>"
 				return

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -266,7 +266,7 @@ It's fairly easy to fix if dealing with single letters but not so much with comp
 
 		var/atom/oldeye=M.client.eye
 		var/aiEyeFlag = 0
-		if(istype(oldeye, /mob/eye/aiEye))
+		if(istype(oldeye, /mob/observer/eye/aiEye))
 			aiEyeFlag = 1
 
 		var/x
@@ -399,8 +399,8 @@ proc/is_blind(A)
 					follow = "([ghost_follow_link(subject, M)]) "
 				if(M.stat != DEAD && M.client.holder)
 					follow = "([admin_jump_link(subject, M.client.holder)]) "
-				var/mob/dead/observer/DM
-				if(istype(subject, /mob/dead/observer))
+				var/mob/observer/dead/DM
+				if(istype(subject, /mob/observer/dead))
 					DM = subject
 				if(M.client.holder) 							// What admins see
 					lname = "[keyname][(DM && DM.anonsay) ? "*" : (DM ? "" : "^")] ([name])"

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -105,7 +105,7 @@
 
 			if(alert(src,"Are you sure you wish to observe? You will have to wait 15 minutes before being able to respawn!","Player Setup","Yes","No") == "Yes")
 				if(!client)	return 1
-				var/mob/dead/observer/observer = new()
+				var/mob/observer/dead/observer = new()
 
 				spawning = 1
 				src << sound(null, repeat = 0, wait = 0, volume = 85, channel = 1) // MAD JAMS cant last forever yo
@@ -131,7 +131,7 @@
 				observer.real_name = client.prefs.real_name
 				observer.name = observer.real_name
 				if(!client.holder && !config.antag_hud_allowed)           // For new ghosts we remove the verb from even showing up if it's not allowed.
-					observer.verbs -= /mob/dead/observer/verb/toggle_antagHUD        // Poor guys, don't know what they are missing!
+					observer.verbs -= /mob/observer/dead/verb/toggle_antagHUD        // Poor guys, don't know what they are missing!
 				observer.key = key
 				qdel(src)
 

--- a/code/modules/nano/interaction/default.dm
+++ b/code/modules/nano/interaction/default.dm
@@ -9,7 +9,7 @@
 /mob/proc/default_can_use_topic(var/src_object)
 	return STATUS_CLOSE // By default no mob can do anything with NanoUI
 
-/mob/dead/observer/default_can_use_topic(var/src_object)
+/mob/observer/dead/default_can_use_topic(var/src_object)
 	if(can_admin_interact())
 		return STATUS_INTERACTIVE							// Admins are more equal
 	if(!client || get_dist(src_object, src)	> client.view)	// Preventing ghosts from having a million windows open by limiting to objects in range

--- a/code/modules/nano/interaction/physical.dm
+++ b/code/modules/nano/interaction/physical.dm
@@ -8,7 +8,7 @@
 /mob/proc/check_physical_distance(var/src_object)
 	return STATUS_CLOSE
 
-/mob/dead/observer/check_physical_distance(var/src_object)
+/mob/observer/dead/check_physical_distance(var/src_object)
 	return default_can_use_topic(src_object)
 
 /mob/living/check_physical_distance(var/src_object)

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -121,7 +121,7 @@
 
 /obj/item/organ/external/examine()
 	..()
-	if(in_range(usr, src) || istype(usr, /mob/dead/observer))
+	if(in_range(usr, src) || istype(usr, /mob/observer/dead))
 		for(var/obj/item/I in contents)
 			if(istype(I, /obj/item/organ))
 				continue

--- a/code/modules/paperwork/clipboard.dm
+++ b/code/modules/paperwork/clipboard.dm
@@ -147,7 +147,7 @@
 			
 			if(P && (P.loc == src) && istype(P, /obj/item/weapon/paper) )
 			
-				if(!(istype(usr, /mob/living/carbon/human) || istype(usr, /mob/dead/observer) || istype(usr, /mob/living/silicon)))
+				if(!(istype(usr, /mob/living/carbon/human) || istype(usr, /mob/observer/dead) || istype(usr, /mob/living/silicon)))
 					usr << browse("<HTML><HEAD><TITLE>[P.name]</TITLE></HEAD><BODY>[stars(P.info)][P.stamps]</BODY></HTML>", "window=[P.name]")
 					onclose(usr, "[P.name]")
 				else

--- a/code/modules/paperwork/folders.dm
+++ b/code/modules/paperwork/folders.dm
@@ -102,7 +102,7 @@
 		else if(href_list["read"])
 			var/obj/item/weapon/paper/P = locate(href_list["read"])
 			if(P && (P.loc == src) && istype(P))
-				if(!(istype(usr, /mob/living/carbon/human) || istype(usr, /mob/dead/observer) || istype(usr, /mob/living/silicon)))
+				if(!(istype(usr, /mob/living/carbon/human) || istype(usr, /mob/observer/dead) || istype(usr, /mob/living/silicon)))
 					usr << browse("<HTML><HEAD><TITLE>[P.name]</TITLE></HEAD><BODY>[stars(P.info)][P.stamps]</BODY></HTML>", "window=[P.name]")
 					onclose(usr, "[P.name]")
 				else

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -73,14 +73,14 @@
 
 /obj/item/weapon/paper/examine(mob/user)
 	..()
-	if(in_range(user, src) || istype(user, /mob/dead/observer))
+	if(in_range(user, src) || istype(user, /mob/observer/dead))
 		show_content(usr)
 	else
 		user << "<span class='notice'>You have to go closer if you want to read it.</span>"
 	return
 
 /obj/item/weapon/paper/proc/show_content(var/mob/user, var/forceshow=0)
-	if(!(istype(user, /mob/living/carbon/human) || istype(user, /mob/dead/observer) || istype(user, /mob/living/silicon)) && !forceshow)
+	if(!(istype(user, /mob/living/carbon/human) || istype(user, /mob/observer/dead) || istype(user, /mob/living/silicon)) && !forceshow)
 		user << browse("<HTML><HEAD><TITLE>[name]</TITLE></HEAD><BODY>[stars(info)][stamps]</BODY></HTML>", "window=[name]")
 		onclose(user, "[name]")
 	else

--- a/code/modules/paperwork/paper_bundle.dm
+++ b/code/modules/paperwork/paper_bundle.dm
@@ -122,7 +122,7 @@
 
 	if(istype(pages[page], /obj/item/weapon/paper))
 		var/obj/item/weapon/paper/P = W
-		if(!(istype(usr, /mob/living/carbon/human) || istype(usr, /mob/dead/observer) || istype(usr, /mob/living/silicon)))
+		if(!(istype(usr, /mob/living/carbon/human) || istype(usr, /mob/observer/dead) || istype(usr, /mob/living/silicon)))
 			dat+= "<HTML><HEAD><TITLE>[P.name]</TITLE></HEAD><BODY>[stars(P.info)][P.stamps]</BODY></HTML>"
 		else
 			dat+= "<HTML><HEAD><TITLE>[P.name]</TITLE></HEAD><BODY>[P.info][P.stamps]</BODY></HTML>"

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -866,7 +866,7 @@
 
 	if(locked && !issilicon(usr) )
 		if(isobserver(usr) )
-			var/mob/dead/observer/O = usr	//Added to allow admin nanoUI interactions.
+			var/mob/observer/dead/O = usr	//Added to allow admin nanoUI interactions.
 			if(!O.can_admin_interact() )	//NanoUI /should/ make this not needed, but better safe than sorry.
 				usr << "Try as you might, your ghostly fingers can't press the buttons."
 				return 1

--- a/code/modules/power/singularity/act.dm
+++ b/code/modules/power/singularity/act.dm
@@ -134,10 +134,7 @@
 /atom/proc/singuloCanEat()
 	return 1
 
-/mob/dead/singuloCanEat()
-	return 0
-
-/mob/eye/singuloCanEat()
+/mob/observer/singuloCanEat()
 	return 0
 
 /mob/new_player/singuloCanEat()

--- a/code/modules/random_map/drop/droppod.dm
+++ b/code/modules/random_map/drop/droppod.dm
@@ -112,7 +112,7 @@
 	// Splatter anything under us that survived the explosion.
 	if(value != SD_EMPTY_TILE && T.contents.len)
 		for(var/atom/movable/AM in T)
-			if(AM.simulated && !istype(AM, /mob/dead))
+			if(AM.simulated && !istype(AM, /mob/observer))
 				qdel(AM)
 
 	// Also spawn doors and loot.
@@ -173,7 +173,7 @@
 	else
 		var/list/candidates = list()
 		for(var/client/player in clients)
-			if(player.mob && istype(player.mob, /mob/dead/observer))
+			if(player.mob && istype(player.mob, /mob/observer/dead))
 				candidates |= player
 
 		if(!candidates.len)

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Other.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Other.dm
@@ -66,7 +66,7 @@
 		O.color = color
 
 /datum/reagent/paint/touch_mob(var/mob/M)
-	if(istype(M) && !istype(M, /mob/dead)) //painting ghosts: not allowed
+	if(istype(M) && !istype(M, /mob/observer)) //painting ghosts: not allowed
 		M.color = color //maybe someday change this to paint only clothes and exposed body parts for human mobs.
 
 /datum/reagent/paint/get_data()

--- a/code/modules/spells/spellbook.dm
+++ b/code/modules/spells/spellbook.dm
@@ -361,7 +361,7 @@
 		for(var/V in stored_swap.mind.special_verbs)
 			stored_swap.verbs -= V
 
-	var/mob/dead/observer/ghost = stored_swap.ghostize(0)
+	var/mob/observer/dead/ghost = stored_swap.ghostize(0)
 	ghost.spell_list = stored_swap.spell_list
 
 	user.mind.transfer_to(stored_swap)

--- a/code/modules/spells/targeted/mind_transfer.dm
+++ b/code/modules/spells/targeted/mind_transfer.dm
@@ -47,7 +47,7 @@
 			for(var/V in victim.mind.special_verbs)
 				victim.verbs -= V
 
-		var/mob/dead/observer/ghost = victim.ghostize(0)
+		var/mob/observer/dead/ghost = victim.ghostize(0)
 		ghost.spell_list += victim.spell_list//If they have spells, transfer them. Now we basically have a backup mob.
 
 		caster.mind.transfer_to(victim)


### PR DESCRIPTION
``/mob/dead/observer`` -> ``/mob/observer/dead``
``/mob/eye`` -> ``/mob/observer/eye``

Reason being that they are similar in that they both don't interact with the world in any way. Some procs were shared, some checks as well, and it overall makes more sense this way. Plus, there were no ``/mob/dead`` mobs.