### PR TITLE
Reinforced Walls

### DIFF
--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -143,7 +143,8 @@
 
 	user << "<span class='notice'>You begin adding the plating...</span>"
 
-	if(!do_after(user,40) || !S.use(2))
+	var/amount_to_use = reinf_material ? 1 : 2
+	if(!do_after(user,40) || !S.use(amount_to_use))
 		return 1 //once we've gotten this far don't call parent attackby()
 
 	if(anchored)
@@ -167,7 +168,7 @@
 		user << "<span class='notice'>\The [src] is already reinforced.</span>"
 		return 0
 
-	if(S.get_amount() < 2)
+	if(S.get_amount() < 1)
 		user << "<span class='notice'>There isn't enough material here to reinforce the girder.</span>"
 		return 0
 
@@ -177,7 +178,7 @@
 		return 0
 
 	user << "<span class='notice'>Now reinforcing...</span>"
-	if (!do_after(user,40) || !S.use(2))
+	if (!do_after(user,40) || !S.use(1))
 		return 1 //don't call parent attackby() past this point
 	user << "<span class='notice'>You added reinforcement!</span>"
 

--- a/code/game/turfs/simulated/wall_attacks.dm
+++ b/code/game/turfs/simulated/wall_attacks.dm
@@ -217,8 +217,7 @@
 				if (istype(W, /obj/item/weapon/wirecutters))
 					playsound(src, 'sound/items/Wirecutter.ogg', 100, 1)
 					construction_stage = 5
-					new /obj/item/stack/rods( src )
-					user << "<span class='notice'>You cut the outer grille.</span>"
+					user << "<span class='notice'>You cut through the outer grille.</span>"
 					update_icon()
 					return
 			if(5)
@@ -229,16 +228,13 @@
 						return
 					construction_stage = 4
 					update_icon()
-					user << "<span class='notice'>You remove the support lines.</span>"
+					user << "<span class='notice'>You unscrew the support lines.</span>"
 					return
-				else if( istype(W, /obj/item/stack/rods) )
-					var/obj/item/stack/O = W
-					if(O.get_amount()>0)
-						O.use(1)
-						construction_stage = 6
-						update_icon()
-						user << "<span class='notice'>You replace the outer grille.</span>"
-						return
+				else if (istype(W, /obj/item/weapon/wirecutters))
+					construction_stage = 6
+					user << "<span class='notice'>You mend the outer grille.</span>"
+					update_icon()
+					return
 			if(4)
 				var/cut_cover
 				if(istype(W,/obj/item/weapon/weldingtool))
@@ -260,6 +256,15 @@
 					construction_stage = 3
 					update_icon()
 					user << "<span class='notice'>You press firmly on the cover, dislodging it.</span>"
+					return
+				else if (istype(W, /obj/item/weapon/screwdriver))
+					user << "<span class='notice'>You begin screwing down the support lines.</span>"
+					playsound(src, 'sound/items/Screwdriver.ogg', 100, 1)
+					if(!do_after(user,40) || !istype(src, /turf/simulated/wall) || construction_stage != 4)
+						return
+					construction_stage = 5
+					update_icon()
+					user << "<span class='notice'>You screw down the support lines.</span>"
 					return
 			if(3)
 				if (istype(W, /obj/item/weapon/crowbar))
@@ -299,8 +304,7 @@
 						return
 					construction_stage = 0
 					update_icon()
-					new /obj/item/stack/rods(src)
-					user << "<span class='notice'>The support rods drop out as you cut them loose from the frame.</span>"
+					user << "<span class='notice'>The slice through the support rods.</span>"
 					return
 			if(0)
 				if(istype(W, /obj/item/weapon/crowbar))

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -162,7 +162,8 @@
 			reinf_material.place_dismantled_girder(src, reinf_material)
 		else
 			material.place_dismantled_girder(src)
-		material.place_dismantled_product(src,devastated)
+		if(!devastated)
+			material.place_dismantled_product(src)
 
 	for(var/obj/O in src.contents) //Eject contents!
 		if(istype(O,/obj/structure/sign/poster))

--- a/code/modules/materials/materials.dm
+++ b/code/modules/materials/materials.dm
@@ -195,9 +195,8 @@ var/list/name_to_material
 
 // General wall debris product placement.
 // Not particularly necessary aside from snowflakey cult girders.
-/material/proc/place_dismantled_product(var/turf/target,var/is_devastated)
-	for(var/x=1;x<(is_devastated?2:3);x++)
-		place_sheet(target)
+/material/proc/place_dismantled_product(var/turf/target)
+	place_sheet(target)
 
 // Debris product. Used ALL THE TIME.
 /material/proc/place_sheet(var/turf/target)


### PR DESCRIPTION
 - Lowers amount needed for building a reinforced wall from a girder from
four to two sheets.
 - Gets rid of rod products from dismantling a reinforced wall.
 - Adds one more extra step for undoing the deconstruction.

If I'm not mistaken, building reinforced walls used to only take two plasteel sheets per wall. With 10 sheets per stack of plasteel spawned in engineering, this will now make it possible to build five walls per stack and 15 walls in total with their given materials instead of half of it.