### PR TITLE
Cable coil adjustments and changes

### DIFF
--- a/code/__defines/misc.dm
+++ b/code/__defines/misc.dm
@@ -38,24 +38,37 @@
 #define 	  LIFE_HUD 10 // STATUS_HUD that only reports dead or alive
 
 //some colors
-#define COLOR_WHITE   "#FFFFFF"
-#define COLOR_SILVER  "#C0C0C0"
-#define COLOR_GRAY    "#808080"
-#define COLOR_BLACK   "#000000"
-#define COLOR_RED     "#FF0000"
-#define COLOR_MAROON  "#800000"
-#define COLOR_YELLOW  "#FFFF00"
-#define COLOR_OLIVE   "#808000"
-#define COLOR_LIME    "#00FF00"
-#define COLOR_GREEN   "#008000"
-#define COLOR_CYAN    "#00FFFF"
-#define COLOR_TEAL    "#008080"
-#define COLOR_BLUE    "#0000FF"
-#define COLOR_NAVY    "#000080"
-#define COLOR_PINK    "#FF00FF"
-#define COLOR_PURPLE  "#800080"
-#define COLOR_ORANGE  "#FF9900"
-#define COLOR_LUMINOL "#66FFFF"
+#define COLOR_WHITE   			"#FFFFFF"
+#define COLOR_SILVER  			"#C0C0C0"
+#define COLOR_GRAY    			"#808080"
+#define COLOR_BLACK   			"#000000"
+#define COLOR_RED     			"#FF0000"
+#define COLOR_MAROON 			"#800000"
+#define COLOR_YELLOW  			"#FFFF00"
+#define COLOR_OLIVE  			"#808000"
+#define COLOR_LIME   			"#00FF00"
+#define COLOR_GREEN   			"#008000"
+#define COLOR_CYAN    			"#00FFFF"
+#define COLOR_TEAL    			"#008080"
+#define COLOR_BLUE    			"#0000FF"
+#define COLOR_NAVY    			"#000080"
+#define COLOR_PINK    			"#FF00FF"
+#define COLOR_PURPLE  			"#800080"
+#define COLOR_ORANGE  			"#FF9900"
+#define COLOR_LUMINOL 			"#66FFFF"
+#define COLOR_BEIGE 			"#CEB689"
+#define COLOR_BLUE_GRAY 		"#6A97B0"
+#define COLOR_BROWN 			"#B19664"
+#define COLOR_DARK_BROWN 		"#917448"
+#define COLOR_DARK_ORANGE 		"#B95A00"
+#define COLOR_GREEN_GRAY 		"#8DAF6A"
+#define COLOR_RED_GRAY 			"#AA5F61"
+#define COLOR_PALE_BLUE_GRAY	"#8BBBD5"
+#define COLOR_PALE_GREEN_GRAY 	"#AED18B"
+#define COLOR_PALE_RED_GRAY		"#CC9090"
+#define COLOR_PALE_PURPLE_GRAY	"#BDA2BA"
+#define COLOR_PURPLE_GRAY 		"#A2819E"
+
 //	Shuttles.
 
 // These define the time taken for the shuttle to get to the space station, and the time before it leaves again.
@@ -143,19 +156,6 @@
 #define PROJECTILE_CONTINUE   -1 //if the projectile should continue flying after calling bullet_act()
 #define PROJECTILE_FORCE_MISS -2 //if the projectile should treat the attack as a miss (suppresses attack and admin logs) - only applies to mobs.
 
-// Custom colors
-#define COLOR_BEIGE "#CEB689"
-#define COLOR_BLUE_GRAY "#6A97B0"
-#define COLOR_BROWN "#B19664"
-#define COLOR_DARK_BROWN "#917448"
-#define COLOR_DARK_ORANGE "#B95A00"
-#define COLOR_GREEN_GRAY "#8DAF6A"
-#define COLOR_RED_GRAY "#AA5F61"
-#define COLOR_PALE_BLUE_GRAY "#8BBBD5"
-#define COLOR_PALE_GREEN_GRAY "#AED18B"
-#define COLOR_PALE_RED_GRAY "#CC9090"
-#define COLOR_PALE_PURPLE_GRAY "#BDA2BA"
-#define COLOR_PURPLE_GRAY "#A2819E"
 
 // Vending stuff
 #define CAT_NORMAL 1

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -21,6 +21,27 @@ If d1 = 0 and d2 = dir, it's a O-X cable, getting from the center of the tile to
 If d1 = dir1 and d2 = dir2, it's a full X-X cable, getting from dir1 to dir2
 By design, d1 is the smallest direction and d2 is the highest
 */
+var/list/possible_cable_coil_colours = list(
+		"White" = COLOR_WHITE,
+		"Silver" = COLOR_SILVER,
+		"Gray" = COLOR_GRAY,
+		"Black" = COLOR_BLACK,
+		"Red" = COLOR_RED,
+		"Maroon" = COLOR_MAROON,
+		"Yellow" = COLOR_YELLOW,
+		"Olive" = COLOR_OLIVE,
+		"Lime" = COLOR_GREEN,
+		"Green" = COLOR_LIME,
+		"Cyan" = COLOR_CYAN,
+		"Teal" = COLOR_TEAL,
+		"Blue" = COLOR_BLUE,
+		"Navy" = COLOR_NAVY,
+		"Pink" = COLOR_PINK,
+		"Purple" = COLOR_PURPLE,
+		"Orange" = COLOR_ORANGE,
+		"Beige" = COLOR_BEIGE,
+		"Brown" = COLOR_BROWN
+	)
 
 /obj/structure/cable
 	level = 1
@@ -464,6 +485,7 @@ obj/structure/cable/proc/cableColor(var/colorC)
 	slot_flags = SLOT_BELT
 	item_state = "coil"
 	attack_verb = list("whipped", "lashed", "disciplined", "flogged")
+	stacktype = /obj/item/stack/cable_coil
 
 /obj/item/stack/cable_coil/cyborg
 	name = "cable coil synthesizer"
@@ -472,7 +494,6 @@ obj/structure/cable/proc/cableColor(var/colorC)
 	matter = null
 	uses_charge = 1
 	charge_costs = list(1)
-	stacktype = /obj/item/stack/cable_coil
 
 /obj/item/stack/cable_coil/suicide_act(mob/user)
 	if(locate(/obj/item/weapon/stool) in user.loc)
@@ -531,6 +552,17 @@ obj/structure/cable/proc/cableColor(var/colorC)
 		icon_state = "coil"
 		name = "cable coil"
 
+/obj/item/stack/cable_coil/proc/set_cable_color(var/selected_color, var/user)
+	if(!selected_color)
+		return
+
+	var/final_color = possible_cable_coil_colours[selected_color]
+	if(!final_color)
+		final_color = possible_cable_coil_colours["Red"]
+		selected_color = "red"
+	color = final_color
+	user << "<span class='notice'>You change \the [src]'s color to [lowertext(selected_color)].</span>"
+
 /obj/item/stack/cable_coil/proc/update_wclass()
 	if(amount == 1)
 		w_class = 1.0
@@ -571,42 +603,17 @@ obj/structure/cable/proc/cableColor(var/colorC)
 	set name = "Change Colour"
 	set category = "Object"
 
-	var/list/possible_colours = list ("Yellow", "Green", "Pink", "Blue", "Orange", "Cyan", "Red")
-	var/selected_type = input("Pick new colour.", "Cable Colour", null, null) as null|anything in possible_colours
-
-	if(selected_type)
-		switch(selected_type)
-			if("Yellow")
-				color = COLOR_YELLOW
-			if("Green")
-				color = COLOR_LIME
-			if("Pink")
-				color = COLOR_PINK
-			if("Blue")
-				color = COLOR_BLUE
-			if("Orange")
-				color = COLOR_ORANGE
-			if("Cyan")
-				color = COLOR_CYAN
-			else
-				color = COLOR_RED
-		usr << "You change your cable coil's colour to [selected_type]"
+	var/selected_type = input("Pick new colour.", "Cable Colour", null, null) as null|anything in possible_cable_coil_colours
+	set_cable_color(selected_type, usr)
 
 // Items usable on a cable coil :
 //   - Wirecutters : cut them duh !
 //   - Cable coil : merge cables
-/obj/item/stack/cable_coil/proc/can_merge(var/obj/item/stack/cable_coil/C)
-	return color == C.color
-
-/obj/item/stack/cable_coil/cyborg/can_merge()
-	return 1
 
 /obj/item/stack/cable_coil/transfer_to(obj/item/stack/cable_coil/S)
 	if(!istype(S))
+		world << 1
 		return
-	if(!can_merge(S))
-		return
-
 	..()
 
 /obj/item/stack/cable_coil/use()
@@ -880,7 +887,51 @@ obj/structure/cable/proc/cableColor(var/colorC)
 	stacktype = /obj/item/stack/cable_coil
 	color = COLOR_WHITE
 
+/obj/item/stack/cable_coil/silver
+	stacktype = /obj/item/stack/cable_coil
+	color = COLOR_SILVER
+
+/obj/item/stack/cable_coil/gray
+	stacktype = /obj/item/stack/cable_coil
+	color = COLOR_GRAY
+
+/obj/item/stack/cable_coil/black
+	stacktype = /obj/item/stack/cable_coil
+	color = COLOR_BLACK
+
+/obj/item/stack/cable_coil/maroon
+	stacktype = /obj/item/stack/cable_coil
+	color = COLOR_MAROON
+
+/obj/item/stack/cable_coil/olive
+	stacktype = /obj/item/stack/cable_coil
+	color = COLOR_OLIVE
+
+/obj/item/stack/cable_coil/lime
+	stacktype = /obj/item/stack/cable_coil
+	color = COLOR_LIME
+
+/obj/item/stack/cable_coil/teal
+	stacktype = /obj/item/stack/cable_coil
+	color = COLOR_TEAL
+
+/obj/item/stack/cable_coil/navy
+	stacktype = /obj/item/stack/cable_coil
+	color = COLOR_NAVY
+
+/obj/item/stack/cable_coil/purple
+	stacktype = /obj/item/stack/cable_coil
+	color = COLOR_PURPLE
+
+/obj/item/stack/cable_coil/beige
+	stacktype = /obj/item/stack/cable_coil
+	color = COLOR_BEIGE
+
+/obj/item/stack/cable_coil/brown
+	stacktype = /obj/item/stack/cable_coil
+	color = COLOR_BROWN
+
 /obj/item/stack/cable_coil/random/New()
 	stacktype = /obj/item/stack/cable_coil
-	color = pick(COLOR_RED, COLOR_BLUE, COLOR_LIME, COLOR_WHITE, COLOR_PINK, COLOR_YELLOW, COLOR_CYAN)
+	color = pick(COLOR_RED, COLOR_BLUE, COLOR_LIME, COLOR_WHITE, COLOR_PINK, COLOR_YELLOW, COLOR_CYAN, COLOR_SILVER, COLOR_GRAY, COLOR_BLACK, COLOR_MAROON, COLOR_OLIVE, COLOR_LIME, COLOR_TEAL, COLOR_NAVY, COLOR_PURPLE, COLOR_BEIGE, COLOR_BROWN)
 	..()

--- a/html/changelogs/Yoshax - cablecoil.yml
+++ b/html/changelogs/Yoshax - cablecoil.yml
@@ -1,0 +1,37 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Yoshax
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Cables of any color can now be merged."
+  - tweak: "More and different colors are now available to be used by cable."


### PR DESCRIPTION
- Adjusts and adds more colors of cables
- Removes limitation of being unable to join different colors of cable
- Allows merging of different kinds of cable
- Adjusts the color changing proc to be nicer as per Baystation12/Baystation#11645
  - Does not add the fancy color changing via multitool due to lack of prerequisite

