### PR TITLE
Sanitizing text twice breaks quotes

### DIFF
--- a/code/modules/client/preference_setup/general/01_basic.dm
+++ b/code/modules/client/preference_setup/general/01_basic.dm
@@ -107,7 +107,7 @@ datum/preferences/proc/set_biological_gender(var/gender)
 	else if(href_list["metadata"])
 		var/new_metadata = sanitize(input(user, "Enter any information you'd like others to see, such as Roleplay-preferences:", "Game Preference" , pref.metadata)) as message|null
 		if(new_metadata && CanUseTopic(user))
-			pref.metadata = sanitize(new_metadata)
+			pref.metadata = new_metadata
 			return TOPIC_REFRESH
 
 	return ..()


### PR DESCRIPTION
Someone didn't read the comment in text.dm helpers, I see. This text is sanitized 2 lines above. Don't do it twice, nothing changed.

Fixes https://github.com/VOREStation/VOREStation/issues/276

(Do cross-repo magic-word closes work? _We're about to find out!_ :tada: )