### PR TITLE
Properly log dropper-related assault for admins

### DIFF
--- a/code/modules/reagents/reagent_containers/dropper.dm
+++ b/code/modules/reagents/reagent_containers/dropper.dm
@@ -54,14 +54,16 @@
 						user.visible_message("<span class='warning'>[user] tries to squirt something into [target]'s eyes, but fails!</span>", "<span class='notice'>You transfer [trans] units of the solution.</span>")
 						return
 
-				trans = reagents.trans_to_mob(target, reagents.total_volume, CHEM_INGEST)
-				user.visible_message("<span class='warning'>[user] squirts something into [target]'s eyes!</span>", "<span class='notice'>You transfer [trans] units of the solution.</span>")
-
 				var/mob/living/M = target
 				var/contained = reagentlist()
 				M.attack_log += text("\[[time_stamp()]\] <font color='orange'>Has been squirted with [name] by [user.name] ([user.ckey]). Reagents: [contained]</font>")
 				user.attack_log += text("\[[time_stamp()]\] <font color='red'>Used the [name] to squirt [M.name] ([M.key]). Reagents: [contained]</font>")
 				msg_admin_attack("[user.name] ([user.ckey]) squirted [M.name] ([M.key]) with [name]. Reagents: [contained] (INTENT: [uppertext(user.a_intent)]) (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[user.x];Y=[user.y];Z=[user.z]'>JMP</a>)")
+
+				trans = reagents.trans_to_mob(target, reagents.total_volume, CHEM_INGEST)
+				user.visible_message("<span class='warning'>[user] squirts something into [target]'s eyes!</span>", "<span class='notice'>You transfer [trans] units of the solution.</span>")
+
+
 				return
 
 			else


### PR DESCRIPTION
Fixes bug #1219

Moving the logging from post-dropping (when the dropper is empty) to Pre-drop, post-dropable check (it should now be located at the point when a drop is going to occur, but just prior to actually doing so).

As always, please review this change to make sure I didn't break anything.  All I did was cut-paste the lines to a few lines above, but hey, never hurts to double-check!