### PR TITLE
Fixes floor decal layering

### DIFF
--- a/code/game/turfs/flooring/flooring_decals.dm
+++ b/code/game/turfs/flooring/flooring_decals.dm
@@ -21,7 +21,7 @@ var/list/floor_decals = list()
 		var/cache_key = "[alpha]-[color]-[dir]-[icon_state]-[layer]"
 		if(!floor_decals[cache_key])
 			var/image/I = image(icon = src.icon, icon_state = src.icon_state, dir = src.dir)
-			I.layer = T.layer + 0.01
+			I.layer = T.layer
 			I.color = src.color
 			I.alpha = src.alpha
 			floor_decals[cache_key] = I


### PR DESCRIPTION
Right now, floor tile decals are able to layer over things such as girders, blood, and cult runes. They'd also show above the damage of the very tile they were on. 
Mainly a port from Bay, but testing seemed to show that this fixes the above issues.