### PR TITLE
Makes Teshari admin-spawnable like all other species

### DIFF
--- a/code/modules/mob/living/carbon/human/human_species.dm
+++ b/code/modules/mob/living/carbon/human/human_species.dm
@@ -17,6 +17,10 @@
 /mob/living/carbon/human/diona/New(var/new_loc)
 	..(new_loc, "Diona")
 
+/mob/living/carbon/human/teshari/New(var/new_loc)
+	h_style = "Teshari Default"
+	..(new_loc, "Teshari")
+
 /mob/living/carbon/human/machine/New(var/new_loc)
 	h_style = "blue IPC screen"
 	..(new_loc, "Machine")


### PR DESCRIPTION
Just adds them to the same list as all other species, so they can be spawned by admins for events or to replace bodies for players or whatever. Simple change.