### PR TITLE
Hardsuits are now only checked for access when not sealed

### DIFF
--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -495,6 +495,8 @@
 		return 1
 
 	if(istype(user))
+		if(!canremove)
+			return 1
 		if(malfunction_check(user))
 			return 0
 		if(user.back != src)


### PR DESCRIPTION
Access is checked when you are trying to seal the suit, you cannot seal it without the proper ID. If the suit is not sealed you require ID to use any part of it.

If the suit is sealed, you no longer need an ID to use it, as it was checked upon sealing.