### PR TITLE
Increase the size of a number of defines used to save records, names and books

### DIFF
--- a/code/__defines/misc.dm
+++ b/code/__defines/misc.dm
@@ -78,10 +78,10 @@
 
 // Setting this much higher than 1024 could allow spammers to DOS the server easily.
 #define MAX_MESSAGE_LEN       1024
-#define MAX_PAPER_MESSAGE_LEN 3072
-#define MAX_BOOK_MESSAGE_LEN  9216
+#define MAX_PAPER_MESSAGE_LEN 6144
+#define MAX_BOOK_MESSAGE_LEN  12288
 #define MAX_LNAME_LEN         64
-#define MAX_NAME_LEN          26
+#define MAX_NAME_LEN          52
 
 // Event defines.
 #define EVENT_LEVEL_MUNDANE  1


### PR DESCRIPTION
This increases the size of the defines used to determine the max length for:
- Names
- Books
- Paper
- Records

This is intended namely to allow people to have longer records to properly snowflake like good ol' Old Man Henderson.

This increases the size of Paper Length by 100%, Book Length by 33% and Name Length by 100%.