### PR TITLE
Actually fixes lung rupturing and does so with less runtimes

### DIFF
--- a/code/modules/mob/living/carbon/breathe.dm
+++ b/code/modules/mob/living/carbon/breathe.dm
@@ -24,6 +24,11 @@
 		breath = get_breath_from_internal() //First, check for air from internals
 		if(!breath)
 			breath = get_breath_from_environment() //No breath from internals so let's try to get air from our location
+		if(!breath)
+			var/static/datum/gas_mixture/vacuum //avoid having to create a new gas mixture for each breath in space
+			if(!vacuum) vacuum = new
+
+			breath = vacuum //still nothing? must be vacuum
 
 	handle_breath(breath)
 	handle_post_breath(breath)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -932,9 +932,8 @@
 /mob/living/carbon/human/proc/rupture_lung()
 	var/obj/item/organ/internal/lungs/L = internal_organs_by_name[O_LUNGS]
 
-	if(L && !L.is_bruised())
-		src.custom_pain("You feel a stabbing pain in your chest!", 1)
-		L.damage = L.min_bruised_damage
+	if(L)
+		L.rupture()
 
 /*
 /mob/living/carbon/human/verb/simulate()

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -332,6 +332,12 @@
 		adjustOxyLoss(-5)
 		return
 
+	if(should_have_organ(O_LUNGS))
+		var/obj/item/organ/internal/lungs/L = internal_organs_by_name[O_LUNGS]
+		if(breath.total_moles < BREATH_MOLES / 5 || breath.total_moles > BREATH_MOLES * 5)
+			if(!L.is_bruised() && prob(5))
+				rupture_lung()
+
 	if(!breath || (breath.total_moles == 0) || suiciding)
 		failed_last_breath = 1
 		if(suiciding)

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -332,12 +332,6 @@
 		adjustOxyLoss(-5)
 		return
 
-	if(should_have_organ(O_LUNGS))
-		var/obj/item/organ/internal/lungs/L = internal_organs_by_name[O_LUNGS]
-		if(breath.total_moles < BREATH_MOLES / 5 || breath.total_moles > BREATH_MOLES * 5)
-			if(!L.is_bruised() && prob(5))
-				rupture_lung()
-
 	if(!breath || (breath.total_moles == 0) || suiciding)
 		failed_last_breath = 1
 		if(suiciding)
@@ -349,11 +343,21 @@
 		else
 			adjustOxyLoss(HUMAN_CRIT_MAX_OXYLOSS)
 
+		if(should_have_organ(O_LUNGS))
+			var/obj/item/organ/internal/lungs/L = internal_organs_by_name[O_LUNGS]
+			if(!L.is_bruised() && prob(5))
+				if(breath.total_moles)
+					if(breath.total_moles < BREATH_MOLES / 5 || breath.total_moles > BREATH_MOLES * 5)
+						rupture_lung()
+				else
+					rupture_lung()
+
 		oxygen_alert = max(oxygen_alert, 1)
 
 		return 0
 
 	var/safe_pressure_min = 16 // Minimum safe partial pressure of breathable gas in kPa
+
 
 	// Lung damage increases the minimum safe pressure.
 	if(should_have_organ(O_LUNGS))

--- a/code/modules/organs/internal/lungs.dm
+++ b/code/modules/organs/internal/lungs.dm
@@ -24,3 +24,10 @@
 		if(prob(4))
 			spawn owner.emote("me", 1, "gasps for air!")
 			owner.losebreath += 15
+
+
+/obj/item/organ/internal/lungs/proc/rupture()
+	var/obj/item/organ/external/parent = owner.get_organ(parent_organ)
+	if(istype(parent))
+		owner.custom_pain("You feel a stabbing pain in your [parent.name]!", 1)
+	parent.bruise()

--- a/code/modules/organs/internal/lungs.dm
+++ b/code/modules/organs/internal/lungs.dm
@@ -18,16 +18,15 @@
 			owner.emote("cough")		//respitory tract infection
 
 	if(is_bruised())
-		if(prob(2))
+		if(prob(4))
 			spawn owner.emote("me", 1, "coughs up blood!")
 			owner.drip(10)
-		if(prob(4))
+		if(prob(8))
 			spawn owner.emote("me", 1, "gasps for air!")
 			owner.losebreath += 15
-
 
 /obj/item/organ/internal/lungs/proc/rupture()
 	var/obj/item/organ/external/parent = owner.get_organ(parent_organ)
 	if(istype(parent))
 		owner.custom_pain("You feel a stabbing pain in your [parent.name]!", 1)
-	parent.bruise()
+	bruise()

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -247,6 +247,9 @@ var/list/organ_cache = list()
 			if(parent && !silent)
 				owner.custom_pain("Something inside your [parent.name] hurts a lot.", 1)
 
+/obj/item/organ/proc/bruise()
+	damage = max(damage, min_bruised_damage)
+
 /obj/item/organ/proc/robotize() //Being used to make robutt hearts, etc
 	robotic = ORGAN_ROBOT
 	src.status &= ~ORGAN_BROKEN

--- a/html/changelogs/Yoshax - rupturelungs.yml
+++ b/html/changelogs/Yoshax - rupturelungs.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Yoshax
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Lungs will now once again rupture when you are in an area where you cannot breathe. This has a relatively small chance to happen."


### PR DESCRIPTION
Corrects the mistakes in #2288 

Also doubles the changes for an increase in breath loss and coughing up blood when you have lung damage from 2% and 4% to 4% and 8% respectively. Lung rupturing has a 5% change to trigger when breathing happens, which is every 4 ticks.