### PR TITLE
Captain job title changes

### DIFF
--- a/code/game/jobs/job/captain.dm
+++ b/code/game/jobs/job/captain.dm
@@ -1,7 +1,7 @@
 var/datum/announcement/minor/captain_announcement = new(do_newscast = 1)
 
 /datum/job/captain
-	title = "Captain"
+	title = "Station Administrator"
 	flag = CAPTAIN
 	department = "Command"
 	head_position = 1
@@ -11,7 +11,7 @@ var/datum/announcement/minor/captain_announcement = new(do_newscast = 1)
 	spawn_positions = 1
 	supervisors = "company officials and Corporate Regulations"
 	selection_color = "#1D1D4F"
-	alt_titles = list("Station Administrator")
+	alt_titles = list("Site Manager")
 	idtype = /obj/item/weapon/card/id/gold
 	req_admin_notify = 1
 	access = list() 			//See get_access()


### PR DESCRIPTION
Removes Captain as a title, sets default to Station Administrator, and adds a new title, Site Manager.

- The title of 'Captain' makes very little sense anymore, it's suited to a ship, or vessel where the captain has full, super authority. They're not here. They're basically just like a District Manager.

I have not renamed areas, or clothing or anything of the sort because I do not wish to put the effort in to change it all and it get turned down.