### PR TITLE
Adds a timer to staffwho AFK notifications.

### DIFF
--- a/code/game/verbs/who.dm
+++ b/code/game/verbs/who.dm
@@ -86,7 +86,10 @@
 					msg += " - Playing"
 
 				if(C.is_afk())
-					msg += " (AFK)"
+					var/seconds = C.last_activity_seconds()
+					msg += " (AFK - "
+					msg += "[round(seconds / 60)] minutes, "
+					msg += "[seconds % 60] seconds)"
 				msg += "\n"
 
 				num_admins_online++
@@ -101,7 +104,10 @@
 					modmsg += " - Playing"
 
 				if(C.is_afk())
-					modmsg += " (AFK)"
+					var/seconds = C.last_activity_seconds()
+					modmsg += " (AFK - "
+					modmsg += "[round(seconds / 60)] minutes, "
+					modmsg += "[seconds % 60] seconds)"
 				modmsg += "\n"
 				num_mods_online++
 
@@ -115,7 +121,10 @@
 					mentmsg += " - Playing"
 
 				if(C.is_afk())
-					mentmsg += " (AFK)"
+					var/seconds = C.last_activity_seconds()
+					mentmsg += " (AFK - "
+					mentmsg += "[round(seconds / 60)] minutes, "
+					mentmsg += "[seconds % 60] seconds)"
 				mentmsg += "\n"
 				num_mentors_online++
 

--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -281,6 +281,9 @@
 	if(inactivity > duration)	return inactivity
 	return 0
 
+/client/proc/last_activity_seconds()
+	return inactivity / 10
+
 //send resources to the client. It's here in its own proc so we can move it around easiliy if need be
 /client/proc/send_resources()
 


### PR DESCRIPTION
When using staffwho, AFK staff (currently apparently 5 minutes of inactivity) now report exactly how long they've been inactive for, such as follows. http://i.imgur.com/aUYkuwC.png
(Ignore the missing space before minutes, that was fixed)

This is so that when you use staffwho you can see which staff are more or less nominally AFK and which staff have stayed logged on to the server but actually have been AFK for literal hours.