### PR TITLE
Window Verb Fix

### DIFF
--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -334,6 +334,7 @@
 	//player-constructed windows
 	if (constructed)
 		anchored = 0
+		update_verbs()
 
 	if (start_dir)
 		set_dir(start_dir)


### PR DESCRIPTION
Windows constructed by players will now also immediately show the rotation verbs. Small derp, one-liner.