### PR TITLE
Fixes runtimes with suits

### DIFF
--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -267,8 +267,6 @@ This saves us from having to call add_fingerprint() any time something is put in
 			update_inv_shoes(redraw_mob)
 		if(slot_wear_suit)
 			src.wear_suit = W
-			if((wear_suit.flags_inv & HIDESHOES) || (w_uniform.flags_inv & HIDESHOES))
-				update_inv_shoes(0)
 			W.equipped(src, slot)
 			update_inv_wear_suit(redraw_mob)
 		if(slot_w_uniform)

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -499,6 +499,9 @@ var/global/list/damage_icon_parts = list()
 	else
 		overlays_standing[UNIFORM_LAYER]	= null
 
+	//hiding/revealing shoes if necessary
+	update_inv_shoes(0)
+
 	if(update_icons)
 		update_icons()
 
@@ -774,9 +777,11 @@ var/global/list/damage_icon_parts = list()
 	else
 		overlays_standing[SUIT_LAYER]	= null
 		update_tail_showing(0)
-		update_inv_shoes(0)
 
 	update_collar(0)
+
+	//hide/show shoes if necessary
+	update_inv_shoes(0)
 
 	if(update_icons)   update_icons()
 


### PR DESCRIPTION
Naked and trying to wear a suit, it will attempt to access w_uniform.inv_flags which will be null and runtime. Things like putting on a rig and trying to deploy them would do this.

Moves shoe redrawing to uniform and suit update_inv code in update_icons, rather than in inventory.dm. update_icons already had code for this as the top line in update_inv_shoes checked if it should be hidden.