### PR TITLE
Followup to blindness fix

### DIFF
--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -153,7 +153,7 @@
 		eye_blurry = max(eye_blurry-1, 0)
 
 	//Ears
-	if(disabilities & DEAF)		//disabled-deaf, doesn't get better on its own
+	if(sdisabilities & DEAF)		//disabled-deaf, doesn't get better on its own
 		setEarDamage(-1, max(ear_deaf, 1))
 	else
 		// deafness heals slowly over time, unless ear_damage is over 100


### PR DESCRIPTION
Fixes deafness as well. In this case, if you had `COUGHING`... you'd go `DEAF`. They were both `0x2`.

This actually cherrypicks the Bay commit that fixes blind and deaf so this will perserve merge-ability with your upstream. If you call Bay your upstream, anyway.