### PR TITLE
Adds orderable tank transfer valves (not actual bombs) to the cargo Phoron crate

### DIFF
--- a/code/datums/supplypacks/robotics.dm
+++ b/code/datums/supplypacks/robotics.dm
@@ -11,7 +11,7 @@
 	group = "Robotics"
 	access = access_robotics
 
-/datum/supply_packs/eng/robotics
+/datum/supply_packs/robotics/robotics_assembly
 	name = "Robotics assembly crate"
 	contains = list(
 			/obj/item/device/assembly/prox_sensor = 3,

--- a/code/datums/supplypacks/science.dm
+++ b/code/datums/supplypacks/science.dm
@@ -13,12 +13,15 @@
 	containername = "coolant tank crate"
 
 /datum/supply_packs/sci/phoron
-	name = "Phoron assembly crate"
+	name = "Phoron research crate"
 	contains = list(
 			/obj/item/weapon/tank/phoron = 3,
+			/obj/item/weapon/tank/oxygen = 3,
 			/obj/item/device/assembly/igniter = 3,
 			/obj/item/device/assembly/prox_sensor = 3,
-			/obj/item/device/assembly/timer = 3
+			/obj/item/device/assembly/timer = 3,
+			/obj/item/device/assembly/signaler = 3,
+			/obj/item/device/transfer_valve = 3
 			)
 	cost = 10
 	containertype = /obj/structure/closet/crate/secure/phoron

--- a/html/changelogs/Yoshax - bombs.yml
+++ b/html/changelogs/Yoshax - bombs.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Yoshax
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "The phoron assembly crate in cargo has been renamed to a Phoron research crate and now contains more supplies including tank transfer valves."


### PR DESCRIPTION
They have been unobtainable for the longest time because of BOMBS!! but I feel as though they should be orderable. Because SCIENCE!!!

