### PR TITLE
Fixes ling transforms

### DIFF
--- a/code/game/gamemodes/changeling/absorbed_dna.dm
+++ b/code/game/gamemodes/changeling/absorbed_dna.dm
@@ -1,0 +1,12 @@
+/datum/absorbed_dna
+	var/name
+	var/datum/dna/dna
+	var/speciesName
+	var/list/languages
+
+/datum/absorbed_dna/New(var/newName, var/newDNA, var/newSpecies, var/newLanguages)
+	..()
+	name = newName
+	dna = newDNA
+	speciesName = newSpecies
+	languages = newLanguages

--- a/code/game/gamemodes/changeling/changeling_powers.dm
+++ b/code/game/gamemodes/changeling/changeling_powers.dm
@@ -1,9 +1,8 @@
 var/global/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","Epsilon","Zeta","Eta","Theta","Iota","Kappa","Lambda","Mu","Nu","Xi","Omicron","Pi","Rho","Sigma","Tau","Upsilon","Phi","Chi","Psi","Omega")
 
 /datum/changeling //stores changeling powers, changeling recharge thingie, changeling absorbed DNA and changeling ID (for changeling hivemind)
-	var/list/absorbed_dna = list()
-	var/list/absorbed_species = list()
-	var/list/absorbed_languages = list()
+	var/list/datum/absorbed_dna/absorbed_dna = list()
+	var/list/absorbed_languages = list() // Necessary because of set_species stuff
 	var/absorbedcount = 0
 	var/chem_charges = 20
 	var/chem_recharge_rate = 0.5
@@ -23,25 +22,36 @@ var/global/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","E
 
 /datum/changeling/New(var/gender=FEMALE)
 	..()
-	var/honorific = (gender == FEMALE) ? "Ms." : "Mr."
 	if(possible_changeling_IDs.len)
 		changelingID = pick(possible_changeling_IDs)
 		possible_changeling_IDs -= changelingID
-		changelingID = "[honorific] [changelingID]"
+		changelingID = "[changelingID]"
 	else
-		changelingID = "[honorific] [rand(1,999)]"
+		changelingID = "[rand(1,999)]"
 
 /datum/changeling/proc/regenerate()
 	chem_charges = min(max(0, chem_charges+chem_recharge_rate), chem_storage)
 	geneticdamage = max(0, geneticdamage-1)
 
 /datum/changeling/proc/GetDNA(var/dna_owner)
-	var/datum/dna/chosen_dna
-	for(var/datum/dna/DNA in absorbed_dna)
-		if(dna_owner == DNA.real_name)
-			chosen_dna = DNA
-			break
-	return chosen_dna
+	for(var/datum/absorbed_dna/DNA in absorbed_dna)
+		if(dna_owner == DNA.name)
+			return DNA
+
+/mob/proc/absorbDNA(var/datum/absorbed_dna/newDNA)
+	var/datum/changeling/changeling = null
+	if(src.mind && src.mind.changeling)
+		changeling = src.mind.changeling
+	if(!changeling)
+		return
+
+	for(var/language in newDNA.languages)
+		changeling.absorbed_languages |= language
+
+	changeling_update_languages(changeling.absorbed_languages)
+
+	if(!changeling.GetDNA(newDNA.name)) // Don't duplicate - I wonder if it's possible for it to still be a different DNA? DNA code could use a rewrite
+		changeling.absorbed_dna += newDNA
 
 //Restores our verbs. It will only restore verbs allowed during lesser (monkey) form if we are not human
 /mob/proc/make_changeling()
@@ -70,14 +80,13 @@ var/global/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","E
 			if(!(P in src.verbs))
 				src.verbs += P.verbpath
 
-	mind.changeling.absorbed_dna |= dna
+	for(var/language in languages)
+		mind.changeling.absorbed_languages |= language
 
 	var/mob/living/carbon/human/H = src
 	if(istype(H))
-		mind.changeling.absorbed_species += H.species.name
-
-	for(var/language in languages)
-		mind.changeling.absorbed_languages |= language
+		var/datum/absorbed_dna/newDNA = new(H.real_name, H.dna, H.species.name, H.languages)
+		absorbDNA(newDNA)
 
 	return 1
 
@@ -118,18 +127,14 @@ var/global/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","E
 
 	return changeling
 
-
 //Used to dump the languages from the changeling datum into the actual mob.
 /mob/proc/changeling_update_languages(var/updated_languages)
-
 	languages = list()
 	for(var/language in updated_languages)
 		languages += language
 
 	//This isn't strictly necessary but just to be safe...
 	add_language("Changeling")
-
-	return
 
 	//////////
 	//STINGS//	//They get a pretty header because there's just so fucking many of them ;_;
@@ -171,9 +176,3 @@ var/global/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","E
 	if(!T.mind || !T.mind.changeling)	return T	//T will be affected by the sting
 	T << "<span class='warning'>You feel a tiny prick.</span>"
 	return
-
-
-
-
-
-

--- a/code/game/gamemodes/changeling/powers/absorb.dm
+++ b/code/game/gamemodes/changeling/powers/absorb.dm
@@ -65,33 +65,21 @@
 	src << "<span class='notice'>We have absorbed [T]!</span>"
 	src.visible_message("<span class='danger'>[src] sucks the fluids from [T]!</span>")
 	T << "<span class='danger'>You have been absorbed by the changeling!</span>"
-
-	T.dna.real_name = T.real_name //Set this again, just to be sure that it's properly set.
-	changeling.absorbed_dna |= T.dna
 	if(src.nutrition < 400)
 		src.nutrition = min((src.nutrition + T.nutrition), 400)
 	changeling.chem_charges += 10
-//	changeling.geneticpoints += 2
 	src.verbs += /mob/proc/changeling_respec
 	src << "<span class='notice'>We can now re-adapt, reverting our evolution so that we may start anew, if needed.</span>"
 
-	//Steal all of their languages!
-	for(var/language in T.languages)
-		if(!(language in changeling.absorbed_languages))
-			changeling.absorbed_languages += language
-
-	changeling_update_languages(changeling.absorbed_languages)
-
-	//Steal their species!
-	if(T.species && !(T.species.name in changeling.absorbed_species))
-		changeling.absorbed_species += T.species.name
+	var/datum/absorbed_dna/newDNA = new(T.real_name, T.dna, T.species.name, T.languages)
+	absorbDNA(newDNA)
 
 	if(T.mind && T.mind.changeling)
 		if(T.mind.changeling.absorbed_dna)
-			for(var/dna_data in T.mind.changeling.absorbed_dna)	//steal all their loot
+			for(var/datum/absorbed_dna/dna_data in T.mind.changeling.absorbed_dna)	//steal all their loot
 				if(dna_data in changeling.absorbed_dna)
 					continue
-				changeling.absorbed_dna += dna_data
+				absorbDNA(dna_data)
 				changeling.absorbedcount++
 			T.mind.changeling.absorbed_dna.len = 1
 

--- a/code/game/gamemodes/changeling/powers/extract_dna_sting.dm
+++ b/code/game/gamemodes/changeling/powers/extract_dna_sting.dm
@@ -19,6 +19,9 @@
 
 	var/mob/living/carbon/human/T = changeling_sting(40, /mob/proc/changeling_extract_dna_sting)
 
+	if(!T)
+		return
+
 	if(!istype(T) || T.isSynthetic())
 		src << "<span class='warning'>\The [T] is not compatible with our biology.</span>"
 		return 0
@@ -31,10 +34,8 @@
 		src << "<span class='warning'>This creature's DNA is ruined beyond useability!</span>"
 		return 0
 
-	T.dna.real_name = T.real_name
-	changeling.absorbed_dna |= T.dna
-	if(T.species && !(T.species.name in changeling.absorbed_species))
-		changeling.absorbed_species += T.species.name
+	var/datum/absorbed_dna/newDNA = new(T.real_name, T.dna, T.species.name, T.languages)
+	absorbDNA(newDNA)
 
 	feedback_add_details("changeling_powers","ED")
 	return 1

--- a/code/game/gamemodes/changeling/powers/hivemind.dm
+++ b/code/game/gamemodes/changeling/powers/hivemind.dm
@@ -27,9 +27,9 @@ var/list/datum/dna/hivemind_bank = list()
 	if(!changeling)	return
 
 	var/list/names = list()
-	for(var/datum/dna/DNA in changeling.absorbed_dna)
+	for(var/datum/absorbed_dna/DNA in changeling.absorbed_dna)
 		if(!(DNA in hivemind_bank))
-			names += DNA.real_name
+			names += DNA.name
 
 	if(names.len <= 0)
 		src << "<span class='notice'>The airwaves already have all of our DNA.</span>"
@@ -38,7 +38,7 @@ var/list/datum/dna/hivemind_bank = list()
 	var/S = input("Select a DNA to channel: ", "Channel DNA", null) as null|anything in names
 	if(!S)	return
 
-	var/datum/dna/chosen_dna = changeling.GetDNA(S)
+	var/datum/absorbed_dna/chosen_dna = changeling.GetDNA(S)
 	if(!chosen_dna)
 		return
 
@@ -57,9 +57,9 @@ var/list/datum/dna/hivemind_bank = list()
 	if(!changeling)	return
 
 	var/list/names = list()
-	for(var/datum/dna/DNA in hivemind_bank)
+	for(var/datum/absorbed_dna/DNA in hivemind_bank)
 		if(!(DNA in changeling.absorbed_dna))
-			names[DNA.real_name] = DNA
+			names[DNA.name] = DNA
 
 	if(names.len <= 0)
 		src << "<span class='notice'>There's no new DNA to absorb from the air.</span>"
@@ -67,12 +67,12 @@ var/list/datum/dna/hivemind_bank = list()
 
 	var/S = input("Select a DNA absorb from the air: ", "Absorb DNA", null) as null|anything in names
 	if(!S)	return
-	var/datum/dna/chosen_dna = names[S]
+	var/datum/absorbed_dna/chosen_dna = names[S]
 	if(!chosen_dna)
 		return
 
 	changeling.chem_charges -= 20
-	changeling.absorbed_dna += chosen_dna
+	absorbDNA(chosen_dna)
 	src << "<span class='notice'>We absorb the DNA of [S] from the air.</span>"
 	feedback_add_details("changeling_powers","HD")
 	return 1

--- a/code/game/gamemodes/changeling/powers/transform.dm
+++ b/code/game/gamemodes/changeling/powers/transform.dm
@@ -4,12 +4,6 @@
 	genomecost = 0
 	verbpath = /mob/proc/changeling_transform
 
-/datum/power/changeling/change_species
-	name = "Change Species"
-	desc = "We take on the apperance of a species that we have absorbed."
-	genomecost = 0
-	verbpath = /mob/proc/changeling_change_species
-
 //Change our DNA to that of somebody we've absorbed.
 /mob/proc/changeling_transform()
 	set category = "Changeling"
@@ -19,73 +13,42 @@
 	if(!changeling)	return
 
 	var/list/names = list()
-	for(var/datum/dna/DNA in changeling.absorbed_dna)
-		names += "[DNA.real_name]"
+	for(var/datum/absorbed_dna/DNA in changeling.absorbed_dna)
+		names += "[DNA.name]"
 
 	var/S = input("Select the target DNA: ", "Target DNA", null) as null|anything in names
 	if(!S)	return
 
-	var/datum/dna/chosen_dna = changeling.GetDNA(S)
+	var/datum/absorbed_dna/chosen_dna = changeling.GetDNA(S)
 	if(!chosen_dna)
 		return
 
 	changeling.chem_charges -= 5
 	src.visible_message("<span class='warning'>[src] transforms!</span>")
 	changeling.geneticdamage = 5
-	src.dna = chosen_dna.Clone()
+
+	if(ishuman(src))
+		var/mob/living/carbon/human/H = src
+		var/newSpecies = chosen_dna.speciesName
+		H.set_species(newSpecies,1)
+
+	src.dna = chosen_dna.dna.Clone()
 	src.dna.b_type = "AB+" //This is needed to avoid blood rejection bugs.  The fact that the blood type might not match up w/ records could be a *FEATURE* too.
 	if(ishuman(src))
 		var/mob/living/carbon/human/H = src
 		H.b_type = "AB+" //For some reason we have two blood types on the mob.
 		for(var/flavor in H.flavor_texts) //Nulls out flavor text, so we don't keep our previous mob's flavor.
 			flavor = null
-	src.real_name = chosen_dna.real_name
+	src.real_name = chosen_dna.name
 	src.flavor_text = ""
 	src.UpdateAppearance()
 	domutcheck(src, null)
+	changeling_update_languages(changeling.absorbed_languages)
 
 	src.verbs -= /mob/proc/changeling_transform
-	spawn(10)	src.verbs += /mob/proc/changeling_transform
-
-	feedback_add_details("changeling_powers","TR")
-	return 1
-
-//Used to switch species based on the changeling datum.
-/mob/proc/changeling_change_species()
-
-	set category = "Changeling"
-	set name = "Change Species (5)"
-
-	var/mob/living/carbon/human/H = src
-	if(!istype(H))
-		src << "<span class='warning'>We may only use this power while in humanoid form.</span>"
-		return
-
-	var/datum/changeling/changeling = changeling_power(5,1,0)
-	if(!changeling)	return
-
-	if(changeling.absorbed_species.len < 2)
-		src << "<span class='warning'>We do not know of any other species genomes to use.</span>"
-		return
-
-	var/S = input("Select the target species: ", "Target Species", null) as null|anything in changeling.absorbed_species
-	if(!S)	return
-
-	domutcheck(src, null)
-
-	changeling.chem_charges -= 5
-	changeling.geneticdamage = 5
-
-	src.visible_message("<span class='warning'>[src] transforms!</span>")
-
-	src.verbs -= /mob/proc/changeling_change_species
-	H.set_species(S,1) //Until someone moves body colour into DNA, they're going to have to use the default.
-
 	spawn(10)
-		src.verbs += /mob/proc/changeling_change_species
+		src.verbs += /mob/proc/changeling_transform
 		src.regenerate_icons()
 
-	changeling_update_languages(changeling.absorbed_languages)
 	feedback_add_details("changeling_powers","TR")
-
 	return 1

--- a/html/changelogs/Kelenius-lingFixes.yml
+++ b/html/changelogs/Kelenius-lingFixes.yml
@@ -1,0 +1,39 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Kelenius
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Changelings will now change appearance and species together when transforming."
+  - tweak: "Changelings no longer have gender honorifics in lingchat."
+  - rscadd: "Absorbing the DNA from any source will allow you to use its name, species, and languages."
+  - bugfix: "DNA extract sting won't produce a strange message if there's no target."

--- a/polaris.dme
+++ b/polaris.dme
@@ -261,6 +261,7 @@
 #include "code\game\gamemodes\objective.dm"
 #include "code\game\gamemodes\setupgame.dm"
 #include "code\game\gamemodes\calamity\calamity.dm"
+#include "code\game\gamemodes\changeling\absorbed_dna.dm"
 #include "code\game\gamemodes\changeling\changeling.dm"
 #include "code\game\gamemodes\changeling\changeling_powers.dm"
 #include "code\game\gamemodes\changeling\generic_equip_procs.dm"


### PR DESCRIPTION
Lings transform name and species together
Ling always get languages from the DNA, be it by absorb, channel, or DNA sting
Removed gender honorifics in lingchat because sometimes there's only one female in the crew and it's easy to guess

Fixes #1305