### PR TITLE
Fixes mapped-in double beds being made of steel and lacking padding.

### DIFF
--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -184,6 +184,9 @@
 	icon_state = "doublebed"
 	base_icon = "doublebed"
 
+/obj/structure/bed/double/padded/New(var/newloc)
+	..(newloc,"wood","cotton")
+
 /obj/structure/bed/double/post_buckle_mob(mob/living/M as mob)
 	if(M == buckled_mob)
 		M.pixel_y = 13


### PR DESCRIPTION
Adds a child object of the double bed that spawns already padded with cotton and has a frame made of wood, just like the single bed already has an analogue.

Never thought I'd say this, but thanks to Eros Research Platform for mapping these in and making me realize that I forgot to include a version meant to be mapped-in/spawned.