### PR TITLE
A large amount of changeling changes.

### DIFF
--- a/code/game/antagonist/station/changeling.dm
+++ b/code/game/antagonist/station/changeling.dm
@@ -73,4 +73,14 @@
 					if(player.current.client.prefs.organ_data["torso"] == "cyborg") // Full synthetic.
 						return 0
 					return 1
- 	return 0
+	return 0
+
+/datum/antagonist/changeling/print_player_full(var/datum/mind/ply)
+	var/text = print_player_lite(ply)
+
+	if(ply.changeling)
+		var/datum/changeling/ling_datum = ply.changeling
+		text += " (had [ling_datum.max_geneticpoints] genomes)"
+		text += "<br>Bought [english_list(ling_datum.purchased_powers_history)]."
+
+	return text

--- a/code/game/gamemodes/changeling/changeling_powers.dm
+++ b/code/game/gamemodes/changeling/changeling_powers.dm
@@ -14,11 +14,12 @@ var/global/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","E
 	var/isabsorbing = 0
 	var/geneticpoints = 5
 	var/max_geneticpoints = 5
-	var/purchasedpowers = list()
+	var/list/purchased_powers = list()
 	var/mimicing = ""
 	var/cloaked = 0
 	var/armor_deployed = 0 //This is only used for changeling_generic_equip_all_slots() at the moment.
 	var/recursive_enhancement = 0 //Used to power up other abilities from the ling power with the same name.
+	var/list/purchased_powers_history = list() //Used for round-end report, includes respec uses too.
 
 /datum/changeling/New(var/gender=FEMALE)
 	..()
@@ -60,10 +61,10 @@ var/global/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","E
 	// Code to auto-purchase free powers.
 	for(var/datum/power/changeling/P in powerinstances)
 		if(!P.genomecost) // Is it free?
-			if(!(P in mind.changeling.purchasedpowers)) // Do we not have it already?
+			if(!(P in mind.changeling.purchased_powers)) // Do we not have it already?
 				mind.changeling.purchasePower(mind, P.name, 0)// Purchase it. Don't remake our verbs, we're doing it after this.
 
-	for(var/datum/power/changeling/P in mind.changeling.purchasedpowers)
+	for(var/datum/power/changeling/P in mind.changeling.purchased_powers)
 		if(P.isVerb)
 			if(lesser_form && !P.allowduringlesserform)	continue
 			if(!(P in src.verbs))
@@ -83,7 +84,7 @@ var/global/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","E
 //removes our changeling verbs
 /mob/proc/remove_changeling_powers()
 	if(!mind || !mind.changeling)	return
-	for(var/datum/power/changeling/P in mind.changeling.purchasedpowers)
+	for(var/datum/power/changeling/P in mind.changeling.purchased_powers)
 		if(P.isVerb)
 			verbs -= P.verbpath
 

--- a/code/game/gamemodes/changeling/modularchangling.dm
+++ b/code/game/gamemodes/changeling/modularchangling.dm
@@ -249,7 +249,7 @@ var/list/datum/power/changeling/powerinstances = list()
 	for(var/datum/power/changeling/P in powerinstances)
 		var/ownsthis = 0
 
-		if(P in purchasedpowers)
+		if(P in purchased_powers)
 			ownsthis = 1
 
 
@@ -324,7 +324,7 @@ var/list/datum/power/changeling/powerinstances = list()
 		M.current << "This is awkward.  Changeling power purchase failed, please report this bug to a coder!"
 		return
 
-	if(Thepower in purchasedpowers)
+	if(Thepower in purchased_powers)
 		M.current << "We have already evolved this ability!"
 		return
 
@@ -335,7 +335,10 @@ var/list/datum/power/changeling/powerinstances = list()
 
 	geneticpoints -= Thepower.genomecost
 
-	purchasedpowers += Thepower
+	purchased_powers += Thepower
+
+	if(Thepower.genomecost > 0)
+		purchased_powers_history.Add("[Pname] ([Thepower.genomecost] points)")
 
 	if(!Thepower.isVerb && Thepower.verbpath)
 		call(M.current, Thepower.verbpath)()

--- a/code/game/gamemodes/changeling/powers/absorb.dm
+++ b/code/game/gamemodes/changeling/powers/absorb.dm
@@ -1,10 +1,10 @@
 /datum/power/changeling/absorb_dna
 	name = "Absorb DNA"
-	desc = "Permits us to syphon the DNA from a human. They become one with us, and we become stronger."
+	desc = "Permits us to syphon the DNA from a human. They become one with us, and we become stronger if they were of our kind."
 	genomecost = 0
 	verbpath = /mob/proc/changeling_absorb_dna
 
-//Absorbs the victim's DNA making them uncloneable. Requires a strong grip on the victim.
+//Absorbs the victim's DNA. Requires a strong grip on the victim.
 //Doesn't cost anything as it's the most basic ability.
 /mob/proc/changeling_absorb_dna()
 	set category = "Changeling"
@@ -27,9 +27,10 @@
 		src << "<span class='warning'>We do not know how to parse this creature's DNA!</span>"
 		return
 
-	if(HUSK in T.mutations)
-		src << "<span class='warning'>This creature's DNA is ruined beyond useability!</span>"
-		return
+	if(HUSK in T.mutations) //Lings can always absorb other lings, unless someone beat them to it first.
+		if(!T.mind.changeling || T.mind.changeling && T.mind.changeling.geneticpoints < 0)
+			src << "<span class='warning'>This creature's DNA is ruined beyond useability!</span>"
+			return
 
 	if(G.state != GRAB_KILL)
 		src << "<span class='warning'>We must have a tighter grip to absorb this creature.</span>"

--- a/code/game/gamemodes/changeling/powers/armblade.dm
+++ b/code/game/gamemodes/changeling/powers/armblade.dm
@@ -2,6 +2,7 @@
 	name = "Arm Blade"
 	desc = "We reform one of our arms into a deadly blade."
 	helptext = "We may retract our armblade by dropping it.  It can deflect projectiles."
+	enhancedtext = "The blade will have armor peneratration."
 	genomecost = 2
 	verbpath = /mob/proc/changeling_arm_blade
 
@@ -10,9 +11,16 @@
 	set category = "Changeling"
 	set name = "Arm Blade (20)"
 
-	if(changeling_generic_weapon(/obj/item/weapon/melee/arm_blade))
-		return 1
-	return 0
+	if(src.mind.changeling.recursive_enhancement)
+		if(changeling_generic_weapon(/obj/item/weapon/melee/arm_blade/greater))
+			src << "<span class='notice'>We prepare an extra sharp blade.</span>"
+			src.mind.changeling.recursive_enhancement = 0
+			return 1
+
+	else
+		if(changeling_generic_weapon(/obj/item/weapon/melee/arm_blade))
+			return 1
+		return 0
 
 /obj/item/weapon/melee/arm_blade
 	name = "arm blade"
@@ -30,6 +38,11 @@
 	throw_speed = 0
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
 	var/mob/living/creator //This is just like ninja swords, needed to make sure dumb shit that removes the sword doesn't make it stay around.
+
+/obj/item/weapon/melee/arm_blade/greater
+	name = "arm greatblade"
+	desc = "A grotesque blade made out of bone and flesh that cleaves through people and armor as a hot knife through butter."
+	armor_penetration = 30
 
 /obj/item/weapon/melee/arm_blade/New(location)
 	..()

--- a/code/game/gamemodes/changeling/powers/bioelectrogenesis.dm
+++ b/code/game/gamemodes/changeling/powers/bioelectrogenesis.dm
@@ -4,6 +4,7 @@
 	On demand, we can attempt to recharge anything in our active hand, or we can touch someone with an electrified hand, shocking them."
 	helptext = "We can shock someone by grabbing them and using this ability, or using the ability with an empty hand and touching them.  \
 	Shocking someone costs ten chemicals per use."
+	enhancedtext = "Shocking biologicals without grabbing only requires five chemicals, and has more disabling power."
 	genomecost = 2
 	verbpath = /mob/proc/changeling_bioelectrogenesis
 
@@ -21,8 +22,14 @@
 		return 0
 
 	if(held_item == null)
-		if(changeling_generic_weapon(/obj/item/weapon/electric_hand,0))  //Chemical cost is handled in the equip proc.
-			return 1
+		if(src.mind.changeling.recursive_enhancement)
+			if(changeling_generic_weapon(/obj/item/weapon/electric_hand/efficent))
+				src << "<span class='notice'>We will shock others more efficently.</span>"
+				src.mind.changeling.recursive_enhancement = 0
+				return 1
+		else
+			if(changeling_generic_weapon(/obj/item/weapon/electric_hand,0))  //Chemical cost is handled in the equip proc.
+				return 1
 		return 0
 
 	else
@@ -30,12 +37,11 @@
 		if(istype(held_item,/obj/item/weapon/grab))
 			var/obj/item/weapon/grab/G = held_item
 			if(G.affecting)
-				G.affecting.electrocute_act(5,src,1.0,BP_TORSO)
-				var/agony = 60 //The same as a stunbaton.
-				var/stun = 0
-				G.affecting.stun_effect_act(stun, agony, BP_TORSO, src)
+				G.affecting.electrocute_act(10,src,1.0,BP_TORSO)
+				var/agony = 80 //Does more than if hit with an electric hand, since grabbing is slower.
+				G.affecting.stun_effect_act(0, agony, BP_TORSO, src)
 
-				msg_admin_attack("[key_name(src)] stunned [key_name(G.affecting)] with the [src].")
+				msg_admin_attack("[key_name(src)] shocked [key_name(G.affecting)] with the [src].")
 
 				visible_message("<span class='warning'>Arcs of electricity strike [G.affecting]!</span>",
 				"<span class='warning'>Our hand channels raw electricity into [G.affecting].</span>",
@@ -72,7 +78,7 @@
 					new /obj/effect/effect/sparks(T)
 					held_item.update_icon()
 					i--
-					sleep(10)
+					sleep(1 SECOND)
 				success = 1
 			if(success == 0) //If we couldn't do anything with the ability, don't deduct the chemicals.
 				src << "<span class='warning'>We are unable to affect \the [held_item].</span>"
@@ -85,6 +91,14 @@
 	desc = "You could probably shock someone badly if you touched them, or recharge something."
 	icon = 'icons/obj/weapons.dmi'
 	icon_state = "electric_hand"
+	var/shock_cost = 10
+	var/agony_amount = 60
+	var/electrocute_amount = 10
+
+/obj/item/weapon/electric_hand/efficent
+	shock_cost = 5
+	agony_amount = 80
+	electrocute_amount = 20
 
 /obj/item/weapon/electric_hand/New()
 	if(ismob(loc))
@@ -108,22 +122,20 @@
 	if(istype(target,/mob/living/carbon))
 		var/mob/living/carbon/C = target
 
-		if(user.mind.changeling.chem_charges < 10)
+		if(user.mind.changeling.chem_charges < shock_cost)
 			src << "<span class='warning'>We require more chemicals to electrocute [C]!</span>"
 			return 0
 
-		C.electrocute_act(5,src,1.0,BP_TORSO)
-		var/agony = 60 //The same as a stunbaton.
-		var/stun = 0
-		C.stun_effect_act(stun, agony, BP_TORSO, src)
+		C.electrocute_act(electrocute_amount,src,1.0,BP_TORSO)
+		C.stun_effect_act(0, agony_amount, BP_TORSO, src)
 
-		msg_admin_attack("[key_name(user)] stunned [key_name(C)] with the [src].")
+		msg_admin_attack("[key_name(user)] shocked [key_name(C)] with the [src].")
 
 		visible_message("<span class='warning'>Arcs of electricity strike [C]!</span>",
 		"<span class='warning'>Our hand channels raw electricity into [C]</span>",
 		"<span class='italics'>You hear sparks!</span>")
 		//qdel(src)  //Since we're no longer a one hit stun, we need to stick around.
-		user.mind.changeling.chem_charges -= 10
+		user.mind.changeling.chem_charges -= shock_cost
 		return 1
 
 	else if(istype(target,/mob/living/silicon))
@@ -163,7 +175,7 @@
 					new /obj/effect/effect/sparks(Turf)
 					T.update_icon()
 					i--
-					sleep(10)
+					sleep(1 SECOND)
 				success = 1
 				break
 			if(success == 0)

--- a/code/game/gamemodes/changeling/powers/cryo_sting.dm
+++ b/code/game/gamemodes/changeling/powers/cryo_sting.dm
@@ -1,7 +1,8 @@
 /datum/power/changeling/cryo_sting
 	name = "Cryogenic Sting"
 	desc = "We silently sting a biological with a cocktail of chemicals that freeze them."
-	helptext = "Does not provide a warning to the victim, though they will likely realize they are suddenly freezing."
+	helptext = "Does not provide a warning to the victim, though they will likely realize they are suddenly freezing.  Has \
+	a three minute cooldown between uses."
 	enhancedtext = "Increases the amount of chemicals injected."
 	genomecost = 1
 	verbpath = /mob/proc/changeling_cryo_sting

--- a/code/game/gamemodes/changeling/powers/delayed_toxin_sting.dm
+++ b/code/game/gamemodes/changeling/powers/delayed_toxin_sting.dm
@@ -1,7 +1,8 @@
 /datum/power/changeling/delayed_toxic_sting
 	name = "Delayed Toxic Sting"
-	desc = "We silently sting a biological, causing a significant amount of toxins after a few minutes, allowing us to not implicate ourselves."
-	helptext = "The toxin takes effect in about two minutes."
+	desc = "We silently sting a biological, causing a significant amount of toxins after a few minutes, allowing us to not \
+	implicate ourselves."
+	helptext = "The toxin takes effect in about two minutes.  The sting has a three minute cooldown between uses."
 	enhancedtext = "The toxic damage is doubled."
 	genomecost = 1
 	verbpath = /mob/proc/changeling_delayed_toxic_sting
@@ -25,7 +26,7 @@
 			while(i)
 				T.adjustToxLoss(1)
 				i--
-				sleep(20)
+				sleep(2 SECONDS)
 	src.verbs -= /mob/proc/changeling_delayed_toxic_sting
 	spawn(3 MINUTES)
 		src << "<span class='notice'>We are ready to use our delayed toxic string once more.</span>"

--- a/code/game/gamemodes/changeling/powers/electric_lockpick.dm
+++ b/code/game/gamemodes/changeling/powers/electric_lockpick.dm
@@ -78,6 +78,7 @@
 		else //Probably broken or no power.
 			user << "<span class='warning'>The door does not respond to the pulse.</span>"
 		door.add_fingerprint(user)
+		log_and_message_admins("finger-lockpicked \an [door].")
 		ling_datum.chem_charges -= 10
 		return 1
 
@@ -86,7 +87,7 @@
 		user << "<span class='notice'>We send an electrical pulse up our finger, and into \the [O].</span>"
 		O.add_fingerprint(user)
 		O.emag_act(1,user,src)
-		log_and_message_admins("emagged \an [O].")
+		log_and_message_admins("finger-lockpicked \an [O].")
 		ling_datum.chem_charges -= 10
 
 		return 1

--- a/code/game/gamemodes/changeling/powers/endoarmor.dm
+++ b/code/game/gamemodes/changeling/powers/endoarmor.dm
@@ -1,7 +1,7 @@
 /datum/power/changeling/endoarmor
 	name = "Endoarmor"
 	desc = "We grow hard plating underneath our skin, making us more resilient to harm by increasing our maximum health potential by 50 points."
-	helptext = "Our maximum health is increased to 150 health."
+	helptext = "Our maximum health is increased by 50 points."
 	genomecost = 1
 	isVerb = 0
 	verbpath = /mob/proc/changeling_endoarmor

--- a/code/game/gamemodes/changeling/powers/enfeebling_string.dm
+++ b/code/game/gamemodes/changeling/powers/enfeebling_string.dm
@@ -1,7 +1,8 @@
 /datum/power/changeling/enfeebling_string
 	name = "Enfeebling String"
 	desc = "We sting a biological with a potent toxin that will greatly weaken them for a short period of time."
-	helptext = "Lowers the maximum health of the victim for a few minutes.  This sting will also warn them of this."
+	helptext = "Lowers the maximum health of the victim for a few minutes.  This sting will also warn them of this.  Has a \
+	five minute coodown between uses."
 	enhancedtext = "Maximum health is lowered further."
 	genomecost = 1
 	verbpath = /mob/proc/changeling_enfeebling_string
@@ -17,17 +18,21 @@
 	if(ishuman(T))
 		var/mob/living/carbon/human/H = T
 
-		var/effect = 30
+		var/effect = 30 //percent
 		if(src.mind.changeling.recursive_enhancement)
 			effect = effect + 20
 			src << "<span class='notice'>We make them extremely weak.</span>"
 			src.mind.changeling.recursive_enhancement = 0
+		var/health_to_take_away = H.maxHealth * (effect / 100)
 
-		H.maxHealth -= effect
-		H << "<span class='danger'>You feel a small prick and you feel weak.</span>"
-		spawn(300) //Five minutes
+		H.maxHealth -= health_to_take_away
+		H << "<span class='danger'>You feel a small prick and you feel extremly weak!</span>"
+		src.verbs -= /mob/proc/changeling_enfeebling_string
+		spawn(5 MINUTES)
+			src.verbs |= /mob/proc/changeling_enfeebling_string
+			src << "<span class='notice'>Our enfeebling string is ready to be used once more.</span>"
 			if(H) //Just incase we stop existing in five minutes for whatever reason.
-				H.maxHealth += 30
+				H.maxHealth += health_to_take_away
 				if(!H.stat) //It'd be weird to no longer feel weak when you're dead.
 					H << "<span class='notice'>You no longer feel extremly weak.</span>"
 	feedback_add_details("changeling_powers","ES")

--- a/code/game/gamemodes/changeling/powers/fleshmend.dm
+++ b/code/game/gamemodes/changeling/powers/fleshmend.dm
@@ -31,10 +31,10 @@
 				C.adjustBruteLoss(-heal_amount)
 				C.adjustOxyLoss(-heal_amount)
 				C.adjustFireLoss(-heal_amount)
-				sleep(10)
+				sleep(1 SECOND)
 
 	src.verbs -= /mob/proc/changeling_fleshmend
-	spawn(500)
+	spawn(50 SECONDS)
 		src << "<span class='notice'>Our regeneration has slowed to normal levels.</span>"
 		src.verbs += /mob/proc/changeling_fleshmend
 	feedback_add_details("changeling_powers","FM")

--- a/code/game/gamemodes/changeling/powers/respec.dm
+++ b/code/game/gamemodes/changeling/powers/respec.dm
@@ -9,7 +9,7 @@
 
 	src.remove_changeling_powers() //First, remove the verbs.
 	var/datum/changeling/ling_datum = src.mind.changeling
-	ling_datum.purchasedpowers = list() //Then wipe all the powers we bought.
+	ling_datum.purchased_powers = list() //Then wipe all the powers we bought.
 	ling_datum.geneticpoints = ling_datum.max_geneticpoints //Now refund our points to the maximum.
 	ling_datum.chem_recharge_rate = 0.5 //If glands were bought, revert that upgrade.
 	ling_datum.chem_storage = 50
@@ -20,6 +20,8 @@
 	src.make_changeling() //And give back our freebies.
 
 	src << "<span class='notice'>We have removed our evolutions from this form, and are now ready to readapt.</span>"
+
+	ling_datum.purchased_powers_history.Add("Re-adapt (Reset to [ling_datum.max_geneticpoints])")
 
 	//Now to lose the verb, so no unlimited resets.
 	src.verbs -= /mob/proc/changeling_respec

--- a/code/game/gamemodes/changeling/powers/revive.dm
+++ b/code/game/gamemodes/changeling/powers/revive.dm
@@ -33,10 +33,13 @@
 	if(ishuman(C))
 		var/mob/living/carbon/human/H = src
 		H.restore_blood()
+		H.mutations.Remove(HUSK)
+		H.status_flags -= DISFIGURED
+		H.update_body(1)
 	C << "<span class='notice'>We have regenerated.</span>"
 	C.status_flags &= ~(FAKEDEATH)
 	C.update_canmove()
-	C.mind.changeling.purchasedpowers -= C
+	C.mind.changeling.purchased_powers -= C
 	feedback_add_details("changeling_powers","CR")
 	C.stat = CONSCIOUS
 	src.verbs -= /mob/proc/changeling_revive

--- a/code/game/gamemodes/changeling/powers/transform.dm
+++ b/code/game/gamemodes/changeling/powers/transform.dm
@@ -37,6 +37,8 @@
 	if(ishuman(src))
 		var/mob/living/carbon/human/H = src
 		H.b_type = "AB+" //For some reason we have two blood types on the mob.
+		for(var/flavor in H.flavor_texts) //Nulls out flavor text, so we don't keep our previous mob's flavor.
+			flavor = null
 	src.real_name = chosen_dna.real_name
 	src.flavor_text = ""
 	src.UpdateAppearance()


### PR DESCRIPTION
Round-end report now displays a history of powers the changeling had bought for that round, including resets.
Renames purchasedpowers to purchased_powers because I like my underscores.
Changelings can always be absorbed by other changelings if the body is husked and wasn't already absorbed.
Reviving clears the husked status, fixing an exploit where a ling could be husked and alive, and be unabsorbable.
A stronger variant of the armblade is available if one also buys recursive enhancement (totaling 5 points).  The stronger variant has 30 armor pen, but no additional effects.
A stronger varient of the electric hand is available for those who buy recursive enhancement, which does more halloss and costs less chemicals to channel electricity, also costing 5 points.
Normal electric hand made a little stronger when using it by grabbing someone, since grabbing is harder.
Cryosting description now says it has a cooldown.
Delayed toxin sting also now says it has a cooldown.
Changes log produced when using finger-lockpick.
Endoarmor description made slightly more accurate, for those which may not have a base health of 100.
Enfeebling string now reduces a person's health by a percentage, so teshari are not instantly killed by a recursive enhanced version of it.  Enfeebling sting now has a 5 minute cooldown as well.
Replaces some sleep numbers with X SECONDS/SECOND to make it more clear how long it is.
Transforming will wipe your flavor text, instead of keeping your previous identity's flavor text.

Half-fixes #969