### PR TITLE
Fix the letter ÿ in nano-ui displays

### DIFF
--- a/code/_helpers/text.dm
+++ b/code/_helpers/text.dm
@@ -324,4 +324,11 @@ proc/TextPreview(var/string,var/len=40)
 				return 1
 	return 0
 
+/**
+ * Strip out the special beyond characters for \proper and \improper
+ * from text that will be sent to the browser.
+ */
+/proc/strip_improper(var/text)
+	return replacetext(replacetext(text, "\proper", ""), "\improper", "")
+
 #define gender2text(gender) capitalize(gender)

--- a/code/modules/nano/nanoui.dm
+++ b/code/modules/nano/nanoui.dm
@@ -345,10 +345,11 @@ nanoui is used to open and update nano browser uis
 
 	var/template_data_json = "{}" // An empty JSON object
 	if (templates.len > 0)
-		template_data_json = json_encode(templates)
+		template_data_json = strip_improper(json_encode(templates))
 
 	var/list/send_data = get_send_data(initial_data)
 	var/initial_data_json = replacetext(replacetext(json_encode(send_data), "&#34;", "&amp;#34;"), "'", "&#39;")
+	initial_data_json = strip_improper(initial_data_json);
 
 	var/url_parameters_json = json_encode(list("src" = "\ref[src]"))
 
@@ -459,7 +460,7 @@ nanoui is used to open and update nano browser uis
 	var/list/send_data = get_send_data(data)
 
 	//user << list2json(data) // used for debugging
-	user << output(list2params(list(json_encode(send_data))),"[window_id].browser:receiveUpdateData")
+	user << output(list2params(list(strip_improper(json_encode(send_data)))),"[window_id].browser:receiveUpdateData")
 
  /**
   * This Topic() proc is called whenever a user clicks on a link within a Nano UI


### PR DESCRIPTION
* Particularly noticable on the cartridge button of the PDA, any time we transmit a name containing \improper or \proper using nanoui it shows up as ÿ
* This is becuase BYOND internally handles these escapes by simply using character 0xFF etc.
* We'd better strip them out before sending them as JSON data so they aren't rendered as ÿ when treated as utf-8 encoding.