### PR TITLE
Allows jobbaning from cargo jobs again

### DIFF
--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -440,6 +440,27 @@
 				counter = 0
 		jobs += "</tr></table>"
 
+	//Cargo (Yellow)
+		counter = 0
+		jobs += "<table cellpadding='1' cellspacing='0' width='100%'>"
+		jobs += "<tr bgcolor='fff5cc'><th colspan='[length(cargo_positions)]'><a href='?src=\ref[src];jobban3=cargodept;jobban4=\ref[M]'>Cargo Positions</a></th></tr><tr align='center'>"
+		for(var/jobPos in cargo_positions)
+			if(!jobPos)	continue
+			var/datum/job/job = job_master.GetJob(jobPos)
+			if(!job) continue
+
+			if(jobban_isbanned(M, job.title))
+				jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=[job.title];jobban4=\ref[M]'><font color=red>[replacetext(job.title, " ", "&nbsp")]</font></a></td>"
+				counter++
+			else
+				jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=[job.title];jobban4=\ref[M]'>[replacetext(job.title, " ", "&nbsp")]</a></td>"
+				counter++
+
+			if(counter >= 5) //So things dont get squiiiiished!
+				jobs += "</tr><tr align='center'>"
+				counter = 0
+		jobs += "</tr></table>"
+
 	//Medical (White)
 		counter = 0
 		jobs += "<table cellpadding='1' cellspacing='0' width='100%'>"
@@ -613,6 +634,12 @@
 					joblist += temp.title
 			if("engineeringdept")
 				for(var/jobPos in engineering_positions)
+					if(!jobPos)	continue
+					var/datum/job/temp = job_master.GetJob(jobPos)
+					if(!temp) continue
+					joblist += temp.title
+			if("cargodept")
+				for(var/jobPos in cargo_positions)
 					if(!jobPos)	continue
 					var/datum/job/temp = job_master.GetJob(jobPos)
 					if(!temp) continue


### PR DESCRIPTION
Someone updated the cargo jobs in jobs.dm a while ago and changed them from civilian to cargo or something along those lines. This made it so users couldn't be banned/unbanned from the QM, Cargo tech, and miner.

This PR fixes that and makes them bannable once more by adding in a cargo department line in the jobban panel

Screenshot: http://puu.sh/rfyuD/b59cddcf8b.png