### PR TITLE
Adds a check to the greytide virus to see if the APCs are operating.

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -292,12 +292,14 @@ var/list/mob/living/forced_ambiance_list = new
 		mob << "<span class='notice'>The sudden appearance of gravity makes you fall to the floor!</span>"
 
 /area/proc/prison_break()
-	for(var/obj/machinery/power/apc/temp_apc in src)
-		temp_apc.overload_lighting(70)
-	for(var/obj/machinery/door/airlock/temp_airlock in src)
-		temp_airlock.prison_open()
-	for(var/obj/machinery/door/window/temp_windoor in src)
-		temp_windoor.open()
+	var/obj/machinery/power/apc/theAPC = get_apc()
+	if(theAPC.operating)
+		for(var/obj/machinery/power/apc/temp_apc in src)
+			temp_apc.overload_lighting(70)
+		for(var/obj/machinery/door/airlock/temp_airlock in src)
+			temp_airlock.prison_open()
+		for(var/obj/machinery/door/window/temp_windoor in src)
+			temp_windoor.open()
 
 /area/proc/has_gravity()
 	return has_gravity

--- a/code/modules/events/prison_break.dm
+++ b/code/modules/events/prison_break.dm
@@ -61,9 +61,12 @@
 /datum/event/prison_break/tick()
 	if(activeFor == releaseWhen)
 		if(areas && areas.len > 0)
+			var/obj/machinery/power/apc/theAPC = null
 			for(var/area/A in areas)
-				for(var/obj/machinery/light/L in A)
-					L.flicker(10)
+				theAPC = A.get_apc()
+				if(theAPC.operating)	//If the apc's off, it's a little hard to overload the lights.
+					for(var/obj/machinery/light/L in A)
+						L.flicker(10)
 
 
 /datum/event/prison_break/end()

--- a/html/changelogs/Datraen-PBAPCCheck.yml
+++ b/html/changelogs/Datraen-PBAPCCheck.yml
@@ -1,0 +1,6 @@
+author: Datraen
+
+delete-after: True
+
+changes: 
+  - bugfix: "Adds a check to prison breaks that makes sure the APC is on before continuing."


### PR DESCRIPTION
Should fix #799

As a note: This checks whether or not the breaker's been turned on. If it's desired, it could be changed to whether or not it has a cell, and whether or not that cell has charge.