### PR TITLE
Fixes chem masters not filling bottles when sprite is never changed.

### DIFF
--- a/code/modules/reagents/Chemistry-Machinery.dm
+++ b/code/modules/reagents/Chemistry-Machinery.dm
@@ -22,8 +22,8 @@
 	var/condi = 0
 	var/useramount = 15 // Last used amount
 	var/pillamount = 10
-	var/bottlesprite = 1
-	var/pillsprite = 1
+	var/bottlesprite = "1"
+	var/pillsprite = "1"
 	var/max_pill_count = 20
 	var/tab = "home"
 	var/analyze_data[0]


### PR DESCRIPTION
Without setting a sprite, you'd get a type mismatch when trying to combine the number and the string for the bottle icon.

@SinTwo Condimaster's UI still need fixing.