### PR TITLE
Makes pierce damage heal correctly when bandaged

### DIFF
--- a/code/modules/organs/wound.dm
+++ b/code/modules/organs/wound.dm
@@ -92,7 +92,7 @@
 
 	// checks whether the wound has been appropriately treated
 	proc/is_treated()
-		if(damage_type == BRUISE || damage_type == CUT)
+		if(damage_type == BRUISE || damage_type == CUT || damage_type == PIERCE)
 			return bandaged
 		else if(damage_type == BURN)
 			return salved


### PR DESCRIPTION
Makes pierce damage heal correctly when bandaged.

For some reason it didn't heal before. I presume this was an oversight, as it means that if you got a pierce wound that had more than 15 damage nothing less than bicaridine, tricordazine, cryo, or some other brute damage healing chemical would fix it.

If this is intended, feel free to close the PR. It just seems extremely odd that every other brute wound type will heal when bandaged with the exception of pierce damage.