### PR TITLE
Command age limits

### DIFF
--- a/code/game/jobs/job/captain.dm
+++ b/code/game/jobs/job/captain.dm
@@ -19,6 +19,7 @@ var/datum/announcement/minor/captain_announcement = new(do_newscast = 1)
 	minimal_player_age = 14
 	economic_modifier = 20
 
+	minimum_character_age = 25
 	ideal_character_age = 70 // Old geezer captains ftw
 
 
@@ -67,6 +68,8 @@ var/datum/announcement/minor/captain_announcement = new(do_newscast = 1)
 	req_admin_notify = 1
 	minimal_player_age = 10
 	economic_modifier = 10
+
+	minimum_character_age = 25
 	ideal_character_age = 50
 
 	access = list(access_security, access_sec_doors, access_brig, access_forensics_lockers,

--- a/code/game/jobs/job/engineering.dm
+++ b/code/game/jobs/job/engineering.dm
@@ -13,6 +13,7 @@
 	req_admin_notify = 1
 	economic_modifier = 10
 
+	minimum_character_age = 25
 	ideal_character_age = 50
 
 

--- a/code/game/jobs/job/medical.dm
+++ b/code/game/jobs/job/medical.dm
@@ -19,6 +19,7 @@
 			access_chemistry, access_virology, access_cmo, access_surgery, access_RC_announce,
 			access_keycard_auth, access_sec_doors, access_psychiatrist, access_eva, access_external_airlocks, access_maint_tunnels)
 
+	minimum_character_age = 25
 	minimal_player_age = 10
 	ideal_character_age = 50
 

--- a/code/game/jobs/job/science.dm
+++ b/code/game/jobs/job/science.dm
@@ -21,6 +21,7 @@
 			            access_research, access_robotics, access_xenobiology, access_ai_upload, access_tech_storage,
 			            access_RC_announce, access_keycard_auth, access_tcomsat, access_gateway, access_xenoarch)
 
+	minimum_character_age = 25
 	minimal_player_age = 14
 	ideal_character_age = 50
 

--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -20,6 +20,7 @@
 			            access_forensics_lockers, access_morgue, access_maint_tunnels, access_all_personal_lockers,
 			            access_research, access_engine, access_mining, access_medical, access_construction, access_mailsorting,
 			            access_heads, access_hos, access_RC_announce, access_keycard_auth, access_gateway, access_external_airlocks)
+	minimum_character_age = 25
 	minimal_player_age = 14
 
 	equip(var/mob/living/carbon/human/H)


### PR DESCRIPTION
Adds the agreed-upon 25 year age limit for Head of Staff roles utilizng Zuhayr's refactored job age system that never actually got used!