### PR TITLE
Armblade Additions plus One Other Thing

### DIFF
--- a/code/game/gamemodes/changeling/powers/self_respiration.dm
+++ b/code/game/gamemodes/changeling/powers/self_respiration.dm
@@ -1,8 +1,8 @@
 /datum/power/changeling/self_respiration
 	name = "Self Respiration"
-	desc = "We evolve our body to no longer require drawing oxygen from the atmosphere.."
+	desc = "We evolve our body to no longer require drawing oxygen from the atmosphere."
 	helptext = "We will no longer require internals, and we cannot inhale any gas, including harmful ones."
-	genomecost = 1
+	genomecost = 0
 	isVerb = 0
 	verbpath = /mob/proc/changeling_self_respiration
 

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -808,23 +808,23 @@ About the new airlock wires panel:
 			else
 				spawn(0)	close(1)
 
-	else if(istype(C, /obj/item/weapon/material/twohanded/fireaxe) && !arePowerSystemsOn())
+	// Check if we're using a crowbar or armblade, and if the airlock's unpowered for whatever reason (off, broken, etc).
+	else if( (istype(C, /obj/item/weapon/material/twohanded/fireaxe) || istype(C, /obj/item/weapon/melee/arm_blade) ) && !arePowerSystemsOn())
 		if(locked)
 			user << "<span class='notice'>The airlock's bolts prevent it from being forced.</span>"
 		else if( !welded && !operating )
+			if(istype(C, /obj/item/weapon/material/twohanded/fireaxe)) // If this is a fireaxe, make sure it's held in two hands.
+				var/obj/item/weapon/material/twohanded/fireaxe/F = C
+				if(!F.wielded)
+					user << "<span class='warning'>You need to be wielding \the [F] to do that.</span>"
+					return
+			// At this point, it's an armblade or a fireaxe that passed the wielded test, let's try to open it.
 			if(density)
-				var/obj/item/weapon/material/twohanded/fireaxe/F = C
-				if(F.wielded)
-					spawn(0)	open(1)
-				else
-					user << "<span class='warning'>You need to be wielding \the [C] to do that.</span>"
+				spawn(0)
+					open(1)
 			else
-				var/obj/item/weapon/material/twohanded/fireaxe/F = C
-				if(F.wielded)
-					spawn(0)	close(1)
-				else
-					user << "<span class='warning'>You need to be wielding \the [C] to do that.</span>"
-
+				spawn(0)
+					close(1)
 	else
 		..()
 	return

--- a/code/game/machinery/doors/blast_door.dm
+++ b/code/game/machinery/doors/blast_door.dm
@@ -86,11 +86,17 @@
 
 // Proc: attackby()
 // Parameters: 2 (C - Item this object was clicked with, user - Mob which clicked this object)
-// Description: If we are clicked with crowbar or wielded fire axe, try to manually open the door.
+// Description: If we are clicked with crowbar, wielded fire axe, or armblade, try to manually open the door.
 // This only works on broken doors or doors without power. Also allows repair with Plasteel.
 /obj/machinery/door/blast/attackby(obj/item/weapon/C as obj, mob/user as mob)
 	src.add_fingerprint(user)
-	if(istype(C, /obj/item/weapon/crowbar) || (istype(C, /obj/item/weapon/material/twohanded/fireaxe) && C:wielded == 1))
+	if(istype(C, /obj/item/weapon/crowbar) || istype(C, /obj/item/weapon/material/twohanded/fireaxe) || istype(C, /obj/item/weapon/melee/arm_blade))
+		if(istype(C,/obj/item/weapon/material/twohanded/fireaxe))
+			var/obj/item/weapon/material/twohanded/fireaxe/F = C
+			if(!F.wielded)
+				user << "<span class='warning'>You need to be wielding \the [F] to do that.</span>"
+				return
+
 		if(((stat & NOPOWER) || (stat & BROKEN)) && !( src.operating ))
 			force_toggle()
 		else
@@ -144,7 +150,7 @@
 	if(stat & BROKEN)
 		stat &= ~BROKEN
 
-		
+
 /obj/machinery/door/blast/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
 	if(air_group) return 1
 	return ..()

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -235,7 +235,7 @@
 		user << "<span class='danger'>\The [src] is welded shut!</span>"
 		return
 
-	if(istype(C, /obj/item/weapon/crowbar) || istype(C,/obj/item/weapon/material/twohanded/fireaxe))
+	if(istype(C, /obj/item/weapon/crowbar) || istype(C,/obj/item/weapon/material/twohanded/fireaxe) || istype(C, /obj/item/weapon/melee/arm_blade))
 		if(operating)
 			return
 


### PR DESCRIPTION
Armblades can now force depowered or broken airlocks, firelocks, and blast doors, just like a crowbar.
Armblades can slash APCs to cut all the wires.  Fixing the damage is as simple as mending all the wires.
Cleans up the fireaxe wielding check in airlock.dm
Removes colon cancer in blast_door.dm
Allows supplying an argument to not shock the user when cutting wires directly in wires.dm
Not armblade related: Self Respiration is now a free passive ability instead of costing one genome.