### PR TITLE
Turret Fix

### DIFF
--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -598,9 +598,9 @@ var/list/turret_icons
 	update_icon()
 	timeout = 10
 
-/obj/machinery/porta_turret/proc/set_raised_raising(var/raised, var/raising)
-	raised = raised
-	raising = raising
+/obj/machinery/porta_turret/proc/set_raised_raising(var/incoming_raised, var/incoming_raising)
+	raised = incoming_raised
+	raising = incoming_raising
 	density = raised || raising
 
 /obj/machinery/porta_turret/proc/target(var/mob/living/target)


### PR DESCRIPTION
Turrets can now deploy properly and not be stuck in a state of deploying forever if a target is in range.

Future devs, please make sure your arguments for procs are distinct from variables on the object itself.