### PR TITLE
Traitor Borg lockdown, blowing-up fixed; can now self-hack.

### DIFF
--- a/code/_onclick/cyborg.dm
+++ b/code/_onclick/cyborg.dm
@@ -32,7 +32,7 @@
 		CtrlClickOn(A)
 		return
 
-	if(stat || lockcharge || weakened || stunned || paralysis)
+	if(stat || lockdown || weakened || stunned || paralysis)
 		return
 
 	if(!canClick())

--- a/code/datums/wires/robot.dm
+++ b/code/datums/wires/robot.dm
@@ -16,7 +16,7 @@ var/const/BORG_WIRE_CAMERA = 16
 	. += text("<br>\n[(R.lawupdate ? "The LawSync light is on." : "The LawSync light is off.")]")
 	. += text("<br>\n[(R.connected_ai ? "The AI link light is on." : "The AI link light is off.")]")
 	. += text("<br>\n[((!isnull(R.camera) && R.camera.status == 1) ? "The Camera light is on." : "The Camera light is off.")]")
-	. += text("<br>\n[(R.lockcharge ? "The lockdown light is on." : "The lockdown light is off.")]")
+	. += text("<br>\n[(R.lockdown ? "The lockdown light is on." : "The lockdown light is off.")]")
 	return .
 
 /datum/wires/robot/UpdateCut(var/index, var/mended)
@@ -64,7 +64,7 @@ var/const/BORG_WIRE_CAMERA = 16
 				R << "Your camera lense focuses loudly."
 
 		if(BORG_WIRE_LOCKED_DOWN)
-			R.SetLockdown(!R.lockcharge) // Toggle
+			R.SetLockdown(!R.lockdown) // Toggle
 
 /datum/wires/robot/CanUse(var/mob/living/L)
 	var/mob/living/silicon/robot/R = holder

--- a/code/game/machinery/computer/robot.dm
+++ b/code/game/machinery/computer/robot.dm
@@ -58,7 +58,7 @@
 			return
 
 		// Antagonistic cyborgs? Left here for downstream
-		if(target.mind.special_role || target.emagged)
+		if(target.mind && (target.mind.special_role || target.emagged))
 			target << "Extreme danger.  Termination codes detected.  Scrambling security codes and automatic AI unlink triggered."
 			target.ResetSecurityCodes()
 		else

--- a/code/game/machinery/computer/robot.dm
+++ b/code/game/machinery/computer/robot.dm
@@ -58,7 +58,7 @@
 			return
 
 		// Antagonistic cyborgs? Left here for downstream
-		if(target.mind && target.mind.special_role && target.emagged)
+		if(target.mind.special_role || target.emagged)
 			target << "Extreme danger.  Termination codes detected.  Scrambling security codes and automatic AI unlink triggered."
 			target.ResetSecurityCodes()
 		else
@@ -101,6 +101,7 @@
 		else
 			target.canmove = !target.canmove
 			target.lockcharge = !target.canmove //when canmove is 1, lockcharge should be 0
+			target.lockdown = !target.canmove
 			if (target.lockcharge)
 				target << "You have been locked down!"
 			else
@@ -115,8 +116,8 @@
 		if(!target || !istype(target))
 			return
 
-		// Antag AI checks
-		if(!istype(user, /mob/living/silicon/ai) || !(user.mind.special_role && user.mind.original == user))
+		// Antag synthetic checks
+		if(!istype(user, /mob/living/silicon) || !(user.mind.special_role && user.mind.original == user))
 			user << "Access Denied"
 			return
 
@@ -202,6 +203,10 @@
 		robot["module"] = R.module ? R.module.name : "None"
 		robot["master_ai"] = R.connected_ai ? R.connected_ai.name : "None"
 		robot["hackable"] = 0
+		//Antag synths should be able to hack themselves and see their hacked status.
+		if(operator && istype(operator, /mob/living/silicon) && (operator.mind.special_role && operator.mind.original == operator))
+			robot["hacked"] = R.emagged ? 1 : 0
+			robot["hackable"] = R.emagged? 0 : 1
 		// Antag AIs know whether linked cyborgs are hacked or not.
 		if(operator && istype(operator, /mob/living/silicon/ai) && (R.connected_ai == operator) && (operator.mind.special_role && operator.mind.original == operator))
 			robot["hacked"] = R.emagged ? 1 : 0

--- a/code/modules/mob/living/silicon/robot/life.dm
+++ b/code/modules/mob/living/silicon/robot/life.dm
@@ -336,7 +336,7 @@
 			weaponlock_time = 120
 
 /mob/living/silicon/robot/update_canmove()
-	if(paralysis || stunned || weakened || buckled || lockcharge || !is_component_functioning("actuator")) canmove = 0
+	if(paralysis || stunned || weakened || buckled || lockdown || !is_component_functioning("actuator")) canmove = 0
 	else canmove = 1
 	return canmove
 

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -81,7 +81,8 @@
 	var/weapon_lock = 0
 	var/weaponlock_time = 120
 	var/lawupdate = 1 //Cyborgs will sync their laws with their AI by default
-	var/lockcharge //Used when locking down a borg to preserve cell charge
+	var/lockcharge //Used when looking to see if a borg is locked down.
+	var/lockdown = 0 //Controls whether or not the borg is actually locked down.
 	var/speed = 0 //Cause sec borgs gotta go fast //No they dont!
 	var/scrambledcodes = 0 // Used to determine if a borg shows up on the robotics console.  Setting to one hides them.
 	var/tracking_entities = 0 //The number of known entities currently accessing the internal camera
@@ -864,6 +865,7 @@
 	disconnect_from_ai()
 	lawupdate = 0
 	lockcharge = 0
+	lockdown = 0
 	canmove = 1
 	scrambledcodes = 1
 	//Disconnect it's camera so it's not so easily tracked.
@@ -887,6 +889,7 @@
 	// They stay locked down if their wire is cut.
 	if(wires.LockedCut())
 		state = 1
+	lockdown = state
 	lockcharge = state
 	update_canmove()
 

--- a/code/modules/nano/interaction/base.dm
+++ b/code/modules/nano/interaction/base.dm
@@ -32,6 +32,6 @@
 	. = STATUS_INTERACTIVE
 	if(cell.charge <= 0)
 		return STATUS_CLOSE
-	if(lockcharge)
+	if(lockdown)
 		. = STATUS_DISABLED
 	return min(., ..())


### PR DESCRIPTION
Traitorborgs were supposed to not be lockable, but canmove was updated based on lockcharge. A separate variable was created so that borgs can appear to be locked down on the console.
Traitorborgs that were emagged were not supposed to be exploded when the button was pressed, changed to traitorborgs or emagged.

Traitorborgs can also now hack themselves.