### PR TITLE
Splash helper

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -317,6 +317,23 @@
 	return
 */
 
+/mob/living/verb/set_clumsiness()
+	set name = "Set Clumsiness"
+	set category = "IC"
+	set desc = "Toggles whether or not your character is clumsy and will fail at pouring stuff without warning."
+
+	if (src.clumsy == 0)
+		usr<<"You will now splash onto reagent holders."
+		src.clumsy = 1
+	else if (src.clumsy == 1)
+		usr<<"You will now splash onto reagent holders and placeables."
+		src.clumsy = 2
+	else
+		usr<<"You will no longer splash onto things without confirmation."
+		src.clumsy = 0
+
+	return
+
 /mob/verb/abandon_mob()
 	set name = "Respawn"
 	set category = "OOC"

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -321,16 +321,20 @@
 	set name = "Set Clumsiness"
 	set category = "IC"
 	set desc = "Toggles whether or not your character is clumsy and will fail at pouring stuff without warning."
+	var/list/modes = list("Holders", "Holders/Placeables", "Clumsy")
+	var/selection = input("Set clumsiness:", "Sensitivity", modes[src.clumsy+1]) in modes
 
-	if (src.clumsy == 0)
-		usr<<"You will now splash onto reagent holders."
-		src.clumsy = 1
-	else if (src.clumsy == 1)
-		usr<<"You will now splash onto reagent holders and placeables."
-		src.clumsy = 2
-	else
+	if (selection == modes[1])
 		usr<<"You will no longer splash onto things without confirmation."
 		src.clumsy = 0
+	else if (selection == modes[2])
+		usr<<"You will now splash reagents onto reagent holders."
+		src.clumsy = 1
+	else if (selection == modes[3])
+		usr<<"You will now splash reagents onto reagent holders and placeables."
+		src.clumsy = 2
+	else
+		usr<<"Something went wrong, you should ahelp this."
 
 	return
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -325,13 +325,13 @@
 	var/selection = input("Set clumsiness:", "Sensitivity", modes[src.clumsy+1]) in modes
 
 	if (selection == modes[1])
-		usr<<"You will no longer splash onto things without confirmation."
+		usr<<"You will no longer miss loadables and fillables without confirmation."
 		src.clumsy = 0
 	else if (selection == modes[2])
-		usr<<"You will now splash reagents onto reagent holders."
+		usr<<"You will now splash reagents onto fillables."
 		src.clumsy = 1
 	else if (selection == modes[3])
-		usr<<"You will now splash reagents onto reagent holders and placeables."
+		usr<<"You will now splash reagents onto fillables and placeables."
 		src.clumsy = 2
 	else
 		usr<<"Something went wrong, you should ahelp this."

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -325,16 +325,16 @@
 	var/selection = input("Set clumsiness:", "Sensitivity", modes[src.clumsy+1]) in modes
 
 	if (selection == modes[1])
-		usr<<"You will no longer miss loadables and fillables without confirmation."
+		src<<"You will no longer miss loadables and fillables without confirmation."
 		src.clumsy = 0
 	else if (selection == modes[2])
-		usr<<"You will now splash reagents onto fillables."
+		src<<"You will now splash reagents onto fillables."
 		src.clumsy = 1
 	else if (selection == modes[3])
-		usr<<"You will now splash reagents onto fillables and placeables."
+		src<<"You will now splash reagents onto fillables and placeables."
 		src.clumsy = 2
 	else
-		usr<<"Something went wrong, you should ahelp this."
+		src<<"Something went wrong, you should ahelp this."
 
 	return
 

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -6,7 +6,7 @@
 	var/datum/mind/mind
 
 	var/stat = 0 //Whether a mob is alive or dead. TODO: Move this to living - Nodrak
-	var/clumsy = 0 // Consider moving this as well...
+	var/clumsy = 0 //Decides whether or not the user should be queried before frivolously splashing stuff
 
 	//Not in use yet
 	var/obj/effect/organstructure/organStructure = null

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -6,6 +6,7 @@
 	var/datum/mind/mind
 
 	var/stat = 0 //Whether a mob is alive or dead. TODO: Move this to living - Nodrak
+	var/clumsy = 0 // Consider moving this as well...
 
 	//Not in use yet
 	var/obj/effect/organstructure/organStructure = null

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -85,7 +85,12 @@
 			return
 
 		//Help the user avoid clumsy splashing mistakes due to finicky sprites etc.
-		if (istype(target, /turf))
+		if  (user.clumsy == 0 && istype(target, /obj/item/weapon/reagent_containers))
+			var/resp = alert(user, "Do you really want to splash the solution?", "Splash the solution?", "Abort", "Proceed")
+			if (resp == "Abort")
+				return
+
+		if (user.clumsy <= 1 && istype(target, /turf))
 			for (var/thing in target)
 				if (is_type_in_list(thing, can_be_placed_into))
 					var/response = alert(user, "Do you really want to splash the solution?", "Splash the solution?", "Abort", "Proceed")

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -85,36 +85,44 @@
 			return
 
 		//Help the user avoid clumsy splashing mistakes due to finicky sprites etc.
-		//TODO: add check for blockage, windows etc.
-		//for lidded containers as well as effects (radium puddles, blood, etc.)
-		if  (user.clumsy == 0 && (istype(target, /obj/item/weapon/reagent_containers)))
-			var/resp = alert(user, "Do you really want to splash the solution?", "Splash the solution?", "Abort", "Proceed")
-			if (resp == "Abort")
-				return
-			else if (get_dist(user, target)>1)
-				user << "You are too far away."
-				return
-			else if (user.stat != 0)
-				return
-			else if (src.loc != user)
-				user << "You need to hold the [src] to splash with it."
-				return
+		if (reagents.total_volume) //don't pop a dialog if it's empty...
+			//handle lidded containers
+			if  (user.clumsy == 0 && (istype(target, /obj/item/weapon/reagent_containers)))
+				var/resp = alert(user, "Do you really want to splash the solution?", "Splash the solution?", "Abort", "Proceed")
+				if (resp == "Abort")
+					return
+				else if (!user.Adjacent(target))
+					user << "You cannot reach the [src]."
+					return
+				else if (user.stat != 0)
+					return
+				else if (src.loc != user)
+					user << "You need to hold the [src] to splash with it."
+					return
 
-		//handles splashes onto floors and effects (puddles, blood etc.)
-		if (user.clumsy <= 1 && (istype(target, /turf) || istype(target, /obj/effect) ))
-			for (var/thing in target)
-				if (is_type_in_list(thing, can_be_placed_into))
-					var/response = alert(user, "Do you really want to splash the solution?", "Splash the solution?", "Abort", "Proceed")
-					if (response == "Abort")
-						return
-					else if (get_dist(user, target)>1)
-						user << "You are too far away."
-						return
-					else if (user.stat != 0) //mob isn't fully alive
-						return
-					else if (src.loc != user) //mob doesn't carry the container in an equipment slot
-						user << "You need to hold the [src] to splash with it."
-						return
+			//handles splashes onto floors and effects (puddles, blood etc.)
+			if (user.clumsy <= 1 && (istype(target, /turf) || istype(target, /obj/effect) ))
+
+				//resolve contentless effects
+				var/intarget = null
+				if (istype(target, /obj/effect))
+					intarget = target.loc
+				else intarget = target
+
+				//iterate over things in content
+				for (var/thing in intarget)
+					if (is_type_in_list(thing, can_be_placed_into))
+						var/response = alert(user, "Do you really want to splash the solution?", "Splash the solution?", "Abort", "Proceed")
+						if (response == "Abort")
+							return
+						else if (!user.Adjacent(target))
+							user << "You cannot reach that."
+							return
+						else if (user.stat != 0) //mob isn't fully alive
+							return
+						else if (src.loc != user) //mob doesn't carry the container in an equipment slot
+							user << "You need to hold the [src] to splash with it."
+							return
 					break
 
 		if(reagents.total_volume)
@@ -137,6 +145,7 @@
 			name = base_name
 		else
 			name = "[base_name] ([label_text])"
+
 
 /obj/item/weapon/reagent_containers/glass/beaker
 	name = "beaker"

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -85,7 +85,7 @@
 			return
 
 		//Help the user avoid clumsy splashing mistakes due to finicky sprites etc.
-		//TODO: add check for turf accesibility, refactor into one block
+		//TODO: add check for blockage, windows etc.
 		//for lidded containers as well as effects (radium puddles, blood, etc.)
 		if  (user.clumsy == 0 && (istype(target, /obj/item/weapon/reagent_containers)))
 			var/resp = alert(user, "Do you really want to splash the solution?", "Splash the solution?", "Abort", "Proceed")
@@ -95,6 +95,9 @@
 				user << "You are too far away."
 				return
 			else if (user.stat != 0)
+				return
+			else if (src.loc != user)
+				user << "You need to hold the [src] to splash with it."
 				return
 
 		//handles splashes onto floors and effects (puddles, blood etc.)
@@ -107,7 +110,10 @@
 					else if (get_dist(user, target)>1)
 						user << "You are too far away."
 						return
-					else if (user.stat != 0)
+					else if (user.stat != 0) //mob isn't fully alive
+						return
+					else if (src.loc != user) //mob doesn't carry the container in an equipment slot
+						user << "You need to hold the [src] to splash with it."
 						return
 					break
 

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -85,16 +85,24 @@
 			return
 
 		//Help the user avoid clumsy splashing mistakes due to finicky sprites etc.
-		if  (user.clumsy == 0 && istype(target, /obj/item/weapon/reagent_containers))
+		//for lidded containers as well as effects (radium puddles, blood, etc.)
+		if  (user.clumsy == 0 && (istype(target, /obj/item/weapon/reagent_containers) || istype(target, /obj/effect)))
 			var/resp = alert(user, "Do you really want to splash the solution?", "Splash the solution?", "Abort", "Proceed")
 			if (resp == "Abort")
 				return
+			else if (get_dist(user, target)>1)
+				user << "You are too far away."
+				return
 
+		//handles splashes onto floors
 		if (user.clumsy <= 1 && istype(target, /turf))
 			for (var/thing in target)
 				if (is_type_in_list(thing, can_be_placed_into))
 					var/response = alert(user, "Do you really want to splash the solution?", "Splash the solution?", "Abort", "Proceed")
 					if (response == "Abort")
+						return
+					else if (get_dist(user, target)>1)
+						user << "You are too far away."
 						return
 					break
 

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -84,6 +84,15 @@
 		if(standard_pour_into(user, target))
 			return
 
+		//Help the user avoid clumsy splashing mistakes due to finicky sprites etc.
+		if (istype(target, /turf))
+			for (var/thing in target)
+				if (is_type_in_list(thing, can_be_placed_into))
+					var/response = alert(user, "Do you really want to splash the solution?", "Splash the solution?", "Abort", "Proceed")
+					if (response == "Abort")
+						return
+					break
+
 		if(reagents.total_volume)
 			user << "<span class='notice'>You splash the solution onto [target].</span>"
 			reagents.splash(target, reagents.total_volume)

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -85,6 +85,7 @@
 			return
 
 		//Help the user avoid clumsy splashing mistakes due to finicky sprites etc.
+		//TODO: add check for turf accesibility, refactor into one block
 		//for lidded containers as well as effects (radium puddles, blood, etc.)
 		if  (user.clumsy == 0 && (istype(target, /obj/item/weapon/reagent_containers)))
 			var/resp = alert(user, "Do you really want to splash the solution?", "Splash the solution?", "Abort", "Proceed")
@@ -92,6 +93,8 @@
 				return
 			else if (get_dist(user, target)>1)
 				user << "You are too far away."
+				return
+			else if (user.stat != 0)
 				return
 
 		//handles splashes onto floors and effects (puddles, blood etc.)
@@ -103,6 +106,8 @@
 						return
 					else if (get_dist(user, target)>1)
 						user << "You are too far away."
+						return
+					else if (user.stat != 0)
 						return
 					break
 

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -86,7 +86,7 @@
 
 		//Help the user avoid clumsy splashing mistakes due to finicky sprites etc.
 		//for lidded containers as well as effects (radium puddles, blood, etc.)
-		if  (user.clumsy == 0 && (istype(target, /obj/item/weapon/reagent_containers) || istype(target, /obj/effect)))
+		if  (user.clumsy == 0 && (istype(target, /obj/item/weapon/reagent_containers)))
 			var/resp = alert(user, "Do you really want to splash the solution?", "Splash the solution?", "Abort", "Proceed")
 			if (resp == "Abort")
 				return
@@ -94,8 +94,8 @@
 				user << "You are too far away."
 				return
 
-		//handles splashes onto floors
-		if (user.clumsy <= 1 && istype(target, /turf))
+		//handles splashes onto floors and effects (puddles, blood etc.)
+		if (user.clumsy <= 1 && (istype(target, /turf) || istype(target, /obj/effect) ))
 			for (var/thing in target)
 				if (is_type_in_list(thing, can_be_placed_into))
 					var/response = alert(user, "Do you really want to splash the solution?", "Splash the solution?", "Abort", "Proceed")


### PR DESCRIPTION
This pr adds a dialogue to help players avoid clumsy splashing mistakes related to partially transparent sprites and small targets. Depending on a 'clumsiness' setting, the game will ask the player to confirm splashing turfs with loadable machinery on them as well as reagent containers with lids before it actually splashes the target.