### PR TITLE
Rewrites Emotes + LOOC and makes Communicators work

### DIFF
--- a/code/_helpers/global_lists.dm
+++ b/code/_helpers/global_lists.dm
@@ -11,6 +11,7 @@ var/global/list/human_mob_list = list()				//List of all human mobs and sub-type
 var/global/list/silicon_mob_list = list()			//List of all silicon mobs, including clientless
 var/global/list/living_mob_list = list()			//List of all alive mobs, including clientless. Excludes /mob/new_player
 var/global/list/dead_mob_list = list()				//List of all dead mobs, including clientless. Excludes /mob/new_player
+var/global/list/listening_objects = list()			//List of all objects which care about receiving messages (communicators, radios, etc)
 
 var/global/list/cable_list = list()					//Index for all cables, so that powernets don't have to look through the entire world all the time
 var/global/list/chemical_reactions_list				//list of all /datum/chemical_reaction datums. Used during chemical reactions

--- a/code/_onclick/hud/hud.dm
+++ b/code/_onclick/hud/hud.dm
@@ -6,12 +6,14 @@ var/datum/global_hud/global_hud = new()
 var/list/global_huds = list(
 		global_hud.druggy,
 		global_hud.blurry,
+		global_hud.whitense,
 		global_hud.vimpaired,
 		global_hud.darkMask,
 		global_hud.nvg,
 		global_hud.thermal,
 		global_hud.meson,
-		global_hud.science)
+		global_hud.science
+		)
 
 /datum/hud/var/obj/screen/grab_intent
 /datum/hud/var/obj/screen/hurt_intent
@@ -21,6 +23,7 @@ var/list/global_huds = list(
 /datum/global_hud
 	var/obj/screen/druggy
 	var/obj/screen/blurry
+	var/obj/screen/whitense
 	var/list/vimpaired
 	var/list/darkMask
 	var/obj/screen/nvg
@@ -52,6 +55,14 @@ var/list/global_huds = list(
 	blurry.icon_state = "blurry"
 	blurry.layer = 17
 	blurry.mouse_opacity = 0
+
+	//static overlay effect for cameras and the like
+	whitense = new /obj/screen()
+	whitense.screen_loc = ui_entire_screen
+	whitense.icon = 'icons/effects/static.dmi'
+	whitense.icon_state = "1 light"
+	whitense.layer = 17
+	whitense.mouse_opacity = 0
 
 	nvg = setup_overlay("nvg_hud")
 	thermal = setup_overlay("thermal_hud")

--- a/code/game/verbs/ooc.dm
+++ b/code/game/verbs/ooc.dm
@@ -147,42 +147,6 @@
 		var/admin_stuff = "/([key])([admin_jump_link(mob, target.holder)])"
 		
 		target << "<span class='ooc'><span class='looc'>" + create_text_tag("looc", "LOOC:", target) + " <span class='prefix'>(R)</span><EM>[display_name][admin_stuff]:</EM> <span class='message'>[msg]</span></span></span>"
-/*
-	for(var/client/target in clients)
-		if(target.is_preference_enabled(/datum/client_preference/show_looc))
-			var/prefix = ""
-			var/admin_stuff = ""
-			var/send = 0
-
-			// Admins get extra data.
-			if(target in admins)
-				admin_stuff += "/([key])"
-				if(target != src)
-					admin_stuff += "([admin_jump_link(mob, target.holder)])"
-
-			// For AIs, needs work done to see if the eye is in range as we're going over clients not mobs.
-			if(isAI(target.mob))
-				var/mob/living/silicon/ai/A = target.mob
-				if(A.eyeobj in m_viewers)
-					send = 1
-					prefix = "(Eye) " // Prefer the (Eye) prefix if they are in range of core and eye.
-				else if (A in m_viewers)
-					send = 1
-					prefix = "(Core) "
-
-			// If you're in range, you get the LOOC.
-			else if(target.mob in m_viewers)
-				send = 1
-				
-			// If you weren't going to otherwise get it, but can see (R)LOOC.
-			if(!send && (target in admins) && target.is_preference_enabled(/datum/client_preference/holder/show_rlooc))
-				send = 1
-				prefix = "(R)"
-
-			// Deliver message directly to the client with stream operator, not another proc. LOOC is important.
-			if(send)
-				target << "<span class='ooc'><span class='looc'>" + create_text_tag("looc", "LOOC:", target) + " <span class='prefix'>[prefix]</span><EM>[display_name][admin_stuff]:</EM> <span class='message'>[msg]</span></span></span>"
-*/
 
 /mob/proc/get_looc_source()
 	return src

--- a/code/game/verbs/ooc.dm
+++ b/code/game/verbs/ooc.dm
@@ -106,7 +106,13 @@
 	log_ooc("(LOCAL) [mob.name]/[key] : [msg]")
 
 	var/mob/source = mob.get_looc_source()
-	var/list/heard = get_mobs_or_objects_in_view(7, get_turf(source), 1, 0)
+	var/turf/T = get_turf(source)
+	if(!T) return
+	var/list/in_range = get_mobs_and_objs_in_view_fast(T,world.view,0)
+	var/list/m_viewers = in_range["mobs"]
+
+	var/list/receivers = list() // Clients, not mobs.
+	var/list/r_receivers = list()
 
 	var/display_name = key
 	if(holder && holder.fakekey)
@@ -114,34 +120,69 @@
 	if(mob.stat != DEAD)
 		display_name = mob.name
 
+	// Everyone in normal viewing range of the LOOC
+	for(var/mob/viewer in m_viewers)
+		if(viewer.client && viewer.client.is_preference_enabled(/datum/client_preference/show_looc))
+			receivers |= viewer.client
+		else if(istype(viewer,/mob/observer/eye)) // For AI eyes and the like
+			var/mob/observer/eye/E = viewer
+			if(E.owner && E.owner.client)
+				receivers |= E.owner.client
+
+	// Admins with RLOOC displayed who weren't already in
+	for(var/client/admin in admins)
+		if(!(admin in receivers) && admin.is_preference_enabled(/datum/client_preference/holder/show_rlooc))
+			r_receivers |= admin
+
+	// Send a message
+	for(var/client/target in receivers)
+		var/admin_stuff = ""
+		
+		if(target in admins)
+			admin_stuff += "/([key])"
+
+		target << "<span class='ooc'><span class='looc'>" + create_text_tag("looc", "LOOC:", target) + " <EM>[display_name][admin_stuff]:</EM> <span class='message'>[msg]</span></span></span>"
+
+	for(var/client/target in r_receivers)
+		var/admin_stuff = "/([key])([admin_jump_link(mob, target.holder)])"
+		
+		target << "<span class='ooc'><span class='looc'>" + create_text_tag("looc", "LOOC:", target) + " <span class='prefix'>(R)</span><EM>[display_name][admin_stuff]:</EM> <span class='message'>[msg]</span></span></span>"
+/*
 	for(var/client/target in clients)
 		if(target.is_preference_enabled(/datum/client_preference/show_looc))
 			var/prefix = ""
 			var/admin_stuff = ""
 			var/send = 0
 
+			// Admins get extra data.
 			if(target in admins)
 				admin_stuff += "/([key])"
 				if(target != src)
 					admin_stuff += "([admin_jump_link(mob, target.holder)])"
 
-			if(target.mob in heard)
-				send = 1
-				if(isAI(target.mob))
+			// For AIs, needs work done to see if the eye is in range as we're going over clients not mobs.
+			if(isAI(target.mob))
+				var/mob/living/silicon/ai/A = target.mob
+				if(A.eyeobj in m_viewers)
+					send = 1
+					prefix = "(Eye) " // Prefer the (Eye) prefix if they are in range of core and eye.
+				else if (A in m_viewers)
+					send = 1
 					prefix = "(Core) "
 
-			else if(isAI(target.mob)) // Special case
-				var/mob/living/silicon/ai/A = target.mob
-				if(A.eyeobj in hearers(7, source))
-					send = 1
-					prefix = "(Eye) "
-
+			// If you're in range, you get the LOOC.
+			else if(target.mob in m_viewers)
+				send = 1
+				
+			// If you weren't going to otherwise get it, but can see (R)LOOC.
 			if(!send && (target in admins) && target.is_preference_enabled(/datum/client_preference/holder/show_rlooc))
 				send = 1
 				prefix = "(R)"
 
+			// Deliver message directly to the client with stream operator, not another proc. LOOC is important.
 			if(send)
 				target << "<span class='ooc'><span class='looc'>" + create_text_tag("looc", "LOOC:", target) + " <span class='prefix'>[prefix]</span><EM>[display_name][admin_stuff]:</EM> <span class='message'>[msg]</span></span></span>"
+*/
 
 /mob/proc/get_looc_source()
 	return src

--- a/code/modules/mob/living/voice/voice.dm
+++ b/code/modules/mob/living/voice/voice.dm
@@ -42,12 +42,9 @@
 // Parameters: None
 // Description: Adds a static overlay to the client's screen.
 /mob/living/voice/Login()
-	var/obj/screen/static_effect = new() //Since what the player sees is essentially a video feed, from a vast distance away, the view isn't going to be perfect.
-	static_effect.screen_loc = ui_entire_screen
-	static_effect.icon = 'icons/effects/static.dmi'
-	static_effect.icon_state = "1 light"
-	static_effect.mouse_opacity = 0 //So the static doesn't get in the way of clicking.
-	client.screen.Add(static_effect)
+	..()
+	client.screen |= global_hud.whitense
+	client.screen |= global_hud.darkMask
 
 // Proc: Destroy()
 // Parameters: None

--- a/code/modules/mob/living/voice/voice.dm
+++ b/code/modules/mob/living/voice/voice.dm
@@ -107,7 +107,7 @@
 // Proc: say()
 // Parameters: 4 (generic say() arguments)
 // Description: Adds a speech bubble to the communicator device, then calls ..() to do the real work.
-/mob/living/voice/say(var/message, var/datum/language/speaking = null, var/verb="says", var/alt_name="")
+/mob/living/voice/say(var/message, var/datum/language/speaking = null, var/verb="says", var/alt_name="", var/whispering=0)
 	//Speech bubbles.
 	if(comm)
 		var/speech_bubble_test = say_test(message)
@@ -119,4 +119,8 @@
 			M << speech_bubble
 		src << speech_bubble
 
-	..(message, speaking, verb, alt_name) //mob/living/say() can do the actual talking.
+	..(message, speaking, verb, alt_name, whispering) //mob/living/say() can do the actual talking.
+
+/mob/living/voice/custom_emote(var/m_type=1,var/message = null,var/range=world.view)
+	if(!comm) return
+	..(m_type,message,comm.video_range)

--- a/code/modules/surgery/limb_reattach.dm
+++ b/code/modules/surgery/limb_reattach.dm
@@ -40,7 +40,7 @@
 
 	end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 		var/obj/item/organ/external/E = tool
-		user.visible_message("<span class='notice'>[user] has attached [target]'s [E.name] to the [E.amputation_point].</span>>",	\
+		user.visible_message("<span class='notice'>[user] has attached [target]'s [E.name] to the [E.amputation_point].</span>",	\
 		"<span class='notice'>You have attached [target]'s [E.name] to the [E.amputation_point].</span>")
 		user.drop_from_inventory(E)
 		E.replaced(target)


### PR DESCRIPTION
Now communicators work, and the camera sucks slightly more for ghost calls (welder overlay). Emotes can only be seen if you're within 4 turfs of the display. Look, your eyesight isn't that great. I don't care what you say. Beyond that it's like "You can see movement". This happens to be the range of the welder overlay. Go figure.

LOOC and Emote switched to use the get_mobs_and_objs_in_view_fast proc that they should have been using, which vastly simplifies both. Also rewrites said proc a bit.

Moves the static overlay from the /voice mob to be a global hud overlay so it can be used elsewhere rather than being snowflake. I'll probably slap it on cameras or something.

Next up: player to player video calls like cameras between communicators.

Fixes #1762 