### PR TITLE
Overhauls bot AI

### DIFF
--- a/code/game/objects/items/devices/PDA/cart.dm
+++ b/code/game/objects/items/devices/PDA/cart.dm
@@ -354,12 +354,12 @@
 			var/muleData[0]
 			muleData["name"] = M.suffix
 			muleData["location"] = get_area(M)
-			muleData["mode"] = M.mode
+			muleData["paused"] = M.paused
 			muleData["home"] = M.homeName
 			muleData["target"] = M.targetName
 			muleData["ref"] = "\ref[M]"
 			muleData["load"] = M.load ? M.load.name : "Nothing"
-			
+
 			mulebotsData[++mulebotsData.len] = muleData.Copy()
 
 		values["mulebotcount"] = count

--- a/code/modules/mob/living/bot/bot.dm
+++ b/code/modules/mob/living/bot/bot.dm
@@ -6,6 +6,7 @@
 	layer = MOB_LAYER
 	universal_speak = 1
 	density = 0
+
 	var/obj/item/weapon/card/id/botcard = null
 	var/list/botcard_access = list()
 	var/on = 1
@@ -13,10 +14,27 @@
 	var/locked = 1
 	var/emagged = 0
 	var/light_strength = 3
+	var/busy = 0
 
 	var/obj/access_scanner = null
 	var/list/req_access = list()
 	var/list/req_one_access = list()
+
+	var/atom/target = null
+	var/list/ignore_list = list()
+	var/list/patrol_path = list()
+	var/list/target_path = list()
+
+	var/wait_if_pulled = 0 // Only applies to moving to the target
+	var/will_patrol = 0 // Not a setting - whether or no this type of bots patrols at all
+	var/patrol_speed = 1 // How many times per tick we move when patrolling
+	var/target_speed = 2 // Ditto for chasing the target
+	var/min_target_dist = 1 // How close we try to get to the target
+	var/max_target_dist = 50 // How far we are willing to go
+	var/max_patrol_dist = 250
+
+	var/target_patience = 5
+	var/frustration = 0
 
 /mob/living/bot/New()
 	..()
@@ -39,6 +57,9 @@
 	weakened = 0
 	stunned = 0
 	paralysis = 0
+
+	if(on && !client && !busy)
+		handleAI()
 
 /mob/living/bot/updatehealth()
 	if(status_flags & GODMODE)
@@ -109,6 +130,102 @@
 /mob/living/bot/emag_act(var/remaining_charges, var/mob/user)
 	return 0
 
+/mob/living/bot/proc/handleAI()
+	if(ignore_list.len)
+		for(var/atom/A in ignore_list)
+			if(!A.loc || prob(1))
+				ignore_list -= A
+	handleRegular()
+	if(target && confirmTarget(target))
+		if(Adjacent(target))
+			handleAdjacentTarget()
+		else
+			handleRangedTarget()
+		if(get_dist(src, target) > min_target_dist && (!wait_if_pulled || !pulledby))
+			for(var/i = 1 to target_speed)
+				stepToTarget()
+				sleep(20 / target_speed)
+	else
+		target = null
+		lookForTargets()
+		if(will_patrol && !pulledby && !target)
+			if(patrol_path.len)
+				for(var/i = 1 to patrol_speed)
+					handlePatrol()
+					if(i < patrol_speed)
+						sleep(20 / target_speed)
+			else
+				startPatrol()
+		else
+			handleIdle()
+
+/mob/living/bot/proc/handleRegular()
+	return
+
+/mob/living/bot/proc/handleAdjacentTarget()
+	return
+
+/mob/living/bot/proc/handleRangedTarget()
+	return
+
+/mob/living/bot/proc/stepToTarget()
+	if(!target || !target.loc)
+		return
+	if(!target_path.len || get_turf(target) != target_path[target_path.len])
+		calcTargetPath()
+	makeStep(target_path)
+	return
+
+/mob/living/bot/proc/lookForTargets()
+	return
+
+/mob/living/bot/proc/confirmTarget(var/atom/A)
+	if(A.invisibility >= INVISIBILITY_LEVEL_ONE)
+		return 0
+	if(A in ignore_list)
+		return 0
+	if(!A.loc)
+		return 0
+	return 1
+
+/mob/living/bot/proc/handlePatrol()
+	makeStep(patrol_path)
+	return
+
+/mob/living/bot/proc/startPatrol()
+	var/turf/T = getPatrolTurf()
+	if(T)
+		patrol_path = AStar(get_turf(loc), T, /turf/proc/CardinalTurfsWithAccess, /turf/proc/Distance, 0, max_patrol_dist, id = botcard)
+		if(!patrol_path)
+			patrol_path = list()
+	return
+
+/mob/living/bot/proc/getPatrolTurf()
+	return null
+
+/mob/living/bot/proc/handleIdle()
+	return
+
+/mob/living/bot/proc/calcTargetPath()
+	target_path = AStar(get_turf(loc), get_turf(target), /turf/proc/CardinalTurfsWithAccess, /turf/proc/Distance, 0, max_target_dist, id = botcard)
+	if(!target_path)
+		if(target && target.loc)
+			ignore_list |= target
+		target = null
+		target_path = list()
+	return
+
+/mob/living/bot/proc/makeStep(var/list/path)
+	if(!path.len)
+		return
+	var/turf/T = path[1]
+	if(get_turf(src) == T)
+		path -= T
+		makeStep(path)
+		return
+
+	step_towards(src, T)
+
 /mob/living/bot/proc/turn_on()
 	if(stat)
 		return 0
@@ -121,6 +238,10 @@
 	on = 0
 	set_light(0)
 	update_icons()
+	target = null
+	target_path = list()
+	patrol_path = list()
+	ignore_list = list()
 
 /mob/living/bot/proc/explode()
 	qdel(src)
@@ -141,7 +262,7 @@
 	//	for(var/turf/simulated/t in oview(src,1))
 
 	for(var/d in cardinal)
-		var/turf/simulated/T = get_step(src, d)
+		var/turf/T = get_step(src, d)
 		if(istype(T) && !T.density)
 			if(!LinkBlockedWithAccess(src, T, ID))
 				L.Add(T)

--- a/code/modules/mob/living/bot/ed209bot.dm
+++ b/code/modules/mob/living/bot/ed209bot.dm
@@ -7,7 +7,6 @@
 	health = 100
 	maxHealth = 100
 
-	bot_version = "2.5"
 	is_ranged = 1
 	preparing_arrest_sounds = new()
 
@@ -20,7 +19,7 @@
 	var/last_shot = 0
 
 /mob/living/bot/secbot/ed209/update_icons()
-	if(on && is_attacking)
+	if(on && busy)
 		icon_state = "ed209-c"
 	else
 		icon_state = "ed209[on]"
@@ -49,6 +48,9 @@
 
 	new /obj/effect/decal/cleanable/blood/oil(Tsec)
 	qdel(src)
+
+/mob/living/bot/secbot/ed209/handleRangedTarget()
+	RangedAttack(target)
 
 /mob/living/bot/secbot/ed209/RangedAttack(var/atom/A)
 	if(last_shot + shot_delay > world.time)

--- a/code/modules/mob/living/bot/farmbot.dm
+++ b/code/modules/mob/living/bot/farmbot.dm
@@ -22,17 +22,12 @@
 
 	var/obj/structure/reagent_dispensers/watertank/tank
 
-	var/attacking = 0
-	var/list/path = list()
-	var/atom/target
-	var/frustration = 0
-
-/mob/living/bot/farmbot/New()
-	..()
-	spawn(5)
-		tank = locate() in contents
-		if(!tank)
-			tank = new /obj/structure/reagent_dispensers/watertank(src)
+/mob/living/bot/farmbot/New(var/newloc, var/newTank)
+	..(newloc)
+	if(!newTank)
+		newTank = new /obj/structure/reagent_dispensers/watertank(src)
+	tank = newTank
+	tank.forceMove(src)
 
 /mob/living/bot/farmbot/attack_hand(var/mob/user as mob)
 	. = ..()
@@ -110,63 +105,55 @@
 	else
 		icon_state = "farmbot[on]"
 
-/mob/living/bot/farmbot/Life()
-	..()
-	if(!on)
-		return
+/mob/living/bot/farmbot/handleRegular()
 	if(emagged && prob(1))
 		flick("farmbot_broke", src)
-	if(client)
-		return
 
-	if(target)
-		if(Adjacent(target))
-			UnarmedAttack(target)
-			path = list()
-			target = null
-		else
-			if(path.len && frustration < 5)
-				if(path[1] == loc)
-					path -= path[1]
-				var/t = step_towards(src, path[1])
-				if(t)
-					path -= path[1]
-				else
-					++frustration
-			else
-				path = list()
-				target = null
+/mob/living/bot/farmbot/handleAdjacentTarget()
+	UnarmedAttack(target)
+
+/mob/living/bot/farmbot/lookForTargets()
+	if(emagged)
+		for(var/mob/living/carbon/human/H in view(7, src))
+			target = H
+			return
 	else
-		if(emagged)
-			for(var/mob/living/carbon/human/H in view(7, src))
-				target = H
-				break
-		else
-			for(var/obj/machinery/portable_atmospherics/hydroponics/tray in view(7, src))
-				if(process_tray(tray))
-					target = tray
-					frustration = 0
-					break
-			if(!target && refills_water && tank && tank.reagents.total_volume < tank.reagents.maximum_volume)
-				for(var/obj/structure/sink/source in view(7, src))
-					target = source
-					frustration = 0
-					break
-		if(target)
-			var/t = get_dir(target, src) // Turf with the tray is impassable, so a* can't navigate directly to it
-			path = AStar(loc, get_step(target, t), /turf/proc/CardinalTurfsWithAccess, /turf/proc/Distance, 0, 30, id = botcard)
-			if(!path)
-				path = list()
+		for(var/obj/machinery/portable_atmospherics/hydroponics/tray in view(7, src))
+			if(confirmTarget(tray))
+				target = tray
+				return
+		if(!target && refills_water && tank && tank.reagents.total_volume < tank.reagents.maximum_volume)
+			for(var/obj/structure/sink/source in view(7, src))
+				target = source
+				return
+
+/mob/living/bot/farmbot/calcTargetPath() // We need to land NEXT to the tray, because the tray itself is impassable
+	for(var/trayDir in list(NORTH, SOUTH, EAST, WEST))
+		target_path = AStar(get_turf(loc), get_step(get_turf(target), trayDir), /turf/proc/CardinalTurfsWithAccess, /turf/proc/Distance, 0, max_target_dist, id = botcard)
+		if(target_path)
+			break
+	if(!target_path)
+		ignore_list |= target
+		target = null
+		target_path = list()
+	return
+
+/mob/living/bot/farmbot/stepToTarget() // Same reason
+	var/turf/T = get_turf(target)
+	if(!target_path.len || !T.Adjacent(target_path[target_path.len]))
+		calcTargetPath()
+	makeStep(target_path)
+	return
 
 /mob/living/bot/farmbot/UnarmedAttack(var/atom/A, var/proximity)
 	if(!..())
 		return
-	if(attacking)
+	if(busy)
 		return
 
 	if(istype(A, /obj/machinery/portable_atmospherics/hydroponics))
 		var/obj/machinery/portable_atmospherics/hydroponics/T = A
-		var/t = process_tray(T)
+		var/t = confirmTarget(T)
 		switch(t)
 			if(0)
 				return
@@ -174,7 +161,7 @@
 				action = "water" // Needs a better one
 				update_icons()
 				visible_message("<span class='notice'>[src] starts [T.dead? "removing the plant from" : "harvesting"] \the [A].</span>")
-				attacking = 1
+				busy = 1
 				if(do_after(src, 30))
 					visible_message("<span class='notice'>[src] [T.dead? "removes the plant from" : "harvests"] \the [A].</span>")
 					T.attack_hand(src)
@@ -182,7 +169,7 @@
 				action = "water"
 				update_icons()
 				visible_message("<span class='notice'>[src] starts watering \the [A].</span>")
-				attacking = 1
+				busy = 1
 				if(do_after(src, 30))
 					playsound(loc, 'sound/effects/slosh.ogg', 25, 1)
 					visible_message("<span class='notice'>[src] waters \the [A].</span>")
@@ -191,7 +178,7 @@
 				action = "hoe"
 				update_icons()
 				visible_message("<span class='notice'>[src] starts uprooting the weeds in \the [A].</span>")
-				attacking = 1
+				busy = 1
 				if(do_after(src, 30))
 					visible_message("<span class='notice'>[src] uproots the weeds in \the [A].</span>")
 					T.weedlevel = 0
@@ -199,11 +186,11 @@
 				action = "fertile"
 				update_icons()
 				visible_message("<span class='notice'>[src] starts fertilizing \the [A].</span>")
-				attacking = 1
+				busy = 1
 				if(do_after(src, 30))
-					visible_message("<span class='notice'>[src] waters \the [A].</span>")
+					visible_message("<span class='notice'>[src] fertilizes \the [A].</span>")
 					T.reagents.add_reagent("ammonia", 10)
-		attacking = 0
+		busy = 0
 		action = ""
 		update_icons()
 		T.update_icon()
@@ -213,20 +200,20 @@
 		action = "water"
 		update_icons()
 		visible_message("<span class='notice'>[src] starts refilling its tank from \the [A].</span>")
-		attacking = 1
+		busy = 1
 		while(do_after(src, 10) && tank.reagents.total_volume < tank.reagents.maximum_volume)
 			tank.reagents.add_reagent("water", 10)
 			if(prob(5))
 				playsound(loc, 'sound/effects/slosh.ogg', 25, 1)
-		attacking = 0
+		busy = 0
 		action = ""
 		update_icons()
 		visible_message("<span class='notice'>[src] finishes refilling its tank.</span>")
 	else if(emagged && ishuman(A))
 		var/action = pick("weed", "water")
-		attacking = 1
+		busy = 1
 		spawn(50) // Some delay
-			attacking = 0
+			busy = 0
 		switch(action)
 			if("weed")
 				flick("farmbot_hoe", src)
@@ -238,7 +225,8 @@
 				A.attack_generic(src, 5, t)
 			if("water")
 				flick("farmbot_water", src)
-				visible_message("<span class='danger'>[src] splashes [A] with water!</span>") // That's it. RP effect.
+				visible_message("<span class='danger'>[src] splashes [A] with water!</span>")
+				tank.reagents.splash(A, 100)
 
 /mob/living/bot/farmbot/explode()
 	visible_message("<span class='danger'>[src] blows apart!</span>")
@@ -261,8 +249,22 @@
 	qdel(src)
 	return
 
-/mob/living/bot/farmbot/proc/process_tray(var/obj/machinery/portable_atmospherics/hydroponics/tray)
-	if(!tray || !istype(tray))
+/mob/living/bot/farmbot/confirmTarget(var/atom/targ)
+	if(!..())
+		return 0
+
+	if(emagged && ishuman(targ))
+		if(targ in view(world.view, src))
+			return 1
+		return 0
+
+	if(istype(targ, /obj/structure/sink))
+		if(!tank || tank.reagents.total_volume >= tank.reagents.maximum_volume)
+			return 0
+		return 1
+
+	var/obj/machinery/portable_atmospherics/hydroponics/tray = targ
+	if(!istype(tray))
 		return 0
 
 	if(tray.closed_system || !tray.seed)
@@ -291,27 +293,27 @@
 	icon_state = "water_arm"
 	var/build_step = 0
 	var/created_name = "Farmbot"
+	var/obj/tank
 	w_class = 3.0
 
-	New()
-		..()
-		spawn(4) // If an admin spawned it, it won't have a watertank it, so lets make one for em!
-			var tank = locate(/obj/structure/reagent_dispensers/watertank) in contents
-			if(!tank)
-				new /obj/structure/reagent_dispensers/watertank(src)
-
+/obj/item/weapon/farmbot_arm_assembly/New(var/newloc, var/theTank)
+	..(newloc)
+	if(!theTank) // If an admin spawned it, it won't have a watertank it, so lets make one for em!
+		tank = new /obj/structure/reagent_dispensers/watertank(src)
+	else
+		tank = theTank
+		tank.forceMove(src)
 
 /obj/structure/reagent_dispensers/watertank/attackby(var/obj/item/robot_parts/S, mob/user as mob)
 	if ((!istype(S, /obj/item/robot_parts/l_arm)) && (!istype(S, /obj/item/robot_parts/r_arm)))
 		..()
 		return
 
-	var/obj/item/weapon/farmbot_arm_assembly/A = new /obj/item/weapon/farmbot_arm_assembly(loc)
-
 	user << "You add the robot arm to [src]."
-	loc = A //Place the water tank into the assembly, it will be needed for the finished bot
 	user.drop_from_inventory(S)
 	qdel(S)
+
+	new /obj/item/weapon/farmbot_arm_assembly(loc, src)
 
 /obj/item/weapon/farmbot_arm_assembly/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	..()
@@ -339,10 +341,7 @@
 	else if((isprox(W)) && (build_step == 3))
 		build_step++
 		user << "You complete the Farmbot! Beep boop."
-		var/mob/living/bot/farmbot/S = new /mob/living/bot/farmbot(get_turf(src))
-		for(var/obj/structure/reagent_dispensers/watertank/wTank in contents)
-			wTank.loc = S
-			S.tank = wTank
+		var/mob/living/bot/farmbot/S = new /mob/living/bot/farmbot(get_turf(src), tank)
 		S.name = created_name
 		user.remove_from_mob(W)
 		qdel(W)

--- a/code/modules/mob/living/bot/medbot.dm
+++ b/code/modules/mob/living/bot/medbot.dm
@@ -3,21 +3,16 @@
 	desc = "A little medical robot. He looks somewhat underwhelmed."
 	icon_state = "medibot0"
 	req_access = list(access_medical)
-
-	var/skin = null //Set to "tox", "ointment" or "o2" for the other two firstaid kits.
 	botcard_access = list(access_medical, access_morgue, access_surgery, access_chemistry, access_virology, access_genetics)
 
+	var/skin = null //Set to "tox", "ointment" or "o2" for the other two firstaid kits.
+
 	//AI vars
-	var/frustration = 0
-	var/list/path = list()
-	var/mob/living/carbon/human/patient = null
-	var/mob/ignored = list() // Used by emag
 	var/last_newpatient_speak = 0
 	var/vocal = 1
 
 	//Healing vars
 	var/obj/item/weapon/reagent_containers/glass/reagent_glass = null //Can be set to draw from this for reagents.
-	var/currently_healing = 0
 	var/injection_amount = 15 //How much reagent do we inject at a time?
 	var/heal_threshold = 10 //Start healing when they have this much damage in a category
 	var/use_beaker = 0 //Use reagents in beaker instead of default treatment agents.
@@ -29,49 +24,26 @@
 	var/treatment_emag = "toxin"
 	var/declare_treatment = 0 //When attempting to treat a patient, should it notify everyone wearing medhuds?
 
-/mob/living/bot/medbot/Life()
-	..()
+/mob/living/bot/medbot/handleIdle()
+	if(vocal && prob(1))
+		var/message = pick("Radar, put a mask on!", "There's always a catch, and it's the best there is.", "I knew it, I should've been a plastic surgeon.", "What kind of medbay is this? Everyone's dropping like dead flies.", "Delicious!")
+		say(message)
 
-	if(!on)
-		return
+/mob/living/bot/medbot/handleAdjacentTarget()
+	UnarmedAttack(target)
 
-	if(!client)
+/mob/living/bot/medbot/lookForTargets()
+	for(var/mob/living/carbon/human/H in view(7, src)) // Time to find a patient!
+		if(confirmTarget(H))
+			target = H
+			if(last_newpatient_speak + 300 < world.time)
+				var/message = pick("Hey, [H.name]! Hold on, I'm coming.", "Wait [H.name]! I want to help!", "[H.name], you appear to be injured!")
+				say(message)
+				custom_emote(1, "points at [H.name].")
+				last_newpatient_speak = world.time
+			break
 
-		if(vocal && prob(1))
-			var/message = pick("Radar, put a mask on!", "There's always a catch, and it's the best there is.", "I knew it, I should've been a plastic surgeon.", "What kind of medbay is this? Everyone's dropping like dead flies.", "Delicious!")
-			say(message)
-
-		if(patient)
-			if(Adjacent(patient))
-				if(!currently_healing)
-					UnarmedAttack(patient)
-			else
-				if(path.len && (get_dist(patient, path[path.len]) > 2)) // We have a path, but it's off
-					path = list()
-				if(!path.len && (get_dist(src, patient) > 1))
-					spawn(0)
-						path = AStar(loc, get_turf(patient), /turf/proc/CardinalTurfsWithAccess, /turf/proc/Distance, 0, 30, id = botcard)
-						if(!path)
-							path = list()
-				if(path.len)
-					step_to(src, path[1])
-					path -= path[1]
-					++frustration
-				if(get_dist(src, patient) > 7 || frustration > 8)
-					patient = null
-		else
-			for(var/mob/living/carbon/human/H in view(7, src)) // Time to find a patient!
-				if(valid_healing_target(H))
-					patient = H
-					frustration = 0
-					if(last_newpatient_speak + 300 < world.time)
-						var/message = pick("Hey, [H.name]! Hold on, I'm coming.", "Wait [H.name]! I want to help!", "[H.name], you appear to be injured!")
-						say(message)
-						custom_emote(1, "points at [H.name].")
-						last_newpatient_speak = world.time
-					break
-
-/mob/living/bot/medbot/UnarmedAttack(var/mob/living/carbon/human/H, var/proximity)
+/mob/living/bot/medbot/UnarmedAttack(var/mob/living/carbon/human/H)
 	if(!..())
 		return
 
@@ -81,25 +53,27 @@
 	if(!istype(H))
 		return
 
+	if(busy)
+		return
+
 	if(H.stat == DEAD)
 		var/death_message = pick("No! NO!", "Live, damnit! LIVE!", "I... I've never lost a patient before. Not today, I mean.")
 		say(death_message)
-		patient = null
+		target = null
 		return
 
-	var/t = valid_healing_target(H)
+	var/t = confirmTarget(H)
 	if(!t)
 		var/message = pick("All patched up!", "An apple a day keeps me away.", "Feel better soon!")
 		say(message)
-		patient = null
+		target = null
 		return
 
-	icon_state = "medibots"
 	visible_message("<span class='warning'>[src] is trying to inject [H]!</span>")
 	if(declare_treatment)
 		var/area/location = get_area(src)
 		broadcast_medical_hud_message("[src] is treating <b>[H]</b> in <b>[location]</b>", src)
-	currently_healing = 1
+	busy = 1
 	update_icons()
 	if(do_mob(src, H, 30))
 		if(t == 1)
@@ -107,14 +81,14 @@
 		else
 			H.reagents.add_reagent(t, injection_amount)
 		visible_message("<span class='warning'>[src] injects [H] with the syringe!</span>")
-	currently_healing = 0
+	busy = 0
 	update_icons()
 
 /mob/living/bot/medbot/update_icons()
 	overlays.Cut()
 	if(skin)
 		overlays += image('icons/obj/aibots.dmi', "medskin_[skin]")
-	if(currently_healing)
+	if(busy)
 		icon_state = "medibots"
 	else
 		icon_state = "medibot[on]"
@@ -226,13 +200,13 @@
 			user << "<span class='warning'>You short out [src]'s reagent synthesis circuits.</span>"
 		visible_message("<span class='warning'>[src] buzzes oddly!</span>")
 		flick("medibot_spark", src)
-		patient = null
-		currently_healing = 0
+		target = null
+		busy = 0
 		emagged = 1
 		on = 1
 		update_icons()
 		. = 1
-	ignored |= user
+	ignore_list |= user
 
 /mob/living/bot/medbot/explode()
 	on = 0
@@ -255,15 +229,15 @@
 	qdel(src)
 	return
 
-/mob/living/bot/medbot/proc/valid_healing_target(var/mob/living/carbon/human/H)
+/mob/living/bot/medbot/confirmTarget(var/mob/living/carbon/human/H)
+	if(!..())
+		return 0
+
 	if(H.stat == DEAD) // He's dead, Jim
-		return null
+		return 0
 
 	if(H.suiciding)
-		return null
-
-	if(H in ignored)
-		return null
+		return 0
 
 	if(emagged)
 		return treatment_emag

--- a/nano/templates/pda.tmpl
+++ b/nano/templates/pda.tmpl
@@ -775,14 +775,10 @@ Used In File(s): \code\game\objects\items\devices\PDA\PDA.dm
 				<div class="item">
 					<div class="itemLabel">Status:</div>
 					<div class="itemContent">
-						{{if value.mode == 0}}
-							Idle
-						{{else value.mode == 1}}
-							Moving
-						{{else value.mode == 2}}
-							Unloading
-						{{else}}
-							Calculating path
+						{{if value.paused == 0}}
+							Nominal
+						{{else value.paused == 1}}
+							Paused
 						{{/if}}
 					</div>
 				</div>


### PR DESCRIPTION
Instead of every bot defining its own AI, it's now defined at the base level and broken into individual functions.
Bot movement speed is now a variable.
Everything related to patrols has been removed. I will return to this later. It's currently broken anyway.
Signals and signal listeners sent to the hell where they belong.

Fixes:
Floorbots will now cover asteroid tiles.
Farmbots will now correctly navigate to the trays.