### PR TITLE
Smokable Item Rework

### DIFF
--- a/code/game/objects/items/weapons/cigs_lighters.dm
+++ b/code/game/objects/items/weapons/cigs_lighters.dm
@@ -120,7 +120,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	if(ishuman(loc))
 		var/mob/living/carbon/human/C = loc
 		if (src == C.wear_mask && C.check_has_mouth()) //cigarette in mouth
-			if (prob(20) && timeout <= 0) //in mouth, inhaling
+			if (C.sleeping <= 0 && prob(20) && timeout <= 0) //in mouth, inhaling
 				timeout = todefault
 
 				//random drag strength
@@ -137,10 +137,10 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 					C << "You inhale the [src.name]."
 
 				//transfer any smoked reagents
-				reagents.trans_to_mob(C, base+drag, CHEM_INGEST, REM)
+				reagents.trans_to_mob(C, base+drag, CHEM_BLOOD, 1)
 			else
 				//in mouth, not actively inhaling 
-				reagents.trans_to_mob(C, 0.1*base, CHEM_INGEST, REM)
+				reagents.trans_to_mob(C, 0.1*base, CHEM_BLOOD, 1)
 				reagents.remove_any(0.9*base)
 
 		else

--- a/code/game/objects/items/weapons/cigs_lighters.dm
+++ b/code/game/objects/items/weapons/cigs_lighters.dm
@@ -102,7 +102,6 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	..()
 	flags |= NOREACT // so it doesn't react until you light it
 	create_reagents(chem_volume) // making the cigarrete a chemical holder with a maximum volume of 15
-	max_smoketime = smoketime
 
 /obj/item/clothing/mask/smokable/process()
 	var/turf/location = get_turf(src)
@@ -258,6 +257,10 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	weldermes = "<span class='notice'>USER casually lights the NAME with FLAME.</span>"
 	ignitermes = "<span class='notice'>USER fiddles with FLAME, and manages to light their NAME.</span>"
 
+/obj/item/clothing/mask/smokable/cigarette/New()
+	..()
+	max_smoketime = smoketime
+
 /obj/item/clothing/mask/smokable/cigarette/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	..()
 
@@ -364,8 +367,9 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	icon_on = "pipeon"  //Note - these are in masks.dmi
 	icon_off = "pipeoff"
 	smoketime = 0
+	max_smoketime = 900
 	todefault = 7
-	chem_volume = 50 //50 ~= cigarette
+	chem_volume = 45
 	matchmes = "<span class='notice'>USER lights their NAME with their FLAME.</span>"
 	lightermes = "<span class='notice'>USER manages to light their NAME with FLAME.</span>"
 	zippomes = "<span class='rose'>With much care, USER lights their NAME with their FLAME.</span>"
@@ -417,10 +421,12 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 		if (!G.dry)
 			user << "<span class='notice'>[G] must be dried before you stuff it into [src].</span>"
 			return
-		if (smoketime)
-			user << "<span class='notice'>[src] is already packed.</span>"
+		world << "smoketime [smoketime] max [max_smoketime]"
+		if (smoketime>=max_smoketime)
+			user << "<span class='notice'>[src] is already stuffed!</span>"
 			return
-		smoketime = 1000
+		else
+			smoketime += 300
 		if(G.reagents)
 			G.reagents.trans_to_obj(src, G.reagents.total_volume)
 		name = "[G.name]-packed [initial(name)]"
@@ -450,7 +456,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	item_state = "cobpipeoff"
 	icon_on = "cobpipeon"  //Note - these are in masks.dmi
 	icon_off = "cobpipeoff"
-	chem_volume = 35
+	chem_volume = 45
 
 /////////
 //ZIPPO//

--- a/code/game/objects/items/weapons/cigs_lighters.dm
+++ b/code/game/objects/items/weapons/cigs_lighters.dm
@@ -421,7 +421,6 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 		if (!G.dry)
 			user << "<span class='notice'>[G] must be dried before you stuff it into [src].</span>"
 			return
-		world << "smoketime [smoketime] max [max_smoketime]"
 		if (smoketime>=max_smoketime)
 			user << "<span class='notice'>[src] is already stuffed!</span>"
 			return

--- a/code/game/objects/items/weapons/cigs_lighters.dm
+++ b/code/game/objects/items/weapons/cigs_lighters.dm
@@ -109,12 +109,20 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	if(location)
 		location.hotspot_expose(700, 5)
 	if(reagents && reagents.total_volume) // check if it has any reagents at all
+
+		//process all reagents in the current part of the smokable
+		var/base = reagents.total_volume/smoketime //chemical density for smoketime
+
 		if(ishuman(loc))
 			var/mob/living/carbon/human/C = loc
-			if (src == C.wear_mask && C.check_has_mouth()) // if it's in the human/monkey mouth, transfer reagents to the mob
-				reagents.trans_to_mob(C, REM, CHEM_INGEST, 0.2) // Most of it is not inhaled... balance reasons.
-		else // else just remove some of the reagents
-			reagents.remove_any(REM)
+			if (src == C.wear_mask && C.check_has_mouth()) //cigarette in mouth
+				var/drag = rand(0,10)/1000.0 //strength of ingestant's inhalation, mostly useful for near-threshold doses
+				reagents.trans_to_mob(C, base+drag, CHEM_INGEST, REM)
+			else
+				//in hand, behind ear, etc.
+				reagents.remove_any(base)
+		else //just burning
+			reagents.remove_any(base)
 
 /obj/item/clothing/mask/smokable/proc/light(var/flavor_text = "[usr] lights the [name].")
 	if(!src.lit)

--- a/code/game/objects/items/weapons/cigs_lighters.dm
+++ b/code/game/objects/items/weapons/cigs_lighters.dm
@@ -114,35 +114,32 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	if(location)
 		location.hotspot_expose(700, 5)
 
-	//deprecated: non-dipped cigs are handled generally
-	//if(reagents && reagents.total_volume) // check if it has any reagents at all
-
 	//process all reagents in the current part of the smokable
 	var/base = reagents.total_volume/smoketime //chemical density for smoketime
 
 	if(ishuman(loc))
 		var/mob/living/carbon/human/C = loc
 		if (src == C.wear_mask && C.check_has_mouth()) //cigarette in mouth
-			//world << "timeout was [timeout]"
 			if (prob(20) && timeout <= 0) //in mouth, inhaling
 				timeout = todefault
 
+				//random drag strength
 				var/rvar = rand(1,5)
 				var/drag = rvar*base
 
 				//compensate for drag
 				smoketime -= rvar
 
+				//hint the smoker about non-tobacco presence
 				if (reagents && reagents.total_volume && prob(20))
 					C << "You inhale the [src.name], there is an off taste to it..."
 				else
 					C << "You inhale the [src.name]."
 
-				//world << "Drag-Ingestion [(base+drag)*REM]"
+				//transfer any smoked reagents
 				reagents.trans_to_mob(C, base+drag, CHEM_INGEST, REM)
 			else
 				//in mouth, not actively inhaling 
-				//world << "Ingested [0.1*base*REM], wasted [0.9*base]"
 				reagents.trans_to_mob(C, 0.1*base, CHEM_INGEST, REM)
 				reagents.remove_any(0.9*base)
 

--- a/code/game/objects/items/weapons/cigs_lighters.dm
+++ b/code/game/objects/items/weapons/cigs_lighters.dm
@@ -116,8 +116,8 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 		if(ishuman(loc))
 			var/mob/living/carbon/human/C = loc
 			if (src == C.wear_mask && C.check_has_mouth()) //cigarette in mouth
-				var/drag = rand(0,10)/1000.0 //strength of ingestant's inhalation, mostly useful for near-threshold doses
-				reagents.trans_to_mob(C, base+drag, CHEM_INGEST, REM)
+				var/drag = rand(0,5)/100.0 //strength of ingestant's inhalation
+				reagents.trans_to_mob(C, base, CHEM_INGEST, REM+drag)
 			else
 				//in hand, behind ear, etc.
 				reagents.remove_any(base)
@@ -274,7 +274,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	throw_speed = 0.5
 	item_state = "cigaroff"
 	smoketime = 1500
-	chem_volume = 20
+	chem_volume = 75 //75 ~= cigarette
 	matchmes = "<span class='notice'>USER lights their NAME with their FLAME.</span>"
 	lightermes = "<span class='notice'>USER manages to offend their NAME by lighting it with FLAME.</span>"
 	zippomes = "<span class='rose'>With a flick of their wrist, USER lights their NAME with their FLAME.</span>"
@@ -295,7 +295,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	icon_on = "cigar2on"
 	icon_off = "cigar2off"
 	smoketime = 7200
-	chem_volume = 30
+	chem_volume = 75 //360 ~= cigarette
 
 /obj/item/weapon/cigbutt
 	name = "cigarette butt"
@@ -335,7 +335,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	icon_on = "pipeon"  //Note - these are in masks.dmi
 	icon_off = "pipeoff"
 	smoketime = 0
-	chem_volume = 50
+	chem_volume = 50 //50 ~= cigarette
 	matchmes = "<span class='notice'>USER lights their NAME with their FLAME.</span>"
 	lightermes = "<span class='notice'>USER manages to light their NAME with FLAME.</span>"
 	zippomes = "<span class='rose'>With much care, USER lights their NAME with their FLAME.</span>"

--- a/code/game/objects/items/weapons/cigs_lighters.dm
+++ b/code/game/objects/items/weapons/cigs_lighters.dm
@@ -89,6 +89,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	var/type_butt = null
 	var/chem_volume = 0
 	var/smoketime = 0
+	var/max_smoketime = 0
 	var/timeout = 0 //rate limiter
 	var/todefault = 5
 	var/matchmes = "USER lights NAME with FLAME"
@@ -101,6 +102,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	..()
 	flags |= NOREACT // so it doesn't react until you light it
 	create_reagents(chem_volume) // making the cigarrete a chemical holder with a maximum volume of 15
+	max_smoketime = smoketime
 
 /obj/item/clothing/mask/smokable/process()
 	var/turf/location = get_turf(src)
@@ -271,7 +273,8 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	if(!proximity)
 		return
 	if(istype(glass)) //you can dip cigarettes into beakers
-		var/transfered = glass.reagents.trans_to_obj(src, chem_volume)
+		//don't fill more than there is cigarette to fill, if that makes sense...
+		var/transfered = glass.reagents.trans_to_obj(src, chem_volume*(smoketime/max_smoketime) - reagents.total_volume)
 		if(transfered)	//if reagents were transfered, show the message
 			user << "<span class='notice'>You dip \the [src] into \the [glass].</span>"
 		else			//if not, either the beaker was empty, or the cigarette was full

--- a/code/game/objects/items/weapons/storage/fancy.dm
+++ b/code/game/objects/items/weapons/storage/fancy.dm
@@ -143,17 +143,15 @@
 	flags |= NOREACT
 	for(var/i = 1 to storage_slots)
 		new /obj/item/clothing/mask/smokable/cigarette(src)
-	create_reagents(15 * storage_slots)//so people can inject cigarettes without opening a packet, now with being able to inject the whole one
 
 /obj/item/weapon/storage/fancy/cigarettes/update_icon()
 	icon_state = "[initial(icon_state)][contents.len]"
 	return
 
 /obj/item/weapon/storage/fancy/cigarettes/remove_from_storage(obj/item/W as obj, atom/new_location)
-		var/obj/item/clothing/mask/smokable/cigarette/C = W
-		if(!istype(C)) return // what
-		reagents.trans_to_obj(C, (reagents.total_volume/contents.len))
-		..()
+	var/obj/item/clothing/mask/smokable/cigarette/C = W
+	if(!istype(C)) return // what
+	..()
 
 /obj/item/weapon/storage/fancy/cigarettes/attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob)
 	if(!istype(M, /mob))
@@ -161,9 +159,7 @@
 
 	if(M == user && user.zone_sel.selecting == O_MOUTH && contents.len > 0 && !user.wear_mask)
 		var/obj/item/clothing/mask/smokable/cigarette/W = new /obj/item/clothing/mask/smokable/cigarette(user)
-		reagents.trans_to_obj(W, (reagents.total_volume/contents.len))
 		user.equip_to_slot_if_possible(W, slot_wear_mask)
-		reagents.maximum_volume = 15 * contents.len
 		contents.len--
 		user << "<span class='notice'>You take a cigarette out of the pack.</span>"
 		update_icon()
@@ -236,7 +232,6 @@
 	flags |= NOREACT
 	for(var/i = 1 to storage_slots)
 		new /obj/item/clothing/mask/smokable/cigarette/cigar(src)
-	create_reagents(15 * storage_slots)
 
 /obj/item/weapon/storage/fancy/cigar/update_icon()
 	icon_state = "[initial(icon_state)][contents.len]"
@@ -245,7 +240,6 @@
 /obj/item/weapon/storage/fancy/cigar/remove_from_storage(obj/item/W as obj, atom/new_location)
 		var/obj/item/clothing/mask/smokable/cigarette/cigar/C = W
 		if(!istype(C)) return
-		reagents.trans_to_obj(C, (reagents.total_volume/contents.len))
 		..()
 
 /obj/item/weapon/storage/fancy/cigar/attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob)
@@ -254,9 +248,7 @@
 
 	if(M == user && user.zone_sel.selecting == O_MOUTH && contents.len > 0 && !user.wear_mask)
 		var/obj/item/clothing/mask/smokable/cigarette/cigar/W = new /obj/item/clothing/mask/smokable/cigarette/cigar(user)
-		reagents.trans_to_obj(W, (reagents.total_volume/contents.len))
 		user.equip_to_slot_if_possible(W, slot_wear_mask)
-		reagents.maximum_volume = 15 * contents.len
 		contents.len--
 		user << "<span class='notice'>You take a cigar out of the case.</span>"
 		update_icon()


### PR DESCRIPTION
*... or: Putting the Cancer Back Into Cigarettes.*

**This is a rework of the old smokable code which adds some more polished mechanics and irons out a few kinks that have accumulated over the years.**

## Changes
* Smokables containing reagents now have their reagents distributed evenly.
* Pipes are now stuffed with 1-3 ingredients, allowing more variation in taste and power.
* Instead of having a fixed burn-time and reagent distribution, smokables are now affected by inhalation, and in the case of pipes, stuffing.
* Information pertaining to your smoking is now echoed back to you, primarily whether or not the cigarette you're smoking is actually a sherm.
* Cigarettes and cigarette-based items can no longer be filled to the (unburnt) max when it has been lit, instead it fills as much as possible.
* Broken packet injection code has been removed.