### PR TITLE
Makes handcuff resisting take priority over unbuckle resisting by removing bucklecuff resisting

### DIFF
--- a/code/modules/mob/living/carbon/resist.dm
+++ b/code/modules/mob/living/carbon/resist.dm
@@ -19,17 +19,13 @@
 		return TRUE
 
 	if(handcuffed)
-		world << "1"
 		spawn() escape_handcuffs()
 	else if(legcuffed)
-		world << "2"
 		spawn() escape_legcuffs()
 	else
-		world << "3"
 		..()
 
 /mob/living/carbon/proc/escape_handcuffs()
-	world << "4"
 	//if(!(last_special <= world.time)) return
 
 	//This line represent a significant buff to grabs...
@@ -62,7 +58,6 @@
 
 	if(do_after(src, breakouttime, incapacitation_flags = INCAPACITATION_DISABLED & INCAPACITATION_KNOCKDOWN))
 		if(!handcuffed)
-			world << "5"
 			return
 		visible_message(
 			"<span class='danger'>\The [src] manages to remove \the [handcuffed]!</span>",

--- a/code/modules/mob/living/carbon/resist.dm
+++ b/code/modules/mob/living/carbon/resist.dm
@@ -18,17 +18,18 @@
 			ExtinguishMob()
 		return TRUE
 
-	if(..())
-		return TRUE
-
 	if(handcuffed)
+		world << "1"
 		spawn() escape_handcuffs()
 	else if(legcuffed)
+		world << "2"
 		spawn() escape_legcuffs()
 	else
+		world << "3"
 		..()
 
 /mob/living/carbon/proc/escape_handcuffs()
+	world << "4"
 	//if(!(last_special <= world.time)) return
 
 	//This line represent a significant buff to grabs...
@@ -59,8 +60,9 @@
 		"<span class='warning'>You attempt to remove \the [HC]. (This will take around [displaytime] minutes and you need to stand still)</span>"
 		)
 
-	if(do_after(src, breakouttime, incapacitation_flags = INCAPACITATION_DEFAULT & ~INCAPACITATION_RESTRAINED))
-		if(!handcuffed || buckled)
+	if(do_after(src, breakouttime, incapacitation_flags = INCAPACITATION_DISABLED & INCAPACITATION_KNOCKDOWN))
+		if(!handcuffed)
+			world << "5"
 			return
 		visible_message(
 			"<span class='danger'>\The [src] manages to remove \the [handcuffed]!</span>",

--- a/html/changelogs/Yoshax - Shitcuritygohome.yml
+++ b/html/changelogs/Yoshax - Shitcuritygohome.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: N3X15
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Bucklecuffing as it has been known for the longest time is no longer a thing. When you resist when cuffed and buckled to something, you will now resist out of the handcuffs first, allowing you to simply unbuckle yourself once done."

--- a/html/changelogs/Yoshax - Shitcuritygohome.yml
+++ b/html/changelogs/Yoshax - Shitcuritygohome.yml
@@ -22,7 +22,7 @@
 #################################
 
 # Your name.  
-author: N3X15
+author: Yoshax
 
 # Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
 delete-after: True


### PR DESCRIPTION
It is one of the oldest things we have, it is unnecessary, and being able to restrain someone for 4 minutes is far too long. Two minutes is more than enough time, it is highly unnecessary to have, and people get in trouble by staff when they do it most of the time.

With this PR, as noted in the changelog, when you are buckled and handcuffed, you will now **resist out of the handcuffs first**.