### PR TITLE
Lunchboxes should now fit in backpacks

### DIFF
--- a/code/game/objects/items/weapons/storage/toolbox.dm
+++ b/code/game/objects/items/weapons/storage/toolbox.dm
@@ -86,6 +86,7 @@
 	item_state = "toolbox_pink"
 	desc = "A little lunchbox. This one is the colors of the rainbow!"
 	w_class = 3
+	max_w_class = 2
 	var/filled = FALSE
 	attack_verb = list("lunched")
 

--- a/code/game/objects/items/weapons/storage/toolbox.dm
+++ b/code/game/objects/items/weapons/storage/toolbox.dm
@@ -85,6 +85,7 @@
 	icon_state = "lunchbox_rainbow"
 	item_state = "toolbox_pink"
 	desc = "A little lunchbox. This one is the colors of the rainbow!"
+	w_class = 3
 	var/filled = FALSE
 	attack_verb = list("lunched")
 


### PR DESCRIPTION
Overrides the w_class from toolbox; makes lunchboxes small enough to fit in bags.