### PR TITLE
Developers now appear in Staffwho

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -65,6 +65,7 @@ var/list/gamemode_cache = list()
 	var/usewhitelist = 0
 	var/kick_inactive = 0				//force disconnect for inactive players after this many minutes, if non-0
 	var/show_mods = 0
+	var/show_devs = 0
 	var/show_mentors = 0
 	var/mods_can_tempban = 0
 	var/mods_can_job_tempban = 0
@@ -504,6 +505,9 @@ var/list/gamemode_cache = list()
 
 				if("show_mods")
 					config.show_mods = 1
+
+				if("show_devs")
+					config.show_devs = 1
 
 				if("show_mentors")
 					config.show_mentors = 1

--- a/code/game/verbs/who.dm
+++ b/code/game/verbs/who.dm
@@ -69,9 +69,11 @@
 
 	var/msg = ""
 	var/modmsg = ""
+	var/devmsg = ""
 	var/mentmsg = ""
 	var/num_mods_online = 0
 	var/num_admins_online = 0
+	var/num_devs_online = 0
 	var/num_mentors_online = 0
 	if(holder)
 		for(var/client/C in admins)
@@ -118,6 +120,23 @@
 				modmsg += "\n"
 				num_mods_online++
 
+			else if(R_SERVER & C.holder.rights)
+				devmsg += "\t[C] is a [C.holder.rank]"
+				if(isobserver(C.mob))
+					devmsg += " - Observing"
+				else if(istype(C.mob,/mob/new_player))
+					devmsg += " - Lobby"
+				else
+					devmsg += " - Playing"
+
+				if(C.is_afk())
+					var/seconds = C.last_activity_seconds()
+					devmsg += "(AFK - "
+					devmsg += "[round(seconds / 60)] minutes, "
+					devmsg += "[seconds % 60] seconds)"
+				devmsg += "\n"
+				num_devs_online++
+
 			else if(R_MENTOR & C.holder.rights)
 				mentmsg += "\t[C] is a [C.holder.rank]"
 				if(isobserver(C.mob))
@@ -144,6 +163,9 @@
 			else if (R_MOD & C.holder.rights)
 				modmsg += "\t[C] is a [C.holder.rank]\n"
 				num_mods_online++
+			else if (R_SERVER & C.holder.rights)
+				devmsg += "\t[C] is a [C.holder.rank]\n"
+				num_devs_online++
 			else if (R_MENTOR & C.holder.rights)
 				mentmsg += "\t[C] is a [C.holder.rank]\n"
 				num_mentors_online++
@@ -154,6 +176,9 @@
 
 	if(config.show_mods)
 		msg += "\n<b> Current Moderators ([num_mods_online]):</b>\n" + modmsg
+
+	if(config.show_devs)
+		msg += "\n<b> Current Developers ([num_devs_online]):</b>\n" + devmsg
 
 	if(config.show_mentors)
 		msg += "\n<b> Current Mentors ([num_mentors_online]):</b>\n" + mentmsg

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -76,6 +76,8 @@ SQL_ENABLED
 ## disconnect players who did nothing during the set amount of minutes
 # KICK_INACTIVE 10
 
+##Show developers on staffwho
+SHOW_DEVS
 ##Show mods on staffwho
 SHOW_MODS
 


### PR DESCRIPTION
Fixes #1857 

Adds a config option to show developers, when on they appear under moderators but above mentors.

![show_devs](https://cloud.githubusercontent.com/assets/10236878/16399879/f58573ec-3c9b-11e6-8c62-35b0afd58fd7.png)

This shows the setup when all of the configs are on.