### PR TITLE
Fixes chemical explosions

### DIFF
--- a/code/game/objects/effects/effect_system.dm
+++ b/code/game/objects/effects/effect_system.dm
@@ -513,16 +513,3 @@ steam.start() -- spawns the effect
 				round(min(light, BOMBCAP_LIGHT_RADIUS)), 
 				round(min(flash, BOMBCAP_FLASH_RADIUS))
 				)
-
-	proc/holder_damage(var/atom/holder)
-		if(holder)
-			var/dmglevel = 4
-
-			if (round(amount/8) > 0)
-				dmglevel = 1
-			else if (round(amount/4) > 0)
-				dmglevel = 2
-			else if (round(amount/2) > 0)
-				dmglevel = 3
-
-			if(dmglevel<4) holder.ex_act(dmglevel)

--- a/code/game/objects/items/weapons/grenades/chem_grenade.dm
+++ b/code/game/objects/items/weapons/grenades/chem_grenade.dm
@@ -17,9 +17,7 @@
 	var/affected_area = 3
 
 	New()
-		var/datum/reagents/R = new/datum/reagents(1000)
-		reagents = R
-		R.my_atom = src
+		create_reagents(1000)
 
 	attack_self(mob/user as mob)
 		if(!stage || stage==1)

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -397,7 +397,7 @@
 	R.touch_turf(target)
 	return
 
-/datum/reagents/proc/trans_to_obj(var/turf/target, var/amount = 1, var/multiplier = 1, var/copy = 0) // Objects may or may not; if they do, it's probably a beaker or something and we need to transfer properly; otherwise, just touch.
+/datum/reagents/proc/trans_to_obj(var/obj/target, var/amount = 1, var/multiplier = 1, var/copy = 0) // Objects may or may not; if they do, it's probably a beaker or something and we need to transfer properly; otherwise, just touch.
 	if(!target)
 		return
 

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -594,7 +594,6 @@
 /datum/chemical_reaction/explosion_potassium/on_reaction(var/datum/reagents/holder, var/created_volume)
 	var/datum/effect/effect/system/reagents_explosion/e = new()
 	e.set_up(round (created_volume/10, 1), holder.my_atom, 0, 0)
-	e.holder_damage(holder.my_atom)
 	if(isliving(holder.my_atom))
 		e.amount *= 0.5
 		var/mob/living/L = holder.my_atom
@@ -660,7 +659,6 @@
 /datum/chemical_reaction/nitroglycerin/on_reaction(var/datum/reagents/holder, var/created_volume)
 	var/datum/effect/effect/system/reagents_explosion/e = new()
 	e.set_up(round (created_volume/2, 1), holder.my_atom, 0, 0)
-	e.holder_damage(holder.my_atom)
 	if(isliving(holder.my_atom))
 		e.amount *= 0.5
 		var/mob/living/L = holder.my_atom

--- a/html/changelogs/Kelenius-plzExplode.yml
+++ b/html/changelogs/Kelenius-plzExplode.yml
@@ -1,0 +1,6 @@
+author: Kelenius
+
+delete-after: True
+
+changes: 
+  - bugfix: "Potassium and nitroglycerin explosive grenades now work."


### PR DESCRIPTION
And a typo fix in ``trans_to_obj`` that didn't cause any issues but was bad.
tl;dr: ``holder_damage`` triggered ``ex_act`` on holder, deleting it if it was a beaker or a grenade, leading to runtimes, leading to proc stopping, leading to no explosion happening.
Fixes #720
Fixes #870

All it takes for a coder to fix a bug is to be personally affected by it!