### PR TITLE
Spaceheater/Recharger Power Changes

### DIFF
--- a/code/game/machinery/recharger.dm
+++ b/code/game/machinery/recharger.dm
@@ -7,7 +7,7 @@ obj/machinery/recharger
 	anchored = 1
 	use_power = 1
 	idle_power_usage = 4
-	active_power_usage = 15000	//15 kW
+	active_power_usage = 40000	//40 kW
 	var/obj/item/charging = null
 	var/list/allowed_devices = list(/obj/item/weapon/gun/energy, /obj/item/weapon/melee/baton, /obj/item/device/laptop, /obj/item/weapon/cell)
 	var/icon_state_charged = "recharger2"

--- a/code/game/machinery/spaceheater.dm
+++ b/code/game/machinery/spaceheater.dm
@@ -6,9 +6,9 @@
 	name = "space heater"
 	desc = "Made by Space Amish using traditional space techniques, this heater is guaranteed not to set the station on fire."
 	var/obj/item/weapon/cell/cell
-	var/cell_type = /obj/item/weapon/cell/apc
+	var/cell_type = /obj/item/weapon/cell/high
 	var/on = 0
-	var/set_temperature = T0C + 50	//K
+	var/set_temperature = T0C + 20	//K
 	var/heating_power = 40000
 
 


### PR DESCRIPTION
**Changes:**
 - Spaceheater now spawns with a high-capacity cell and set to 20 Kelvin.
This will make them last for 50 game seconds (1000 ticks) and reach a rough delta temperature of 500 'Kelvintiles' over its lifetime. Still not much, but better than before while not breaching laws of physics or giving celltypes otherwise not obtainable at roundstart.
 - Recharger now charges devices with 40 kW rather than 15 kW.
Will roughly lower charge time of regular weapons from about eight minutes down to one or two, while still being less effective than the cell recharger that uses 60 kW.

**For reference:**
Temperature change for rooms with usual amount of air molecules in Kelvin/Celsius every 20 ticks:
`temperature_change = 40000 W / (2080 K/W * amount_tiles_in_room)`

Recharged power in cell units every 20 ticks:
`restored_cell_units = charge_power * 0.002`
*With 40 kW charge_power: ~40 cell units per second*

Rechargables cell units:
`Energy gun: 2000`
`Carbine: 2000`
`Laser Cannon: 2400`
`LWAP: 1600`
`Xray: 1000`
`Laptop: 500`
`Stunbaton: 10000`
*(Swap out Stunbaton cell 2560! Thing uses a freaking car battery.)*