### PR TITLE
Clicking a stack no longer transfers one sheet at a time.

### DIFF
--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -298,14 +298,16 @@
 
 /obj/item/stack/attack_hand(mob/user as mob)
 	if (user.get_inactive_hand() == src)
-		var/obj/item/stack/F = src.split(1)
-		if (F)
-			user.put_in_hands(F)
-			src.add_fingerprint(user)
-			F.add_fingerprint(user)
-			spawn(0)
-				if (src && usr.machine==src)
-					src.interact(usr)
+		var/N = input("How many stacks of [src] would you like to split off?", "Split stacks", 1) as num|null
+		if(N)
+			var/obj/item/stack/F = src.split(N)
+			if (F)
+				user.put_in_hands(F)
+				src.add_fingerprint(user)
+				F.add_fingerprint(user)
+				spawn(0)
+					if (src && usr.machine==src)
+						src.interact(usr)
 	else
 		..()
 	return
@@ -313,10 +315,7 @@
 /obj/item/stack/attackby(obj/item/W as obj, mob/user as mob)
 	if (istype(W, /obj/item/stack))
 		var/obj/item/stack/S = W
-		if (user.get_inactive_hand()==src)
-			src.transfer_to(S, 1)
-		else
-			src.transfer_to(S)
+		src.transfer_to(S)
 
 		spawn(0) //give the stacks a chance to delete themselves if necessary
 			if (S && usr.machine==S)

--- a/html/changelogs/Aztectornado_Stack.yml
+++ b/html/changelogs/Aztectornado_Stack.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Aztectornado
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Clicking a stack of sheets (Metal, phoron...) in your other hand now asks how many you want to split off the stack, courtesy of Baycode"


### PR DESCRIPTION
 Know how when you click a sheet stack (eg metal) in your other hand, you'd pull one sheet off, and then clicking again would add one extra sheet, so every time you needed only a small amount, you'd have to sit there spamclicking against the server ticks?

No more!

This adds a simple little popup so that when you click a sheet stack in your other hand, you'll instead get asked how many sheets you want to split off from the main stack, skipping tedious spamclicking! Since you now no longer need to transfer them one sheet at a time, this also makes it so clicking a sheet in your offhand with a sheet in your primary hand will merge the two stacks together, just as if you clicked the sheets while they were lying on the ground. 

This is useful for times when you maybe don't want to take /all/ of the metal from engineering storage, or if you want to divide up the spoils of mining between robotics and RnD to some specific ratio. The input defaults to 1 when first opened though, so if you're in a hurry and only want one diamond to throw into the deconstruction machine, you can just click or hit enter after it opens.