### PR TITLE
Fix inconsistency with alien whitelist

### DIFF
--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -342,7 +342,7 @@ var/global/datum/controller/occupations/job_master
 						else
 							permitted = 1
 
-						if(G.whitelisted && !is_alien_whitelisted(H, G.whitelisted))
+						if(G.whitelisted && !is_alien_whitelisted(H, all_species[G.whitelisted]))
 							permitted = 0
 
 						if(!permitted)

--- a/code/game/jobs/whitelist.dm
+++ b/code/game/jobs/whitelist.dm
@@ -30,22 +30,48 @@ var/list/whitelist = list()
 	else
 		alien_whitelist = splittext(text, "\n")
 
-//todo: admin aliens
-/proc/is_alien_whitelisted(mob/M, var/species)
-	if(!config.usealienwhitelist)
-		return 1
-	if(species == "human" || species == "Human")
-		return 1
-	if(check_rights(R_ADMIN, 0))
-		return 1
-	if(!alien_whitelist)
-		return 0
-	if(M && species)
+/proc/is_alien_whitelisted(mob/M, var/datum/species/species)
+	//They are admin or the whitelist isn't in use
+	if(whitelist_overrides(M)) return 1
+
+	//You did something wrong
+	if(!M || !species) return 0
+
+	//The species isn't even whitelisted
+	if(!(species.spawn_flags & SPECIES_IS_WHITELISTED)) return 1
+
+	//If we have a loaded file, search it
+	if(alien_whitelist)
 		for (var/s in alien_whitelist)
-			if(findtext(s,"[M.ckey] - [species]"))
+			if(findtext(s,"[M.ckey] - [species.name]"))
 				return 1
 			if(findtext(s,"[M.ckey] - All"))
 				return 1
+
+/proc/is_lang_whitelisted(mob/M, var/datum/language/language)
+	//They are admin or the whitelist isn't in use
+	if(whitelist_overrides(M)) return 1
+
+	//You did something wrong
+	if(!M || !language) return 0
+
+	//The language isn't even whitelisted
+	if(!(language.flags & WHITELISTED)) return 1
+
+	//If we have a loaded file, search it
+	if(alien_whitelist)
+		for (var/s in alien_whitelist)
+			if(findtext(s,"[M.ckey] - [language.name]"))
+				return 1
+			if(findtext(s,"[M.ckey] - All"))
+				return 1
+
+/proc/whitelist_overrides(mob/M)
+	if(!config.usealienwhitelist)
+		return 1
+	if(check_rights(R_ADMIN, 0))
+		return 1
+
 	return 0
 
 #undef WHITELISTFILE

--- a/code/modules/client/preference_setup/general/02_language.dm
+++ b/code/modules/client/preference_setup/general/02_language.dm
@@ -49,7 +49,7 @@
 			var/list/available_languages = S.secondary_langs.Copy()
 			for(var/L in all_languages)
 				var/datum/language/lang = all_languages[L]
-				if(!(lang.flags & RESTRICTED) && (!config.usealienwhitelist || is_alien_whitelisted(user, L) || !(lang.flags & WHITELISTED)))
+				if(!(lang.flags & RESTRICTED) && (is_lang_whitelisted(user, lang)))
 					available_languages |= L
 
 			// make sure we don't let them waste slots on the default languages

--- a/code/modules/client/preference_setup/general/03_body.dm
+++ b/code/modules/client/preference_setup/general/03_body.dm
@@ -640,11 +640,11 @@ var/global/list/valid_bloodtypes = list("A+", "A-", "B+", "B-", "AB+", "AB-", "O
 	dat += "</table><center><hr/>"
 
 	var/restricted = 0
-	if(config.usealienwhitelist) //If we're using the whitelist, make sure to check it!
-		if(!(current_species.spawn_flags & SPECIES_CAN_JOIN))
-			restricted = 2
-		else if((current_species.spawn_flags & SPECIES_IS_WHITELISTED) && !is_alien_whitelisted(preference_mob(),current_species))
-			restricted = 1
+
+	if(!(current_species.spawn_flags & SPECIES_CAN_JOIN))
+		restricted = 2
+	else if(!is_alien_whitelisted(preference_mob(),current_species))
+		restricted = 1
 
 	if(restricted)
 		if(restricted == 1)

--- a/code/modules/client/preference_setup/loadout/loadout.dm
+++ b/code/modules/client/preference_setup/loadout/loadout.dm
@@ -55,7 +55,7 @@ var/list/gear_datums = list()
 	var/list/valid_gear_choices = list()
 	for(var/gear_name in gear_datums)
 		var/datum/gear/G = gear_datums[gear_name]
-		if(G.whitelisted && !is_alien_whitelisted(preference_mob(), G.whitelisted))
+		if(G.whitelisted && !is_alien_whitelisted(preference_mob(), all_species[G.whitelisted]))
 			continue
 		if(max_cost && G.cost > max_cost)
 			continue

--- a/code/modules/mob/living/carbon/alien/diona/progression.dm
+++ b/code/modules/mob/living/carbon/alien/diona/progression.dm
@@ -1,6 +1,6 @@
 /mob/living/carbon/alien/diona/confirm_evolution()
 
-	if(!is_alien_whitelisted(src, "Diona") && config.usealienwhitelist)
+	if(!is_alien_whitelisted(src, all_species["Diona"]))
 		src << alert("You are currently not whitelisted to play as a full diona.")
 		return null
 

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -152,16 +152,6 @@
 			usr << "\red The round is either not ready, or has already finished..."
 			return
 
-		if(client.prefs.species != "Human" && !check_rights(R_ADMIN, 0))
-			if(!is_alien_whitelisted(src, client.prefs.species) && config.usealienwhitelist)
-				src << alert("You are currently not whitelisted to play [client.prefs.species].")
-				return 0
-
-			var/datum/species/S = all_species[client.prefs.species]
-			if(!(S.spawn_flags & SPECIES_IS_WHITELISTED))
-				src << alert("Your current species,[client.prefs.species], is not available for play on the station.")
-				return 0
-
 		LateChoices()
 
 	if(href_list["manifest"])
@@ -176,15 +166,14 @@
 			usr << "<span class='danger'>The station is currently exploding. Joining would go poorly.</span>"
 			return
 
-		if(client.prefs.species != "Human")
-			if(!is_alien_whitelisted(src, client.prefs.species) && config.usealienwhitelist)
-				src << alert("You are currently not whitelisted to play [client.prefs.species].")
-				return 0
+		if(!is_alien_whitelisted(src, all_species[client.prefs.species]))
+			src << alert("You are currently not whitelisted to play [client.prefs.species].")
+			return 0
 
-			var/datum/species/S = all_species[client.prefs.species]
-			if(!(S.spawn_flags & SPECIES_CAN_JOIN))
-				src << alert("Your current species, [client.prefs.species], is not available for play on the station.")
-				return 0
+		var/datum/species/S = all_species[client.prefs.species]
+		if(!(S.spawn_flags & SPECIES_CAN_JOIN))
+			src << alert("Your current species, [client.prefs.species], is not available for play on the station.")
+			return 0
 
 		AttemptLateSpawn(href_list["SelectedJob"],client.prefs.spawnpoint)
 		return
@@ -413,7 +402,7 @@
 
 	if(chosen_species && use_species_name)
 		// Have to recheck admin due to no usr at roundstart. Latejoins are fine though.
-		if(is_species_whitelisted(chosen_species) || has_admin_rights())
+		if(is_alien_whitelisted(chosen_species))
 			new_character = new(loc, use_species_name)
 
 	if(!new_character)
@@ -424,8 +413,7 @@
 	for(var/lang in client.prefs.alternate_languages)
 		var/datum/language/chosen_language = all_languages[lang]
 		if(chosen_language)
-			if(!config.usealienwhitelist || !(chosen_language.flags & WHITELISTED) || is_alien_whitelisted(src, lang) || has_admin_rights() \
-				|| (new_character.species && (chosen_language.name in new_character.species.secondary_langs)))
+			if(is_lang_whitelisted(src,chosen_language) || (new_character.species && (chosen_language.name in new_character.species.secondary_langs)))
 				new_character.add_language(lang)
 
 	if(ticker.random_players)
@@ -487,10 +475,6 @@
 /mob/new_player/proc/has_admin_rights()
 	return check_rights(R_ADMIN, 0, src)
 
-/mob/new_player/proc/is_species_whitelisted(datum/species/S)
-	if(!S) return 1
-	return is_alien_whitelisted(src, S.name) || !config.usealienwhitelist || !(S.spawn_flags & SPECIES_IS_WHITELISTED)
-
 /mob/new_player/get_species()
 	var/datum/species/chosen_species
 	if(client.prefs.species)
@@ -499,7 +483,7 @@
 	if(!chosen_species)
 		return "Human"
 
-	if(is_species_whitelisted(chosen_species) || has_admin_rights())
+	if(is_alien_whitelisted(chosen_species))
 		return chosen_species.name
 
 	return "Human"


### PR DESCRIPTION
The alien whitelist had some _interesting behavior_. Such as that the way new_player.dm was written, all things not "Human" were whitelisted. Regardless of the SPECIES_IS_WHITELISTED flag. Which is unfortunate. Because that's what that flag is for.

This simplifies new_player and redoes is_alien_whitelisted, and removes the unnecessary is_species_whitelisted (probably part of the confusion, since is_alien_whitelisted was used when is_species_whitelisted should have been used). Also adds is_lang_whitelisted because passing languages or species to the same place is unusual.

Oh also there was no exception for gear, such that if say, the Tajaran fur clothing thing wanted to be spawned, even if Tajaran was not a whitelisted species, it'd not let you spawn with it. Doesn't make much sense.