### PR TITLE
Allows cards to go on the ear slot

### DIFF
--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -15,7 +15,8 @@
 	name = "card"
 	desc = "Does card things."
 	icon = 'icons/obj/card.dmi'
-	w_class = 1.0
+	w_class = 1
+	slot_flags = SLOT_EARS
 	var/associated_account_number = 0
 
 	var/list/files = list(  )


### PR DESCRIPTION
Allows ID cards, emags, and disks to go on the ear slot.
Port of: https://github.com/Baystation12/Baystation12/pull/13382