### PR TITLE
Makes communicators not show up on camera networks by default

### DIFF
--- a/code/game/machinery/camera/presets.dm
+++ b/code/game/machinery/camera/presets.dm
@@ -17,8 +17,7 @@ var/global/list/station_networks = list(
 										NETWORK_RESEARCH_OUTPOST,
 										NETWORK_ROBOTS,
 										NETWORK_PRISON,
-										NETWORK_SECURITY,
-										NETWORK_COMMUNICATORS
+										NETWORK_SECURITY
 										)
 var/global/list/engineering_networks = list(
 										NETWORK_ENGINE,


### PR DESCRIPTION
Now you can have communicators and not worry about the HoS spying on you in the bathroom.