### PR TITLE
Prevent lobby players from seeing emotes

### DIFF
--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -511,7 +511,12 @@
 /mob/new_player/is_ready()
 	return ready && ..()
 
+// Prevents lobby players from seeing say, even with ghostears
 /mob/new_player/hear_say(var/message, var/verb = "says", var/datum/language/language = null, var/alt_name = "",var/italics = 0, var/mob/speaker = null)
+	return
+
+// Prevents lobby players from seeing emotes, even with ghosteyes
+/mob/new_player/show_message(msg, type, alt, alt_type)
 	return
 
 /mob/new_player/hear_radio()


### PR DESCRIPTION
Someone had already added a 'return-only' override for hear_say for new_player mobs to keep their ghostears from working in the lobby, however ghostsight/eyes/whateveritscalled has not worked as it should and it seems like nobody thought to add a show_message block for emotes.