### PR TITLE
Removes "Long Hair Alt" and "Shoulder Length Hair Alt" 

### DIFF
--- a/code/modules/mob/new_player/sprite_accessories.dm
+++ b/code/modules/mob/new_player/sprite_accessories.dm
@@ -103,10 +103,6 @@
 		name = "Shoulder-length Hair"
 		icon_state = "hair_b"
 
-	longalt
-		name = "Shoulder-length Hair Alt"
-		icon_state = "hair_longfringe"
-
 	/*longish
 		name = "Longer Hair"
 		icon_state = "hair_b2"*/
@@ -114,10 +110,6 @@
 	longer
 		name = "Long Hair"
 		icon_state = "hair_vlong"
-
-	longeralt
-		name = "Long Hair Alt"
-		icon_state = "hair_vlongfringe"
 
 	longest
 		name = "Very Long Hair"


### PR DESCRIPTION
They are identical to "Longer Fringe" and "Long Fringe" respectively. By identical to, I don't mean the sprites are the same - I mean they reference the exact same sprite! This has been a thing for a long time, for my knowledge, so people that have it set in their preferences may get some unexpected baldness - they should be able to fix that with mirrors fine if they don't notice before joining, though.

(Fixes #1106)