### PR TITLE
Splint changes + fixes

### DIFF
--- a/code/__defines/damage_organs.dm
+++ b/code/__defines/damage_organs.dm
@@ -35,9 +35,8 @@
 #define ORGAN_BLEEDING   (1<<1)
 #define ORGAN_BROKEN     (1<<2)
 #define ORGAN_DESTROYED  (1<<3)
-#define ORGAN_SPLINTED   (1<<4)
-#define ORGAN_DEAD       (1<<5)
-#define ORGAN_MUTATED    (1<<6)
+#define ORGAN_DEAD       (1<<4)
+#define ORGAN_MUTATED    (1<<5)
 
 #define DROPLIMB_EDGE 0
 #define DROPLIMB_BLUNT 1

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -463,11 +463,11 @@ its easier to just keep the beam vertical.
 			//spawn(0)
 			//if(I) //It's possible that it could be deleted in the meantime.
 			var/obj/O = I
-			O.show_message( message, 1, blind_message, 2)
+			O.show_message(message, 1, blind_message, 2)
 		else if(ismob(I))
 			var/mob/M = I
 			if(M.see_invisible >= invisibility) // Cannot view the invisible
-				M.show_message( message, 1, blind_message, 2)
+				M.show_message(message, 1, blind_message, 2)
 			else if (blind_message)
 				M.show_message(blind_message, 2)
 
@@ -488,7 +488,24 @@ its easier to just keep the beam vertical.
 			spawn(0)
 				if(I) //It's possible that it could be deleted in the meantime.
 					var/obj/O = I
-					O.show_message( message, 2, deaf_message, 1)
+					O.show_message(message, 2, deaf_message, 1)
 		else if(ismob(I))
 			var/mob/M = I
-			M.show_message( message, 2, deaf_message, 1)
+			M.show_message(message, 2, deaf_message, 1)
+
+/atom/movable/proc/dropInto(var/atom/destination)
+	while(istype(destination))
+		var/atom/drop_destination = destination.onDropInto(src)
+		if(!istype(drop_destination) || drop_destination == destination)
+			return forceMove(destination)
+		destination = drop_destination
+	return forceMove(null)
+
+/atom/proc/onDropInto(var/atom/movable/AM)
+	return // If onDropInto returns null, then dropInto will forceMove AM into us.
+
+/atom/movable/onDropInto(var/atom/movable/AM)
+	return loc // If onDropInto returns something, then dropInto will attempt to drop AM there.
+
+/atom/proc/InsertedContents()
+	return contents

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -63,13 +63,35 @@
 	return
 
 /atom/movable/proc/forceMove(atom/destination)
+	if(loc == destination)
+		return 0
+	var/is_origin_turf = isturf(loc)
+	var/is_destination_turf = isturf(destination)
+	// It is a new area if:
+	//  Both the origin and destination are turfs with different areas.
+	//  When either origin or destination is a turf and the other is not.
+	var/is_new_area = (is_origin_turf ^ is_destination_turf) || (is_origin_turf && is_destination_turf && loc.loc != destination.loc)
+
+	var/atom/origin = loc
+	loc = destination
+
+	if(origin)
+		origin.Exited(src, destination)
+		if(is_origin_turf)
+			for(var/atom/movable/AM in origin)
+				AM.Uncrossed(src)
+			if(is_new_area && is_origin_turf)
+				origin.loc.Exited(src, destination)
+
 	if(destination)
-		if(loc)
-			loc.Exited(src)
-		loc = destination
-		loc.Entered(src)
-		return 1
-	return 0
+		destination.Entered(src, origin)
+		if(is_destination_turf) // If we're entering a turf, cross all movable atoms
+			for(var/atom/movable/AM in loc)
+				if(AM != src)
+					AM.Crossed(src)
+			if(is_new_area && is_destination_turf)
+				destination.loc.Entered(src, origin)
+	return 1
 
 //called when src is thrown into hit_atom
 /atom/movable/proc/throw_impact(atom/hit_atom, var/speed)

--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -329,7 +329,7 @@
 					organStatus["broken"] = E.broken_description
 				if(E.status & ORGAN_ROBOT)
 					organStatus["robotic"] = 1
-				if(E.status & ORGAN_SPLINTED)
+				if(E.splinted)
 					organStatus["splinted"] = 1
 				if(E.status & ORGAN_BLEEDING)
 					organStatus["bleeding"] = 1
@@ -483,7 +483,7 @@
 					break
 				if(istype(e, /obj/item/organ/external/chest) && occupant.is_lung_ruptured())
 					lung_ruptured = "Lung ruptured:"
-				if(e.status & ORGAN_SPLINTED)
+				if(e.splinted)
 					splint = "Splinted:"
 				if(e.status & ORGAN_BLEEDING)
 					bled = "Bleeding:"

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -161,7 +161,7 @@ REAGENT SCANNER
 				continue
 			var/limb = e.name
 			if(e.status & ORGAN_BROKEN)
-				if(((e.name == "l_arm") || (e.name == "r_arm") || (e.name == "l_leg") || (e.name == "r_leg")) && (!(e.status & ORGAN_SPLINTED)))
+				if(((e.name == "l_arm") || (e.name == "r_arm") || (e.name == "l_leg") || (e.name == "r_leg")) && (!e.splinted))
 					user << "<span class='warning'>Unsecured fracture in subject [limb]. Splinting recommended for transport.</span>"
 			if(e.has_infected_wound())
 				user << "<span class='warning'>Infected wound detected in subject [limb]. Disinfection recommended.</span>"

--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -264,7 +264,7 @@
 		if(!(affecting.organ_tag in splintable_organs))
 			user << "<span class='danger'>You can't use \the [src] to apply a splint there!</span>"
 			return
-		if(affecting.status & ORGAN_SPLINTED)
+		if(affecting.splinted)
 			user << "<span class='danger'>[M]'s [limb] is already splinted!</span>"
 			return
 		if (M != user)

--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -275,17 +275,21 @@
 				user << "<span class='danger'>You can't apply a splint to the arm you're using!</span>"
 				return
 			user.visible_message("<span class='danger'>[user] starts to apply \the [src] to their [limb].</span>", "<span class='danger'>You start to apply \the [src] to your [limb].</span>", "<span class='danger'>You hear something being wrapped.</span>")
-		if(do_after(user, 50))
-			if (M != user)
-				user.visible_message("<span class='danger'>[user] finishes applying \the [src] to [M]'s [limb].</span>", "<span class='danger'>You finish applying \the [src] to [M]'s [limb].</span>", "<span class='danger'>You hear something being wrapped.</span>")
-			else
-				if(prob(25))
-					user.visible_message("<span class='danger'>[user] successfully applies \the [src] to their [limb].</span>", "<span class='danger'>You successfully apply \the [src] to your [limb].</span>", "<span class='danger'>You hear something being wrapped.</span>")
-				else
-					user.visible_message("<span class='danger'>[user] fumbles \the [src].</span>", "<span class='danger'>You fumble \the [src].</span>", "<span class='danger'>You hear something being wrapped.</span>")
+		if(do_after(user, 50, M))
+			if(M == user && prob(75))
+				user.visible_message("<span class='danger'>\The [user] fumbles [src].</span>", "<span class='danger'>You fumble [src].</span>", "<span class='danger'>You hear something being wrapped.</span>")
+				return
+			var/obj/item/stack/medical/splint/S = split(1)
+			if(S)
+				if(affecting.apply_splint(S))
+					S.forceMove(affecting)
+					if (M != user)
+						user.visible_message("<span class='danger'>\The [user] finishes applying [src] to [M]'s [limb].</span>", "<span class='danger'>You finish applying \the [src] to [M]'s [limb].</span>", "<span class='danger'>You hear something being wrapped.</span>")
+					else
+						user.visible_message("<span class='danger'>\The [user] successfully applies [src] to their [limb].</span>", "<span class='danger'>You successfully apply \the [src] to your [limb].</span>", "<span class='danger'>You hear something being wrapped.</span>")
 					return
-			affecting.status |= ORGAN_SPLINTED
-			use(1)
+				S.dropInto(src.loc) //didn't get applied, so just drop it
+			user.visible_message("<span class='danger'>\The [user] fails to apply [src].</span>", "<span class='danger'>You fail to apply [src].</span>", "<span class='danger'>You hear something being wrapped.</span>")
 		return
 
 

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -394,3 +394,6 @@
 	var/shake_dir = pick(-1, 1)
 	animate(src, transform=turn(matrix(), 8*shake_dir), pixel_x=init_px + 2*shake_dir, time=1)
 	animate(transform=null, pixel_x=init_px, time=6, easing=ELASTIC_EASING)
+
+/obj/structure/closet/onDropInto(var/atom/movable/AM)
+	return

--- a/code/modules/clothing/spacesuits/spacesuits.dm
+++ b/code/modules/clothing/spacesuits/spacesuits.dm
@@ -77,11 +77,11 @@
 /obj/item/clothing/suit/space/proc/check_limb_support(var/mob/living/carbon/human/user)
 
 	// If this isn't set, then we don't need to care.
-	if(!istype(user) || isnull(supporting_limbs) || !supporting_limbs.len)
+	if(!istype(user) || isnull(supporting_limbs))
 		return
 
 	if(user.wear_suit == src)
-		for(var/obj/item/organ/external/E in user.organs)
+		for(var/obj/item/organ/external/E in user.bad_external_organs)
 			if(E.is_broken() && E.apply_splint(src))
 				user << "You feel [src] constrict about your [E.name], supporting it."
 				supporting_limbs |= E
@@ -91,3 +91,10 @@
 			if(E.splinted == src && E.remove_splint(src))
 				user << "\The [src] stops supporting your [E.name]."
 		supporting_limbs.Cut()
+
+/obj/item/clothing/suit/space/proc/handle_fracture(var/mob/living/carbon/human/user, var/obj/item/organ/external/E)
+	if(!istype(user) || isnull(supporting_limbs))
+		return
+	if(E.is_broken() && E.apply_splint(src))
+		user << "You feel [src] constrict about your [E.name], supporting it."
+		supporting_limbs |= E

--- a/code/modules/clothing/spacesuits/spacesuits.dm
+++ b/code/modules/clothing/spacesuits/spacesuits.dm
@@ -63,7 +63,7 @@
 	var/list/supporting_limbs //If not-null, automatically splints breaks. Checked when removing the suit.
 
 /obj/item/clothing/suit/space/equipped(mob/M)
-	check_limb_support()
+	check_limb_support(M)
 	..()
 
 /obj/item/clothing/suit/space/dropped(var/mob/user)
@@ -77,14 +77,17 @@
 /obj/item/clothing/suit/space/proc/check_limb_support(var/mob/living/carbon/human/user)
 
 	// If this isn't set, then we don't need to care.
-	if(!supporting_limbs || !supporting_limbs.len)
+	if(!istype(user) || isnull(supporting_limbs) || !supporting_limbs.len)
 		return
 
-	if(!istype(user) || user.wear_suit == src)
-		return
-
-	// Otherwise, remove the splints.
-	for(var/obj/item/organ/external/E in supporting_limbs)
-		E.status &= ~ ORGAN_SPLINTED
-		user << "The suit stops supporting your [E.name]."
-	supporting_limbs = list()
+	if(user.wear_suit == src)
+		for(var/obj/item/organ/external/E in user.organs)
+			if(E.apply_splint(src))
+				user << "You feel [src] constrict about your [E.name], supporting it."
+				supporting_limbs |= E
+	else
+		// Otherwise, remove the splints.
+		for(var/obj/item/organ/external/E in supporting_limbs)
+			if(E.splinted == src && E.remove_splint(src))
+				user << "\The [src] stops supporting your [E.name]."
+		supporting_limbs.Cut()

--- a/code/modules/clothing/spacesuits/spacesuits.dm
+++ b/code/modules/clothing/spacesuits/spacesuits.dm
@@ -82,7 +82,7 @@
 
 	if(user.wear_suit == src)
 		for(var/obj/item/organ/external/E in user.organs)
-			if(E.apply_splint(src))
+			if(E.is_broken() && E.apply_splint(src))
 				user << "You feel [src] constrict about your [E.name], supporting it."
 				supporting_limbs |= E
 	else

--- a/code/modules/games/cards.dm
+++ b/code/modules/games/cards.dm
@@ -146,7 +146,7 @@
 		for(var/datum/playingcard/P in cards)
 			H.cards += P
 		H.concealed = src.concealed
-		user.drop_from_inventory(src,user.loc)
+		user.drop_from_inventory(src)
 		qdel(src)
 		H.update_icon()
 		return

--- a/code/modules/mob/holder.dm
+++ b/code/modules/mob/holder.dm
@@ -50,6 +50,11 @@ var/list/holder_mob_icon_cache = list()
 			continue
 		M.forceMove(get_turf(src))
 
+/obj/item/weapon/holder/onDropInto(var/atom/movable/AM)
+	if(ismob(loc))   // Bypass our holding mob and drop directly to its loc
+		return loc.loc
+	return ..()
+
 /obj/item/weapon/holder/GetID()
 	for(var/mob/M in contents)
 		var/obj/item/I = M.GetIdCard()

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -126,16 +126,12 @@ var/list/slot_equipment_priority = list( \
 
 // Removes an item from inventory and places it in the target atom.
 // If canremove or other conditions need to be checked then use unEquip instead.
-/mob/proc/drop_from_inventory(var/obj/item/W, var/atom/Target = null)
 
+/mob/proc/drop_from_inventory(var/obj/item/W, var/atom/target = null)
 	if(W)
-		if(!Target)
-			Target = loc
-
-		remove_from_mob(W)
-		if(!(W && W.loc)) return 1 // self destroying objects (tk, grabs)
-
-		W.forceMove(Target)
+		remove_from_mob(W, target)
+		if(!(W && W.loc))
+			return 1 // self destroying objects (tk, grabs)
 		update_icons()
 		return 1
 	return 0
@@ -194,7 +190,9 @@ var/list/slot_equipment_priority = list( \
 
 
 //Attemps to remove an object on a mob.
-/mob/proc/remove_from_mob(var/obj/O)
+/mob/proc/remove_from_mob(var/obj/O, var/atom/target)
+	if(!O) // Nothing to remove, so we succeed.
+		return 1
 	src.u_equip(O)
 	if (src.client)
 		src.client.screen -= O
@@ -202,7 +200,10 @@ var/list/slot_equipment_priority = list( \
 	O.screen_loc = null
 	if(istype(O, /obj/item))
 		var/obj/item/I = O
-		I.forceMove(src.loc)
+		if(target)
+			I.forceMove(target)
+		else
+			I.dropInto(loc)
 		I.dropped(src)
 	return 1
 

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -251,8 +251,8 @@
 	//splints
 	for(var/organ in list(BP_L_LEG, BP_R_LEG, BP_L_ARM, BP_R_ARM))
 		var/obj/item/organ/external/o = get_organ(organ)
-		if(o && o.status & ORGAN_SPLINTED)
-			msg += "<span class='warning'>[T.He] [T.has] a splint on [T.his] [o.name]!</span>\n"
+		if(o && o.splinted && o.splinted.loc == o)
+			msg += "<span class='warning'>[T.He] [T.has] \a [o.splinted] on [T.his] [o.name]!</span>\n"
 
 	if(suiciding)
 		msg += "<span class='warning'>[T.He] appears to have commited suicide... there is no hope of recovery.</span>\n"

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1013,7 +1013,7 @@
 /mob/living/carbon/human/proc/handle_embedded_objects()
 
 	for(var/obj/item/organ/external/organ in src.organs)
-		if(organ.status & ORGAN_SPLINTED) //Splints prevent movement.
+		if(organ.splinted) //Splints prevent movement.
 			continue
 		for(var/obj/item/O in organ.implants)
 			if(!istype(O,/obj/item/weapon/implant) && prob(5)) //Moving with things stuck in you could be bad.

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -45,7 +45,7 @@
 			var/obj/item/organ/external/E = get_organ(organ_name)
 			if(!E || E.is_stump())
 				tally += 4
-			if(E.status & ORGAN_SPLINTED)
+			if(E.splinted)
 				tally += 0.5
 			else if(E.status & ORGAN_BROKEN)
 				tally += 1.5
@@ -57,7 +57,7 @@
 			var/obj/item/organ/external/E = get_organ(organ_name)
 			if(!E || E.is_stump())
 				tally += 4
-			else if(E.status & ORGAN_SPLINTED)
+			else if(E.splinted)
 				tally += 0.5
 			else if(E.status & ORGAN_BROKEN)
 				tally += 1.5

--- a/code/modules/mob/living/carbon/human/human_organs.dm
+++ b/code/modules/mob/living/carbon/human/human_organs.dm
@@ -142,10 +142,10 @@
 		return
 
 	for (var/obj/item/organ/external/E in organs)
-		if(!E || !E.can_grasp || (E.status & ORGAN_SPLINTED))
+		if(!E || !E.can_grasp)
 			continue
 
-		if(E.is_broken() || E.is_dislocated())
+		if((E.is_broken() || E.is_dislocated()) && !E.splinted)
 			switch(E.body_part)
 				if(HAND_LEFT, ARM_LEFT)
 					if(!l_hand)

--- a/code/modules/mob/living/carbon/human/stripping.dm
+++ b/code/modules/mob/living/carbon/human/stripping.dm
@@ -126,8 +126,12 @@
 		var/removed_splint
 		for(var/obj/item/organ/external/o in organs)
 			if (o && o.status & ORGAN_SPLINTED)
-				o.status &= ~ORGAN_SPLINTED
-				removed_splint = 1
+				var/obj/item/S = o.splinted
+				if(istype(S) && S.loc == o) //can only remove splints that are actually worn on the organ (deals with hardsuit splints)
+					S.add_fingerprint(user)
+					if(o.remove_splints())
+						user.put_in_active_hand(S)
+						removed_splint = 1
 		if(removed_splint)
 			visible_message("<span class='danger'>\The [user] removes \the [src]'s splints!</span>")
 		else

--- a/code/modules/mob/living/carbon/human/stripping.dm
+++ b/code/modules/mob/living/carbon/human/stripping.dm
@@ -125,11 +125,11 @@
 	if(can_reach_splints)
 		var/removed_splint
 		for(var/obj/item/organ/external/o in organs)
-			if (o && o.status & ORGAN_SPLINTED)
+			if (o && o.splinted)
 				var/obj/item/S = o.splinted
 				if(istype(S) && S.loc == o) //can only remove splints that are actually worn on the organ (deals with hardsuit splints)
 					S.add_fingerprint(user)
-					if(o.remove_splints())
+					if(o.remove_splint())
 						user.put_in_active_hand(S)
 						removed_splint = 1
 		if(removed_splint)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -519,7 +519,7 @@
 			for(var/name in H.organs_by_name)
 				var/obj/item/organ/external/e = H.organs_by_name[name]
 				if(e && H.lying)
-					if(((e.status & ORGAN_BROKEN && !(e.status & ORGAN_SPLINTED)) || e.status & ORGAN_BLEEDING) && (H.getBruteLoss() + H.getFireLoss() >= 100))
+					if(((e.status & ORGAN_BROKEN && !(e.splinted)) || e.status & ORGAN_BLEEDING) && (H.getBruteLoss() + H.getFireLoss() >= 100))
 						return 1
 						break
 		return 0

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -254,7 +254,6 @@ var/list/organ_cache = list()
 	robotic = ORGAN_ROBOT
 	src.status &= ~ORGAN_BROKEN
 	src.status &= ~ORGAN_BLEEDING
-	src.status &= ~ORGAN_SPLINTED
 	src.status &= ~ORGAN_CUT_AWAY
 
 /obj/item/organ/proc/mechassist() //Used to add things like pacemakers, etc

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -529,11 +529,11 @@ This function completely restores a damaged organ to perfect condition.
 //external organs handle brokenness a bit differently when it comes to damage. Instead brute_dam is checked inside process()
 //this also ensures that an external organ cannot be "broken" without broken_description being set.
 /obj/item/organ/external/is_broken()
-	return ((status & ORGAN_CUT_AWAY) || ((status & ORGAN_BROKEN) && !(status & ORGAN_SPLINTED)))
+	return ((status & ORGAN_CUT_AWAY) || ((status & ORGAN_BROKEN) && !(splinted)))
 
 //Determines if we even need to process this organ.
 /obj/item/organ/external/proc/need_process()
-	if(status & (ORGAN_CUT_AWAY|ORGAN_BLEEDING|ORGAN_BROKEN|ORGAN_DESTROYED|ORGAN_SPLINTED|ORGAN_DEAD|ORGAN_MUTATED))
+	if(status & (ORGAN_CUT_AWAY|ORGAN_BLEEDING|ORGAN_BROKEN|ORGAN_DESTROYED|ORGAN_DEAD|ORGAN_MUTATED))
 		return 1
 	if((brute_dam || burn_dam) && (robotic < ORGAN_ROBOT)) //Robot limbs don't autoheal and thus don't need to process when damaged
 		return 1
@@ -1011,25 +1011,11 @@ Note that amputating the affected organ does in fact remove the infection from t
 	// This is mostly for the ninja suit to stop ninja being so crippled by breaks.
 	// TODO: consider moving this to a suit proc or process() or something during
 	// hardsuit rewrite.
-	if(!(status & ORGAN_SPLINTED) && owner && istype(owner.wear_suit, /obj/item/clothing/suit/space))
+
+	if(!(splinted) && owner && istype(owner.wear_suit, /obj/item/clothing/suit/space))
 		var/obj/item/clothing/suit/space/suit = owner.wear_suit
 		suit.check_limb_support()
 
-/obj/item/organ/external/proc/apply_splint(var/atom/movable/splint)
-	if(!splinted)
-		splinted = splint
-		status |= ORGAN_SPLINTED
-		return 1
-	return 0
-
-/obj/item/organ/external/proc/remove_splint()
-	if(splinted)
-		if(splinted.loc == src)
-			splinted.dropInto(owner? owner.loc : src.loc)
-		splinted = null
-		status &= ~(ORGAN_SPLINTED)
-		return 1
-	return 0
 
 /obj/item/organ/external/proc/mend_fracture()
 	if(robotic >= ORGAN_ROBOT)
@@ -1039,6 +1025,20 @@ Note that amputating the affected organ does in fact remove the infection from t
 
 	status &= ~ORGAN_BROKEN
 	return 1
+
+/obj/item/organ/external/proc/apply_splint(var/atom/movable/splint)
+	if(!splinted)
+		splinted = splint
+		return 1
+	return 0
+
+/obj/item/organ/external/proc/remove_splint()
+	if(splinted)
+		if(splinted.loc == src)
+			splinted.dropInto(owner? owner.loc : src.loc)
+		splinted = null
+		return 1
+	return 0
 
 /obj/item/organ/external/robotize(var/company, var/skip_prosthetics = 0, var/keep_organs = 0)
 
@@ -1063,6 +1063,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 
 	dislocated = -1
 	cannot_break = 1
+	remove_splint()
 	get_icon()
 	unmutate()
 

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -1014,8 +1014,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 
 	if(!(splinted) && owner && istype(owner.wear_suit, /obj/item/clothing/suit/space))
 		var/obj/item/clothing/suit/space/suit = owner.wear_suit
-		suit.check_limb_support()
-
+		suit.handle_fracture(owner, src)
 
 /obj/item/organ/external/proc/mend_fracture()
 	if(robotic >= ORGAN_ROBOT)

--- a/code/modules/surgery/bones.dm
+++ b/code/modules/surgery/bones.dm
@@ -140,7 +140,6 @@
 		user.visible_message("\blue [user] has mended the damaged bones in [target]'s [affected.name] with \the [tool]."  , \
 			"\blue You have mended the damaged bones in [target]'s [affected.name] with \the [tool]." )
 		affected.status &= ~ORGAN_BROKEN
-		affected.status &= ~ORGAN_SPLINTED
 		affected.stage = 0
 
 	fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)

--- a/html/changelogs/Yoshax - Splint.yml
+++ b/html/changelogs/Yoshax - Splint.yml
@@ -1,0 +1,37 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Yoshax
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Splints are once again reusable and have been improved behind the scenes."
+  - bugfix: "Removing splints will now correctly give you the splint used to splint the organ."


### PR DESCRIPTION
Fixes the lazy, sloppy hackfix done in #2454

Partial manual ports Baystation12/Baystation12#13481
Ports Baystation12/Baystation12#13073

Splints can now once again be removed, and removing it returns the splint used. Splinting is now a var on the limb that saves the item used.