### PR TITLE
Soap no longer qdels blood

### DIFF
--- a/code/game/objects/items/weapons/clown_items.dm
+++ b/code/game/objects/items/weapons/clown_items.dm
@@ -34,6 +34,10 @@
 	//So this is a workaround. This also makes more sense from an IC standpoint. ~Carn
 	if(user.client && (target in user.client.screen))
 		user << "<span class='notice'>You need to take that [target.name] off before cleaning it.</span>"
+	else if(istype(target,/obj/effect/decal/cleanable/blood))
+		user << "<span class='notice'>You scrub \the [target.name] out.</span>"
+		target.clean_blood()
+		return	//Blood is a cleanable decal, therefore needs to be accounted for before all cleanable decals.
 	else if(istype(target,/obj/effect/decal/cleanable))
 		user << "<span class='notice'>You scrub \the [target.name] out.</span>"
 		qdel(target)


### PR DESCRIPTION
Catches the qdel beforehand, as blood is a cleanable decal and was being qdel'd by the block right below it.