### PR TITLE
Ninja Nerfs

### DIFF
--- a/code/modules/clothing/spacesuits/rig/modules/computer.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/computer.dm
@@ -434,6 +434,8 @@
 	holder.spark_system.start()
 	playsound(H.loc, 'sound/effects/sparks2.ogg', 50, 1)
 
+	H.break_cloak()
+
 	if(!holder.cell)
 		H << "<span class = 'danger'>Your power sink flashes an error; there is no cell in your rig.</span>"
 		drain_complete(H)

--- a/code/modules/clothing/spacesuits/rig/modules/modules.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/modules.dm
@@ -198,6 +198,8 @@
 
 	active = 0
 
+	next_use = world.time + module_cooldown
+
 	spawn(1)
 		if(suit_overlay_inactive)
 			suit_overlay = suit_overlay_inactive

--- a/code/modules/clothing/spacesuits/rig/modules/ninja.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/ninja.dm
@@ -19,7 +19,7 @@
 	use_power_cost = 50
 	active_power_cost = 10
 	passive_power_cost = 0
-	module_cooldown = 30
+	module_cooldown = 50
 
 	activate_string = "Enable Cloak"
 	deactivate_string = "Disable Cloak"
@@ -29,6 +29,8 @@
 
 	suit_overlay_active =   "stealth_active"
 	suit_overlay_inactive = "stealth_inactive"
+
+	var/cloak_overuse = 0 // Tracks how long the module has been in use recently.
 
 /obj/item/rig_module/stealth_field/activate()
 
@@ -61,13 +63,26 @@
 		O.show_message("[H.name] appears from thin air!",1)
 	playsound(get_turf(H), 'sound/effects/stealthoff.ogg', 75, 1)
 
+/obj/item/rig_module/stealth_field/emp_act(severity_class) // EMP disables the cloak.
+	deactivate()
+
+// This makes the cloak cost exponentially more as they stay cloaked, which punishes cloak spam and rewards careful use of the cloak.
+// The cloak can last for just under two minutes with a 20K cell, if used nonstop.
+/obj/item/rig_module/stealth_field/process()
+	if(active)
+		cloak_overuse++
+	else
+		cloak_overuse = max(--cloak_overuse, 0)
+	active_power_cost = (2 ** (Floor(cloak_overuse / 10))) * 5 // Every ten ticks spent cloaked doubles the cost.
+	return ..()
+
 
 /obj/item/rig_module/teleporter
 
 	name = "teleportation module"
 	desc = "A complex, sleek-looking, hardsuit-integrated teleportation module."
 	icon_state = "teleporter"
-	use_power_cost = 200
+	use_power_cost = 300
 	redundant = 1
 	usable = 1
 	selectable = 1

--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -703,6 +703,10 @@
 	//possibly damage some modules
 	take_hit((100/severity_class), "electrical pulse", 1)
 
+	// Some modules may want special behaviour for being EMPed, so the pulse is passed down to them.
+	for(var/obj/item/rig_module/module in installed_modules)
+		module.emp_act(severity_class)
+
 /obj/item/weapon/rig/proc/shock(mob/user)
 	if (electrocute_mob(user, cell, src)) //electrocute_mob() handles removing charge from the cell, no need to do that here.
 		spark_system.start()

--- a/code/modules/clothing/spacesuits/rig/suits/light.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/light.dm
@@ -82,7 +82,7 @@
 
 	chest_type = /obj/item/clothing/suit/space/rig/light/ninja
 	glove_type = /obj/item/clothing/gloves/rig/light/ninja
-	cell_type =  /obj/item/weapon/cell/hyper
+	cell_type =  /obj/item/weapon/cell/super
 
 	req_access = list(access_syndicate)
 

--- a/code/modules/projectiles/projectile/energy.dm
+++ b/code/modules/projectiles/projectile/energy.dm
@@ -65,14 +65,14 @@
 	damage_type = CLONE
 	irradiate = 40
 
-
+// Ninja dart
 /obj/item/projectile/energy/dart
 	name = "dart"
 	icon_state = "toxin"
 	damage = 5
 	damage_type = TOX
-	weaken = 5
-
+	agony = 120
+	check_armour = "energy"
 
 /obj/item/projectile/energy/bolt
 	name = "bolt"


### PR DESCRIPTION
It is now impossible to remain cloaked while recharging.
Ninja RIG now has a super cell (20k) instead of a hyper cell (30k).
Cloaking now has a five second cooldown.
Being hit with an EMP will disable the cloak and put it on cooldown.
Energy cost for staying cloaked now ramps up slowly over time as the ninja remains cloaked, at an exponential rate, and ramps down when visible.  The goal is to promote short, tactical uses of invisibility instead of being able to be invisible for 80% of the round and be untouchable.  The cloak can last about two minutes if constantly cloaked.
Ninja darts now do a massive amount of agony damage instead of a instant stun, and checks for energy armor.
Ninja teleport cost increased to 3k, from 2k.