### PR TITLE
Retail Scanners, Price List Update and Interface Improvements

### DIFF
--- a/code/modules/economy/cash_register.dm
+++ b/code/modules/economy/cash_register.dm
@@ -123,7 +123,7 @@
 				transaction_amount += t_amount
 				price_list += t_amount
 				playsound(src, 'sound/machines/twobeep.ogg', 25)
-				src.visible_message("\icon[src][transaction_purpose]: [transaction_amount] Thaler\s.")
+				src.visible_message("\icon[src][transaction_purpose]: [t_amount] Thaler\s.")
 			if("reset_log")
 				transaction_logs.Cut()
 				usr << "\icon[src]<span class='notice'>Transaction log reset.</span>"
@@ -180,16 +180,16 @@
 	if (!transaction_amount)
 		return
 
-	if(!confirm(I))
+	if (cash_open)
+		playsound(src, 'sound/machines/buzz-sigh.ogg', 25)
+		usr << "\icon[src]<span class='warning'>The cash box is open.</span>"
+		return
+
+	if((item_list.len > 1 || item_list[item_list[1]] > 1) && !confirm(I))
 		return
 
 	if (!linked_account)
 		usr.visible_message("\icon[src]<span class='warning'>Unable to connect to linked account.</span>")
-		return
-
-	if (cash_open)
-		playsound(src, 'sound/machines/buzz-sigh.ogg', 25)
-		usr << "\icon[src]<span class='warning'>The cash box is open.</span>"
 		return
 
 	// Access account for transaction
@@ -245,12 +245,12 @@
 	if (!transaction_amount)
 		return
 
-	if(!confirm(E))
-		return
-
 	if (cash_open)
 		playsound(src, 'sound/machines/buzz-sigh.ogg', 25)
 		usr << "\icon[src]<span class='warning'>The cash box is open.</span>"
+		return
+
+	if((item_list.len > 1 || item_list[item_list[1]] > 1) && !confirm(E))
 		return
 
 	// Access account for transaction
@@ -283,12 +283,12 @@
 	if (!transaction_amount)
 		return
 
-	if(!confirm(SC))
-		return
-
 	if (cash_open)
 		playsound(src, 'sound/machines/buzz-sigh.ogg', 25)
 		usr << "\icon[src]<span class='warning'>The cash box is open.</span>"
+		return
+
+	if((item_list.len > 1 || item_list[item_list[1]] > 1) && !confirm(SC))
 		return
 
 	if(transaction_amount > SC.worth)
@@ -313,6 +313,9 @@
 
 /obj/machinery/cash_register/proc/scan_item_price(obj/O)
 	if(!istype(O))	return
+	if(item_list.len > 10)
+		src.visible_message("\icon[src]<span class='warning'>Only up to ten different items allowed per purchase.</span>")
+		return
 	if (cash_open)
 		playsound(src, 'sound/machines/buzz-sigh.ogg', 25)
 		usr << "\icon[src]<span class='warning'>The cash box is open.</span>"
@@ -330,8 +333,13 @@
 		transaction_purpose += "<br>"
 	transaction_purpose += "[O]: [price] Thaler\s"
 	transaction_amount += price
-	item_list += "[O]"
-	price_list += price
+	for(var/obj/previously_scanned in item_list)
+		if(O == previously_scanned || istype(O, previously_scanned.type))
+			. = item_list[previously_scanned]++
+	if(!.)
+		item_list[O] = 1
+		price_list += price
+		. = 1
 	// Animation and sound
 	playsound(src, 'sound/machines/twobeep.ogg', 25)
 	// Reset confirmation
@@ -356,8 +364,10 @@
 	</table>
 	<table width=300>
 	"}
+	var/obj/O
 	for(var/i=1, i<=item_list.len, i++)
-		dat += "<tr><td class=\"tx-name\">[item_list[i]]</td><td class=\"tx-data\" width=50>[price_list[i]] &thorn</td></tr>"
+		O = item_list[i]
+		dat += "<tr><td class=\"tx-name\">[item_list[O]] x [O.name]</td><td class=\"tx-data\" width=50>[price_list[i] * item_list[O]] &thorn</td></tr>"
 	dat += "<tr></tr><tr><td colspan=\"2\" class=\"tx-name\" style='text-align: right'><b>Total Amount: [transaction_amount] &thorn</b></td></tr>"
 	dat += "</table></html>"
 

--- a/code/modules/economy/cash_register.dm
+++ b/code/modules/economy/cash_register.dm
@@ -51,10 +51,6 @@
 			overlays -= "register_cash"
 		else
 			open_cash_box()
-	// Reset if necessary
-	else if(transaction_amount)
-		reset_memory()
-		user << "<span class='notice'>You reset the machine's memory.</span>"
 	else
 		user.set_machine(src)
 		interact(user)
@@ -76,7 +72,12 @@
 		dat += "Linked account: <a href='?src=\ref[src];choice=link_account'>[linked_account ? linked_account.owner_name : "None"]</a><br>"
 		dat += "<a href='?src=\ref[src];choice=toggle_cash_lock'>[cash_locked? "Unlock" : "Lock"] Cash Box</a> | "
 	dat += "<a href='?src=\ref[src];choice=custom_order'>Custom Order</a><hr>"
-	for(var/i=1, i<=transaction_logs.len, i++)
+
+	if(item_list.len)
+		dat += get_current_transaction()
+		dat += "<br>"
+
+	for(var/i=transaction_logs.len, i>=1, i--)
 		dat += "[transaction_logs[i]]<br>"
 
 	if(transaction_logs.len)
@@ -118,12 +119,46 @@
 				if (!t_purpose || !Adjacent(usr)) return
 				transaction_purpose = t_purpose
 				item_list += t_purpose
-				var/t_amount = input("Enter price", "New price") as num
+				var/t_amount = round(input("Enter price", "New price") as num)
 				if (!t_amount || !Adjacent(usr)) return
 				transaction_amount += t_amount
 				price_list += t_amount
 				playsound(src, 'sound/machines/twobeep.ogg', 25)
 				src.visible_message("\icon[src][transaction_purpose]: [t_amount] Thaler\s.")
+			if("set_amount")
+				var/item_name = locate(href_list["item"])
+				var/n_amount = round(input("Enter amount", "New amount") as num)
+				n_amount = Clamp(n_amount, 0, 20)
+				if (!item_list[item_name] || !Adjacent(usr)) return
+				transaction_amount += (n_amount - item_list[item_name]) * price_list[item_name]
+				if(!n_amount)
+					item_list -= item_name
+					price_list -= item_name
+				else
+					item_list[item_name] = n_amount
+			if("subtract")
+				var/item_name = locate(href_list["item"])
+				if(item_name)
+					transaction_amount -= price_list[item_name]
+					item_list[item_name]--
+					if(item_list[item_name] <= 0)
+						item_list -= item_name
+						price_list -= item_name
+			if("add")
+				var/item_name = locate(href_list["item"])
+				if(item_list[item_name] >= 20) return
+				transaction_amount += price_list[item_name]
+				item_list[item_name]++
+			if("clear")
+				var/item_name = locate(href_list["item"])
+				if(item_name)
+					transaction_amount -= price_list[item_name] * item_list[item_name]
+					item_list -= item_name
+					price_list -= item_name
+				else
+					transaction_amount = 0
+					item_list.Cut()
+					price_list.Cut()
 			if("reset_log")
 				transaction_logs.Cut()
 				usr << "\icon[src]<span class='notice'>Transaction log reset.</span>"
@@ -333,24 +368,43 @@
 		transaction_purpose += "<br>"
 	transaction_purpose += "[O]: [price] Thaler\s"
 	transaction_amount += price
-	for(var/obj/previously_scanned in item_list)
-		if(O == previously_scanned || istype(O, previously_scanned.type))
+	for(var/previously_scanned in item_list)
+		if(price == price_list[previously_scanned] && O.name == previously_scanned)
 			. = item_list[previously_scanned]++
 	if(!.)
-		item_list[O] = 1
-		price_list += price
+		item_list[O.name] = 1
+		price_list[O.name] = price
 		. = 1
 	// Animation and sound
 	playsound(src, 'sound/machines/twobeep.ogg', 25)
 	// Reset confirmation
 	confirm_item = null
+	updateDialog()
+
+
+/obj/machinery/cash_register/proc/get_current_transaction()
+	var/dat = {"
+	<head><style>
+		.tx-title-r {text-align: center; background-color:#ffdddd; font-weight: bold}
+		.tx-name-r {background-color: #eebbbb}
+		.tx-data-r {text-align: right; background-color: #ffcccc;}
+	</head></style>
+	<table width=300>
+	<tr><td colspan="2" class="tx-title-r">New Entry</td></tr>
+	<tr></tr>"}
+	var/item_name
+	for(var/i=1, i<=item_list.len, i++)
+		item_name = item_list[i]
+		dat += "<tr><td class=\"tx-name-r\">[item_list[item_name] ? "<a href='?src=\ref[src];choice=subtract;item=\ref[item_name]'>-</a> <a href='?src=\ref[src];choice=set_amount;item=\ref[item_name]'>Set</a> <a href='?src=\ref[src];choice=add;item=\ref[item_name]'>+</a> [item_list[item_name]] x " : ""][item_name] <a href='?src=\ref[src];choice=clear;item=\ref[item_name]'>Remove</a></td><td class=\"tx-data-r\" width=50>[price_list[item_name] * item_list[item_name]] &thorn</td></tr>"
+	dat += "</table><table width=300>"
+	dat += "<tr><td class=\"tx-name-r\"><a href='?src=\ref[src];choice=clear'>Clear Entry</a></td><td class=\"tx-name-r\" style='text-align: right'><b>Total Amount: [transaction_amount] &thorn</b></td></tr>"
+	dat += "</table></html>"
+	return dat
 
 
 /obj/machinery/cash_register/proc/add_transaction_log(var/c_name, var/p_method, var/t_amount)
 	var/dat = {"
-	<!DOCTYPE html><html>
 	<head><style>
-		.tx-table {border: 1px solid black;}
 		.tx-title {text-align: center; background-color:#ddddff; font-weight: bold}
 		.tx-name {background-color: #bbbbee}
 		.tx-data {text-align: right; background-color: #ccccff;}
@@ -364,10 +418,10 @@
 	</table>
 	<table width=300>
 	"}
-	var/obj/O
+	var/item_name
 	for(var/i=1, i<=item_list.len, i++)
-		O = item_list[i]
-		dat += "<tr><td class=\"tx-name\">[item_list[O]] x [O.name]</td><td class=\"tx-data\" width=50>[price_list[i] * item_list[O]] &thorn</td></tr>"
+		item_name = item_list[i]
+		dat += "<tr><td class=\"tx-name\">[item_list[item_name] ? "[item_list[item_name]] x " : ""][item_name]</td><td class=\"tx-data\" width=50>[price_list[item_name] * item_list[item_name]] &thorn</td></tr>"
 	dat += "<tr></tr><tr><td colspan=\"2\" class=\"tx-name\" style='text-align: right'><b>Total Amount: [transaction_amount] &thorn</b></td></tr>"
 	dat += "</table></html>"
 

--- a/code/modules/economy/price_list.dm
+++ b/code/modules/economy/price_list.dm
@@ -18,6 +18,9 @@
 
 // Juices, soda and similar //
 
+/datum/reagent/water
+	price_tag = 2
+
 /datum/reagent/drink/juice
 	price_tag = 2
 
@@ -49,7 +52,6 @@
 	price_tag = 2
 
 
-
 // Hot Drinks //
 
 /datum/reagent/drink/rewriter
@@ -62,6 +64,15 @@
 	price_tag = 3
 
 /datum/reagent/drink/hot_coco
+	price_tag = 3
+
+/obj/item/weapon/reagent_containers/food/drinks/coffee
+	price_tag = 3
+
+/obj/item/weapon/reagent_containers/food/drinks/tea
+	price_tag = 3
+
+/obj/item/weapon/reagent_containers/food/drinks/h_chocolate
 	price_tag = 3
 
 
@@ -101,6 +112,15 @@
 	price_tag = 5
 
 /datum/reagent/ethanol/whiskey
+	price_tag = 5
+
+/datum/reagent/ethanol/specialwhiskey
+	price_tag = 5
+
+/datum/reagent/ethanol/patron
+	price_tag = 5
+
+/datum/reagent/ethanol/goldschlager
 	price_tag = 5
 
 /datum/reagent/ethanol/coffee/brave_bull // Not an original liquor in its own. But since it's a mix of purely Tequila
@@ -202,13 +222,10 @@
 /datum/reagent/ethanol/erikasurprise
 	price_tag = 4
 
-/datum/reagent/ethanol/gargleblaster
+/datum/reagent/ethanol/gargle_blaster
 	price_tag = 4
 
 /datum/reagent/ethanol/gintonic
-	price_tag = 4
-
-/datum/reagent/ethanol/goldschlager
 	price_tag = 4
 
 /datum/reagent/ethanol/hippies_delight
@@ -248,9 +265,6 @@
 	price_tag = 4
 
 /datum/reagent/ethanol/neurotoxin
-	price_tag = 4
-
-/datum/reagent/ethanol/patron
 	price_tag = 4
 
 /datum/reagent/ethanol/red_mead
@@ -301,9 +315,6 @@
 /datum/reagent/ethanol/whiskeysoda
 	price_tag = 4
 
-/datum/reagent/ethanol/specialwhiskey
-	price_tag = 4
-
 
 // Cocktails without alcohol //
 
@@ -339,9 +350,105 @@
 
 
 //***************//
-//---Foodstuff---//
+//----Bottles----//
 //***************//
 
+// Juices, soda and similar //
+
+/obj/item/weapon/reagent_containers/food/drinks/bottle/cola
+	price_tag = 6
+
+/obj/item/weapon/reagent_containers/food/drinks/bottle/space_up
+	price_tag = 6
+
+/obj/item/weapon/reagent_containers/food/drinks/bottle/space_mountain_wind
+	price_tag = 6
+
+/obj/item/weapon/reagent_containers/food/drinks/bottle/orangejuice
+	price_tag = 6
+
+/obj/item/weapon/reagent_containers/food/drinks/bottle/cream
+	price_tag = 6
+
+/obj/item/weapon/reagent_containers/food/drinks/bottle/tomatojuice
+	price_tag = 6
+
+/obj/item/weapon/reagent_containers/food/drinks/bottle/limejuice
+	price_tag = 6
+
+
+// Beer //
+
+/obj/item/weapon/reagent_containers/food/drinks/bottle/small/beer
+	price_tag = 3
+
+/obj/item/weapon/reagent_containers/food/drinks/bottle/small/ale
+	price_tag = 3
+
+
+// Spirituous Liquors //
+
+/obj/item/weapon/reagent_containers/food/drinks/bottle/absinthe
+	price_tag = 15
+
+/obj/item/weapon/reagent_containers/food/drinks/bottle/bluecuracao
+	price_tag = 15
+
+/obj/item/weapon/reagent_containers/food/drinks/bottle/gin
+	price_tag = 15
+
+/obj/item/weapon/reagent_containers/food/drinks/bottle/kahlua
+	price_tag = 15
+
+/obj/item/weapon/reagent_containers/food/drinks/bottle/melonliquor
+	price_tag = 15
+
+/obj/item/weapon/reagent_containers/food/drinks/bottle/rum
+	price_tag = 15
+
+/obj/item/weapon/reagent_containers/food/drinks/bottle/tequilla
+	price_tag = 15
+
+/obj/item/weapon/reagent_containers/food/drinks/bottle/vodka
+	price_tag = 15
+
+/obj/item/weapon/reagent_containers/food/drinks/bottle/whiskey
+	price_tag = 15
+
+/obj/item/weapon/reagent_containers/food/drinks/bottle/specialwhiskey
+	price_tag = 15
+
+/obj/item/weapon/reagent_containers/food/drinks/bottle/patron
+	price_tag = 15
+
+/obj/item/weapon/reagent_containers/food/drinks/bottle/goldschlager
+	price_tag = 15
+
+/obj/item/weapon/reagent_containers/food/drinks/bottle/bottleofnothing
+	price_tag = 15
+
+/obj/item/weapon/reagent_containers/food/drinks/bottle/grenadine
+	price_tag = 15
+
+
+// Wines //
+
+/obj/item/weapon/reagent_containers/food/drinks/bottle/wine
+	price_tag = 25
+
+/obj/item/weapon/reagent_containers/food/drinks/bottle/cognac
+	price_tag = 25
+
+/obj/item/weapon/reagent_containers/food/drinks/bottle/vermouth
+	price_tag = 25
+
+/obj/item/weapon/reagent_containers/food/drinks/bottle/pwine
+	price_tag = 25
+
+
+//***************//
+//---Foodstuff---//
+//***************//
 
 // Snacks //
 
@@ -812,3 +919,38 @@
 /obj/item/pizzabox
 	get_item_cost()
 		return get_item_cost(pizza)
+
+
+//***************//
+//----Smokes-----//
+//***************//
+
+/obj/item/weapon/storage/fancy/cigarettes
+	price_tag = 15
+
+/obj/item/weapon/storage/fancy/cigarettes/luckystars
+	price_tag = 17
+
+/obj/item/weapon/storage/fancy/cigarettes/jerichos
+	price_tag = 22
+
+/obj/item/weapon/storage/fancy/cigarettes/menthols
+	price_tag = 18
+
+/obj/item/weapon/storage/fancy/cigar
+	price_tag = 27
+
+/obj/item/weapon/storage/fancy/cigarettes/carcinomas
+	price_tag  = 23
+
+/obj/item/weapon/storage/fancy/cigarettes/professionals
+	price_tag = 25
+
+/obj/item/weapon/storage/box/matches
+	price_tag = 1
+
+/obj/item/weapon/flame/lighter
+	price_tag = 2
+
+/obj/item/weapon/flame/lighter/zippo
+	price_tag = 5


### PR DESCRIPTION
 - Fixed price path of Gargleblaster.
 - Added price for glass of water, booze-o-mat bottles and cigarette vendor items.
 - Purchasing a single item will not require a confirm swipe.
 - Amount of the same item type in transaction log is now tracked.
 - Current list of items in memory can be seen and edited on interface

![image](http://i.imgur.com/bQBLvZC.png)