### PR TITLE
SmartFridges are now Smart(er)

### DIFF
--- a/code/game/machinery/kitchen/smartfridge.dm
+++ b/code/game/machinery/kitchen/smartfridge.dm
@@ -310,10 +310,11 @@
 				var/hasRecord = FALSE	//Check to see if this passes or not.
 				for(var/datum/data/stored_item/I in item_records)
 					if(istype(G, I.item_path))
-						stock(G, I)
-						hasRecord = TRUE
+						if(G.name == I.item_name)
+							stock(G, I)
+							hasRecord = TRUE
 				if(!hasRecord)
-					var/datum/data/stored_item/item = new/datum/data/stored_item(src, G.type)
+					var/datum/data/stored_item/item = new/datum/data/stored_item(src, G.type, G.name)
 					stock(G, item)
 					item_records.Add(item)
 					


### PR DESCRIPTION
Now checks the name of the item as well, instead of just the path.

This was a problem for when you were storing fruit, as it would just be stored as "Fruit"

Slime cores will get separated between mutated, modified and spawned now, too.