### PR TITLE
(Actually) Fixes #1795

### DIFF
--- a/code/modules/organs/subtypes/machine.dm
+++ b/code/modules/organs/subtypes/machine.dm
@@ -35,6 +35,9 @@
 
 /obj/item/organ/internal/mmi_holder/New(var/mob/living/carbon/human/new_owner, var/internal)
 	..(new_owner, internal)
+	var/mob/living/carbon/human/dummy/mannequin/M = new_owner
+	if(istype(M))
+		return
 	if(!stored_mmi)
 		stored_mmi = new(src)
 	sleep(-1)


### PR DESCRIPTION
Prevents the MMI from actually spawning inside of the mannequin, as it is not needed and the mob only exists in nullspace to generate images.
This prevents the MMI from calling Life() and generating runtimes, as well as preventing it from adding to the mob lists.
Fixes #1795.