### PR TITLE
Catches a missing removal of the circuit board.

### DIFF
--- a/code/game/machinery/kitchen/microwave.dm
+++ b/code/game/machinery/kitchen/microwave.dm
@@ -327,7 +327,7 @@
 	src.updateUsrDialog()
 
 /obj/machinery/microwave/proc/dispose()
-	for (var/obj/O in (contents-component_parts))
+	for (var/obj/O in ((contents-component_parts)-circuit))
 		O.loc = src.loc
 	if (src.reagents.total_volume)
 		src.dirty++


### PR DESCRIPTION
When you eject the microwave components, circuit board pops out.

Forgot this check when I was testing everything else. Whoops.