### PR TITLE
Two-handed items drop check.

### DIFF
--- a/code/game/objects/items/weapons/material/twohanded.dm
+++ b/code/game/objects/items/weapons/material/twohanded.dm
@@ -68,6 +68,12 @@
 /obj/item/weapon/material/twohanded/update_icon()
 	icon_state = "[base_icon][wielded]"
 	item_state = icon_state
+	
+/obj/item/weapon/material/twohanded/dropped()
+	..()
+	if(wielded)
+		spawn(0)
+			update_held_icon()
 
 /*
  * Fireaxe

--- a/html/changelogs/datraen-twohanddrop.yml
+++ b/html/changelogs/datraen-twohanddrop.yml
@@ -1,0 +1,6 @@
+author: Datraen
+
+delete-after: True
+
+changes: 
+  - bugfix: "Checks to see if new a two-handed weapon can be wielded when dropped."


### PR DESCRIPTION
Adds a check to see if the item can be wielded when given or dropped when it is wielded.

This one was sitting around for a while.