### PR TITLE
Increases cell charge loss on mecha halloss hit

### DIFF
--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -1639,8 +1639,8 @@
 	name = "Pan-Galactic Gargle Blaster"
 	id = "gargleblaster"
 	result = "gargleblaster"
-	required_reagents = list("vodka" = 1, "gin" = 1, "whiskey" = 1, "cognac" = 1, "limejuice" = 1)
-	result_amount = 5
+	required_reagents = list("vodka" = 2, "gin" = 1, "whiskey" = 1, "cognac" = 1, "limejuice" = 1)
+	result_amount = 6
 
 /datum/chemical_reaction/brave_bull
 	name = "Brave Bull"


### PR DESCRIPTION
Increases charge loss from (5 \* projectile_halloss) to (15 \* projectile_halloss).

Hitting a mecha ten times with an energy gun on stun would therefore result in a charge loss of 15\*40\*10=6000 points.
For Reference:
Normal Power Cell: 5,000
High-Capacity Power Cell: 10,000

Should make using tasers on mechs a way more viable option than it was before.