### PR TITLE
Removes "Goebbles"

### DIFF
--- a/config/names/last.txt
+++ b/config/names/last.txt
@@ -502,7 +502,6 @@ Stamos
 Sagan
 Hawking
 Dawkins
-Goebbles
 McShain
 McDonohugh
 Power


### PR DESCRIPTION
(despite it not actually being spelt correctly) from the last name list, on staff request.