### PR TITLE
Adds preference to mute remote LOOC chatter heard by admins.

### DIFF
--- a/code/game/verbs/ooc.dm
+++ b/code/game/verbs/ooc.dm
@@ -136,7 +136,7 @@
 					send = 1
 					prefix = "(Eye) "
 
-			if(!send && (target in admins))
+			if(!send && (target in admins) && target.is_preference_enabled(/datum/client_preference/holder/show_rlooc))
 				send = 1
 				prefix = "(R)"
 

--- a/code/modules/client/preference_setup/global/setting_datums.dm
+++ b/code/modules/client/preference_setup/global/setting_datums.dm
@@ -190,3 +190,9 @@ var/list/_client_preferences_by_type
 	key = "CHAT_RADIO"
 	enabled_description = "Show"
 	disabled_description = "Hide"
+
+/datum/client_preference/holder/show_rlooc
+	description ="Remote LOOC chat"
+	key = "CHAT_RLOOC"
+	enabled_description = "Show"
+	disabled_description = "Hide"


### PR DESCRIPTION
* Lets people remain on standby for adminhelps without having all that spam scrolling stuff off the screen if they are not taking on the role of policing LOOC.