### PR TITLE
Removes Assault Carbine from uplink

### DIFF
--- a/code/datums/uplink/ammunition.dm
+++ b/code/datums/uplink/ammunition.dm
@@ -41,7 +41,7 @@
 /datum/uplink_item/item/ammo/a556/ap
 	name = "10rnd Rifle Magazine (5.56mm AP)"
 	path = /obj/item/ammo_magazine/a556/ap
-
+/*
 /datum/uplink_item/item/ammo/a556m
 	name = "20rnd Rifle Magazine (5.56mm)"
 	path = /obj/item/ammo_magazine/a556m
@@ -51,7 +51,7 @@
 	name = "20rnd Rifle Magazine (5.56mm AP)"
 	path = /obj/item/ammo_magazine/a556m/ap
 	item_cost = 4
-
+*/
 /datum/uplink_item/item/ammo/c762
 	name = "20rnd Rifle Magazine (7.62mm)"
 	path = /obj/item/ammo_magazine/c762

--- a/code/datums/uplink/visible_weapons.dm
+++ b/code/datums/uplink/visible_weapons.dm
@@ -60,11 +60,11 @@
 	item_cost = 7
 	path = /obj/item/weapon/gun/projectile/automatic/sts35
 
-/datum/uplink_item/item/visible_weapons/bullpuprifle
+/*/datum/uplink_item/item/visible_weapons/bullpuprifle
 	name = "Assault Rifle (5.56mm)"
 	item_cost = 7
 	path = /obj/item/weapon/gun/projectile/automatic/carbine
-
+*/
 /datum/uplink_item/item/visible_weapons/combatshotgun
 	name = "Combat Shotgun"
 	item_cost = 7

--- a/html/changelogs/anewbe.yml
+++ b/html/changelogs/anewbe.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Anewbe
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscdel: "Removes assault carbine from uplink."


### PR DESCRIPTION
The 5.56 Bullpup Assault Carbine and its magazines are no longer purchasable from the antag uplink.

Still randomly shows up as Renegade or Raider, and as such the ammo remains in hacked autolathes.