### PR TITLE
Allows Circuit-Brains (Digital) to be chosen as an FBP brain-type.

### DIFF
--- a/code/modules/client/preference_setup/general/03_body.dm
+++ b/code/modules/client/preference_setup/general/03_body.dm
@@ -121,6 +121,8 @@ var/global/list/valid_bloodtypes = list("A+", "A-", "B+", "B-", "AB+", "AB-", "O
 				I.mechassist()
 			else if(status == "mechanical")
 				I.robotize()
+			else if(status == "digital")
+				I.digitize()
 	return
 
 /datum/category_item/player_setup_item/general/body/content(var/mob/user)
@@ -197,6 +199,11 @@ var/global/list/valid_bloodtypes = list("A+", "A-", "B+", "B-", "AB+", "AB-", "O
 			if(ind > 1)
 				. += ", "
 			. += "\tSynthetic [organ_name]"
+		else if(status == "digital")
+			++ind
+			if(ind > 1)
+				. += ", "
+			. += "\tDigital [organ_name]"
 		else if(status == "assisted")
 			++ind
 			if(ind > 1)
@@ -549,6 +556,8 @@ var/global/list/valid_bloodtypes = list("A+", "A-", "B+", "B-", "AB+", "AB-", "O
 		var/list/organ_choices = list("Normal","Assisted","Mechanical")
 		if(pref.organ_data[BP_TORSO] == "cyborg")
 			organ_choices -= "Normal"
+			if(organ_name == "Brain")
+				organ_choices += "Digital"
 
 		var/new_state = input(user, "What state do you wish the organ to be in?") as null|anything in organ_choices
 		if(!new_state) return
@@ -560,6 +569,8 @@ var/global/list/valid_bloodtypes = list("A+", "A-", "B+", "B-", "AB+", "AB-", "O
 				pref.organ_data[organ] = "assisted"
 			if("Mechanical")
 				pref.organ_data[organ] = "mechanical"
+			if("Digital")
+				pref.organ_data[organ] = "digital"
 		return TOPIC_REFRESH
 
 	else if(href_list["disabilities"])

--- a/code/modules/mob/living/carbon/brain/brain_item.dm
+++ b/code/modules/mob/living/carbon/brain/brain_item.dm
@@ -21,6 +21,9 @@
 /obj/item/organ/internal/brain/mechassist()
 	replace_self_with(/obj/item/organ/internal/mmi_holder)
 
+/obj/item/organ/internal/brain/digitize()
+	replace_self_with(/obj/item/organ/internal/mmi_holder/robot)
+
 /obj/item/organ/internal/brain/proc/replace_self_with(replace_path)
 	var/mob/living/carbon/human/tmp_owner = owner
 	qdel(src)

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -259,6 +259,10 @@ var/list/organ_cache = list()
 	min_bruised_damage = 15
 	min_broken_damage = 35
 
+/obj/item/organ/proc/digitize() //Used to make circuit organs like robobrains
+	robotize()
+	src.status &= "digital"
+
 /obj/item/organ/emp_act(severity)
 	if(!(robotic >= ORGAN_ROBOT))
 		return

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -259,9 +259,8 @@ var/list/organ_cache = list()
 	min_bruised_damage = 15
 	min_broken_damage = 35
 
-/obj/item/organ/proc/digitize() //Used to make circuit organs like robobrains
+/obj/item/organ/proc/digitize() //Used to make the circuit-brain. On this level in the event more circuit-organs are added/tweaks are wanted.
 	robotize()
-	src.status &= "digital"
 
 /obj/item/organ/emp_act(severity)
 	if(!(robotic >= ORGAN_ROBOT))

--- a/code/modules/organs/subtypes/machine.dm
+++ b/code/modules/organs/subtypes/machine.dm
@@ -84,9 +84,18 @@
 /obj/item/organ/internal/mmi_holder/posibrain
 	name = "positronic brain interface"
 	brain_type = /obj/item/device/mmi/digital/posibrain
-	
+
 
 /obj/item/organ/internal/mmi_holder/posibrain/update_from_mmi()
 	..()
 	stored_mmi.icon_state = "posibrain-occupied"
+	icon_state = stored_mmi.icon_state
+
+/obj/item/organ/internal/mmi_holder/robot
+	name = "digital brain interface"
+	brain_type = /obj/item/device/mmi/digital/robot
+
+/obj/item/organ/internal/mmi_holder/robot/update_from_mmi()
+	..()
+	stored_mmi.icon_state = "mainboard"
 	icon_state = stored_mmi.icon_state


### PR DESCRIPTION
I've opened this so it is available for staff discussion, and not gathering dust sitting in my repo-folder.

This will allow FBP's to choose to have a circuit-based brain in character set-up, similarly to MMI or Positronic brains, through the selection of the 'Digital' option in brain selection.