### PR TITLE
Corrects ChemMaster Bottle Sprites

### DIFF
--- a/code/modules/reagents/Chemistry-Machinery.dm
+++ b/code/modules/reagents/Chemistry-Machinery.dm
@@ -249,7 +249,7 @@
 				P.name = "[name] bottle"
 				P.pixel_x = rand(-7, 7) //random position
 				P.pixel_y = rand(-7, 7)
-				P.icon_state = "bottle"+bottlesprite
+				P.icon_state = "bottle-"+bottlesprite
 				reagents.trans_to_obj(P,60)
 				P.update_icon()
 			else


### PR DESCRIPTION
Changes the sprite assignment to the newer bottle types, rather than the old ones.

The old bottles are unmaintained and do not display any quantity indication or color.