### PR TITLE
Adds hub visibility as a config option

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -4,6 +4,8 @@ var/list/gamemode_cache = list()
 	var/server_name = null				// server name (for world name / status)
 	var/server_suffix = 0				// generate numeric suffix based on server port
 
+	var/start_hub_visible = 0			// world.visibility to set on world start
+
 	var/nudge_script_path = "nudge.py"  // where the nudge.py script is located
 
 	var/log_ooc = 0						// log OOC channel
@@ -267,6 +269,9 @@ var/list/gamemode_cache = list()
 			switch (name)
 				if ("resource_urls")
 					config.resource_urls = splittext(value, " ")
+
+				if ("start_hub_visible")
+					config.start_hub_visible = 1
 
 				if ("admin_legacy_system")
 					config.admin_legacy_system = 1

--- a/code/controllers/master_controller.dm
+++ b/code/controllers/master_controller.dm
@@ -32,6 +32,7 @@ datum/controller/game_controller/New()
 
 datum/controller/game_controller/proc/setup()
 	world.tick_lag = config.Ticklag
+	world.visibility = config.start_hub_visible
 
 	spawn(20)
 		createRandomZlevel()

--- a/code/hub.dm
+++ b/code/hub.dm
@@ -1,8 +1,10 @@
 /world
 
 	hub = "Exadv1.spacestation13"
-	hub_password = "SORRYNOPASSWORD"
+	hub_password = "kMZy3U5jJHSiBQjr"
 	name = "Space Station 13"
+	visibility = 0
+
 /* This is for any host that would like their server to appear on the main SS13 hub.
 To use it, simply replace the password above, with the password found below, and it should work.
 If not, let us know on the main tgstation IRC channel of irc.rizon.net #tgstation13 we can help you there.

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -1,6 +1,9 @@
 ## Server name: This appears at the top of the screen in-game. In this case it will read "tgstation: station_name" where station_name is the randomly generated name of the station for the round. Remove the # infront of SERVERNAME and replace 'tgstation' with the name of your choice
 # SERVERNAME spacestation13
 
+## Uncomment START_HUB_VISIBLE to cause the server to default to VISIBLE on the hub. Admins with appropriate access levels can toggle this at run time via server -> toggle hub visbility.
+# START_HUB_VISIBLE
+
 ## Alert levels
 ALERT_GREEN All threats to the station have passed. Security may not have weapons visible, privacy laws are once again fully enforced.
 ALERT_BLUE_UPTO The station has received reliable information about possible hostile activity on the station. Security staff may have weapons visible, random searches are permitted.

--- a/html/changelogs/Spookerton_hub-visibility.yml
+++ b/html/changelogs/Spookerton_hub-visibility.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Spookerton
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Changes hub visibility to be controlled by a config option."


### PR DESCRIPTION
* Compiles with the correct hub password by default.
* Sets world visibility to 0 to maintain prior behavior.
* Adds a configuration toggle for setting the world public on startup.

And that's about it.
Since this causes world visibility to be decided at run time, it may override command line DD start switches. Unsure if that will be problematic for anyone.

* actually fuggit, reopening as one commit.