### PR TITLE
Reverts ammo change, fixes P90, changes SVD mag name

### DIFF
--- a/code/datums/uplink/ammunition.dm
+++ b/code/datums/uplink/ammunition.dm
@@ -60,14 +60,14 @@
 	name = "20rnd Rifle Magazine (7.62mm AP)"
 	path = /obj/item/ammo_magazine/c762/ap
 
-/datum/uplink_item/item/ammo/SVD
+/datum/uplink_item/item/ammo/s762
 	name = "10rnd Rifle Magazine (7.62mm)"
-	path = /obj/item/ammo_magazine/SVD
+	path = /obj/item/ammo_magazine/s762
 	item_cost = 1 // Half the capacity.
 
-/datum/uplink_item/item/ammo/SVD/ap
+/datum/uplink_item/item/ammo/s762/ap
 	name = "10rnd Rifle Magazine (7.62mm AP)"
-	path = /obj/item/ammo_magazine/SVD/ap
+	path = /obj/item/ammo_magazine/s762/ap
 
 /datum/uplink_item/item/ammo/a10mm
 	name = "SMG Magazine (10mm)"

--- a/code/game/machinery/autolathe_datums.dm
+++ b/code/game/machinery/autolathe_datums.dm
@@ -491,7 +491,7 @@
 /////// 5.56mm
 /datum/autolathe/recipe/rifle_556
 	name = "10rnd rifle magazine (5.56mm)"
-	path = /obj/item/ammo_magazine/a556/empty
+	path = /obj/item/ammo_magazine/a556
 	category = "Arms and Ammunition"
 	hidden = 1
 

--- a/code/game/machinery/autolathe_datums.dm
+++ b/code/game/machinery/autolathe_datums.dm
@@ -513,9 +513,9 @@
 	hidden = 1
 
 /////// 7.62
-/datum/autolathe/recipe/rifle_SVD
+/datum/autolathe/recipe/rifle_small_762
 	name = "10rnd rifle magazine (7.62mm)"
-	path = /obj/item/ammo_magazine/SVD
+	path = /obj/item/ammo_magazine/s762
 	category = "Arms and Ammunition"
 	hidden = 1
 

--- a/code/modules/projectiles/ammunition/boxes.dm
+++ b/code/modules/projectiles/ammunition/boxes.dm
@@ -387,8 +387,8 @@
 /obj/item/ammo_magazine/c762/empty
 	initial_ammo = 0
 
-/obj/item/ammo_magazine/SVD
-	name = "\improper SVD magazine (7.62mm)"
+/obj/item/ammo_magazine/s762 // 's' for small!
+	name = "magazine (7.62mm)"
 	icon_state = "SVD"
 	mag_type = MAGAZINE
 	caliber = "a762"
@@ -397,11 +397,11 @@
 	max_ammo = 10
 	multiple_sprites = 1
 
-/obj/item/ammo_magazine/SVD/empty
+/obj/item/ammo_magazine/s762/empty
 	initial_ammo = 0
 
-/obj/item/ammo_magazine/SVD/ap
-	name = "\improper SVD magazine (7.62mm armor-piercing)"
+/obj/item/ammo_magazine/s762/ap
+	name = "magazine (7.62mm armor-piercing)"
 	ammo_type = /obj/item/ammo_casing/a762/ap
 
 /obj/item/ammo_magazine/clip/a762

--- a/code/modules/projectiles/guns/projectile/automatic.dm
+++ b/code/modules/projectiles/guns/projectile/automatic.dm
@@ -61,7 +61,7 @@
 	slot_flags = SLOT_BACK
 	load_method = MAGAZINE
 	magazine_type = /obj/item/ammo_magazine/c762
-	allowed_magazines = list(/obj/item/ammo_magazine/c762, /obj/item/ammo_magazine/SVD)
+	allowed_magazines = list(/obj/item/ammo_magazine/c762, /obj/item/ammo_magazine/s762)
 
 	one_handed_penalty = 4
 
@@ -73,7 +73,7 @@
 
 /obj/item/weapon/gun/projectile/automatic/sts35/update_icon(var/ignore_inhands)
 	..()
-	if(istype(ammo_magazine,/obj/item/ammo_magazine/SVD))
+	if(istype(ammo_magazine,/obj/item/ammo_magazine/s762))
 		icon_state = "arifle-small"
 	else
 		icon_state = (ammo_magazine)? "arifle" : "arifle-empty"

--- a/code/modules/projectiles/guns/projectile/automatic.dm
+++ b/code/modules/projectiles/guns/projectile/automatic.dm
@@ -305,7 +305,7 @@
 	icon_state = "p90smg"
 	item_state = "p90"
 	w_class = 3
-	caliber = "5mm"
+	caliber = "9mm"
 	origin_tech = list(TECH_COMBAT = 5, TECH_MATERIAL = 2)
 	slot_flags = SLOT_BELT // ToDo: Belt sprite.
 	fire_sound = 'sound/weapons/Gunshot_light.ogg'

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -177,17 +177,17 @@
 	penetrating = 1
 
 /obj/item/projectile/bullet/rifle/a762
-	damage = 35
+	damage = 25
 
 /obj/item/projectile/bullet/rifle/a762/ap
-	damage = 30
+	damage = 20
 	armor_penetration = 50 // At 40 or more armor, this will do more damage than standard rounds.
 
 /obj/item/projectile/bullet/rifle/a556
-	damage = 25
+	damage = 35
 
 /obj/item/projectile/bullet/rifle/a556/ap
-	damage = 20
+	damage = 30
 	armor_penetration = 50 // At 30 or more armor, this will do more damage than standard rounds.
 
 /obj/item/projectile/bullet/rifle/a145

--- a/html/changelogs/JerTheAce_GunsGunsGuns.yml
+++ b/html/changelogs/JerTheAce_GunsGunsGuns.yml
@@ -38,7 +38,6 @@ changes:
   - rscadd: "All magazines and ammunitions can now be produced with the autolathe."
   - maptweak: "New bullpup SMG is available in armory area on CentCom level."
   - tweak: "Revolvers now use 6 shots. Finally."
-  - tweak: "5.56 now does less damage, 7.62 does more, because previously it was backwards which made no sense."
   - tweak: "Most guns that didn't use magazines before for some reason (such as the Uzi) now use magazines."
   - tweak: "All casings now update icons if they have been spent."
   - tweak: "Corrects Pulse Rifle charge cost consistency."


### PR DESCRIPTION
Reverts a change I made in https://github.com/PolarisSS13/Polaris/pull/1877 to the 5.56 and 7.62 ammunition types because this has been regarded as a poor decision by me for balance reasons because at the time of the change being decided I was assuming the carbine rifle would be in cargo, and it was not included in cargo.

I'm not about to argue better ways to fix the balance right now because it's more complicated than just changing some damage values, so let's just undo the damage I did. Hah. That was a pun.

Also corrects the P90's ammunition type, as was addressed in
https://github.com/PolarisSS13/Polaris/pull/1878

Also corrects a mistake I left behind when undoing my autolathe changes from the "Guns Guns Guns" update after a staff meeting said not to change that stuff.

Also changes the SVD magazine's name, because it's just a 10 round 762 magazine now, and it's compatible with the STS.

tl;dr this sets the Z8 Bulldog and STS damage values back to what they were before without changing anything else. The guns go back to being exactly what they were before.