### PR TITLE
Allows snow overlay to be shoveled

### DIFF
--- a/code/game/objects/effects/overlays.dm
+++ b/code/game/objects/effects/overlays.dm
@@ -59,6 +59,13 @@
 	icon_state = "snow"
 	anchored = 1
 
+// Thought this might be useful for burying things in snow. Todo: Add a version that gradually reaccumulates over time by means of alpha transparency. -Spades
+/obj/effect/overlay/snow/attackby(obj/item/W as obj, mob/user as mob)
+	if (istype(W, /obj/item/weapon/shovel))
+		visible_message("<span class='notice'>[user] shovels away \the [src].</span>")
+		qdel(src)
+		return
+
 /obj/effect/overlay/snow/floor
 	icon_state = "snowfloor"
 	layer = 2.01 //Just above floor

--- a/code/game/objects/effects/overlays.dm
+++ b/code/game/objects/effects/overlays.dm
@@ -59,11 +59,13 @@
 	icon_state = "snow"
 	anchored = 1
 
-// Thought this might be useful for burying things in snow. Todo: Add a version that gradually reaccumulates over time by means of alpha transparency. -Spades
+// Todo: Add a version that gradually reaccumulates over time by means of alpha transparency. -Spades
 /obj/effect/overlay/snow/attackby(obj/item/W as obj, mob/user as mob)
 	if (istype(W, /obj/item/weapon/shovel))
-		visible_message("<span class='notice'>[user] shovels away \the [src].</span>")
-		qdel(src)
+		user.visible_message("<span class='notice'>[user] begins to shovel away \the [src].</span>")
+		if(do_after(user, 40))
+			user << "<span class='notice'>You have finished shoveling!</span>"
+			qdel(src)
 		return
 
 /obj/effect/overlay/snow/floor


### PR DESCRIPTION
Working on a snowfield away map and figured this might be useful for hiding things under snow, like tiles to a base, or wires, or certain items.

Could be useful for events, or that snow map that someone's working on.