### PR TITLE
Smoke grenade changes and adjustment

### DIFF
--- a/code/game/objects/effects/effect_system.dm
+++ b/code/game/objects/effects/effect_system.dm
@@ -226,7 +226,7 @@ steam.start() -- spawns the effect
 
 /obj/effect/effect/smoke/bad
 	time_to_live = 200
-	var/list/projectiles
+	//var/list/projectiles
 
 /obj/effect/effect/smoke/bad/Move()
 	..()
@@ -255,52 +255,6 @@ steam.start() -- spawns the effect
 /obj/effect/effect/smoke/bad/proc/on_projectile_delete(obj/item/projectile/beam/proj)
 	projectiles -= proj
 */
-
-/////////////////////////////////////////////
-// Sleep smoke
-/////////////////////////////////////////////
-
-/obj/effect/effect/smoke/sleepy
-
-/obj/effect/effect/smoke/sleepy/Move()
-	..()
-	for(var/mob/living/carbon/M in get_turf(src))
-		affect(M)
-
-/obj/effect/effect/smoke/sleepy/affect(mob/living/carbon/M as mob )
-	if (!..())
-		return 0
-
-	M.drop_item()
-	M:sleeping += 1
-	if(prob(20))
-		M.emote("cough")
-/////////////////////////////////////////////
-// Mustard Gas
-/////////////////////////////////////////////
-
-
-/obj/effect/effect/smoke/mustard
-	name = "mustard gas"
-	icon_state = "mustard"
-
-/obj/effect/effect/smoke/mustard/Move()
-	..()
-	for(var/mob/living/carbon/human/M in get_turf(src))
-		affect(M)
-
-/obj/effect/effect/smoke/mustard/affect(var/mob/living/carbon/human/M)
-	if (!..())
-		return 0
-	if (M.wear_suit != null)
-		return 0
-
-	M.burn_skin(0.75)
-	if(prob(20))
-		M.emote("cough")
-		M.emote("gasp")
-	M.updatehealth()
-	return
 
 /////////////////////////////////////////////
 // Smoke spread
@@ -350,14 +304,6 @@ steam.start() -- spawns the effect
 
 /datum/effect/effect/system/smoke_spread/bad
 	smoke_type = /obj/effect/effect/smoke/bad
-
-/datum/effect/effect/system/smoke_spread/sleepy
-	smoke_type = /obj/effect/effect/smoke/sleepy
-
-
-/datum/effect/effect/system/smoke_spread/mustard
-	smoke_type = /obj/effect/effect/smoke/mustard
-
 
 /////////////////////////////////////////////
 //////// Attach an Ion trail to any object, that spawns when it moves (like for the jetpack)

--- a/code/game/objects/effects/effect_system.dm
+++ b/code/game/objects/effects/effect_system.dm
@@ -321,7 +321,7 @@ steam.start() -- spawns the effect
 	if(direct)
 		direction = direct
 
-/datum/effect/effect/system/smoke_spread/start()
+/datum/effect/effect/system/smoke_spread/start(var/I)
 	var/i = 0
 	for(i=0, i<src.number, i++)
 		if(src.total_smoke > 20)
@@ -331,6 +331,7 @@ steam.start() -- spawns the effect
 				src.location = get_turf(holder)
 			var/obj/effect/effect/smoke/smoke = PoolOrNew(smoke_type, src.location)
 			src.total_smoke++
+			smoke.color = I
 			var/direction = src.direction
 			if(!direction)
 				if(src.cardinals)
@@ -507,9 +508,9 @@ steam.start() -- spawns the effect
 				M << "<span class='warning'>The solution violently explodes.</span>"
 
 			explosion(
-				location, 
-				round(min(devst, BOMBCAP_DVSTN_RADIUS)), 
-				round(min(heavy, BOMBCAP_HEAVY_RADIUS)), 
-				round(min(light, BOMBCAP_LIGHT_RADIUS)), 
+				location,
+				round(min(devst, BOMBCAP_DVSTN_RADIUS)),
+				round(min(heavy, BOMBCAP_HEAVY_RADIUS)),
+				round(min(light, BOMBCAP_LIGHT_RADIUS)),
 				round(min(flash, BOMBCAP_FLASH_RADIUS))
 				)

--- a/code/game/objects/effects/effect_system.dm
+++ b/code/game/objects/effects/effect_system.dm
@@ -240,6 +240,7 @@ steam.start() -- spawns the effect
 	if(prob(25))
 		M.emote("cough")
 
+/* Not feasile until a later date
 /obj/effect/effect/smoke/bad/Crossed(atom/movable/M as mob|obj)
 	..()
 	if(istype(M, /obj/item/projectile/beam))
@@ -253,6 +254,8 @@ steam.start() -- spawns the effect
 
 /obj/effect/effect/smoke/bad/proc/on_projectile_delete(obj/item/projectile/beam/proj)
 	projectiles -= proj
+*/
+
 /////////////////////////////////////////////
 // Sleep smoke
 /////////////////////////////////////////////

--- a/code/game/objects/items/weapons/grenades/smokebomb.dm
+++ b/code/game/objects/items/weapons/grenades/smokebomb.dm
@@ -38,4 +38,6 @@
 
 /obj/item/weapon/grenade/smokebomb/attackby(obj/item/I as obj, mob/user as mob)
 	if(istype(I,/obj/item/device/multitool))
-		smoke_color = input(user, "Choose a color for the smoke:") as color|null
+		var/new_smoke_color = input(user, "Choose a color for the smoke:", "Smoke Color", smoke_color) as color|null
+		if(new_smoke_color)
+			smoke_color = new_smoke_color

--- a/code/game/objects/items/weapons/grenades/smokebomb.dm
+++ b/code/game/objects/items/weapons/grenades/smokebomb.dm
@@ -7,6 +7,14 @@
 	item_state = "flashbang"
 	slot_flags = SLOT_BELT
 	var/datum/effect/effect/system/smoke_spread/bad/smoke
+	var/smoke_color
+	var/smoke_strength = 4
+
+/obj/item/weapon/grenade/smokebomb/red
+	smoke_color = "#FF0000"
+
+/obj/item/weapon/grenade/smokebomb/blue
+	smoke_color = "#0000FF"
 
 /obj/item/weapon/grenade/smokebomb/New()
 	..()
@@ -22,13 +30,9 @@
 	playsound(src.loc, 'sound/effects/smoke.ogg', 50, 1, -3)
 	src.smoke.set_up(10, 0, usr.loc)
 	spawn(0)
-		src.smoke.start()
-		sleep(10)
-		src.smoke.start()
-		sleep(10)
-		src.smoke.start()
-		sleep(10)
-		src.smoke.start()
+		for(var/i = 1 to smoke_strength)
+			src.smoke.start(smoke_color)
+			sleep(10)
 
 	for(var/obj/effect/blob/B in view(8,src))
 		var/damage = round(30/(get_dist(B,src)+1))

--- a/code/game/objects/items/weapons/grenades/smokebomb.dm
+++ b/code/game/objects/items/weapons/grenades/smokebomb.dm
@@ -1,5 +1,5 @@
 /obj/item/weapon/grenade/smokebomb
-	desc = "It is set to detonate in 2 seconds."
+	desc = "It is set to detonate in 2 seconds. These high-tech grenades can have their color adapted on the fly with a multitool!"
 	name = "smoke bomb"
 	icon = 'icons/obj/grenade.dmi'
 	icon_state = "flashbang"
@@ -9,12 +9,6 @@
 	var/datum/effect/effect/system/smoke_spread/bad/smoke
 	var/smoke_color
 	var/smoke_strength = 4
-
-/obj/item/weapon/grenade/smokebomb/red
-	smoke_color = "#FF0000"
-
-/obj/item/weapon/grenade/smokebomb/blue
-	smoke_color = "#0000FF"
 
 /obj/item/weapon/grenade/smokebomb/New()
 	..()
@@ -41,3 +35,7 @@
 	sleep(80)
 	qdel(src)
 	return
+
+/obj/item/weapon/grenade/smokebomb/attackby(obj/item/I as obj, mob/user as mob)
+	if(istype(I,/obj/item/device/multitool))
+		smoke_color = input(user, "Choose a color for the smoke:") as color|null

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -130,8 +130,6 @@
 
 	var/in_throw_mode = 0
 
-	var/coughedtime = null
-
 	var/inertia_dir = 0
 
 	var/music_lastplayed = "null"


### PR DESCRIPTION
- Adjusts smoke grenade code
- Smoke grenades can now change their color on-the-fly with a multiool. High-tech stuff.
- Adds a smoke_strength variable to smoke grenades
    - Smoke strength controls how much smoke is produced
    - Future smoke grenades can be made to have more or less smoke