### PR TITLE
Replaces previous microwave hackfix with proper checks.

### DIFF
--- a/code/game/machinery/kitchen/microwave.dm
+++ b/code/game/machinery/kitchen/microwave.dm
@@ -18,8 +18,6 @@
 	var/global/list/acceptable_items // List of the items you can put in
 	var/global/list/acceptable_reagents // List of the reagents you can put in
 	var/global/max_n_of_items = 0
-	
-	var/list/ingredient_list = list()	//MUST BE INTIALIZED OR YOU GET RUNTIME ERRORS
 
 
 // see code/modules/food/recipes_microwave.dm for recipes
@@ -116,13 +114,12 @@
 			user << "<span class='warning'>It's dirty!</span>"
 			return 1
 	else if(is_type_in_list(O,acceptable_items))
-		if (ingredient_list.len>=max_n_of_items)
+		if (contents.len>=(max_n_of_items + component_parts.len))	//Adds component_parts to the maximum number of items.
 			user << "<span class='warning'>This [src] is full of ingredients, you cannot put more.</span>"
 			return 1
 		if(istype(O, /obj/item/stack) && O:get_amount() > 1) // This is bad, but I can't think of how to change it
 			var/obj/item/stack/S = O
-			var/obj/item/stack/K = new O.type (src) //Needed for change into ingredient lists, rather than just contents.
-			ingredient_list += K
+			new O.type (src)
 			S.use(1)
 			user.visible_message( \
 				"<span class='notice'>\The [user] has added one of [O] to \the [src].</span>", \
@@ -132,7 +129,6 @@
 		//	user.remove_from_mob(O)	//This just causes problems so far as I can tell. -Pete
 			user.drop_item()
 			O.loc = src
-			ingredient_list += O
 			user.visible_message( \
 				"<span class='notice'>\The [user] has added \the [O] to \the [src].</span>", \
 				"<span class='notice'>You add \the [O] to \the [src].</span>")
@@ -181,7 +177,7 @@
 		var/list/items_counts = new
 		var/list/items_measures = new
 		var/list/items_measures_p = new
-		for (var/obj/O in ingredient_list)
+		for (var/obj/O in (contents-component_parts))
 			var/display_name = O.name
 			if (istype(O,/obj/item/weapon/reagent_containers/food/snacks/egg))
 				items_measures[display_name] = "egg"
@@ -241,7 +237,7 @@
 	if(stat & (NOPOWER|BROKEN))
 		return
 	start()
-	if (reagents.total_volume==0 && !(locate(/obj) in ingredient_list)) //dry run
+	if (reagents.total_volume==0 && !(locate(/obj) in (contents-component_parts))) //dry run
 		if (!wzhzhzh(10))
 			abort()
 			return
@@ -303,7 +299,7 @@
 	return 1
 
 /obj/machinery/microwave/proc/has_extra_item()
-	for (var/obj/O in ingredient_list)
+	for (var/obj/O in (contents-component_parts))
 		if ( \
 				!istype(O,/obj/item/weapon/reagent_containers/food) && \
 				!istype(O, /obj/item/weapon/grown) \
@@ -329,9 +325,8 @@
 	src.updateUsrDialog()
 
 /obj/machinery/microwave/proc/dispose()
-	for (var/obj/O in ingredient_list)
+	for (var/obj/O in (contents-component_parts))
 		O.loc = src.loc
-		ingredient_list -= O
 	if (src.reagents.total_volume)
 		src.dirty++
 	src.reagents.clear_reagents()
@@ -365,7 +360,7 @@
 /obj/machinery/microwave/proc/fail()
 	var/obj/item/weapon/reagent_containers/food/snacks/badrecipe/ffuu = new(src)
 	var/amount = 0
-	for (var/obj/O in ingredient_list-ffuu)
+	for (var/obj/O in (contents-ffuu)-component_parts)
 		amount++
 		if (O.reagents)
 			var/id = O.reagents.get_master_reagent_id()


### PR DESCRIPTION
Previously a second list was used, rather than a proper removal of the components_list. The procs were restricted rather than checking for if it was a machine and proceeding appropriately.

Reverts #1270 and replaces it with proper code.

DNM was due to a proc being missed, which would result in component parts* being qdel'd.