### PR TITLE
Improves/fixes surplus crates

### DIFF
--- a/code/datums/uplink/ammunition.dm
+++ b/code/datums/uplink/ammunition.dm
@@ -4,6 +4,7 @@
 /datum/uplink_item/item/ammo
 	item_cost = 20
 	category = /datum/uplink_category/ammunition
+	blacklisted = 1
 
 /datum/uplink_item/item/ammo/a357
 	name = ".357 Speedloader"

--- a/code/datums/uplink/announcements.dm
+++ b/code/datums/uplink/announcements.dm
@@ -3,6 +3,7 @@
 *****************/
 /datum/uplink_item/abstract/announcements
 	category = /datum/uplink_category/services
+	blacklisted = 1
 
 /datum/uplink_item/abstract/announcements/buy(var/obj/item/device/uplink/U, var/mob/user)
 	. = ..()

--- a/code/datums/uplink/badassery.dm
+++ b/code/datums/uplink/badassery.dm
@@ -19,6 +19,7 @@
 /datum/uplink_item/item/badassery/random_one
 	name = "Random Item"
 	desc = "Buys you one random item."
+	blacklisted = 1
 
 /datum/uplink_item/item/badassery/random_one/buy(var/obj/item/device/uplink/U, var/mob/user)
 	var/datum/uplink_item/item = default_uplink_selection.get_random_item(U.uses)

--- a/code/datums/uplink/badassery.dm
+++ b/code/datums/uplink/badassery.dm
@@ -78,7 +78,7 @@
 
 /datum/uplink_item/item/badassery/surplus/get_goods(var/obj/item/device/uplink/U, var/loc)
 	var/obj/structure/largecrate/C = new(loc)
-	var/random_items = get_random_uplink_items(null, item_worth, C)
+	var/random_items = get_surplus_items(null, item_worth, C)
 	for(var/datum/uplink_item/I in random_items)
 		I.purchase_log(U)
 		I.get_goods(U, C)

--- a/code/datums/uplink/uplink_items.dm
+++ b/code/datums/uplink/uplink_items.dm
@@ -31,6 +31,7 @@ var/datum/uplink/uplink = new()
 	var/item_cost = 0
 	var/datum/uplink_category/category		// Item category
 	var/list/datum/antagonist/antag_roles	// Antag roles this item is displayed to. If empty, display to all.
+	var/blacklisted = 0
 
 /datum/uplink_item/item
 	var/path = null
@@ -166,6 +167,18 @@ datum/uplink_item/dd_SortValue()
 	var/list/bought_items = list()
 	while(remaining_TC)
 		var/datum/uplink_item/I = default_uplink_selection.get_random_item(remaining_TC, U, bought_items)
+		if(!I)
+			break
+		bought_items += I
+		remaining_TC -= I.cost(remaining_TC, U)
+
+	return bought_items
+
+/proc/get_surplus_items(var/obj/item/device/uplink/U, var/remaining_TC, var/loc)
+	var/list/bought_items = list()
+	var/override = 1
+	while(remaining_TC)
+		var/datum/uplink_item/I = all_uplink_selection.get_random_item(remaining_TC, U, bought_items, override)
 		if(!I)
 			break
 		bought_items += I

--- a/code/game/objects/items/devices/uplink_random_lists.dm
+++ b/code/game/objects/items/devices/uplink_random_lists.dm
@@ -28,13 +28,10 @@ var/datum/uplink_random_selection/all_uplink_selection = new/datum/uplink_random
 	for(var/i = 0; i < attempts; i++)
 		var/datum/uplink_random_item/RI
 		if(items_override)
-			world << 1
 			RI = pick(all_items)
 		else
-			world << 2
 			RI = pick(items)
 		if(!prob(RI.keep_probability))
-			world << 3
 			continue
 		var/datum/uplink_item/I = uplink.items_assoc[RI.uplink_item]
 		if(I.cost(telecrystals, U) > telecrystals)
@@ -46,6 +43,7 @@ var/datum/uplink_random_selection/all_uplink_selection = new/datum/uplink_random
 		return I
 
 /datum/uplink_random_selection/all/New()
+	..()
 	for(var/datum/uplink_item/item in uplink.items)
 		if(item.blacklisted)
 			continue

--- a/code/game/objects/items/devices/uplink_random_lists.dm
+++ b/code/game/objects/items/devices/uplink_random_lists.dm
@@ -1,4 +1,5 @@
 var/datum/uplink_random_selection/default_uplink_selection = new/datum/uplink_random_selection/default()
+var/datum/uplink_random_selection/all_uplink_selection = new/datum/uplink_random_selection/all()
 
 /datum/uplink_random_item
 	var/uplink_item				// The uplink item
@@ -14,17 +15,26 @@ var/datum/uplink_random_selection/default_uplink_selection = new/datum/uplink_ra
 
 /datum/uplink_random_selection
 	var/list/datum/uplink_random_item/items
+	var/list/datum/uplink_random_item/all_items
 
 /datum/uplink_random_selection/New()
 	..()
 	items = list()
+	all_items = list()
 
-/datum/uplink_random_selection/proc/get_random_item(var/telecrystals, obj/item/device/uplink/U, var/list/bought_items)
+/datum/uplink_random_selection/proc/get_random_item(var/telecrystals, obj/item/device/uplink/U, var/list/bought_items, var/items_override = 0)
 	var/const/attempts = 50
 
 	for(var/i = 0; i < attempts; i++)
-		var/datum/uplink_random_item/RI = pick(items)
+		var/datum/uplink_random_item/RI
+		if(items_override)
+			world << 1
+			RI = pick(all_items)
+		else
+			world << 2
+			RI = pick(items)
 		if(!prob(RI.keep_probability))
+			world << 3
 			continue
 		var/datum/uplink_item/I = uplink.items_assoc[RI.uplink_item]
 		if(I.cost(telecrystals, U) > telecrystals)
@@ -34,6 +44,13 @@ var/datum/uplink_random_selection/default_uplink_selection = new/datum/uplink_ra
 		if(U && !I.can_buy(U))
 			continue
 		return I
+
+/datum/uplink_random_selection/all/New()
+	for(var/datum/uplink_item/item in uplink.items)
+		if(item.blacklisted)
+			continue
+		else
+			all_items += new/datum/uplink_random_item(item.type)
 
 /datum/uplink_random_selection/default/New()
 	..()


### PR DESCRIPTION
I just wanna say, this is pretty bad code. But I plan to redo a lot of this in the near future. The item selection for surplus crates is just woeful at the moment.

This replaces a huge custom built list with an automatically generated list that uses a blacklist.
Blacklisted things are:
 - Ammo
 - Annoucements
 - Random items

The bad code will be gone in the future, this is just a bit of a hack fix.