### PR TITLE
Adds Slowdown for Pulling Heavy Items

### DIFF
--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -35,6 +35,11 @@
 	for(var/obj/item/I in list(r_hand, l_hand) )
 		tally += max(I.slowdown, 0)
 
+	// Dragging heavy objects will also slow you down, similar to above.
+	if(pulling && istype(pulling, /obj/item))
+		var/obj/item/pulled = pulling
+		tally += max(pulled.slowdown, 0)
+
 	if(istype(buckled, /obj/structure/bed/chair/wheelchair))
 		for(var/organ_name in list(BP_L_HAND, BP_R_HAND, BP_L_ARM, BP_R_ARM))
 			var/obj/item/organ/external/E = get_organ(organ_name)


### PR DESCRIPTION
Makes dragging items which would have slowed you down if worn or carried slow you down when dragged, fixing an exploit where one could move faster by dragging something instead of carrying or wearing it.