### PR TITLE
Adds a new optional 'ambitions' system.

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -61,9 +61,12 @@
 
 	//put this here for easier tracking ingame
 	var/datum/money_account/initial_account
-	
+
 	//used for antag tcrystal trading, more info in code\game\objects\items\telecrystals.dm
 	var/accept_tcrystals = 0
+
+	//used for optional self-objectives that antagonists can give themselves, which are displayed at the end of the round.
+	var/ambitions
 
 /datum/mind/New(var/key)
 	src.key = key
@@ -147,7 +150,7 @@
 
 	if(href_list["add_antagonist"])
 		var/datum/antagonist/antag = all_antag_types[href_list["add_antagonist"]]
-		if(antag) 
+		if(antag)
 			if(antag.add_antagonist(src, 1, 1, 0, 1, 1)) // Ignore equipment and role type for this.
 				log_admin("[key_name_admin(usr)] made [key_name(src)] into a [antag.role_text].")
 			else

--- a/code/game/antagonist/antagonist_create.dm
+++ b/code/game/antagonist/antagonist_create.dm
@@ -105,6 +105,11 @@
 
 	show_objectives(player)
 
+	player.current << "<span class='notice'>Once you decide on a goal to pursue, you can optionally display it to \
+	everyone at the end of the shift with the <b>Set Ambition</b> verb, located in the IC tab.  You can change this at any time, \
+	and it otherwise has no bearing on your round.</span>"
+	player.current.verbs |= /mob/living/proc/write_ambition
+
 	// Clown clumsiness check, I guess downstream might use it.
 	if (player.current.mind)
 		if (player.current.mind.assigned_role == "Clown")

--- a/code/game/antagonist/antagonist_objectives.dm
+++ b/code/game/antagonist/antagonist_objectives.dm
@@ -30,3 +30,21 @@
 			world << "<span class='danger'><font size = 3>[loss_text]</font></span>"
 			if(loss_feedback_tag) feedback_set_details("round_end_result","[loss_feedback_tag]")
 
+/mob/living/proc/write_ambition()
+	set name = "Set Ambition"
+	set category = "IC"
+	set src = usr
+
+	if(!mind)
+		return
+	if(!src.mind.special_role)
+		src << "<span class='warning'>While you may perhaps have goals, this verb's meant to only be visible \
+		to antagonists.  Please make a bug report!</span>"
+		return
+	var/new_ambitions = input(src, "Write a short sentence of what your character hopes to accomplish \
+	today as an antagonist.  Remember that this is purely optional.  It will be shown at the end of the \
+	round for everybody else.", "Ambitions", mind.ambitions) as null|message
+	new_ambitions = sanitize(new_ambitions)
+	if(new_ambitions)
+		mind.ambitions = new_ambitions
+		src << "<span class='notice'>You've set your goal to be '[new_ambitions]'.<span>"

--- a/code/game/antagonist/antagonist_print.dm
+++ b/code/game/antagonist/antagonist_print.dm
@@ -7,6 +7,9 @@
 	for(var/datum/mind/P in current_antagonists)
 		text += print_player_full(P)
 		text += get_special_objective_text(P)
+		if(P.ambitions)
+			text += "<br>Their goals for today were..."
+			text += "<br><b>[P.ambitions]</b>"
 		if(!global_objectives.len && P.objectives && P.objectives.len)
 			var/failed
 			var/num = 1


### PR DESCRIPTION
Antagonists can set custom objective-like goals for themselves, which everyone can see at the end of the round.  This otherwise has no impact on the round.
Pictures:
![Picture of being turned into an antag](http://puu.sh/nPbvB/4bc562fabd.png)
![Picture of setting an ambition](http://puu.sh/nPbU7/b466365232.png)
![Picture of round-end report](http://puu.sh/nPbXF/9f09061c82.png)