### PR TITLE
Makes opening/closing pizza boxes easier

### DIFF
--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -2892,6 +2892,19 @@
 	var/list/boxes = list() // If the boxes are stacked, they come here
 	var/boxtag = ""
 
+
+/obj/item/pizzabox/proc/closepizzabox()
+
+	if( boxes.len > 0 )
+		return
+
+	open = !open
+
+	if( open && pizza )
+		ismessy = 1
+
+	update_icon()
+
 /obj/item/pizzabox/update_icon()
 
 	overlays = list()
@@ -2970,15 +2983,12 @@
 
 /obj/item/pizzabox/attack_self( mob/user as mob )
 
-	if( boxes.len > 0 )
-		return
+	closepizzabox()
 
-	open = !open
+/obj/item/pizzabox/AltClick()
 
-	if( open && pizza )
-		ismessy = 1
-
-	update_icon()
+	if(Adjacent(usr))
+		closepizzabox()
 
 /obj/item/pizzabox/attackby( obj/item/I as obj, mob/user as mob )
 	if( istype(I, /obj/item/pizzabox/) )


### PR DESCRIPTION
Alt-click now opens/closes pizza boxes like a laptop.

The current method is:
1: Pull pizza out of box
2: Pick box up in other hand
3: Put pizza back in box
4: Use pizza box
5: Optional, put box back on table

I've made sure this only works if the user is living and ajacent to the boxes, and alt-click on a stack of pizza boxes is ignored.