### PR TITLE
Makes loadout datums more flexible.

### DIFF
--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -355,7 +355,7 @@ var/global/datum/controller/occupations/job_master
 							// adding an arg to a bunch of different procs. Will look into it after this merge. ~ Z
 							if(G.slot == slot_wear_mask || G.slot == slot_wear_suit || G.slot == slot_head)
 								custom_equip_leftovers += thing
-							else if(H.equip_to_slot_or_del(new G.path(H), G.slot))
+							else if(H.equip_to_slot_or_del(G.spawn_item(H), G.slot))
 								H << "<span class='notice'>Equipping you with [thing]!</span>"
 								custom_equip_slots.Add(G.slot)
 							else
@@ -375,7 +375,7 @@ var/global/datum/controller/occupations/job_master
 				if(G.slot in custom_equip_slots)
 					spawn_in_storage += thing
 				else
-					if(H.equip_to_slot_or_del(new G.path(H), G.slot))
+					if(H.equip_to_slot_or_del(G.spawn_item(H), G.slot))
 						H << "<span class='notice'>Equipping you with [thing]!</span>"
 						custom_equip_slots.Add(G.slot)
 					else

--- a/code/modules/client/preference_setup/loadout/gear_tweaks.dm
+++ b/code/modules/client/preference_setup/loadout/gear_tweaks.dm
@@ -1,0 +1,28 @@
+/datum/gear_tweak/proc/apply_tweak(var/obj/item/I)
+	return
+
+/*
+* Color adjustment
+*/
+/datum/gear_tweak/color
+	var/item_color
+
+/datum/gear_tweak/color/New(var/item_color)
+	src.item_color = item_color
+	..()
+
+/datum/gear_tweak/color/apply_tweak(var/obj/item/I)
+	I.color = item_color
+
+/*
+* Icon state adjustment
+*/
+/datum/gear_tweak/icon_state
+	var/icon_state
+
+/datum/gear_tweak/icon_state/New(var/icon_state)
+	src.icon_state = icon_state
+	..()
+
+/datum/gear_tweak/icon_state/apply_tweak(var/obj/item/I)
+	I.icon_state = icon_state

--- a/code/modules/client/preference_setup/loadout/loadout.dm
+++ b/code/modules/client/preference_setup/loadout/loadout.dm
@@ -157,5 +157,10 @@ var/list/gear_datums = list()
 	var/list/allowed_roles //Roles that can spawn with this item.
 	var/whitelisted        //Term to check the whitelist for..
 	var/sort_category = "General"
+	var/list/gear_tweaks = list() //List of datums which will alter the item after it has been spawned.
 
-
+/datum/gear/proc/spawn_item(var/location)
+	var/item = new path(location)
+	for(var/datum/gear_tweak/gt in gear_tweaks)
+		gt.apply_tweak(item)
+	return item

--- a/polaris.dme
+++ b/polaris.dme
@@ -989,6 +989,7 @@
 #include "code\modules\client\preference_setup\global\03_pai.dm"
 #include "code\modules\client\preference_setup\global\04_communicators.dm"
 #include "code\modules\client\preference_setup\global\setting_datums.dm"
+#include "code\modules\client\preference_setup\loadout\gear_tweaks.dm"
 #include "code\modules\client\preference_setup\loadout\loadout.dm"
 #include "code\modules\client\preference_setup\loadout\loadout_accessories.dm"
 #include "code\modules\client\preference_setup\loadout\loadout_cosmetics.dm"


### PR DESCRIPTION
Loadout item definitions can now also take a list of tweaks, which will adjust the item after spawn.
Currently includes color and icon state changes.

Ports Baystation12/Baystation12#12306