### PR TITLE
Revert "Disables alternative title validation to allow for admins to give people/themselves retainable non-standard titles"

### DIFF
--- a/code/modules/client/preference_setup/occupation/occupation.dm
+++ b/code/modules/client/preference_setup/occupation/occupation.dm
@@ -49,10 +49,10 @@
 	if(!job_master)
 		return
 
-	/*for(var/datum/job/job in job_master.occupations)
+	for(var/datum/job/job in job_master.occupations)
 		var/alt_title = pref.player_alt_titles[job.title]
 		if(alt_title && !(alt_title in job.alt_titles))
-			pref.player_alt_titles -= job.title*/
+			pref.player_alt_titles -= job.title
 
 /datum/category_item/player_setup_item/occupation/content(mob/user, limit = 16, list/splitJobs = list("Chief Medical Officer"))
 	if(!job_master)


### PR DESCRIPTION
Reverts PolarisSS13/Polaris#1678

For jobs that have alternate titles that provide additional clothes, or equipment, e.g. Medical Doctor vs Surgeon (one getting a jumpsuit, the other scrubs), the equipment is not given, and does not default, instead leaving the person naked and without an ID.