### PR TITLE
Removes unnecessary line for evidence bag boxes

### DIFF
--- a/code/modules/detectivework/tools/storage.dm
+++ b/code/modules/detectivework/tools/storage.dm
@@ -24,7 +24,6 @@
 /obj/item/weapon/storage/box/evidence
 	name = "evidence bag box"
 	desc = "A box claiming to contain evidence bags."
-	storage_slots = 6
 
 /obj/item/weapon/storage/box/evidence/New()
 	..()


### PR DESCRIPTION
Caused evidence bag boxes to only have six slots, unlike the regular box which has 7 slots.