### PR TITLE
Planetary Walls

### DIFF
--- a/code/game/turfs/unsimulated/planetary.dm
+++ b/code/game/turfs/unsimulated/planetary.dm
@@ -1,0 +1,47 @@
+// This is a wall you surround the area of your "planet" with, that makes the atmosphere inside stay within bounds, even if canisters
+// are opened or other strange things occur.
+/turf/unsimulated/wall/planetary
+	name = "railroading"
+	desc = "Choo choo!"
+	icon = 'icons/turf/walls.dmi'
+	icon_state = "riveted"
+	opacity = 1
+	density = 1
+	alpha = 0
+	blocks_air = 0
+
+	// Set these to get your desired planetary atmosphere.
+	oxygen = 0
+	nitrogen = 0
+	carbon_dioxide = 0
+	phoron = 0
+	temperature = T20C
+
+// Normal station/earth air.
+/turf/unsimulated/wall/planetary/normal
+	oxygen = MOLES_O2STANDARD
+	nitrogen = MOLES_N2STANDARD
+
+/turf/unsimulated/wall/planetary/firnir
+	temperature = 570
+	carbon_dioxide = 0.04863
+
+/turf/unsimulated/wall/planetary/tyr
+	temperature = 405
+	carbon_dioxide = 0.15848
+
+// Wiki says it's 92.6 kPa, composition 18.1% O2 80.8% N2 1.1% trace.  We're gonna pretend trace is actually nitrogen.
+/turf/unsimulated/wall/planetary/sif
+	oxygen		= 114.50978 * 0.181
+	nitrogen	= 114.50978 * 0.819
+	temperature	= 243.15 // Roughly -30C / -22F
+
+// Fairly close to Mars in terms of temperature and pressure.
+/turf/unsimulated/wall/planetary/magni
+	carbon_dioxide = 0.90998361
+	temperature = 202
+
+/turf/unsimulated/wall/planetary/desert
+	oxygen = MOLES_O2STANDARD
+	nitrogen = MOLES_N2STANDARD
+	temperature = 310.92 // About 37.7C / 100F

--- a/polaris.dme
+++ b/polaris.dme
@@ -904,6 +904,7 @@
 #include "code\game\turfs\space\transit.dm"
 #include "code\game\turfs\unsimulated\beach.dm"
 #include "code\game\turfs\unsimulated\floor.dm"
+#include "code\game\turfs\unsimulated\planetary.dm"
 #include "code\game\turfs\unsimulated\walls.dm"
 #include "code\game\verbs\ignore.dm"
 #include "code\game\verbs\ooc.dm"


### PR DESCRIPTION
Adds a new type of wall, which makes atmospherics pretend there is actually something beyond the wall that has gas to merge with.  This is used by surrounding your "planet" with this wall.  It's suggested you find more natural ways to wall off the area aways from this final wall (like using trees).
I added some presets for normal air, as well as all of the terrestrial planets of the Vir system.

Thanks to Mloc for telling me that unsimulated walls can do this, so I don't need to use a horrific invisible atmospherics machine.