### PR TITLE
Adds accuracy penalties for certain detrimental states.

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -154,7 +154,16 @@ emp_act
 	if(user == src) // Attacking yourself can't miss
 		return target_zone
 
-	var/hit_zone = get_zone_with_miss_chance(target_zone, src)
+	// Certain statuses make it harder to score a hit.  These are the same as gun accuracy, however melee doesn't use multiples of 15.
+	var/accuracy_penalty = 0
+	if(user.eye_blind)
+		accuracy_penalty += 75
+	if(user.eye_blurry)
+		accuracy_penalty += 15
+	if(user.confused)
+		accuracy_penalty += 30
+
+	var/hit_zone = get_zone_with_miss_chance(target_zone, src, accuracy_penalty)
 
 	if(!hit_zone)
 		visible_message("<span class='danger'>\The [user] misses [src] with \the [I]!</span>")

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -333,6 +333,14 @@
 	P.accuracy = accuracy + acc_mod
 	P.dispersion = dispersion
 
+	// Certain statuses make it harder to aim, blindness especially.  Same chances as melee, however guns accuracy uses multiples of 15.
+	if(user.confused)
+		accuracy -= 2
+	if(user.eye_blind)
+		accuracy -= 5
+	if(user.eye_blurry)
+		accuracy -= 1
+
 	//accuracy bonus from aiming
 	if (aim_targets && (target in aim_targets))
 		//If you aim at someone beforehead, it'll hit more often.


### PR DESCRIPTION
Being blind gives an additional 75% chance to miss.
Having blurry eyes gives an additional 15% chance to miss.
Being confused gives an additional 30% chance to miss.

This was done so that if the PR for flashes to apply these effects instead of a stun are merged (#2020), they would hopefully still be useful if someone is trying to robust you.  Melee and ranged penalties should be equivalent, despite different numbers due to how the different code works.