### PR TITLE
Makes hyperzine not make you move sanic speeds

### DIFF
--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -14,7 +14,7 @@
 		return -3 // Returning -1 will actually result in a slowdown for Teshari.
 
 	if(CE_SPEEDBOOST in chem_effects)
-		return -3
+		return -1
 
 	var/health_deficiency = (maxHealth - health)
 	if(health_deficiency >= 40) tally += (health_deficiency / 25)

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -14,7 +14,7 @@
 		return -3 // Returning -1 will actually result in a slowdown for Teshari.
 
 	if(CE_SPEEDBOOST in chem_effects)
-		return -1
+		return -3
 
 	var/health_deficiency = (maxHealth - health)
 	if(health_deficiency >= 40) tally += (health_deficiency / 25)

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -310,7 +310,7 @@
 	description = "Hyperzine is a highly effective, long lasting, muscle stimulant."
 	reagent_state = LIQUID
 	color = "#FF3300"
-	metabolism = REM * 0.15
+	metabolism = REM * 10
 	overdose = REAGENTS_OVERDOSE * 0.5
 
 /datum/reagent/hyperzine/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -310,7 +310,7 @@
 	description = "Hyperzine is a highly effective, long lasting, muscle stimulant."
 	reagent_state = LIQUID
 	color = "#FF3300"
-	metabolism = REM * 10
+	metabolism = REM * 1.5
 	overdose = REAGENTS_OVERDOSE * 0.5
 
 /datum/reagent/hyperzine/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)


### PR DESCRIPTION
Hyperzine makes you fast. Due to some change a while back, it now makes you 3X as fast as it used to. This results in players moving _at the speed of fucking light_ instead of being a chemical that was helpful but not insanely over powered.

Showing how fast you are on hyperzine: https://i.gyazo.com/7d52bc71b74d435f8f45c74ddd3d0591.mp4

Hyperzine is easy to make (Literally 3 clicks in the chem dispencer), can be made into 14.88U pills to prevent ODing, and lasts bloody ages to fully metabolize.

This PR makes it so hyperzine makes you a _little_ faster, but not speeds that puts sonic to shame,