### PR TITLE
Fixes the Evidence box's storage amount

### DIFF
--- a/code/modules/detectivework/tools/storage.dm
+++ b/code/modules/detectivework/tools/storage.dm
@@ -24,7 +24,7 @@
 /obj/item/weapon/storage/box/evidence
 	name = "evidence bag box"
 	desc = "A box claiming to contain evidence bags."
-	storage_slots = 6
+	storage_slots = 7
 
 /obj/item/weapon/storage/box/evidence/New()
 	..()


### PR DESCRIPTION
<s>Buffs the evidence box to 7 slots from 6, since normal boxes have 7 slots.
Nukes the storage slot line entirely. rips.</s> Don't merge this, will redo within the hour.