### PR TITLE
Aim Intent Changes

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -87,6 +87,7 @@
 	if(in_throw_mode)
 		if(isturf(A) || isturf(A.loc))
 			throw_item(A)
+			trigger_aiming(TARGET_CAN_CLICK)
 			return 1
 		throw_mode_off()
 
@@ -94,6 +95,7 @@
 
 	if(W == A) // Handle attack_self
 		W.attack_self(src)
+		trigger_aiming(TARGET_CAN_CLICK)
 		update_inv_active_hand(0)
 		return 1
 
@@ -113,6 +115,8 @@
 			if(ismob(A)) // No instant mob attacking
 				setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 			UnarmedAttack(A, 1)
+
+		trigger_aiming(TARGET_CAN_CLICK)
 		return 1
 
 	if(!isturf(loc)) // This is going to stop you from telekinesing from inside a closet, but I don't shed many tears for that
@@ -134,12 +138,15 @@
 				if(ismob(A)) // No instant mob attacking
 					setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 				UnarmedAttack(A, 1)
+			trigger_aiming(TARGET_CAN_CLICK)
 			return
 		else // non-adjacent click
 			if(W)
 				W.afterattack(A, src, 0, params) // 0: not Adjacent
 			else
 				RangedAttack(A, params)
+
+			trigger_aiming(TARGET_CAN_CLICK)
 	return 1
 
 /mob/proc/setClickCooldown(var/timeout)
@@ -325,7 +332,7 @@
 		else		direction = WEST
 	if(direction != dir)
 		facedir(direction)
-		
+
 /obj/screen/click_catcher
 	icon = 'icons/mob/screen1_full.dmi'
 	icon_state = "passage0"
@@ -341,4 +348,4 @@
 	else
 		var/turf/T = screen_loc2turf(modifiers["screen-loc"], get_turf(usr))
 		T.Click(location, control, params)
-	return 1 
+	return 1

--- a/code/modules/projectiles/targeting/targeting_overlay.dm
+++ b/code/modules/projectiles/targeting/targeting_overlay.dm
@@ -23,6 +23,7 @@
 	owner = newowner
 	loc = null
 	verbs.Cut()
+	toggle_permission(TARGET_CAN_RADIO)
 
 /obj/aiming_overlay/proc/toggle_permission(var/perm)
 
@@ -202,6 +203,7 @@ obj/aiming_overlay/proc/update_aiming_deferred()
 		else
 			owner << "<span class='notice'>You will no longer aim rather than fire.</span>"
 			owner.client.remove_gun_icons()
+		owner.gun_setting_icon.icon_state = "gun[active]"
 
 /obj/aiming_overlay/proc/cancel_aiming(var/no_message = 0)
 	if(!aiming_with || !aiming_at)

--- a/code/modules/projectiles/targeting/targeting_triggers.dm
+++ b/code/modules/projectiles/targeting/targeting_triggers.dm
@@ -1,4 +1,8 @@
-/mob/living/proc/trigger_aiming(var/trigger_type)
+//as core click exists at the mob level
+/mob/proc/trigger_aiming(var/trigger_type)
+	return
+
+/mob/living/trigger_aiming(var/trigger_type)
 	if(!aimed.len)
 		return
 	for(var/obj/aiming_overlay/AO in aimed)
@@ -23,7 +27,3 @@
 	var/obj/item/weapon/gun/G = aiming_with
 	if(istype(G))
 		G.Fire(aiming_at, owner)
-
-/mob/living/ClickOn(var/atom/A, var/params)
-	. = ..()
-	trigger_aiming(TARGET_CAN_CLICK)


### PR DESCRIPTION
Manually ports https://github.com/Baystation12/Baystation12/pull/12614 's fix to not make examining trigger the autofire.
The toggle to shoot if the target talks on the radio defaults to off.
The aim intent icon now updates when clicked.