### PR TITLE
[DNM] Communicator tweak

### DIFF
--- a/code/game/objects/items/devices/communicator/communicator.dm
+++ b/code/game/objects/items/devices/communicator/communicator.dm
@@ -709,7 +709,7 @@ var/global/list/obj/item/device/communicator/all_communicators = list()
 /obj/item/device/communicator/hear_talk(mob/living/M, text, verb, datum/language/speaking)
 	for(var/obj/item/device/communicator/comm in communicating)
 		var/list/mobs_to_relay = list()
-		mobs_to_relay |= viewers(get_turf(comm))
+		mobs_to_relay |= hearers(get_turf(comm))
 		mobs_to_relay |= comm.contents //Needed so ghost-callers can see speech.
 		for(var/mob/mob in mobs_to_relay)
 			//Can whoever is hearing us understand?

--- a/code/game/objects/items/devices/communicator/communicator.dm
+++ b/code/game/objects/items/devices/communicator/communicator.dm
@@ -696,7 +696,7 @@ var/global/list/obj/item/device/communicator/all_communicators = list()
 /obj/item/device/communicator/see_emote(mob/living/M, text)
 	var/rendered = "\icon[src] <span class='message'>[text]</span>"
 	for(var/obj/item/device/communicator/comm in communicating)
-		for(var/mob/mob in viewers(get_turf(comm))) //We can't use visible_message(), or else we will get an infinite loop if two communicators hear each other.
+		for(var/mob/mob in hearers(get_turf(comm))) //We can't use visible_message(), or else we will get an infinite loop if two communicators hear each other.
 			mob.show_message(rendered)
 		for(var/mob/living/voice/V in comm.contents)
 			V.show_message(rendered)


### PR DESCRIPTION
Communicators ain't be wavin' 'n shit. Use 'hearers' instead of 'viewers'.

Makes it so communicators can be heard while inside other ~~people~~ objects. So if you're hiding inside a ~~tajaran~~ locker you can hear the communicator in the same room as you.

:wink: **COUGH** :sweat_smile: 