### PR TITLE
Adds a check to prevent traitor cyborgs from being able to hack other cyborgs.

### DIFF
--- a/code/game/machinery/computer/robot.dm
+++ b/code/game/machinery/computer/robot.dm
@@ -132,7 +132,7 @@
 		if(!target || !istype(target))
 			return
 
-		message_admins("<span class='notice'>[key_name_admin(usr)] emagged [target.name] using robotic console!</span>")
+		message_admins("<span class='notice'>[key_name_admin(usr)] emagged [target.name] using the robotic console!</span>")
 		log_game("[key_name(usr)] emagged [target.name] using robotic console!")
 		target.emagged = 1
 		target << "<span class='notice'>Failsafe protocols overriden. New tools available.</span>"
@@ -204,11 +204,11 @@
 		robot["master_ai"] = R.connected_ai ? R.connected_ai.name : "None"
 		robot["hackable"] = 0
 		//Antag synths should be able to hack themselves and see their hacked status.
-		if(operator && istype(operator, /mob/living/silicon) && (operator.mind.special_role && operator.mind.original == operator))
+		if(operator && isrobot(operator) && (operator.mind.special_role && operator.mind.original == operator) && (operator == R))
 			robot["hacked"] = R.emagged ? 1 : 0
 			robot["hackable"] = R.emagged? 0 : 1
 		// Antag AIs know whether linked cyborgs are hacked or not.
-		if(operator && istype(operator, /mob/living/silicon/ai) && (R.connected_ai == operator) && (operator.mind.special_role && operator.mind.original == operator))
+		if(operator && isAI(operator) && (R.connected_ai == operator) && (operator.mind.special_role && operator.mind.original == operator))
 			robot["hacked"] = R.emagged ? 1 : 0
 			robot["hackable"] = R.emagged? 0 : 1
 		robots.Add(list(robot))

--- a/html/changelogs/datraen-TraitorHackCheckFix.yml
+++ b/html/changelogs/datraen-TraitorHackCheckFix.yml
@@ -1,0 +1,7 @@
+author: Datraen
+
+delete-after: True
+
+changes: 
+  - bugfix: "Stops traitorborgs from being able to hack other borgs."
+  - bugfix: "Stops traitorAIs from being able to hack unlinked borgs."


### PR DESCRIPTION
Watched it happen in a round and realized that I didn't add a check for it.