### PR TITLE
Upgrades default suit cooler cell

### DIFF
--- a/code/game/objects/items/devices/suit_cooling.dm
+++ b/code/game/objects/items/devices/suit_cooling.dm
@@ -31,7 +31,7 @@
 
 /obj/item/device/suit_cooling_unit/New()
 	processing_objects |= src
-	cell = new/obj/item/weapon/cell()	//comes with the crappy default power cell - high-capacity ones shouldn't be hard to find
+	cell = new/obj/item/weapon/cell/high()	//comes not with the crappy default power cell - because this is dedicated EVA equipment
 	cell.loc = src
 
 /obj/item/device/suit_cooling_unit/process()


### PR DESCRIPTION
Considering suit coolers are dedicated EVA equipment instead of emergency equipment, it's strange that they come equipped with a cell that lasts a handful of minutes in operation instead of a duration more comparable to an oxygen tank's.

This upgrades their default cell so that FBPs can grab, combine, and go just like other crewmembers.

Looking at the history of suit coolers, their current crap-cap cells were put in back in 2014. Since the usage of suit coolers has gone from non-existent to regularly-used I think it's about time we rethink this decision.

Edit: Forgot to state the new cell is High Cap. This boosts charge from 1,000 to 10,000, so the duration goes from under 10 minutes to just around an hour.