### PR TITLE
Gives Skrell their warblenames back.

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station.dm
@@ -150,7 +150,7 @@
 	the secrets of their empire to their allies."
 	num_alternate_languages = 2
 	secondary_langs = list("Skrellian", "Schechi")
-	name_language = null
+	name_language = "Skrellian"
 
 	min_age = 19
 	max_age = 80


### PR DESCRIPTION
Current Skrell lore dictates that while these are the Skrell's true names, they take up names that are human or make their own names pronounceable to humans. Having the ability to randomly generate the Skrell name is ideal if you want to have a humanized Skrell name, whereas randomly generating a human name can be done off of a human slot.