### PR TITLE
Fixes #1837

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -87,6 +87,7 @@
 	name = "External Airlock"
 	icon = 'icons/obj/doors/Doorext.dmi'
 	assembly_type = /obj/structure/door_assembly/door_assembly_ext
+	opacity = 0
 
 /obj/machinery/door/airlock/glass
 	name = "Glass Airlock"


### PR DESCRIPTION
They obviously have little windows on them. And this is how they used to be. Was probably an oversight when they were converted to another format or something. Airlocks without windows are preeeetty silly.