### PR TITLE
Uplink pricing adjustments

### DIFF
--- a/code/datums/uplink/badassery.dm
+++ b/code/datums/uplink/badassery.dm
@@ -61,17 +61,17 @@
 /datum/uplink_item/item/badassery/surplus/merc2
 	name = "Surplus Crate - 240 TC"
 	item_cost = DEFAULT_TELECRYSTAL_AMOUNT * 2
-	item_worth = 360
+	item_worth = 540
 
 /datum/uplink_item/item/badassery/surplus/merc4
 	name = "Surplus Crate - 480 TC"
 	item_cost = DEFAULT_TELECRYSTAL_AMOUNT * 4
-	item_worth = 720
+	item_worth = 1200
 
 /datum/uplink_item/item/badassery/surplus/merc6
 	name = "Surplus Crate - 720 TC"
 	item_cost = DEFAULT_TELECRYSTAL_AMOUNT * 6
-	item_worth = 1440
+	item_worth = 1980
 
 /datum/uplink_item/item/badassery/surplus/New()
 	..()

--- a/code/datums/uplink/stealth_items.dm
+++ b/code/datums/uplink/stealth_items.dm
@@ -31,10 +31,10 @@
 
 /datum/uplink_item/item/stealth_items/voice
 	name = "Voice Changer"
-	item_cost = 30
+	item_cost = 15
 	path = /obj/item/clothing/mask/gas/voice
 
 /datum/uplink_item/item/stealth_items/camera_floppy
 	name = "Camera Network Access - Floppy"
-	item_cost = 30
+	item_cost = 15
 	path = /obj/item/weapon/disk/file/cameras/syndicate

--- a/code/datums/uplink/stealthy_weapons.dm
+++ b/code/datums/uplink/stealthy_weapons.dm
@@ -26,10 +26,10 @@
 
 /datum/uplink_item/item/stealthy_weapons/cigarette_kit
 	name = "Cigarette Kit"
-	item_cost = 15
+	item_cost = 10
 	path = /obj/item/weapon/storage/box/syndie_kit/cigarette
 
 /datum/uplink_item/item/stealthy_weapons/random_toxin
 	name = "Random Toxin - Beaker"
-	item_cost = 15
+	item_cost = 10
 	path = /obj/item/weapon/storage/box/syndie_kit/toxin

--- a/code/datums/uplink/tools.dm
+++ b/code/datums/uplink/tools.dm
@@ -38,7 +38,7 @@
 
 /datum/uplink_item/item/tools/encryptionkey_radio
 	name = "Encrypted Radio Channel Key"
-	item_cost = 20
+	item_cost = 10
 	path = /obj/item/device/encryptionkey/syndicate
 
 /datum/uplink_item/item/tools/hacking_tool
@@ -51,7 +51,7 @@
 
 /datum/uplink_item/item/tools/encryptionkey_binary
 	name = "Binary Translator Key"
-	item_cost = 20
+	item_cost = 15
 	path = /obj/item/device/encryptionkey/binary
 
 /datum/uplink_item/item/tools/emag
@@ -61,12 +61,12 @@
 
 /datum/uplink_item/item/tools/clerical
 	name = "Morphic Clerical Kit"
-	item_cost = 15
+	item_cost = 10
 	path = /obj/item/weapon/storage/box/syndie_kit/clerical
 
 /datum/uplink_item/item/tools/money
 	name = "Operations Funding"
-	item_cost = 15
+	item_cost = 10
 	path = /obj/item/weapon/storage/secure/briefcase/money
 	desc = "A briefcase with 10,000 untraceable thalers for funding your sneaky activities."
 
@@ -82,7 +82,7 @@
 
 /datum/uplink_item/item/tools/powersink
 	name = "Powersink (DANGER!)"
-	item_cost = 50
+	item_cost = 40
 	path = /obj/item/device/powersink
 
 /datum/uplink_item/item/tools/ai_module

--- a/code/datums/uplink/visible_weapons.dm
+++ b/code/datums/uplink/visible_weapons.dm
@@ -11,7 +11,7 @@
 
 /datum/uplink_item/item/visible_weapons/combatknife
 	name = "Combat Knife"
-	item_cost = 30
+	item_cost = 20
 	path = /obj/item/weapon/material/hatchet/tacknife/combatknife
 
 /datum/uplink_item/item/visible_weapons/energy_sword


### PR DESCRIPTION
- Fixes the surplus crate item worth scaling because I can't math
- Halves the price of voice changer and camera floppy disk thing because 30 is too damn high
- Reduces cigarette kit and toxin beaker from 15 to 10 because they're not very useful and should cost a little less
- Reduces cost of radio keys because nobody ever uses them
- Reduces cost of clerical kit and money briefcase to be a little more sensible
- Reduces powersink cost because it's so unused (Will look into attempting to tweak the numbers at some point in the near future so it drains better)
- Reduces combat knife price a little because 30 seems a little high