### PR TITLE
Unlimited Welder Fix

### DIFF
--- a/code/game/objects/items/weapons/tools.dm
+++ b/code/game/objects/items/weapons/tools.dm
@@ -216,7 +216,7 @@
 		if(prob(5))
 			remove_fuel(1)
 
-		if(get_fuel() == 0)
+		if(get_fuel() < 1)
 			setWelding(0)
 
 	//I'm not sure what this does. I assume it has to do with starting fires...


### PR DESCRIPTION
Fixes a bug where welders are infinite use.  With this, the Welder will not turn on unless it has at least 1u of welder fuel.  Previously, it worked on 'not zero', which allowed it to weld endlessly with fractions of 1u inside (as it was not Zero, but could not deduct 1 from it when used).

Corrects bug #768 