### PR TITLE
Fixes Exosuit Fabricator Deconstruction and makes Jukeboxes constructable

### DIFF
--- a/code/game/machinery/frame.dm
+++ b/code/game/machinery/frame.dm
@@ -218,7 +218,10 @@
 				if(component_check)
 					playsound(src.loc, 'sound/items/Screwdriver.ogg', 50, 1)
 					var/obj/machinery/new_machine = new src.circuit.build_path(src.loc, src.dir)
+					// Handle machines that have allocated default parts in thier constructor.
 					if(new_machine.component_parts)
+						for(var/CP in new_machine.component_parts)
+							qdel(CP)
 						new_machine.component_parts.Cut()
 					else
 						new_machine.component_parts = list()

--- a/code/game/machinery/jukebox.dm
+++ b/code/game/machinery/jukebox.dm
@@ -19,6 +19,7 @@ datum/track/New(var/title_name, var/audio)
 	use_power = 1
 	idle_power_usage = 10
 	active_power_usage = 100
+	circuit = /obj/item/weapon/circuitboard/jukebox
 
 	var/playing = 0
 
@@ -35,6 +36,14 @@ datum/track/New(var/title_name, var/audio)
 		new/datum/track("Trai`Tor", 'sound/music/traitor.ogg'),
 	)
 
+/obj/machinery/media/jukebox/New()
+	..()
+	circuit = new circuit(src)
+	component_parts = list()
+	component_parts += new /obj/item/weapon/stock_parts/capacitor(src)
+	component_parts += new /obj/item/weapon/stock_parts/console_screen(src)
+	component_parts += new /obj/item/stack/cable_coil(src, 5)
+	RefreshParts()
 
 /obj/machinery/media/jukebox/Destroy()
 	StopPlaying()
@@ -163,6 +172,10 @@ datum/track/New(var/title_name, var/audio)
 /obj/machinery/media/jukebox/attackby(obj/item/W as obj, mob/user as mob)
 	src.add_fingerprint(user)
 
+	if(default_deconstruction_screwdriver(user, W))
+		return
+	if(default_deconstruction_crowbar(user, W))
+		return
 	if(istype(W, /obj/item/weapon/wrench))
 		if(playing)
 			StopPlaying()

--- a/code/game/mecha/mech_fabricator.dm
+++ b/code/game/mecha/mech_fabricator.dm
@@ -28,7 +28,7 @@
 
 /obj/machinery/mecha_part_fabricator/New()
 	..()
-
+	circuit = new circuit(src)
 	component_parts = list()
 	component_parts += new /obj/item/weapon/stock_parts/matter_bin(src)
 	component_parts += new /obj/item/weapon/stock_parts/matter_bin(src)

--- a/code/game/objects/items/weapons/circuitboards/machinery/jukebox.dm
+++ b/code/game/objects/items/weapons/circuitboards/machinery/jukebox.dm
@@ -1,0 +1,13 @@
+#ifndef T_BOARD
+#error T_BOARD macro is not defined but we need it!
+#endif
+
+/obj/item/weapon/circuitboard/jukebox
+	name = T_BOARD("jukebox")
+	build_path = "/obj/machinery/media/jukebox"
+	board_type = "machine"
+	origin_tech = list(TECH_MAGNET = 2, TECH_DATA = 1)
+	req_components = list(
+							/obj/item/weapon/stock_parts/capacitor = 1,
+							/obj/item/weapon/stock_parts/console_screen = 1,
+							/obj/item/stack/cable_coil = 5)

--- a/code/modules/research/designs.dm
+++ b/code/modules/research/designs.dm
@@ -756,6 +756,13 @@ CIRCUITS BELOW
 	build_path = /obj/item/weapon/circuitboard/arcade/orion_trail
 	sort_string = "MAAAA"
 
+/datum/design/circuit/oriontrail
+	name = "jukebox"
+	id = "jukebox"
+	req_tech = list(TECH_MAGNET = 2, TECH_DATA = 1)
+	build_path = /obj/item/weapon/circuitboard/jukebox
+	sort_string = "MAAAB"
+
 /datum/design/circuit/seccamera
 	name = "security camera monitor"
 	id = "seccamera"

--- a/code/modules/research/designs.dm
+++ b/code/modules/research/designs.dm
@@ -756,7 +756,7 @@ CIRCUITS BELOW
 	build_path = /obj/item/weapon/circuitboard/arcade/orion_trail
 	sort_string = "MAAAA"
 
-/datum/design/circuit/oriontrail
+/datum/design/circuit/jukebox
 	name = "jukebox"
 	id = "jukebox"
 	req_tech = list(TECH_MAGNET = 2, TECH_DATA = 1)

--- a/polaris.dme
+++ b/polaris.dme
@@ -721,6 +721,7 @@
 #include "code\game\objects\items\weapons\circuitboards\computer\telecomms.dm"
 #include "code\game\objects\items\weapons\circuitboards\machinery\biogenerator.dm"
 #include "code\game\objects\items\weapons\circuitboards\machinery\cloning.dm"
+#include "code\game\objects\items\weapons\circuitboards\machinery\jukebox.dm"
 #include "code\game\objects\items\weapons\circuitboards\machinery\mech_recharger.dm"
 #include "code\game\objects\items\weapons\circuitboards\machinery\mining_drill.dm"
 #include "code\game\objects\items\weapons\circuitboards\machinery\pacman.dm"


### PR DESCRIPTION
* Fixes Issue #1606 - You need to have the circuit be an actual instance, not a path.
* Makes Jukeboxes constructable
  * Adds circuit board.
  * Adds design to print board on autolathe.
  * Makes jukeboxes deconstructable back to frame.