### PR TITLE
Ambition system tweaks

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -109,6 +109,8 @@
 			output += "<B>Objective #[obj_count]</B>: [objective.explanation_text]"
 			obj_count++
 
+	if(ambitions)
+		output += "<HR><B>Ambitions:</B> [ambitions]<br>"
 	recipient << browse(output,"window=memory")
 
 /datum/mind/proc/edit_memory()
@@ -142,7 +144,8 @@
 
 	else
 		out += "None."
-	out += "<br><a href='?src=\ref[src];obj_add=1'>\[add\]</a>"
+	out += "<br><a href='?src=\ref[src];obj_add=1'>\[add\]</a><br><br>"
+	out += "<b>Ambitions:</b> [ambitions ? ambitions : "None"] <a href='?src=\ref[src];amb_edit=\ref[src]'>\[edit\]</a></br>"
 	usr << browse(out, "window=edit_memory[src]")
 
 /datum/mind/Topic(href, href_list)
@@ -181,6 +184,18 @@
 		var/new_memo = sanitize(input("Write new memory", "Memory", memory) as null|message)
 		if (isnull(new_memo)) return
 		memory = new_memo
+
+	else if (href_list["amb_edit"])
+		var/datum/mind/mind = locate(href_list["amb_edit"])
+		if(!mind)
+			return
+		var/new_ambition = input("Enter a new ambition", "Memory", mind.ambitions) as null|message
+		if(isnull(new_ambition))
+			return
+		if(mind)
+			mind.ambitions = sanitize(new_ambition)
+			mind.current << "<span class='warning'>Your ambitions have been changed by higher powers, they are now: [mind.ambitions]</span>"
+		log_and_message_admins("made [key_name(mind.current)]'s ambitions be '[mind.ambitions]'.")
 
 	else if (href_list["obj_edit"] || href_list["obj_add"])
 		var/datum/objective/objective

--- a/code/game/antagonist/antagonist_add.dm
+++ b/code/game/antagonist/antagonist_add.dm
@@ -30,6 +30,12 @@
 	if(faction_verb && player.current)
 		player.current.verbs |= faction_verb
 
+	spawn(1 SECOND) //Added a delay so that this should pop up at the bottom and not the top of the text flood the new antag gets.
+		player.current << "<span class='notice'>Once you decide on a goal to pursue, you can optionally display it to \
+			everyone at the end of the shift with the <b>Set Ambition</b> verb, located in the IC tab.  You can change this at any time, \
+			and it otherwise has no bearing on your round.</span>"
+	player.current.verbs |= /mob/living/proc/write_ambition
+
 	// Handle only adding a mind and not bothering with gear etc.
 	if(nonstandard_role_type)
 		faction_members |= player
@@ -50,5 +56,8 @@
 		player.special_role = null
 		update_icons_removed(player)
 		BITSET(player.current.hud_updateflag, SPECIALROLE_HUD)
+		if(!is_special_character(player))
+			player.current.verbs -= /mob/living/proc/write_ambition
+			player.ambitions = ""
 		return 1
 	return 0

--- a/code/game/antagonist/antagonist_create.dm
+++ b/code/game/antagonist/antagonist_create.dm
@@ -104,17 +104,6 @@
 		create_nuke()
 
 	show_objectives(player)
-
-	player.current << "<span class='notice'>Once you decide on a goal to pursue, you can optionally display it to \
-	everyone at the end of the shift with the <b>Set Ambition</b> verb, located in the IC tab.  You can change this at any time, \
-	and it otherwise has no bearing on your round.</span>"
-	player.current.verbs |= /mob/living/proc/write_ambition
-
-	// Clown clumsiness check, I guess downstream might use it.
-	if (player.current.mind)
-		if (player.current.mind.assigned_role == "Clown")
-			player.current << "You have evolved beyond your clownish nature, allowing you to wield weapons without harming yourself."
-			player.current.mutations.Remove(CLUMSY)
 	return 1
 
 /datum/antagonist/proc/set_antag_name(var/mob/living/player)

--- a/code/game/antagonist/antagonist_objectives.dm
+++ b/code/game/antagonist/antagonist_objectives.dm
@@ -37,14 +37,19 @@
 
 	if(!mind)
 		return
-	if(!src.mind.special_role)
+	if(!is_special_character(mind))
 		src << "<span class='warning'>While you may perhaps have goals, this verb's meant to only be visible \
 		to antagonists.  Please make a bug report!</span>"
 		return
 	var/new_ambitions = input(src, "Write a short sentence of what your character hopes to accomplish \
 	today as an antagonist.  Remember that this is purely optional.  It will be shown at the end of the \
 	round for everybody else.", "Ambitions", mind.ambitions) as null|message
+	if(isnull(new_ambitions))
+		return
+	mind.ambitions = new_ambitions
 	new_ambitions = sanitize(new_ambitions)
 	if(new_ambitions)
-		mind.ambitions = new_ambitions
 		src << "<span class='notice'>You've set your goal to be '[new_ambitions]'.</span>"
+	else
+		src << "<span class='notice'>You leave your ambitions behind.</span>"
+	log_and_message_admins("has set their ambitions to now be: [new_ambitions].")

--- a/code/game/antagonist/antagonist_print.dm
+++ b/code/game/antagonist/antagonist_print.dm
@@ -9,7 +9,7 @@
 		text += get_special_objective_text(P)
 		if(P.ambitions)
 			text += "<br>Their goals for today were..."
-			text += "<br><b>[P.ambitions]</b>"
+			text += "<br><span class='notice'>[P.ambitions]</span>"
 		if(!global_objectives.len && P.objectives && P.objectives.len)
 			var/failed
 			var/num = 1

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -895,22 +895,26 @@ proc/admin_notice(var/message, var/rights)
 
 ////////////////////////////////////////////////////////////////////////////////////////////////ADMIN HELPER PROCS
 
-/proc/is_special_character(mob/M as mob) // returns 1 for specail characters and 2 for heroes of gamemode
+/proc/is_special_character(var/character) // returns 1 for special characters and 2 for heroes of gamemode
 	if(!ticker || !ticker.mode)
 		return 0
-	if (!istype(M))
-		return 0
+	var/datum/mind/M
+	if (ismob(character))
+		var/mob/C = character
+		M = C.mind
+	else if(istype(character, /datum/mind))
+		M = character
 
-	if(M.mind)
+	if(M)
 		if(ticker.mode.antag_templates && ticker.mode.antag_templates.len)
 			for(var/datum/antagonist/antag in ticker.mode.antag_templates)
-				if(antag.is_antagonist(M.mind))
+				if(antag.is_antagonist(M))
 					return 2
-		else if(M.mind.special_role)
+		else if(M.special_role)
 			return 1
 
-	if(isrobot(M))
-		var/mob/living/silicon/robot/R = M
+	if(isrobot(character))
+		var/mob/living/silicon/robot/R = character
 		if(R.emagged)
 			return 1
 


### PR DESCRIPTION
Ports Bay's port of this.  Did it manually because of ugly merge conflicts.
What Psi did:
Admins can now see and set ambitions in antag panel.
Makes is_special_character() a bit better.
What I did:
Setting ambitions, with the verb or with admin powers, is now logged.
Round-end text changed to be blue instead of bolded, for better readability.
Makes the ambition system known to the antag at the bottom of the chat log instead of before the 'you are a X' prompt.