### PR TITLE
[XENOARCH] Checks to see if the turf is a floor before spawning artifacts.

### DIFF
--- a/code/modules/research/xenoarchaeology/master_controller.dm
+++ b/code/modules/research/xenoarchaeology/master_controller.dm
@@ -9,9 +9,12 @@
 #define ARTIFACTSPAWNNUM_LOWER 6
 #define ARTIFACTSPAWNNUM_UPPER 12
 
-datum/controller/game_controller/proc/SetupXenoarch()
+/datum/controller/game_controller/proc/SetupXenoarch()
 	//create digsites
 	for(var/turf/simulated/mineral/M in block(locate(1,1,1), locate(world.maxx, world.maxy, world.maxz)))
+		if(M.density)
+			continue
+			
 		if(isnull(M.geologic_data))
 			M.geologic_data = new/datum/geosample(M)
 

--- a/html/changelogs/Datraen-SpawnTurf.yml
+++ b/html/changelogs/Datraen-SpawnTurf.yml
@@ -1,0 +1,6 @@
+author: Datraen
+
+delete-after: True
+
+changes: 
+  - bugfix: "Artifacts will no longer spawn on floor turfs."


### PR DESCRIPTION
Resolves #631 by checking to see if the turf is dense, which is true when it is a wall, but not true if it is a floor.