### PR TITLE
Allow building lights on windows.

### DIFF
--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -271,6 +271,9 @@
 			else
 				new glasstype(loc)
 			qdel(src)
+	else if(istype(W,/obj/item/frame) && anchored)
+		var/obj/item/frame/F = W
+		F.try_build(src)
 	else
 		user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 		if(W.damtype == BRUTE || W.damtype == BURN)


### PR DESCRIPTION
I noticed that the current station map has many locations where lights and such are mounted on windows.  But you cannot actually construct lights this way in-game.   In the interest of making stuff doable in-game, this enables placing of frames on anchored windows.
![example of lights on windows](https://cloud.githubusercontent.com/assets/14110581/15561305/59f43d3e-22c2-11e6-97e1-e505faac625c.PNG)
