### PR TITLE
Security Camera edits

### DIFF
--- a/code/__defines/machinery.dm
+++ b/code/__defines/machinery.dm
@@ -27,12 +27,12 @@ var/global/defer_powernet_rebuild = 0      // True if net rebuild will be called
 #define AI_CAMERA_LUMINOSITY 6
 
 // Camera networks
-#define NETWORK_CRESCENT "Crescent"
-#define NETWORK_CAFE_DOCK "Cafe Dock"
+#define NETWORK_CRESCENT "Spaceport"
+// #define NETWORK_CAFE_DOCK "Cafe Dock"
 #define NETWORK_CARGO "Cargo"
 #define NETWORK_CIVILIAN "Civilian"
-#define NETWORK_CIVILIAN_EAST "Civilian East"
-#define NETWORK_CIVILIAN_WEST "Civilian West"
+// #define NETWORK_CIVILIAN_EAST "Civilian East"
+// #define NETWORK_CIVILIAN_WEST "Civilian West"
 #define NETWORK_COMMAND "Command"
 #define NETWORK_ENGINE "Engine"
 #define NETWORK_ENGINEERING "Engineering"
@@ -41,7 +41,7 @@ var/global/defer_powernet_rebuild = 0      // True if net rebuild will be called
 #define NETWORK_EXODUS "Northern Star"
 #define NETWORK_MEDICAL "Medical"
 #define NETWORK_MERCENARY "MercurialNet"
-#define NETWORK_MINE "MINE"
+#define NETWORK_MINE "Mining Outpost"
 #define NETWORK_NORTHERN_STAR "Northern Star"
 #define NETWORK_RESEARCH "Research"
 #define NETWORK_RESEARCH_OUTPOST "Research Outpost"

--- a/code/game/machinery/camera/presets.dm
+++ b/code/game/machinery/camera/presets.dm
@@ -1,10 +1,10 @@
 // PRESETS
 var/global/list/station_networks = list(
-										NETWORK_CAFE_DOCK,
+//										NETWORK_CAFE_DOCK,
 										NETWORK_CARGO,
 										NETWORK_CIVILIAN,
-										NETWORK_CIVILIAN_EAST,
-										NETWORK_CIVILIAN_WEST,
+//										NETWORK_CIVILIAN_EAST,
+//										NETWORK_CIVILIAN_WEST,
 										NETWORK_COMMAND,
 										NETWORK_ENGINE,
 										NETWORK_ENGINEERING,
@@ -29,8 +29,10 @@ var/global/list/engineering_networks = list(
 /obj/machinery/camera/network/crescent
 	network = list(NETWORK_CRESCENT)
 
+/*
 /obj/machinery/camera/network/cafe_dock
 	network = list(NETWORK_CAFE_DOCK)
+*/
 
 /obj/machinery/camera/network/cargo
 	network = list(NETWORK_CARGO)
@@ -38,11 +40,13 @@ var/global/list/engineering_networks = list(
 /obj/machinery/camera/network/civilian
 	network = list(NETWORK_CIVILIAN)
 
+/*
 /obj/machinery/camera/network/civilian_east
 	network = list(NETWORK_CIVILIAN_EAST)
 
 /obj/machinery/camera/network/civilian_west
 	network = list(NETWORK_CIVILIAN_WEST)
+*/
 
 /obj/machinery/camera/network/command
 	network = list(NETWORK_COMMAND)


### PR DESCRIPTION
* Renames the 'MINE' network to 'Mining Outpost'.

* Renames the 'Crescent' network to 'Spaceport'.

* Comments out the Civilian East Network, since no cameras used it.

* Comments out the Civilian West Network, since no cameras used it.

* Comments out the 'Cafe Dock' Network, since no cameras used it.

No issues encountered during testing.