### PR TITLE
Lockdown fix

### DIFF
--- a/code/game/machinery/computer/robot.dm
+++ b/code/game/machinery/computer/robot.dm
@@ -91,7 +91,7 @@
 		if(!target || !istype(target))
 			return
 
-		var/istraitor = (target.mind.special_role == "Traitor")
+		var/istraitor = target.mind.special_role
 		if (istraitor)
 			target.lockcharge = !target.lockcharge
 			if (target.lockcharge)

--- a/code/game/machinery/computer/robot.dm
+++ b/code/game/machinery/computer/robot.dm
@@ -91,7 +91,7 @@
 		if(!target || !istype(target))
 			return
 
-		var/istraitor = traitors.is_antagonist(target.mind)
+		var/istraitor = (target.mind.special_role == "Traitor")
 		if (istraitor)
 			target.lockcharge = !target.lockcharge
 			if (target.lockcharge)

--- a/code/game/machinery/computer/robot.dm
+++ b/code/game/machinery/computer/robot.dm
@@ -187,7 +187,7 @@
 		robot["name"] = R.name
 		if(R.stat)
 			robot["status"] = "Not Responding"
-		else if (!R.canmove)
+		else if (R.lockcharge)
 			robot["status"] = "Lockdown"
 		else
 			robot["status"] = "Operational"

--- a/html/changelogs/emperorjon-11_Apr._Lockdown_fix.yml
+++ b/html/changelogs/emperorjon-11_Apr._Lockdown_fix.yml
@@ -1,0 +1,6 @@
+author: EmperorJon
+
+delete-after: True
+
+changes: 
+  - bugfix: "Robotics Console now correctly shows the operational/lockdown state and button based off if it thinks the synthetic is locked down or not."

--- a/html/changelogs/emperorjon-11_Apr._Lockdown_fix.yml
+++ b/html/changelogs/emperorjon-11_Apr._Lockdown_fix.yml
@@ -4,3 +4,4 @@ delete-after: True
 
 changes: 
   - bugfix: "Robotics Console now correctly shows the operational/lockdown state and button based off if it thinks the synthetic is locked down or not."
+  - bugfix: "Autotraitor synths now behave the same as Traitor synths - they are not locked down."


### PR DESCRIPTION
Borgs now show the correct operational status/lock-unlock button in the UI.
Autotraitor borgs cannot be locked down.