### PR TITLE
Laptop ID Computer Fix

### DIFF
--- a/code/game/machinery/computer3/computers/card.dm
+++ b/code/game/machinery/computer3/computers/card.dm
@@ -36,7 +36,7 @@
 		jobs_all += "<table><tr><td></td><td><b>Command</b></td>"
 
 		jobs_all += "</tr><tr height='20'><td><b>Special</b></td>"//Station Administrator in special because he is head of heads ~Intercross21
-		jobs_all += "<td weight='100'><a href='?src=\ref[src];;assign=Captain'>Station Administrator</a></td>"
+		jobs_all += "<td weight='100'><a href='?src=\ref[src];;assign=Station Administrator'>Station Administrator</a></td>"
 		jobs_all += "<td weight='100'><a href='?src=\ref[src];;assign=Custom'>Custom</a></td>"
 
 		counter = 0

--- a/code/game/machinery/computer3/computers/card.dm
+++ b/code/game/machinery/computer3/computers/card.dm
@@ -311,11 +311,15 @@
 
 				writer.assignment = t1
 				writer.name = text("[writer.registered_name]'s ID Card ([writer.assignment])")
+				data_core.manifest_modify(writer.registered_name, writer.assignment)
+				callHook("reassign_employee", list(writer))
 
 		if("reg" in href_list)
 			if(auth)
 				writer.registered_name = href_list["reg"]
 				writer.name = text("[writer.registered_name]'s ID Card ([writer.assignment])")
+				data_core.manifest_modify(writer.registered_name, writer.assignment)
+				callHook("reassign_employee", list(writer))
 
 		computer.updateUsrDialog()
 		return

--- a/nano/templates/identification_computer.tmpl
+++ b/nano/templates/identification_computer.tmpl
@@ -137,7 +137,7 @@
               <tr>
                 <th>Special</th>
                 <td>
-                  {{:helper.link("Captain", '', {'choice' : 'assign', 'assign_target' : 'Captain'}, data.target_rank == 'Captain' ? 'disabled' : null)}}
+                  {{:helper.link("Station Administrator", '', {'choice' : 'assign', 'assign_target' : 'Station Administrator'}, data.target_rank == 'Station Administrator' ? 'disabled' : null)}}
                   {{:helper.link("Custom", '', {'choice' : 'assign', 'assign_target' : 'Custom'})}}
                 </td>
               </tr>


### PR DESCRIPTION
The manifest should now be updated correctly when using laptops.
-edit- You can now give people captain access with one button press again.