### PR TITLE
Fixes preferences typo

### DIFF
--- a/code/modules/client/preferences_toggle_procs.dm
+++ b/code/modules/client/preferences_toggle_procs.dm
@@ -8,7 +8,7 @@
 
 	toggle_preference(pref_path)
 
-	src << "You will [ (is_preference_enabled(pref_path)) ? "now" : " no longer"] hear all mob speech as a ghost."
+	src << "You will [ (is_preference_enabled(pref_path)) ? "now" : "no longer"] hear all mob speech as a ghost."
 
 	prefs.save_preferences()
 
@@ -23,7 +23,7 @@
 
 	toggle_preference(pref_path)
 
-	src << "You will [ (is_preference_enabled(pref_path)) ? "now" : " no longer"] see all emotes as a ghost."
+	src << "You will [ (is_preference_enabled(pref_path)) ? "now" : "no longer"] see all emotes as a ghost."
 
 	prefs.save_preferences()
 


### PR DESCRIPTION
fixes an extra space in the messages to toggle off ghost-ears and ambient noise.