### PR TITLE
Adds EPv2 Circuit

### DIFF
--- a/code/modules/integrated_electronics/input_output.dm
+++ b/code/modules/integrated_electronics/input_output.dm
@@ -286,6 +286,64 @@
 		O.show_message(text("\icon[] *beep* *beep*", src), 3, "*beep* *beep*", 2)
 
 
+/obj/item/integrated_circuit/input/EPv2
+	name = "\improper EPv2 circuit"
+	desc = "Enables the sending and receiving of messages on the Exonet with the EPv2 protocol."
+	extended_desc = "An EPv2 address is a string with the format of XXXX:XXXX:XXXX:XXXX.  Data can be send or received using the \
+	second pin on each side, with additonal data reserved for the third pin.  When a message is received, the second activaiton pin \
+	will pulse whatever's connected to it.  Pulsing the first activation pin will send a message."
+	icon_state = "signal"
+	number_of_inputs = 3
+	number_of_outputs = 3
+	number_of_activators = 2
+	complexity = 4
+	input_names = list(
+		"target EPv2 address",
+		"data to send",
+		"secondary text"
+	)
+	output_names = list(
+		"address received",
+		"data received",
+		"secondary text received"
+	)
+	activator_names = list(
+		"send data",
+		"on data received"
+	)
+	var/datum/exonet_protocol/exonet = null
+
+/obj/item/integrated_circuit/input/EPv2/New()
+	..()
+	exonet = new(src)
+	exonet.make_address("EPv2_circuit-\ref[src]")
+	desc += "This circuit's EPv2 address is: [exonet.address]."
+
+/obj/item/integrated_circuit/input/EPv2/Destroy()
+	if(exonet)
+		exonet.remove_address()
+		qdel(exonet)
+	..()
+
+/obj/item/integrated_circuit/input/EPv2/work()
+	if(..())
+		var/datum/integrated_io/target_address = inputs[1]
+		var/datum/integrated_io/message = inputs[2]
+		var/datum/integrated_io/text = inputs[3]
+		if(istext(target_address.data))
+			exonet.send_message(target_address.data, message.data, text.data)
+
+/obj/item/integrated_circuit/input/receive_exonet_message(var/atom/origin_atom, var/origin_address, var/message, var/text)
+	var/datum/integrated_io/message_received = outputs[1]
+	var/datum/integrated_io/data_received = outputs[2]
+	var/datum/integrated_io/text_received = outputs[3]
+
+	var/datum/integrated_io/A = activators[2]
+	A.push_data()
+
+	message_received.write_data_to_pin(origin_address)
+	data_received.write_data_to_pin(message)
+	text_received.write_data_to_pin(text)
 
 /obj/item/integrated_circuit/output/screen
 	name = "screen"

--- a/code/modules/research/designs.dm
+++ b/code/modules/research/designs.dm
@@ -1743,6 +1743,12 @@ CIRCUITS BELOW
 	sort_string = "WAAEK"
 	req_tech = list(TECH_ENGINEERING = 2, TECH_DATA = 2, TECH_ILLEGAL = 1)
 
+/datum/design/circuit/integrated_circuit/input_output/EPv2
+	id = "cc-epv2"
+	build_path = /obj/item/integrated_circuit/input/EPv2
+	sort_string = "WAAEL"
+	req_tech = list(TECH_ENGINEERING = 2, TECH_DATA = 2, TECH_MAGNETS = 2, TECH_BLUESPACE = 2)
+
 
 /datum/design/circuit/integrated_circuit/logic/AssembleDesignName()
 	..()


### PR DESCRIPTION
Adds a circuit that allows it to send and receive EPv2 messages, allowing for a more robust transmission of data that signalers cannot deliver.  Bonus: Communicators can send text messages to custom machines using this.

Image: http://puu.sh/rfRdX/0a9955758b.png