### PR TITLE
Makes robotic limbs actually repairable

### DIFF
--- a/code/game/objects/items/weapons/tools.dm
+++ b/code/game/objects/items/weapons/tools.dm
@@ -441,6 +441,7 @@
 				return ..()
 		else
 			user << "<span class='notice'>Nothing to fix!</span>"
+			S.update_wounds()
 		return
 	return ..()
 

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -285,9 +285,9 @@
 			else if(temp.wounds.len > 0 || temp.open)
 				if(temp.is_stump() && temp.parent_organ && organs_by_name[temp.parent_organ])
 					var/obj/item/organ/external/parent = organs_by_name[temp.parent_organ]
-					wound_flavor_text["[temp.name]"] = "<span class='warning'>[T.He] has [temp.get_wounds_desc()] on [T.His] [parent.name].</span><br>"
+					wound_flavor_text["[temp.name]"] = "<span class='warning'>[T.He] has [temp.get_wounds_desc()] on [T.his] [parent.name].</span><br>"
 				else
-					wound_flavor_text["[temp.name]"] = "<span class='warning'>[T.He] has [temp.get_wounds_desc()] on [T.His] [temp.name].</span><br>"
+					wound_flavor_text["[temp.name]"] = "<span class='warning'>[T.He] has [temp.get_wounds_desc()] on [T.his] [temp.name].</span><br>"
 				if(temp.status & ORGAN_BLEEDING)
 					is_bleeding["[temp.name]"] = "<span class='danger'>[T.His] [temp.name] is bleeding!</span><br>"
 			else

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -349,6 +349,7 @@
 
 	//Sync the organ's damage with its wounds
 	src.update_damages()
+	src.update_wounds()
 	owner.updatehealth()
 
 	var/result = update_icon()
@@ -602,6 +603,9 @@ Note that amputating the affected organ does in fact remove the infection from t
 /obj/item/organ/external/proc/update_wounds()
 
 	if((status & ORGAN_ROBOT)) //Robotic limbs don't heal or get worse.
+		for(var/datum/wound/W in wounds)
+			if(W.damage <= 0)
+				wounds -= W
 		return
 
 	for(var/datum/wound/W in wounds)
@@ -1129,17 +1133,23 @@ Note that amputating the affected organ does in fact remove the infection from t
 		if(brute_dam)
 			switch(brute_dam)
 				if(0 to 20)
-					. += " some dents"
+					. += "some dents"
 				if(21 to INFINITY)
-					. += pick(" a lot of dents"," severe denting")
+					. += pick("a lot of dents","severe denting")
 		if(brute_dam && burn_dam)
-			. += " and"
+			. += " and "
 		if(burn_dam)
 			switch(burn_dam)
 				if(0 to 20)
-					. += " some burns"
+					. += "some burns"
 				if(21 to INFINITY)
-					. += pick(" a lot of burns"," severe melting")
+					. += pick("a lot of burns","severe melting")
+		if(open)
+			if(brute_dam || burn_dam)
+				. += " and an open panel"
+			else
+				. += "an open panel"
+
 		return
 
 	var/list/wound_descriptors = list()


### PR DESCRIPTION
Complete repair of robotic limbs was unfortunately impossible, resulting in things like the screenshot below, so I corrected this. A more technical explanation is in the commit message for that.

![Problematic](http://i.imgur.com/YRXfLuCm.png)

Also corrected some grammar problems with examine in regards to damage on limbs, and the always uppercase gender pronoun in wound messages. Also added a message for when a robolimb has a maintenance panel open.