### PR TITLE
Fixes NEARSIGHTED = BLIND

### DIFF
--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -145,7 +145,7 @@
 
 /mob/living/proc/handle_disabilities()
 	//Eyes
-	if(disabilities & BLIND || stat)	//blindness from disability or unconsciousness doesn't get better on its own
+	if(sdisabilities & BLIND || stat)	//blindness from disability or unconsciousness doesn't get better on its own
 		eye_blind = max(eye_blind, 1)
 	else if(eye_blind)			//blindness, heals slowly over time
 		eye_blind = max(eye_blind-1,0)


### PR DESCRIPTION
An ancient typo, apparently from 9d38bcc so you don't get to blame me for this one. Just unearthed it.

`BLIND` and `NEARSIGHTED` are both `0x1` but supposed to be in different vars. `BLIND` is in `sdisabilities` but was checking `disabilities` and therefore blinding everyone with nearsightedness. It was hidden by the workaround code to make/prevent blindness that I corrected.