### PR TITLE
Fixes #1660 - Photos no longer show everyone naked.

### DIFF
--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -580,8 +580,9 @@ var/global/list/damage_icon_parts = list()
 		return
 
 	if(l_ear || r_ear)
-		var/image/both = image("icon" = null)
-		
+		// Blank image upon which to layer left & right overlays.
+		var/image/both = image("icon" = 'icons/effects/effects.dmi', "icon_state" = "nothing")
+
 		if(l_ear)
 			var/image/standing
 			var/t_type = l_ear.icon_state


### PR DESCRIPTION
* update_inv_ears() overlays left and right ears upon a "blank" icon.  Unfortunately doing ```image("icon" = null)``` encourages BYOND to create an image of the current mob!   So everyone's "ears" icon is actually their whole body, layerd on top of uniforms, hair, etc.
* Lets not do that.  A transparant image is already in effects.dmi for this purpose.