### PR TITLE
Makes flashes confuse and blind the person instead of stunning

### DIFF
--- a/code/game/objects/items/devices/flash.dm
+++ b/code/game/objects/items/devices/flash.dm
@@ -74,13 +74,17 @@
 		if(M.stat!=DEAD)
 			var/safety = M:eyecheck()
 			if(safety <= 0)
-				var/flash_strength = 10
+				var/flash_strength = 5
 				if(ishuman(M))
 					var/mob/living/carbon/human/H = M
 					flash_strength *= H.species.flash_mod
-				if(flash_strength > 0)
-					M.Weaken(flash_strength)
-					M.flash_eyes()
+
+					if(flash_strength > 0)
+						H.confused = max(H.confused, flash_strength)
+						H.eye_blind = max(H.eye_blind, flash_strength)
+						H.eye_blurry = max(H.eye_blurry, flash_strength + 5)
+						H.flash_eyes()
+
 			else
 				flashfail = 1
 

--- a/html/changelogs/Yoshax - flashnerf.yml
+++ b/html/changelogs/Yoshax - flashnerf.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Yoshax
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Flashes no longer provide an instant stun. Flashes now confuse and blind the affected person for five seconds and in addition makes their eyes blurry for ten seconds."


### PR DESCRIPTION
We have removed most of the previously existing instant stuns but kept flash as such. In its current state you can flash someone and pin them onto the floor, and there is basically nothing they can do. There is no reason for it, and it should go.

Flash will now:
Conufse for 5 seconds
Blind for 5 seconds
Blurry for 10 seconds