### PR TITLE
Increases accuracy penalties in detrimental states

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -159,9 +159,9 @@ emp_act
 	if(user.eye_blind)
 		accuracy_penalty += 75
 	if(user.eye_blurry)
-		accuracy_penalty += 15
-	if(user.confused)
 		accuracy_penalty += 30
+	if(user.confused)
+		accuracy_penalty += 45
 
 	var/hit_zone = get_zone_with_miss_chance(target_zone, src, accuracy_penalty)
 

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -334,12 +334,12 @@
 	P.dispersion = dispersion
 
 	// Certain statuses make it harder to aim, blindness especially.  Same chances as melee, however guns accuracy uses multiples of 15.
-	if(user.confused)
-		accuracy -= 2
 	if(user.eye_blind)
 		accuracy -= 5
 	if(user.eye_blurry)
-		accuracy -= 1
+		accuracy -= 2
+	if(user.confused)
+		accuracy -= 3
 
 	//accuracy bonus from aiming
 	if (aim_targets && (target in aim_targets))


### PR DESCRIPTION
As is, you have a 50% chance to strike the chest when blurry eyes and confused, which I feel is too high. With this, you will have 15% chance to strike the chest, which I feel is far more sensible.

You should not be able to fight well in a state like that, but it should leave room to perform other actions.