### PR TITLE
Fix - Prevents making oversize stacks in autolathe.

### DIFF
--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -102,6 +102,7 @@
 				//Build list of multipliers for sheets.
 				if(R.is_stack)
 					if(max_sheets && max_sheets > 0)
+						max_sheets = min(max_sheets, R.max_stack) // Limit to the max allowed by stack type.
 						multiplier_string  += "<br>"
 						for(var/i = 5;i<max_sheets;i*=2) //5,10,20,40...
 							multiplier_string  += "<a href='?src=\ref[src];make=[index];multiplier=[i]'>\[x[i]\]</a>"

--- a/code/game/machinery/autolathe_datums.dm
+++ b/code/game/machinery/autolathe_datums.dm
@@ -16,7 +16,10 @@
 			recipe.resources = list()
 			for(var/material in I.matter)
 				recipe.resources[material] = I.matter[material]*1.25 // More expensive to produce than they are to recycle.
-			qdel(I)
+		if(recipe.is_stack && istype(I, /obj/item/stack))
+			var/obj/item/stack/IS = I
+			recipe.max_stack = IS.max_amount
+		qdel(I)
 
 /datum/autolathe/recipe
 	var/name = "object"
@@ -26,6 +29,7 @@
 	var/category
 	var/power_use = 0
 	var/is_stack
+	var/max_stack
 
 /datum/autolathe/recipe/bucket
 	name = "bucket"


### PR DESCRIPTION
- Previously when making stack'd items in autolathe, it lets you make as big a stack as you have materials loaded, even if it is larger than the maximum stack size for that material.
- Now autolathe recipies remember this, and autolathe respects maximum stack size.
- Note: This issue is not usually noticeable because the starting max metal capacity of autolathe is too small to produce huge stacks.  But an upgraded (matter bins) autolathe has enough to produce stacks of 100+