### PR TITLE
Organize and Beautify Admin Secrets Panel

### DIFF
--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -594,25 +594,32 @@ proc/admin_notice(var/message, var/rights)
 	usr << browse(dat, "window=admin2;size=210x280")
 	return
 
-/datum/admins/proc/Secrets()
+/datum/admins/proc/Secrets(var/datum/admin_secret_category/active_category = null)
 	if(!check_rights(0))	return
 
+	// Print the header with category selection buttons.
 	var/dat = "<B>The first rule of adminbuse is: you don't talk about the adminbuse.</B><HR>"
 	for(var/datum/admin_secret_category/category in admin_secrets.categories)
 		if(!category.can_view(usr))
 			continue
-		dat += "<B>[category.name]</B><br>"
-		if(category.desc)
-			dat += "<I>[category.desc]</I><BR>"
-		for(var/datum/admin_secret_item/item in category.items)
+		dat += "<A href='?src=\ref[src];admin_secrets_panel=\ref[category]'>[category.name]</A> "
+	dat += "<HR>"
+
+	// If a category is selected, print its description and then options
+	if(istype(active_category) && active_category.can_view(usr))
+		dat += "<B>[active_category.name]</B><BR>"
+		if(active_category.desc)
+			dat += "<I>[active_category.desc]</I><BR>"
+		for(var/datum/admin_secret_item/item in active_category.items)
 			if(!item.can_view(usr))
 				continue
 			dat += "<A href='?src=\ref[src];admin_secrets=\ref[item]'>[item.name()]</A><BR>"
 		dat += "<BR>"
-	usr << browse(dat, "window=secrets")
+
+	var/datum/browser/popup = new(usr, "secrets", "Secrets", 500, 500)
+	popup.set_content(dat)
+	popup.open()
 	return
-
-
 
 /////////////////////////////////////////////////////////////////////////////////////////////////admins2.dm merge
 //i.e. buttons/verbs

--- a/code/modules/admin/admin_secrets.dm
+++ b/code/modules/admin/admin_secrets.dm
@@ -22,6 +22,9 @@ var/datum/admin_secrets/admin_secrets = new()
 		dd_insertObjectList(category.items, item)
 		items += item
 
+//
+// Secret Item Category - Each subtype is a category for organizing secret commands.
+//
 /datum/admin_secret_category
 	var/name = ""
 	var/desc = ""
@@ -37,6 +40,10 @@ var/datum/admin_secrets/admin_secrets = new()
 			return 1
 	return 0
 
+//
+// Secret Item Datum - Each subtype is a command on the secrets panel.
+// 	Override execute() with the implementation of the command.
+//
 /datum/admin_secret_item
 	var/name = ""
 	var/category = null

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1644,6 +1644,10 @@
 		log_and_message_admins("created [number] [english_list(paths)]")
 		return
 
+	else if(href_list["admin_secrets_panel"])
+		var/datum/admin_secret_category/AC = locate(href_list["admin_secrets_panel"]) in admin_secrets.categories
+		src.Secrets(AC)
+
 	else if(href_list["admin_secrets"])
 		var/datum/admin_secret_item/item = locate(href_list["admin_secrets"]) in admin_secrets.items
 		item.execute(usr)


### PR DESCRIPTION
* Add browser styles to Admin Secrets panel to make it look nice.
* Show only one category at once, with buttons to switch between categories at the top.
![pretty secrets](https://cloud.githubusercontent.com/assets/14110581/15620597/2627558c-2429-11e6-99f0-c7e36627a9aa.PNG)
* We had this on our old server. Copied it over and thought you might want it also.  As a side note, the datum-based approach to this panel is a great improvement.
