### PR TITLE
Gender tweaks and adjustments

### DIFF
--- a/code/_helpers/global_lists.dm
+++ b/code/_helpers/global_lists.dm
@@ -23,6 +23,9 @@ var/global/list/joblist = list()					//list of all jobstypes, minus borg and AI
 
 var/global/list/turfs = list()						//list of all turfs
 
+#define all_genders_define_list list(MALE,FEMALE,PLURAL,NEUTER)
+#define all_genders_text_list list("Male","Female","Plural","Neuter")
+
 //Languages/species/whitelist.
 var/global/list/all_species[0]
 var/global/list/all_languages[0]

--- a/code/_helpers/text.dm
+++ b/code/_helpers/text.dm
@@ -323,3 +323,5 @@ proc/TextPreview(var/string,var/len=40)
 			if(48 to 57)			//Numbers
 				return 1
 	return 0
+
+#define gender2text(gender) capitalize(gender)

--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -1,3 +1,4 @@
+
 /hook/startup/proc/createDatacore()
 	data_core = new /datum/datacore()
 	return 1
@@ -186,7 +187,7 @@
 		G.fields["fingerprint"]	= md5(H.dna.uni_identity)
 		G.fields["p_stat"]		= "Active"
 		G.fields["m_stat"]		= "Stable"
-		G.fields["sex"]			= H.gender
+		G.fields["sex"]			= gender2text(H.gender)
 		G.fields["species"]		= H.get_species()
 		G.fields["home_system"]	= H.home_system
 		G.fields["citizenship"]	= H.citizenship
@@ -199,6 +200,7 @@
 		var/datum/data/record/M = CreateMedicalRecord(H.real_name, id)
 		M.fields["b_type"]		= H.b_type
 		M.fields["b_dna"]		= H.dna.unique_enzymes
+		M.fields["id_gender"]	= gender2text(H.identifying_gender)
 		if(H.med_record && !jobban_isbanned(H, "Records"))
 			M.fields["notes"] = H.med_record
 
@@ -214,7 +216,8 @@
 		L.fields["rank"] 		= H.mind.assigned_role
 		L.fields["age"]			= H.age
 		L.fields["fingerprint"]	= md5(H.dna.uni_identity)
-		L.fields["sex"]			= H.gender
+		L.fields["sex"]			= gender2text(H.gender)
+		L.fields["id_gender"]	= gender2text(H.identifying_gender)
 		L.fields["b_type"]		= H.b_type
 		L.fields["b_dna"]		= H.dna.unique_enzymes
 		L.fields["enzymes"]		= H.dna.SE // Used in respawning
@@ -418,7 +421,7 @@
 	G.fields["id"] = id
 	G.fields["rank"] = "Unassigned"
 	G.fields["real_rank"] = "Unassigned"
-	G.fields["sex"] = "Male"
+	G.fields["sex"] = "Unknown"
 	G.fields["age"] = "Unknown"
 	G.fields["fingerprint"] = "Unknown"
 	G.fields["p_stat"] = "Active"
@@ -460,6 +463,7 @@
 	M.fields["name"]		= name
 	M.fields["b_type"]		= "AB+"
 	M.fields["b_dna"]		= md5(name)
+	M.fields["id_gender"]	= "Unknown"
 	M.fields["mi_dis"]		= "None"
 	M.fields["mi_dis_d"]	= "No minor disabilities have been declared."
 	M.fields["ma_dis"]		= "None"

--- a/code/game/machinery/computer/medical.dm
+++ b/code/game/machinery/computer/medical.dm
@@ -49,11 +49,11 @@
 /obj/machinery/computer/med_data/attack_hand(mob/user as mob)
 	if(..())
 		return
-	var/dat
+	var/dat = list()
 	if (src.temp)
-		dat = text("<TT>[src.temp]</TT><BR><BR><A href='?src=\ref[src];temp=1'>Clear Screen</A>")
+		dat += text("<TT>[src.temp]</TT><BR><BR><A href='?src=\ref[src];temp=1'>Clear Screen</A>")
 	else
-		dat = text("Confirm Identity: <A href='?src=\ref[];scan=1'>[]</A><HR>", src, (src.scan ? text("[]", src.scan.name) : "----------"))
+		dat += text("Confirm Identity: <A href='?src=\ref[];scan=1'>[]</A><HR>", src, (src.scan ? text("[]", src.scan.name) : "----------"))
 		if (src.authenticated)
 			switch(src.screen)
 				if(1.0)
@@ -85,8 +85,12 @@
 					if ((istype(src.active1, /datum/data/record) && data_core.general.Find(src.active1)))
 						dat += "<table><tr><td>Name: [active1.fields["name"]] \
 								ID: [active1.fields["id"]]<BR>\n	\
-								Sex: <A href='?src=\ref[src];field=sex'>[active1.fields["sex"]]</A><BR>\n	\
-								Age: <A href='?src=\ref[src];field=age'>[active1.fields["age"]]</A><BR>\n	\
+								Sex: <A href='?src=\ref[src];field=sex'>[active1.fields["sex"]]</A><BR>\n"
+						if ((istype(src.active2, /datum/data/record) && data_core.medical.Find(src.active2)))
+							dat += "Gender identity: <A href='?src=\ref[src];field=id_gender'>[active2.fields["id_gender"]]</A><BR>"
+						else
+							dat += "Gender identity: <A href='?src=\ref[src];field=id_gender'>Unknown</A><BR>"
+						dat +=  "Age: <A href='?src=\ref[src];field=age'>[active1.fields["age"]]</A><BR>\n	\
 								Fingerprint: <A href='?src=\ref[src];field=fingerprint'>[active1.fields["fingerprint"]]</A><BR>\n	\
 								Physical Status: <A href='?src=\ref[src];field=p_stat'>[active1.fields["p_stat"]]</A><BR>\n	\
 								Mental Status: <A href='?src=\ref[src];field=m_stat'>[active1.fields["m_stat"]]</A><BR></td><td align = center valign = top> \
@@ -135,6 +139,7 @@
 				else
 		else
 			dat += text("<A href='?src=\ref[];login=1'>{Log In}</A>", src)
+	dat = jointext(dat,null)
 	user << browse(text("<HEAD><TITLE>Medical Records</TITLE></HEAD><TT>[]</TT>", dat), "window=med_rec")
 	onclose(user, "med_rec")
 	return
@@ -249,10 +254,10 @@
 							src.active1.fields["fingerprint"] = t1
 					if("sex")
 						if (istype(src.active1, /datum/data/record))
-							if (src.active1.fields["sex"] == "Male")
-								src.active1.fields["sex"] = "Female"
-							else
-								src.active1.fields["sex"] = "Male"
+							src.active1.fields["sex"] = next_in_list(src.active1.fields["sex"], all_genders_text_list)
+					if("id_gender")
+						if (istype(src.active2, /datum/data/record))
+							src.active2.fields["id_gender"] = next_in_list(src.active2.fields["id_gender"], all_genders_text_list)
 					if("age")
 						if (istype(src.active1, /datum/data/record))
 							var/t1 = input("Please input age:", "Med. records", src.active1.fields["age"], null)  as num

--- a/code/modules/client/preference_setup/general/01_basic.dm
+++ b/code/modules/client/preference_setup/general/01_basic.dm
@@ -1,7 +1,6 @@
 /datum/category_item/player_setup_item/general/basic
 	name = "Basic"
 	sort_order = 1
-	var/list/valid_player_genders = list(MALE, FEMALE, NEUTER, PLURAL)
 
 /datum/category_item/player_setup_item/general/basic/load_character(var/savefile/S)
 	S["real_name"]				>> pref.real_name
@@ -23,7 +22,7 @@
 	if(!pref.species) pref.species = "Human"
 	var/datum/species/S = all_species[pref.species ? pref.species : "Human"]
 	pref.age			= sanitize_integer(pref.age, S.min_age, S.max_age, initial(pref.age))
-	pref.gender 		= sanitize_inlist(pref.gender, valid_player_genders, pick(valid_player_genders))
+	pref.gender 		= sanitize_inlist(pref.gender, S.genders, pick(S.genders))
 	pref.real_name		= sanitize_name(pref.real_name, pref.species)
 	if(!pref.real_name)
 		pref.real_name	= random_name(pref.gender, pref.species)
@@ -36,13 +35,14 @@
 	. += "(<a href='?src=\ref[src];random_name=1'>Random Name</A>) "
 	. += "(<a href='?src=\ref[src];always_random_name=1'>Always Random Name: [pref.be_random_name ? "Yes" : "No"]</a>)"
 	. += "<br>"
-	. += "<b>Gender:</b> <a href='?src=\ref[src];gender=1'><b>[capitalize(lowertext(pref.gender))]</b></a><br>"
+	. += "<b>Gender:</b> <a href='?src=\ref[src];gender=1'><b>[gender2text(pref.gender)]</b></a><br>"
 	. += "<b>Age:</b> <a href='?src=\ref[src];age=1'>[pref.age]</a><br>"
 	. += "<b>Spawn Point</b>: <a href='?src=\ref[src];spawnpoint=1'>[pref.spawnpoint]</a><br>"
 	if(config.allow_Metadata)
 		. += "<b>OOC Notes:</b> <a href='?src=\ref[src];metadata=1'> Edit </a><br>"
 
 /datum/category_item/player_setup_item/general/basic/OnTopic(var/href,var/list/href_list, var/mob/user)
+	var/datum/species/S = all_species[pref.species]
 	if(href_list["rename"])
 		var/raw_name = input(user, "Choose your character's name:", "Character Name")  as text|null
 		if (!isnull(raw_name) && CanUseTopic(user))
@@ -63,12 +63,13 @@
 		return TOPIC_REFRESH
 
 	else if(href_list["gender"])
-		pref.gender = next_in_list(pref.gender, valid_player_genders)
+		var/new_gender = input(user, "Choose your character's gender:", "Character Preference", pref.gender) as null|anything in S.genders
+		if(new_gender && CanUseTopic(user))
+			pref.gender = new_gender
 		return TOPIC_REFRESH
 
 	else if(href_list["age"])
 		if(!pref.species) pref.species = "Human"
-		var/datum/species/S = all_species[pref.species]
 		var/new_age = input(user, "Choose your character's age:\n([S.min_age]-[S.max_age])", "Character Preference", pref.age) as num|null
 		if(new_age && CanUseTopic(user))
 			pref.age = max(min(round(text2num(new_age)), S.max_age), S.min_age)
@@ -76,8 +77,8 @@
 
 	else if(href_list["spawnpoint"])
 		var/list/spawnkeys = list()
-		for(var/S in spawntypes)
-			spawnkeys += S
+		for(var/spawntype in spawntypes)
+			spawnkeys += spawntype
 		var/choice = input(user, "Where would you like to spawn when late-joining?") as null|anything in spawnkeys
 		if(!choice || !spawntypes[choice] || !CanUseTopic(user))	return TOPIC_NOACTION
 		pref.spawnpoint = choice

--- a/code/modules/client/preference_setup/general/01_basic.dm
+++ b/code/modules/client/preference_setup/general/01_basic.dm
@@ -116,5 +116,5 @@ datum/preferences/proc/set_biological_gender(var/gender)
 	if(pref.organ_data[BP_TORSO] != "cyborg")
 		return possible_genders
 	possible_genders = possible_genders.Copy()
-	possible_genders += NEUTER
+	possible_genders |= NEUTER
 	return possible_genders

--- a/code/modules/client/preference_setup/general/01_basic.dm
+++ b/code/modules/client/preference_setup/general/01_basic.dm
@@ -75,7 +75,7 @@ datum/preferences/proc/set_biological_gender(var/gender)
 		return TOPIC_REFRESH
 
 	else if(href_list["bio_gender"])
-		var/new_gender = input(user, "Choose your character's biological gender:", "Character Preference", pref.biological_gender) as null|anything in S.genders
+		var/new_gender = input(user, "Choose your character's biological gender:", "Character Preference", pref.biological_gender) as null|anything in get_genders()
 		if(new_gender && CanUseTopic(user))
 			pref.set_biological_gender(new_gender)
 		return TOPIC_REFRESH
@@ -109,3 +109,12 @@ datum/preferences/proc/set_biological_gender(var/gender)
 			return TOPIC_REFRESH
 
 	return ..()
+
+/datum/category_item/player_setup_item/general/basic/proc/get_genders()
+	var/datum/species/S = all_species[pref.species]
+	var/list/possible_genders = S.genders
+	if(pref.organ_data[BP_TORSO] != "cyborg")
+		return possible_genders
+	possible_genders = possible_genders.Copy()
+	possible_genders += NEUTER
+	return possible_genders

--- a/code/modules/client/preference_setup/general/03_body.dm
+++ b/code/modules/client/preference_setup/general/03_body.dm
@@ -191,7 +191,7 @@ var/global/list/valid_bloodtypes = list("A+", "A-", "B+", "B-", "AB+", "AB-", "O
 	return mob_species && (mob_species.appearance_flags & flag)
 
 /datum/category_item/player_setup_item/general/body/OnTopic(var/href,var/list/href_list, var/mob/user)
-	var/mob_species = all_species[pref.species]
+	var/datum/species/mob_species = all_species[pref.species]
 
 	if(href_list["random"])
 		pref.randomize_appearance_for()
@@ -220,18 +220,17 @@ var/global/list/valid_bloodtypes = list("A+", "A-", "B+", "B-", "AB+", "AB-", "O
 		var/prev_species = pref.species
 		pref.species = href_list["set_species"]
 		if(prev_species != pref.species)
-			mob_species = all_species[pref.species]
-			if(!(pref.gender in mob_species.genders))
-				pref.gender = mob_species.genders[1]
+			if(!(pref.biological_gender in mob_species.genders))
+				pref.set_biological_gender(mob_species.genders[1])
 
 
 			//grab one of the valid hair styles for the newly chosen species
 			var/list/valid_hairstyles = list()
 			for(var/hairstyle in hair_styles_list)
 				var/datum/sprite_accessory/S = hair_styles_list[hairstyle]
-				if(pref.gender == MALE && S.gender == FEMALE)
+				if(pref.biological_gender == MALE && S.gender == FEMALE)
 					continue
-				if(pref.gender == FEMALE && S.gender == MALE)
+				if(pref.biological_gender == FEMALE && S.gender == MALE)
 					continue
 				if(!(pref.species in S.species_allowed))
 					continue
@@ -247,9 +246,9 @@ var/global/list/valid_bloodtypes = list("A+", "A-", "B+", "B-", "AB+", "AB-", "O
 			var/list/valid_facialhairstyles = list()
 			for(var/facialhairstyle in facial_hair_styles_list)
 				var/datum/sprite_accessory/S = facial_hair_styles_list[facialhairstyle]
-				if(pref.gender == MALE && S.gender == FEMALE)
+				if(pref.biological_gender == MALE && S.gender == FEMALE)
 					continue
-				if(pref.gender == FEMALE && S.gender == MALE)
+				if(pref.biological_gender == FEMALE && S.gender == MALE)
 					continue
 				if(!(pref.species in S.species_allowed))
 					continue
@@ -341,9 +340,9 @@ var/global/list/valid_bloodtypes = list("A+", "A-", "B+", "B-", "AB+", "AB-", "O
 		var/list/valid_facialhairstyles = list()
 		for(var/facialhairstyle in facial_hair_styles_list)
 			var/datum/sprite_accessory/S = facial_hair_styles_list[facialhairstyle]
-			if(pref.gender == MALE && S.gender == FEMALE)
+			if(pref.biological_gender == MALE && S.gender == FEMALE)
 				continue
-			if(pref.gender == FEMALE && S.gender == MALE)
+			if(pref.biological_gender == FEMALE && S.gender == MALE)
 				continue
 			if(!(pref.species in S.species_allowed))
 				continue

--- a/code/modules/client/preference_setup/general/03_body.dm
+++ b/code/modules/client/preference_setup/general/03_body.dm
@@ -220,6 +220,11 @@ var/global/list/valid_bloodtypes = list("A+", "A-", "B+", "B-", "AB+", "AB-", "O
 		var/prev_species = pref.species
 		pref.species = href_list["set_species"]
 		if(prev_species != pref.species)
+			mob_species = all_species[pref.species]
+			if(!(pref.gender in mob_species.genders))
+				pref.gender = mob_species.genders[1]
+
+
 			//grab one of the valid hair styles for the newly chosen species
 			var/list/valid_hairstyles = list()
 			for(var/hairstyle in hair_styles_list)

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -25,7 +25,6 @@ datum/preferences
 	//character preferences
 	var/real_name						//our character's name
 	var/be_random_name = 0				//whether we are a random name every round
-	var/gender = MALE					//gender of character (well duh)
 	var/age = 30						//age of character
 	var/spawnpoint = "Arrivals Shuttle" //where this character will spawn (0-2).
 	var/b_type = "A+"					//blood type (not-chooseable)
@@ -119,8 +118,8 @@ datum/preferences
 
 /datum/preferences/New(client/C)
 	player_setup = new(src)
-	gender = pick(MALE, FEMALE)
-	real_name = random_name(gender,species)
+	set_biological_gender(pick(MALE, FEMALE))
+	real_name = random_name(identifying_gender,species)
 	b_type = pick(4;"O-", 36;"O+", 3;"A-", 28;"A+", 1;"B-", 20;"B+", 1;"AB-", 5;"AB+")
 
 	gear = list()
@@ -254,7 +253,7 @@ datum/preferences
 	// Sanitizing rather than saving as someone might still be editing when copy_to occurs.
 	player_setup.sanitize_setup()
 	if(be_random_name)
-		real_name = random_name(gender,species)
+		real_name = random_name(identifying_gender,species)
 
 	if(config.humans_need_surnames)
 		var/firstspace = findtext(real_name, " ")
@@ -284,7 +283,8 @@ datum/preferences
 	character.gen_record = gen_record
 	character.exploit_record = exploit_record
 
-	character.gender = gender
+	character.gender = biological_gender
+	character.identifying_gender = identifying_gender
 	character.age = age
 	character.b_type = b_type
 

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -26,7 +26,7 @@
 
 	var/msg = "<span class='info'>*---------*\nThis is "
 
-	var/datum/gender/T = gender_datums[gender]
+	var/datum/gender/T = gender_datums[get_gender()]
 	if(skipjumpsuit && skipface) //big suits/masks/helmets make it hard to tell their gender
 		T = gender_datums[PLURAL]
 	else

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1104,6 +1104,9 @@
 	if(species.holder_type)
 		holder_type = species.holder_type
 
+	if(!(gender in species.genders))
+		gender = species.genders[1]
+
 	icon_state = lowertext(species.name)
 
 	species.create_organs(src)

--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -91,3 +91,5 @@
 	mob_bump_flag = HUMAN
 	mob_push_flags = ~HEAVY
 	mob_swap_flags = ~HEAVY
+
+	var/identifying_gender // In case the human identifies as another gender than it's biological

--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -55,6 +55,8 @@
 		sum += H.ear_protection
 	return sum
 
+/mob/living/carbon/human/get_gender()
+	return identifying_gender ? identifying_gender : gender
 
 #undef HUMAN_EATING_NO_ISSUE
 #undef HUMAN_EATING_NO_MOUTH

--- a/code/modules/mob/living/carbon/human/species/outsider/shadow.dm
+++ b/code/modules/mob/living/carbon/human/species/outsider/shadow.dm
@@ -21,6 +21,8 @@
 	flags = NO_SCAN | NO_SLIP | NO_POISON | NO_MINOR_CUT
 	spawn_flags = IS_RESTRICTED
 
+	genders = list(NEUTER)
+
 /datum/species/shadow/handle_death(var/mob/living/carbon/human/H)
 	spawn(1)
 		new /obj/effect/decal/cleanable/ash(H.loc)

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -147,6 +147,8 @@
 		BP_R_FOOT = list("path" = /obj/item/organ/external/foot/right)
 		)
 
+	var/list/genders = list(MALE, FEMALE, PLURAL)
+
 	// Bump vars
 	var/bump_flag = HUMAN	// What are we considered to be when bumped?
 	var/push_flags = ~HEAVY	// What can we push?

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -147,7 +147,7 @@
 		BP_R_FOOT = list("path" = /obj/item/organ/external/foot/right)
 		)
 
-	var/list/genders = list(MALE, FEMALE, PLURAL)
+	var/list/genders = list(MALE, FEMALE)
 
 	// Bump vars
 	var/bump_flag = HUMAN	// What are we considered to be when bumped?

--- a/code/modules/mob/living/carbon/human/species/station/golem.dm
+++ b/code/modules/mob/living/carbon/human/species/station/golem.dm
@@ -23,6 +23,8 @@
 
 	death_message = "becomes completely motionless..."
 
+	genders = list(NEUTER)
+
 /datum/species/golem/handle_post_spawn(var/mob/living/carbon/human/H)
 	if(H.mind)
 		H.mind.assigned_role = "Golem"

--- a/code/modules/mob/living/carbon/human/species/station/slime.dm
+++ b/code/modules/mob/living/carbon/human/species/station/slime.dm
@@ -44,6 +44,8 @@
 		BP_R_FOOT = list("path" = /obj/item/organ/external/foot/right/unbreakable)
 		)
 
+	genders = list(NEUTER)
+
 /datum/species/slime/handle_death(var/mob/living/carbon/human/H)
 	spawn(1)
 		if(H)

--- a/code/modules/mob/living/carbon/human/species/station/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station.dm
@@ -253,6 +253,7 @@
 
 	reagent_tag = IS_DIONA
 
+	genders = list(PLURAL)
 /datum/species/diona/can_understand(var/mob/other)
 	var/mob/living/carbon/alien/diona/D = other
 	if(istype(D))

--- a/code/modules/mob/living/voice/voice.dm
+++ b/code/modules/mob/living/voice/voice.dm
@@ -33,7 +33,7 @@
 			var/datum/preferences/p = speaker.client.prefs
 			name = p.real_name
 			real_name = name
-			gender = p.gender
+			gender = p.identifying_gender
 
 			for(var/language in p.alternate_languages)
 				add_language(language)

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -127,7 +127,7 @@
 			observer.alpha = 127
 
 			if(client.prefs.be_random_name)
-				client.prefs.real_name = random_name(client.prefs.gender)
+				client.prefs.real_name = random_name(client.prefs.identifying_gender)
 			observer.real_name = client.prefs.real_name
 			observer.name = observer.real_name
 			if(!client.holder && !config.antag_hud_allowed)           // For new ghosts we remove the verb from even showing up if it's not allowed.
@@ -493,7 +493,7 @@
 
 /mob/new_player/get_gender()
 	if(!client || !client.prefs) ..()
-	return client.prefs.gender
+	return client.prefs.biological_gender
 
 /mob/new_player/is_ready()
 	return ready && ..()

--- a/code/modules/mob/new_player/preferences_setup.dm
+++ b/code/modules/mob/new_player/preferences_setup.dm
@@ -1,8 +1,8 @@
 /datum/preferences
 	//The mob should have a gender you want before running this proc. Will run fine without H
 /datum/preferences/proc/randomize_appearance_for(var/mob/living/carbon/human/H)
-	gender = pick(MALE, FEMALE)
-	var/datum/species/current_species = all_species[species]
+	var/datum/species/current_species = all_species[species ? species : "Human"]
+	set_biological_gender(pick(current_species.genders))
 
 	if(current_species)
 		if(current_species.flags & HAS_SKIN_TONE)
@@ -25,8 +25,8 @@
 		use_head_species = H.species.get_bodytype()
 
 	if(use_head_species)
-		h_style = random_hair_style(gender, species)
-		f_style = random_facial_hair_style(gender, species)
+		h_style = random_hair_style(biological_gender, species)
+		f_style = random_facial_hair_style(biological_gender, species)
 
 	randomize_hair_color("hair")
 	randomize_hair_color("facial")
@@ -202,7 +202,7 @@
 	qdel(preview_icon)
 
 	var/g = "m"
-	if(gender == FEMALE)	g = "f"
+	if(biological_gender == FEMALE)	g = "f"
 
 	var/icon/icobase
 	var/datum/species/current_species = all_species[species]

--- a/code/modules/nano/modules/human_appearance.dm
+++ b/code/modules/nano/modules/human_appearance.dm
@@ -27,7 +27,7 @@
 				cut_and_generate_data()
 				return 1
 	if(href_list["gender"])
-		if(can_change(APPEARANCE_GENDER))
+		if(can_change(APPEARANCE_GENDER) && (href_list["gender"] in owner.species.genders))
 			if(owner.change_gender(href_list["gender"]))
 				cut_and_generate_data()
 				return 1
@@ -108,6 +108,12 @@
 		data["species"] = species
 
 	data["change_gender"] = can_change(APPEARANCE_GENDER)
+	if(data["change_gender"])
+		var/genders[0]
+		for(var/gender in owner.species.genders)
+			genders[++genders.len] =  list("gender_name" = gender2text(gender), "gender_key" = gender)
+		data["genders"] = genders
+
 	data["change_skin_tone"] = can_change_skin_tone()
 	data["change_skin_color"] = can_change_skin_color()
 	data["change_eye_color"] = can_change(APPEARANCE_EYE_COLOR)

--- a/code/modules/nano/modules/human_appearance.dm
+++ b/code/modules/nano/modules/human_appearance.dm
@@ -31,6 +31,10 @@
 			if(owner.change_gender(href_list["gender"]))
 				cut_and_generate_data()
 				return 1
+	if(href_list["gender_id"])
+		if(can_change(APPEARANCE_GENDER) && (href_list["gender_id"] in all_genders_define_list))
+			owner.identifying_gender = href_list["gender_id"]
+			return 1
 	if(href_list["skin_tone"])
 		if(can_change_skin_tone())
 			var/new_s_tone = input(usr, "Choose your character's skin-tone:\n(Light 1 - 220 Dark)", "Skin Tone", -owner.s_tone + 35) as num|null
@@ -100,6 +104,7 @@
 
 	data["specimen"] = owner.species.name
 	data["gender"] = owner.gender
+	data["gender_id"] = owner.identifying_gender
 	data["change_race"] = can_change(APPEARANCE_RACE)
 	if(data["change_race"])
 		var/species[0]
@@ -113,6 +118,11 @@
 		for(var/gender in owner.species.genders)
 			genders[++genders.len] =  list("gender_name" = gender2text(gender), "gender_key" = gender)
 		data["genders"] = genders
+		var/id_genders[0]
+		for(var/gender in all_genders_define_list)
+			id_genders[++id_genders.len] =  list("gender_name" = gender2text(gender), "gender_key" = gender)
+		data["id_genders"] = id_genders
+
 
 	data["change_skin_tone"] = can_change_skin_tone()
 	data["change_skin_color"] = can_change_skin_color()

--- a/code/modules/nano/modules/human_appearance.dm
+++ b/code/modules/nano/modules/human_appearance.dm
@@ -27,7 +27,7 @@
 				cut_and_generate_data()
 				return 1
 	if(href_list["gender"])
-		if(can_change(APPEARANCE_GENDER) && (href_list["gender"] in owner.species.genders))
+		if(can_change(APPEARANCE_GENDER) && (href_list["gender"] in get_genders()))
 			if(owner.change_gender(href_list["gender"]))
 				cut_and_generate_data()
 				return 1
@@ -115,7 +115,7 @@
 	data["change_gender"] = can_change(APPEARANCE_GENDER)
 	if(data["change_gender"])
 		var/genders[0]
-		for(var/gender in owner.species.genders)
+		for(var/gender in get_genders())
 			genders[++genders.len] =  list("gender_name" = gender2text(gender), "gender_key" = gender)
 		data["genders"] = genders
 		var/id_genders[0]
@@ -179,3 +179,13 @@
 	if(!valid_hairstyles.len || !valid_facial_hairstyles.len)
 		valid_hairstyles = owner.generate_valid_hairstyles(check_gender = 0)
 		valid_facial_hairstyles = owner.generate_valid_facial_hairstyles()
+
+
+/datum/nano_module/appearance_changer/proc/get_genders()
+	var/datum/species/S = owner.species
+	var/list/possible_genders = S.genders
+	if(!owner.internal_organs_by_name["cell"])
+		return possible_genders
+	possible_genders = possible_genders.Copy()
+	possible_genders |= NEUTER
+	return possible_genders

--- a/html/changelogs/Yoshax-gendertweak.yml
+++ b/html/changelogs/Yoshax-gendertweak.yml
@@ -1,0 +1,4 @@
+author: Yoshax
+delete-after: True
+changes:
+  - tweak"Splits gender into biological gender and gender identity. Biological gender modifies the sprite (for between male and female) and gender identity determines what pronouns show up when examined or suchlike. Both are displayed in medical records and such. "

--- a/nano/templates/appearance_changer.tmpl
+++ b/nano/templates/appearance_changer.tmpl
@@ -17,8 +17,9 @@
             Gender:
         </div>
         <div class="itemContentWide">
-            {{:helper.link('Male', null, { 'gender' : 'male'}, null, data.gender == 'male' ? 'selected' : null)}}
-            {{:helper.link('Female', null, { 'gender' : 'female'}, null, data.gender == 'female' ? 'selected' : null)}}
+            {{for data.genders}}
+				{{:helper.link(value.gender_name, null, { 'gender' : value.gender_key}, null, data.gender == value.gender_key ? 'selected' : null)}}
+			{{/for}}
         </div>
     </div>
 {{/if}}

--- a/nano/templates/appearance_changer.tmpl
+++ b/nano/templates/appearance_changer.tmpl
@@ -14,11 +14,21 @@
 {{if data.change_gender}}
     <div class="item">
         <div class="itemLabelNarrow">
-            Gender:
+            Biological Gender:
         </div>
         <div class="itemContentWide">
             {{for data.genders}}
 				{{:helper.link(value.gender_name, null, { 'gender' : value.gender_key}, null, data.gender == value.gender_key ? 'selected' : null)}}
+			{{/for}}
+        </div>
+		
+	<div class="item">
+        <div class="itemLabelNarrow">
+            Gender Identity:
+        </div>
+        <div class="itemContentWide">
+            {{for data.id_genders}}
+				{{:helper.link(value.gender_name, null, { 'gender_id' : value.gender_key}, null, data.gender_id == value.gender_key ? 'selected' : null)}}
 			{{/for}}
         </div>
     </div>


### PR DESCRIPTION
Ports:
Baystation12/Baystation12#12669
Baystation12/Baystation12#12702

Splits gender into biological gender and gender identity.
- allows species' gender selection to be limited
- biological gender determines sprite where appropriate
- both are shown in medical records
- gender identity determines pronouns upon examine and suchlike to allow for androgynous/agender/other things