### PR TITLE
Xenobio Update #5

### DIFF
--- a/code/modules/xenobio2/_xeno_setup.dm
+++ b/code/modules/xenobio2/_xeno_setup.dm
@@ -93,6 +93,12 @@ var/global/list/xenoChemList = list("mutationtoxin",
 	var/val = traits["[trait]"]
 	return val
 	
+/datum/xeno/traits/proc/copy_traits(var/datum/xeno/traits/target)
+	target.traits = traits
+	target.chemlist = chemlist
+	target.chems = chems
+	target.source = source
+	
 /datum/xeno/traits/New()
 	..()
 	set_trait(TRAIT_XENO_COLOR,	"#CACACA")

--- a/code/modules/xenobio2/machinery/core_extractor.dm
+++ b/code/modules/xenobio2/machinery/core_extractor.dm
@@ -110,7 +110,8 @@
 		icon_state = "scanner_1old"
 		for(var/i=1 to occupant.cores)
 			var/obj/item/xenoproduct/slime/core/C = new(src)
-			C.traits = occupant.traitdat
+			C.traits = new()
+			occupant.traitdat.copy_traits(C.traits)
 			
 			C.nameVar = occupant.nameVar
 			


### PR DESCRIPTION
Rather than setting the traits to be the same, it would be better to copy the values into new traits.

Should fix any slime duplication or sudden mutations upon growing.