### PR TITLE
Construction Tweaks and Fixes

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -412,12 +412,16 @@ About the new airlock wires panel:
 	if(electrified_until && isAllPowerLoss())
 		electrify(0)
 
+	update_icon()
+
 /obj/machinery/door/airlock/proc/loseBackupPower()
 	backup_power_lost_until = backupPowerCablesCut() ? -1 : world.time + SecondsToTicks(60)
 
 	// Disable electricity if required
 	if(electrified_until && isAllPowerLoss())
 		electrify(0)
+
+	update_icon()
 
 /obj/machinery/door/airlock/proc/regainMainPower()
 	if(!mainPowerCablesCut())
@@ -426,10 +430,14 @@ About the new airlock wires panel:
 		if(!backup_power_lost_until)
 			backup_power_lost_until = -1
 
+	update_icon()
+
 /obj/machinery/door/airlock/proc/regainBackupPower()
 	if(!backupPowerCablesCut())
 		// Restore backup power only if main power is offline, otherwise permanently disable
 		backup_power_lost_until = main_power_lost_until == 0 ? -1 : 0
+
+	update_icon()
 
 /obj/machinery/door/airlock/proc/electrify(var/duration, var/feedback = 0)
 	var/message = ""
@@ -781,7 +789,7 @@ About the new airlock wires panel:
 				if (istype(da, /obj/structure/door_assembly/multi_tile))
 					da.set_dir(src.dir)
 
- 				da.anchored = 1
+				da.anchored = 1
 				if(mineral)
 					da.glass = mineral
 				//else if(glass)

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -65,6 +65,7 @@
 			bound_height = width * world.icon_size
 
 	health = maxhealth
+	update_icon()
 
 	update_nearby_tiles(need_rebuild=1)
 	return

--- a/code/game/objects/structures/door_assembly.dm
+++ b/code/game/objects/structures/door_assembly.dm
@@ -7,7 +7,7 @@
 	w_class = 5
 	var/state = 0
 	var/base_icon_state = ""
-	var/base_name = "Airlock"
+	var/base_name = "airlock"
 	var/obj/item/weapon/airlock_electronics/electronics = null
 	var/airlock_type = "" //the type path of the airlock once completed
 	var/glass_type = "/glass"
@@ -19,91 +19,91 @@
 
 /obj/structure/door_assembly/door_assembly_com
 	base_icon_state = "com"
-	base_name = "Command Airlock"
+	base_name = "Command airlock"
 	glass_type = "/glass_command"
 	airlock_type = "/command"
 
 /obj/structure/door_assembly/door_assembly_sec
 	base_icon_state = "sec"
-	base_name = "Security Airlock"
+	base_name = "Security airlock"
 	glass_type = "/glass_security"
 	airlock_type = "/security"
 
 /obj/structure/door_assembly/door_assembly_eng
 	base_icon_state = "eng"
-	base_name = "Engineering Airlock"
+	base_name = "Engineering airlock"
 	glass_type = "/glass_engineering"
 	airlock_type = "/engineering"
 
 /obj/structure/door_assembly/door_assembly_eat
 	base_icon_state = "eat"
-	base_name = "Engineering Atmos Airlock"
+	base_name = "Engineering atmos airlock"
 	glass_type = "/glass_engineeringatmos"
 	airlock_type = "/engineering"
 
 /obj/structure/door_assembly/door_assembly_min
 	base_icon_state = "min"
-	base_name = "Mining Airlock"
+	base_name = "Mining airlock"
 	glass_type = "/glass_mining"
 	airlock_type = "/mining"
 
 /obj/structure/door_assembly/door_assembly_atmo
 	base_icon_state = "atmo"
-	base_name = "Atmospherics Airlock"
+	base_name = "Atmospherics airlock"
 	glass_type = "/glass_atmos"
 	airlock_type = "/atmos"
 
 /obj/structure/door_assembly/door_assembly_research
 	base_icon_state = "res"
-	base_name = "Research Airlock"
+	base_name = "Research airlock"
 	glass_type = "/glass_research"
 	airlock_type = "/research"
 
 /obj/structure/door_assembly/door_assembly_science
 	base_icon_state = "sci"
-	base_name = "Science Airlock"
+	base_name = "Science airlock"
 	glass_type = "/glass_science"
 	airlock_type = "/science"
 
 /obj/structure/door_assembly/door_assembly_med
 	base_icon_state = "med"
-	base_name = "Medical Airlock"
+	base_name = "Medical airlock"
 	glass_type = "/glass_medical"
 	airlock_type = "/medical"
 
 /obj/structure/door_assembly/door_assembly_mai
 	base_icon_state = "mai"
-	base_name = "Maintenance Airlock"
+	base_name = "Maintenance airlock"
 	airlock_type = "/maintenance"
 	glass = -1
 
 /obj/structure/door_assembly/door_assembly_ext
 	base_icon_state = "ext"
-	base_name = "External Airlock"
+	base_name = "External airlock"
 	airlock_type = "/external"
 	glass = -1
 
 /obj/structure/door_assembly/door_assembly_fre
 	base_icon_state = "fre"
-	base_name = "Freezer Airlock"
+	base_name = "Freezer airlock"
 	airlock_type = "/freezer"
 	glass = -1
 
 /obj/structure/door_assembly/door_assembly_hatch
 	base_icon_state = "hatch"
-	base_name = "Airtight Hatch"
+	base_name = "airtight hatch"
 	airlock_type = "/hatch"
 	glass = -1
 
 /obj/structure/door_assembly/door_assembly_mhatch
 	base_icon_state = "mhatch"
-	base_name = "Maintenance Hatch"
+	base_name = "maintenance hatch"
 	airlock_type = "/maintenance_hatch"
 	glass = -1
 
 /obj/structure/door_assembly/door_assembly_highsecurity // Borrowing this until WJohnston makes sprites for the assembly
 	base_icon_state = "highsec"
-	base_name = "High Security Airlock"
+	base_name = "high security airlock"
 	airlock_type = "/highsecurity"
 	glass = -1
 
@@ -221,7 +221,6 @@
 			W.loc = src
 			user << "<span class='notice'>You installed the airlock electronics!</span>"
 			src.state = 2
-			src.name = "Near finished Airlock Assembly"
 			src.electronics = W
 
 	else if(istype(W, /obj/item/weapon/crowbar) && state == 2 )
@@ -238,7 +237,6 @@
 			if(!src) return
 			user << "<span class='notice'>You removed the airlock electronics!</span>"
 			src.state = 1
-			src.name = "Wired Airlock Assembly"
 			electronics.loc = src.loc
 			electronics = null
 
@@ -294,9 +292,9 @@
 	switch (state)
 		if(0)
 			if (anchored)
-				name = "Secured "
+				name = "secured "
 		if(1)
-			name = "Wired "
+			name = "wired "
 		if(2)
-			name = "Near Finished "
-	name += "[glass == 1 ? "Window " : ""][istext(glass) ? "[glass] Airlock" : base_name] Assembly"
+			name = "near finished "
+	name += "[glass == 1 ? "window " : ""][istext(glass) ? "[glass] airlock" : base_name] assembly ([created_name])"

--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -126,7 +126,8 @@
 		return ..()
 
 /obj/structure/girder/proc/construct_wall(obj/item/stack/material/S, mob/user)
-	if(S.get_amount() < 2)
+	var/amount_to_use = reinf_material ? 1 : 2
+	if(S.get_amount() < amount_to_use)
 		user << "<span class='notice'>There isn't enough material here to construct a wall.</span>"
 		return 0
 
@@ -143,7 +144,6 @@
 
 	user << "<span class='notice'>You begin adding the plating...</span>"
 
-	var/amount_to_use = reinf_material ? 1 : 2
 	if(!do_after(user,40) || !S.use(amount_to_use))
 		return 1 //once we've gotten this far don't call parent attackby()
 

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -161,6 +161,7 @@
 	if(reinf) tforce *= 0.25
 	if(health - tforce <= 7 && !reinf)
 		anchored = 0
+		update_verbs()
 		update_nearby_icons()
 		step(src, get_dir(AM, src))
 	take_damage(tforce)

--- a/code/modules/materials/materials.dm
+++ b/code/modules/materials/materials.dm
@@ -395,7 +395,7 @@ var/list/name_to_material
 	weight = 15
 	door_icon_base = "stone"
 	destruction_desc = "shatters"
-	window_options = list("One Direction" = 1, "Full Window" = 4)
+	window_options = list("One Direction" = 1, "Full Window" = 4, "Windoor" = 2)
 	created_window = /obj/structure/window/basic
 	rod_product = /obj/item/stack/material/glass/reinforced
 
@@ -425,6 +425,12 @@ var/list/name_to_material
 	for (var/obj/structure/window/check_window in user.loc)
 		window_count++
 		possible_directions  -= check_window.dir
+	for (var/obj/structure/windoor_assembly/check_assembly in user.loc)
+		window_count++
+		possible_directions -= check_assembly.dir
+	for (var/obj/machinery/door/window/check_windoor in user.loc)
+		window_count++
+		possible_directions -= check_windoor.dir
 
 	// Get the closest available dir to the user's current facing.
 	var/build_dir = SOUTHWEST //Default to southwest for fulltile windows.
@@ -435,18 +441,12 @@ var/list/name_to_material
 	else
 		if(choice in list("One Direction","Windoor"))
 			if(possible_directions.len)
-				for(var/direction in list(user.dir, turn(user.dir,90), turn(user.dir,180), turn(user.dir,270) ))
+				for(var/direction in list(user.dir, turn(user.dir,90), turn(user.dir,270), turn(user.dir,180)))
 					if(direction in possible_directions)
 						build_dir = direction
 						break
 			else
 				failed_to_build = 1
-			if(!failed_to_build && choice == "Windoor")
-				if(!is_reinforced())
-					user << "<span class='warning'>This material is not reinforced enough to use for a door.</span>"
-					return
-				if((locate(/obj/structure/windoor_assembly) in T.contents) || (locate(/obj/machinery/door/window) in T.contents))
-					failed_to_build = 1
 	if(failed_to_build)
 		user << "<span class='warning'>There is no room in this location.</span>"
 		return 1
@@ -454,7 +454,8 @@ var/list/name_to_material
 	var/build_path = /obj/structure/windoor_assembly
 	var/sheets_needed = window_options[choice]
 	if(choice == "Windoor")
-		build_dir = user.dir
+		if(is_reinforced())
+			build_path = /obj/structure/windoor_assembly/secure
 	else
 		build_path = created_window
 
@@ -484,7 +485,7 @@ var/list/name_to_material
 	weight = 30
 	stack_origin_tech = "materials=2"
 	composite_material = list(DEFAULT_WALL_MATERIAL = SHEET_MATERIAL_AMOUNT / 2, "glass" = SHEET_MATERIAL_AMOUNT)
-	window_options = list("One Direction" = 1, "Full Window" = 4, "Windoor" = 5)
+	window_options = list("One Direction" = 1, "Full Window" = 4, "Windoor" = 2)
 	created_window = /obj/structure/window/reinforced
 	wire_product = null
 	rod_product = null
@@ -497,6 +498,7 @@ var/list/name_to_material
 	integrity = 100
 	icon_colour = "#FC2BC5"
 	stack_origin_tech = list(TECH_MATERIAL = 4)
+	window_options = list("One Direction" = 1, "Full Window" = 4)
 	created_window = /obj/structure/window/phoronbasic
 	wire_product = null
 	rod_product = /obj/item/stack/material/glass/phoronrglass
@@ -507,6 +509,7 @@ var/list/name_to_material
 	stack_type = /obj/item/stack/material/glass/phoronrglass
 	stack_origin_tech = list(TECH_MATERIAL = 5)
 	composite_material = list() //todo
+	window_options = list("One Direction" = 1, "Full Window" = 4)
 	created_window = /obj/structure/window/phoronreinforced
 	hardness = 40
 	weight = 30

--- a/html/changelogs/Hubblenaut-Master.yml
+++ b/html/changelogs/Hubblenaut-Master.yml
@@ -1,0 +1,47 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Hubblenaut
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Windoor assemblies can now be named with a pen."
+  - rscadd: "Windoor and airlock assemblies now show their custom name during construction phase."
+  - tweak: "Windoors can now be made out of two sheets of glass or reinforced glass, for normal and secure windoors respectively."
+  - tweak: "Windoors now automatically close after construction."
+  - tweak: "Adjusts the algorism for how windoors and windows are placed on construction (when there are already windows co on the same turf)."
+  - bugfix: "Windoors will now drop exactly the materials they were made of."
+  - bugfix: "Prying a broken circuit out of a windoor will no longer cause duplicates to drop."
+  - bugfix: "Airlocks no longer spark after spawn and several other icon update issues were fixed."
+  - bugfix: "Fixes reinforced walls not being constructable with one sheet left in stack."
+  - bugfix: "Windows that were busted out of their frame by force are now correctly rotatable."
+  - bugfix: "Lots of spellchecking and code cleanup in windoor and airlock code."
+  - rscdel: "Killed innocent kittens."


### PR DESCRIPTION
**Reinforced Walls**
 - Fixes reinforced walls construction when having one sheet left in the stack

**Windoor Assemblies**
 - Assemblies are now made with two sheets of either normal or reinforced glass sheets, for normal and secure windoors respecting.
 - Assemblies can now be named with a pen, just like airlocks.
 - Windoor assemblies now get placed like windows, and windows take windoor assemblies into account when placed. As a side effect, that part of the code looks much nicer now, as windows and windoors use the same placement algorithm when constructed.
 - Decapitalises windoor assembly names.
 - Shattering windoors will make them drop exactly what they were made of now. (Two shards, a piece of wire and the airlock electronics, optionally two rods if the windoor was secure)
 - Prying emagged windoors will no longer make them shatter on top of returning to an assembly.
 - Cleans up some code and adds its own `update_icon()` proc.

**Airlock Assemblies**
 - Fixes airlocks occasionally not updating their icon correctly.
 - Fixes airlocks causing sparks on spawn as if they were damaged.
 - Fixes airlock not being anchored after being turned into an assembly.
 - Decapitalises airlock names.

**Windoors and Airlocks**
 - Assemblies now show the name they will have after construction in brackets.

**Windows**
 - Windows that get unanchored by force will now correctly have the rotate verb.

*All bugfixes and tweaks thoroughly tested, all is working.*