### PR TITLE
Adds a check for can_speak to prevent null language procs being called.

### DIFF
--- a/code/modules/mob/language/language.dm
+++ b/code/modules/mob/language/language.dm
@@ -158,7 +158,12 @@
 
 // Can we speak this language, as opposed to just understanding it?
 /mob/proc/can_speak(datum/language/speaking)
-	return (speaking.can_speak_special(src) && (universal_speak || (speaking && speaking.flags & INNATE) || speaking in src.languages))
+//Prevents someone from speaking a null language.
+	if(speaking)
+		return (speaking.can_speak_special(src) && (universal_speak || (speaking && speaking.flags & INNATE) || speaking in src.languages))
+	else
+		log_debug("[src] attempted to speak a null language.")
+		return 0
 
 /mob/proc/get_language_prefix()
 	if(client && client.prefs.language_prefixes && client.prefs.language_prefixes.len)

--- a/code/modules/mob/language/language.dm
+++ b/code/modules/mob/language/language.dm
@@ -160,7 +160,7 @@
 /mob/proc/can_speak(datum/language/speaking)
 //Prevents someone from speaking a null language.
 	if(speaking)
-		return (speaking.can_speak_special(src) && (universal_speak || (speaking && speaking.flags & INNATE) || speaking in src.languages))
+		return (speaking.can_speak_special(src) && (universal_speak || (speaking && (speaking.flags & INNATE)) || speaking in src.languages))
 	else
 		log_debug("[src] attempted to speak a null language.")
 		return 0


### PR DESCRIPTION
Prevents runtimes* from procs on a null.