### PR TITLE
Loyalty implant for HoP

### DIFF
--- a/code/game/jobs/job/captain.dm
+++ b/code/game/jobs/job/captain.dm
@@ -30,13 +30,13 @@ var/datum/announcement/minor/captain_announcement = new(do_newscast = 1)
 			if(2) H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/captain(H), slot_back)
 			if(3) H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/satchel/cap(H), slot_back)
 			if(4) H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/satchel(H), slot_back)
-		H.equip_to_slot_or_del(new /obj/item/clothing/under/rank/captain(H), slot_w_uniform) 
+		H.equip_to_slot_or_del(new /obj/item/clothing/under/rank/captain(H), slot_w_uniform)
 		if(H.age>49)
-			// Since we can have something other than the default uniform at this  
+			// Since we can have something other than the default uniform at this
 			// point, check if we can actually attach the medal
 			var/obj/item/clothing/uniform = H.w_uniform
 			var/obj/item/clothing/accessory/medal/gold/captain/medal = new()
-			
+
 			if(uniform && uniform.can_attach_accessory(medal))
 				uniform.attach_accessory(null, medal)
 			else
@@ -107,4 +107,5 @@ var/datum/announcement/minor/captain_announcement = new(do_newscast = 1)
 			H.equip_to_slot_or_del(new /obj/item/weapon/storage/box/ids(H), slot_l_hand)
 		else
 			H.equip_to_slot_or_del(new /obj/item/weapon/storage/box/ids(H.back), slot_in_backpack)
+		H.implant_loyalty()
 		return 1

--- a/html/changelogs/JerTheAce_HoPLoyalty.yml
+++ b/html/changelogs/JerTheAce_HoPLoyalty.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: JerTheAce
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Head of Personnel now has a loyalty implant."


### PR DESCRIPTION
I'm pretty sure this used to be the case and I don't know why it was changed.

Why would you NOT give a loyalty implant to the guy who can give himself (and others) all access, is second in command to the Captain, and has access to everyone's bank accounts?

HoS, HoP, and Captain all have the power to individually single handedly doom the entire station if they decide they want to be jerks at work that day. If NanoTrasen is going to buy loyalty implants for them, they should have implants for all three of them or none at all.