### PR TITLE
Fixes beating people up during surgery

### DIFF
--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -110,6 +110,7 @@ proc/do_surgery(mob/living/carbon/M, mob/living/user, obj/item/tool)
 
 	if (user.a_intent == I_HELP)
 		user << "<span class='warning'>You can't see any useful way to use [tool] on [M].</span>"
+		return 1
 	return 0
 
 proc/sort_surgeries()


### PR DESCRIPTION
Fixes #1684 

My description in the issue was wrong, it's missing the return 1 that was causing issues. This will however make it so you can't use items on someone who on the table while on help intent, such as health analysers or such. Such is life.