### PR TITLE
Maybe Perhaps Last Major Technomancer PR

### DIFF
--- a/code/game/gamemodes/technomancer/catalog.dm
+++ b/code/game/gamemodes/technomancer/catalog.dm
@@ -1,8 +1,13 @@
+#define ALL_SPELLS "All"
+#define OFFENSIVE_SPELLS "Offensive"
+#define DEFENSIVE_SPELLS "Defensive"
+#define UTILITY_SPELLS "Utility"
+#define SUPPORT_SPELLS "Support"
+
 var/list/all_technomancer_spells = typesof(/datum/technomancer/spell) - /datum/technomancer/spell
 var/list/all_technomancer_equipment = typesof(/datum/technomancer/equipment) - /datum/technomancer/equipment
 var/list/all_technomancer_consumables = typesof(/datum/technomancer/consumable) - /datum/technomancer/consumable
 var/list/all_technomancer_assistance = typesof(/datum/technomancer/assistance) - /datum/technomancer/assistance
-var/list/all_technomancer_presets = typesof(/datum/technomancer/presets) - /datum/technomancer/presets
 
 /datum/technomancer
 	var/name = "technomancer thing"
@@ -12,6 +17,9 @@ var/list/all_technomancer_presets = typesof(/datum/technomancer/presets) - /datu
 	var/hidden = 0
 	var/obj_path = null
 	var/ability_icon_state = null
+
+/datum/technomancer/spell
+	var/category = ALL_SPELLS
 
 /obj/item/weapon/technomancer_catalog
 	name = "catalog"
@@ -27,8 +35,8 @@ var/list/all_technomancer_presets = typesof(/datum/technomancer/presets) - /datu
 	var/list/equipment_instances = list()
 	var/list/consumable_instances = list()
 	var/list/assistance_instances = list()
-	var/list/preset_instances = list()
 	var/tab = 0
+	var/spell_tab = ALL_SPELLS
 	var/show_scepter_text = 0
 
 /obj/item/weapon/technomancer_catalog/apprentice
@@ -72,14 +80,22 @@ var/list/all_technomancer_presets = typesof(/datum/technomancer/presets) - /datu
 	if(!assistance_instances.len)
 		for(var/A in all_technomancer_assistance)
 			assistance_instances += new A()
-	if(!preset_instances.len)
-		for(var/P in all_technomancer_presets)
-			preset_instances += new P()
 
 /obj/item/weapon/technomancer_catalog/apprentice/set_up()
 	..()
 	for(var/datum/technomancer/assistance/apprentice/A in assistance_instances)
 		assistance_instances.Remove(A)
+
+// Proc: show_categories()
+// Parameters: 1 (category - the category link to display)
+// Description: Shows an href link to go to a spell subcategory if the category is not already selected, otherwise is bold, to reduce
+// code duplicating.
+/obj/item/weapon/technomancer_catalog/proc/show_categories(var/category)
+	if(category)
+		if(spell_tab != category)
+			return "<a href='byond://?src=\ref[src];spell_category=[category]'>[category]</a>"
+		else
+			return "<b>[category]</b>"
 
 // Proc: attack_self()
 // Parameters: 1 (user - the mob clicking on the catelog)
@@ -100,12 +116,16 @@ var/list/all_technomancer_presets = typesof(/datum/technomancer/presets) - /datu
 			dat += "<align='center'><b>Functions</b> | "
 			dat += "<a href='byond://?src=\ref[src];tab_choice=1'>Equipment</a> | "
 			dat += "<a href='byond://?src=\ref[src];tab_choice=2'>Consumables</a> | "
-			dat += "<a href='byond://?src=\ref[src];tab_choice=3'>Assistance</a> | "
-			dat += "<a href='byond://?src=\ref[src];tab_choice=4'>Presets</a></align><br>"
+			dat += "<a href='byond://?src=\ref[src];tab_choice=3'>Assistance</a></align><br>"
 			dat += "You currently have a budget of <b>[budget]/[max_budget]</b>.<br><br>"
 			dat += "<a href='byond://?src=\ref[src];refund_functions=1'>Refund Functions</a><br><br>"
-			for(var/datum/technomancer/spell in spell_instances)
+
+			dat += "[show_categories(ALL_SPELLS)] | [show_categories(OFFENSIVE_SPELLS)] | [show_categories(DEFENSIVE_SPELLS)] | \
+			[show_categories(UTILITY_SPELLS)] | [show_categories(SUPPORT_SPELLS)]<br>"
+			for(var/datum/technomancer/spell/spell in spell_instances)
 				if(spell.hidden)
+					continue
+				if(spell_tab != ALL_SPELLS && spell.category != spell_tab)
 					continue
 				dat += "<b>[spell.name]</b><br>"
 				dat += "<i>[spell.desc]</i><br>"
@@ -123,8 +143,7 @@ var/list/all_technomancer_presets = typesof(/datum/technomancer/presets) - /datu
 			dat += "<align='center'><a href='byond://?src=\ref[src];tab_choice=0'>Functions</a> | "
 			dat += "<b>Equipment</b> | "
 			dat += "<a href='byond://?src=\ref[src];tab_choice=2'>Consumables</a> | "
-			dat += "<a href='byond://?src=\ref[src];tab_choice=3'>Assistance</a> | "
-			dat += "<a href='byond://?src=\ref[src];tab_choice=4'>Presets</a></align><br>"
+			dat += "<a href='byond://?src=\ref[src];tab_choice=3'>Assistance</a></align><br>"
 			dat += "You currently have a budget of <b>[budget]/[max_budget]</b>.<br><br>"
 			for(var/datum/technomancer/equipment/E in equipment_instances)
 				dat += "<b>[E.name]</b><br>"
@@ -141,8 +160,7 @@ var/list/all_technomancer_presets = typesof(/datum/technomancer/presets) - /datu
 			dat += "<align='center'><a href='byond://?src=\ref[src];tab_choice=0'>Functions</a> | "
 			dat += "<a href='byond://?src=\ref[src];tab_choice=1'>Equipment</a> | "
 			dat += "<b>Consumables</b> | "
-			dat += "<a href='byond://?src=\ref[src];tab_choice=3'>Assistance</a> | "
-			dat += "<a href='byond://?src=\ref[src];tab_choice=4'>Presets</a></align><br>"
+			dat += "<a href='byond://?src=\ref[src];tab_choice=3'>Assistance</a></align><br>"
 			dat += "You currently have a budget of <b>[budget]/[max_budget]</b>.<br><br>"
 			for(var/datum/technomancer/consumable/C in consumable_instances)
 				dat += "<b>[C.name]</b><br>"
@@ -159,32 +177,13 @@ var/list/all_technomancer_presets = typesof(/datum/technomancer/presets) - /datu
 			dat += "<align='center'><a href='byond://?src=\ref[src];tab_choice=0'>Functions</a> | "
 			dat += "<a href='byond://?src=\ref[src];tab_choice=1'>Equipment</a> | "
 			dat += "<a href='byond://?src=\ref[src];tab_choice=2'>Consumables</a> | "
-			dat += "<b>Assistance</b> | "
-			dat += "<a href='byond://?src=\ref[src];tab_choice=4'>Presets</a></align><br>"
+			dat += "<b>Assistance</b></align><br>"
 			dat += "You currently have a budget of <b>[budget]/[max_budget]</b>.<br><br>"
 			for(var/datum/technomancer/assistance/A in assistance_instances)
 				dat += "<b>[A.name]</b><br>"
 				dat += "<i>[A.desc]</i><br>"
 				if(A.cost <= budget)
 					dat += "<a href='byond://?src=\ref[src];item_choice=[A.name]'>Purchase</a> ([A.cost])<br><br>"
-				else
-					dat += "<font color='red'><b>Cannot afford!</b></font><br><br>"
-			user << browse(dat, "window=radio")
-			onclose(user, "radio")
-		if(4) //Presets
-			var/dat = ""
-			user.set_machine(src)
-			dat += "<align='center'><a href='byond://?src=\ref[src];tab_choice=0'>Functions</a> | "
-			dat += "<a href='byond://?src=\ref[src];tab_choice=1'>Equipment</a> | "
-			dat += "<a href='byond://?src=\ref[src];tab_choice=2'>Consumables</a> | "
-			dat += "<a href='byond://?src=\ref[src];tab_choice=3'>Assistance</a> | "
-			dat += "<b>Presets</b></align><br>"
-			dat += "You currently have a budget of <b>[budget]/[max_budget]</b>.<br><br>"
-			for(var/datum/technomancer/presets/P in preset_instances)
-				dat += "<b>[P.name]</b><br>"
-				dat += "<i>[P.desc]</i><br>"
-				if(P.cost <= budget)
-					dat += "<a href='byond://?src=\ref[src];spell_choice=[P.name]'>Purchase</a> ([P.cost])<br><br>"
 				else
 					dat += "<font color='red'><b>Cannot afford!</b></font><br><br>"
 			user << browse(dat, "window=radio")
@@ -210,6 +209,8 @@ var/list/all_technomancer_presets = typesof(/datum/technomancer/presets) - /datu
 		H.set_machine(src)
 		if(href_list["tab_choice"])
 			tab = text2num(href_list["tab_choice"])
+		if(href_list["spell_category"])
+			spell_tab = href_list["spell_category"]
 		if(href_list["spell_choice"])
 			var/datum/technomancer/new_spell = null
 			//Locate the spell.

--- a/code/game/gamemodes/technomancer/instability.dm
+++ b/code/game/gamemodes/technomancer/instability.dm
@@ -212,4 +212,4 @@
 			outgoing_instability = outgoing_instability * armor_factor
 			H.adjust_instability(outgoing_instability)
 
-	set_light(distance, distance, l_color = "#C26DDE")
+	set_light(distance, distance * 2, l_color = "#C26DDE")

--- a/code/game/gamemodes/technomancer/spells/abjuration.dm
+++ b/code/game/gamemodes/technomancer/spells/abjuration.dm
@@ -4,6 +4,7 @@
 	far away from the caster.  Failing that, it may inhibit those entities in some form."
 	cost = 40
 	obj_path = /obj/item/weapon/spell/abjuration
+	category = UTILITY_SPELLS
 
 /obj/item/weapon/spell/abjuration
 	name = "abjuration"

--- a/code/game/gamemodes/technomancer/spells/apportation.dm
+++ b/code/game/gamemodes/technomancer/spells/apportation.dm
@@ -4,6 +4,7 @@
 	will grab them automatically."
 	cost = 50
 	obj_path = /obj/item/weapon/spell/apportation
+	category = UTILITY_SPELLS
 
 /obj/item/weapon/spell/apportation
 	name = "apportation"

--- a/code/game/gamemodes/technomancer/spells/audible_deception.dm
+++ b/code/game/gamemodes/technomancer/spells/audible_deception.dm
@@ -6,6 +6,7 @@
 	cost = 150
 	obj_path = /obj/item/weapon/spell/audible_deception
 	ability_icon_state = "tech_audibledeception"
+	category = UTILITY_SPELLS
 
 /obj/item/weapon/spell/audible_deception
 	name = "audible deception"

--- a/code/game/gamemodes/technomancer/spells/aura/biomed_aura.dm
+++ b/code/game/gamemodes/technomancer/spells/aura/biomed_aura.dm
@@ -4,6 +4,7 @@
 	cost = 150
 	obj_path = /obj/item/weapon/spell/aura/biomed
 	ability_icon_state = "tech_biomedaura"
+	category = SUPPORT_SPELLS
 
 /obj/item/weapon/spell/aura/biomed
 	name = "restoration aura"

--- a/code/game/gamemodes/technomancer/spells/aura/fire_aura.dm
+++ b/code/game/gamemodes/technomancer/spells/aura/fire_aura.dm
@@ -7,6 +7,7 @@
 	cost = 150
 	obj_path = /obj/item/weapon/spell/aura/fire
 	ability_icon_state = "tech_fireaura"
+	category = OFFENSIVE_SPELLS
 
 /obj/item/weapon/spell/aura/fire
 	name = "Fire Storm"
@@ -20,7 +21,6 @@
 		qdel(src)
 	var/list/nearby_things = range(4,owner)
 
-	var/fire_prob = 10
 	var/temp_change = 25
 	var/temp_cap = 500
 	var/fire_power = 2
@@ -28,7 +28,6 @@
 	if(check_for_scepter())
 		temp_change = 50
 		temp_cap = 700
-		fire_prob = 25
 		fire_power = 4
 	for(var/mob/living/carbon/human/H in nearby_things)
 		if(is_ally(H))
@@ -41,16 +40,11 @@
 
 	turf_check:
 		for(var/turf/simulated/T in nearby_things)
-			if(prob(fire_prob))
+			if(prob(30))
 				for(var/mob/living/carbon/human/H in T)
 					if(is_ally(H))
 						continue turf_check
 				T.hotspot_expose(1000, 50, 1)
 				T.create_fire(fire_power)
-
-
-//		//We use hotspot_expose() to allow firesuits to protect from this aura.
-//		var/turf/location = get_turf(H)
-//		location.hotspot_expose(1000, 50, 1)
 
 	owner.adjust_instability(1)

--- a/code/game/gamemodes/technomancer/spells/aura/frost_aura.dm
+++ b/code/game/gamemodes/technomancer/spells/aura/frost_aura.dm
@@ -6,6 +6,7 @@
 	cost = 150
 	obj_path = /obj/item/weapon/spell/aura/frost
 	ability_icon_state = "tech_frostaura"
+	category = DEFENSIVE_SPELLS // Scepter-less frost aura is nonlethal.
 
 /obj/item/weapon/spell/aura/frost
 	name = "chilling aura"
@@ -34,9 +35,5 @@
 		if(protection < 1)
 			var/cold_factor = abs(protection - 1)
 			H.bodytemperature = max( (H.bodytemperature - temp_change) * cold_factor, temp_cap)
-
-//		//We use hotspot_expose() to allow firesuits to protect from this aura.
-//		var/turf/location = get_turf(H)
-//		location.hotspot_expose(1, 50, 1)
 
 	owner.adjust_instability(1)

--- a/code/game/gamemodes/technomancer/spells/aura/shock_aura.dm
+++ b/code/game/gamemodes/technomancer/spells/aura/shock_aura.dm
@@ -4,6 +4,7 @@
 	cost = 150
 	obj_path = /obj/item/weapon/spell/aura/shock
 	ability_icon_state = "tech_shockaura"
+	category = OFFENSIVE_SPELLS
 
 /obj/item/weapon/spell/aura/shock
 	name = "electric aura"

--- a/code/game/gamemodes/technomancer/spells/aura/unstable_aura.dm
+++ b/code/game/gamemodes/technomancer/spells/aura/unstable_aura.dm
@@ -5,6 +5,7 @@
 	cost = 150
 	obj_path = /obj/item/weapon/spell/aura/unstable
 	ability_icon_state = "tech_unstableaura"
+	category = OFFENSIVE_SPELLS
 
 /obj/item/weapon/spell/aura/unstable
 	name = "degen aura"

--- a/code/game/gamemodes/technomancer/spells/blink.dm
+++ b/code/game/gamemodes/technomancer/spells/blink.dm
@@ -5,6 +5,7 @@
 	enhancement_desc = "Blink distance is increased greatly."
 	cost = 100
 	obj_path = /obj/item/weapon/spell/blink
+	category = UTILITY_SPELLS
 
 /obj/item/weapon/spell/blink
 	name = "blink"

--- a/code/game/gamemodes/technomancer/spells/chroma.dm
+++ b/code/game/gamemodes/technomancer/spells/chroma.dm
@@ -4,6 +4,7 @@
 	useful to trick someone into believing you're casting a different spell, or perhaps just for fun."
 	cost = 25
 	obj_path = /obj/item/weapon/spell/chroma
+	category = UTILITY_SPELLS
 
 /obj/item/weapon/spell/chroma
 	name = "chroma"

--- a/code/game/gamemodes/technomancer/spells/condensation.dm
+++ b/code/game/gamemodes/technomancer/spells/condensation.dm
@@ -5,6 +5,7 @@
 	ability_icon_state = "tech_condensation"
 	cost = 50
 	obj_path = /obj/item/weapon/spell/condensation
+	category = UTILITY_SPELLS
 
 /obj/item/weapon/spell/condensation
 	name = "condensation"

--- a/code/game/gamemodes/technomancer/spells/control.dm
+++ b/code/game/gamemodes/technomancer/spells/control.dm
@@ -7,6 +7,7 @@
 	around the entity is merely a hologram used to allow the user to know if the creature is safe or not."
 	cost = 200
 	obj_path = /obj/item/weapon/spell/control
+	category = UTILITY_SPELLS
 
 /mob/living/carbon/human/proc/technomancer_control()
 	place_spell_in_hand(/obj/item/weapon/spell/control)

--- a/code/game/gamemodes/technomancer/spells/dispel.dm
+++ b/code/game/gamemodes/technomancer/spells/dispel.dm
@@ -6,6 +6,7 @@
 	cost = 25
 	obj_path = /obj/item/weapon/spell/dispel
 	ability_icon_state = "tech_dispel"
+	category = SUPPORT_SPELLS
 
 /obj/item/weapon/spell/dispel
 	name = "dispel"

--- a/code/game/gamemodes/technomancer/spells/energy_siphon.dm
+++ b/code/game/gamemodes/technomancer/spells/energy_siphon.dm
@@ -7,6 +7,7 @@
 	cost = 150
 	obj_path = /obj/item/weapon/spell/energy_siphon
 	ability_icon_state = "tech_energysiphon"
+	category = UTILITY_SPELLS
 
 /obj/item/weapon/spell/energy_siphon
 	name = "energy siphon"

--- a/code/game/gamemodes/technomancer/spells/flame_tongue.dm
+++ b/code/game/gamemodes/technomancer/spells/flame_tongue.dm
@@ -4,6 +4,7 @@
 	cost = 100
 	obj_path = /obj/item/weapon/spell/flame_tongue
 	ability_icon_state = "tech_flametongue"
+	category = OFFENSIVE_SPELLS
 
 /obj/item/weapon/spell/flame_tongue
 	name = "flame tongue"

--- a/code/game/gamemodes/technomancer/spells/gambit.dm
+++ b/code/game/gamemodes/technomancer/spells/gambit.dm
@@ -4,6 +4,7 @@
 	ability_icon_state = "tech_gambit"
 	cost = 50
 	obj_path = /obj/item/weapon/spell/gambit
+	category = UTILITY_SPELLS
 
 /var/global/list/all_technomancer_gambit_spells = typesof(/obj/item/weapon/spell) - list(
 	/obj/item/weapon/spell,

--- a/code/game/gamemodes/technomancer/spells/illusion.dm
+++ b/code/game/gamemodes/technomancer/spells/illusion.dm
@@ -5,6 +5,7 @@
 	cost = 100
 	obj_path = /obj/item/weapon/spell/illusion
 	ability_icon_state = "tech_illusion"
+	category = UTILITY_SPELLS
 
 /obj/item/weapon/spell/illusion
 	name = "illusion"

--- a/code/game/gamemodes/technomancer/spells/insert/corona.dm
+++ b/code/game/gamemodes/technomancer/spells/insert/corona.dm
@@ -5,6 +5,7 @@
 	cost = 100
 	obj_path = /obj/item/weapon/spell/insert/corona
 	ability_icon_state = "tech_corona"
+	category = SUPPORT_SPELLS
 
 /obj/item/weapon/spell/insert/corona
 	name = "corona"

--- a/code/game/gamemodes/technomancer/spells/insert/haste.dm
+++ b/code/game/gamemodes/technomancer/spells/insert/haste.dm
@@ -1,10 +1,11 @@
 /datum/technomancer/spell/haste
 	name = "Haste"
-	desc = "Allows the target to run at speeds that should not be possible for an ordinary being.  For three seconds, the target \
+	desc = "Allows the target to run at speeds that should not be possible for an ordinary being.  For five seconds, the target \
 	runs extremly fast, and cannot be slowed by any means."
 	cost = 100
 	obj_path = /obj/item/weapon/spell/insert/haste
 	ability_icon_state = "tech_haste"
+	category = SUPPORT_SPELLS
 
 /obj/item/weapon/spell/insert/haste
 	name = "haste"
@@ -22,7 +23,7 @@
 			L.force_max_speed = 1
 			L << "<span class='notice'>You suddenly find it much easier to move.</span>"
 			L.adjust_instability(10)
-			spawn(3 SECONDS)
+			spawn(5 SECONDS)
 				if(src)
 					on_expire()
 

--- a/code/game/gamemodes/technomancer/spells/insert/mend_burns.dm
+++ b/code/game/gamemodes/technomancer/spells/insert/mend_burns.dm
@@ -5,6 +5,7 @@
 	cost = 50
 	obj_path = /obj/item/weapon/spell/insert/mend_burns
 	ability_icon_state = "tech_mendburns"
+	category = SUPPORT_SPELLS
 
 /obj/item/weapon/spell/insert/mend_burns
 	name = "mend burns"
@@ -19,10 +20,10 @@
 	spawn(1)
 		if(ishuman(host))
 			var/mob/living/carbon/human/H = host
-			for(var/i = 0, i<25,i++)
+			for(var/i = 0, i<5,i++)
 				if(H)
-					H.adjustFireLoss(-1)
-					H.adjust_instability(0.5)
-					origin.adjust_instability(0.5)
+					H.adjustFireLoss(-5)
+					H.adjust_instability(2.5)
+					origin.adjust_instability(2.5)
 					sleep(10)
 		on_expire()

--- a/code/game/gamemodes/technomancer/spells/insert/mend_metal.dm
+++ b/code/game/gamemodes/technomancer/spells/insert/mend_metal.dm
@@ -4,6 +4,7 @@
 	cost = 50
 	obj_path = /obj/item/weapon/spell/insert/mend_metal
 	ability_icon_state = "tech_mendwounds"
+	category = SUPPORT_SPELLS
 
 /obj/item/weapon/spell/insert/mend_metal
 	name = "mend metal"
@@ -18,14 +19,14 @@
 	spawn(1)
 		if(ishuman(host))
 			var/mob/living/carbon/human/H = host
-			for(var/i = 0, i<25,i++)
+			for(var/i = 0, i<5,i++)
 				if(H)
 					for(var/obj/item/organ/external/O in H.organs)
 						if(O.robotic < ORGAN_ROBOT) // Robot parts only.
 							continue
-						O.heal_damage(1, 0, internal = 1, robo_repair = 1)
+						O.heal_damage(5, 0, internal = 1, robo_repair = 1)
 
-					H.adjust_instability(0.5)
-					origin.adjust_instability(0.5)
-					sleep(10)
+					H.adjust_instability(2.5)
+					origin.adjust_instability(2.5)
+					sleep(1 SECOND)
 		on_expire()

--- a/code/game/gamemodes/technomancer/spells/insert/mend_organs.dm
+++ b/code/game/gamemodes/technomancer/spells/insert/mend_organs.dm
@@ -5,6 +5,7 @@
 	cost = 75
 	obj_path = /obj/item/weapon/spell/insert/mend_organs
 	ability_icon_state = "tech_mendwounds"
+	category = SUPPORT_SPELLS
 
 /obj/item/weapon/spell/insert/mend_organs
 	name = "mend organs"
@@ -19,13 +20,13 @@
 	spawn(1)
 		if(ishuman(host))
 			var/mob/living/carbon/human/H = host
-			for(var/i = 0, i<25,i++)
+			for(var/i = 0, i<5,i++)
 				if(H)
 					for(var/obj/item/organ/O in H.internal_organs)
 						if(O.damage > 0)
-							O.damage = max(O.damage - 0.2, 0)
+							O.damage = max(O.damage - 1, 0)
 
-					H.adjust_instability(0.5)
-					origin.adjust_instability(0.5)
-					sleep(10)
+					H.adjust_instability(2.5)
+					origin.adjust_instability(2.5)
+					sleep(1 SECOND)
 		on_expire()

--- a/code/game/gamemodes/technomancer/spells/insert/mend_wires.dm
+++ b/code/game/gamemodes/technomancer/spells/insert/mend_wires.dm
@@ -5,6 +5,7 @@
 	cost = 50
 	obj_path = /obj/item/weapon/spell/insert/mend_wires
 	ability_icon_state = "tech_mendwounds"
+	category = SUPPORT_SPELLS
 
 /obj/item/weapon/spell/insert/mend_wires
 	name = "mend wires"
@@ -19,14 +20,14 @@
 	spawn(1)
 		if(ishuman(host))
 			var/mob/living/carbon/human/H = host
-			for(var/i = 0, i<25,i++)
+			for(var/i = 0, i<5,i++)
 				if(H)
 					for(var/obj/item/organ/external/O in H.organs)
 						if(O.robotic < ORGAN_ROBOT) // Robot parts only.
 							continue
-						O.heal_damage(0, 1, internal = 1, robo_repair = 1)
+						O.heal_damage(0, 5, internal = 1, robo_repair = 1)
 
-					H.adjust_instability(0.5)
-					origin.adjust_instability(0.5)
+					H.adjust_instability(2.5)
+					origin.adjust_instability(2.5)
 					sleep(10)
 		on_expire()

--- a/code/game/gamemodes/technomancer/spells/insert/mend_wounds.dm
+++ b/code/game/gamemodes/technomancer/spells/insert/mend_wounds.dm
@@ -5,6 +5,7 @@
 	cost = 50
 	obj_path = /obj/item/weapon/spell/insert/mend_wounds
 	ability_icon_state = "tech_mendwounds"
+	category = SUPPORT_SPELLS
 
 /obj/item/weapon/spell/insert/mend_wounds
 	name = "mend wounds"
@@ -19,10 +20,10 @@
 	spawn(1)
 		if(ishuman(host))
 			var/mob/living/carbon/human/H = host
-			for(var/i = 0, i<25,i++)
+			for(var/i = 0, i<5,i++)
 				if(H)
-					H.adjustBruteLoss(-1)
-					H.adjust_instability(0.5)
-					origin.adjust_instability(0.5)
-					sleep(10)
+					H.adjustBruteLoss(-5)
+					H.adjust_instability(2.5)
+					origin.adjust_instability(2.5)
+					sleep(1 SECOND)
 		on_expire()

--- a/code/game/gamemodes/technomancer/spells/insert/purify.dm
+++ b/code/game/gamemodes/technomancer/spells/insert/purify.dm
@@ -1,10 +1,11 @@
 /datum/technomancer/spell/purify
 	name = "Purify"
-	desc = "Clenses the body of harmful impurities, such as toxins, radiation, viruses, and such.  \
+	desc = "Clenses the body of harmful impurities, such as toxins, radiation, viruses, genetic damage, and such.  \
 	Instability is split between the target and technomancer, if seperate."
 	cost = 25
 	obj_path = /obj/item/weapon/spell/insert/purify
 	ability_icon_state = "tech_purify"
+	category = SUPPORT_SPELLS
 
 /obj/item/weapon/spell/insert/purify
 	name = "purify"
@@ -23,12 +24,12 @@
 			H.disabilities = 0
 //			for(var/datum/disease/D in H.viruses)
 //				D.cure()
-			for(var/i = 0, i<25,i++)
+			for(var/i = 0, i<5,i++)
 				if(H)
-					H.adjustToxLoss(-1)
-					H.adjustCloneLoss(-1)
-					H.radiation = max(host.radiation - 2, 0)
-					H.adjust_instability(0.5)
-					origin.adjust_instability(0.5)
-					sleep(10)
+					H.adjustToxLoss(-5)
+					H.adjustCloneLoss(-5)
+					H.radiation = max(host.radiation - 10, 0)
+					H.adjust_instability(2.5)
+					origin.adjust_instability(2.5)
+					sleep(1 SECOND)
 		on_expire()

--- a/code/game/gamemodes/technomancer/spells/insert/repel_missiles.dm
+++ b/code/game/gamemodes/technomancer/spells/insert/repel_missiles.dm
@@ -1,10 +1,11 @@
 /datum/technomancer/spell/repel_missiles
 	name = "Repel Missiles"
 	desc = "Places a repulsion field around you, which attempts to deflect incoming bullets and lasers, making them 30% less likely \
-	to hit you.  The field lasts for two minutes and can be granted to yourself or an ally."
+	to hit you.  The field lasts for five minutes and can be granted to yourself or an ally."
 	cost = 60
 	obj_path = /obj/item/weapon/spell/insert/repel_missiles
 	ability_icon_state = "tech_repelmissiles"
+	category = SUPPORT_SPELLS
 
 /obj/item/weapon/spell/insert/repel_missiles
 	name = "repel missiles"
@@ -21,7 +22,7 @@
 			var/mob/living/L = host
 			L.evasion += 2
 			L << "<span class='notice'>You have a repulsion field around you, which will attempt to deflect projectiles.</span>"
-			spawn(2 MINUTES)
+			spawn(5 MINUTES)
 				if(src)
 					on_expire()
 

--- a/code/game/gamemodes/technomancer/spells/instability_tap.dm
+++ b/code/game/gamemodes/technomancer/spells/instability_tap.dm
@@ -5,6 +5,7 @@
 	cost = 120
 	obj_path = /obj/item/weapon/spell/instability_tap
 	ability_icon_state = "tech_instabilitytap"
+	category = UTILITY_SPELLS
 
 /obj/item/weapon/spell/instability_tap
 	name = "instability tap"

--- a/code/game/gamemodes/technomancer/spells/mark_recall.dm
+++ b/code/game/gamemodes/technomancer/spells/mark_recall.dm
@@ -6,6 +6,7 @@
 	cost = 50
 	obj_path = /obj/item/weapon/spell/mark
 	ability_icon_state = "tech_mark"
+	category = UTILITY_SPELLS
 
 //The object to teleport to when Recall is used.
 /obj/effect/mark_spell
@@ -52,6 +53,7 @@
 	cost = 50
 	obj_path = /obj/item/weapon/spell/recall
 	ability_icon_state = "tech_recall"
+	category = UTILITY_SPELLS
 
 /obj/item/weapon/spell/recall
 	name = "recall"

--- a/code/game/gamemodes/technomancer/spells/oxygenate.dm
+++ b/code/game/gamemodes/technomancer/spells/oxygenate.dm
@@ -5,6 +5,7 @@
 	cost = 70
 	obj_path = /obj/item/weapon/spell/oxygenate
 	ability_icon_state = "oxygenate"
+	category = SUPPORT_SPELLS
 
 /obj/item/weapon/spell/oxygenate
 	name = "oxygenate"

--- a/code/game/gamemodes/technomancer/spells/passwall.dm
+++ b/code/game/gamemodes/technomancer/spells/passwall.dm
@@ -6,6 +6,7 @@
 	cost = 100
 	obj_path = /obj/item/weapon/spell/passwall
 	ability_icon_state = "tech_passwall"
+	category = UTILITY_SPELLS
 
 /obj/item/weapon/spell/passwall
 	name = "passwall"
@@ -21,53 +22,55 @@
 	if(!allowed_to_teleport())
 		user << "<span class='warning'>You can't teleport here!</span>"
 		return 0
-	if(isturf(hit_atom))
-		var/turf/T = hit_atom 				//Turf we touched.
-		var/turf/our_turf = get_turf(user)	//Where we are.
-		if(!T.density)
-			user << "<span class='warning'>Perhaps you should try using passWALL on a wall.</span>"
+//	if(isturf(hit_atom))
+
+	var/turf/T = get_turf(hit_atom)		//Turf we touched.
+	var/turf/our_turf = get_turf(user)	//Where we are.
+	if(!T.density)
+		if(!T.check_density())
+			user << "<span class='warning'>Perhaps you should try using passWALL on a wall, or other solid object.</span>"
 			return 0
-		var/direction = get_dir(our_turf, T)
-		var/total_cost = 0
-		var/turf/checked_turf = T			//Turf we're currently checking for density in the loop below.
-		var/turf/found_turf = null			//Our destination, if one is found.
-		var/i = maximum_distance
+	var/direction = get_dir(our_turf, T)
+	var/total_cost = 0
+	var/turf/checked_turf = T			//Turf we're currently checking for density in the loop below.
+	var/turf/found_turf = null			//Our destination, if one is found.
+	var/i = maximum_distance
 
-		visible_message("<span class='info'>[user] rests a hand on \the [T].</span>")
-		busy = 1
+	visible_message("<span class='info'>[user] rests a hand on \the [hit_atom].</span>")
+	busy = 1
 
-		var/datum/effect/effect/system/spark_spread/spark_system = PoolOrNew(/datum/effect/effect/system/spark_spread)
-		spark_system.set_up(5, 0, our_turf)
+	var/datum/effect/effect/system/spark_spread/spark_system = PoolOrNew(/datum/effect/effect/system/spark_spread)
+	spark_system.set_up(5, 0, our_turf)
 
-		while(i)
-			checked_turf = get_step(checked_turf, direction) //Advance in the given direction
-			total_cost += check_for_scepter() ? 400 : 800 //Phasing through matter's expensive, you know.
-			i--
-			if(!checked_turf.density) //If we found a destination (a non-dense turf), then we can stop.
-				var/dense_objs_on_turf = 0
-				for(var/atom/movable/stuff in checked_turf.contents) //Make sure nothing dense is where we want to go, like an airlock or window.
-					if(stuff.density)
-						dense_objs_on_turf = 1
+	while(i)
+		checked_turf = get_step(checked_turf, direction) //Advance in the given direction
+		total_cost += check_for_scepter() ? 400 : 800 //Phasing through matter's expensive, you know.
+		i--
+		if(!checked_turf.density) //If we found a destination (a non-dense turf), then we can stop.
+			var/dense_objs_on_turf = 0
+			for(var/atom/movable/stuff in checked_turf.contents) //Make sure nothing dense is where we want to go, like an airlock or window.
+				if(stuff.density)
+					dense_objs_on_turf = 1
 
-				if(!dense_objs_on_turf) //If we found a non-dense turf with nothing dense on it, then that's our destination.
-					found_turf = checked_turf
-					break
-			sleep(10)
+			if(!dense_objs_on_turf) //If we found a non-dense turf with nothing dense on it, then that's our destination.
+				found_turf = checked_turf
+				break
+		sleep(10)
 
-		if(found_turf)
-			if(user.loc != our_turf)
-				user << "<span class='warning'>You need to stand still in order to phase through the wall.</span>"
-				return 0
-			if(pay_energy(total_cost) && !user.incapacitated() )
-				visible_message("<span class='warning'>[user] appears to phase through \the [T]!</span>")
-				user << "<span class='info'>You find a destination on the other side of \the [T], and phase through it.</span>"
-				spark_system.start()
-				user.forceMove(found_turf)
-				qdel(src)
-				return 1
-			else
-				user << "<span class='warning'>You don't have enough energy to phase through these walls!</span>"
-				busy = 0
+	if(found_turf)
+		if(user.loc != our_turf)
+			user << "<span class='warning'>You need to stand still in order to phase through \the [hit_atom].</span>"
+			return 0
+		if(pay_energy(total_cost) && !user.incapacitated() )
+			visible_message("<span class='warning'>[user] appears to phase through \the [hit_atom]!</span>")
+			user << "<span class='info'>You find a destination on the other side of \the [hit_atom], and phase through it.</span>"
+			spark_system.start()
+			user.forceMove(found_turf)
+			qdel(src)
+			return 1
 		else
-			user << "<span class='info'>You weren't able to find an open space to go to.</span>"
+			user << "<span class='warning'>You don't have enough energy to phase through these walls!</span>"
 			busy = 0
+	else
+		user << "<span class='info'>You weren't able to find an open space to go to.</span>"
+		busy = 0

--- a/code/game/gamemodes/technomancer/spells/phase_shift.dm
+++ b/code/game/gamemodes/technomancer/spells/phase_shift.dm
@@ -4,6 +4,7 @@
 	draining your powercell."
 	cost = 80
 	obj_path = /obj/item/weapon/spell/phase_shift
+	category = DEFENSIVE_SPELLS
 
 /obj/item/weapon/spell/phase_shift
 	name = "phase shift"

--- a/code/game/gamemodes/technomancer/spells/projectile/beam.dm
+++ b/code/game/gamemodes/technomancer/spells/projectile/beam.dm
@@ -4,6 +4,7 @@
 	cost = 150
 	ability_icon_state = "tech_beam"
 	obj_path = /obj/item/weapon/spell/projectile/beam
+	category = OFFENSIVE_SPELLS
 
 /obj/item/weapon/spell/projectile/beam
 	name = "beam"
@@ -12,12 +13,13 @@
 	cast_methods = CAST_RANGED
 	aspect = ASPECT_LIGHT
 	spell_projectile = /obj/item/projectile/beam/blue
-	energy_cost_per_shot = 500
+	energy_cost_per_shot = 400
 	instability_per_shot = 3
 	cooldown = 10
+	fire_sound = 'sound/weapons/Laser.ogg'
 
 /obj/item/projectile/beam/blue
-	damage = 20
+	damage = 30
 
 	muzzle_type = /obj/effect/projectile/laser_blue/muzzle
 	tracer_type = /obj/effect/projectile/laser_blue/tracer

--- a/code/game/gamemodes/technomancer/spells/projectile/chain_lightning.dm
+++ b/code/game/gamemodes/technomancer/spells/projectile/chain_lightning.dm
@@ -5,6 +5,7 @@
 	strike up to four targets, including yourself if conditions allow it to occur."
 	cost = 150
 	obj_path = /obj/item/weapon/spell/projectile/chain_lightning
+	category = OFFENSIVE_SPELLS
 
 /obj/item/weapon/spell/projectile/chain_lightning
 	name = "chain lightning"
@@ -16,6 +17,7 @@
 	energy_cost_per_shot = 3000
 	instability_per_shot = 10
 	cooldown = 20
+	fire_sound = 'sound/weapons/gauss_shoot.ogg'
 
 /obj/item/projectile/beam/chain_lightning
 	name = "lightning"

--- a/code/game/gamemodes/technomancer/spells/projectile/force_missile.dm
+++ b/code/game/gamemodes/technomancer/spells/projectile/force_missile.dm
@@ -4,6 +4,7 @@
 	that armor designed to protect from blunt force will mitigate this function as well."
 	cost = 100
 	obj_path = /obj/item/weapon/spell/projectile/force_missile
+	category = OFFENSIVE_SPELLS
 
 /obj/item/weapon/spell/projectile/force_missile
 	name = "force missile"
@@ -12,13 +13,14 @@
 	cast_methods = CAST_RANGED
 	aspect = ASPECT_FORCE
 	spell_projectile = /obj/item/projectile/force_missile
-	energy_cost_per_shot = 400
+	energy_cost_per_shot = 300
 	instability_per_shot = 2
-	cooldown = 10
+	cooldown = 5
+	fire_sound = 'sound/weapons/wave.ogg'
 
 /obj/item/projectile/force_missile
 	name = "force missile"
 	icon_state = "force_missile"
-	damage = 20
+	damage = 25
 	damage_type = BRUTE
 	check_armour = "melee"

--- a/code/game/gamemodes/technomancer/spells/projectile/lightning.dm
+++ b/code/game/gamemodes/technomancer/spells/projectile/lightning.dm
@@ -5,6 +5,7 @@
 	strike."
 	cost = 150
 	obj_path = /obj/item/weapon/spell/projectile/lightning
+	category = OFFENSIVE_SPELLS
 
 /obj/item/weapon/spell/projectile/lightning
 	name = "lightning strike"
@@ -16,7 +17,8 @@
 	energy_cost_per_shot = 2500
 	instability_per_shot = 10
 	cooldown = 20
-	pre_shot_delay = 20
+	pre_shot_delay = 10
+	fire_sound = 'sound/weapons/gauss_shoot.ogg'
 
 /obj/item/projectile/beam/lightning
 	name = "lightning"

--- a/code/game/gamemodes/technomancer/spells/projectile/overload.dm
+++ b/code/game/gamemodes/technomancer/spells/projectile/overload.dm
@@ -4,6 +4,7 @@
 	This energy pierces all known armor."
 	cost = 150
 	obj_path = /obj/item/weapon/spell/projectile/overload
+	category = OFFENSIVE_SPELLS
 
 /obj/item/weapon/spell/projectile/overload
 	name = "overload"
@@ -13,9 +14,10 @@
 	aspect = ASPECT_UNSTABLE
 	spell_projectile = /obj/item/projectile/overload
 	energy_cost_per_shot = 0 // Handled later
-	instability_per_shot = 15
+	instability_per_shot = 12
 	cooldown = 10
 	pre_shot_delay = 4
+	fire_sound = 'sound/effects/supermatter.ogg'
 
 /obj/item/projectile/overload
 	name = "overloaded bolt"
@@ -25,15 +27,15 @@
 	armor_penetration = 100
 
 /obj/item/weapon/spell/projectile/overload/on_ranged_cast(atom/hit_atom, mob/living/user)
-	energy_cost_per_shot = round(core.max_energy * 0.15)
+	energy_cost_per_shot = round(core.max_energy * 0.10)
 	var/energy_before_firing = core.energy
 	if(set_up(hit_atom, user))
 		var/obj/item/projectile/overload/P = new spell_projectile(get_turf(user))
 		P.launch(hit_atom)
 		if(check_for_scepter())
-			P.damage = round(energy_before_firing * 0.003) // 3% of their current energy pool.
+			P.damage = round(energy_before_firing * 0.004) // 4% of their current energy pool.
 		else
-			P.damage = round(energy_before_firing * 0.002) // 2% of their current energy pool.
+			P.damage = round(energy_before_firing * 0.003) // 3% of their current energy pool.
 		owner.adjust_instability(instability_per_shot)
 		return 1
 

--- a/code/game/gamemodes/technomancer/spells/projectile/projectile.dm
+++ b/code/game/gamemodes/technomancer/spells/projectile/projectile.dm
@@ -7,12 +7,15 @@
 	var/energy_cost_per_shot = 0
 	var/instability_per_shot = 0
 	var/pre_shot_delay = 0
+	var/fire_sound = null
 
 /obj/item/weapon/spell/projectile/on_ranged_cast(atom/hit_atom, mob/living/user)
 	var/turf/T = get_turf(hit_atom)
 	if(set_up(hit_atom, user))
 		var/obj/item/projectile/new_projectile = new spell_projectile(get_turf(user))
 		new_projectile.launch(T)
+		if(fire_sound)
+			playsound(get_turf(src), fire_sound, 75, 1)
 		owner.adjust_instability(instability_per_shot)
 		return 1
 	return 0
@@ -23,7 +26,7 @@
 			if(pre_shot_delay)
 				var/image/target_image = image(icon = 'icons/obj/spells.dmi', loc = get_turf(hit_atom), icon_state = "target")
 				user << target_image
-				user.Stun(pre_shot_delay)
+				user.Stun(pre_shot_delay / 10)
 				sleep(pre_shot_delay)
 				qdel(target_image)
 			return 1

--- a/code/game/gamemodes/technomancer/spells/radiance.dm
+++ b/code/game/gamemodes/technomancer/spells/radiance.dm
@@ -3,6 +3,7 @@
 	desc = "Causes you to be very radiant, glowing brightly in visible light, thermal energy, and deadly ionizing radiation."
 	cost = 180
 	obj_path = /obj/item/weapon/spell/radiance
+	category = OFFENSIVE_SPELLS
 
 /obj/item/weapon/spell/radiance
 	name = "radiance"

--- a/code/game/gamemodes/technomancer/spells/reflect.dm
+++ b/code/game/gamemodes/technomancer/spells/reflect.dm
@@ -4,6 +4,7 @@
 	cost = 120
 	obj_path = /obj/item/weapon/spell/reflect
 	ability_icon_state = "tech_reflect"
+	category = DEFENSIVE_SPELLS
 
 /obj/item/weapon/spell/reflect
 	name = "\proper reflect shield"

--- a/code/game/gamemodes/technomancer/spells/resurrect.dm
+++ b/code/game/gamemodes/technomancer/spells/resurrect.dm
@@ -6,6 +6,7 @@
 	cost = 100
 	obj_path = /obj/item/weapon/spell/resurrect
 	ability_icon_state = "tech_resurrect"
+	category = SUPPORT_SPELLS
 
 /obj/item/weapon/spell/resurrect
 	name = "resurrect"

--- a/code/game/gamemodes/technomancer/spells/shared_burden.dm
+++ b/code/game/gamemodes/technomancer/spells/shared_burden.dm
@@ -3,6 +3,7 @@
 	desc = "One of the few functions able to adjust instability, this allows you to take someone else's instability."
 	cost = 50
 	obj_path = /obj/item/weapon/spell/shared_burden
+	category = SUPPORT_SPELLS
 
 /obj/item/weapon/spell/shared_burden
 	name = "shared burden"

--- a/code/game/gamemodes/technomancer/spells/shield.dm
+++ b/code/game/gamemodes/technomancer/spells/shield.dm
@@ -5,6 +5,7 @@
 	cost = 120
 	obj_path = /obj/item/weapon/spell/shield
 	ability_icon_state = "tech_shield"
+	category = DEFENSIVE_SPELLS
 
 /obj/item/weapon/spell/shield
 	name = "\proper energy shield"

--- a/code/game/gamemodes/technomancer/spells/spawner/darkness.dm
+++ b/code/game/gamemodes/technomancer/spells/spawner/darkness.dm
@@ -3,6 +3,7 @@
 	desc = "Disrupts photons moving in a local area, causing darkness to shroud yourself or a position of your choosing."
 	cost = 30
 	obj_path = /obj/item/weapon/spell/spawner/darkness
+	category = UTILITY_SPELLS
 
 /obj/item/weapon/spell/spawner/darkness
 	name = "darkness"

--- a/code/game/gamemodes/technomancer/spells/spawner/fire_blast.dm
+++ b/code/game/gamemodes/technomancer/spells/spawner/fire_blast.dm
@@ -4,6 +4,7 @@
 	sure to not be close to the disturbance yourself."
 	cost = 175
 	obj_path = /obj/item/weapon/spell/spawner/fire_blast
+	category = OFFENSIVE_SPELLS
 
 /obj/item/weapon/spell/spawner/fire_blast
 	name = "fire blast"

--- a/code/game/gamemodes/technomancer/spells/spawner/pulsar.dm
+++ b/code/game/gamemodes/technomancer/spells/spawner/pulsar.dm
@@ -3,6 +3,7 @@
 	desc = "Emits electronic pulses to destroy, disable, or otherwise harm devices and machines.  Be sure to not hit yourself with this."
 	cost = 150
 	obj_path = /obj/item/weapon/spell/spawner/pulsar
+	category = OFFENSIVE_SPELLS
 
 /obj/item/weapon/spell/spawner/pulsar
 	name = "pulsar"

--- a/code/game/gamemodes/technomancer/spells/summon/summon_creature.dm
+++ b/code/game/gamemodes/technomancer/spells/summon/summon_creature.dm
@@ -8,6 +8,7 @@
 	enhancement_desc = "Summoned entities will never harm their summoner."
 	cost = 200
 	obj_path = /obj/item/weapon/spell/summon/summon_creature
+	category = UTILITY_SPELLS
 
 /obj/item/weapon/spell/summon/summon_creature
 	name = "summon creature"

--- a/code/game/gamemodes/technomancer/spells/summon/summon_ward.dm
+++ b/code/game/gamemodes/technomancer/spells/summon/summon_ward.dm
@@ -5,6 +5,7 @@
 	enhancement_desc = "Wards can detect invisibile entities, and are more specific in relaying information about what it sees."
 	cost = 100
 	obj_path = /obj/item/weapon/spell/summon/summon_ward
+	category = UTILITY_SPELLS
 
 /obj/item/weapon/spell/summon/summon_ward
 	name = "summon ward"

--- a/code/game/gamemodes/technomancer/spells/targeting_matrix.dm
+++ b/code/game/gamemodes/technomancer/spells/targeting_matrix.dm
@@ -5,6 +5,7 @@
 	cost = 150
 	ability_icon_state = "tech_targetingmatrix"
 	obj_path = /obj/item/weapon/spell/targeting_matrix
+	category = UTILITY_SPELLS
 
 /obj/item/weapon/spell/targeting_matrix
 	name = "targeting matrix"

--- a/code/game/gamemodes/technomancer/spells/track.dm
+++ b/code/game/gamemodes/technomancer/spells/track.dm
@@ -3,9 +3,10 @@
 	desc = "Acts as directional guidance towards an object that belongs to you or your team.  It can also point towards your allies.  \
 	Wonderful if you're worried someone will steal your valuables, like a certain shiny Scepter..."
 	enhancement_desc = "You will be able to track most other entities in addition to your belongings and allies."
-	cost = 30
+	cost = 25
 	obj_path = /obj/item/weapon/spell/track
 	ability_icon_state = "tech_track"
+	category = UTILITY_SPELLS
 
 // This stores a ref to all important items that belong to a Technomancer, in case of theft.  Used by the spell below.
 // I feel dirty for adding yet another global list used by one thing, but the only alternative is to loop through world, and yeahhh.

--- a/code/game/gamemodes/technomancer/spells/warp_strike.dm
+++ b/code/game/gamemodes/technomancer/spells/warp_strike.dm
@@ -4,6 +4,7 @@
 	cost = 200
 	obj_path = /obj/item/weapon/spell/warp_strike
 	ability_icon_state = "tech_warpstrike"
+	category = OFFENSIVE_SPELLS
 
 /obj/item/weapon/spell/warp_strike
 	name = "warp strike"

--- a/polaris.dme
+++ b/polaris.dme
@@ -418,7 +418,6 @@
 #include "code\game\gamemodes\technomancer\core_obj.dm"
 #include "code\game\gamemodes\technomancer\equipment.dm"
 #include "code\game\gamemodes\technomancer\instability.dm"
-#include "code\game\gamemodes\technomancer\presets.dm"
 #include "code\game\gamemodes\technomancer\spell_objs.dm"
 #include "code\game\gamemodes\technomancer\spell_objs_helpers.dm"
 #include "code\game\gamemodes\technomancer\technomancer.dm"


### PR DESCRIPTION
Adds ability to sort the spells section of the catalog into categories.  The categories available are 'All', 'Offensive', 'Defensive', 'Utility', and 'Support'.  An example is here;
![Category example](http://puu.sh/qHjz9/33636f8ad2.png)
Removes preset section on catalog as it was unused.
Projectile spells now have a sound when fired.
Haste lasts five seconds instead of three.
Repel Missiles lasts for five minutes instead of two.
All healing spells work five times as fast, healing in five seconds instead of twenty five seconds.  The amount of instability and healing done has been multiplied to remain consistent.
Passwall can now be used on more than just walls, if there's something dense on the same tile.
Force Missile is now 25% cheaper to cast, and has a cooldown of .5 seconds instead of one second, and does 5 more damage.
Beam's damage is increased by 10, and energy cost decreased by 25%.
Lightning's warm-up time is now one second instead of two.
Overload now costs 10% of total energy instead of 15%, and damage scaled with 4% of their current energy reserves, and 5% with the Scepter, instead of 3%/4%.  Additionally, instability per shot is lowered to 12 from 15.
Track now costs 25 points instead of 30 in the catalog, because roundness.
Fire Aura should look more impressive without a Scepter.
Fixes bug where shooting Lightning made you motionless for twenty seconds.