### PR TITLE
Firing a gun while cloaked will now unclock you.

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -163,6 +163,8 @@
 
 	add_fingerprint(user)
 
+	user.break_cloak()
+
 	if(!special_check(user))
 		return
 


### PR DESCRIPTION
Fixes an exploit where cloaked persons could fire guns without decloaking.