### PR TITLE
Reverts the second mob clean up because of incomplete implementation.

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -391,7 +391,7 @@
 		switch(href_list["common"])
 			if("undress")
 				for(var/obj/item/W in current)
-					current.removeItem(W, force = 1)
+					current.drop_from_inventory(W)
 			if("takeuplink")
 				take_uplink()
 				memory = null//Remove any memory they may have had.

--- a/code/defines/obj/weapon.dm
+++ b/code/defines/obj/weapon.dm
@@ -100,7 +100,7 @@
 		user.visible_message("<span class='warning'>[user] has unsheathed \a [concealed_blade] from \his [src]!</span>", "You unsheathe \the [concealed_blade] from \the [src].")
 		// Calling drop/put in hands to properly call item drop/pickup procs
 		playsound(user.loc, 'sound/weapons/flipblade.ogg', 50, 1)
-		user.removeItem(src)
+		user.drop_from_inventory(src)
 		user.put_in_hands(concealed_blade)
 		user.put_in_hands(src)
 		user.update_inv_l_hand(0)
@@ -112,7 +112,8 @@
 /obj/item/weapon/cane/concealed/attackby(var/obj/item/weapon/material/butterfly/W, var/mob/user)
 	if(!src.concealed_blade && istype(W))
 		user.visible_message("<span class='warning'>[user] has sheathed \a [W] into \his [src]!</span>", "You sheathe \the [W] into \the [src].")
-		user.removeItem(W, src)
+		user.drop_from_inventory(W)
+		W.loc = src
 		src.concealed_blade = W
 		update_icon()
 	else

--- a/code/game/antagonist/antagonist_equip.dm
+++ b/code/game/antagonist/antagonist_equip.dm
@@ -6,7 +6,8 @@
 	// This could use work.
 	if(flags & ANTAG_CLEAR_EQUIPMENT)
 		for(var/obj/item/thing in player.contents)
-			if(player.removeItem(thing, force = 1))
+			player.drop_from_inventory(thing)
+			if(thing.loc != player)
 				qdel(thing)
 	return 1
 

--- a/code/game/dna/genes/monkey.dm
+++ b/code/game/dna/genes/monkey.dm
@@ -22,7 +22,7 @@
 		for(var/obj/item/W in (H.contents-implants))
 			if (W==H.w_uniform) // will be teared
 				continue
-			H.removeItem(W, force = 1)
+			H.drop_from_inventory(W)
 		M.transforming = 1
 		M.canmove = 0
 		M.icon = null
@@ -90,7 +90,7 @@
 		W.loc = null
 	if(!connected)
 		for(var/obj/item/W in (Mo.contents-implants))
-			Mo.removeItem(W, force = 1)
+			Mo.drop_from_inventory(W)
 		M.transforming = 1
 		M.canmove = 0
 		M.icon = null

--- a/code/game/gamemodes/changeling/powers/armblade.dm
+++ b/code/game/gamemodes/changeling/powers/armblade.dm
@@ -79,7 +79,7 @@
 							organ.implants -= src
 			host.pinned -= src
 			host.embedded -= src
-			host.removeItem(src, force = 1)
+			host.drop_from_inventory(src)
 		spawn(1)
 			if(src)
 				qdel(src)

--- a/code/game/gamemodes/changeling/powers/lesser_form.dm
+++ b/code/game/gamemodes/changeling/powers/lesser_form.dm
@@ -78,7 +78,7 @@
 	qdel(animation)
 
 	for(var/obj/item/W in src)
-		C.removeItem(W, force = 1)
+		C.drop_from_inventory(W)
 
 	var/mob/living/carbon/human/O = new /mob/living/carbon/human( src )
 	if (C.dna.GetUIState(DNA_UI_GENDER))

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -830,11 +830,11 @@ var/list/sacrificed = list()
 					return
 				cultist.buckled = null
 				if (cultist.handcuffed)
-					cultist.removeItem(cultist.handcuffed, force = 1)
+					cultist.drop_from_inventory(cultist.handcuffed)
 				if (cultist.legcuffed)
-					cultist.removeItem(cultist.legcuffed, force = 1)
+					cultist.drop_from_inventory(cultist.legcuffed)
 				if (istype(cultist.wear_mask, /obj/item/clothing/mask/muzzle))
-					cultist.removeItem(cultist.wear_mask, force = 1)
+					cultist.drop_from_inventory(cultist.wear_mask)
 				if(istype(cultist.loc, /obj/structure/closet)&&cultist.loc:welded)
 					cultist.loc:welded = 0
 				if(istype(cultist.loc, /obj/structure/closet/secure_closet)&&cultist.loc:locked)

--- a/code/game/gamemodes/endgame/supermatter_cascade/blob.dm
+++ b/code/game/gamemodes/endgame/supermatter_cascade/blob.dm
@@ -93,7 +93,7 @@
 
 	playsound(src, 'sound/effects/supermatter.ogg', 50, 1)
 
-	user.removeItem(W, force = 1)
+	user.drop_from_inventory(W)
 	Consume(W)
 
 

--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -198,7 +198,8 @@
 		var/obj/item/stack/stack = eating
 		stack.use(max(1, round(total_used/mass_per_sheet))) // Always use at least 1 to prevent infinite materials.
 	else
-		user.deleteItem(O)
+		user.remove_from_mob(O)
+		qdel(O)
 
 	updateUsrDialog()
 	return

--- a/code/game/machinery/biogenerator.dm
+++ b/code/game/machinery/biogenerator.dm
@@ -55,7 +55,8 @@
 		if(beaker)
 			user << "<span class='notice'>]The [src] is already loaded.</span>"
 		else
-			user.removeItem(O, src)
+			user.remove_from_mob(O)
+			O.loc = src
 			beaker = O
 			updateUsrDialog()
 	else if(processing)
@@ -86,7 +87,8 @@
 		if(i >= 10)
 			user << "<span class='notice'>\The [src] is full! Activate it.</span>"
 		else
-			user.removeItem(O, src)
+			user.remove_from_mob(O)
+			O.loc = src
 			user << "<span class='notice'>You put \the [O] in \the [src]</span>"
 	update_icon()
 	return

--- a/code/game/machinery/camera/camera_assembly.dm
+++ b/code/game/machinery/camera/camera_assembly.dm
@@ -127,7 +127,8 @@
 	if(is_type_in_list(W, possible_upgrades) && !is_type_in_list(W, upgrades)) // Is a possible upgrade and isn't in the camera already.
 		user << "You attach \the [W] into the assembly inner circuits."
 		upgrades += W
-		user.removeItem(W, src)
+		user.remove_from_mob(W)
+		W.loc = src
 		return
 
 	// Taking out upgrades

--- a/code/game/machinery/computer/card.dm
+++ b/code/game/machinery/computer/card.dm
@@ -59,9 +59,13 @@
 	if(!istype(id_card))
 		return ..()
 
-	if(!scan && (access_change_ids in id_card.access) && user.removeItem(id_card, src))
+	if(!scan && (access_change_ids in id_card.access) && user.unEquip(id_card))
+		user.drop_item()
+		id_card.forceMove(src)
 		scan = id_card
-	else if(!modify && user.removeItem(id_card, src))
+	else if(!modify)
+		user.drop_item()
+		id_card.forceMove(src)
 		modify = id_card
 
 	nanomanager.update_uis(src)
@@ -153,7 +157,8 @@
 					modify = null
 			else
 				var/obj/item/I = usr.get_active_hand()
-				if (istype(I, /obj/item/weapon/card/id) && usr.removeItem(I, src))
+				if (istype(I, /obj/item/weapon/card/id) && usr.unEquip(I))
+					I.forceMove(src)
 					modify = I
 
 		if ("scan")

--- a/code/game/machinery/computer/guestpass.dm
+++ b/code/game/machinery/computer/guestpass.dm
@@ -61,6 +61,7 @@
 	..()
 	uid = "[rand(100,999)]-G[rand(10,99)]"
 
+
 /obj/machinery/computer/guestpass/attackby(obj/I, mob/user)
 	if(istype(I, /obj/item/weapon/screwdriver) && circuit)
 		user << "<span class='notice'>You start disconnecting the monitor.</span>"
@@ -82,7 +83,8 @@
 			qdel(src)
 		return
 	if(istype(I, /obj/item/weapon/card/id))
-		if(!giver && user.removeItem(I, src))
+		if(!giver && user.unEquip(I))
+			I.forceMove(src)
 			giver = I
 			updateUsrDialog()
 		else if(giver)
@@ -175,7 +177,8 @@
 					accesses.Cut()
 				else
 					var/obj/item/I = usr.get_active_hand()
-					if (istype(I, /obj/item/weapon/card/id) && usr.removeItem(I, src))
+					if (istype(I, /obj/item/weapon/card/id) && usr.unEquip(I))
+						I.loc = src
 						giver = I
 				updateUsrDialog()
 

--- a/code/game/machinery/computer/medical.dm
+++ b/code/game/machinery/computer/medical.dm
@@ -36,7 +36,8 @@
 	return
 
 /obj/machinery/computer/med_data/attackby(var/obj/item/O, var/mob/user)
-	if(istype(O, /obj/item/weapon/card/id) && !scan && user.removeItem(O, src))
+	if(istype(O, /obj/item/weapon/card/id) && !scan && user.unEquip(O))
+		O.loc = src
 		scan = O
 		user << "You insert \the [O]."
 	else

--- a/code/game/machinery/computer/security.dm
+++ b/code/game/machinery/computer/security.dm
@@ -248,7 +248,8 @@ What a mess.*/
 					scan = null
 				else
 					var/obj/item/I = usr.get_active_hand()
-					if (istype(I, /obj/item/weapon/card/id) && usr.removeItem(I, src))
+					if (istype(I, /obj/item/weapon/card/id) && usr.unEquip(I))
+						I.loc = src
 						scan = I
 
 			if("Log Out")

--- a/code/game/machinery/computer/skills.dm
+++ b/code/game/machinery/computer/skills.dm
@@ -25,7 +25,8 @@
 	var/order = 1 // -1 = Descending - 1 = Ascending
 
 /obj/machinery/computer/skills/attackby(obj/item/O as obj, var/mob/user)
-	if(istype(O, /obj/item/weapon/card/id) && !scan && user.removeItem(O, src))
+	if(istype(O, /obj/item/weapon/card/id) && !scan && user.unEquip(O))
+		O.loc = src
 		scan = O
 		user << "You insert [O]."
 	else
@@ -184,7 +185,8 @@ What a mess.*/
 					scan = null
 				else
 					var/obj/item/I = usr.get_active_hand()
-					if (istype(I, /obj/item/weapon/card/id) && usr.removeItem(I, src))
+					if (istype(I, /obj/item/weapon/card/id) && usr.unEquip(I))
+						I.loc = src
 						scan = I
 
 			if("Log Out")

--- a/code/game/machinery/computer3/computers/HolodeckControl.dm
+++ b/code/game/machinery/computer3/computers/HolodeckControl.dm
@@ -154,7 +154,7 @@
 		if(isobj(obj))
 			var/mob/M = obj.loc
 			if(ismob(M))
-				M.removeItem(obj)
+				M.remove_from_mob(obj)
 				M.update_icons()	//so their overlays update
 
 		if(!silent)

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -386,7 +386,8 @@
 /obj/machinery/cryopod/proc/despawn_occupant()
 	//Drop all items into the pod.
 	for(var/obj/item/W in occupant)
-		occupant.removeItem(W, src, force = 1)
+		occupant.drop_from_inventory(W)
+		W.forceMove(src)
 
 		if(W.contents.len) //Make sure we catch anything not handled by qdel() on the items.
 			for(var/obj/item/O in W.contents)

--- a/code/game/machinery/kitchen/microwave.dm
+++ b/code/game/machinery/kitchen/microwave.dm
@@ -128,7 +128,9 @@
 				"<span class='notice'>You add one of [O] to \the [src].</span>")
 			return
 		else
-			user.removeItem(O, src)
+		//	user.remove_from_mob(O)	//This just causes problems so far as I can tell. -Pete
+			user.drop_item()
+			O.loc = src
 			user.visible_message( \
 				"<span class='notice'>\The [user] has added \the [O] to \the [src].</span>", \
 				"<span class='notice'>You add \the [O] to \the [src].</span>")

--- a/code/game/machinery/kitchen/smartfridge.dm
+++ b/code/game/machinery/kitchen/smartfridge.dm
@@ -218,7 +218,8 @@
 			user << "<span class='notice'>\The [src] is full.</span>"
 			return 1
 		else
-			user.removeItem(O, src)
+			user.remove_from_mob(O)
+			O.loc = src
 			if(item_quants[O.name])
 				item_quants[O.name]++
 			else

--- a/code/game/machinery/pipe/construction.dm
+++ b/code/game/machinery/pipe/construction.dm
@@ -311,7 +311,7 @@ Buildable meters
 /obj/item/pipe/afterattack(turf/simulated/floor/target, mob/user, proximity)
 	if(!proximity) return
 	if(istype(target))
-		user.removeItem(src, target)
+		user.drop_from_inventory(src, target)
 	else
 		return ..()
 

--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -746,7 +746,7 @@ var/list/turret_icons
 				if(isrobot(user))
 					return
 				var/obj/item/weapon/gun/energy/E = I //typecasts the item to an energy gun
-				if(!user.removeItem(I))
+				if(!user.unEquip(I))
 					user << "<span class='notice'>\the [I] is stuck to your hand, you cannot put it in \the [src]</span>"
 					return
 				installation = I.type //installation becomes I.type
@@ -767,7 +767,7 @@ var/list/turret_icons
 		if(4)
 			if(isprox(I))
 				build_step = 5
-				if(!user.removeItem(I))
+				if(!user.unEquip(I))
 					user << "<span class='notice'>\the [I] is stuck to your hand, you cannot put it in \the [src]</span>"
 					return
 				user << "<span class='notice'>You add the prox sensor to the turret.</span>"

--- a/code/game/machinery/seed_extractor.dm
+++ b/code/game/machinery/seed_extractor.dm
@@ -11,7 +11,7 @@ obj/machinery/seed_extractor/attackby(var/obj/item/O as obj, var/mob/user as mob
 	// Fruits and vegetables.
 	if(istype(O, /obj/item/weapon/reagent_containers/food/snacks/grown) || istype(O, /obj/item/weapon/grown))
 
-		user.removeItem(O)
+		user.remove_from_mob(O)
 
 		var/datum/seed/new_seed_type
 		if(istype(O, /obj/item/weapon/grown))

--- a/code/game/machinery/supplybeacon.dm
+++ b/code/game/machinery/supplybeacon.dm
@@ -17,7 +17,8 @@
 		return
 	var/obj/S = new deploy_path(get_turf(user))
 	user.visible_message("<span class='notice'>\The [user] deploys \the [S].</span>")
-	user.deleteItem(src)
+	user.unEquip(src)
+	qdel(src)
 
 /obj/machinery/power/supply_beacon
 	name = "supply beacon"

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -260,7 +260,8 @@
 		cashmoney.worth -= currently_vending.price
 
 		if(cashmoney.worth <= 0)
-			usr.deleteItem(cashmoney)
+			usr.drop_from_inventory(cashmoney)
+			qdel(cashmoney)
 		else
 			cashmoney.update_icon()
 

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -794,7 +794,8 @@
 		return
 
 	else if(istype(W, /obj/item/mecha_parts/mecha_tracking))
-		user.removeItem(W, src)
+		user.drop_from_inventory(W)
+		W.forceMove(src)
 		user.visible_message("[user] attaches [W] to [src].", "You attach [W] to [src]")
 		return
 

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -85,7 +85,7 @@
 /obj/item/Destroy()
 	if(ismob(loc))
 		var/mob/m = loc
-		m.removeItem(src, force = 1)
+		m.drop_from_inventory(src)
 		m.update_inv_r_hand()
 		m.update_inv_l_hand()
 		src.loc = null
@@ -178,7 +178,7 @@
 
 	src.throwing = 0
 	if (src.loc == user)
-		if(!user.removeItem(src))
+		if(!user.unEquip(src))
 			return
 	else
 		if(isliving(src.loc))

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -1152,13 +1152,15 @@ var/global/list/obj/item/device/pda/PDAs = list()
 			return 1
 		else
 			var/obj/item/I = user.get_active_hand()
-			if (istype(I, /obj/item/weapon/card/id) && user.removeItem(I, src))
+			if (istype(I, /obj/item/weapon/card/id) && user.unEquip(I))
+				I.loc = src
 				id = I
 			return 1
 	else
 		var/obj/item/weapon/card/I = user.get_active_hand()
-		if (istype(I, /obj/item/weapon/card/id) && I:registered_name && user.removeItem(I, src))
+		if (istype(I, /obj/item/weapon/card/id) && I:registered_name && user.unEquip(I))
 			var/obj/old_id = id
+			I.loc = src
 			id = I
 			user.put_in_hands(old_id)
 			return 1

--- a/code/game/objects/items/devices/modkit.dm
+++ b/code/game/objects/items/devices/modkit.dm
@@ -23,7 +23,8 @@
 
 	if(!parts)
 		user << "<span class='warning'>This kit has no parts for this modification left.</span>"
-		user.deleteItem(src)
+		user.drop_from_inventory(src)
+		qdel(src)
 		return
 
 	var/allowed = 0
@@ -58,7 +59,8 @@
 		parts &= ~MODKIT_SUIT
 
 	if(!parts)
-		user.deleteItem(src)
+		user.drop_from_inventory(src)
+		qdel(src)
 
 /obj/item/device/modkit/examine(mob/user)
 	..(user)

--- a/code/game/objects/items/devices/radio/electropack.dm
+++ b/code/game/objects/items/devices/radio/electropack.dm
@@ -27,11 +27,13 @@
 		var/obj/item/assembly/shock_kit/A = new /obj/item/assembly/shock_kit( user )
 		A.icon = 'icons/obj/assemblies.dmi'
 
-		user.removeItem(W, A)
+		user.drop_from_inventory(W)
+		W.loc = A
 		W.master = A
 		A.part1 = W
 
-		user.removeItem(src, A)
+		user.drop_from_inventory(src)
+		loc = A
 		master = A
 		A.part2 = src
 

--- a/code/game/objects/items/devices/telecrystal.dm
+++ b/code/game/objects/items/devices/telecrystal.dm
@@ -15,6 +15,7 @@ For new antags, make sure to add "player.mind.accept_tcrystals = 1" if you want 
 /obj/item/device/telecrystal/attack_self(mob/user as mob)
 	if(user.mind.accept_tcrystals) //Checks to see if antag type allows for tcrystals
 		user.mind.tcrystals += 1
-		user.deleteItem(src)
+		user.drop_from_inventory(src)
+		qdel(src)
 	return
 	

--- a/code/game/objects/items/devices/transfer_valve.dm
+++ b/code/game/objects/items/devices/transfer_valve.dm
@@ -47,8 +47,9 @@
 		if(attached_device)
 			user << "<span class='warning'>There is already an device attached to the valve, remove it first.</span>"
 			return
-		user.removeItem(A, src)
+		user.remove_from_mob(item)
 		attached_device = A
+		A.loc = src
 		user << "<span class='notice'>You attach the [item] to the valve controls and secure it.</span>"
 		A.holder = src
 		A.toggle_secure()	//this calls update_icon(), which calls update_icon() on the holder (i.e. the bomb).

--- a/code/game/objects/items/glassjar.dm
+++ b/code/game/objects/items/glassjar.dm
@@ -72,7 +72,8 @@
 			return
 		var/obj/item/weapon/spacecash/S = W
 		user.visible_message("<span class='notice'>[user] puts [S.worth] [S.worth > 1 ? "thalers" : "thaler"] into \the [src].</span>")
-		user.removeItem(S, src)
+		user.drop_from_inventory(S)
+		S.loc = src
 		update_icon()
 
 /obj/item/glass_jar/update_icon() // Also updates name and desc

--- a/code/game/objects/items/robot/robot_items.dm
+++ b/code/game/objects/items/robot/robot_items.dm
@@ -19,7 +19,7 @@
 	if(!istype(user))
 		var/mob/living/temp = user
 		if(istype(temp))
-			temp.removeItem(src, force = 1)
+			temp.drop_from_inventory(src)
 		qdel(src)
 		return
 

--- a/code/game/objects/items/robot/robot_parts.dm
+++ b/code/game/objects/items/robot/robot_parts.dm
@@ -118,7 +118,7 @@
 			B.loc = get_turf(src)
 			user << "<span class='notice'>You armed the robot frame.</span>"
 			if (user.get_inactive_hand()==src)
-				user.removeItem(src)
+				user.remove_from_mob(src)
 				user.put_in_inactive_hand(B)
 			qdel(src)
 		else

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -187,7 +187,7 @@
 		amount -= used
 		if (amount <= 0)
 			if(usr)
-				usr.removeItem(src)
+				usr.remove_from_mob(src)
 			qdel(src) //should be safe to qdel immediately since if someone is still using this stack it will persist for a little while longer
 		return 1
 	else

--- a/code/game/objects/items/weapons/RCD.dm
+++ b/code/game/objects/items/weapons/RCD.dm
@@ -51,7 +51,8 @@
 		if((stored_matter + 10) > 30)
 			user << "<span class='notice'>The RCD can't hold any more matter-units.</span>"
 			return
-		user.deleteItem(W)
+		user.drop_from_inventory(W)
+		qdel(W)
 		stored_matter += 10
 		playsound(src.loc, 'sound/machines/click.ogg', 50, 1)
 		user << "<span class='notice'>The RCD now holds [stored_matter]/30 matter-units.</span>"

--- a/code/game/objects/items/weapons/cigs_lighters.dm
+++ b/code/game/objects/items/weapons/cigs_lighters.dm
@@ -156,7 +156,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 			var/mob/living/M = loc
 			if (!nomessage)
 				M << "<span class='notice'>Your [name] goes out.</span>"
-			M.removeItem(src) //un-equip it so the overlays can update
+			M.remove_from_mob(src) //un-equip it so the overlays can update
 			M.update_inv_wear_mask(0)
 			M.update_inv_l_hand(0)
 			M.update_inv_r_hand(1)

--- a/code/game/objects/items/weapons/dna_injector.dm
+++ b/code/game/objects/items/weapons/dna_injector.dm
@@ -93,7 +93,7 @@
 
 	spawn(0)//this prevents the collapse of space-time continuum
 		if (user)
-			user.removeItem(src, force = 1)
+			user.drop_from_inventory(src)
 		qdel(src)
 	return uses
 

--- a/code/game/objects/items/weapons/gift_wrappaper.dm
+++ b/code/game/objects/items/weapons/gift_wrappaper.dm
@@ -109,7 +109,7 @@
 	if(!ispath(gift_type,/obj/item))	return
 
 	var/obj/item/I = new gift_type(M)
-	M.removeItem(src)
+	M.remove_from_mob(src)
 	M.put_in_hands(I)
 	I.add_fingerprint(M)
 	qdel(src)

--- a/code/game/objects/items/weapons/grenades/chem_grenade.dm
+++ b/code/game/objects/items/weapons/grenades/chem_grenade.dm
@@ -59,7 +59,8 @@
 			path = 1
 			user << "<span class='notice'>You add [W] to the metal casing.</span>"
 			playsound(src.loc, 'sound/items/Screwdriver2.ogg', 25, -3)
-			user.removeItem(det, src)
+			user.remove_from_mob(det)
+			det.loc = src
 			detonator = det
 			if(istimer(detonator.a_left))
 				var/obj/item/device/assembly/timer/T = detonator.a_left
@@ -175,7 +176,7 @@
 
 		if(istype(loc, /mob/living/carbon))		//drop dat grenade if it goes off in your hand
 			var/mob/living/carbon/C = loc
-			C.removeItem(src)
+			C.drop_from_inventory(src)
 			C.throw_mode_off()
 
 		invisibility = INVISIBILITY_MAXIMUM //Why am i doing this?

--- a/code/game/objects/items/weapons/handcuffs.dm
+++ b/code/game/objects/items/weapons/handcuffs.dm
@@ -81,7 +81,7 @@
 	if(dispenser)
 		cuffs = new(get_turf(user))
 	else
-		user.removeItem(cuffs)
+		user.drop_from_inventory(cuffs)
 	cuffs.loc = target
 	target.handcuffed = cuffs
 	target.update_inv_handcuffed()

--- a/code/game/objects/items/weapons/implants/implanter.dm
+++ b/code/game/objects/items/weapons/implants/implanter.dm
@@ -126,7 +126,7 @@
 		c.scanned = A
 		if(istype(A.loc,/mob/living/carbon/human))
 			var/mob/living/carbon/human/H = A.loc
-			H.removeItem(A)
+			H.remove_from_mob(A)
 		else if(istype(A.loc,/obj/item/weapon/storage))
 			var/obj/item/weapon/storage/S = A.loc
 			S.remove_from_storage(A)

--- a/code/game/objects/items/weapons/improvised_components.dm
+++ b/code/game/objects/items/weapons/improvised_components.dm
@@ -62,7 +62,9 @@
 		finished = new /obj/item/weapon/melee/baton/cattleprod(get_turf(user))
 		user << "<span class='notice'>You fasten the wirecutters to the top of the rod with the cable, prongs outward.</span>"
 	if(finished)
-		user.deleteItem(src)
-		user.deleteItem(I)
+		user.drop_from_inventory(src)
+		user.drop_from_inventory(I)
+		qdel(I)
+		qdel(src)
 		user.put_in_hands(finished)
 	update_icon(user)

--- a/code/game/objects/items/weapons/material/ashtray.dm
+++ b/code/game/objects/items/weapons/material/ashtray.dm
@@ -50,7 +50,8 @@ var/global/list/ashtray_cache = list()
 		if (contents.len >= max_butts)
 			user << "\The [src] is full."
 			return
-		user.removeItem(W, src)
+		user.remove_from_mob(W)
+		W.loc = src
 
 		if (istype(W,/obj/item/clothing/mask/smokable/cigarette))
 			var/obj/item/clothing/mask/smokable/cigarette/cig = W

--- a/code/game/objects/items/weapons/material/material_weapons.dm
+++ b/code/game/objects/items/weapons/material/material_weapons.dm
@@ -83,7 +83,7 @@
 	T.visible_message("<span class='danger'>\The [src] [material.destruction_desc]!</span>")
 	if(istype(loc, /mob/living))
 		var/mob/living/M = loc
-		M.removeItem(src, force = 1)
+		M.drop_from_inventory(src)
 	playsound(src, "shatter", 70, 1)
 	if(!consumed && drops_debris) material.place_shard(T)
 	qdel(src)

--- a/code/game/objects/items/weapons/melee/energy.dm
+++ b/code/game/objects/items/weapons/melee/energy.dm
@@ -207,7 +207,7 @@
 	..()
 
 /obj/item/weapon/melee/energy/blade/attack_self(mob/user as mob)
-	user.removeItem(src, force = 1)
+	user.drop_from_inventory(src)
 	spawn(1) if(src) qdel(src)
 
 /obj/item/weapon/melee/energy/blade/dropped()
@@ -225,5 +225,5 @@
 							organ.implants -= src
 			host.pinned -= src
 			host.embedded -= src
-			host.removeItem(src, force = 1)
+			host.drop_from_inventory(src)
 		spawn(1) if(src) qdel(src)

--- a/code/game/objects/items/weapons/mop_deploy.dm
+++ b/code/game/objects/items/weapons/mop_deploy.dm
@@ -52,7 +52,7 @@
 	..()
 
 /obj/item/weapon/mop_deploy/attack_self(mob/user as mob)
-	user.removeItem(src, force = 1)
+	user.drop_from_inventory(src)
 	spawn(1) if(src) del(src)
 
 /obj/item/weapon/mop_deploy/dropped()
@@ -70,5 +70,5 @@
 							organ.implants -= src
 			host.pinned -= src
 			host.embedded -= src
-			host.removeItem(src, force = 1)
+			host.drop_from_inventory(src)
 		spawn(1) if(src) del(src)

--- a/code/game/objects/items/weapons/storage/bags.dm
+++ b/code/game/objects/items/weapons/storage/bags.dm
@@ -153,7 +153,7 @@
 				break
 
 		if(!inserted || !S.amount)
-			usr.removeItem(S)
+			usr.remove_from_mob(S)
 			usr.update_icons()	//update our overlays
 			if (usr.client && usr.s_active != src)
 				usr.client.screen -= S

--- a/code/game/objects/items/weapons/storage/laundry_basket.dm
+++ b/code/game/objects/items/weapons/storage/laundry_basket.dm
@@ -82,6 +82,6 @@
 	use_to_pickup = 0
 
 /obj/item/weapon/storage/laundry_basket/offhand/dropped(mob/user as mob)
-	user.removeItem(linked, force = 1)
+	user.drop_from_inventory(linked)
 	return
 

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -69,7 +69,7 @@
 		if (( usr.restrained() ) || ( usr.stat ))
 			return
 
-		if ((src.loc == usr) && !usr.removeItem(src))
+		if ((src.loc == usr) && !usr.unEquip(src))
 			return
 
 		switch(over_object.name)
@@ -347,7 +347,7 @@
 /obj/item/weapon/storage/proc/handle_item_insertion(obj/item/W as obj, prevent_warning = 0)
 	if(!istype(W)) return 0
 	if(usr)
-		usr.removeItem(W)
+		usr.remove_from_mob(W)
 		usr.update_icons()	//update our overlays
 	W.loc = src
 	W.on_enter_storage(src)

--- a/code/game/objects/items/weapons/tanks/tank_types.dm
+++ b/code/game/objects/items/weapons/tanks/tank_types.dm
@@ -104,7 +104,8 @@
 		if ((!F.status)||(F.ptank))	return
 		src.master = F
 		F.ptank = src
-		user.removeItem(src, F)
+		user.remove_from_mob(src)
+		src.loc = F
 	return
 
 /*

--- a/code/game/objects/items/weapons/tape.dm
+++ b/code/game/objects/items/weapons/tape.dm
@@ -62,7 +62,8 @@
 		else if(user.zone_sel.selecting == "r_hand" || user.zone_sel.selecting == "l_hand")
 			var/obj/item/weapon/handcuffs/cable/tape/T = new(user)
 			if(!T.place_handcuffs(H, user))
-				user.deleteItem(T)
+				user.unEquip(T)
+				qdel(T)
 		else
 			return ..()
 		return 1
@@ -70,7 +71,7 @@
 /obj/item/weapon/tape_roll/proc/stick(var/obj/item/weapon/W, mob/user)
 	if(!istype(W, /obj/item/weapon/paper))
 		return
-	user.removeItem(W)
+	user.drop_from_inventory(W)
 	var/obj/item/weapon/ducttape/tape = new(get_turf(src))
 	tape.attach(W)
 	user.put_in_hands(tape)
@@ -106,7 +107,7 @@
 
 	user << "You remove \the [initial(name)] from [stuck]."
 
-	user.removeItem(src)
+	user.drop_from_inventory(src)
 	stuck.forceMove(get_turf(src))
 	user.put_in_hands(stuck)
 	stuck = null
@@ -128,7 +129,8 @@
 			user << "You cannot reach that from here."		// can only place stuck papers in cardinal directions, to
 			return											// reduce papers around corners issue.
 
-	user.removeItem(src, source_turf)
+	user.drop_from_inventory(src)
+	forceMove(source_turf)
 
 	if(params)
 		var/list/mouse_control = params2list(params)

--- a/code/game/objects/items/weapons/tools.dm
+++ b/code/game/objects/items/weapons/tools.dm
@@ -195,12 +195,12 @@
 		if (user.client)
 			user.client.screen -= src
 		if (user.r_hand == src)
-			user.removeItem(src)
+			user.remove_from_mob(src)
 		else
-			user.removeItem(src)
+			user.remove_from_mob(src)
 		src.master = F
 		src.layer = initial(src.layer)
-		user.removeItem(src)
+		user.remove_from_mob(src)
 		if (user.client)
 			user.client.screen -= src
 		src.loc = F

--- a/code/game/objects/items/weapons/traps.dm
+++ b/code/game/objects/items/weapons/traps.dm
@@ -36,7 +36,7 @@
 				)
 
 			deployed = 1
-			user.removeItem(src)
+			user.drop_from_inventory(src)
 			update_icon()
 			anchored = 1
 

--- a/code/game/objects/structures/coathanger.dm
+++ b/code/game/objects/structures/coathanger.dm
@@ -21,7 +21,7 @@
 	if (can_hang && !coat)
 		user.visible_message("[user] hangs [W] on \the [src].", "You hang [W] on the \the [src]")
 		coat = W
-		user.removeItem(coat, src)
+		user.drop_from_inventory(coat, src)
 		update_icon()
 	else
 		user << "<span class='notice'>You cannot hang [W] on [src]</span>"

--- a/code/game/objects/structures/crates_lockers/closets/fireaxe.dm
+++ b/code/game/objects/structures/crates_lockers/closets/fireaxe.dm
@@ -66,7 +66,8 @@
 					user << "<span class='warning'>Unwield the axe first.</span>"
 					return
 				fireaxe = O
-				user.removeItem(O, src)
+				user.remove_from_mob(O)
+				src.contents += O
 				user << "<span class='notice'>You place the fire axe back in the [src.name].</span>"
 				update_icon()
 			else

--- a/code/game/objects/structures/extinguisher.dm
+++ b/code/game/objects/structures/extinguisher.dm
@@ -27,7 +27,8 @@
 		return
 	if(istype(O, /obj/item/weapon/extinguisher))
 		if(!has_extinguisher && opened)
-			user.removeItem(O, src)
+			user.remove_from_mob(O)
+			contents += O
 			has_extinguisher = O
 			user << "<span class='notice'>You place [O] in [src].</span>"
 		else

--- a/code/game/objects/structures/noticeboard.dm
+++ b/code/game/objects/structures/noticeboard.dm
@@ -33,7 +33,8 @@
 		if(notices < 5)
 			O.add_fingerprint(user)
 			add_fingerprint(user)
-			user.removeItem(O, src)
+			user.drop_from_inventory(O)
+			O.loc = src
 			notices++
 			icon_state = "nboard0[notices]"	//update sprite
 			user << "<span class='notice'>You pin the paper to the noticeboard.</span>"

--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -96,7 +96,9 @@
 			user << "\The [src] is already padded."
 			return
 		var/obj/item/stack/C = W
-		if(C.get_amount() < 1)
+		if(C.get_amount() < 1) // How??
+			user.drop_from_inventory(C)
+			qdel(C)
 			return
 		var/padding_type //This is awful but it needs to be like this until tiles are given a material var.
 		if(istype(W,/obj/item/stack/tile/carpet))
@@ -110,7 +112,8 @@
 			return
 		C.use(1)
 		if(!istype(src.loc, /turf))
-			user.removeItem(src, get_turf(src))
+			user.drop_from_inventory(src)
+			src.loc = get_turf(src)
 		user << "You add padding to \the [src]."
 		add_padding(padding_type)
 		return

--- a/code/game/objects/structures/stool_bed_chair_nest/stools.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/stools.dm
@@ -72,7 +72,7 @@ var/global/list/stool_cache = list() //haha stool
 /obj/item/weapon/stool/attack(mob/M as mob, mob/user as mob)
 	if (prob(5) && istype(M,/mob/living))
 		user.visible_message("<span class='danger'>[user] breaks [src] over [M]'s back!</span>")
-		user.removeItem(src)
+		user.remove_from_mob(src)
 		dismantle()
 		qdel(src)
 		var/mob/living/T = M
@@ -112,7 +112,9 @@ var/global/list/stool_cache = list() //haha stool
 			user << "\The [src] is already padded."
 			return
 		var/obj/item/stack/C = W
-		if(C.get_amount() < 1)
+		if(C.get_amount() < 1) // How??
+			user.drop_from_inventory(C)
+			qdel(C)
 			return
 		var/padding_type //This is awful but it needs to be like this until tiles are given a material var.
 		if(istype(W,/obj/item/stack/tile/carpet))
@@ -126,7 +128,8 @@ var/global/list/stool_cache = list() //haha stool
 			return
 		C.use(1)
 		if(!istype(src.loc, /turf))
-			user.removeItem(src, get_turf(src))
+			user.drop_from_inventory(src)
+			src.loc = get_turf(src)
 		user << "You add padding to \the [src]."
 		add_padding(padding_type)
 		return

--- a/code/game/objects/structures/target_stake.dm
+++ b/code/game/objects/structures/target_stake.dm
@@ -27,7 +27,8 @@
 		if(istype(W, /obj/item/target))
 			density = 0
 			W.density = 1
-			user.removeItem(W, loc)
+			user.remove_from_mob(W)
+			W.loc = loc
 			W.layer = 3.1
 			pinned_target = W
 			user << "You slide the target into the stake."

--- a/code/modules/admin/secrets/admin_secrets/prison_warp.dm
+++ b/code/modules/admin/secrets/admin_secrets/prison_warp.dm
@@ -27,7 +27,7 @@
 				if(istype(W, /obj/item/organ/external))
 					continue
 					//don't strip organs
-				H.removeItem(W)
+				H.drop_from_inventory(W)
 			//teleport person to cell
 			H.loc = pick(prisonwarp)
 			H.equip_to_slot_or_del(new /obj/item/clothing/under/color/orange(H), slot_w_uniform)

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -973,7 +973,7 @@
 
 		//strip their stuff and stick it in the crate
 		for(var/obj/item/I in M)
-			M.removeItem(I, locker)
+			M.drop_from_inventory(I, locker)
 		M.update_icons()
 
 		//so they black out before warping
@@ -1006,7 +1006,7 @@
 			return
 
 		for(var/obj/item/I in M)
-			M.removeItem(I, force = 1)
+			M.drop_from_inventory(I)
 
 		M.Paralyse(5)
 		sleep(5)
@@ -1031,7 +1031,7 @@
 			return
 
 		for(var/obj/item/I in M)
-			M.removeItem(I, force = 1)
+			M.drop_from_inventory(I)
 
 		M.Paralyse(5)
 		sleep(5)
@@ -1078,7 +1078,7 @@
 			return
 
 		for(var/obj/item/I in M)
-			M.removeItem(I, force = 1)
+			M.drop_from_inventory(I)
 
 		if(istype(M, /mob/living/carbon/human))
 			var/mob/living/carbon/human/observer = M

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -426,7 +426,7 @@
 	for (var/obj/item/I in M)
 		if (istype(I, /obj/item/weapon/implant))
 			continue
-		M.removeItem(I)
+		M.drop_from_inventory(I)
 		if(I.loc != M)
 			qdel(I)
 	switch(dresscode)

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -10,7 +10,7 @@
 		return
 
 	for(var/obj/item/W in M)
-		M.removeItem(W, force = 1)
+		M.drop_from_inventory(W)
 
 	log_admin("[key_name(usr)] made [key_name(M)] drop everything!")
 	message_admins("[key_name_admin(usr)] made [key_name_admin(M)] drop everything!", 1)
@@ -28,7 +28,7 @@
 			return
 		//strip their stuff before they teleport into a cell :downs:
 		for(var/obj/item/W in M)
-			M.removeItem(W, force = 1)
+			M.drop_from_inventory(W)
 		//teleport person to cell
 		M.Paralyse(5)
 		sleep(5)	//so they black out before warping

--- a/code/modules/assembly/bomb.dm
+++ b/code/modules/assembly/bomb.dm
@@ -86,7 +86,7 @@
 	var/obj/item/device/onetankbomb/R = new /obj/item/device/onetankbomb(loc)
 
 	M.drop_item()			//Remove the assembly from your hands
-	M.removeItem(src)	//Remove the tank from your character,in case you were holding it
+	M.remove_from_mob(src)	//Remove the tank from your character,in case you were holding it
 	M.put_in_hands(R)		//Equips the bomb if possible, or puts it on the floor.
 
 	R.bombassembly = S	//Tell the bomb about its assembly part

--- a/code/modules/assembly/holder.dm
+++ b/code/modules/assembly/holder.dm
@@ -36,8 +36,8 @@
 		if((!isassembly(D))||(!isassembly(D2)))	return 0
 		if((D:secured)||(D2:secured))	return 0
 		if(user)
-			user.removeItem(D)
-			user.removeItem(D2)
+			user.remove_from_mob(D)
+			user.remove_from_mob(D2)
 		D:holder = src
 		D2:holder = src
 		D.loc = src

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -432,7 +432,8 @@
 		if(holding)
 			user << "<span class='warning'>\The [src] is already holding \a [holding].</span>"
 			return
-		user.removeItem(I, src)
+		user.unEquip(I)
+		I.forceMove(src)
 		holding = I
 		user.visible_message("<span class='notice'>\The [user] shoves \the [I] into \the [src].</span>")
 		verbs |= /obj/item/clothing/shoes/proc/draw_knife
@@ -631,7 +632,7 @@
 		if (( usr.restrained() ) || ( usr.stat ))
 			return
 
-		if (!usr.removeItem(src))
+		if (!usr.unEquip(src))
 			return
 
 		switch(over_object.name)

--- a/code/modules/clothing/shoes/magboots.dm
+++ b/code/modules/clothing/shoes/magboots.dm
@@ -43,7 +43,8 @@
 			user << "You are unable to wear \the [src] as \the [H.shoes] are in the way."
 			shoes = null
 			return 0
-		H.removeItem(shoes, src)	//Remove the old shoes so you can put on the magboots.
+		H.drop_from_inventory(shoes)	//Remove the old shoes so you can put on the magboots.
+		shoes.forceMove(src)
 
 	if(!..())
 		if(shoes) 	//Put the old shoes back on if the check fails.

--- a/code/modules/clothing/spacesuits/rig/modules/combat.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/combat.dm
@@ -55,7 +55,8 @@
 		return 0
 
 	user << "<font color='blue'><b>You slot \the [input_device] into the suit module.</b></font>"
-	user.deleteItem(input_device)
+	user.drop_from_inventory(input_device)
+	qdel(input_device)
 	accepted_item.charges++
 	return 1
 
@@ -203,7 +204,8 @@
 		return
 
 	for(var/obj/item/weapon/melee/energy/blade/blade in M.contents)
-		M.deleteItem(blade)
+		M.drop_from_inventory(blade)
+		qdel(blade)
 
 /obj/item/rig_module/fabricator
 

--- a/code/modules/clothing/spacesuits/rig/modules/computer.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/computer.dm
@@ -208,7 +208,8 @@
 				else
 					return 0
 			else
-				user.removeItem(ai, src)
+				user.drop_from_inventory(ai)
+				ai.forceMove(src)
 				ai_card = ai
 				ai_mob << "<font color='blue'>You have been transferred to \the [holder]'s [src].</font>"
 				user << "<font color='blue'>You load [ai_mob] into \the [holder]'s [src].</font>"

--- a/code/modules/clothing/spacesuits/rig/modules/ninja.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/ninja.dm
@@ -200,6 +200,6 @@
 		return
 	explosion(get_turf(src), explosion_values[1], explosion_values[2], explosion_values[3], explosion_values[4])
 	if(holder && holder.wearer)
-		holder.wearer.removeItem(src)
+		holder.wearer.drop_from_inventory(src)
 		qdel(holder)
 	qdel(src)

--- a/code/modules/clothing/spacesuits/rig/modules/utility.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/utility.dm
@@ -458,7 +458,8 @@
 		return
 
 	for(var/obj/item/weapon/mop_deploy/blade in M.contents)
-		M.deleteItem(blade)
+		M.drop_from_inventory(blade)
+		del(blade)
 
 
 	//Space Cleaner Launcher
@@ -500,7 +501,8 @@
 		return 0
 
 	user << "<font color='blue'><b>You slot \the [input_device] into the suit module.</b></font>"
-	user.deleteItem(input_device)
+	user.drop_from_inventory(input_device)
+	del(input_device)
 	accepted_item.charges++
 	return 1
 

--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -157,7 +157,7 @@
 	for(var/obj/item/piece in list(gloves,boots,helmet,chest))
 		var/mob/living/M = piece.loc
 		if(istype(M))
-			M.removeItem(piece)
+			M.drop_from_inventory(piece)
 		qdel(piece)
 	processing_objects -= src
 	qdel(wires)
@@ -307,7 +307,7 @@
 		if(piece.loc != src && !(wearer && piece.loc == wearer))
 			if(istype(piece.loc, /mob/living))
 				M = piece.loc
-				M.removeItem(piece)
+				M.unEquip(piece)
 			piece.forceMove(src)
 
 	if(!istype(wearer) || loc != wearer || wearer.back != src || canremove || !cell || cell.charge <= 0)
@@ -562,7 +562,7 @@
 		M.visible_message("<font color='blue'>[M] starts putting on \the [src]...</font>", "<font color='blue'>You start putting on \the [src]...</font>")
 		if(!do_after(M,seal_delay))
 			if(M && M.back == src)
-				if(!M.removeItem(src))
+				if(!M.unEquip(src))
 					return
 			src.forceMove(get_turf(src))
 			return
@@ -620,7 +620,7 @@
 					if(use_obj && check_slot == use_obj)
 						H << "<font color='blue'><b>Your [use_obj.name] [use_obj.gender == PLURAL ? "retract" : "retracts"] swiftly.</b></font>"
 						use_obj.canremove = 1
-						holder.removeItem(use_obj)
+						holder.drop_from_inventory(use_obj)
 						use_obj.forceMove(get_turf(src))
 						use_obj.dropped()
 						use_obj.canremove = 0
@@ -653,23 +653,27 @@
 	if(sealed)
 		if(H.head)
 			var/obj/item/garbage = H.head
-			H.deleteItem(garbage)
+			H.drop_from_inventory(garbage)
 			H.head = null
+			qdel(garbage)
 
 		if(H.gloves)
 			var/obj/item/garbage = H.gloves
-			H.deleteItem(garbage)
+			H.drop_from_inventory(garbage)
 			H.gloves = null
+			qdel(garbage)
 
 		if(H.shoes)
 			var/obj/item/garbage = H.shoes
-			H.deleteItem(garbage)
+			H.drop_from_inventory(garbage)
 			H.shoes = null
+			qdel(garbage)
 
 		if(H.wear_suit)
 			var/obj/item/garbage = H.wear_suit
-			H.deleteItem(garbage)
+			H.drop_from_inventory(garbage)
 			H.wear_suit = null
+			qdel(garbage)
 
 	for(var/piece in list("helmet","gauntlets","chest","boots"))
 		toggle_piece(piece, H, ONLY_DEPLOY)

--- a/code/modules/clothing/spacesuits/rig/rig_attackby.dm
+++ b/code/modules/clothing/spacesuits/rig/rig_attackby.dm
@@ -56,7 +56,7 @@
 				user << "\The [src] already has a tank installed."
 				return
 
-			if(!user.removeItem(W)) return
+			if(!user.unEquip(W)) return
 			air_supply = W
 			W.forceMove(src)
 			user << "You slot [W] into [src] and tighten the connecting valve."
@@ -84,7 +84,7 @@
 				return
 			if(!user || !W)
 				return
-			if(!user.removeItem(mod)) return
+			if(!user.unEquip(mod)) return
 			user << "You install \the [mod] into \the [src]."
 			installed_modules |= mod
 			mod.forceMove(src)
@@ -94,7 +94,7 @@
 
 		else if(!cell && istype(W,/obj/item/weapon/cell))
 
-			if(!user.removeItem(W)) return
+			if(!user.unEquip(W)) return
 			user << "You jack \the [W] into \the [src]'s battery mount."
 			W.forceMove(src)
 			src.cell = W

--- a/code/modules/clothing/spacesuits/void/void.dm
+++ b/code/modules/clothing/spacesuits/void/void.dm
@@ -125,28 +125,24 @@
 		H = helmet.loc
 		if(istype(H))
 			if(helmet && H.head == helmet)
-				H.removeItem(helmet, src)
+				H.drop_from_inventory(helmet)
+				helmet.forceMove(src)
 
 	if(boots)
 		boots.canremove = 1
 		H = boots.loc
 		if(istype(H))
 			if(boots && H.shoes == boots)
-				H.removeItem(boots, src)
+				H.drop_from_inventory(boots)
+				boots.forceMove(src)
 
 	if(tank)
 		tank.canremove = 1
-		H = tank.loc
-		if(istype(H))
-			if(tank && H.s_store == tank)
-				H.removeItem(tank, src)
+		tank.forceMove(src)
 
 	if(cooler)
 		cooler.canremove = 1
-		H = cooler.loc
-		if(istype(H))
-			if(cooler && H.s_store == cooler)
-				H.removeItem(cooler, src)
+		cooler.forceMove(src)
 
 /obj/item/clothing/suit/space/void/verb/toggle_helmet()
 
@@ -169,7 +165,8 @@
 	if(H.head == helmet)
 		H << "<span class='notice'>You retract your suit helmet.</span>"
 		helmet.canremove = 1
-		H.removeItem(helmet, src)
+		H.drop_from_inventory(helmet)
+		helmet.forceMove(src)
 	else
 		if(H.head)
 			H << "<span class='danger'>You cannot deploy your helmet while wearing \the [H.head].</span>"
@@ -207,7 +204,7 @@
 		cooler = null
 	H << "<span class='info'>You press the emergency release, ejecting \the [removing] from your suit.</span>"
 	removing.canremove = 1
-	H.removeItem(removing)
+	H.drop_from_inventory(removing)
 
 /obj/item/clothing/suit/space/void/attackby(obj/item/W as obj, mob/user as mob)
 

--- a/code/modules/clothing/suits/toggles.dm
+++ b/code/modules/clothing/suits/toggles.dm
@@ -32,7 +32,7 @@
 	suittoggled = 0
 	if(ishuman(hood.loc))
 		var/mob/living/carbon/H = hood.loc
-		H.removeItem(hood, force = 1)
+		H.unEquip(hood, 1)
 		H.update_inv_wear_suit()
 	hood.loc = src
 

--- a/code/modules/clothing/under/accessories/holster.dm
+++ b/code/modules/clothing/under/accessories/holster.dm
@@ -17,7 +17,8 @@
 	if(istype(user))
 		user.stop_aiming(no_message=1)
 	holstered = I
-	user.removeItem(holstered, src)
+	user.drop_from_inventory(holstered)
+	holstered.loc = src
 	holstered.add_fingerprint(user)
 	w_class = max(w_class, holstered.w_class)
 	user.visible_message("<span class='notice'>[user] holsters \the [holstered].</span>", "<span class='notice'>You holster \the [holstered].</span>")

--- a/code/modules/detectivework/microscope/dnascanner.dm
+++ b/code/modules/detectivework/microscope/dnascanner.dm
@@ -43,8 +43,9 @@
 
 	var/obj/item/weapon/forensics/swab/swab = W
 	if(istype(swab) && swab.is_used())
-		user.removeItem(swab, src)
+		user.unEquip(W)
 		src.bloodsamp = swab
+		swab.loc = src
 		user << "<span class='notice'>You insert \the [W] into \the [src].</span>"
 	else
 		user << "<span class='warning'>\The [src] only accepts used swabs.</span>"

--- a/code/modules/detectivework/microscope/microscope.dm
+++ b/code/modules/detectivework/microscope/microscope.dm
@@ -18,7 +18,8 @@
 
 	if(istype(W, /obj/item/weapon/forensics/swab)|| istype(W, /obj/item/weapon/sample/fibers) || istype(W, /obj/item/weapon/sample/print))
 		user << "<span class='notice'>You insert \the [W] into the microscope.</span>"
-		user.removeItem(W, src)
+		user.unEquip(W)
+		W.forceMove(src)
 		sample = W
 		update_icon()
 		return

--- a/code/modules/detectivework/tools/evidencebag.dm
+++ b/code/modules/detectivework/tools/evidencebag.dm
@@ -32,7 +32,7 @@
 			user.client.screen -= I
 			U.contents.Remove(I)
 		else if(user.item_is_in_hands(I))
-			user.removeItem(I)
+			user.drop_from_inventory(I)
 		else
 			return
 

--- a/code/modules/detectivework/tools/rag.dm
+++ b/code/modules/detectivework/tools/rag.dm
@@ -40,7 +40,7 @@
 /obj/item/weapon/reagent_containers/glass/rag/attack_self(mob/user as mob)
 	if(on_fire)
 		user.visible_message("<span class='warning'>\The [user] stamps out [src].</span>", "<span class='warning'>You stamp out [src].</span>")
-		user.removeItem(src)
+		user.unEquip(src)
 		extinguish()
 	else
 		remove_contents(user)

--- a/code/modules/detectivework/tools/sample_kits.dm
+++ b/code/modules/detectivework/tools/sample_kits.dm
@@ -42,7 +42,7 @@
 
 /obj/item/weapon/sample/attackby(var/obj/O, var/mob/user)
 	if(O.type == src.type)
-		user.removeItem(O)
+		user.unEquip(O)
 		if(merge_evidence(O, user))
 			qdel(O)
 		return 1

--- a/code/modules/economy/cash.dm
+++ b/code/modules/economy/cash.dm
@@ -21,11 +21,13 @@
 		if(istype(W, /obj/item/weapon/spacecash/ewallet)) return 0
 
 		var/obj/item/weapon/spacecash/SC = W
+
 		SC.adjust_worth(src.worth)
 		if(istype(user, /mob/living/carbon/human))
 			var/mob/living/carbon/human/h_user = user
-			h_user.removeItem(src)
-			h_user.removeItem(SC)
+
+			h_user.drop_from_inventory(src)
+			h_user.drop_from_inventory(SC)
 			h_user.put_in_hands(SC)
 		user << "<span class='notice'>You combine the Thalers to a bundle of [SC.worth] Thalers.</span>"
 		qdel(src)
@@ -77,6 +79,7 @@
 /obj/item/weapon/spacecash/attack_self()
 	var/amount = input(usr, "How many Thalers do you want to take? (0 to [src.worth])", "Take Money", 20) as num
 	amount = round(Clamp(amount, 0, src.worth))
+
 	if(!amount)
 		return
 
@@ -135,6 +138,7 @@
 
 proc/spawn_money(var/sum, spawnloc, mob/living/carbon/human/human_user as mob)
 	var/obj/item/weapon/spacecash/SC = new (spawnloc)
+
 	SC.set_worth(sum)
 	if (ishuman(human_user) && !human_user.get_active_hand())
 		human_user.put_in_hands(SC)

--- a/code/modules/economy/cash_register.dm
+++ b/code/modules/economy/cash_register.dm
@@ -182,7 +182,7 @@
 			overlays |= "register_cash"
 			if(ishuman(user))
 				var/mob/living/carbon/human/H = user
-				H.removeItem(SC)
+				H.drop_from_inventory(SC)
 			qdel(SC)
 		else
 			scan_cash(SC)
@@ -335,7 +335,7 @@
 		if(!SC.worth)
 			if(ishuman(SC.loc))
 				var/mob/living/carbon/human/H = SC.loc
-				H.removeItem(SC)
+				H.drop_from_inventory(SC)
 			qdel(SC)
 		cash_stored += transaction_amount
 

--- a/code/modules/games/cards.dm
+++ b/code/modules/games/cards.dm
@@ -146,7 +146,8 @@
 		for(var/datum/playingcard/P in cards)
 			H.cards += P
 		H.concealed = src.concealed
-		user.deleteItem(src)
+		user.drop_from_inventory(src,user.loc)
+		qdel(src)
 		H.update_icon()
 		return
 	..()

--- a/code/modules/holodeck/HolodeckControl.dm
+++ b/code/modules/holodeck/HolodeckControl.dm
@@ -211,7 +211,7 @@
 	if(isobj(obj))
 		var/mob/M = obj.loc
 		if(ismob(M))
-			M.removeItem(obj)
+			M.remove_from_mob(obj)
 			M.update_icons()	//so their overlays update
 
 	if(!silent)

--- a/code/modules/hydroponics/beekeeping/beehive.dm
+++ b/code/modules/hydroponics/beekeeping/beehive.dm
@@ -67,7 +67,8 @@
 		++frames
 		user.visible_message("<span class='notice'>[user] loads \the [I] into \the [src].</span>", "<span class='notice'>You load \the [I] into \the [src].</span>")
 		update_icon()
-		user.deleteItem(I)
+		user.drop_from_inventory(I)
+		qdel(I)
 		return
 	else if(istype(I, /obj/item/bee_pack))
 		var/obj/item/bee_pack/B = I
@@ -228,7 +229,8 @@
 	if(do_after(user, 30))
 		user.visible_message("<span class='notice'>[user] constructs a beehive.</span>", "<span class='notice'>You construct a beehive.</span>")
 		new /obj/machinery/beehive(get_turf(user))
-		user.deleteItem(src)
+		user.drop_from_inventory(src)
+		qdel(src)
 	return
 
 /obj/item/stack/wax

--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -288,7 +288,7 @@
 			if(prob(35))
 				if(user)
 					user << "<span class='danger'>\The [src] has fallen to bits.</span>"
-					user.removeItem(src)
+					user.drop_from_inventory(src)
 				qdel(src)
 
 		add_fingerprint(user)

--- a/code/modules/hydroponics/seed_machines.dm
+++ b/code/modules/hydroponics/seed_machines.dm
@@ -88,7 +88,8 @@
 		if(S.seed && S.seed.get_trait(TRAIT_IMMUTABLE) > 0)
 			user << "That seed is not compatible with our genetics technology."
 		else
-			user.removeItem(W, src)
+			user.drop_from_inventory(W)
+			W.loc = src
 			seed = W
 			user << "You load [W] into [src]."
 		return
@@ -113,7 +114,8 @@
 					user << "That disk does not have any gene data loaded."
 					return
 
-			user.removeItem(W, src)
+			user.drop_from_inventory(W)
+			W.loc = src
 			loaded_disk = W
 			user << "You load [W] into [src]."
 

--- a/code/modules/hydroponics/seed_storage.dm
+++ b/code/modules/hydroponics/seed_storage.dm
@@ -225,7 +225,7 @@
 /obj/machinery/seed_storage/proc/add(var/obj/item/seeds/O as obj)
 	if (istype(O.loc, /mob))
 		var/mob/user = O.loc
-		user.removeItem(O)
+		user.remove_from_mob(O)
 	else if(istype(O.loc,/obj/item/weapon/storage))
 		var/obj/item/weapon/storage/S = O.loc
 		S.remove_from_storage(O, src)

--- a/code/modules/hydroponics/trays/tray.dm
+++ b/code/modules/hydroponics/trays/tray.dm
@@ -475,7 +475,7 @@
 		if(!seed)
 
 			var/obj/item/seeds/S = O
-			user.removeItem(O)
+			user.remove_from_mob(O)
 
 			if(!S.seed)
 				user << "The packet seems to be empty. You throw it away."
@@ -520,7 +520,7 @@
 	else if ( istype(O, /obj/item/weapon/plantspray) )
 
 		var/obj/item/weapon/plantspray/spray = O
-		user.removeItem(O)
+		user.remove_from_mob(O)
 		toxins += spray.toxicity
 		pestlevel -= spray.pest_kill_str
 		weedlevel -= spray.weed_kill_str

--- a/code/modules/mining/satchel_ore_boxdm.dm
+++ b/code/modules/mining/satchel_ore_boxdm.dm
@@ -12,7 +12,8 @@
 
 /obj/structure/ore_box/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	if (istype(W, /obj/item/weapon/ore))
-		user.removeItem(W, src)
+		user.remove_from_mob(W)
+		src.contents += W
 	if (istype(W, /obj/item/weapon/storage))
 		var/obj/item/weapon/storage/S = W
 		S.hide_from(usr)

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -24,6 +24,7 @@ var/list/slot_equipment_priority = list( \
 //This proc is called whenever someone clicks an inventory ui slot.
 /mob/proc/attack_ui(var/slot)
 	var/obj/item/W = get_active_hand()
+
 	var/obj/item/E = get_equipped_item(slot)
 	if (istype(E))
 		if(istype(W))
@@ -50,8 +51,10 @@ var/list/slot_equipment_priority = list( \
 	if(!W.mob_can_equip(src, slot))
 		if(del_on_fail)
 			qdel(W)
-		else if(!disable_warning)
-			src << "\red You are unable to equip that." //Only print if del_on_fail is false
+
+		else
+			if(!disable_warning)
+				src << "\red You are unable to equip that." //Only print if del_on_fail is false
 		return 0
 
 	equip_to_slot(W, slot, redraw_mob) //This proc should not ever fail.
@@ -121,6 +124,22 @@ var/list/slot_equipment_priority = list( \
 	W.dropped()
 	return 0
 
+// Removes an item from inventory and places it in the target atom.
+// If canremove or other conditions need to be checked then use unEquip instead.
+/mob/proc/drop_from_inventory(var/obj/item/W, var/atom/Target = null)
+
+	if(W)
+		if(!Target)
+			Target = loc
+
+		remove_from_mob(W)
+		if(!(W && W.loc)) return 1 // self destroying objects (tk, grabs)
+
+		W.forceMove(Target)
+		update_icons()
+		return 1
+	return 0
+
 //Drops the item in our left hand
 /mob/proc/drop_l_hand(var/atom/Target)
 	return 0
@@ -165,36 +184,28 @@ var/list/slot_equipment_priority = list( \
 			break
 	return slot
 
-/mob/proc/removeItem(var/obj/item/I, var/atom/T = loc, var/force = 0)
-	if(!I) // Nothing to remove, so we succeed.
-		return 1
-	if(!force && !src.canUnEquip(I))
-		return 0
 
-	u_equip(I)
-	if(src.client)
-		src.client.screen -= I
-
-	I.layer = initial(I.layer)
-	I.screen_loc = null
-
-	I.dropped(src)
-
-	if(I && I.loc) // Some items self-delete
-		I.forceMove(T)
-
+//This differs from remove_from_mob() in that it checks if the item can be unequipped first.
+/mob/proc/unEquip(obj/item/I, force = 0) //Force overrides NODROP for things like wizarditis and admin undress.
+	if(!(force || canUnEquip(I)))
+		return
+	drop_from_inventory(I)
 	return 1
 
-/mob/proc/deleteItem(var/obj/item/I)
-	u_equip(I)
-	if(src.client)
-		src.client.screen -= I
 
-	I.screen_loc = null
+//Attemps to remove an object on a mob.
+/mob/proc/remove_from_mob(var/obj/O)
+	src.u_equip(O)
+	if (src.client)
+		src.client.screen -= O
+	O.layer = initial(O.layer)
+	O.screen_loc = null
+	if(istype(O, /obj/item))
+		var/obj/item/I = O
+		I.forceMove(src.loc)
+		I.dropped(src)
+	return 1
 
-	I.dropped(src)
-	if(I && I.loc)
-		qdel(I)
 
 //Returns the item equipped to the specified slot, if any.
 /mob/proc/get_equipped_item(var/slot)

--- a/code/modules/mob/living/bot/cleanbot.dm
+++ b/code/modules/mob/living/bot/cleanbot.dm
@@ -189,7 +189,8 @@
 		var/mob/living/bot/cleanbot/A = new /mob/living/bot/cleanbot(T)
 		A.name = created_name
 		user << "<span class='notice'>You add the robot arm to the bucket and sensor assembly. Beep boop!</span>"
-		user.deleteItem(src)
+		user.drop_from_inventory(src)
+		qdel(src)
 
 	else if(istype(O, /obj/item/weapon/pen))
 		var/t = sanitizeSafe(input(user, "Enter new robot name", name, created_name), MAX_NAME_LEN)

--- a/code/modules/mob/living/bot/ed209bot.dm
+++ b/code/modules/mob/living/bot/ed209bot.dm
@@ -185,5 +185,7 @@
 				user << "<span class='notice'>You complete the ED-209.</span>"
 				var/turf/T = get_turf(src)
 				new /mob/living/bot/secbot/ed209(T,created_name,lasercolor)
+				user.drop_item()
 				qdel(W)
-				user.deleteItem(src)
+				user.drop_from_inventory(src)
+				qdel(src)

--- a/code/modules/mob/living/bot/farmbot.dm
+++ b/code/modules/mob/living/bot/farmbot.dm
@@ -22,12 +22,14 @@
 
 	var/obj/structure/reagent_dispensers/watertank/tank
 
+
 /mob/living/bot/farmbot/New(var/newloc, var/newTank)
 	..(newloc)
 	if(!newTank)
 		newTank = new /obj/structure/reagent_dispensers/watertank(src)
 	tank = newTank
 	tank.forceMove(src)
+
 
 /mob/living/bot/farmbot/attack_hand(var/mob/user as mob)
 	. = ..()
@@ -105,9 +107,12 @@
 	else
 		icon_state = "farmbot[on]"
 
+
 /mob/living/bot/farmbot/handleRegular()
 	if(emagged && prob(1))
 		flick("farmbot_broke", src)
+
+
 
 /mob/living/bot/farmbot/handleAdjacentTarget()
 	UnarmedAttack(target)
@@ -148,11 +153,13 @@
 /mob/living/bot/farmbot/UnarmedAttack(var/atom/A, var/proximity)
 	if(!..())
 		return
+
 	if(busy)
 		return
 
 	if(istype(A, /obj/machinery/portable_atmospherics/hydroponics))
 		var/obj/machinery/portable_atmospherics/hydroponics/T = A
+
 		var/t = confirmTarget(T)
 		switch(t)
 			if(0)
@@ -161,6 +168,7 @@
 				action = "water" // Needs a better one
 				update_icons()
 				visible_message("<span class='notice'>[src] starts [T.dead? "removing the plant from" : "harvesting"] \the [A].</span>")
+
 				busy = 1
 				if(do_after(src, 30))
 					visible_message("<span class='notice'>[src] [T.dead? "removes the plant from" : "harvests"] \the [A].</span>")
@@ -169,6 +177,7 @@
 				action = "water"
 				update_icons()
 				visible_message("<span class='notice'>[src] starts watering \the [A].</span>")
+
 				busy = 1
 				if(do_after(src, 30))
 					playsound(loc, 'sound/effects/slosh.ogg', 25, 1)
@@ -178,6 +187,7 @@
 				action = "hoe"
 				update_icons()
 				visible_message("<span class='notice'>[src] starts uprooting the weeds in \the [A].</span>")
+
 				busy = 1
 				if(do_after(src, 30))
 					visible_message("<span class='notice'>[src] uproots the weeds in \the [A].</span>")
@@ -186,10 +196,13 @@
 				action = "fertile"
 				update_icons()
 				visible_message("<span class='notice'>[src] starts fertilizing \the [A].</span>")
+
 				busy = 1
 				if(do_after(src, 30))
+
 					visible_message("<span class='notice'>[src] fertilizes \the [A].</span>")
 					T.reagents.add_reagent("ammonia", 10)
+
 		busy = 0
 		action = ""
 		update_icons()
@@ -200,19 +213,23 @@
 		action = "water"
 		update_icons()
 		visible_message("<span class='notice'>[src] starts refilling its tank from \the [A].</span>")
+
 		busy = 1
 		while(do_after(src, 10) && tank.reagents.total_volume < tank.reagents.maximum_volume)
 			tank.reagents.add_reagent("water", 10)
 			if(prob(5))
 				playsound(loc, 'sound/effects/slosh.ogg', 25, 1)
+
 		busy = 0
 		action = ""
 		update_icons()
 		visible_message("<span class='notice'>[src] finishes refilling its tank.</span>")
 	else if(emagged && ishuman(A))
 		var/action = pick("weed", "water")
+
 		busy = 1
 		spawn(50) // Some delay
+
 			busy = 0
 		switch(action)
 			if("weed")
@@ -225,6 +242,7 @@
 				A.attack_generic(src, 5, t)
 			if("water")
 				flick("farmbot_water", src)
+
 				visible_message("<span class='danger'>[src] splashes [A] with water!</span>")
 				tank.reagents.splash(A, 100)
 
@@ -248,6 +266,7 @@
 	s.start()
 	qdel(src)
 	return
+
 
 /mob/living/bot/farmbot/confirmTarget(var/atom/targ)
 	if(!..())
@@ -296,6 +315,7 @@
 	var/obj/tank
 	w_class = 3.0
 
+
 /obj/item/weapon/farmbot_arm_assembly/New(var/newloc, var/theTank)
 	..(newloc)
 	if(!theTank) // If an admin spawned it, it won't have a watertank it, so lets make one for em!
@@ -309,8 +329,11 @@
 		..()
 		return
 
+
 	user << "You add the robot arm to [src]."
-	user.deleteItem(S)
+
+	user.drop_from_inventory(S)
+	qdel(S)
 
 	new /obj/item/weapon/farmbot_arm_assembly(loc, src)
 
@@ -320,26 +343,35 @@
 		build_step++
 		user << "You add the plant analyzer to [src]."
 		name = "farmbot assembly"
-		user.deleteItem(W)
+
+		user.remove_from_mob(W)
+		qdel(W)
 
 	else if((istype(W, /obj/item/weapon/reagent_containers/glass/bucket)) && (build_step == 1))
 		build_step++
 		user << "You add a bucket to [src]."
 		name = "farmbot assembly with bucket"
-		user.deleteItem(W)
+
+		user.remove_from_mob(W)
+		qdel(W)
 
 	else if((istype(W, /obj/item/weapon/material/minihoe)) && (build_step == 2))
 		build_step++
 		user << "You add a minihoe to [src]."
 		name = "farmbot assembly with bucket and minihoe"
-		user.deleteItem(W)
+
+		user.remove_from_mob(W)
+		qdel(W)
 
 	else if((isprox(W)) && (build_step == 3))
 		build_step++
 		user << "You complete the Farmbot! Beep boop."
+
 		var/mob/living/bot/farmbot/S = new /mob/living/bot/farmbot(get_turf(src), tank)
 		S.name = created_name
-		user.deleteItem(W)
+
+		user.remove_from_mob(W)
+		qdel(W)
 		qdel(src)
 
 	else if(istype(W, /obj/item/weapon/pen))

--- a/code/modules/mob/living/bot/floorbot.dm
+++ b/code/modules/mob/living/bot/floorbot.dm
@@ -289,7 +289,8 @@
 		var/obj/item/weapon/toolbox_tiles/B = new /obj/item/weapon/toolbox_tiles
 		user.put_in_hands(B)
 		user << "<span class='notice'>You add the tiles into the empty toolbox. They protrude from the top.</span>"
-		user.deleteItem(src)
+		user.drop_from_inventory(src)
+		qdel(src)
 	else
 		user << "<span class='warning'>You need 10 floor tiles for a floorbot.</span>"
 	return
@@ -314,7 +315,8 @@
 		B.created_name = created_name
 		user.put_in_hands(B)
 		user << "<span class='notice'>You add the sensor to the toolbox and tiles!</span>"
-		user.deleteItem(src)
+		user.drop_from_inventory(src)
+		qdel(src)
 	else if (istype(W, /obj/item/weapon/pen))
 		var/t = sanitizeSafe(input(user, "Enter new robot name", name, created_name), MAX_NAME_LEN)
 		if(!t)
@@ -343,7 +345,8 @@
 		var/mob/living/bot/floorbot/A = new /mob/living/bot/floorbot(T)
 		A.name = created_name
 		user << "<span class='notice'>You add the robot arm to the odd looking toolbox assembly! Boop beep!</span>"
-		user.deleteItem(src)
+		user.drop_from_inventory(src)
+		qdel(src)
 	else if(istype(W, /obj/item/weapon/pen))
 		var/t = sanitizeSafe(input(user, "Enter new robot name", name, created_name), MAX_NAME_LEN)
 		if(!t)

--- a/code/modules/mob/living/bot/medbot.dm
+++ b/code/modules/mob/living/bot/medbot.dm
@@ -283,7 +283,8 @@
 	qdel(S)
 	user.put_in_hands(A)
 	user << "<span class='notice'>You add the robot arm to the first aid kit.</span>"
-	user.deleteItem(src)
+	user.drop_from_inventory(src)
+	qdel(src)
 
 /obj/item/weapon/firstaid_arm_assembly
 	name = "first aid/robot arm assembly"
@@ -330,4 +331,5 @@
 					var/mob/living/bot/medbot/S = new /mob/living/bot/medbot(T)
 					S.skin = skin
 					S.name = created_name
-					user.deleteItem(src)
+					user.drop_from_inventory(src)
+					qdel(src)

--- a/code/modules/mob/living/bot/secbot.dm
+++ b/code/modules/mob/living/bot/secbot.dm
@@ -228,7 +228,8 @@
 		var/obj/item/weapon/secbot_assembly/A = new /obj/item/weapon/secbot_assembly
 		user.put_in_hands(A)
 		user << "You add the signaler to the helmet."
-		user.deleteItem(src)
+		user.drop_from_inventory(src)
+		qdel(src)
 	else
 		return
 

--- a/code/modules/mob/living/carbon/alien/diona/diona_attacks.dm
+++ b/code/modules/mob/living/carbon/alien/diona/diona_attacks.dm
@@ -16,7 +16,7 @@
 		if(hat)
 			user << "<span class='warning'>\The [src] is already wearing \the [hat].</span>"
 			return
-		user.removeItem(W)
+		user.unEquip(W)
 		wear_hat(W)
 		user.visible_message("<span class='notice'>\The [user] puts \the [W] on \the [src].</span>")
 		return

--- a/code/modules/mob/living/carbon/alien/progression.dm
+++ b/code/modules/mob/living/carbon/alien/progression.dm
@@ -34,7 +34,7 @@
 		adult.key = src.key
 
 	for (var/obj/item/W in src.contents)
-		src.removeItem(W, force = 1)
+		src.drop_from_inventory(W)
 
 	for(var/datum/language/L in languages)
 		adult.add_language(L.name)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -327,7 +327,8 @@
 	if(!item) return //Grab processing has a chance of returning null
 
 
-	src.removeItem(item, loc)
+	src.remove_from_mob(item)
+	item.loc = src.loc
 
 	//actually throw it!
 	if (item)

--- a/code/modules/mob/living/carbon/give.dm
+++ b/code/modules/mob/living/carbon/give.dm
@@ -37,6 +37,6 @@
 		src << "<span class='warning'>Their hands are full.</span>"
 		return
 
-	if(src.removeItem(I))
+	if(src.unEquip(I))
 		target.put_in_hands(I) // If this fails it will just end up on the floor, but that's fitting for things like dionaea.
 		target.visible_message("<span class='notice'>\The [src] handed \the [I] to \the [target].</span>")

--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -11,7 +11,7 @@
 	sleep(1)
 
 	for(var/obj/item/I in src)
-		removeItem(I)
+		drop_from_inventory(I)
 		I.throw_at(get_edge_target_turf(src,pick(alldirs)), rand(1,3), round(30/I.w_class))
 
 	..(species.gibbed_anim)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1348,10 +1348,10 @@
 		S << "<span class='danger'>[U] pops your [current_limb.joint] back in!</span>"
 	current_limb.undislocate()
 
-/mob/living/carbon/human/removeItem(var/obj/item/I, var/atom/T = loc, var/force = 0)
-	if(I in src.organs)
-		return 0
-	return ..()
+/mob/living/carbon/human/drop_from_inventory(var/obj/item/W, var/atom/Target = null)
+	if(W in organs)
+		return
+	..()
 
 /mob/living/carbon/human/reset_view(atom/A, update_hud = 1)
 	..()

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -281,7 +281,7 @@
 				//Actually disarm them
 				for(var/obj/item/I in holding)
 					if(I)
-						removeItem(I)
+						drop_from_inventory(I)
 						visible_message("<span class='danger'>[M] has disarmed [src]!</span>")
 						playsound(loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
 						return

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -56,7 +56,7 @@ emp_act
 			if(c_hand && (stun_amount || agony_amount > 10))
 				msg_admin_attack("[src.name] ([src.ckey]) was disarmed by a stun effect")
 
-				removeItem(c_hand)
+				drop_from_inventory(c_hand)
 				if (affected.status & ORGAN_ROBOT)
 					emote("me", 1, "drops what they were holding, their [affected.name] malfunctioning!")
 				else

--- a/code/modules/mob/living/carbon/human/human_organs.dm
+++ b/code/modules/mob/living/carbon/human/human_organs.dm
@@ -117,7 +117,7 @@
 			var/obj/item/organ/external/E = get_organ(limb_tag)
 			if(!E)
 				visible_message("<span class='danger'>Lacking a functioning left hand, \the [src] drops \the [l_hand].</span>")
-				removeItem(l_hand)
+				drop_from_inventory(l_hand)
 				break
 
 	if(r_hand)
@@ -125,7 +125,7 @@
 			var/obj/item/organ/external/E = get_organ(limb_tag)
 			if(!E)
 				visible_message("<span class='danger'>Lacking a functioning right hand, \the [src] drops \the [r_hand].</span>")
-				removeItem(r_hand)
+				drop_from_inventory(r_hand)
 				break
 
 	// Check again...
@@ -141,11 +141,11 @@
 				if(HAND_LEFT, ARM_LEFT)
 					if(!l_hand)
 						continue
-					removeItem(l_hand)
+					drop_from_inventory(l_hand)
 				if(HAND_RIGHT, ARM_RIGHT)
 					if(!r_hand)
 						continue
-					removeItem(r_hand)
+					drop_from_inventory(r_hand)
 
 			var/emote_scream = pick("screams in pain and ", "lets out a sharp cry and ", "cries out and ")
 			emote("me", 1, "[(E.can_feel_pain()) ? "" : emote_scream ]drops what they were holding in their [E.name]!")
@@ -155,11 +155,11 @@
 				if(HAND_LEFT, ARM_LEFT)
 					if(!l_hand)
 						continue
-					removeItem(l_hand)
+					drop_from_inventory(l_hand)
 				if(HAND_RIGHT, ARM_RIGHT)
 					if(!r_hand)
 						continue
-					removeItem(r_hand)
+					drop_from_inventory(r_hand)
 
 			emote("me", 1, "drops what they were holding, their [E.name] malfunctioning!")
 

--- a/code/modules/mob/living/carbon/human/human_powers.dm
+++ b/code/modules/mob/living/carbon/human/human_powers.dm
@@ -139,7 +139,7 @@
 
 
 	for(var/obj/item/W in src)
-		removeItem(W, force = 1)
+		drop_from_inventory(W)
 
 	visible_message("<span class='warning'>\The [src] quivers slightly, then splits apart with a wet slithering noise.</span>")
 

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -85,18 +85,18 @@ This saves us from having to call add_fingerprint() any time something is put in
 
 	if (W == wear_suit)
 		if(s_store)
-			removeItem(s_store)
+			drop_from_inventory(s_store)
 		wear_suit = null
 		update_inv_wear_suit()
 	else if (W == w_uniform)
 		if (r_store)
-			removeItem(r_store)
+			drop_from_inventory(r_store)
 		if (l_store)
-			removeItem(l_store)
+			drop_from_inventory(l_store)
 		if (wear_id)
-			removeItem(wear_id)
+			drop_from_inventory(wear_id)
 		if (belt)
-			removeItem(belt)
+			drop_from_inventory(belt)
 		w_uniform = null
 		update_inv_w_uniform()
 	else if (W == gloves)
@@ -289,7 +289,7 @@ This saves us from having to call add_fingerprint() any time something is put in
 			update_inv_s_store(redraw_mob)
 		if(slot_in_backpack)
 			if(src.get_active_hand() == W)
-				src.removeItem(W)
+				src.remove_from_mob(W)
 			W.loc = src.back
 		if(slot_tie)
 			var/obj/item/clothing/under/uniform = src.w_uniform

--- a/code/modules/mob/living/carbon/human/stripping.dm
+++ b/code/modules/mob/living/carbon/human/stripping.dm
@@ -82,8 +82,8 @@
 
 	if(stripping)
 		admin_attack_log(user, src, "Attempted to remove \a [target_slot]", "Target of an attempt to remove \a [target_slot].", "attempted to remove \a [target_slot] from")
-		removeItem(target_slot)
-	else if(user.removeItem(held))
+		unEquip(target_slot)
+	else if(user.unEquip(held))
 		equip_to_slot_if_possible(held, text2num(slot_to_strip), 0, 1, 1)
 		if(held.loc != src)
 			user.put_in_hands(held)
@@ -94,9 +94,9 @@
 		user << "<span class='warning'>\The [src] has nothing in their pockets.</span>"
 		return
 	if(r_store)
-		removeItem(r_store)
+		unEquip(r_store)
 	if(l_store)
-		removeItem(l_store)
+		unEquip(l_store)
 	visible_message("<span class='danger'>\The [user] empties \the [src]'s pockets!</span>")
 
 // Modify the current target sensor level.

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -748,7 +748,7 @@ var/global/list/damage_icon_parts = list()
 		standing.color = wear_suit.color
 
 		if( istype(wear_suit, /obj/item/clothing/suit/straight_jacket) )
-			removeItem(handcuffed, force = 1)
+			drop_from_inventory(handcuffed)
 			drop_l_hand()
 			drop_r_hand()
 

--- a/code/modules/mob/living/carbon/resist.dm
+++ b/code/modules/mob/living/carbon/resist.dm
@@ -66,7 +66,7 @@
 			"<span class='danger'>\The [src] manages to remove \the [handcuffed]!</span>",
 			"<span class='notice'>You successfully remove \the [handcuffed].</span>"
 			)
-		removeItem(handcuffed)
+		drop_from_inventory(handcuffed)
 
 /mob/living/carbon/proc/escape_legcuffs()
 	if(!canClick())
@@ -101,7 +101,7 @@
 			"<span class='notice'>You successfully remove \the [legcuffed].</span>"
 			)
 
-		removeItem(legcuffed)
+		drop_from_inventory(legcuffed)
 		legcuffed = null
 		update_inv_legcuffed()
 

--- a/code/modules/mob/living/inventory.dm
+++ b/code/modules/mob/living/inventory.dm
@@ -38,11 +38,11 @@
 
 //Drops the item in our left hand
 /mob/living/drop_l_hand(var/atom/Target)
-	return removeItem(l_hand, Target)
+	return drop_from_inventory(l_hand, Target)
 
 //Drops the item in our right hand
 /mob/living/drop_r_hand(var/atom/Target)
-	return removeItem(r_hand, Target)
+	return drop_from_inventory(r_hand, Target)
 
 /mob/living/proc/hands_are_full()
 	return (r_hand && l_hand)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -393,11 +393,11 @@ default behaviour is:
 		var/mob/living/carbon/C = src
 
 		if (C.handcuffed && !initial(C.handcuffed))
-			C.removeItem(C.handcuffed)
+			C.drop_from_inventory(C.handcuffed)
 		C.handcuffed = initial(C.handcuffed)
 
 		if (C.legcuffed && !initial(C.legcuffed))
-			C.removeItem(C.legcuffed)
+			C.drop_from_inventory(C.legcuffed)
 		C.legcuffed = initial(C.legcuffed)
 	BITSET(hud_updateflag, HEALTH_HUD)
 	BITSET(hud_updateflag, STATUS_HUD)
@@ -595,7 +595,7 @@ default behaviour is:
 	var/mob/M = H.loc //Get our mob holder (if any).
 
 	if(istype(M))
-		M.removeItem(H)
+		M.drop_from_inventory(H)
 		M << "<span class='warning'>\The [H] wriggles out of your grip!</span>"
 		src << "<span class='warning'>You wriggle out of \the [M]'s grip!</span>"
 
@@ -771,10 +771,10 @@ default behaviour is:
 /mob/living/proc/slip(var/slipped_on,stun_duration=8)
 	return 0
 
-/mob/living/carbon/removeItem(var/obj/item/I, var/atom/T = loc, var/force = 0)
-	if(I in src.internal_organs)
-		return 0
-	return ..()
+/mob/living/carbon/drop_from_inventory(var/obj/item/W, var/atom/Target = null)
+	if(W in internal_organs)
+		return
+	..()
 
 /mob/living/touch_map_edge()
 
@@ -895,8 +895,8 @@ default behaviour is:
 
 	if(lying)
 		density = 0
-		if(l_hand) removeItem(l_hand)
-		if(r_hand) removeItem(r_hand)
+		if(l_hand) unEquip(l_hand)
+		if(r_hand) unEquip(r_hand)
 	else
 		density = initial(density)
 

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -268,7 +268,7 @@
 					affecting.implants -= card
 					H.visible_message("<span class='danger'>\The [src] explodes out of \the [H]'s [affecting.name] in shower of gore!</span>")
 					break
-		holder.removeItem(card)
+		holder.drop_from_inventory(card)
 	else if(istype(card.loc,/obj/item/device/pda))
 		var/obj/item/device/pda/holder = card.loc
 		holder.pai = null
@@ -386,7 +386,7 @@
 	if(istype(H))
 		var/mob/living/M = H.loc
 		if(istype(M))
-			M.removeItem(H)
+			M.drop_from_inventory(H)
 		H.loc = get_turf(src)
 		src.loc = get_turf(H)
 

--- a/code/modules/mob/living/silicon/robot/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone.dm
@@ -145,7 +145,7 @@ var/list/mob_hat_cache = list()
 		if(hat)
 			user << "<span class='warning'>\The [src] is already wearing \the [hat].</span>"
 			return
-		user.removeItem(W)
+		user.unEquip(W)
 		wear_hat(W)
 		user.visible_message("<span class='notice'>\The [user] puts \the [W] on \the [src].</span>")
 		return

--- a/code/modules/mob/living/simple_animal/constructs/soulstone.dm
+++ b/code/modules/mob/living/simple_animal/constructs/soulstone.dm
@@ -118,7 +118,7 @@
 		return
 
 	for(var/obj/item/W in T)
-		T.removeItem(W)
+		T.drop_from_inventory(W)
 
 	new /obj/effect/decal/remains/human(T.loc) //Spawns a skeleton
 	T.invisibility = 101

--- a/code/modules/mob/living/simple_animal/parrot.dm
+++ b/code/modules/mob/living/simple_animal/parrot.dm
@@ -607,8 +607,9 @@
 			stolen_item = C.r_hand
 
 		if(stolen_item)
-			C.removeItem(stolen_item, src)
+			C.remove_from_mob(stolen_item)
 			held_item = stolen_item
+			stolen_item.loc = src
 			visible_message("[src] grabs the [held_item] out of [C]'s hand!", "\blue You snag the [held_item] out of [C]'s hand!", "You hear the sounds of wings flapping furiously.")
 			return held_item
 

--- a/code/modules/mob/mob_grab_specials.dm
+++ b/code/modules/mob/mob_grab_specials.dm
@@ -106,7 +106,9 @@
 	target.attack_log += text("\[[time_stamp()]\] <font color='orange'>Headbutted by [attacker.name] ([attacker.ckey])</font>")
 	msg_admin_attack("[key_name(attacker)] has headbutted [key_name(target)]")
 
-	attacker.deleteItem(src)
+	attacker.drop_from_inventory(src)
+	src.loc = null
+	qdel(src)
 	return
 
 /obj/item/weapon/grab/proc/dislocate(mob/living/carbon/human/target, mob/living/attacker, var/target_zone)

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -4,7 +4,7 @@
 	for(var/obj/item/W in src)
 		if (W==w_uniform) // will be torn
 			continue
-		removeItem(W, force = 1)
+		drop_from_inventory(W)
 	regenerate_icons()
 	transforming = 1
 	canmove = 0
@@ -31,7 +31,7 @@
 		return
 
 	for(var/obj/item/W in src)
-		removeItem(W, force = 1)
+		drop_from_inventory(W)
 	set_species(species.primitive_form)
 	dna.SetSEState(MONKEYBLOCK,1)
 	dna.SetSEValueRange(MONKEYBLOCK,0xDAC, 0xFFF)
@@ -57,7 +57,7 @@
 	if (transforming)
 		return
 	for(var/obj/item/W in src)
-		removeItem(W, force = 1)
+		drop_from_inventory(W)
 	transforming = 1
 	canmove = 0
 	icon = null
@@ -113,7 +113,7 @@
 	if (transforming)
 		return
 	for(var/obj/item/W in src)
-		removeItem(W, force = 1)
+		drop_from_inventory(W)
 	regenerate_icons()
 	transforming = 1
 	canmove = 0
@@ -165,7 +165,7 @@
 	if (transforming)
 		return
 	for(var/obj/item/W in src)
-		removeItem(W, force = 1)
+		drop_from_inventory(W)
 	regenerate_icons()
 	transforming = 1
 	canmove = 0
@@ -199,7 +199,7 @@
 	if (transforming)
 		return
 	for(var/obj/item/W in src)
-		removeItem(W, force = 1)
+		drop_from_inventory(W)
 	regenerate_icons()
 	transforming = 1
 	canmove = 0
@@ -228,7 +228,7 @@
 	if(transforming)
 		return
 	for(var/obj/item/W in src)
-		removeItem(W, force = 1)
+		drop_from_inventory(W)
 
 	regenerate_icons()
 	transforming = 1

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -323,7 +323,7 @@ var/list/organ_cache = list()
 	var/datum/reagent/blood/B = locate(/datum/reagent/blood) in reagents.reagent_list
 	blood_splatter(src,B,1)
 
-	user.removeItem(src)
+	user.drop_from_inventory(src)
 	var/obj/item/weapon/reagent_containers/food/snacks/organ/O = new(get_turf(src))
 	O.name = name
 	O.icon = icon

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -833,12 +833,12 @@ Note that amputating the affected organ does in fact remove the infection from t
 		holder.visible_message(\
 			"\The [holder.handcuffed.name] falls off of [holder.name].",\
 			"\The [holder.handcuffed.name] falls off you.")
-		holder.removeItem(holder.handcuffed, force = 1)
+		holder.drop_from_inventory(holder.handcuffed)
 	if (holder.legcuffed && body_part in list(FOOT_LEFT, FOOT_RIGHT, LEG_LEFT, LEG_RIGHT))
 		holder.visible_message(\
 			"\The [holder.legcuffed.name] falls off of [holder.name].",\
 			"\The [holder.legcuffed.name] falls off you.")
-		holder.removeItem(holder.legcuffed, force = 1)
+		holder.drop_from_inventory(holder.legcuffed)
 
 /obj/item/organ/external/proc/bandage()
 	var/rval = 0
@@ -1005,7 +1005,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 	W.add_blood(owner)
 	if(ismob(W.loc))
 		var/mob/living/H = W.loc
-		H.removeItem(W)
+		H.drop_from_inventory(W)
 	W.loc = owner
 
 /obj/item/organ/external/removed(var/mob/living/user, var/ignore_children = 0)

--- a/code/modules/organs/subtypes/machine.dm
+++ b/code/modules/organs/subtypes/machine.dm
@@ -75,7 +75,7 @@
 
 	var/mob/living/holder_mob = loc
 	if(istype(holder_mob))
-		holder_mob.removeItem(src)
+		holder_mob.drop_from_inventory(src)
 	qdel(src)
 
 /obj/item/organ/internal/mmi_holder/posibrain

--- a/code/modules/paperwork/faxmachine.dm
+++ b/code/modules/paperwork/faxmachine.dm
@@ -122,7 +122,8 @@ var/list/adminfaxes = list()	//cache for faxes that have been sent to admins
 				scan = null
 		else
 			var/obj/item/I = usr.get_active_hand()
-			if (istype(I, /obj/item/weapon/card/id) && usr.removeItem(I, src))
+			if (istype(I, /obj/item/weapon/card/id) && usr.unEquip(I))
+				I.loc = src
 				scan = I
 		authenticated = 0
 

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -307,7 +307,7 @@
 				"<span class='[class]'>You burn right through \the [src], turning it to ash. It flutters through the air before settling on the floor in a heap.</span>")
 
 				if(user.get_inactive_hand() == src)
-					user.removeItem(src)
+					user.drop_from_inventory(src)
 
 				new /obj/effect/decal/cleanable/ash(src.loc)
 				qdel(src)
@@ -415,23 +415,23 @@
 			B.name = name
 		else if (P.name != "paper" && P.name != "photo")
 			B.name = P.name
-		user.removeItem(P)
+		user.drop_from_inventory(P)
 		if (istype(user, /mob/living/carbon/human))
 			var/mob/living/carbon/human/h_user = user
 			if (h_user.r_hand == src)
-				h_user.removeItem(src)
+				h_user.drop_from_inventory(src)
 				h_user.put_in_r_hand(B)
 			else if (h_user.l_hand == src)
-				h_user.removeItem(src)
+				h_user.drop_from_inventory(src)
 				h_user.put_in_l_hand(B)
 			else if (h_user.l_store == src)
-				h_user.removeItem(src)
+				h_user.drop_from_inventory(src)
 				B.loc = h_user
 				B.layer = 20
 				h_user.l_store = B
 				h_user.update_inv_pockets()
 			else if (h_user.r_store == src)
-				h_user.removeItem(src)
+				h_user.drop_from_inventory(src)
 				B.loc = h_user
 				B.layer = 20
 				h_user.r_store = B

--- a/code/modules/paperwork/paper_bundle.dm
+++ b/code/modules/paperwork/paper_bundle.dm
@@ -34,7 +34,7 @@
 
 	// merging bundles
 	else if(istype(W, /obj/item/weapon/paper_bundle))
-		user.removeItem(W)
+		user.drop_from_inventory(W)
 		for(var/obj/O in W)
 			O.loc = src
 			O.add_fingerprint(usr)
@@ -61,7 +61,8 @@
 	else if(istype(sheet, /obj/item/weapon/photo))
 		user << "<span class='notice'>You add [(sheet.name == "photo") ? "the photo" : sheet.name] to [(src.name == "paper bundle") ? "the paper bundle" : src.name].</span>"
 
-	user.removeItem(sheet, src)
+	user.drop_from_inventory(sheet)
+	sheet.loc = src
 
 	pages.Insert(index, sheet)
 
@@ -84,7 +85,7 @@
 				"<span class='[class]'>You burn right through \the [src], turning it to ash. It flutters through the air before settling on the floor in a heap.</span>")
 
 				if(user.get_inactive_hand() == src)
-					user.removeItem(src)
+					user.drop_from_inventory(src)
 
 				new /obj/effect/decal/cleanable/ash(src.loc)
 				qdel(src)
@@ -167,7 +168,7 @@
 
 			if(pages.len <= 1)
 				var/obj/item/weapon/paper/P = src[1]
-				usr.removeItem(src)
+				usr.drop_from_inventory(src)
 				usr.put_in_hands(P)
 				qdel(src)
 
@@ -205,7 +206,8 @@
 		O.loc = usr.loc
 		O.layer = initial(O.layer)
 		O.add_fingerprint(usr)
-	usr.deleteItem(src)
+	usr.drop_from_inventory(src)
+	qdel(src)
 	return
 
 

--- a/code/modules/paperwork/papershredder.dm
+++ b/code/modules/paperwork/papershredder.dm
@@ -31,7 +31,8 @@
 				user << "<span class='warning'>\The [src] is full; please empty it before you continue.</span>"
 				return
 			paperamount += paper_result
-			user.deleteItem(W)
+			user.drop_from_inventory(W)
+			qdel(W)
 			playsound(src.loc, 'sound/items/pshred.ogg', 75, 1)
 			if(paperamount > max_paper)
 				user <<"<span class='danger'>\The [src] was too full, and shredded paper goes everywhere!</span>"
@@ -118,7 +119,7 @@
 /obj/item/weapon/shreddedp/proc/FireBurn()
 	var/mob/living/M = loc
 	if(istype(M))
-		M.removeItem(src)
+		M.drop_from_inventory(src)
 	PoolOrNew(/obj/effect/decal/cleanable/ash,get_turf(src))
 	qdel(src)
 

--- a/code/modules/power/antimatter/control.dm
+++ b/code/modules/power/antimatter/control.dm
@@ -158,7 +158,8 @@
 			user << "\red There is already a [fueljar] inside!"
 			return
 		fueljar = W
-		user.removeItem(W, src)
+		user.remove_from_mob(W)
+		W.loc = src
 		user.update_icons()
 		user.visible_message("[user.name] loads an [W.name] into the [src.name].", \
 				"You load an [W.name].", \

--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -108,7 +108,8 @@
 		if(stored_ammo.len >= max_ammo)
 			user << "<span class='warning'>[src] is full!</span>"
 			return
-		user.removeItem(C, src)
+		user.remove_from_mob(C)
+		C.loc = src
 		stored_ammo.Insert(1, C) //add to the head of the list
 		update_icon()
 

--- a/code/modules/projectiles/guns/launcher/crossbow.dm
+++ b/code/modules/projectiles/guns/launcher/crossbow.dm
@@ -136,7 +136,7 @@
 /obj/item/weapon/gun/launcher/crossbow/attackby(obj/item/W as obj, mob/user as mob)
 	if(!bolt)
 		if (istype(W,/obj/item/weapon/arrow))
-			user.removeItem(W, src)
+			user.drop_from_inventory(W, src)
 			bolt = W
 			user.visible_message("[user] slides [bolt] into [src].","You slide [bolt] into [src].")
 			update_icon()

--- a/code/modules/projectiles/guns/launcher/grenade_launcher.dm
+++ b/code/modules/projectiles/guns/launcher/grenade_launcher.dm
@@ -47,7 +47,8 @@
 		if(grenades.len >= max_grenades)
 			user << "<span class='warning'>[src] is full.</span>"
 			return
-		user.removeItem(G, src)
+		user.remove_from_mob(G)
+		G.loc = src
 		grenades.Insert(1, G) //add to the head of the list, so that it is loaded on the next pump
 		user.visible_message("[user] inserts \a [G] into [src].", "<span class='notice'>You insert \a [G] into [src].</span>")
 		return
@@ -105,7 +106,8 @@
 		if(chambered)
 			user << "<span class='warning'>[src] is already loaded.</span>"
 			return
-		user.removeItem(G, src)
+		user.remove_from_mob(G)
+		G.loc = src
 		chambered = G
 		user.visible_message("[user] load \a [G] into [src].", "<span class='notice'>You load \a [G] into [src].</span>")
 		return

--- a/code/modules/projectiles/guns/launcher/pneumatic.dm
+++ b/code/modules/projectiles/guns/launcher/pneumatic.dm
@@ -65,7 +65,7 @@
 
 /obj/item/weapon/gun/launcher/pneumatic/attackby(obj/item/W as obj, mob/user as mob)
 	if(!tank && istype(W,/obj/item/weapon/tank))
-		user.removeItem(W, src)
+		user.drop_from_inventory(W, src)
 		tank = W
 		user.visible_message("[user] jams [W] into [src]'s valve and twists it closed.","You jam [W] into [src]'s valve and twist it closed.")
 		update_icon()
@@ -161,7 +161,8 @@
 /obj/item/weapon/cannonframe/attackby(obj/item/W as obj, mob/user as mob)
 	if(istype(W,/obj/item/pipe))
 		if(buildstate == 0)
-			user.deleteItem(W)
+			user.drop_from_inventory(W)
+			qdel(W)
 			user << "<span class='notice'>You secure the piping inside the frame.</span>"
 			buildstate++
 			update_icon()
@@ -178,7 +179,8 @@
 			return
 	else if(istype(W,/obj/item/device/transfer_valve))
 		if(buildstate == 4)
-			user.deleteItem(W)
+			user.drop_from_inventory(W)
+			qdel(W)
 			user << "<span class='notice'>You install the transfer valve and connect it to the piping.</span>"
 			buildstate++
 			update_icon()

--- a/code/modules/projectiles/guns/launcher/syringe_gun.dm
+++ b/code/modules/projectiles/guns/launcher/syringe_gun.dm
@@ -22,7 +22,8 @@
 	if(istype(I, /obj/item/weapon/reagent_containers/syringe))
 		syringe = I
 		user << "<span class='notice'>You carefully insert [syringe] into [src].</span>"
-		user.removeItem(syringe, src)
+		user.remove_from_mob(syringe)
+		syringe.loc = src
 		sharp = 1
 		name = "syringe dart"
 		update_icon()
@@ -122,7 +123,8 @@
 		if(darts.len >= max_darts)
 			user << "<span class='warning'>[src] is full!</span>"
 			return
-		user.removeItem(C, src)
+		user.remove_from_mob(C)
+		C.loc = src
 		darts += C //add to the end
 		user.visible_message("[user] inserts \a [C] into [src].", "<span class='notice'>You insert \a [C] into [src].</span>")
 	else

--- a/code/modules/projectiles/guns/projectile.dm
+++ b/code/modules/projectiles/guns/projectile.dm
@@ -104,7 +104,8 @@
 				if(ammo_magazine)
 					user << "<span class='warning'>[src] already has a magazine loaded.</span>" //already a magazine here
 					return
-				user.removeItem(AM, src)
+				user.remove_from_mob(AM)
+				AM.loc = src
 				ammo_magazine = AM
 				user.visible_message("[user] inserts [AM] into [src].", "<span class='notice'>You insert [AM] into [src].</span>")
 				playsound(src.loc, 'sound/weapons/flipblade.ogg', 50, 1)
@@ -133,7 +134,8 @@
 			user << "<span class='warning'>[src] is full.</span>"
 			return
 
-		user.removeItem(C, src)
+		user.remove_from_mob(C)
+		C.loc = src
 		loaded.Insert(1, C) //add to the head of the list
 		user.visible_message("[user] inserts \a [C] into [src].", "<span class='notice'>You insert \a [C] into [src].</span>")
 		playsound(src.loc, 'sound/weapons/empty.ogg', 50, 1)

--- a/code/modules/projectiles/projectile/change.dm
+++ b/code/modules/projectiles/projectile/change.dm
@@ -25,7 +25,7 @@
 				if(istype(W, /obj/item/weapon/implant))	//TODO: Carn. give implants a dropped() or something
 					qdel(W)
 					continue
-				M.removeItem(W, force = 1)
+				M.drop_from_inventory(W)
 
 		var/mob/living/new_mob
 

--- a/code/modules/reagents/Chemistry-Machinery.dm
+++ b/code/modules/reagents/Chemistry-Machinery.dm
@@ -393,7 +393,8 @@
 		user << "\The [O] is not suitable for blending."
 		return 1
 
-	user.removeItem(O, src)
+	user.remove_from_mob(O)
+	O.loc = src
 	holdingitems += O
 	src.updateUsrDialog()
 	return 0

--- a/code/modules/reagents/dispenser/dispenser2.dm
+++ b/code/modules/reagents/dispenser/dispenser2.dm
@@ -50,7 +50,7 @@
 		return
 
 	if(user)
-		user.removeItem(C)
+		user.drop_from_inventory(C)
 		user << "<span class='notice'>You add \the [C] to \the [src].</span>"
 
 	C.loc = src
@@ -103,7 +103,8 @@
 			return
 
 		container =  RC
-		user.removeItem(RC, src)
+		user.drop_from_inventory(RC)
+		RC.loc = src
 		user << "<span class='notice'>You set \the [RC] on \the [src].</span>"
 		nanomanager.update_uis(src) // update all UIs attached to src
 

--- a/code/modules/reagents/reagent_containers/food/drinks/bottle.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks/bottle.dm
@@ -49,7 +49,7 @@
 /obj/item/weapon/reagent_containers/food/drinks/bottle/proc/smash(var/newloc, atom/against = null)
 	if(ismob(loc))
 		var/mob/M = loc
-		M.removeItem(src)
+		M.drop_from_inventory(src)
 
 	//Creates a shattering noise and replaces the bottle with a broken_bottle
 	var/obj/item/weapon/broken_bottle/B = new /obj/item/weapon/broken_bottle(newloc)
@@ -110,9 +110,10 @@
 
 /obj/item/weapon/reagent_containers/food/drinks/bottle/proc/insert_rag(obj/item/weapon/reagent_containers/glass/rag/R, mob/user)
 	if(!isGlass || rag) return
-	if(user.removeItem(R, src))
+	if(user.unEquip(R))
 		user << "<span class='notice'>You stuff [R] into [src].</span>"
 		rag = R
+		rag.forceMove(src)
 		flags &= ~OPENCONTAINER
 		update_icon()
 

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -19,7 +19,7 @@
 	if(!usr)	return
 	if(!reagents.total_volume)
 		M.visible_message("<span class='notice'>[M] finishes eating \the [src].</span>","<span class='notice'>You finish eating \the [src].</span>")
-		usr.removeItem(src)	//so icons update :[
+		usr.drop_from_inventory(src)	//so icons update :[
 
 		if(trash)
 			if(ispath(trash,/obj/item))
@@ -36,7 +36,8 @@
 /obj/item/weapon/reagent_containers/food/snacks/attack(mob/M as mob, mob/user as mob, def_zone)
 	if(!reagents.total_volume)
 		user << "<span class='danger'>None of [src] left!</span>"
-		user.deleteItem(src)
+		user.drop_from_inventory(src)
+		qdel(src)
 		return 0
 
 	if(istype(M, /mob/living/carbon))
@@ -163,8 +164,10 @@
 				return
 
 			user << "\red You slip [W] inside [src]."
-			user.removeItem(W, src)
+			user.remove_from_mob(W)
+			W.dropped(user)
 			add_fingerprint(user)
+			contents += W
 			return
 
 		if (has_edge(W))
@@ -487,7 +490,8 @@
 		return
 	user << "You crack \the [src] into \the [O]."
 	reagents.trans_to(O, reagents.total_volume)
-	user.deleteItem(src)
+	user.drop_from_inventory(src)
+	qdel(src)
 
 /obj/item/weapon/reagent_containers/food/snacks/egg/throw_impact(atom/hit_atom)
 	..()
@@ -1622,7 +1626,7 @@
 		H.name = H.real_name
 		if(ismob(loc))
 			var/mob/M = loc
-			M.removeItem(src)
+			M.unEquip(src)
 		qdel(src)
 		return 1
 

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -226,7 +226,8 @@
 		user << "You add [D] to [src]."
 		qdel(D)
 		user.put_in_hands(new /obj/item/weapon/bucket_sensor)
-		user.deleteItem(src)
+		user.drop_from_inventory(src)
+		qdel(src)
 		return
 	else if(istype(D, /obj/item/weapon/mop))
 		if(reagents.total_volume < 1)

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -31,7 +31,7 @@
 					return
 
 			M << "<span class='notice'>You swallow \the [src].</span>"
-			M.removeItem(src) //icon update
+			M.drop_from_inventory(src) //icon update
 			if(reagents.total_volume)
 				reagents.trans_to_mob(M, reagents.total_volume, CHEM_INGEST)
 			qdel(src)
@@ -53,7 +53,7 @@
 			if(!do_mob(user, M))
 				return
 
-			user.removeItem(src) //icon update
+			user.drop_from_inventory(src) //icon update
 			user.visible_message("<span class='warning'>[user] forces [M] to swallow \the [src].</span>")
 
 			var/contained = reagentlist()

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -243,7 +243,8 @@
 			if (target != user && H.getarmor(target_zone, "melee") > 5 && prob(50))
 				for(var/mob/O in viewers(world.view, user))
 					O.show_message(text("\red <B>[user] tries to stab [target] in \the [hit_area] with [src.name], but the attack is deflected by armor!</B>"), 1)
-				user.deleteItem(src)
+				user.remove_from_mob(src)
+				qdel(src)
 
 				user.attack_log += "\[[time_stamp()]\]<font color='red'> Attacked [target.name] ([target.ckey]) with \the [src] (INTENT: HARM).</font>"
 				target.attack_log += "\[[time_stamp()]\]<font color='orange'> Attacked by [user.name] ([user.ckey]) with [src.name] (INTENT: HARM).</font>"

--- a/code/modules/spells/spellbook.dm
+++ b/code/modules/spells/spellbook.dm
@@ -421,7 +421,7 @@
 		magichead.canremove = 0		//curses!
 		magichead.flags_inv = null	//so you can still see their face
 		magichead.voicechange = 1	//NEEEEIIGHH
-		user.removeItem(user.wear_mask)
+		user.drop_from_inventory(user.wear_mask)
 		user.equip_to_slot_if_possible(magichead, slot_wear_mask, 1, 1)
 		qdel(src)
 	else

--- a/code/modules/spells/targeted/equip/equip.dm
+++ b/code/modules/spells/targeted/equip/equip.dm
@@ -19,7 +19,7 @@
 			var/obj/item/old_item = L.get_equipped_item(slot_id)
 			L.equip_to_slot(new_item, slot_id)
 			if(old_item)
-				L.removeItem(old_item)
+				L.remove_from_mob(old_item)
 				if(delete_old)
 					qdel(old_item)
 				else
@@ -33,7 +33,8 @@
 			for(var/obj/item/to_remove in summoned_items)
 				if(istype(to_remove.loc, /mob))
 					var/mob/M = to_remove.loc
-					M.deleteItem(to_remove)
+					M.remove_from_mob(to_remove)
+					qdel(to_remove)
 
 /spell/targeted/equip_item/proc/summon_item(var/newtype)
 	return new newtype

--- a/code/modules/supermatter/supermatter.dm
+++ b/code/modules/supermatter/supermatter.dm
@@ -342,7 +342,7 @@
 		"<span class=\"danger\">You touch \the [W] to \the [src] when everything suddenly goes silent.\"</span>\n<span class=\"notice\">\The [W] flashes into dust as you flinch away from \the [src].</span>",\
 		"<span class=\"warning\">Everything suddenly goes silent.</span>")
 
-	user.removeItem(W)
+	user.drop_from_inventory(W)
 	Consume(W)
 
 	user.apply_effect(150, IRRADIATE)

--- a/code/modules/surgery/limb_reattach.dm
+++ b/code/modules/surgery/limb_reattach.dm
@@ -30,7 +30,7 @@
 		var/obj/item/organ/external/E = tool
 		user.visible_message("<span class='notice'>[user] has attached [target]'s [E.name] to the [E.amputation_point].</span>>",	\
 		"<span class='notice'>You have attached [target]'s [E.name] to the [E.amputation_point].</span>")
-		user.removeItem(E)
+		user.drop_from_inventory(E)
 		E.replaced(target)
 		E.loc = target
 		target.update_body()

--- a/code/modules/surgery/organs_internal.dm
+++ b/code/modules/surgery/organs_internal.dm
@@ -278,7 +278,7 @@
 		"<span class='notice'>You have transplanted \the [tool] into [target]'s [affected.name].</span>")
 		var/obj/item/organ/O = tool
 		if(istype(O))
-			user.removeItem(O)
+			user.remove_from_mob(O)
 			O.replaced(target,affected)
 
 	fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)

--- a/code/modules/surgery/robotics.dm
+++ b/code/modules/surgery/robotics.dm
@@ -417,7 +417,8 @@
 		var/obj/item/device/mmi/M = tool
 		var/obj/item/organ/internal/mmi_holder/holder = new(target, 1)
 		target.internal_organs_by_name["brain"] = holder
-		user.removeItem(tool, holder)
+		user.drop_from_inventory(tool)
+		tool.loc = holder
 		holder.stored_mmi = tool
 		holder.update_from_mmi()
 

--- a/code/modules/vehicles/vehicle.dm
+++ b/code/modules/vehicles/vehicle.dm
@@ -237,7 +237,8 @@
 	if(!istype(C))
 		return
 
-	H.removeItem(C, src)
+	H.drop_from_inventory(C)
+	C.forceMove(src)
 	cell = C
 	powercheck()
 	usr << "<span class='notice'>You install [C] in [src].</span>"


### PR DESCRIPTION
This caused an error that would then cause machinery to hang on the server, and was reproduced successfully.

I don't like hanging machinery.

The reason why everything isn't forceMove is because this was a revert, with forceMove being implemented where conflicts existed and manually setting the loc was previously in place.
Reverts #1243, #1493.