### PR TITLE
Heavy weapons changes

### DIFF
--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -68,13 +68,15 @@ obj/item/weapon/gun/energy/retro
 	fire_sound = 'sound/weapons/lasercannonfire.ogg'
 	origin_tech = list(TECH_COMBAT = 4, TECH_MATERIAL = 3, TECH_POWER = 3)
 	slot_flags = SLOT_BELT|SLOT_BACK
-	projectile_type = /obj/item/projectile/beam/heavylaser
-	charge_cost = 400
-	max_shots = 6
-	fire_delay = 20
+	projectile_type = /obj/item/projectile/beam/heavylaser/cannon
+	max_shots = 1
+	fire_delay = 30
 //	requires_two_hands = 1
 	one_handed_penalty = 6 // The thing's heavy and huge.
-	accuracy = 2
+	accuracy = 3
+	self_recharge = 1
+	recharge_time = 60
+
 
 /obj/item/weapon/gun/energy/lasercannon/mounted
 	name = "mounted laser cannon"
@@ -83,6 +85,10 @@ obj/item/weapon/gun/energy/retro
 	recharge_time = 10
 	accuracy = 0 // Mounted cannons are just fine the way they are.
 	requires_two_hands = 0 // Not sure if two-handing gets checked for mounted weapons, but better safe than sorry.
+	projectile_type = /obj/item/projectile/beam/heavylaser
+	charge_cost = 400
+	max_shots = 6
+	fire_delay = 20
 
 /obj/item/weapon/gun/energy/xray
 	name = "xray laser gun"

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -74,8 +74,7 @@ obj/item/weapon/gun/energy/retro
 //	requires_two_hands = 1
 	one_handed_penalty = 6 // The thing's heavy and huge.
 	accuracy = 3
-	self_recharge = 1
-	recharge_time = 60
+	charge_cost = 400
 
 
 /obj/item/weapon/gun/energy/lasercannon/mounted

--- a/code/modules/projectiles/guns/projectile/sniper.dm
+++ b/code/modules/projectiles/guns/projectile/sniper.dm
@@ -10,15 +10,14 @@
 	slot_flags = SLOT_BACK
 	origin_tech = list(TECH_COMBAT = 8, TECH_MATERIAL = 2, TECH_ILLEGAL = 8)
 	caliber = "14.5mm"
-	recoil = 3 //extra kickback
+	recoil = 5 //extra kickback
 	fire_sound = 'sound/weapons/sniper.ogg' // extra boom
 	handle_casings = HOLD_CASINGS
 	load_method = SINGLE_CASING
 	max_shells = 1
 	ammo_type = /obj/item/ammo_casing/a145
-	//+2 accuracy over the LWAP because only one shot
-	accuracy = -1
-	scoped_accuracy = 2
+	accuracy = -5
+	scoped_accuracy = 5
 	var/bolt_open = 0
 
 /obj/item/weapon/gun/projectile/heavysniper/update_icon()

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -42,6 +42,10 @@
 	tracer_type = /obj/effect/projectile/laser_heavy/tracer
 	impact_type = /obj/effect/projectile/laser_heavy/impact
 
+/obj/item/projectile/beam/heavylaser/cannon
+	damage = 90
+	armor_penetration = 100
+
 /obj/item/projectile/beam/xray
 	name = "xray beam"
 	icon_state = "xray"

--- a/html/changelogs/Yoshax - heavyguns.yml
+++ b/html/changelogs/Yoshax - heavyguns.yml
@@ -1,0 +1,37 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Yoshax
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "The PTR Sniper is now more accurate when scoped, but less accurate when unscoped. In addition it now has more recoil."
+  - tweak: "The Laser Cannon no longer holds multiple shots. It holds charge for one shot at a time. This is because the beams it fires now do 90 damage with 100 armor penetration. Furthermore, it is now considerably more accurate. Lastly, to counteract it only holding one shot at a time, it now autorecharges, which takes 60 seconds.


### PR DESCRIPTION
This PR proposes changes to the Laser Cannon & PTR Sniper.

PTR:
- More recoil
- Increased scoped accuracy
- Lowered unscoped accuracy

Laser Cannon:
- Is now singleshot
- Does 90 damage, with 100 armor penetration
- Self-recharges which takes 60 seconds
- Is slightly more accurate

Mounted laser cannon retains the current values.

Possible PTR Changes:
- Higher damage

Possibly changes to cannon:
- Higher recharge time
- Remove self recharge

My goals here are to:
- Make the PTR more reliable.
- Make the Cannon into more of a Laser RPG.