### PR TITLE
Xenobio2 Update #7

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -5,11 +5,4 @@
 	destroy_surroundings = 1
 	a_intent = I_HURT
 	hostile = 1
-
-
-/mob/living/simple_animal/hostile/Life()
-
-	. = ..()
-	if(!.)
-		walk(src, 0)
-		return 0
+	

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -117,6 +117,8 @@
 			living_mob_list += src
 			stat = CONSCIOUS
 			density = 1
+		else
+			walk(src, 0)
 		return 0
 
 

--- a/code/modules/xenobio2/machinery/core_extractor.dm
+++ b/code/modules/xenobio2/machinery/core_extractor.dm
@@ -126,6 +126,7 @@
 		spawn(30)
 			icon_state = "scanner_0old"
 			qdel(occupant)
+			occupant = null	//If qdel's being slow or acting up, let's make sure we can't make more cores from this one.
 			inuse = 0
 			eject_contents()
 			update_light_color()

--- a/code/modules/xenobio2/machinery/slime_replicator.dm
+++ b/code/modules/xenobio2/machinery/slime_replicator.dm
@@ -77,8 +77,9 @@
 		S.nameVar = core.nameVar
 		S.name = "[S.nameVar] baby slime"
 		S.ProcessTraits()
-		qdel(core)
 		spawn(30)
+			qdel(core)
+			core = null	//If qdel's being a bit slow or acting up, let's just make sure we can't clone the core.
 			inuse = 0
 			eject_slime()
 			icon_state = "restruct_0"

--- a/code/modules/xenobio2/machinery/slime_replicator.dm
+++ b/code/modules/xenobio2/machinery/slime_replicator.dm
@@ -73,9 +73,10 @@
 	icon_state = "restruct_1"
 	spawn(30)
 		var/mob/living/simple_animal/xeno/slime/S = new(src)
-		S.traitdat = core.traits
+		S.traitdat = new()	//New instance, so that if the core is deleted, the slime retains a trait datum.
 		S.nameVar = core.nameVar
 		S.name = "[S.nameVar] baby slime"
+		core.traits.copy_traits(S.traitdat)
 		S.ProcessTraits()
 		spawn(30)
 			qdel(core)

--- a/code/modules/xenobio2/mob/slime/slime procs.dm
+++ b/code/modules/xenobio2/mob/slime/slime procs.dm
@@ -24,7 +24,23 @@ Slime specific procs go here.
 	traitdat.traits[TRAIT_XENO_CANLEARN] = prob(68)
 	traitdat.traits[TRAIT_XENO_SPEED] = round(rand(-10,10))
 	
-	
+/mob/living/simple_animal/xeno/slime/RandomChemicals()
+	..()
+	if(prob(40))
+		var/hasMutToxin
+		for(var/R in traitdat.chems)
+			if(R == "amutationtoxin")
+				hasMutToxin = 1
+		var/chemamount
+		if(hasMutToxin)
+			var/list/chemchoices = (xenoChemList - traitdat.chems)
+					
+			var/chemtype = pick(chemchoices)
+			chemamount = rand(1,5)
+			traitdat.chems[chemtype] = chemamount
+		else
+			chemamount = rand(1,5)
+			traitdat.chems["amutationtoxin"] = chemamount
 
 /mob/living/simple_animal/xeno/slime/proc/GrowUp()
 	GenerateAdult()

--- a/code/modules/xenobio2/mob/slime/slime procs.dm
+++ b/code/modules/xenobio2/mob/slime/slime procs.dm
@@ -29,7 +29,7 @@ Slime specific procs go here.
 	if(prob(40))
 		var/hasMutToxin
 		for(var/R in traitdat.chems)
-			if(R == "amutationtoxin")
+			if(R == "mutationtoxin")
 				hasMutToxin = 1
 		var/chemamount
 		if(hasMutToxin)
@@ -40,7 +40,7 @@ Slime specific procs go here.
 			traitdat.chems[chemtype] = chemamount
 		else
 			chemamount = rand(1,5)
-			traitdat.chems["amutationtoxin"] = chemamount
+			traitdat.chems["mutationtoxin"] = chemamount
 
 /mob/living/simple_animal/xeno/slime/proc/GrowUp()
 	GenerateAdult()

--- a/code/modules/xenobio2/mob/slime/slime.dm
+++ b/code/modules/xenobio2/mob/slime/slime.dm
@@ -4,6 +4,7 @@ Slime definitions, Life and New live here.
 /mob/living/simple_animal/xeno/slime //Adult values are found here
 	nameVar = "grey"		//When mutated, nameVar might change.
 	desc = "A shifting, mass of goo."
+	faction = "slime"
 	speak_emote = list("garbles", "chirps", "blurbles")
 	colored = 1
 	color = "#CACACA"

--- a/code/modules/xenobio2/mob/slime/slime.dm
+++ b/code/modules/xenobio2/mob/slime/slime.dm
@@ -69,6 +69,7 @@ Slime definitions, Life and New live here.
 						"toxin" = list("toxic" = 0.5),
 						"carpotoxin" = list("toxic" = 1, "mut" = 1.5),
 						"phoron" = list("toxic" = 1.5, "mut" = 0.03),
+						"virusfood" = list("nutr" = 1.5, "mut" = 0.32),
 						"cyanide" = list("toxic" = 3.5),
 						"slimejelly" = list("nutr" = 0.5),
 						"amutationtoxin" = list("toxic" = 0.1, "heal" = 1.5, "mut" = 3),

--- a/code/modules/xenobio2/mob/xeno.dm
+++ b/code/modules/xenobio2/mob/xeno.dm
@@ -8,6 +8,7 @@ Also includes Life and New
 /mob/living/simple_animal/xeno
 	name = "Xeno"
 	real_name = "Xeno"
+	faction = "xeno"	//Needs to be set.
 	desc = "Something's broken, yell at someone."
 	melee_damage_lower = 0
 	melee_damage_upper = 0
@@ -46,33 +47,32 @@ Also includes Life and New
 	
 //Life additions
 /mob/living/simple_animal/xeno/Life()
-	if(src.stat == DEAD)
-		return 0
-	
 	if(stasis)
 		stasis--
 		if(stasis < 0)
 			stasis = 0
 		return 0
+		
 	..()
-	handle_reagents()
-	if((mut_level >= mut_max) && !(mutable & NOMUT))
-		Mutate()
-		mut_level -= mut_max
+	if(!(stat == DEAD))
+		handle_reagents()
+		if((mut_level >= mut_max) && !(mutable & NOMUT))
+			Mutate()
+			mut_level -= mut_max
 			
-	ProcessSpeechBuffer()
+		ProcessSpeechBuffer()
 	
-	//Have to feed the xenos somehow.
-	if(nutrition < 0)
-		nutrition = 0
-	if((nutrition > 0 ) && traitdat.traits[TRAIT_XENO_EATS])
-		if(nutrition >= 300)
-			nutrition -= hunger_factor
-	else
-		if(traitdat.traits[TRAIT_XENO_EATS])
-			health = starve_damage
+		//Have to feed the xenos somehow.
+		if(nutrition < 0)
+			nutrition = 0
+		if((nutrition > 0 ) && traitdat.traits[TRAIT_XENO_EATS])
+			if(nutrition >= 300)
+				nutrition -= hunger_factor
+		else
+			if(traitdat.traits[TRAIT_XENO_EATS])
+				health = starve_damage
 	
-	return 1	//Everything worked okay.
+		return 1	//Everything worked okay.
 	
 /mob/living/simple_animal/xeno/New()
 

--- a/code/modules/xenobio2/mob/xeno.dm
+++ b/code/modules/xenobio2/mob/xeno.dm
@@ -95,3 +95,7 @@ Also includes Life and New
 	if(!health)
 		stat = DEAD
 		
+/mob/living/simple_animal/xeno/Destroy()
+	traitdat.Destroy()	//Let's clean up after ourselves.
+	traitdat = null
+	..()

--- a/code/modules/xenobio2/mob/xeno_product.dm
+++ b/code/modules/xenobio2/mob/xeno_product.dm
@@ -11,3 +11,8 @@ Xenobiological product lives here as a basic type.
 	var/product = "mess"
 	var/nameVar = "blah"
 	
+/obj/item/xenoproduct/Destroy()
+	traits.Destroy()	//Let's not leave any traits hanging around.
+	traits = null
+	..()
+	

--- a/html/changelogs/Datraen-Xenobio2Update7.yml
+++ b/html/changelogs/Datraen-Xenobio2Update7.yml
@@ -1,0 +1,9 @@
+author: Datraen
+
+delete-after: True
+
+changes: 
+  - tweak: "Adds a chance for slimes to get mutation toxin for creation of prometheans (40%)."
+  - bugfix: "Simple animals outside of the hostile subtype won't follow you as a zombie."
+  - bugfix: "Xeno hostility is more apparent now."
+  - bugfix: "Slime cores can no longer create twice as many slimes through an exploit."


### PR DESCRIPTION
- Slime cores would sometimes linger in the slime replicator, allowing for duplication from the same core. The replication and extraction machines null core and occupant variables to avoid this.
- Datums are cleaned up on Destroy() to avoid further issues.
- Slimes being hostile is now more apparent. Before they would be hostile, but remain on the neutral faction, causing no damage to those around them under the same faction.
- Simple mobs out of the hostile subtype would follow their targets after death, this is resolved.
- Additional step added to the mutation proc for a 40% chance of mutation toxin or an extra chemical if the toxin is already present.