### PR TITLE
Fixes cryocells dumping patients out without being asked to

### DIFF
--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -63,10 +63,9 @@
 	return 1
 
 /obj/machinery/atmospherics/unary/cryo_cell/relaymove(mob/user as mob)
-	if(user.stat)
-		return
-	go_out()
-	return
+	// note that relaymove will also be called for mobs outside the cell with UI open
+	if(src.occupant == user && !user.stat)
+		go_out()
 
 /obj/machinery/atmospherics/unary/cryo_cell/attack_hand(mob/user)
 	ui_interact(user)


### PR DESCRIPTION
>Turns out cryo cells would dump occupants out if a person outside opened the UI and moved. This adds a check to prevent that, retaining the movement keys to get out feature that cryo cells apparently have.

Port of: https://github.com/Baystation12/Baystation12/pull/12515