### PR TITLE
Move preferences copy_to() new player mobs into the preference_setup datums.

### DIFF
--- a/code/modules/client/preference_setup/antagonism/01_basic.dm
+++ b/code/modules/client/preference_setup/antagonism/01_basic.dm
@@ -15,6 +15,10 @@ var/global/list/uplink_locations = list("PDA", "Headset", "None")
 /datum/category_item/player_setup_item/antagonism/basic/sanitize_character()
 	pref.uplinklocation	= sanitize_inlist(pref.uplinklocation, uplink_locations, initial(pref.uplinklocation))
 
+// Moved from /datum/preferences/proc/copy_to()
+/datum/category_item/player_setup_item/antagonism/basic/copy_to_mob(var/mob/living/carbon/human/character)
+	character.exploit_record = pref.exploit_record
+
 /datum/category_item/player_setup_item/antagonism/basic/content(var/mob/user)
 	. +="<b>Uplink Type : <a href='?src=\ref[src];antagtask=1'>[pref.uplinklocation]</a></b>"
 	. +="<br>"

--- a/code/modules/client/preference_setup/general/01_basic.dm
+++ b/code/modules/client/preference_setup/general/01_basic.dm
@@ -40,6 +40,25 @@ datum/preferences/proc/set_biological_gender(var/gender)
 	pref.spawnpoint         = sanitize_inlist(pref.spawnpoint, spawntypes, initial(pref.spawnpoint))
 	pref.be_random_name     = sanitize_integer(pref.be_random_name, 0, 1, initial(pref.be_random_name))
 
+// Moved from /datum/preferences/proc/copy_to()
+/datum/category_item/player_setup_item/general/basic/copy_to_mob(var/mob/living/carbon/human/character)
+	if(config.humans_need_surnames)
+		var/firstspace = findtext(pref.real_name, " ")
+		var/name_length = length(pref.real_name)
+		if(!firstspace)	//we need a surname
+			pref.real_name += " [pick(last_names)]"
+		else if(firstspace == name_length)
+			pref.real_name += "[pick(last_names)]"
+
+	character.real_name = pref.real_name
+	character.name = character.real_name
+	if(character.dna)
+		character.dna.real_name = character.real_name
+
+	character.gender = pref.biological_gender
+	character.identifying_gender = pref.identifying_gender
+	character.age = pref.age
+
 /datum/category_item/player_setup_item/general/basic/content()
 	. = list()
 	. += "<b>Name:</b> "

--- a/code/modules/client/preference_setup/general/03_body.dm
+++ b/code/modules/client/preference_setup/general/03_body.dm
@@ -76,6 +76,53 @@ var/global/list/valid_bloodtypes = list("A+", "A-", "B+", "B-", "AB+", "AB-", "O
 	if(!pref.organ_data) pref.organ_data = list()
 	if(!pref.rlimb_data) pref.rlimb_data = list()
 
+// Moved from /datum/preferences/proc/copy_to()
+/datum/category_item/player_setup_item/general/body/copy_to_mob(var/mob/living/carbon/human/character)
+	// Copy basic values
+	character.r_eyes	= pref.r_eyes
+	character.g_eyes	= pref.g_eyes
+	character.b_eyes	= pref.b_eyes
+	character.h_style	= pref.h_style
+	character.r_hair	= pref.r_hair
+	character.g_hair	= pref.g_hair
+	character.b_hair	= pref.b_hair
+	character.f_style	= pref.f_style
+	character.r_facial	= pref.r_facial
+	character.g_facial	= pref.g_facial
+	character.b_facial	= pref.b_facial
+	character.r_skin	= pref.r_skin
+	character.g_skin	= pref.g_skin
+	character.b_skin	= pref.b_skin
+	character.s_tone	= pref.s_tone
+	character.h_style	= pref.h_style
+	character.f_style	= pref.f_style
+	character.b_type	= pref.b_type
+
+	// Destroy/cyborgize organs and limbs.
+	for(var/name in list(BP_HEAD, BP_L_HAND, BP_R_HAND, BP_L_ARM, BP_R_ARM, BP_L_FOOT, BP_R_FOOT, BP_L_LEG, BP_R_LEG, BP_GROIN, BP_TORSO))
+		var/status = pref.organ_data[name]
+		var/obj/item/organ/external/O = character.organs_by_name[name]
+		if(O)
+			if(status == "amputated")
+				O.remove_rejuv()
+			else if(status == "cyborg")
+				if(pref.rlimb_data[name])
+					O.robotize(pref.rlimb_data[name])
+				else
+					O.robotize()
+
+	for(var/name in list(O_HEART,O_EYES,O_BRAIN))
+		var/status = pref.organ_data[name]
+		if(!status)
+			continue
+		var/obj/item/organ/I = character.internal_organs_by_name[name]
+		if(I)
+			if(status == "assisted")
+				I.mechassist()
+			else if(status == "mechanical")
+				I.robotize()
+	return
+
 /datum/category_item/player_setup_item/general/body/content(var/mob/user)
 	. = list()
 	if(!pref.preview_icon)

--- a/code/modules/client/preference_setup/general/04_equipment.dm
+++ b/code/modules/client/preference_setup/general/04_equipment.dm
@@ -18,6 +18,30 @@
 	S["backbag"]	<< pref.backbag
 	S["pdachoice"]	<< pref.pdachoice
 
+// Moved from /datum/preferences/proc/copy_to()
+/datum/category_item/player_setup_item/general/equipment/copy_to_mob(var/mob/living/carbon/human/character)
+	character.all_underwear.Cut()
+	character.all_underwear_metadata.Cut()
+
+	for(var/underwear_category_name in pref.all_underwear)
+		var/datum/category_group/underwear/underwear_category = global_underwear.categories_by_name[underwear_category_name]
+		if(underwear_category)
+			var/underwear_item_name = pref.all_underwear[underwear_category_name]
+			character.all_underwear[underwear_category_name] = underwear_category.items_by_name[underwear_item_name]
+			if(pref.all_underwear_metadata[underwear_category_name])
+				character.all_underwear_metadata[underwear_category_name] = pref.all_underwear_metadata[underwear_category_name]
+		else
+			pref.all_underwear -= underwear_category_name
+
+	// TODO - Looks like this is duplicating the work of sanitize_character() if so, remove
+	if(pref.backbag > 4 || pref.backbag < 1)
+		pref.backbag = 1 //Same as above
+	character.backbag = pref.backbag
+
+	if(pref.pdachoice > 3 || pref.pdachoice < 1)
+		pref.pdachoice = 1
+	character.pdachoice = pref.pdachoice
+
 /datum/category_item/player_setup_item/general/equipment/sanitize_character()
 	if(!islist(pref.gear)) pref.gear = list()
 

--- a/code/modules/client/preference_setup/general/05_background.dm
+++ b/code/modules/client/preference_setup/general/05_background.dm
@@ -30,6 +30,16 @@
 
 	pref.nanotrasen_relation = sanitize_inlist(pref.nanotrasen_relation, COMPANY_ALIGNMENTS, initial(pref.nanotrasen_relation))
 
+// Moved from /datum/preferences/proc/copy_to()
+/datum/category_item/player_setup_item/general/background/copy_to_mob(var/mob/living/carbon/human/character)
+	character.med_record		= pref.med_record
+	character.sec_record		= pref.sec_record
+	character.gen_record		= pref.gen_record
+	character.home_system		= pref.home_system
+	character.citizenship		= pref.citizenship
+	character.personal_faction	= pref.faction
+	character.religion			= pref.religion
+
 /datum/category_item/player_setup_item/general/background/content(var/mob/user)
 	. += "<b>Background Information</b><br>"
 	. += "[company_name] Relation: <a href='?src=\ref[src];nt_relation=1'>[pref.nanotrasen_relation]</a><br/>"

--- a/code/modules/client/preference_setup/general/06_flavor.dm
+++ b/code/modules/client/preference_setup/general/06_flavor.dm
@@ -36,6 +36,18 @@
 /datum/category_item/player_setup_item/general/flavor/sanitize_character()
 	return
 
+// Moved from /datum/preferences/proc/copy_to()
+/datum/category_item/player_setup_item/general/flavor/copy_to_mob(var/mob/living/carbon/human/character)
+	character.flavor_texts["general"]	= pref.flavor_texts["general"]
+	character.flavor_texts["head"]		= pref.flavor_texts["head"]
+	character.flavor_texts["face"]		= pref.flavor_texts["face"]
+	character.flavor_texts["eyes"]		= pref.flavor_texts["eyes"]
+	character.flavor_texts["torso"]		= pref.flavor_texts["torso"]
+	character.flavor_texts["arms"]		= pref.flavor_texts["arms"]
+	character.flavor_texts["hands"]		= pref.flavor_texts["hands"]
+	character.flavor_texts["legs"]		= pref.flavor_texts["legs"]
+	character.flavor_texts["feet"]		= pref.flavor_texts["feet"]
+
 /datum/category_item/player_setup_item/general/flavor/content(var/mob/user)
 	. += "<b>Flavor:</b><br>"
 	. += "<a href='?src=\ref[src];flavor_text=open'>Set Flavor Text</a><br/>"

--- a/code/modules/client/preference_setup/preference_setup.dm
+++ b/code/modules/client/preference_setup/preference_setup.dm
@@ -149,8 +149,6 @@
 
 /datum/category_group/player_setup_category/proc/copy_to_mob(var/mob/living/carbon/human/C)
 	for(var/datum/category_item/player_setup_item/PI in items)
-		PI.sanitize_character()
-	for(var/datum/category_item/player_setup_item/PI in items)
 		PI.copy_to_mob(C)
 
 /datum/category_group/player_setup_category/proc/content(var/mob/user)

--- a/code/modules/client/preference_setup/preference_setup.dm
+++ b/code/modules/client/preference_setup/preference_setup.dm
@@ -72,6 +72,10 @@
 	for(var/datum/category_group/player_setup_category/PS in categories)
 		PS.save_preferences(S)
 
+/datum/category_collection/player_setup_collection/proc/copy_to_mob(var/mob/living/carbon/human/C)
+	for(var/datum/category_group/player_setup_category/PS in categories)
+		PS.copy_to_mob(C)
+
 /datum/category_collection/player_setup_collection/proc/header()
 	var/dat = ""
 	for(var/datum/category_group/player_setup_category/PS in categories)
@@ -143,6 +147,12 @@
 	for(var/datum/category_item/player_setup_item/PI in items)
 		PI.save_preferences(S)
 
+/datum/category_group/player_setup_category/proc/copy_to_mob(var/mob/living/carbon/human/C)
+	for(var/datum/category_item/player_setup_item/PI in items)
+		PI.sanitize_character()
+	for(var/datum/category_item/player_setup_item/PI in items)
+		PI.copy_to_mob(C)
+
 /datum/category_group/player_setup_category/proc/content(var/mob/user)
 	. = "<table style='width:100%'><tr style='vertical-align:top'><td style='width:50%'>"
 	var/current = 0
@@ -199,6 +209,12 @@
 * Called when the item is asked to save user/global settings
 */
 /datum/category_item/player_setup_item/proc/save_preferences(var/savefile/S)
+	return
+
+/*
+* Called when the item is asked to apply its per character settings to a new mob.
+*/
+/datum/category_item/player_setup_item/proc/copy_to_mob(var/mob/living/carbon/human/C)
 	return
 
 /datum/category_item/player_setup_item/proc/content()

--- a/code/modules/client/preference_setup/skills/skills.dm
+++ b/code/modules/client/preference_setup/skills/skills.dm
@@ -18,6 +18,11 @@
 	if(!pref.skills.len)			pref.ZeroSkills()
 	if(pref.used_skillpoints < 0)	pref.used_skillpoints = 0
 
+// Moved from /datum/preferences/proc/copy_to()
+/datum/category_item/player_setup_item/skills/copy_to_mob(var/mob/living/carbon/human/character)
+	character.skills			= pref.skills
+	character.used_skillpoints	= pref.used_skillpoints
+
 /datum/category_item/player_setup_item/skills/content()
 	. = list()
 	. += "<b>Select your Skills</b><br>"

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -251,118 +251,15 @@ datum/preferences
 /datum/preferences/proc/copy_to(mob/living/carbon/human/character, icon_updates = 1)
 	// Sanitizing rather than saving as someone might still be editing when copy_to occurs.
 	player_setup.sanitize_setup()
+
+	// This needs to happen before anything else becuase it sets some variables.
 	character.set_species(species)
+	// Special Case: This references variables owned by two different datums, so do it here.
 	if(be_random_name)
 		real_name = random_name(identifying_gender,species)
 
-	if(config.humans_need_surnames)
-		var/firstspace = findtext(real_name, " ")
-		var/name_length = length(real_name)
-		if(!firstspace)	//we need a surname
-			real_name += " [pick(last_names)]"
-		else if(firstspace == name_length)
-			real_name += "[pick(last_names)]"
-
-	character.real_name = real_name
-	character.name = character.real_name
-	if(character.dna)
-		character.dna.real_name = character.real_name
-
-	character.flavor_texts["general"] = flavor_texts["general"]
-	character.flavor_texts["head"] = flavor_texts["head"]
-	character.flavor_texts["face"] = flavor_texts["face"]
-	character.flavor_texts["eyes"] = flavor_texts["eyes"]
-	character.flavor_texts["torso"] = flavor_texts["torso"]
-	character.flavor_texts["arms"] = flavor_texts["arms"]
-	character.flavor_texts["hands"] = flavor_texts["hands"]
-	character.flavor_texts["legs"] = flavor_texts["legs"]
-	character.flavor_texts["feet"] = flavor_texts["feet"]
-
-	character.med_record = med_record
-	character.sec_record = sec_record
-	character.gen_record = gen_record
-	character.exploit_record = exploit_record
-
-	character.gender = biological_gender
-	character.identifying_gender = identifying_gender
-	character.age = age
-	character.b_type = b_type
-
-	character.r_eyes = r_eyes
-	character.g_eyes = g_eyes
-	character.b_eyes = b_eyes
-
-	character.h_style = h_style
-	character.r_hair = r_hair
-	character.g_hair = g_hair
-	character.b_hair = b_hair
-
-	character.f_style = f_style
-	character.r_facial = r_facial
-	character.g_facial = g_facial
-	character.b_facial = b_facial
-
-	character.r_skin = r_skin
-	character.g_skin = g_skin
-	character.b_skin = b_skin
-
-	character.s_tone = s_tone
-
-	character.h_style = h_style
-	character.f_style = f_style
-
-	character.home_system = home_system
-	character.citizenship = citizenship
-	character.personal_faction = faction
-	character.religion = religion
-
-	character.skills = skills
-	character.used_skillpoints = used_skillpoints
-
-	// Destroy/cyborgize organs and limbs.
-	for(var/name in list(BP_HEAD, BP_L_HAND, BP_R_HAND, BP_L_ARM, BP_R_ARM, BP_L_FOOT, BP_R_FOOT, BP_L_LEG, BP_R_LEG, BP_GROIN, BP_TORSO))
-		var/status = organ_data[name]
-		var/obj/item/organ/external/O = character.organs_by_name[name]
-		if(O)
-			if(status == "amputated")
-				O.remove_rejuv()
-			else if(status == "cyborg")
-				if(rlimb_data[name])
-					O.robotize(rlimb_data[name])
-				else
-					O.robotize()
-
-	for(var/name in list(O_HEART,O_EYES,O_BRAIN))
-		var/status = organ_data[name]
-		if(!status)
-			continue
-		var/obj/item/organ/I = character.internal_organs_by_name[name]
-		if(I)
-			if(status == "assisted")
-				I.mechassist()
-			else if(status == "mechanical")
-				I.robotize()
-
-	character.all_underwear.Cut()
-	character.all_underwear_metadata.Cut()
-
-	for(var/underwear_category_name in all_underwear)
-		var/datum/category_group/underwear/underwear_category = global_underwear.categories_by_name[underwear_category_name]
-		if(underwear_category)
-			var/underwear_item_name = all_underwear[underwear_category_name]
-			character.all_underwear[underwear_category_name] = underwear_category.items_by_name[underwear_item_name]
-			if(all_underwear_metadata[underwear_category_name])
-				character.all_underwear_metadata[underwear_category_name] = all_underwear_metadata[underwear_category_name]
-		else
-			all_underwear -= underwear_category_name
-
-	if(backbag > 4 || backbag < 1)
-		backbag = 1 //Same as above
-	character.backbag = backbag
-
-	if(pdachoice > 3 || pdachoice < 1)
-		pdachoice = 1
-	character.pdachoice = pdachoice
+	// Ask the preferences datums to apply their own settings to the new mob 
+	player_setup.copy_to_mob(character)
 
 	if(icon_updates)
 		character.force_update_limbs()


### PR DESCRIPTION
* The /datum/category_item/player_setup_item datums did a good job of organizing the code for loading/saving/editing preferences data, but all of the code that applies preferences to newly created player mobs was still in a single function.
* This change adds a new proc to player_setup_item datums:  copy_to_mob()  which is called from the traditional copy_to() proc, allowing each preferences datum to apply its own character data to the mob.
* This allowes new preferences to easily compartmentalize their new code.
* I also moved all the code for existing preferences from copy_to()  into the copy_to_mob() on their respective preferences datums.