### PR TITLE
Revert "Fixes doors sparking as if damaged when spawned or created by RCD"

### DIFF
--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -65,7 +65,6 @@
 			bound_height = width * world.icon_size
 
 	health = maxhealth
-	update_icon()
 
 	update_nearby_tiles(need_rebuild=1)
 	return


### PR DESCRIPTION
Reverts PolarisSS13/Polaris#1767

This broke windoors, as the update_icon call was giving all windoors an icon state of "door1".
It's not particularly important, so reverting for now.