### PR TITLE
Revert to old_x and old_y after attack animations

### DIFF
--- a/code/modules/mob/animations.dm
+++ b/code/modules/mob/animations.dm
@@ -140,11 +140,11 @@ note dizziness decrements automatically in the mob's Life() proc.
 	//reset the pixel offsets to zero
 	is_floating = 0
 
-/atom/movable/proc/do_attack_animation(atom/A)
+/mob/proc/do_attack_animation(mob/M)
 
 	var/pixel_x_diff = 0
 	var/pixel_y_diff = 0
-	var/direction = get_dir(src, A)
+	var/direction = get_dir(src, M)
 	switch(direction)
 		if(NORTH)
 			pixel_y_diff = 8
@@ -167,7 +167,7 @@ note dizziness decrements automatically in the mob's Life() proc.
 			pixel_x_diff = -8
 			pixel_y_diff = -8
 	animate(src, pixel_x = pixel_x + pixel_x_diff, pixel_y = pixel_y + pixel_y_diff, time = 2)
-	animate(pixel_x = initial(pixel_x), pixel_y = initial(pixel_y), time = 2)
+	animate(pixel_x = old_x, pixel_y = old_y, time = 2)
 
 /mob/do_attack_animation(atom/A)
 	..()


### PR DESCRIPTION
Does not use initial(pixel_x) and initial(pixel_y) for 'finishing' attack animations, so that mobs can have old_x and old_y updated to reflect a natural pixel offset (e.g. for mobs that are longer/taller than 32x32 and are nudged to fit into a tile).

For example, we have a 32x64 cyborg module which sets pixel_x, pixel_y, old_x, and old_y when selected, however attacking with it resets it to 0 as this doesn't respect old_x and old_y like all other mob anims do (see floating, etc).

Also why define this on atom and then literally never use it on anything other than a mob, in the... mob/animations.dm file?

_Sorry to keep making QOL PRs. I promise I'll send something cool eventually._
_Edit: Actually your Teshari benefit from my code to sprite holders months ago so I did, kinda._