### PR TITLE
Fix temperature display on tank controllers

### DIFF
--- a/nano/templates/atmo_control.tmpl
+++ b/nano/templates/atmo_control.tmpl
@@ -16,7 +16,7 @@
 				{{if value.sensor_data.temperature}}
 					<div class='item'>
 						<div class='itemLabel' style='width: 24%;'>Temperature:</div>
-						<div class='itemContentNarrow'>{{:value.sensor_data.temperature}} kPa</div>
+						<div class='itemContentNarrow'>{{:value.sensor_data.temperature}} K</div>
 					</div>
 				{{/if}}
 				{{if value.sensor_data.oxygen || value.sensor_data.nitrogen || value.sensor_data.carbon_dioxide || value.sensor_data.phoron}}


### PR DESCRIPTION
The tank controller computers had the temperature of the tank they're connected to labeled as "kPa".