### PR TITLE
Resleeving.

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -73,6 +73,7 @@ var/list/gamemode_cache = list()
 	var/ToRban = 0
 	var/automute_on = 0					//enables automuting/spam prevention
 	var/jobs_have_minimal_access = 0	//determines whether jobs use minimal access or expanded access.
+	var/use_cortical_stacks = 0
 
 	var/cult_ghostwriter = 1               //Allows ghosts to write in blood in cult rounds...
 	var/cult_ghostwriter_req_cultists = 10 //...so long as this many cultists are active.
@@ -476,6 +477,9 @@ var/list/gamemode_cache = list()
 
 				if("protect_roles_from_antagonist")
 					config.protect_roles_from_antagonist = 1
+
+				if("use_cortical_stacks")
+					config.use_cortical_stacks = 1
 
 				if ("probability")
 					var/prob_pos = findtext(value, " ")

--- a/code/game/dna/dna_modifier.dm
+++ b/code/game/dna/dna_modifier.dm
@@ -109,8 +109,9 @@
 		usr << "<span class='warning'>The subject cannot have abiotic items on.</span>"
 		return
 	usr.stop_pulling()
-	usr.client.perspective = EYE_PERSPECTIVE
-	usr.client.eye = src
+	if(usr.client)
+		usr.client.perspective = EYE_PERSPECTIVE
+		usr.client.eye = src
 	usr.loc = src
 	src.occupant = usr
 	src.icon_state = "scanner_1"
@@ -153,16 +154,17 @@
 	src.icon_state = "scanner_1"
 
 	// search for ghosts, if the corpse is empty and the scanner is connected to a cloner
-	if(locate(/obj/machinery/computer/cloning, get_step(src, NORTH)) \
-		|| locate(/obj/machinery/computer/cloning, get_step(src, SOUTH)) \
-		|| locate(/obj/machinery/computer/cloning, get_step(src, EAST)) \
-		|| locate(/obj/machinery/computer/cloning, get_step(src, WEST)))
+	if(!config.use_cortical_stacks)
+		if(locate(/obj/machinery/computer/cloning, get_step(src, NORTH)) \
+			|| locate(/obj/machinery/computer/cloning, get_step(src, SOUTH)) \
+			|| locate(/obj/machinery/computer/cloning, get_step(src, EAST)) \
+			|| locate(/obj/machinery/computer/cloning, get_step(src, WEST)))
 
-		if(!M.client && M.mind)
-			for(var/mob/dead/observer/ghost in player_list)
-				if(ghost.mind == M.mind)
-					ghost << "<b><font color = #330033><font size = 3>Your corpse has been placed into a cloning scanner. Return to your body if you want to be resurrected/cloned!</b> (Verbs -> Ghost -> Re-enter corpse)</font></font>"
-					break
+			if(!M.client && M.mind)
+				for(var/mob/dead/observer/ghost in player_list)
+					if(ghost.mind == M.mind)
+						ghost << "<b><font color = #330033><font size = 3>Your corpse has been placed into a cloning scanner. Return to your body if you want to be resurrected/cloned!</b> (Verbs -> Ghost -> Re-enter corpse)</font color>"
+						break
 	return
 
 /obj/machinery/dna_scannernew/proc/go_out()
@@ -209,7 +211,7 @@
 
 /obj/machinery/computer/scan_consolenew
 	name = "DNA Modifier Access Console"
-	desc = "Scand DNA."
+	desc = "Scan DNA."
 	icon = 'icons/obj/computer.dmi'
 	icon_keyboard = "med_key"
 	icon_screen = "dna"

--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -77,22 +77,24 @@
 /obj/machinery/clonepod/proc/growclone(var/datum/dna2/record/R)
 	if(mess || attempting)
 		return 0
-	var/datum/mind/clonemind = locate(R.mind)
+	var/datum/mind/clonemind
 
-	if(!istype(clonemind, /datum/mind))	//not a mind
-		return 0
-	if(clonemind.current && clonemind.current.stat != DEAD)	//mind is associated with a non-dead body
-		return 0
-	if(clonemind.active)	//somebody is using that mind
-		if(ckey(clonemind.key) != R.ckey)
+	if(!config.use_cortical_stacks)
+		clonemind = locate(R.mind)
+		if(!istype(clonemind, /datum/mind))	//not a mind
 			return 0
-	else
-		for(var/mob/dead/observer/G in player_list)
-			if(G.ckey == R.ckey)
-				if(G.can_reenter_corpse)
-					break
-				else
-					return 0
+		if(clonemind.current && clonemind.current.stat != DEAD)	//mind is associated with a non-dead body
+			return 0
+		if(clonemind.active)	//somebody is using that mind
+			if(ckey(clonemind.key) != R.ckey)
+				return 0
+		else
+			for(var/mob/dead/observer/G in player_list)
+				if(G.ckey == R.ckey)
+					if(G.can_reenter_corpse)
+						break
+					else
+						return 0
 
 	attempting = 1 //One at a time!!
 	locked = 1
@@ -104,7 +106,7 @@
 	var/mob/living/carbon/human/H = new /mob/living/carbon/human(src, R.dna.species)
 	occupant = H
 
-	if(!R.dna.real_name)	//to prevent null names
+	if(!R.dna.real_name || config.use_cortical_stacks)	//to prevent null names
 		R.dna.real_name = "clone ([rand(0,999)])"
 	H.real_name = R.dna.real_name
 
@@ -115,9 +117,11 @@
 	//Here let's calculate their health so the pod doesn't immediately eject them!!!
 	H.updatehealth()
 
-	clonemind.transfer_to(H)
-	H.ckey = R.ckey
-	H << "<span class='notice'><b>Consciousness slowly creeps over you as your body regenerates.</b><br><i>So this is what cloning feels like?</i></span>"
+	if(clonemind)
+		clonemind.transfer_to(H)
+		if(R.ckey)
+			H.ckey = R.ckey
+			H << "<span class='notice'><b>Consciousness slowly creeps over you as your body regenerates.</b><br><i>So this is what cloning feels like?</i></span>"
 
 	// -- Mode/mind specific stuff goes here
 	callHook("clone", list(H))
@@ -156,7 +160,7 @@
 		return
 
 	if((occupant) && (occupant.loc == src))
-		if((occupant.stat == DEAD) || (occupant.suiciding) || !occupant.key)  //Autoeject corpses and suiciding dudes.
+		if((occupant.stat == DEAD) || (occupant.suiciding))  //Autoeject corpses and suiciding dudes.
 			locked = 0
 			go_out()
 			connected_message("Clone Rejected: Deceased.")

--- a/code/game/machinery/computer/cloning.dm
+++ b/code/game/machinery/computer/cloning.dm
@@ -56,7 +56,7 @@
 	var/num = 1
 	var/area/A = get_area(src)
 	for(var/obj/machinery/clonepod/P in A.get_contents())
-		if(!P.connected)
+		if(!P.connected || (P.connected == src))
 			pods += P
 			P.connected = src
 			P.name = "[initial(P.name)] #[num++]"
@@ -324,17 +324,24 @@
 					qdel(C)
 					menu = 1
 				else
-
-					var/mob/selected = find_dead_player("[C.ckey]")
-					selected << 'sound/machines/chime.ogg'	//probably not the best sound but I think it's reasonable
-					var/answer = alert(selected,"Do you want to return to life?","Cloning","Yes","No")
-					if(answer != "No" && pod.growclone(C))
+					var/cloning
+					if(config.use_cortical_stacks)
+						cloning = 1
+						pod.growclone(C)
+					else
+						var/mob/selected = find_dead_player("[C.ckey]")
+						selected << 'sound/machines/chime.ogg'	//probably not the best sound but I think it's reasonable
+						var/answer = alert(selected,"Do you want to return to life?","Cloning","Yes","No")
+						if(answer != "No" && pod.growclone(C))
+							cloning = 1
+					if(cloning)
 						temp = "Initiating cloning cycle..."
 						records.Remove(C)
 						qdel(C)
 						menu = 1
 					else
 						temp = "Initiating cloning cycle...<br>Error: Post-initialisation failed. Cloning cycle aborted."
+
 
 		else
 			temp = "Error: Data corruption."
@@ -350,10 +357,13 @@
 	if ((isnull(subject)) || (!(ishuman(subject))) || (!subject.dna))
 		scantemp = "Error: Unable to locate valid genetic data."
 		return
-	if (!subject.has_brain())
-		if(istype(subject, /mob/living/carbon/human))
-			var/mob/living/carbon/human/H = subject
-			if(H.should_have_organ("brain"))
+	if(!config.use_cortical_stacks)
+		if (!subject.has_brain())
+			if(istype(subject, /mob/living/carbon/human))
+				var/mob/living/carbon/human/H = subject
+				if(H.should_have_organ("brain"))
+					scantemp = "Error: No signs of intelligence detected."
+			else
 				scantemp = "Error: No signs of intelligence detected."
 		else
 			scantemp = "Error: No signs of intelligence detected."
@@ -369,12 +379,12 @@
 		scantemp = "Error: Mental interface failure."
 		return
 	if (NOCLONE in subject.mutations)
-		scantemp = "Error: Mental interface failure."
+		scantemp = "Error: Major genetic degradation."
 		return
 	if (subject.species && subject.species.flags & NO_SCAN)
-		scantemp = "Error: Mental interface failure."
+		scantemp = "Error: Incompatible species."
 		return
-	if (!isnull(find_record(subject.ckey)))
+	if (subject.ckey && !isnull(find_record(subject.ckey)))
 		scantemp = "Subject already in database."
 		return
 
@@ -382,7 +392,7 @@
 
 	var/datum/dna2/record/R = new /datum/dna2/record()
 	R.dna=subject.dna
-	R.ckey = subject.ckey
+	R.ckey = subject.ckey ? subject.ckey : "no ckey"
 	R.id= copytext(md5(subject.real_name), 2, 6)
 	R.name=R.dna.real_name
 	R.types=DNA2_BUF_UI|DNA2_BUF_UE|DNA2_BUF_SE

--- a/code/modules/client/preference_setup/general/03_body.dm
+++ b/code/modules/client/preference_setup/general/03_body.dm
@@ -25,6 +25,7 @@ var/global/list/valid_bloodtypes = list("A+", "A-", "B+", "B-", "AB+", "AB-", "O
 	S["disabilities"]		>> pref.disabilities
 	S["organ_data"]			>> pref.organ_data
 	S["rlimb_data"]			>> pref.rlimb_data
+	S["has_cortical_stack"] >> pref.has_cortical_stack
 
 /datum/category_item/player_setup_item/general/body/save_character(var/savefile/S)
 	S["species"]			<< pref.species
@@ -47,6 +48,7 @@ var/global/list/valid_bloodtypes = list("A+", "A-", "B+", "B-", "AB+", "AB-", "O
 	S["disabilities"]		<< pref.disabilities
 	S["organ_data"]			<< pref.organ_data
 	S["rlimb_data"]			<< pref.rlimb_data
+	S["has_cortical_stack"] << pref.has_cortical_stack
 
 /datum/category_item/player_setup_item/general/body/sanitize_character(var/savefile/S)
 	if(!pref.species || !(pref.species in playable_species))
@@ -82,8 +84,15 @@ var/global/list/valid_bloodtypes = list("A+", "A-", "B+", "B-", "AB+", "AB-", "O
 	. += "<table><tr style='vertical-align:top'><td><b>Body</b> "
 	. += "(<a href='?src=\ref[src];random=1'>&reg;</A>)"
 	. += "<br>"
+
+	if(config.use_cortical_stacks)
+		. += "Neural lace: "
+		. += pref.has_cortical_stack ? "present." : "<b>not present. <font color='#FF0000'>Character is unclonable.</font></b>"
+		. += " \[<a href='byond://?src=\ref[src];toggle_stack=1'>toggle</a>\]<br>"
+
 	. += "Species: <a href='?src=\ref[src];show_species=1'>[pref.species]</a><br>"
 	. += "Blood Type: <a href='?src=\ref[src];blood_type=1'>[pref.b_type]</a><br>"
+
 	if(has_flag(mob_species, HAS_SKIN_TONE))
 		. += "Skin Tone: <a href='?src=\ref[src];skin_tone=1'>[-pref.s_tone + 35]/220</a><br>"
 	. += "Needs Glasses: <a href='?src=\ref[src];disabilities=[NEARSIGHTED]'><b>[pref.disabilities & NEARSIGHTED ? "Yes" : "No"]</b></a><br>"
@@ -195,6 +204,10 @@ var/global/list/valid_bloodtypes = list("A+", "A-", "B+", "B-", "AB+", "AB-", "O
 
 	if(href_list["random"])
 		pref.randomize_appearance_for()
+		return TOPIC_REFRESH
+
+	else if(href_list["toggle_stack"])
+		pref.has_cortical_stack = !pref.has_cortical_stack
 		return TOPIC_REFRESH
 
 	else if(href_list["blood_type"])

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -115,6 +115,7 @@ datum/preferences
 	var/client/client = null
 
 	var/datum/category_collection/player_setup_collection/player_setup
+	var/has_cortical_stack = 1
 
 /datum/preferences/New(client/C)
 	player_setup = new(src)
@@ -206,9 +207,9 @@ datum/preferences
 	user << browse(dat, "window=preferences;size=625x736")
 
 /datum/preferences/proc/process_link(mob/user, list/href_list)
-	if(!user)	return
 
-	if(!istype(user, /mob/new_player))	return
+	if(!user)	return
+	if(istype(user, /mob/living)) return
 
 	if(href_list["preference"] == "open_whitelist_forum")
 		if(config.forumurl)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1128,6 +1128,9 @@
 
 	full_prosthetic = null
 
+	if(config && config.use_cortical_stacks && client && client.prefs.has_cortical_stack && should_have_organ("brain"))
+		create_stack()
+
 	if(species)
 		return 1
 	else
@@ -1445,4 +1448,3 @@
 
 /mob/living/carbon/human/is_muzzled()
 	return (wear_mask && (istype(wear_mask, /obj/item/clothing/mask/muzzle) || istype(src.wear_mask, /obj/item/weapon/grenade)))
-

--- a/code/modules/mob/living/carbon/human/species/outsider/shadow.dm
+++ b/code/modules/mob/living/carbon/human/species/outsider/shadow.dm
@@ -11,6 +11,7 @@
 	darksight = 8
 	has_organ = list()
 	siemens_coefficient = 0
+	spawns_with_stack = 0
 
 	blood_color = "#CCCCCC"
 	flesh_color = "#AAAAAA"

--- a/code/modules/mob/living/carbon/human/species/outsider/vox.dm
+++ b/code/modules/mob/living/carbon/human/species/outsider/vox.dm
@@ -20,6 +20,7 @@
 
 	warning_low_pressure = 50
 	hazard_low_pressure = 0
+	spawns_with_stack = 0
 
 	cold_level_1 = 80
 	cold_level_2 = 50

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -69,7 +69,7 @@
 	var/death_sound
 	var/death_message = "seizes up and falls limp, their eyes dead and lifeless..."
 	var/knockout_message = "has been knocked unconscious!"
-
+	var/spawns_with_stack = 1
 	// Environment tolerance/life processes vars.
 	var/reagent_tag                                   //Used for metabolizing reagents.
 	var/breath_type = "oxygen"                        // Non-oxygen gas breathed, if any.

--- a/code/modules/mob/living/carbon/human/species/station/golem.dm
+++ b/code/modules/mob/living/carbon/human/species/station/golem.dm
@@ -10,6 +10,7 @@
 	flags = NO_PAIN | NO_SCAN | NO_POISON | NO_MINOR_CUT
 	spawn_flags = IS_RESTRICTED
 	siemens_coefficient = 0
+	spawns_with_stack = 0
 
 	breath_type = null
 	poison_type = null

--- a/code/modules/mob/living/carbon/human/species/station/monkey.dm
+++ b/code/modules/mob/living/carbon/human/species/station/monkey.dm
@@ -14,6 +14,7 @@
 	mob_size = MOB_SMALL
 	has_fine_manipulation = 0
 	show_ssd = null
+	spawns_with_stack = 0
 
 	gibbed_anim = "gibbed-m"
 	dusted_anim = "dust-m"

--- a/code/modules/mob/living/carbon/human/species/station/slime.dm
+++ b/code/modules/mob/living/carbon/human/species/station/slime.dm
@@ -12,6 +12,7 @@
 	spawn_flags = IS_RESTRICTED
 	siemens_coefficient = 3 //conductive
 	darksight = 3
+	spawns_with_stack = 0
 
 	blood_color = "#05FF9B"
 	flesh_color = "#05FFFB"

--- a/code/modules/mob/living/carbon/human/species/station/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station.dm
@@ -193,6 +193,7 @@
 	show_ssd = "completely quiescent"
 	num_alternate_languages = 1
 	name_language = "Rootspeak"
+	spawns_with_stack = 0
 
 	min_age = 1
 	max_age = 300

--- a/code/modules/mob/living/carbon/human/species/xenomorphs/alien_species.dm
+++ b/code/modules/mob/living/carbon/human/species/xenomorphs/alien_species.dm
@@ -12,6 +12,7 @@
 	has_fine_manipulation = 0
 	siemens_coefficient = 0
 	gluttonous = 3
+	spawns_with_stack = 0
 
 	brute_mod = 0.5 // Hardened carapace.
 	burn_mod = 2    // Weak to fire.

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -445,16 +445,15 @@
 			new_character.dna.SetSEState(GLASSESBLOCK,1,0)
 			new_character.disabilities |= NEARSIGHTED
 
-		// And uncomment this, too.
-		//new_character.dna.UpdateSE()
+		// Give them their cortical stack if we're using them.
+		if(config && config.use_cortical_stacks && client && client.prefs.has_cortical_stack && new_character.should_have_organ("brain"))
+			new_character.create_stack()
 
 		// Do the initial caching of the player's body icons.
 		new_character.force_update_limbs()
 		new_character.update_eyes()
 		new_character.regenerate_icons()
-
 		new_character.key = key		//Manually transfer the key to log them in
-
 		return new_character
 
 	proc/ViewManifest()

--- a/code/modules/organs/misc.dm
+++ b/code/modules/organs/misc.dm
@@ -41,21 +41,3 @@
 
 	spawn(0)
 		qdel(src)
-
-//VOX ORGANS.
-/obj/item/organ/internal/stack
-	name = "cortical stack"
-	parent_organ = BP_HEAD
-	icon_state = "brain-prosthetic"
-	organ_tag = "stack"
-	vital = 1
-	var/backup_time = 0
-	var/datum/mind/backup
-
-/obj/item/organ/internal/stack/process()
-	if(owner && owner.stat != DEAD && !is_broken())
-		backup_time = world.time
-		if(owner.mind) backup = owner.mind
-
-/obj/item/organ/internal/stack/vox/stack
-	name = "vox cortical stack"

--- a/code/modules/organs/organ_stack.dm
+++ b/code/modules/organs/organ_stack.dm
@@ -1,0 +1,75 @@
+/mob/living/carbon/human/proc/create_stack()
+	set waitfor=0
+	sleep(10)
+	internal_organs_by_name["stack"] = new /obj/item/organ/internal/stack(src,1)
+	src << "<span class='notice'>You feel a faint sense of vertigo as your neural lace boots.</span>"
+
+/obj/item/organ/internal/stack
+	name = "neural lace"
+	parent_organ = BP_HEAD
+	icon_state = "brain-prosthetic"
+	organ_tag = "stack"
+	parent_organ = "head"
+	status = ORGAN_ROBOT
+	vital = 1
+
+	var/invasive
+	var/default_language
+	var/list/languages = list()
+	var/datum/mind/backup
+
+/obj/item/organ/internal/stack/emp_act()
+	return
+
+/obj/item/organ/internal/stack/vox
+	name = "cortical stack"
+	invasive = 1
+
+/obj/item/organ/internal/stack/proc/do_backup()
+	if(owner && owner.stat != DEAD && !is_broken() && owner.mind)
+		languages = owner.languages.Copy()
+		backup = owner.mind
+		default_language = owner.default_language
+
+/obj/item/organ/internal/stack/process()
+	do_backup()
+	..()
+
+/obj/item/organ/internal/stack/proc/backup_inviable()
+	return 	(!istype(backup) || backup == owner.mind || (backup.current && backup.current.stat != DEAD))
+
+/obj/item/organ/internal/stack/replaced()
+	..()
+	if(owner && backup_inviable())
+		var/current_owner = owner
+		var/response = input("Your neural backup has been placed into a new body. Do you wish to return to life?", "Resleeving") as anything in list("Yes", "No")
+		if(src && response == "Yes" && owner == current_owner)
+			overwrite()
+	sleep(-1)
+	do_backup()
+
+/obj/item/organ/internal/stack/removed()
+	if(invasive)
+		var/obj/item/organ/external/head = owner.get_organ(parent_organ)
+		owner.visible_message("<span class='danger'>\The [src] rips gaping holes in \the [owner]'s [head.name] as it is torn loose!</span>")
+		head.take_damage(rand(15,20))
+		for(var/obj/item/organ/O in head.contents)
+			O.take_damage(rand(30,70))
+	..()
+
+/obj/item/organ/internal/stack/proc/overwrite()
+	if(owner.mind && owner.ckey) //Someone is already in this body!
+		owner.visible_message("<span class='danger'>\The [owner] spasms violently!</span>")
+		if(prob(66))
+			owner << "<span class='danger'>You fight off the invading tendrils of another mind, holding onto your own body!</span>"
+			return
+		owner.ghostize() // Remove the previous owner to avoid their client getting reset.
+	owner.dna.real_name = backup.name
+	owner.real_name = owner.dna.real_name
+	owner.name = owner.real_name
+	backup.active = 1
+	backup.transfer_to(owner)
+	if(default_language) owner.default_language = default_language
+	owner.languages = languages.Copy()
+	owner << "<span class='notice'>Consciousness slowly creeps over you as your new body awakens.</span>"
+	do_backup()

--- a/polaris.dme
+++ b/polaris.dme
@@ -1512,6 +1512,7 @@
 #include "code\modules\organs\organ_external.dm"
 #include "code\modules\organs\organ_icon.dm"
 #include "code\modules\organs\organ_internal.dm"
+#include "code\modules\organs\organ_stack.dm"
 #include "code\modules\organs\organ_stump.dm"
 #include "code\modules\organs\pain.dm"
 #include "code\modules\organs\robolimbs.dm"


### PR DESCRIPTION
Adds a use_cortical_stack config option. With this config option set:
- Prevents cloning from checking if a mob has a ckey before scanning it, and dumping a ckey from a scan into a freshly cloned body. ie. it disables old cloning mechanics.
- Cloning can produce mindless bodies from scans. They are produced as clone (n) in a similar manner to monkeys.
- A preferences option, defaulting to 'on', causes players to spawn with a neural lace head organ which, lorewise, periodically backs up an exact copy of their neural state and their 'echo', which is a handwaved lore excuse for 1:1 player:mob mechanics.
- This lace is required for 'cloning' in that it must be implanted into a living body to reinstantiate the player after death. This is done with normal organ transplanting surgery.
- The replacement will fail if the player is in another body or not connected to the game.
- Implanting into a body with no lace, but with a player, has a 30% chance of ghosting that player and overwriting their brain with the person being resleeved.

Todo:
- [ ] Get a better sprite for the lace.
- [x] Modify languages so they will transfer with resleeving.
- [ ] Possibly add morph rejection if someone is implanted into a body from a species other than their own, or a body that is entirely unlike their previous body.
- [ ] Add a machine or table that can efficiently remove a lace and swap it to a new body.
- [ ] Add a way to produce blank laces for implantation during gameplay and as a means of getting a usable mind-state from a corpse.