### PR TITLE
Prevent Unexpected SQL Errors

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -21,7 +21,7 @@ var/list/gamemode_cache = list()
 	var/log_pda = 0						// log pda messages
 	var/log_hrefs = 0					// logs all links clicked in-game. Could be used for debugging and tracking down exploits
 	var/log_runtime = 0					// logs world.log to a file
-	var/sql_enabled = 1					// for sql switching
+	var/sql_enabled = 0					// for sql switching
 	var/allow_admin_ooccolor = 0		// Allows admins with relevant permissions to have their own ooc colour
 	var/allow_vote_restart = 0 			// allow votes to restart
 	var/ert_admin_call_only = 0
@@ -289,7 +289,7 @@ var/list/gamemode_cache = list()
 					config.log_access = 1
 
 				if ("sql_enabled")
-					config.sql_enabled = text2num(value)
+					config.sql_enabled = 1
 
 				if ("log_say")
 					config.log_say = 1

--- a/code/world.dm
+++ b/code/world.dm
@@ -558,8 +558,9 @@ var/failed_db_connections = 0
 var/failed_old_db_connections = 0
 
 /hook/startup/proc/connectDB()
-	if(!config.sql_enabled) return 1
-	if(!setup_database_connection())
+	if(!config.sql_enabled)
+		world.log << "SQL connection disabled in config."
+	else if(!setup_database_connection())
 		world.log << "Your server failed to establish a connection with the feedback database."
 	else
 		world.log << "Feedback database connection established."
@@ -601,7 +602,8 @@ proc/establish_db_connection()
 
 
 /hook/startup/proc/connectOldDB()
-	if(!config.sql_enabled) return 1
+	if(!config.sql_enabled)
+		world.log << "SQL connection disabled in config."
 	if(!setup_old_database_connection())
 		world.log << "Your server failed to establish a connection with the SQL database."
 	else

--- a/code/world.dm
+++ b/code/world.dm
@@ -604,7 +604,7 @@ proc/establish_db_connection()
 /hook/startup/proc/connectOldDB()
 	if(!config.sql_enabled)
 		world.log << "SQL connection disabled in config."
-	if(!setup_old_database_connection())
+	else if(!setup_old_database_connection())
 		world.log << "Your server failed to establish a connection with the SQL database."
 	else
 		world.log << "SQL database connection established."

--- a/code/world.dm
+++ b/code/world.dm
@@ -558,6 +558,7 @@ var/failed_db_connections = 0
 var/failed_old_db_connections = 0
 
 /hook/startup/proc/connectDB()
+	if(!config.sql_enabled) return 1
 	if(!setup_database_connection())
 		world.log << "Your server failed to establish a connection with the feedback database."
 	else
@@ -600,6 +601,7 @@ proc/establish_db_connection()
 
 
 /hook/startup/proc/connectOldDB()
+	if(!config.sql_enabled) return 1
 	if(!setup_old_database_connection())
 		world.log << "Your server failed to establish a connection with the SQL database."
 	else

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -68,7 +68,7 @@ LOG_PDA
 ##LOG_ADMINWARN  ## Also duplicates a bunch of other messages.
 
 ## sql switching
-# SQL_ENABLED
+SQL_ENABLED 1
 
 ## disconnect players who did nothing during the set amount of minutes
 # KICK_INACTIVE 10

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -67,8 +67,8 @@ LOG_PDA
 ## log admin warning messages
 ##LOG_ADMINWARN  ## Also duplicates a bunch of other messages.
 
-## sql switching
-SQL_ENABLED 1
+## Enable/disable SQL connection (comment out to disable)
+SQL_ENABLED
 
 ## disconnect players who did nothing during the set amount of minutes
 # KICK_INACTIVE 10


### PR DESCRIPTION
Even when you have SQL disabled, it prints errors to the console about not being able to connect.

99% of people starting a Polaris server are devs who won't have SQL set up.

Also updates the example config to be less misleading, as the SQL option is 1 or 0, not comment/uncomment. The old default was 'enabled' due to the configuration.dm having a default of 1, so that is still the same. Devs will need to set it to 0 to squelch the message.

If you want, change it to 0 in the example config file, but I didn't want to mess with your defaults.

Another from downstream.