### PR TITLE
Ammo mags offset when spawned

### DIFF
--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -91,6 +91,8 @@
 
 /obj/item/ammo_magazine/New()
 	..()
+	pixel_x = rand(-5, 5)
+	pixel_y = rand(-5, 5)
 	if(multiple_sprites)
 		initialize_magazine_icondata(src)
 


### PR DESCRIPTION
Before: Ammo icons all stacked on top of each other on the exact same spot and looked really dumb.

After: Ammo icons now scatter with a variance of + and - five pixels on the X and Y axis, making a pile of ammo LOOK like a pile of ammo.


Really minor change. I think this just looks better.

Later I want to copy the code from food that lets you place things on specific spots, and do it for ammo too, but right now I'm too lazy to test it.