### PR TITLE
Removes the Robot Console's ability to blow up borgs

### DIFF
--- a/code/game/machinery/computer/robot.dm
+++ b/code/game/machinery/computer/robot.dm
@@ -8,8 +8,6 @@
 	req_access = list(access_robotics)
 	circuit = /obj/item/weapon/circuitboard/robotics
 
-	var/safety = 1
-
 /obj/machinery/computer/robotics/attack_ai(var/mob/user as mob)
 	ui_interact(user)
 
@@ -19,8 +17,6 @@
 /obj/machinery/computer/robotics/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1)
 	var/data[0]
 	data["robots"] = get_cyborgs(user)
-	data["safety"] = safety
-	// Also applies for cyborgs. Hides the manual self-destruct button.
 	data["is_ai"] = issilicon(user)
 
 
@@ -39,39 +35,8 @@
 		user << "Access Denied"
 		return
 
-	// Destroys the cyborg
-	if(href_list["detonate"])
-		var/mob/living/silicon/robot/target = get_cyborg_by_name(href_list["detonate"])
-		if(!target || !istype(target))
-			return
-		if(isAI(user) && (target.connected_ai != user))
-			user << "Access Denied. This robot is not linked to you."
-			return
-		// Cyborgs may blow up themselves via the console
-		if(isrobot(user) && user != target)
-			user << "Access Denied."
-			return
-		var/choice = input("Really detonate [target.name]?") in list ("Yes", "No")
-		if(choice != "Yes")
-			return
-		if(!target || !istype(target))
-			return
-
-		// Antagonistic cyborgs? Left here for downstream
-		if(target.mind && (target.mind.special_role || target.emagged))
-			target << "Extreme danger.  Termination codes detected.  Scrambling security codes and automatic AI unlink triggered."
-			target.ResetSecurityCodes()
-		else
-			message_admins("<span class='notice'>[key_name_admin(usr)] detonated [target.name]!</span>")
-			log_game("[key_name(usr)] detonated [target.name]!")
-			target << "<span class='danger'>Self-destruct command received.</span>"
-			spawn(10)
-				target.self_destruct()
-
-
-
 	// Locks or unlocks the cyborg
-	else if (href_list["lockdown"])
+	if (href_list["lockdown"])
 		var/mob/living/silicon/robot/target = get_cyborg_by_name(href_list["lockdown"])
 		if(!target || !istype(target))
 			return
@@ -136,37 +101,6 @@
 		log_game("[key_name(usr)] emagged [target.name] using robotic console!")
 		target.emagged = 1
 		target << "<span class='notice'>Failsafe protocols overriden. New tools available.</span>"
-
-	// Arms the emergency self-destruct system
-	else if(href_list["arm"])
-		if(istype(user, /mob/living/silicon))
-			user << "Access Denied"
-			return
-
-		safety = !safety
-		user << "You [safety ? "disarm" : "arm"] the emergency self destruct"
-
-	// Destroys all accessible cyborgs if safety is disabled
-	else if(href_list["nuke"])
-		if(istype(user, /mob/living/silicon))
-			user << "Access Denied"
-			return
-		if(safety)
-			user << "Self-destruct aborted - safety active"
-			return
-
-		message_admins("<span class='notice'>[key_name_admin(usr)] detonated all cyborgs!</span>")
-		log_game("[key_name(usr)] detonated all cyborgs!")
-
-		for(var/mob/living/silicon/robot/R in mob_list)
-			if(istype(R, /mob/living/silicon/robot/drone))
-				continue
-			// Ignore antagonistic cyborgs
-			if(R.scrambledcodes)
-				continue
-			R << "<span class='danger'>Self-destruct command received.</span>"
-			spawn(10)
-				R.self_destruct()
 
 
 // Proc: get_cyborgs()

--- a/html/changelogs/anewbe.yml
+++ b/html/changelogs/anewbe.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Anewbe
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscdel: "Removed joy"

--- a/html/changelogs/anewbe.yml
+++ b/html/changelogs/anewbe.yml
@@ -33,4 +33,4 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes: 
-  - rscdel: "Removed joy"
+  - rscdel: "Removed detonating borgs via Robotics Console"

--- a/nano/templates/robot_control.tmpl
+++ b/nano/templates/robot_control.tmpl
@@ -1,20 +1,4 @@
-{{if !data.is_ai}}
-	<div class='notice'>
-		<div class="itemContentSmall" style="width: 180px">
-			Emergency Self-Destruct:
-		</div>
-		<div class="itemContentFull">
-			{{if data.safety}}
-				{{:helper.link('ARM', 'unlocked', {'arm' : 1})}}
-				{{:helper.link('DETONATE', 'radiation', {'nuke' : 1}, 'disabled')}}
-			{{else}}
-				{{:helper.link('DISARM', 'locked', {'arm' : 1})}}
-				{{:helper.link('DETONATE', 'radiation', {'nuke' : 1}, null, 'redButton')}}
-			{{/if}}
-		</div>
-		<div class="clearBoth"></div>
-	</div>
-{{/if}}
+
 {{for data.robots}}
 	<hr>
 	<div class='item'>
@@ -75,7 +59,6 @@
 			{{else}}
 				{{:helper.link('Unlock', 'unlocked', {'lockdown' : value.name})}}
 			{{/if}}
-				{{:helper.link('Self-Destruct', 'radiation', {'detonate' : value.name}, null, 'redButton')}}
 			{{if value.hackable}}
 				{{:helper.link('Hack', 'calculator', {'hack' : value.name}, null, 'redButton')}}
 			{{/if}}


### PR DESCRIPTION
It's a weeeeee bit unethical to be able to explode a sapient thing on a whim, yeah? Plus it's probably cheaper to find and correct the borg than to remake/train a new one.