### PR TITLE
Minor Emitter Tweaks

### DIFF
--- a/html/changelogs/Neerti - EmitterTweaks.yml
+++ b/html/changelogs/Neerti - EmitterTweaks.yml
@@ -1,0 +1,38 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Neerti
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Emitters can be examined to see if they are damaged.  They can also be repaired by applying metal sheets to them."
+  - tweak: "Emitters now only explode on death if they are on a powered wire with significant power flowing through it."
+  - bugfix: "Emitters don't explode in one hit, or by tasers or non-damaging projectiles anymore."


### PR DESCRIPTION
Emitters no longer die by shooting a taser or laser tag gun at it.
Emitters don't explode if they are not on a powered wire with sufficient electricity in it.  They will just crumple away instead if integrity is reduced to zero.
Taking any damage to the emitter no longer results in instant death due to me being an idiot awhile ago.
Emitters can be examined to see if they are damaged, and can be repaired by applying metal sheets to it.