### PR TITLE
Grenade Buff

### DIFF
--- a/code/game/objects/items/weapons/grenades/explosive.dm
+++ b/code/game/objects/items/weapons/grenades/explosive.dm
@@ -17,7 +17,8 @@
 //Explosive grenade projectile, borrowed from fragmentation grenade code.
 /obj/item/projectile/bullet/pellet/fragment
 	damage = 10
-	range_step = 2
+	armor_penetration = 30
+	range_step = 2 //projectiles lose a fragment each time they travel this distance. Can be a non-integer.
 
 	base_spread = 0 //causes it to be treated as a shrapnel explosion instead of cone
 	spread_step = 20
@@ -32,9 +33,8 @@
 	icon_state = "frggrenade"
 	item_state = "grenade"
 
-	var/num_fragments = 50  //total number of fragments produced by the grenade
-	var/fragment_damage = 10
-	var/damage_step = 2      //projectiles lose a fragment each time they travel this distance. Can be a non-integer.
+	var/fragment_type = /obj/item/projectile/bullet/pellet/fragment
+	var/num_fragments = 63  //total number of fragments produced by the grenade
 	var/explosion_size = 2   //size of the center explosion
 
 	//The radius of the circle used to launch projectiles. Lower values mean less projectiles are used but if set too low gaps may appear in the spread pattern
@@ -56,9 +56,7 @@
 	for(var/turf/T in target_turfs)
 		var/obj/item/projectile/bullet/pellet/fragment/P = new (O)
 
-		P.damage = fragment_damage
 		P.pellets = fragments_per_projectile
-		P.range_step = damage_step
 		P.shot_from = src.name
 
 		P.launch(T)


### PR DESCRIPTION
Or making grenades great again?

Tweaked the code some, changed the number of fragments spawned from 50 to 63. Damage remains the same, fragments now have a thirty percent armor pen. This also means that how lethal grenades are has gone up by a lot. One landing at your feet is lethal. Standing next to one will seriously hurt. Tile or two back the dropoff is still in effect. 

Basically need some live testing in round with real folk to get a idea of how bad or good this will be. Will likely need to tweak the damage downwards instead of upwards.

Also adjusted the grenade path thingy stuff to select the type of fragments (taken from bay code), on the off chance we add diff types of fragmentation grenades like bay does.