### PR TITLE
Ninja - Fixes and Changes

### DIFF
--- a/code/_helpers/unsorted.dm
+++ b/code/_helpers/unsorted.dm
@@ -137,7 +137,7 @@ Turf and target are seperate in case you want to teleport some distance from a t
 
 			//Now to find a box from center location and make that our destination.
 			for(var/turf/T in block(locate(center.x+b1xerror,center.y+b1yerror,location.z), locate(center.x+b2xerror,center.y+b2yerror,location.z) ))
-				if(density&&T.density)	continue//If density was specified.
+				if(density&&(T.density||T.contains_dense_objects()))	continue//If density was specified.
 				if(T.x>world.maxx || T.x<1)	continue//Don't want them to teleport off the map.
 				if(T.y>world.maxy || T.y<1)	continue
 				destination_list += T
@@ -146,7 +146,7 @@ Turf and target are seperate in case you want to teleport some distance from a t
 			else	return
 
 		else//Same deal here.
-			if(density&&destination.density)	return
+			if(density&&(destination.density||destination.contains_dense_objects()))	return
 			if(destination.x>world.maxx || destination.x<1)	return
 			if(destination.y>world.maxy || destination.y<1)	return
 	else	return
@@ -1310,7 +1310,7 @@ var/mob/dview/dview_mob = new
 // call to generate a stack trace and print to runtime logs
 /proc/crash_with(msg)
 	CRASH(msg)
-	
+
 /proc/screen_loc2turf(scr_loc, turf/origin)
 	var/tX = splittext(scr_loc, ",")
 	var/tY = splittext(tX[2], ":")
@@ -1321,4 +1321,4 @@ var/mob/dview/dview_mob = new
 	tX = max(1, min(world.maxx, origin.x + (text2num(tX) - (world.view + 1))))
 	tY = max(1, min(world.maxy, origin.y + (text2num(tY) - (world.view + 1))))
 	return locate(tX, tY, tZ)
-	
+

--- a/code/modules/clothing/spacesuits/rig/modules/computer.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/computer.dm
@@ -449,8 +449,9 @@
 		drain_complete(H)
 		return
 
-	// Attempts to drain up to 40kW, determines this value from remaining cell capacity to ensure we don't drain too much..
-	var/to_drain = min(40000, ((holder.cell.maxcharge - holder.cell.charge) / CELLRATE))
+	// Attempts to drain up to 12.5*cell-capacity kW, determines this value from remaining cell capacity to ensure we don't drain too much.
+	// 1Ws/(12.5*CELLRATE) = 40s to charge
+	var/to_drain = min(12.5*holder.cell.maxcharge, ((holder.cell.maxcharge - holder.cell.charge) / CELLRATE))
 	var/target_drained = interfaced_with.drain_power(0,0,to_drain)
 	if(target_drained <= 0)
 		H << "<span class = 'danger'>Your power sink flashes a red light; there is no power left in [interfaced_with].</span>"
@@ -460,14 +461,14 @@
 	holder.cell.give(target_drained * CELLRATE)
 	total_power_drained += target_drained
 
-	return 1
+	return
 
 /obj/item/rig_module/power_sink/proc/drain_complete(var/mob/living/M)
 
 	if(!interfaced_with)
-		if(M) M << "<font color='blue'><b>Total power drained:</b> [round(total_power_drained/1000)]kJ.</font>"
+		if(M) M << "<font color='blue'><b>Total power drained:</b> [round(total_power_drained*CELLRATE)] cell units.</font>"
 	else
-		if(M) M << "<font color='blue'><b>Total power drained from [interfaced_with]:</b> [round(total_power_drained/1000)]kJ.</font>"
+		if(M) M << "<font color='blue'><b>Total power drained from [interfaced_with]:</b> [round(total_power_drained*CELLRATE)] cell units.</font>"
 		interfaced_with.drain_power(0,1,0) // Damage the victim.
 
 	drain_loc = null

--- a/code/modules/clothing/spacesuits/rig/modules/ninja.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/ninja.dm
@@ -67,7 +67,7 @@
 	name = "teleportation module"
 	desc = "A complex, sleek-looking, hardsuit-integrated teleportation module."
 	icon_state = "teleporter"
-	use_power_cost = 40
+	use_power_cost = 200
 	redundant = 1
 	usable = 1
 	selectable = 1
@@ -97,8 +97,6 @@
 
 /obj/item/rig_module/teleporter/engage(var/atom/target, var/notify_ai)
 
-	if(!..()) return 0
-
 	var/mob/living/carbon/human/H = holder.wearer
 
 	if(!istype(H.loc, /turf))
@@ -109,9 +107,13 @@
 	if(target)
 		T = get_turf(target)
 	else
-		T = get_teleport_loc(get_turf(H), H, rand(5, 9))
+		T = get_teleport_loc(get_turf(H), H, 6, 1, 1, 1)
 
-	if(!T || T.density)
+	if(!T)
+		H << "<span class='warning'>No valid teleport target found.</span>"
+		return 0
+
+	if(T.density)
 		H << "<span class='warning'>You cannot teleport into solid walls.</span>"
 		return 0
 
@@ -126,6 +128,8 @@
 	if(T.z != H.z || get_dist(T, get_turf(H)) > world.view)
 		H << "<span class='warning'>You cannot teleport to such a distant object.</span>"
 		return 0
+
+	if(!..()) return 0
 
 	phase_out(H,get_turf(H))
 	H.forceMove(T)

--- a/code/modules/clothing/spacesuits/rig/modules/vision.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/vision.dm
@@ -50,6 +50,7 @@
 	usable = 1
 	toggleable = 1
 	disruptive = 0
+	module_cooldown = 0
 
 	engage_string = "Cycle Visor Mode"
 	activate_string = "Enable Visor"

--- a/code/modules/clothing/spacesuits/rig/suits/light.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/light.dm
@@ -82,6 +82,7 @@
 
 	chest_type = /obj/item/clothing/suit/space/rig/light/ninja
 	glove_type = /obj/item/clothing/gloves/rig/light/ninja
+	cell_type =  /obj/item/weapon/cell/hyper
 
 	req_access = list(access_syndicate)
 


### PR DESCRIPTION
 - Improves Emergency Leap to make it a lot less likely to fail.
 - Ninja Rig now spawns with a hyper capacity cell. This is both to make the rig seem more high-tech and prevent players from wasting time trying to get a better cell. (effectively 3x charge now)
 - Teleport cost increased from 500 to 2000 to both accomodate for the increase of charge available and to make it be considered a little less of a way of moving around to avoid too much jackety sax.
 - Charging the suit using the d-sink will now roughly take 40 seconds (from empty to full) regardless of cell size.
 - D-sink will report consumed power in cell units.
 - Fixes failed teleport attempts drawing power.
 - Fixes the suit not being able to charge up to 100%.