### PR TITLE
Technomancer Additions Yet Again

### DIFF
--- a/code/game/antagonist/outsider/technomancer.dm
+++ b/code/game/antagonist/outsider/technomancer.dm
@@ -41,7 +41,9 @@ var/datum/antagonist/technomancer/technomancers
 	technomancer_mob.equip_to_slot_or_del(new /obj/item/weapon/disposable_teleporter/free(technomancer_mob), slot_r_store)
 	technomancer_mob.equip_to_slot_or_del(new /obj/item/weapon/technomancer_catalog(technomancer_mob), slot_l_store)
 	technomancer_mob.equip_to_slot_or_del(new /obj/item/device/radio/headset(technomancer_mob), slot_l_ear)
-	technomancer_mob.equip_to_slot_or_del(new /obj/item/weapon/technomancer_core(technomancer_mob), slot_back)
+	var/obj/item/weapon/technomancer_core/core = new /obj/item/weapon/technomancer_core(technomancer_mob)
+	technomancer_mob.equip_to_slot_or_del(core, slot_back)
+	technomancer_belongings.Add(core) // So it can be Tracked.
 	technomancer_mob.equip_to_slot_or_del(new /obj/item/device/flashlight(technomancer_mob), slot_belt)
 	technomancer_mob.equip_to_slot_or_del(new /obj/item/clothing/shoes/laceup(technomancer_mob), slot_shoes)
 	technomancer_mob.equip_to_slot_or_del(new /obj/item/clothing/head/technomancer/master(technomancer_mob), slot_head)
@@ -59,7 +61,9 @@ var/datum/antagonist/technomancer/technomancers
 	technomancer_mob.equip_to_slot_or_del(catalog, slot_l_store)
 
 	technomancer_mob.equip_to_slot_or_del(new /obj/item/device/radio/headset(technomancer_mob), slot_l_ear)
-	technomancer_mob.equip_to_slot_or_del(new /obj/item/weapon/technomancer_core(technomancer_mob), slot_back)
+	var/obj/item/weapon/technomancer_core/core = new /obj/item/weapon/technomancer_core(technomancer_mob)
+	technomancer_mob.equip_to_slot_or_del(core, slot_back)
+	technomancer_belongings.Add(core) // So it can be Tracked.
 	technomancer_mob.equip_to_slot_or_del(new /obj/item/device/flashlight(technomancer_mob), slot_belt)
 	technomancer_mob.equip_to_slot_or_del(new /obj/item/clothing/shoes/laceup(technomancer_mob), slot_shoes)
 	technomancer_mob.equip_to_slot_or_del(new /obj/item/clothing/head/technomancer/apprentice(technomancer_mob), slot_head)

--- a/code/game/gamemodes/technomancer/catalog.dm
+++ b/code/game/gamemodes/technomancer/catalog.dm
@@ -247,7 +247,8 @@ var/list/all_technomancer_presets = typesof(/datum/technomancer/presets) - /datu
 				if(desired_object.cost <= budget)
 					budget -= desired_object.cost
 					H << "<span class='notice'>You have just bought \a [desired_object.name].</span>"
-					new desired_object.obj_path(get_turf(H))
+					var/obj/O = new desired_object.obj_path(get_turf(H))
+					technomancer_belongings.Add(O) // Used for the Track spell.
 
 				else //Can't afford.
 					H << "<span class='danger'>You can't afford that!</span>"

--- a/code/game/gamemodes/technomancer/core_obj.dm
+++ b/code/game/gamemodes/technomancer/core_obj.dm
@@ -83,6 +83,9 @@
 	energy_delta = energy - old_energy
 	if(world.time % 5 == 0) // Maintaining fat lists is expensive, I imagine.
 		maintain_summon_list()
+	if(wearer && wearer.mind)
+		if(!(technomancers.is_antagonist(wearer.mind))) // In case someone tries to wear a stolen core.
+			wearer.adjust_instability(20)
 
 /obj/item/weapon/technomancer_core/proc/regenerate()
 	energy = min(max(energy + regen_rate, 0), max_energy)

--- a/code/game/gamemodes/technomancer/devices/implants.dm
+++ b/code/game/gamemodes/technomancer/devices/implants.dm
@@ -1,0 +1,11 @@
+/datum/technomancer/consumable/freedom_implant
+	name = "Freedom Implant"
+	desc = "A hidden implant which allows one to escape bindings such as handcuffs."
+	cost = 50
+	obj_path = /obj/item/weapon/storage/box/syndie_kit/imp_freedom
+
+/datum/technomancer/consumable/explosive_implant
+	name = "Explosive Implant"
+	desc = "A hidden implant which will explode if it hears a passphrase."
+	cost = 150
+	obj_path = /obj/item/weapon/storage/box/syndie_kit/imp_explosive

--- a/code/game/gamemodes/technomancer/instability.dm
+++ b/code/game/gamemodes/technomancer/instability.dm
@@ -205,6 +205,11 @@
 			var/radius = max(get_dist(H, src), 1)
 			// People next to the source take a third of the instability.  Further distance decreases the amount absorbed.
 			var/outgoing_instability = (instability / 3) * ( 1 / (radius**2) )
+
+			// Energy armor like from the AMI RIG can protect from this.
+			var/armor = getarmor(null, "energy")
+			var/armor_factor = abs( (armor - 100) / 100)
+			outgoing_instability = outgoing_instability * armor_factor
 			H.adjust_instability(outgoing_instability)
 
 	set_light(distance, distance, l_color = "#C26DDE")

--- a/code/game/gamemodes/technomancer/spells/aura/frost_aura.dm
+++ b/code/game/gamemodes/technomancer/spells/aura/frost_aura.dm
@@ -13,7 +13,7 @@
 	icon_state = "generic"
 	cast_methods = null
 	aspect = ASPECT_FROST
-	glow_color = "#FF6A00"
+	glow_color = "#00B3FF"
 
 /obj/item/weapon/spell/aura/frost/process()
 	if(!pay_energy(100))

--- a/code/game/gamemodes/technomancer/spells/illusion.dm
+++ b/code/game/gamemodes/technomancer/spells/illusion.dm
@@ -46,10 +46,19 @@
 
 /obj/item/weapon/spell/illusion/on_use_cast(mob/user)
 	if(illusion)
-		var/what_to_say = input(user, "What do you want \the [illusion] to say?","Illusion Speak") as null|text
-		what_to_say = sanitize(what_to_say)
-		if(what_to_say)
-			illusion.say(what_to_say)
+		var/choice = alert(user, "Would you like to have \the [illusion] speak, or do an emote?", "Illusion", "Speak","Emote","Cancel")
+		switch(choice)
+			if("Cancel")
+				return
+			if("Speak")
+				var/what_to_say = input(user, "What do you want \the [illusion] to say?","Illusion Speak") as null|text
+				//what_to_say = sanitize(what_to_say) //Sanitize occurs inside say() already.
+				if(what_to_say)
+					illusion.say(what_to_say)
+			if("Emote")
+				var/what_to_emote = input(user, "What do you want \the [illusion] to do?","Illusion Emote") as null|text
+				if(what_to_emote)
+					illusion.emote(what_to_emote)
 
 /obj/item/weapon/spell/illusion/Destroy()
 	if(illusion)

--- a/code/game/gamemodes/technomancer/spells/phase_shift.dm
+++ b/code/game/gamemodes/technomancer/spells/phase_shift.dm
@@ -33,15 +33,24 @@
 		AM.forceMove(get_turf(src))
 	..()
 
+/obj/effect/phase_shift/relaymove(mob/user as mob)
+	if(user.stat)
+		return
+
+	user << "<span class='notice'>You step out of the rift.</span>"
+	user.forceMove(get_turf(src))
+	qdel(src)
+
 /obj/item/weapon/spell/phase_shift/on_use_cast(mob/user)
 	if(isturf(user.loc)) //Check if we're not already in a rift.
-		var/obj/effect/phase_shift/PS = new(get_turf(user))
-		visible_message("<span class='warning'>[user] vanishes into a pink rift!</span>")
-		user << "<span class='info'>You create an unstable rift, and go through it.  Be sure to not stay too long.</span>"
-		user.forceMove(PS)
-	else //We're already in a rift, time to get out.
-		if(istype(loc, /obj/effect/phase_shift))
-			var/obj/effect/phase_shift/PS = user.loc
-			qdel(PS) //Ejecting is handled in Destory()
-			visible_message("<span class='warning'>[user] reappears from the rift as it collapses.</span>")
+		if(pay_energy(2000))
+			var/obj/effect/phase_shift/PS = new(get_turf(user))
+			visible_message("<span class='warning'>[user] vanishes into a pink rift!</span>")
+			user << "<span class='info'>You create an unstable rift, and go through it.  Be sure to not stay too long.</span>"
+			user.forceMove(PS)
+			adjust_instability(10)
 			qdel(src)
+		else
+			user << "<span class='warning'>You don't have enough energy to make a rift!</span>"
+	else //We're already in a rift or something like a closet.
+		user << "<span class='warning'>Making a rift here would probably be a bad idea.</span>"

--- a/code/game/gamemodes/technomancer/spells/track.dm
+++ b/code/game/gamemodes/technomancer/spells/track.dm
@@ -58,9 +58,9 @@ var/list/technomancer_belongings = list()
 		icon_state = "track_unknown"
 
 	else
-		set_dir(get_dir(src,tracked))
+		set_dir(get_dir(src,get_turf(tracked)))
 
-		switch(get_dist(src,tracked))
+		switch(get_dist(src,get_turf(tracked)))
 			if(0)
 				icon_state = "track_direct"
 			if(1 to 8)

--- a/polaris.dme
+++ b/polaris.dme
@@ -421,6 +421,7 @@
 #include "code\game\gamemodes\technomancer\devices\disposable_teleporter.dm"
 #include "code\game\gamemodes\technomancer\devices\gloves_of_regen.dm"
 #include "code\game\gamemodes\technomancer\devices\hypos.dm"
+#include "code\game\gamemodes\technomancer\devices\implants.dm"
 #include "code\game\gamemodes\technomancer\devices\shield_armor.dm"
 #include "code\game\gamemodes\technomancer\devices\tesla_armor.dm"
 #include "code\game\gamemodes\technomancer\spells\abjuration.dm"


### PR DESCRIPTION
Adds cores and other belongings to the tracking list for Track.
Cores worn or held by nontechnomancers cause instability buildup.
Frost Aura glow is now blue and not red.
Illusions can now do emotes as well as talk.
Illusion talking shouldn't be ruined due to double sanitize.
Phase Shift should work properly now.
Freedom and explosive implants can be bought in the catalog.