### PR TITLE
Mob inventory cleanup

### DIFF
--- a/code/ZAS/Fire.dm
+++ b/code/ZAS/Fire.dm
@@ -406,7 +406,7 @@ datum/gas_mixture/proc/check_recombustability(list/fuel_objs)
 	//Get heat transfer coefficients for clothing.
 
 	for(var/obj/item/clothing/C in src)
-		if(l_hand == C || r_hand == C)
+		if(item_is_in_hands(C))
 			continue
 
 		if( C.max_heat_protection_temperature >= last_temperature )

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -94,10 +94,7 @@
 
 	if(W == A) // Handle attack_self
 		W.attack_self(src)
-		if(hand)
-			update_inv_l_hand(0)
-		else
-			update_inv_r_hand(0)
+		update_inv_active_hand(0)
 		return 1
 
 	//Atoms on your person

--- a/code/_onclick/hud/human.dm
+++ b/code/_onclick/hud/human.dm
@@ -162,7 +162,7 @@
 		inv_box.name = "r_hand"
 		inv_box.icon = ui_style
 		inv_box.icon_state = "r_hand_inactive"
-		if(mymob && !mymob.hand)	//This being 0 or null means the right hand is in use
+		if(!target.hand)	//This being 0 or null means the right hand is in use
 			inv_box.icon_state = "r_hand_active"
 		inv_box.screen_loc = ui_rhand
 		inv_box.slot_id = slot_r_hand
@@ -177,7 +177,7 @@
 		inv_box.name = "l_hand"
 		inv_box.icon = ui_style
 		inv_box.icon_state = "l_hand_inactive"
-		if(mymob && mymob.hand)	//This being 1 means the left hand is in use
+		if(target.hand)	//This being 1 means the left hand is in use
 			inv_box.icon_state = "l_hand_active"
 		inv_box.screen_loc = ui_lhand
 		inv_box.slot_id = slot_l_hand

--- a/code/game/antagonist/antagonist_create.dm
+++ b/code/game/antagonist/antagonist_create.dm
@@ -76,7 +76,7 @@
 			P.info = "The nuclear authorization code is: <b>[code]</b>"
 			P.name = "nuclear bomb code"
 			if(leader && leader.current)
-				if(get_turf(P) == get_turf(leader.current) && !(leader.current.l_hand && leader.current.r_hand))
+				if(get_turf(P) == get_turf(leader.current))
 					leader.current.put_in_hands(P)
 
 		if(!code_owner && leader)

--- a/code/game/antagonist/station/renegade.dm
+++ b/code/game/antagonist/station/renegade.dm
@@ -50,8 +50,7 @@ var/datum/antagonist/renegade/renegades
 
 	var/gun_type = pick(spawn_guns)
 	var/obj/item/gun = new gun_type(get_turf(player))
-	if(!(player.l_hand && player.r_hand))
-		player.put_in_hands(gun)
+	player.put_in_hands(gun)
 
 
 /proc/rightandwrong()

--- a/code/game/gamemodes/changeling/generic_equip_procs.dm
+++ b/code/game/gamemodes/changeling/generic_equip_procs.dm
@@ -244,7 +244,7 @@
 
 	var/mob/living/carbon/human/M = src
 
-	if(M.l_hand && M.r_hand) //Make sure our hands aren't full.
+	if(M.hands_are_full()) //Make sure our hands aren't full.
 		src << "<span class='warning'>Our hands are full.  Drop something first.</span>"
 		return 0
 

--- a/code/game/gamemodes/changeling/powers/armblade.dm
+++ b/code/game/gamemodes/changeling/powers/armblade.dm
@@ -55,7 +55,7 @@
 	..()
 
 /obj/item/weapon/melee/arm_blade/process()  //Stolen from ninja swords.
-	if(!creator || loc != creator || (creator.l_hand != src && creator.r_hand != src))
+	if(!creator || loc != creator || !creator.item_is_in_hands(src))
 		// Tidy up a bit.
 		if(istype(loc,/mob/living))
 			var/mob/living/carbon/human/host = loc

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -73,13 +73,10 @@
 
 /obj/item/equipped()
 	..()
-	var/mob/M = loc
+	var/mob/living/M = loc
 	if(!istype(M))
 		return
-	if(M.l_hand)
-		M.l_hand.update_held_icon()
-	if(M.r_hand)
-		M.r_hand.update_held_icon()
+	M.update_held_icons()
 
 /obj/item/Destroy()
 	if(ismob(loc))
@@ -95,8 +92,8 @@
 
 //Checks if the item is being held by a mob, and if so, updates the held icons
 /obj/item/proc/update_held_icon()
-	if(ismob(src.loc))
-		var/mob/M = src.loc
+	if(isliving(src.loc))
+		var/mob/living/M = src.loc
 		if(M.l_hand == src)
 			M.update_inv_l_hand()
 		else if(M.r_hand == src)
@@ -157,7 +154,7 @@
 			size = "huge"
 	return ..(user, distance, "", "It is a [size] item.")
 
-/obj/item/attack_hand(mob/user as mob)
+/obj/item/attack_hand(mob/living/user as mob)
 	if (!user) return
 	if (hasorgans(user))
 		var/mob/living/carbon/human/H = user
@@ -396,17 +393,15 @@ var/list/global/slot_flags_enumeration = list(
 	if((!istype(usr, /mob/living/carbon)) || (istype(usr, /mob/living/carbon/brain)))//Is humanoid, and is not a brain
 		usr << "<span class='warning'>You can't pick things up!</span>"
 		return
+	var/mob/living/carbon/C = usr
 	if( usr.stat || usr.restrained() )//Is not asleep/dead and is not restrained
 		usr << "<span class='warning'>You can't pick things up!</span>"
 		return
 	if(src.anchored) //Object isn't anchored
 		usr << "<span class='warning'>You can't pick that up!</span>"
 		return
-	if(!usr.hand && usr.r_hand) //Right hand is not full
-		usr << "<span class='warning'>Your right hand is full.</span>"
-		return
-	if(usr.hand && usr.l_hand) //Left hand is not full
-		usr << "<span class='warning'>Your left hand is full.</span>"
+	if(C.get_active_hand()) //Hand is not full
+		usr << "<span class='warning'>Your hand is full.</span>"
 		return
 	if(!istype(src.loc, /turf)) //Object is on a turf
 		usr << "<span class='warning'>You can't pick that up!</span>"

--- a/code/game/objects/items/devices/radio/electropack.dm
+++ b/code/game/objects/items/devices/radio/electropack.dm
@@ -12,7 +12,7 @@
 
 	var/code = 2
 
-/obj/item/device/radio/electropack/attack_hand(mob/user as mob)
+/obj/item/device/radio/electropack/attack_hand(mob/living/user as mob)
 	if(src == user.back)
 		user << "<span class='notice'>You need help taking this off!</span>"
 		return

--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -209,7 +209,7 @@
 	amount = 5
 	max_amount = 5
 
-/obj/item/stack/medical/splint/attack(mob/living/carbon/M as mob, mob/user as mob)
+/obj/item/stack/medical/splint/attack(mob/living/carbon/M as mob, mob/living/user as mob)
 	if(..())
 		return 1
 

--- a/code/game/objects/items/weapons/autopsy.dm
+++ b/code/game/objects/items/weapons/autopsy.dm
@@ -160,20 +160,7 @@
 	P.icon_state = "paper_words"
 
 	if(istype(usr,/mob/living/carbon))
-		// place the item in the usr's hand if possible
-		if(!usr.r_hand)
-			P.loc = usr
-			usr.r_hand = P
-			P.layer = 20
-		else if(!usr.l_hand)
-			P.loc = usr
-			usr.l_hand = P
-			P.layer = 20
-
-	if (ismob(src.loc))
-		var/mob/M = src.loc
-		M.update_inv_l_hand()
-		M.update_inv_r_hand()
+		usr.put_in_hands(src)
 
 /obj/item/weapon/autopsy_scanner/attack(mob/living/carbon/human/M as mob, mob/living/carbon/user as mob)
 	if(!istype(M))

--- a/code/game/objects/items/weapons/cigs_lighters.dm
+++ b/code/game/objects/items/weapons/cigs_lighters.dm
@@ -445,39 +445,36 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 /obj/item/weapon/flame/lighter/attack_self(mob/living/user)
 	if(!base_state)
 		base_state = icon_state
-	if(user.r_hand == src || user.l_hand == src)
-		if(!lit)
-			lit = 1
-			icon_state = "[base_state]on"
-			item_state = "[base_state]on"
-			if(istype(src, /obj/item/weapon/flame/lighter/zippo) )
-				user.visible_message("<span class='rose'>Without even breaking stride, [user] flips open and lights [src] in one smooth movement.</span>")
-			else
-				if(prob(95))
-					user.visible_message("<span class='notice'>After a few attempts, [user] manages to light the [src].</span>")
-				else
-					user << "<span class='warning'>You burn yourself while lighting the lighter.</span>"
-					if (user.l_hand == src)
-						user.apply_damage(2,BURN,"l_hand")
-					else
-						user.apply_damage(2,BURN,"r_hand")
-					user.visible_message("<span class='notice'>After a few attempts, [user] manages to light the [src], they however burn their finger in the process.</span>")
-
-			set_light(2)
-			processing_objects.Add(src)
+	if(!lit)
+		lit = 1
+		icon_state = "[base_state]on"
+		item_state = "[base_state]on"
+		if(istype(src, /obj/item/weapon/flame/lighter/zippo) )
+			user.visible_message("<span class='rose'>Without even breaking stride, [user] flips open and lights [src] in one smooth movement.</span>")
 		else
-			lit = 0
-			icon_state = "[base_state]"
-			item_state = "[base_state]"
-			if(istype(src, /obj/item/weapon/flame/lighter/zippo) )
-				user.visible_message("<span class='rose'>You hear a quiet click, as [user] shuts off [src] without even looking at what they're doing.</span>")
+			if(prob(95))
+				user.visible_message("<span class='notice'>After a few attempts, [user] manages to light the [src].</span>")
 			else
-				user.visible_message("<span class='notice'>[user] quietly shuts off the [src].</span>")
+				user << "<span class='warning'>You burn yourself while lighting the lighter.</span>"
+				if (user.get_left_hand() == src)
+					user.apply_damage(2,BURN,"l_hand")
+				else
+					user.apply_damage(2,BURN,"r_hand")
+				user.visible_message("<span class='notice'>After a few attempts, [user] manages to light the [src], they however burn their finger in the process.</span>")
 
-			set_light(0)
-			processing_objects.Remove(src)
+		set_light(2)
+		processing_objects.Add(src)
 	else
-		return ..()
+		lit = 0
+		icon_state = "[base_state]"
+		item_state = "[base_state]"
+		if(istype(src, /obj/item/weapon/flame/lighter/zippo) )
+			user.visible_message("<span class='rose'>You hear a quiet click, as [user] shuts off [src] without even looking at what they're doing.</span>")
+		else
+			user.visible_message("<span class='notice'>[user] quietly shuts off the [src].</span>")
+
+		set_light(0)
+		processing_objects.Remove(src)
 	return
 
 

--- a/code/game/objects/items/weapons/cosmetics.dm
+++ b/code/game/objects/items/weapons/cosmetics.dm
@@ -77,7 +77,5 @@
 	icon_state = "purplecomb"
 	item_state = "purplecomb"
 
-/obj/item/weapon/haircomb/attack_self(mob/user)
-	if(user.r_hand == src || user.l_hand == src)
-		user.visible_message(text("<span class='notice'>[] uses [] to comb their hair with incredible style and sophistication. What a [].</span>", user, src, user.gender == FEMALE ? "lady" : "guy"))
-	return
+/obj/item/weapon/haircomb/attack_self(mob/living/user)
+	user.visible_message(text("<span class='notice'>[] uses [] to comb their hair with incredible style and sophistication. What a [].</span>", user, src, user.gender == FEMALE ? "lady" : "guy"))

--- a/code/game/objects/items/weapons/flamethrower.dm
+++ b/code/game/objects/items/weapons/flamethrower.dm
@@ -39,8 +39,8 @@
 		return null
 	var/turf/location = loc
 	if(istype(location, /mob/))
-		var/mob/M = location
-		if(M.l_hand == src || M.r_hand == src)
+		var/mob/living/M = location
+		if(M.item_is_in_hands(src))
 			location = M.loc
 	if(isturf(location)) //start a fire if possible
 		location.hotspot_expose(700, 2)

--- a/code/game/objects/items/weapons/gift_wrappaper.dm
+++ b/code/game/objects/items/weapons/gift_wrappaper.dm
@@ -125,12 +125,12 @@
 	icon_state = "wrap_paper"
 	var/amount = 20.0
 
-/obj/item/weapon/wrapping_paper/attackby(obj/item/weapon/W as obj, mob/user as mob)
+/obj/item/weapon/wrapping_paper/attackby(obj/item/weapon/W as obj, mob/living/user as mob)
 	..()
 	if (!( locate(/obj/structure/table, src.loc) ))
 		user << "<span class='warning'>You MUST put the paper on a table!</span>"
 	if (W.w_class < 4)
-		if ((istype(user.l_hand, /obj/item/weapon/wirecutters) || istype(user.r_hand, /obj/item/weapon/wirecutters)))
+		if (user.get_type_in_hands(/obj/item/weapon/wirecutters))
 			var/a_used = 2 ** (src.w_class - 1)
 			if (src.amount < a_used)
 				user << "<span class='warning'>You need more paper!</span>"

--- a/code/game/objects/items/weapons/implants/implantpad.dm
+++ b/code/game/objects/items/weapons/implants/implantpad.dm
@@ -24,8 +24,8 @@
 		return
 
 
-	attack_hand(mob/user as mob)
-		if ((src.case && (user.l_hand == src || user.r_hand == src)))
+	attack_hand(mob/living/user as mob)
+		if ((src.case && user.item_is_in_hands(src)))
 			user.put_in_active_hand(case)
 
 			src.case.add_fingerprint(user)

--- a/code/game/objects/items/weapons/material/twohanded.dm
+++ b/code/game/objects/items/weapons/material/twohanded.dm
@@ -29,7 +29,7 @@
 
 /obj/item/weapon/material/twohanded/update_held_icon()
 	var/mob/living/M = loc
-	if(istype(M) && !issmall(M) && ((M.r_hand == src && !M.l_hand) || (M.l_hand == src && !M.r_hand)))
+	if(istype(M) && !issmall(M) && M.item_is_in_hands(src) && !M.hands_are_full())
 		wielded = 1
 		force = force_wielded
 		name = "[base_name] (wielded)"

--- a/code/game/objects/items/weapons/melee/energy.dm
+++ b/code/game/objects/items/weapons/melee/energy.dm
@@ -214,7 +214,7 @@
 	spawn(1) if(src) qdel(src)
 
 /obj/item/weapon/melee/energy/blade/process()
-	if(!creator || loc != creator || (creator.l_hand != src && creator.r_hand != src))
+	if(!creator || loc != creator || !creator.item_is_in_hands(src))
 		// Tidy up a bit.
 		if(istype(loc,/mob/living))
 			var/mob/living/carbon/human/host = loc

--- a/code/game/objects/items/weapons/mop_deploy.dm
+++ b/code/game/objects/items/weapons/mop_deploy.dm
@@ -59,7 +59,7 @@
 	spawn(1) if(src) del(src)
 
 /obj/item/weapon/mop_deploy/process()
-	if(!creator || loc != creator || (creator.l_hand != src && creator.r_hand != src))
+	if(!creator || loc != creator || !creator.item_is_in_hands(src))
 		// Tidy up a bit.
 		if(istype(loc,/mob/living))
 			var/mob/living/carbon/human/host = loc

--- a/code/game/objects/items/weapons/storage/laundry_basket.dm
+++ b/code/game/objects/items/weapons/storage/laundry_basket.dm
@@ -21,7 +21,7 @@
 	var/linked
 
 
-/obj/item/weapon/storage/laundry_basket/attack_hand(mob/user as mob)
+/obj/item/weapon/storage/laundry_basket/attack_hand(mob/living/user as mob)
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user
 		var/obj/item/organ/external/temp = H.get_organ("r_hand")

--- a/code/game/objects/items/weapons/tools.dm
+++ b/code/game/objects/items/weapons/tools.dm
@@ -173,7 +173,7 @@
 		user << text("\icon[] [] contains []/[] units of fuel!", src, src.name, get_fuel(),src.max_fuel )
 
 
-/obj/item/weapon/weldingtool/attackby(obj/item/W as obj, mob/user as mob)
+/obj/item/weapon/weldingtool/attackby(obj/item/W as obj, mob/living/user as mob)
 	if(istype(W,/obj/item/weapon/screwdriver))
 		if(welding)
 			user << "<span class='danger'>Stop welding first!</span>"
@@ -222,9 +222,9 @@
 	//I'm not sure what this does. I assume it has to do with starting fires...
 	//...but it doesnt check to see if the welder is on or not.
 	var/turf/location = src.loc
-	if(istype(location, /mob/))
-		var/mob/M = location
-		if(M.l_hand == src || M.r_hand == src)
+	if(istype(location, /mob/living))
+		var/mob/living/M = location
+		if(M.item_is_in_hands(src))
 			location = get_turf(M)
 	if (istype(location, /turf))
 		location.hotspot_expose(700, 5)

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -93,11 +93,12 @@
 		// check for TK users
 
 		if (istype(usr, /mob/living/carbon/human))
-			if(istype(usr.l_hand, /obj/item/tk_grab) || istype(usr.r_hand, /obj/item/tk_grab/))
-				if(!(usr in nearby))
-					if(usr.client && usr.machine==src)
+			var/mob/living/carbon/human/H = usr
+			if(H.get_type_in_hands(/obj/item/tk_grab))
+				if(!(H in nearby))
+					if(H.client && H.machine==src)
 						is_in_use = 1
-						src.attack_hand(usr)
+						src.attack_hand(H)
 		in_use = is_in_use
 
 /obj/proc/updateDialog()

--- a/code/game/objects/structures/extinguisher.dm
+++ b/code/game/objects/structures/extinguisher.dm
@@ -28,7 +28,7 @@
 	update_icon()
 
 
-/obj/structure/extinguisher_cabinet/attack_hand(mob/user)
+/obj/structure/extinguisher_cabinet/attack_hand(mob/living/user)
 	if(isrobot(user))
 		return
 	if (ishuman(user))

--- a/code/game/objects/structures/janicart.dm
+++ b/code/game/objects/structures/janicart.dm
@@ -107,7 +107,7 @@
 	if(!isliving(usr))
 		return
 	var/mob/living/user = usr
-	
+
 	if(href_list["take"])
 		switch(href_list["take"])
 			if("garbage")
@@ -213,10 +213,10 @@
 		..()
 
 
-/obj/structure/bed/chair/janicart/relaymove(mob/user, direction)
+/obj/structure/bed/chair/janicart/relaymove(mob/living/user, direction)
 	if(user.stat || user.stunned || user.weakened || user.paralysis)
 		unbuckle_mob()
-	if(istype(user.l_hand, /obj/item/key) || istype(user.r_hand, /obj/item/key))
+	if(user.get_type_in_hands(/obj/item/key))
 		step(src, direction)
 		update_mob()
 	else

--- a/code/game/objects/structures/noticeboard.dm
+++ b/code/game/objects/structures/noticeboard.dm
@@ -64,15 +64,14 @@
 			return
 		var/obj/item/P = locate(href_list["write"])
 		if((P && P.loc == src)) //ifthe paper's on the board
-			if(istype(usr.r_hand, /obj/item/weapon/pen)) //and you're holding a pen
-				add_fingerprint(usr)
-				P.attackby(usr.r_hand, usr) //then do ittttt
-			else
-				if(istype(usr.l_hand, /obj/item/weapon/pen)) //check other hand for pen
-					add_fingerprint(usr)
-					P.attackby(usr.l_hand, usr)
+			var/mob/living/M = usr
+			if(istype(M))
+				var/obj/item/weapon/pen/E = M.get_type_in_hands(/obj/item/weapon/pen)
+				if(E)
+					add_fingerprint(M)
+					P.attackby(E, usr)
 				else
-					usr << "<span class='notice'>You'll need something to write with!</span>"
+					M << "<span class='notice'>You'll need something to write with!</span>"
 	if(href_list["read"])
 		var/obj/item/weapon/paper/P = locate(href_list["read"])
 		if((P && P.loc == src))

--- a/code/game/objects/structures/safe.dm
+++ b/code/game/objects/structures/safe.dm
@@ -90,7 +90,7 @@ FLOOR SAFES
 	var/mob/living/carbon/human/user = usr
 
 	var/canhear = 0
-	if(istype(user.l_hand, /obj/item/clothing/accessory/stethoscope) || istype(user.r_hand, /obj/item/clothing/accessory/stethoscope))
+	if(user.get_type_in_hands(/obj/item/clothing/accessory/stethoscope))
 		canhear = 1
 
 	if(href_list["open"])

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -358,7 +358,7 @@
 	if (ishuman(user))
 		var/mob/living/carbon/human/H = user
 		var/obj/item/organ/external/temp = H.organs_by_name["r_hand"]
-		if (user.hand)
+		if (H.hand)
 			temp = H.organs_by_name["l_hand"]
 		if(temp && !temp.is_usable())
 			user << "<span class='notice'>You try to move your [temp.name], but cannot!</span>"

--- a/code/modules/assembly/mousetrap.dm
+++ b/code/modules/assembly/mousetrap.dm
@@ -94,7 +94,7 @@
 		..()
 
 
-	on_found(mob/finder as mob)
+	on_found(mob/living/finder as mob)
 		if(armed)
 			finder.visible_message("<span class='warning'>[finder] accidentally sets off [src], breaking their fingers.</span>", \
 								   "<span class='warning'>You accidentally trigger [src]!</span>")

--- a/code/modules/clothing/head/misc_special.dm
+++ b/code/modules/clothing/head/misc_special.dm
@@ -76,7 +76,7 @@
 	var/turf/location = src.loc
 	if(istype(location, /mob/))
 		var/mob/living/carbon/human/M = location
-		if(M.l_hand == src || M.r_hand == src || M.head == src)
+		if(M.item_is_in_hands(src) || M.head == src)
 			location = M.loc
 
 	if (istype(location, /turf))

--- a/code/modules/clothing/masks/miscellaneous.dm
+++ b/code/modules/clothing/masks/miscellaneous.dm
@@ -22,7 +22,7 @@
     say_verbs = list("mumbles", "says")
 
 // Clumsy folks can't take the mask off themselves.
-/obj/item/clothing/mask/muzzle/attack_hand(mob/user as mob)
+/obj/item/clothing/mask/muzzle/attack_hand(mob/living/user as mob)
 	if(user.wear_mask == src && !user.IsAdvancedToolUser())
 		return 0
 	..()

--- a/code/modules/clothing/spacesuits/rig/rig_attackby.dm
+++ b/code/modules/clothing/spacesuits/rig/rig_attackby.dm
@@ -1,6 +1,6 @@
-/obj/item/weapon/rig/attackby(obj/item/W as obj, mob/user as mob)
+/obj/item/weapon/rig/attackby(obj/item/W as obj, mob/living/user as mob)
 
-	if(!istype(user,/mob/living)) return 0
+	if(!istype(user)) return 0
 
 	if(electrified != 0)
 		if(shock(user)) //Handles removing charge from the cell, as well. No need to do that here.

--- a/code/modules/detectivework/tools/evidencebag.dm
+++ b/code/modules/detectivework/tools/evidencebag.dm
@@ -15,7 +15,7 @@
 
 	var/mob/living/carbon/human/user = usr
 
-	if (!(user.l_hand == src || user.r_hand == src))
+	if(!user.item_is_in_hands(src))
 		return //bag must be in your hands to use
 
 	if (isturf(I.loc))
@@ -31,10 +31,8 @@
 			var/obj/item/weapon/storage/U = I.loc
 			user.client.screen -= I
 			U.contents.Remove(I)
-		else if(user.l_hand == I)					//in a hand
-			user.drop_l_hand()
-		else if(user.r_hand == I)					//in a hand
-			user.drop_r_hand()
+		else if(user.item_is_in_hands(I))
+			user.drop_from_inventory(I)
 		else
 			return
 

--- a/code/modules/games/cards.dm
+++ b/code/modules/games/cards.dm
@@ -77,12 +77,8 @@
 		usr << "There are no cards in the deck."
 		return
 
-	var/obj/item/weapon/hand/H
-	if(user.l_hand && istype(user.l_hand,/obj/item/weapon/hand))
-		H = user.l_hand
-	else if(user.r_hand && istype(user.r_hand,/obj/item/weapon/hand))
-		H = user.r_hand
-	else
+	var/obj/item/weapon/hand/H = user.get_type_in_hands(/obj/item/weapon/hand)
+	if(!H)
 		H = new(get_turf(src))
 		user.put_in_hands(H)
 

--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -172,7 +172,7 @@
 	if(seed) seed.thrown_at(src,hit_atom)
 	..()
 
-/obj/item/weapon/reagent_containers/food/snacks/grown/attackby(var/obj/item/weapon/W, var/mob/user)
+/obj/item/weapon/reagent_containers/food/snacks/grown/attackby(var/obj/item/weapon/W, var/mob/living/user)
 
 	if(seed)
 		if(seed.get_trait(TRAIT_PRODUCES_POWER) && istype(W, /obj/item/stack/cable_coil))
@@ -181,7 +181,7 @@
 				//TODO: generalize this.
 				user << "<span class='notice'>You add some cable to the [src.name] and slide it inside the battery casing.</span>"
 				var/obj/item/weapon/cell/potato/pocell = new /obj/item/weapon/cell/potato(get_turf(user))
-				if(src.loc == user && !(user.l_hand && user.r_hand) && istype(user,/mob/living/carbon/human))
+				if(src.loc == user && istype(user,/mob/living/carbon/human))
 					user.put_in_hands(pocell)
 				pocell.maxcharge = src.potency * 10
 				pocell.charge = pocell.maxcharge

--- a/code/modules/hydroponics/seed.dm
+++ b/code/modules/hydroponics/seed.dm
@@ -150,7 +150,7 @@
 		var/body_coverage = HEAD|FACE|EYES|UPPER_TORSO|LOWER_TORSO|LEGS|FEET|ARMS|HANDS
 
 		for(var/obj/item/clothing/clothes in target)
-			if(target.l_hand == clothes|| target.r_hand == clothes)
+			if(target.item_is_in_hands(clothes))
 				continue
 			body_coverage &= ~(clothes.body_parts_covered)
 
@@ -182,7 +182,7 @@
 				continue
 			var/body_coverage = HEAD|FACE|EYES|UPPER_TORSO|LOWER_TORSO|LEGS|FEET|ARMS|HANDS
 			for(var/obj/item/clothing/clothes in M)
-				if(M.l_hand == clothes || M.r_hand == clothes)
+				if(M.item_is_in_hands(clothes))
 					continue
 				body_coverage &= ~(clothes.body_parts_covered)
 			if(!body_coverage)

--- a/code/modules/hydroponics/trays/tray_tools.dm
+++ b/code/modules/hydroponics/trays/tray_tools.dm
@@ -34,7 +34,7 @@
 	var/obj/item/weapon/paper/P = new /obj/item/weapon/paper(get_turf(src))
 	P.name = "paper - [form_title]"
 	P.info = "[last_data]"
-	if(istype(user,/mob/living/carbon/human) && !(user.l_hand && user.r_hand))
+	if(istype(user,/mob/living/carbon/human))
 		user.put_in_hands(P)
 	user.visible_message("\The [src] spits out a piece of paper.")
 	return

--- a/code/modules/materials/materials.dm
+++ b/code/modules/materials/materials.dm
@@ -128,7 +128,7 @@ var/list/name_to_material
 	S.add_fingerprint(user)
 	S.add_to_stacks(user)
 
-/material/proc/build_wired_product(var/mob/user, var/obj/item/stack/used_stack, var/obj/item/stack/target_stack)
+/material/proc/build_wired_product(var/mob/living/user, var/obj/item/stack/used_stack, var/obj/item/stack/target_stack)
 	if(!wire_product)
 		user << "<span class='warning'>You cannot make anything out of \the [target_stack]</span>"
 		return
@@ -140,8 +140,7 @@ var/list/name_to_material
 	target_stack.use(1)
 	user << "<span class='notice'>You attach wire to the [name].</span>"
 	var/obj/item/product = new wire_product(get_turf(user))
-	if(!(user.l_hand && user.r_hand))
-		user.put_in_hands(product)
+	user.put_in_hands(product)
 
 // Make sure we have a display name and shard icon even if they aren't explicitly set.
 /material/New()

--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -172,10 +172,9 @@ var/list/mining_overlay_cache = list()
 
 	if(istype(AM,/mob/living/carbon/human))
 		var/mob/living/carbon/human/H = AM
-		if((istype(H.l_hand,/obj/item/weapon/pickaxe)) && (!H.hand))
-			attackby(H.l_hand,H)
-		else if((istype(H.r_hand,/obj/item/weapon/pickaxe)) && H.hand)
-			attackby(H.r_hand,H)
+		var/obj/item/weapon/pickaxe/P = H.get_inactive_hand()
+		if(istype(P))
+			src.attackby(P, H)
 
 	else if(istype(AM,/mob/living/silicon/robot))
 		var/mob/living/silicon/robot/R = AM

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -1,43 +1,3 @@
-//This proc is called whenever someone clicks an inventory ui slot.
-/mob/proc/attack_ui(slot)
-	var/obj/item/W = get_active_hand()
-	if(istype(W))
-		equip_to_slot_if_possible(W, slot)
-
-/mob/proc/put_in_any_hand_if_possible(obj/item/W as obj, del_on_fail = 0, disable_warning = 1, redraw_mob = 1)
-	if(equip_to_slot_if_possible(W, slot_l_hand, del_on_fail, disable_warning, redraw_mob))
-		return 1
-	else if(equip_to_slot_if_possible(W, slot_r_hand, del_on_fail, disable_warning, redraw_mob))
-		return 1
-	return 0
-
-//This is a SAFE proc. Use this instead of equip_to_slot()!
-//set del_on_fail to have it delete W if it fails to equip
-//set disable_warning to disable the 'you are unable to equip that' warning.
-//unset redraw_mob to prevent the mob from being redrawn at the end.
-/mob/proc/equip_to_slot_if_possible(obj/item/W as obj, slot, del_on_fail = 0, disable_warning = 0, redraw_mob = 1)
-	if(!istype(W)) return 0
-
-	if(!W.mob_can_equip(src, slot))
-		if(del_on_fail)
-			qdel(W)
-		else
-			if(!disable_warning)
-				src << "\red You are unable to equip that." //Only print if del_on_fail is false
-		return 0
-
-	equip_to_slot(W, slot, redraw_mob) //This proc should not ever fail.
-	return 1
-
-//This is an UNSAFE proc. It merely handles the actual job of equipping. All the checks on whether you can or can't eqip need to be done before! Use mob_can_equip() for that task.
-//In most cases you will want to use equip_to_slot_if_possible()
-/mob/proc/equip_to_slot(obj/item/W as obj, slot)
-	return
-
-//This is just a commonly used configuration for the equip_to_slot_if_possible() proc, used to equip people when the rounds tarts and when events happen and such.
-/mob/proc/equip_to_slot_or_del(obj/item/W as obj, slot)
-	return equip_to_slot_if_possible(W, slot, 1, 1, 0)
-
 //The list of slots by priority. equip_to_appropriate_slot() uses this list. Doesn't matter if a mob type doesn't have a slot.
 var/list/slot_equipment_priority = list( \
 		slot_back,\
@@ -58,6 +18,49 @@ var/list/slot_equipment_priority = list( \
 		slot_r_store\
 	)
 
+/mob
+	var/obj/item/weapon/storage/s_active = null // Even ghosts can/should be able to peek into boxes on the ground
+
+//This proc is called whenever someone clicks an inventory ui slot.
+/mob/proc/attack_ui(var/slot)
+	var/obj/item/W = get_active_hand()
+	if(istype(W))
+		equip_to_slot_if_possible(W, slot)
+
+/* Inventory manipulation */
+
+/mob/proc/put_in_any_hand_if_possible(obj/item/W as obj, del_on_fail = 0, disable_warning = 1, redraw_mob = 1)
+	if(equip_to_slot_if_possible(W, slot_l_hand, del_on_fail, disable_warning, redraw_mob))
+		return 1
+	else if(equip_to_slot_if_possible(W, slot_r_hand, del_on_fail, disable_warning, redraw_mob))
+		return 1
+	return 0
+
+//This is a SAFE proc. Use this instead of equip_to_slot()!
+//set del_on_fail to have it delete W if it fails to equip
+//set disable_warning to disable the 'you are unable to equip that' warning.
+//unset redraw_mob to prevent the mob from being redrawn at the end.
+/mob/proc/equip_to_slot_if_possible(obj/item/W as obj, slot, del_on_fail = 0, disable_warning = 0, redraw_mob = 1)
+	if(!W.mob_can_equip(src, slot))
+		if(del_on_fail)
+			qdel(W)
+		else
+			if(!disable_warning)
+				src << "\red You are unable to equip that." //Only print if del_on_fail is false
+		return 0
+
+	equip_to_slot(W, slot, redraw_mob) //This proc should not ever fail.
+	return 1
+
+//This is an UNSAFE proc. It merely handles the actual job of equipping. All the checks on whether you can or can't eqip need to be done before! Use mob_can_equip() for that task.
+//In most cases you will want to use equip_to_slot_if_possible()
+/mob/proc/equip_to_slot(obj/item/W as obj, slot)
+	return
+
+//This is just a commonly used configuration for the equip_to_slot_if_possible() proc, used to equip people when the rounds tarts and when events happen and such.
+/mob/proc/equip_to_slot_or_del(obj/item/W as obj, slot)
+	return equip_to_slot_if_possible(W, slot, 1, 1, 0)
+
 //Checks if a given slot can be accessed at this time, either to equip or unequip I
 /mob/proc/slot_is_accessible(var/slot, var/obj/item/I, mob/user=null)
 	return 1
@@ -65,8 +68,6 @@ var/list/slot_equipment_priority = list( \
 //puts the item "W" into an appropriate slot in a human's inventory
 //returns 0 if it cannot, 1 if successful
 /mob/proc/equip_to_appropriate_slot(obj/item/W)
-	if(!istype(W)) return 0
-
 	for(var/slot in slot_equipment_priority)
 		if(equip_to_slot_if_possible(W, slot, del_on_fail=0, disable_warning=1, redraw_mob=1))
 			return 1
@@ -74,32 +75,15 @@ var/list/slot_equipment_priority = list( \
 	return 0
 
 /mob/proc/equip_to_storage(obj/item/newitem)
-	// Try put it in their backpack
-	if(istype(src.back,/obj/item/weapon/storage))
-		var/obj/item/weapon/storage/backpack = src.back
-		if(backpack.contents.len < backpack.storage_slots)
-			newitem.forceMove(src.back)
-			return 1
-
-	// Try to place it in any item that can store stuff, on the mob.
-	for(var/obj/item/weapon/storage/S in src.contents)
-		if (S.contents.len < S.storage_slots)
-			newitem.forceMove(S)
-			return 1
 	return 0
 
-//These procs handle putting s tuff in your hand. It's probably best to use these rather than setting l_hand = ...etc
-//as they handle all relevant stuff like adding it to the player's screen and updating their overlays.
+/* Hands */
 
 //Returns the thing in our active hand
 /mob/proc/get_active_hand()
-	if(hand)	return l_hand
-	else		return r_hand
 
 //Returns the thing in our inactive hand
 /mob/proc/get_inactive_hand()
-	if(hand)	return r_hand
-	else		return l_hand
 
 //Puts the item into your l_hand if possible and calls all necessary triggers/updates. returns 1 on success.
 /mob/proc/put_in_l_hand(var/obj/item/W)
@@ -150,16 +134,15 @@ var/list/slot_equipment_priority = list( \
 
 //Drops the item in our left hand
 /mob/proc/drop_l_hand(var/atom/Target)
-	return drop_from_inventory(l_hand, Target)
+	return 0
 
 //Drops the item in our right hand
 /mob/proc/drop_r_hand(var/atom/Target)
-	return drop_from_inventory(r_hand, Target)
+	return 0
 
 //Drops the item in our active hand. TODO: rename this to drop_active_hand or something
 /mob/proc/drop_item(var/atom/Target)
-	if(hand)	return drop_l_hand(Target)
-	else		return drop_r_hand(Target)
+	return
 
 /*
 	Removes the object from any slots the mob might have, calling the appropriate icon update proc.
@@ -173,19 +156,6 @@ var/list/slot_equipment_priority = list( \
 	the search through all the slots, without having to duplicate the rest of the item dropping.
 */
 /mob/proc/u_equip(obj/W as obj)
-	if (W == r_hand)
-		r_hand = null
-		update_inv_r_hand(0)
-	else if (W == l_hand)
-		l_hand = null
-		update_inv_l_hand(0)
-	else if (W == back)
-		back = null
-		update_inv_back(0)
-	else if (W == wear_mask)
-		wear_mask = null
-		update_inv_wear_mask(0)
-	return
 
 /mob/proc/isEquipped(obj/item/I)
 	if(!I)
@@ -229,11 +199,6 @@ var/list/slot_equipment_priority = list( \
 
 //Returns the item equipped to the specified slot, if any.
 /mob/proc/get_equipped_item(var/slot)
-	switch(slot)
-		if(slot_l_hand) return l_hand
-		if(slot_r_hand) return r_hand
-		if(slot_back) return back
-		if(slot_wear_mask) return wear_mask
 	return null
 
 //Outdated but still in use apparently. This should at least be a human proc.

--- a/code/modules/mob/living/bot/floorbot.dm
+++ b/code/modules/mob/living/bot/floorbot.dm
@@ -288,7 +288,7 @@
 
 /* Assembly */
 
-/obj/item/weapon/storage/toolbox/mechanical/attackby(var/obj/item/stack/tile/floor/T, mob/user as mob)
+/obj/item/weapon/storage/toolbox/mechanical/attackby(var/obj/item/stack/tile/floor/T, mob/living/user as mob)
 	if(!istype(T, /obj/item/stack/tile/floor))
 		..()
 		return

--- a/code/modules/mob/living/carbon/alien/diona/diona_attacks.dm
+++ b/code/modules/mob/living/carbon/alien/diona/diona_attacks.dm
@@ -2,7 +2,7 @@
 	var/mob/living/carbon/human/H = over_object
 	if(!istype(H) || !Adjacent(H))
 		return ..()
-	if(H.a_intent == "grab" && hat && !(H.l_hand && H.r_hand))
+	if(H.a_intent == "grab" && hat && !H.hands_are_full())
 		hat.loc = get_turf(src)
 		H.put_in_hands(hat)
 		H.visible_message("<span class='danger'>\The [H] removes \the [src]'s [hat].</span>")

--- a/code/modules/mob/living/carbon/give.dm
+++ b/code/modules/mob/living/carbon/give.dm
@@ -3,40 +3,40 @@
 	set name = "Give"
 
 	// TODO :  Change to incapacitated() on merge.
-	if(usr.stat || usr.lying || usr.resting || usr.buckled)
+	if(src.stat || src.lying || src.resting || src.buckled)
 		return
 	if(!istype(target) || target.stat || target.lying || target.resting || target.buckled || target.client == null)
 		return
 
-	var/obj/item/I = usr.get_active_hand()
+	var/obj/item/I = src.get_active_hand()
 	if(!I)
-		I = usr.get_inactive_hand()
+		I = src.get_inactive_hand()
 	if(!I)
-		usr << "<span class='warning'>You don't have anything in your hands to give to \the [target].</span>"
+		src << "<span class='warning'>You don't have anything in your hands to give to \the [target].</span>"
 		return
 
-	if(alert(target,"[usr] wants to give you \a [I]. Will you accept it?",,"No","Yes") == "No")
-		target.visible_message("<span class='notice'>\The [usr] tried to hand \the [I] to \the [target], \
+	if(alert(target,"[src] wants to give you \a [I]. Will you accept it?",,"No","Yes") == "No")
+		target.visible_message("<span class='notice'>\The [src] tried to hand \the [I] to \the [target], \
 		but \the [target] didn't want it.</span>")
 		return
 
 	if(!I) return
 
 	if(!Adjacent(target))
-		usr << "<span class='warning'>You need to stay in reaching distance while giving an object.</span>"
-		target << "<span class='warning'>\The [usr] moved too far away.</span>"
+		src << "<span class='warning'>You need to stay in reaching distance while giving an object.</span>"
+		target << "<span class='warning'>\The [src] moved too far away.</span>"
 		return
 
-	if(I.loc != usr || (usr.l_hand != I && usr.r_hand != I))
-		usr << "<span class='warning'>You need to keep the item in your hands.</span>"
-		target << "<span class='warning'>\The [usr] seems to have given up on passing \the [I] to you.</span>"
+	if(I.loc != src || !src.item_is_in_hands(I))
+		src << "<span class='warning'>You need to keep the item in your hands.</span>"
+		target << "<span class='warning'>\The [src] seems to have given up on passing \the [I] to you.</span>"
 		return
 
-	if(target.r_hand != null && target.l_hand != null)
+	if(target.hands_are_full())
 		target << "<span class='warning'>Your hands are full.</span>"
-		usr << "<span class='warning'>Their hands are full.</span>"
+		src << "<span class='warning'>Their hands are full.</span>"
 		return
 
-	if(usr.unEquip(I))
+	if(src.unEquip(I))
 		target.put_in_hands(I) // If this fails it will just end up on the floor, but that's fitting for things like dionaea.
-		target.visible_message("<span class='notice'>\The [usr] handed \the [I] to \the [target].</span>")
+		target.visible_message("<span class='notice'>\The [src] handed \the [I] to \the [target].</span>")

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -538,9 +538,9 @@
 		if ("handshake")
 			m_type = 1
 			if (!src.restrained() && !src.r_hand)
-				var/mob/M = null
+				var/mob/living/M = null
 				if (param)
-					for (var/mob/A in view(1, null))
+					for (var/mob/living/A in view(1, null))
 						if (param == A.name)
 							M = A
 							break

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -207,7 +207,7 @@
 
 	var/covered = 0 // Basic coverage can help.
 	for(var/obj/item/clothing/clothes in H)
-		if(H.l_hand == clothes|| H.r_hand == clothes)
+		if(H.item_is_in_hands(clothes))
 			continue
 		if((clothes.body_parts_covered & UPPER_TORSO) && (clothes.body_parts_covered & LOWER_TORSO))
 			covered = 1

--- a/code/modules/mob/living/inventory.dm
+++ b/code/modules/mob/living/inventory.dm
@@ -1,0 +1,172 @@
+/mob/living
+	var/hand = null
+	var/obj/item/l_hand = null
+	var/obj/item/r_hand = null
+	var/obj/item/weapon/back = null//Human/Monkey
+	var/obj/item/weapon/tank/internal = null//Human/Monkey
+	var/obj/item/clothing/mask/wear_mask = null//Carbon
+
+/mob/living/equip_to_storage(obj/item/newitem)
+	// Try put it in their backpack
+	if(istype(src.back,/obj/item/weapon/storage))
+		var/obj/item/weapon/storage/backpack = src.back
+		if(backpack.contents.len < backpack.storage_slots)
+			newitem.forceMove(src.back)
+			return 1
+
+	// Try to place it in any item that can store stuff, on the mob.
+	for(var/obj/item/weapon/storage/S in src.contents)
+		if (S.contents.len < S.storage_slots)
+			newitem.forceMove(S)
+			return 1
+	return 0
+
+//Returns the thing in our active hand
+/mob/living/get_active_hand()
+	if(hand)	return l_hand
+	else		return r_hand
+
+//Returns the thing in our inactive hand
+/mob/living/get_inactive_hand()
+	if(hand)	return r_hand
+	else		return l_hand
+
+//Drops the item in our active hand. TODO: rename this to drop_active_hand or something
+/mob/living/drop_item(var/atom/Target)
+	if(hand)	return drop_l_hand(Target)
+	else		return drop_r_hand(Target)
+
+//Drops the item in our left hand
+/mob/living/drop_l_hand(var/atom/Target)
+	return drop_from_inventory(l_hand, Target)
+
+//Drops the item in our right hand
+/mob/living/drop_r_hand(var/atom/Target)
+	return drop_from_inventory(r_hand, Target)
+
+/mob/living/proc/hands_are_full()
+	return (r_hand && l_hand)
+
+/mob/living/proc/item_is_in_hands(var/obj/item/I)
+	return (I == r_hand || I == l_hand)
+
+/mob/living/proc/update_held_icons()
+	if(l_hand)
+		l_hand.update_held_icon()
+	if(r_hand)
+		r_hand.update_held_icon()
+
+/mob/living/proc/get_type_in_hands(var/T)
+	if(istype(l_hand, T))
+		return l_hand
+	if(istype(r_hand, T))
+		return r_hand
+	return null
+
+/mob/living/proc/get_left_hand()
+	return l_hand
+
+/mob/living/proc/get_right_hand()
+	return r_hand
+
+/mob/living/u_equip(obj/W as obj)
+	if (W == r_hand)
+		r_hand = null
+		update_inv_r_hand(0)
+	else if (W == l_hand)
+		l_hand = null
+		update_inv_l_hand(0)
+	else if (W == back)
+		back = null
+		update_inv_back(0)
+	else if (W == wear_mask)
+		wear_mask = null
+		update_inv_wear_mask(0)
+	return
+
+/mob/living/get_equipped_item(var/slot)
+	switch(slot)
+		if(slot_l_hand) return l_hand
+		if(slot_r_hand) return r_hand
+		if(slot_back) return back
+		if(slot_wear_mask) return wear_mask
+	return null
+
+/mob/living/show_inv(mob/user as mob)
+	user.set_machine(src)
+	var/dat = {"
+	<B><HR><FONT size=3>[name]</FONT></B>
+	<BR><HR>
+	<BR><B>Head(Mask):</B> <A href='?src=\ref[src];item=mask'>[(wear_mask ? wear_mask : "Nothing")]</A>
+	<BR><B>Left Hand:</B> <A href='?src=\ref[src];item=l_hand'>[(l_hand ? l_hand  : "Nothing")]</A>
+	<BR><B>Right Hand:</B> <A href='?src=\ref[src];item=r_hand'>[(r_hand ? r_hand : "Nothing")]</A>
+	<BR><B>Back:</B> <A href='?src=\ref[src];item=back'>[(back ? back : "Nothing")]</A> [((istype(wear_mask, /obj/item/clothing/mask) && istype(back, /obj/item/weapon/tank) && !( internal )) ? text(" <A href='?src=\ref[];item=internal'>Set Internal</A>", src) : "")]
+	<BR>[(internal ? text("<A href='?src=\ref[src];item=internal'>Remove Internal</A>") : "")]
+	<BR><A href='?src=\ref[src];item=pockets'>Empty Pockets</A>
+	<BR><A href='?src=\ref[user];refresh=1'>Refresh</A>
+	<BR><A href='?src=\ref[user];mach_close=mob[name]'>Close</A>
+	<BR>"}
+	user << browse(dat, text("window=mob[];size=325x500", name))
+	onclose(user, "mob[name]")
+	return
+
+/mob/living/ret_grab(obj/effect/list_container/mobl/L as obj, flag)
+	if ((!( istype(l_hand, /obj/item/weapon/grab) ) && !( istype(r_hand, /obj/item/weapon/grab) )))
+		if (!( L ))
+			return null
+		else
+			return L.container
+	else
+		if (!( L ))
+			L = new /obj/effect/list_container/mobl( null )
+			L.container += src
+			L.master = src
+		if (istype(l_hand, /obj/item/weapon/grab))
+			var/obj/item/weapon/grab/G = l_hand
+			if (!( L.container.Find(G.affecting) ))
+				L.container += G.affecting
+				if (G.affecting)
+					G.affecting.ret_grab(L, 1)
+		if (istype(r_hand, /obj/item/weapon/grab))
+			var/obj/item/weapon/grab/G = r_hand
+			if (!( L.container.Find(G.affecting) ))
+				L.container += G.affecting
+				if (G.affecting)
+					G.affecting.ret_grab(L, 1)
+		if (!( flag ))
+			if (L.master == src)
+				var/list/temp = list(  )
+				temp += L.container
+				//L = null
+				qdel(L)
+				return temp
+			else
+				return L.container
+	return
+
+/mob/living/mode()
+	set name = "Activate Held Object"
+	set category = "Object"
+	set src = usr
+
+	if(istype(loc,/obj/mecha)) return
+
+	if(hand)
+		var/obj/item/W = l_hand
+		if (W)
+			W.attack_self(src)
+			update_inv_l_hand()
+	else
+		var/obj/item/W = r_hand
+		if (W)
+			W.attack_self(src)
+			update_inv_r_hand()
+	return
+
+/mob/living/abiotic(var/full_body = 0)
+	if(full_body && ((src.l_hand && !( src.l_hand.abstract )) || (src.r_hand && !( src.r_hand.abstract )) || (src.back || src.wear_mask)))
+		return 1
+
+	if((src.l_hand && !( src.l_hand.abstract )) || (src.r_hand && !( src.r_hand.abstract )))
+		return 1
+	return 0

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -865,3 +865,63 @@ default behaviour is:
 		sleep(350)
 		lastpuke = 0
 
+/mob/living/update_canmove()
+	if(!resting && cannot_stand() && can_stand_overridden())
+		lying = 0
+		canmove = 1
+	else
+		if(istype(buckled, /obj/vehicle))
+			var/obj/vehicle/V = buckled
+			if(cannot_stand())
+				lying = 0
+				canmove = 1
+				pixel_y = V.mob_offset_y - 5
+			else
+				if(buckled.buckle_lying != -1) lying = buckled.buckle_lying
+				canmove = 1
+				pixel_y = V.mob_offset_y
+		else if(buckled)
+			anchored = 1
+			canmove = 0
+			if(istype(buckled))
+				if(buckled.buckle_lying != -1)
+					lying = buckled.buckle_lying
+				if(buckled.buckle_movable)
+					anchored = 0
+					canmove = 1
+
+		else if(cannot_stand())
+			lying = 1
+			canmove = 0
+		else if(stunned)
+			canmove = 0
+		else if(captured)
+			anchored = 1
+			canmove = 0
+			lying = 0
+		else
+			lying = 0
+			canmove = 1
+
+	if(lying)
+		density = 0
+		if(l_hand) unEquip(l_hand)
+		if(r_hand) unEquip(r_hand)
+	else
+		density = initial(density)
+
+	for(var/obj/item/weapon/grab/G in grabbed_by)
+		if(G.state >= GRAB_AGGRESSIVE)
+			canmove = 0
+			break
+
+	//Temporarily moved here from the various life() procs
+	//I'm fixing stuff incrementally so this will likely find a better home.
+	//It just makes sense for now. ~Carn
+	if( update_icon )	//forces a full overlay update
+		update_icon = 0
+		regenerate_icons()
+	else if( lying != lying_prev )
+		update_icons()
+	return canmove
+

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -195,21 +195,6 @@
 
 
 /mob/proc/show_inv(mob/user as mob)
-	user.set_machine(src)
-	var/dat = {"
-	<B><HR><FONT size=3>[name]</FONT></B>
-	<BR><HR>
-	<BR><B>Head(Mask):</B> <A href='?src=\ref[src];item=mask'>[(wear_mask ? wear_mask : "Nothing")]</A>
-	<BR><B>Left Hand:</B> <A href='?src=\ref[src];item=l_hand'>[(l_hand ? l_hand  : "Nothing")]</A>
-	<BR><B>Right Hand:</B> <A href='?src=\ref[src];item=r_hand'>[(r_hand ? r_hand : "Nothing")]</A>
-	<BR><B>Back:</B> <A href='?src=\ref[src];item=back'>[(back ? back : "Nothing")]</A> [((istype(wear_mask, /obj/item/clothing/mask) && istype(back, /obj/item/weapon/tank) && !( internal )) ? text(" <A href='?src=\ref[];item=internal'>Set Internal</A>", src) : "")]
-	<BR>[(internal ? text("<A href='?src=\ref[src];item=internal'>Remove Internal</A>") : "")]
-	<BR><A href='?src=\ref[src];item=pockets'>Empty Pockets</A>
-	<BR><A href='?src=\ref[user];refresh=1'>Refresh</A>
-	<BR><A href='?src=\ref[user];mach_close=mob[name]'>Close</A>
-	<BR>"}
-	user << browse(dat, text("window=mob[];size=325x500", name))
-	onclose(user, "mob[name]")
 	return
 
 //mob verbs are faster than object verbs. See http://www.byond.com/forum/?post=1326139&page=2#comment8198716 for why this isn't atom/verb/examine()
@@ -248,37 +233,6 @@
 
 
 /mob/proc/ret_grab(obj/effect/list_container/mobl/L as obj, flag)
-	if ((!( istype(l_hand, /obj/item/weapon/grab) ) && !( istype(r_hand, /obj/item/weapon/grab) )))
-		if (!( L ))
-			return null
-		else
-			return L.container
-	else
-		if (!( L ))
-			L = new /obj/effect/list_container/mobl( null )
-			L.container += src
-			L.master = src
-		if (istype(l_hand, /obj/item/weapon/grab))
-			var/obj/item/weapon/grab/G = l_hand
-			if (!( L.container.Find(G.affecting) ))
-				L.container += G.affecting
-				if (G.affecting)
-					G.affecting.ret_grab(L, 1)
-		if (istype(r_hand, /obj/item/weapon/grab))
-			var/obj/item/weapon/grab/G = r_hand
-			if (!( L.container.Find(G.affecting) ))
-				L.container += G.affecting
-				if (G.affecting)
-					G.affecting.ret_grab(L, 1)
-		if (!( flag ))
-			if (L.master == src)
-				var/list/temp = list(  )
-				temp += L.container
-				//L = null
-				qdel(L)
-				return temp
-			else
-				return L.container
 	return
 
 /mob/verb/mode()
@@ -286,18 +240,6 @@
 	set category = "Object"
 	set src = usr
 
-	if(istype(loc,/obj/mecha)) return
-
-	if(hand)
-		var/obj/item/W = l_hand
-		if (W)
-			W.attack_self(src)
-			update_inv_l_hand()
-	else
-		var/obj/item/W = r_hand
-		if (W)
-			W.attack_self(src)
-			update_inv_r_hand()
 	return
 
 /*
@@ -735,65 +677,6 @@
 
 //Updates canmove, lying and icons. Could perhaps do with a rename but I can't think of anything to describe it.
 /mob/proc/update_canmove()
-
-	if(!resting && cannot_stand() && can_stand_overridden())
-		lying = 0
-		canmove = 1
-	else
-		if(istype(buckled, /obj/vehicle))
-			var/obj/vehicle/V = buckled
-			if(cannot_stand())
-				lying = 0
-				canmove = 1
-				pixel_y = V.mob_offset_y - 5
-			else
-				if(buckled.buckle_lying != -1) lying = buckled.buckle_lying
-				canmove = 1
-				pixel_y = V.mob_offset_y
-		else if(buckled)
-			anchored = 1
-			canmove = 0
-			if(istype(buckled))
-				if(buckled.buckle_lying != -1)
-					lying = buckled.buckle_lying
-				if(buckled.buckle_movable)
-					anchored = 0
-					canmove = 1
-
-		else if(cannot_stand())
-			lying = 1
-			canmove = 0
-		else if(stunned)
-			canmove = 0
-		else if(captured)
-			anchored = 1
-			canmove = 0
-			lying = 0
-		else
-			lying = 0
-			canmove = 1
-
-	if(lying)
-		density = 0
-		if(l_hand) unEquip(l_hand)
-		if(r_hand) unEquip(r_hand)
-	else
-		density = initial(density)
-
-	for(var/obj/item/weapon/grab/G in grabbed_by)
-		if(G.state >= GRAB_AGGRESSIVE)
-			canmove = 0
-			break
-
-	//Temporarily moved here from the various life() procs
-	//I'm fixing stuff incrementally so this will likely find a better home.
-	//It just makes sense for now. ~Carn
-	if( update_icon )	//forces a full overlay update
-		update_icon = 0
-		regenerate_icons()
-	else if( lying != lying_prev )
-		update_icons()
-
 	return canmove
 
 
@@ -1007,8 +890,7 @@ mob/proc/yank_out_object()
 		R.adjustFireLoss(10)
 
 	selection.forceMove(get_turf(src))
-	if(!(U.l_hand && U.r_hand))
-		U.put_in_hands(selection)
+	U.put_in_hands(selection)
 
 	for(var/obj/item/weapon/O in pinned)
 		if(O == selection)

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -60,7 +60,6 @@
 	var/next_move = null
 	var/transforming = null	//Carbon
 	var/other = 0.0
-	var/hand = null
 	var/eye_blind = null	//Carbon
 	var/eye_blurry = null	//Carbon
 	var/ear_deaf = null		//Carbon
@@ -119,12 +118,6 @@
 	var/m_intent = "run"//Living
 	var/lastKnownIP = null
 	var/obj/buckled = null//Living
-	var/obj/item/l_hand = null//Living
-	var/obj/item/r_hand = null//Living
-	var/obj/item/weapon/back = null//Human/Monkey
-	var/obj/item/weapon/tank/internal = null//Human/Monkey
-	var/obj/item/weapon/storage/s_active = null//Carbon
-	var/obj/item/clothing/mask/wear_mask = null//Carbon
 
 	var/seer = 0 //for cult//Carbon, probably Human
 

--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -5,8 +5,10 @@
 ///Called by client/Move()
 ///Checks to see if you are grabbing anything and if moving will affect your grab.
 /client/proc/Process_Grab()
-	for(var/obj/item/weapon/grab/G in list(mob.l_hand, mob.r_hand))
-		G.reset_kill_state() //no wandering across the station/asteroid while choking someone
+	if(istype(mob, /mob/living))
+		var/mob/living/L = mob
+		for(var/obj/item/weapon/grab/G in list(L.l_hand, L.r_hand))
+			G.reset_kill_state() //no wandering across the station/asteroid while choking someone
 
 /obj/item/weapon/grab
 	name = "grab"

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -288,12 +288,6 @@ It's fairly easy to fix if dealing with single letters but not so much with comp
 
 
 /mob/proc/abiotic(var/full_body = 0)
-	if(full_body && ((src.l_hand && !( src.l_hand.abstract )) || (src.r_hand && !( src.r_hand.abstract )) || (src.back || src.wear_mask)))
-		return 1
-
-	if((src.l_hand && !( src.l_hand.abstract )) || (src.r_hand && !( src.r_hand.abstract )))
-		return 1
-
 	return 0
 
 //converts intent-strings into numbers and back

--- a/code/modules/mob/update_icons.dm
+++ b/code/modules/mob/update_icons.dm
@@ -19,6 +19,15 @@
 /mob/proc/update_inv_back()
 	return
 
+/mob/proc/update_inv_active_hand()
+	return
+
+/mob/living/update_inv_active_hand(var/A)
+	if(hand)
+		update_inv_l_hand(A)
+	else
+		update_inv_r_hand(A)
+
 /mob/proc/update_inv_l_hand()
 	return
 

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -98,7 +98,7 @@
 		if (2)
 			take_damage(4)
 
-/obj/item/organ/external/attack_self(var/mob/user)
+/obj/item/organ/external/attack_self(var/mob/living/user)
 	if(!contents.len)
 		return ..()
 	var/list/removable_objects = list()
@@ -113,8 +113,7 @@
 		var/obj/item/I = pick(removable_objects)
 		I.loc = get_turf(user) //just in case something was embedded that is not an item
 		if(istype(I))
-			if(!(user.l_hand && user.r_hand))
-				user.put_in_hands(I)
+			user.put_in_hands(I)
 		user.visible_message("<span class='danger'>\The [user] rips \the [I] out of \the [src]!</span>")
 		return //no eating the limb until everything's been removed
 	return ..()
@@ -128,7 +127,7 @@
 			usr << "<span class='danger'>There is \a [I] sticking out of it.</span>"
 	return
 
-/obj/item/organ/external/attackby(obj/item/weapon/W as obj, mob/user as mob)
+/obj/item/organ/external/attackby(obj/item/weapon/W as obj, mob/living/user as mob)
 	switch(stage)
 		if(0)
 			if(istype(W,/obj/item/weapon/scalpel))
@@ -145,8 +144,7 @@
 				if(contents.len)
 					var/obj/item/removing = pick(contents)
 					removing.loc = get_turf(user.loc)
-					if(!(user.l_hand && user.r_hand))
-						user.put_in_hands(removing)
+					user.put_in_hands(removing)
 					user.visible_message("<span class='danger'><b>[user]</b> extracts [removing] from [src] with [W]!</span>")
 				else
 					user.visible_message("<span class='danger'><b>[user]</b> fishes around fruitlessly in [src] with [W].</span>")

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -337,8 +337,9 @@
 		var/obj/item/i = usr.get_active_hand() // Check to see if he still got that darn pen, also check if he's using a crayon or pen.
 		var/iscrayon = 0
 		if(!istype(i, /obj/item/weapon/pen))
-			if(usr.back && istype(usr.back,/obj/item/weapon/rig))
-				var/obj/item/weapon/rig/r = usr.back
+			var/mob/living/M = usr
+			if(istype(M) && M.back && istype(M.back,/obj/item/weapon/rig))
+				var/obj/item/weapon/rig/r = M.back
 				var/obj/item/rig_module/device/pen/m = locate(/obj/item/rig_module/device/pen) in r.installed_modules
 				if(!r.offline && m)
 					i = m.device

--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -91,7 +91,7 @@ var/global/photo_count = 0
 /obj/item/weapon/storage/photo_album/MouseDrop(obj/over_object as obj)
 
 	if((istype(usr, /mob/living/carbon/human)))
-		var/mob/M = usr
+		var/mob/living/carbon/human/M = usr
 		if(!( istype(over_object, /obj/screen) ))
 			return ..()
 		playsound(loc, "rustle", 50, 1, -5)

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -93,7 +93,7 @@
 	if(requires_two_hands)
 		var/mob/living/M = loc
 		if(istype(M))
-			if((M.l_hand == src && !M.r_hand) || (M.r_hand == src && !M.l_hand))
+			if(M.item_is_in_hands(src) && !M.hands_are_full())
 				name = "[initial(name)] (wielded)"
 				item_state = wielded_icon
 			else
@@ -179,7 +179,7 @@
 	var/held_acc_mod = 0
 	var/held_disp_mod = 0
 	if(requires_two_hands)
-		if((user.l_hand == src && user.r_hand) || (user.r_hand == src && user.l_hand))
+		if(user.item_is_in_hands(src) && user.hands_are_full())
 			held_acc_mod = -3
 			held_disp_mod = 3
 

--- a/code/modules/projectiles/guns/projectile/pistol.dm
+++ b/code/modules/projectiles/guns/projectile/pistol.dm
@@ -171,10 +171,10 @@
 	name = "holdout signal pistol"
 	magazine_type = /obj/item/ammo_magazine/mc9mm/flash
 
-/obj/item/weapon/gun/projectile/pistol/attack_hand(mob/user as mob)
+/obj/item/weapon/gun/projectile/pistol/attack_hand(mob/living/user as mob)
 	if(user.get_inactive_hand() == src)
 		if(silenced)
-			if(user.l_hand != src && user.r_hand != src)
+			if(!user.item_is_in_hands(src))
 				..()
 				return
 			user << "<span class='notice'>You unscrew [silenced] from [src].</span>"
@@ -185,9 +185,9 @@
 			return
 	..()
 
-/obj/item/weapon/gun/projectile/pistol/attackby(obj/item/I as obj, mob/user as mob)
+/obj/item/weapon/gun/projectile/pistol/attackby(obj/item/I as obj, mob/living/user as mob)
 	if(istype(I, /obj/item/weapon/silencer))
-		if(user.l_hand != src && user.r_hand != src)	//if we're not in his hands
+		if(!user.item_is_in_hands(src))	//if we're not in his hands
 			user << "<span class='notice'>You'll need [src] in your hands to do that.</span>"
 			return
 		user.drop_item()

--- a/code/modules/projectiles/targeting/targeting_overlay.dm
+++ b/code/modules/projectiles/targeting/targeting_overlay.dm
@@ -113,7 +113,8 @@ obj/aiming_overlay/proc/update_aiming_deferred()
 
 	var/cancel_aim = 1
 
-	if(!(aiming_with in owner) || (istype(owner, /mob/living/carbon/human) && (owner.l_hand != aiming_with && owner.r_hand != aiming_with)))
+	var/mob/living/carbon/human/H = owner
+	if(!(aiming_with in owner) || (istype(H) && !H.item_is_in_hands(aiming_with)))
 		owner << "<span class='warning'>You must keep hold of your weapon!</span>"
 	else if(owner.eye_blind)
 		owner << "<span class='warning'>You are blind and cannot see your target!</span>"

--- a/code/modules/research/xenoarchaeology/artifact/artifact.dm
+++ b/code/modules/research/xenoarchaeology/artifact/artifact.dm
@@ -108,10 +108,9 @@
 	. = ..()
 	if(istype(AM,/mob/living/carbon/human))
 		var/mob/living/carbon/human/H = AM
-		if((istype(H.l_hand,/obj/item/weapon/pickaxe)) && (!H.hand))
-			attackby(H.l_hand,H)
-		else if((istype(H.r_hand,/obj/item/weapon/pickaxe)) && H.hand)
-			attackby(H.r_hand,H)
+		var/obj/item/weapon/pickaxe/P = H.get_inactive_hand()
+		if(istype(P))
+			src.attackby(P, H)
 
 	else if(istype(AM,/mob/living/silicon/robot))
 		var/mob/living/silicon/robot/R = AM

--- a/polaris.dme
+++ b/polaris.dme
@@ -1267,6 +1267,7 @@
 #include "code\modules\mob\living\autohiss.dm"
 #include "code\modules\mob\living\damage_procs.dm"
 #include "code\modules\mob\living\default_language.dm"
+#include "code\modules\mob\living\inventory.dm"
 #include "code\modules\mob\living\life.dm"
 #include "code\modules\mob\living\living.dm"
 #include "code\modules\mob\living\living_defense.dm"


### PR DESCRIPTION
Right. This does the following:

1. Moves inventory vars that were on ``/mob`` level to ``/mob/living``. This is to reduce the amount of clutter vars. If observers don't have inventory, they don't need inventory vars.
1. Moves some procs as well, leaving empty definitions on ``/mob`` level.
1. Where necessary, replaces uses of ``/mob`` with ``/mob/living`` to match the first change. This is mostly ``attackby``.
1. Adds more procs for inventory handling: ``/mob/living/proc/hands_are_full()`` returns 1 if both mob's hands are full, 0 otherwise; ``/mob/living/proc/item_is_in_hands(var/obj/item/I)`` returns 1 if ``I`` is in one of mob's hands; and ``/mob/living/proc/get_type_in_hands(var/T)`` returns the item of type ``T`` in the mob's hands, or ``null`` if one isn't found.
1. Uses said procs where possible to minimize the uses of ``l_hand`` and ``r_hand`` vars outside of mob code.

The goal here is to bring mob inventory closer to OOP it should be; right now the game assumes that playable mobs that have inventory have exactly two hands, one active and one inactive, one left and one right, and changing that would be pretty much impossible. I'm not going to try to tackle that in one PR, instead I'll make small, clear changes until all interaction with mob inventory is made via procs and variables are where they should be. Then we will have a much more flexible inventory system that would allow us to easily create mobs with non-standard inventories or hand configurations.

And eventually, cyborg hats.