### PR TITLE
Xenobio2 Update #4

### DIFF
--- a/code/modules/xenobio2/mob/slime/slime procs.dm
+++ b/code/modules/xenobio2/mob/slime/slime procs.dm
@@ -13,11 +13,10 @@ Slime specific procs go here.
 	traitdat.traits[TRAIT_XENO_HUNGER] = rand(1, 20)
 	traitdat.traits[TRAIT_XENO_STARVEDAMAGE] = rand(1, 4)
 	traitdat.traits[TRAIT_XENO_EATS] = prob(95)	//Odds are, that thing'll need to eat.
-	traitdat.traits[TRAIT_XENO_CHROMATIC] = prob(5)	
-	if(traitdat.traits[TRAIT_XENO_CHROMATIC])
+	traitdat.traits[TRAIT_XENO_HOSTILE] = prob(60)	//Let's increase this probabilty.
+	if(prob(10))
+		traitdat.traits[TRAIT_XENO_CHROMATIC] = 1
 		traitdat.traits[TRAIT_XENO_HOSTILE] = 0
-	else
-		traitdat.traits[TRAIT_XENO_HOSTILE] = prob(30)
 	traitdat.traits[TRAIT_XENO_GLOW_STRENGTH] = round(rand(1,3))
 	traitdat.traits[TRAIT_XENO_GLOW_RANGE] = round(rand(1,3))
 	traitdat.traits[TRAIT_XENO_STRENGTH] = round(rand(4,9))

--- a/code/modules/xenobio2/mob/xeno procs.dm
+++ b/code/modules/xenobio2/mob/xeno procs.dm
@@ -29,10 +29,8 @@ Procs for targeting
 		set_light(traitdat.traits[TRAIT_XENO_GLOW_RANGE], traitdat.traits[TRAIT_XENO_GLOW_STRENGTH], traitdat.traits[TRAIT_XENO_BIO_COLOR])
 	else
 		set_light(0, 0, "#000000")	//Should kill any light that shouldn't be there.
-	if(chromatic)
-		hostile = 0	//No. No laser-reflecting hostile creatures. Bad.
-	else
-		hostile = traitdat.traits[TRAIT_XENO_HOSTILE]
+	
+	hostile = traitdat.traits[TRAIT_XENO_HOSTILE]
 
 	speed = traitdat.traits[TRAIT_XENO_SPEED]
 

--- a/code/modules/xenobio2/tools/xeno_trait_scanner.dm
+++ b/code/modules/xenobio2/tools/xeno_trait_scanner.dm
@@ -111,7 +111,7 @@
 			dat += "It bears no characters indicating resilience to damage.<br>"
 			
 	if(growth_max)
-		if(growth_level < 25)
+		if(growth_level < 35)
 			dat += "It appears to be far to growing up.<br>"
 		else if(growth_level > 40)
 			dat += "It appears to be close to growing up.<br>"


### PR DESCRIPTION
Starting nutrition of the slimes might be adjusted down to a different number, but the scanner will now read for > 35/50 instead of > 25/50 for being far from growing up.

Traits are just applied at face value, but trait data for slimes are adjusted to be more likely to become hostile, and chromatic is evaluated after, at 2x the chance.

Should make hostile slimes more common.