### PR TITLE
Makes soulstones take halloss into account.

### DIFF
--- a/code/modules/mob/living/simple_animal/constructs/soulstone.dm
+++ b/code/modules/mob/living/simple_animal/constructs/soulstone.dm
@@ -107,7 +107,7 @@
 	if(src.imprinted != "empty")
 		U << "<span class='danger'>Capture failed!</span>: The soul stone has already been imprinted with [src.imprinted]'s mind!"
 		return
-	if ((T.health + T.halloss) > config.health_threshold_crit && T.stat != DEAD)
+	if ((T.health - T.halloss) > config.health_threshold_crit && T.stat != DEAD)
 		U << "<span class='danger'>Capture failed!</span>: Kill or maim the victim first!"
 		return
 	if(T.client == null)


### PR DESCRIPTION
Soulstones had an error where it added halloss instead of subtracting it.

This resulted in halloss preventing people from being soulstoned, even if they were in critical.

This PR fixes that.