### PR TITLE
Removes JSON encoding of PDA Manifest list.

### DIFF
--- a/code/defines/obj.dm
+++ b/code/defines/obj.dm
@@ -62,9 +62,8 @@ using /datum/datacore/proc/manifest_inject( ), or manifest_insert( )
 */
 
 var/global/list/PDA_Manifest = list()
-var/global/ManifestJSON
 
-/datum/datacore/proc/get_manifest_json()
+/datum/datacore/proc/get_manifest_list()
 	if(PDA_Manifest.len)
 		return
 	var/heads[0]
@@ -146,7 +145,6 @@ var/global/ManifestJSON
 		"bot" = bot,\
 		"misc" = misc\
 		)
-	ManifestJSON = json_encode(PDA_Manifest)
 	return
 
 

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -462,7 +462,7 @@ var/global/list/obj/item/device/pda/PDAs = list()
 				data["convo_job"] = sanitize(c["job"])
 				break
 	if(mode==41)
-		data_core.get_manifest_json()
+		data_core.get_manifest_list()
 
 
 	if(mode==3)
@@ -531,7 +531,7 @@ var/global/list/obj/item/device/pda/PDAs = list()
 
 		data["feed"] = feed
 
-	data["manifest"] = list("__json_cache" = ManifestJSON)
+	data["manifest"] = PDA_Manifest
 
 	nanoUI = data
 	// update the ui if it exists, returns null if no ui is passed/found

--- a/code/modules/mob/living/silicon/pai/software_modules.dm
+++ b/code/modules/mob/living/silicon/pai/software_modules.dm
@@ -121,11 +121,11 @@
 	toggle = 0
 
 	on_ui_interact(mob/living/silicon/pai/user, datum/nanoui/ui=null, force_open=1)
-		data_core.get_manifest_json()
+		data_core.get_manifest_list()
 
 		var/data[0]
 		// This is dumb, but NanoUI breaks if it has no data to send
-		data["manifest"] = list("__json_cache" = ManifestJSON)
+		data["manifest"] = PDA_Manifest
 
 		ui = nanomanager.try_update_ui(user, user, id, ui, data, force_open)
 		if(!ui)

--- a/html/changelogs/Datraen-ManifestTweak.yml
+++ b/html/changelogs/Datraen-ManifestTweak.yml
@@ -1,0 +1,6 @@
+author: Datraen
+
+delete-after: True
+
+changes: 
+  - tweak: "Removed JSON encoding of the PDA Manifest list."


### PR DESCRIPTION
The code worked perfectly with the JSON encoding removed, whereas modifications to the JSON encoding for 510 preparations had created an error.

Resolves #1215