### PR TITLE
Technomancer Tweaks

### DIFF
--- a/code/game/gamemodes/technomancer/clothing.dm
+++ b/code/game/gamemodes/technomancer/clothing.dm
@@ -9,27 +9,30 @@
 
 /obj/item/clothing/under/technomancer
 	name = "initiate's jumpsuit"
-	desc = "It's a blue colored jumpsuit.  There appears to be light-weight armor padding underneath, providing some protection."
+	desc = "It's a blue colored jumpsuit.  There appears to be light-weight armor padding underneath, providing some protection.  \
+	There is also a healthy amount of insulation underneath."
 	icon_state = "initiate"
 	armor = list(melee = 10, bullet = 5, laser = 5, energy = 0, bomb = 0, bio = 0, rad = 0)
-	siemens_coefficient = 0.9
+	siemens_coefficient = 0.3
 
 /obj/item/clothing/under/technomancer/apprentice
 	name = "apprentice's jumpsuit"
 	desc = "It's a blue colored jumpsuit with some silver markings.  There appears to be light-weight armor padding \
-	underneath, providing some protection."
+	underneath, providing some protection.  There is also a healthy amount of insulation underneath."
 	icon_state = "apprentice"
 
 /obj/item/clothing/under/technomancer/master
 	name = "master's jumpsuit"
 	desc = "It's a blue colored jumpsuit with some gold markings.  There appears to be light-weight armor padding \
-	underneath, providing some protection."
+	underneath, providing some protection.  There is also a healthy amount of insulation underneath."
 	icon_state = "technomancer"
 
 /obj/item/clothing/head/technomancer
 	name = "initiate's hat"
 	desc = "It's a somewhat silly looking blue pointed hat."
 	icon_state = "initiate"
+	armor = list(melee = 10, bullet = 5, laser = 5, energy = 0, bomb = 0, bio = 0, rad = 0)
+	siemens_coefficient = 0.3
 
 /obj/item/clothing/head/technomancer/apprentice
 	name = "apprentice's hat"

--- a/code/game/gamemodes/technomancer/devices/disposable_teleporter.dm
+++ b/code/game/gamemodes/technomancer/devices/disposable_teleporter.dm
@@ -2,7 +2,7 @@
 	name = "Disposable Teleporter"
 	desc = "An ultra-safe teleportation device that can directly teleport you to a number of locations at minimal risk, however \
 	it has a limited amount of charges."
-	cost = 100
+	cost = 50
 	obj_path = /obj/item/weapon/disposable_teleporter
 
 /obj/item/weapon/disposable_teleporter

--- a/code/game/gamemodes/technomancer/devices/shield_armor.dm
+++ b/code/game/gamemodes/technomancer/devices/shield_armor.dm
@@ -6,7 +6,7 @@
 	of which your Core can provide.  When you are struck by something, the shield will block 75% of the damage, deducting energy \
 	proportional to the amount of force that was inflicted.  Armor penetration has no effect on the shield's ability to protect \
 	you from harm, however the shield will fail if the energy supply cannot meet demand."
-	cost = 300
+	cost = 200
 	obj_path = /obj/item/clothing/suit/armor/shield
 
 /obj/item/clothing/suit/armor/shield

--- a/code/game/gamemodes/technomancer/devices/tesla_armor.dm
+++ b/code/game/gamemodes/technomancer/devices/tesla_armor.dm
@@ -4,7 +4,7 @@
 	the next attack you suffer, and strike the attacker with a strong bolt of lightning.  This effect requires twenty seconds to \
 	recharge.  If you are attacked while this is recharging, a weaker lightning bolt is sent out, however you won't be protected from \
 	the person beating you."
-	cost = 250
+	cost = 150
 	obj_path = /obj/item/clothing/suit/armor/tesla
 
 /obj/item/clothing/suit/armor/tesla

--- a/code/game/gamemodes/technomancer/equipment.dm
+++ b/code/game/gamemodes/technomancer/equipment.dm
@@ -11,7 +11,7 @@
 	desc = "A core optimized for passive regeneration, however at the cost of capacity.  Has a capacity of 7,000 units of energy, and \
 	recharges at a rate of 70 units.  Complex gravatics and force manipulation allows the wearer to also run slightly faster, and \
 	reduces incoming instability from functions by 10%."
-	cost = 150
+	cost = 100
 	obj_path = /obj/item/weapon/technomancer_core/rapid
 
 /datum/technomancer/equipment/bulky_core
@@ -20,7 +20,7 @@
 	purchase one or more energy-generating Functions as well if using this core.  Has a capacity of 20,000 units of energy, \
 	and recharges at a rate of 25 units.  The intense weight of the core unfortunately can cause the wear to move slightly slower, \
 	and the closeness of the capacitors causes a slight increase in incoming instability by 10%."
-	cost = 150
+	cost = 100
 	obj_path = /obj/item/weapon/technomancer_core/bulky
 
 /datum/technomancer/equipment/unstable
@@ -29,7 +29,7 @@
 	better as the user has more instability, which could prove dangerous to the inexperienced or unprepared.  Has a capacity of 13,000 \
 	units of energy, and recharges at a rate of 35 units at no instability, and approximately 110 units when within the \
 	'yellow zone' of instability.  Incoming instability is also amplified by 30%, due to the nature of this core."
-	cost = 150
+	cost = 100
 	obj_path = /obj/item/weapon/technomancer_core/unstable
 
 /datum/technomancer/equipment/recycling
@@ -38,7 +38,7 @@
 	cores.  The focus on efficency also makes instability less of an issue, as incoming instability from functions are reduced by \
 	40%.  The capacitor is also slightly better, holding 12,000 units of energy, however the reactor is slower to recharge, at a rate \
 	of 40 units."
-	cost = 150
+	cost = 100
 	obj_path = /obj/item/weapon/technomancer_core/recycling
 
 /datum/technomancer/equipment/summoning
@@ -47,13 +47,13 @@
 	entities from vast distances, and keeping them there.  Wearers of this core can maintain up to 30 summons at once, and the energy \
 	demand for maintaining summons is severely reduced.  This comes at the price of capcitors that can only hold 8,000 units of energy, \
 	a recharging rate of 35 energy, and no shielding from instability."
-	cost = 150
+	cost = 100
 	obj_path = /obj/item/weapon/technomancer_core/summoner
 
 /datum/technomancer/equipment/hypo_belt
 	name = "Hypo Belt"
 	desc = "A medical belt designed to carry autoinjectors and other medical equipment.  Comes with one of each hypo."
-	cost = 100
+	cost = 50
 	obj_path = /obj/item/weapon/storage/belt/medical/technomancer
 
 /obj/item/weapon/storage/belt/medical/technomancer
@@ -76,7 +76,7 @@
 	desc = "A belt with a literal pocket which opens to a localized pocket of 'Blue-Space', allowing for more storage.  \
 	The nature of the pocket allows for storage of larger objects than what is typical for other belts, and in larger quanities.  \
 	It will also help keep your pants on."
-	cost = 100
+	cost = 50
 	obj_path = /obj/item/weapon/storage/belt/holding
 
 /obj/item/weapon/storage/belt/holding
@@ -103,7 +103,7 @@
 /datum/technomancer/equipment/omni_sight
 	name = "Omnisight Scanner"
 	desc = "A very rare scanner worn on the face, which allows the wearer to see nearly anything across walls."
-	cost = 400
+	cost = 300
 	obj_path = /obj/item/clothing/glasses/omni
 
 /obj/item/clothing/glasses/omni
@@ -122,7 +122,7 @@
 	name = "Medical HUD"
 	desc = "A commonly available HUD for medical professionals, which displays how healthy an individual is.  \
 	Recommended for support-based apprentices!"
-	cost = 30
+	cost = 25
 	obj_path = /obj/item/clothing/glasses/thermal/plain/monocle
 
 /datum/technomancer/equipment/scepter
@@ -130,7 +130,7 @@
 	desc = "A gem sometimes found in the depths of asteroids makes up the basis for this device.  Energy is channeled into it from \
 	the Core and the user, causing many functions to be enhanced in various ways, so long as it is held in the off-hand.  \
 	Be careful not to lose this!"
-	cost = 300
+	cost = 200
 	obj_path = /obj/item/weapon/scepter
 
 /obj/item/weapon/scepter

--- a/code/game/gamemodes/technomancer/instability.dm
+++ b/code/game/gamemodes/technomancer/instability.dm
@@ -112,7 +112,7 @@
 				rng = rand(0,8)
 				switch(rng)
 					if(0)
-						apply_effect(instability * 0.5, IRRADIATE)
+						apply_effect(instability * 0.3, IRRADIATE)
 					if(1)
 						return
 //						visible_message("<span class='warning'>\The [src] suddenly collapses!</span>",
@@ -120,21 +120,21 @@
 //						Weaken(instability * 0.1)
 					if(2)
 						if(can_feel_pain())
-							apply_effect(instability * 0.5, AGONY)
+							apply_effect(instability * 0.3, AGONY)
 							src << "<span class='danger'>You feel a sharp pain!</span>"
 					if(3)
-						apply_effect(instability * 0.5, EYE_BLUR)
+						apply_effect(instability * 0.3, EYE_BLUR)
 						src << "<span class='danger'>Your eyes start to get cloudy!</span>"
 					if(4)
 						electrocute_act(instability * 0.3, "unstable energies")
 					if(5)
-						adjustFireLoss(instability * 0.2) //10 burn @ 50 instability
+						adjustFireLoss(instability * 0.15) //7.5 burn @ 50 instability
 						src << "<span class='danger'>You feel your skin burn!</span>"
 					if(6)
-						adjustBruteLoss(instability * 0.2) //10 brute @ 50 instability
+						adjustBruteLoss(instability * 0.15) //7.5 brute @ 50 instability
 						src << "<span class='danger'>You feel a sharp pain as an unseen force harms your body!</span>"
 					if(7)
-						adjustToxLoss(instability * 0.2) //10 tox @ 50 instability
+						adjustToxLoss(instability * 0.15) //7.5 tox @ 50 instability
 					if(8)
 						safe_blink(src, range = 6)
 						src << "<span class='warning'>You're teleported against your will!</span>"

--- a/code/game/gamemodes/technomancer/spells/abjuration.dm
+++ b/code/game/gamemodes/technomancer/spells/abjuration.dm
@@ -2,7 +2,7 @@
 	name = "Abjuration"
 	desc = "This ability attempts to send summoned or teleported entities or anomalies to the place from whence they came, or at least \
 	far away from the caster.  Failing that, it may inhibit those entities in some form."
-	cost = 40
+	cost = 25
 	obj_path = /obj/item/weapon/spell/abjuration
 	category = UTILITY_SPELLS
 

--- a/code/game/gamemodes/technomancer/spells/apportation.dm
+++ b/code/game/gamemodes/technomancer/spells/apportation.dm
@@ -2,7 +2,7 @@
 	name = "Apportation"
 	desc = "This allows you to teleport objects into your hand, or to pull people towards you.  If they're close enough, the function \
 	will grab them automatically."
-	cost = 50
+	cost = 25
 	obj_path = /obj/item/weapon/spell/apportation
 	category = UTILITY_SPELLS
 

--- a/code/game/gamemodes/technomancer/spells/audible_deception.dm
+++ b/code/game/gamemodes/technomancer/spells/audible_deception.dm
@@ -3,7 +3,7 @@
 	desc = "Allows you to create a specific sound at a location of your choosing."
 	enhancement_desc = "An extremely loud sound that a large amount of energy and instability becomes available, which will \
 	deafen and stun all who are near the targeted tile, including yourself if unprotected."
-	cost = 150
+	cost = 50
 	obj_path = /obj/item/weapon/spell/audible_deception
 	ability_icon_state = "tech_audibledeception"
 	category = UTILITY_SPELLS

--- a/code/game/gamemodes/technomancer/spells/aura/biomed_aura.dm
+++ b/code/game/gamemodes/technomancer/spells/aura/biomed_aura.dm
@@ -1,7 +1,7 @@
 /datum/technomancer/spell/biomed_aura
 	name = "Restoration Aura"
 	desc = "Heals you and your allies (or everyone, if you want) of trauma and burns slowly, as long as they remain within four meters."
-	cost = 150
+	cost = 100
 	obj_path = /obj/item/weapon/spell/aura/biomed
 	ability_icon_state = "tech_biomedaura"
 	category = SUPPORT_SPELLS

--- a/code/game/gamemodes/technomancer/spells/aura/fire_aura.dm
+++ b/code/game/gamemodes/technomancer/spells/aura/fire_aura.dm
@@ -4,7 +4,7 @@
 	This does not affect you or your allies.  It also causes a large amount of fire to erupt around you, however the main threat is \
 	still the heating up."
 	enhancement_desc = "Increased heat generation, more fires, and higher temperature cap."
-	cost = 150
+	cost = 100
 	obj_path = /obj/item/weapon/spell/aura/fire
 	ability_icon_state = "tech_fireaura"
 	category = OFFENSIVE_SPELLS
@@ -21,13 +21,13 @@
 		qdel(src)
 	var/list/nearby_things = range(4,owner)
 
-	var/temp_change = 25
-	var/temp_cap = 500
+	var/temp_change = 40
+	var/temp_cap = 600
 	var/fire_power = 2
 
 	if(check_for_scepter())
-		temp_change = 50
-		temp_cap = 700
+		temp_change = 80
+		temp_cap = 1000
 		fire_power = 4
 	for(var/mob/living/carbon/human/H in nearby_things)
 		if(is_ally(H))

--- a/code/game/gamemodes/technomancer/spells/aura/frost_aura.dm
+++ b/code/game/gamemodes/technomancer/spells/aura/frost_aura.dm
@@ -3,7 +3,7 @@
 	desc = "Lowers the core body temperature of everyone around you (except for your friends), causing them to freeze to death if \
 	they stay within four meters of you."
 	enhancement_desc = "The chill becomes lethal."
-	cost = 150
+	cost = 100
 	obj_path = /obj/item/weapon/spell/aura/frost
 	ability_icon_state = "tech_frostaura"
 	category = DEFENSIVE_SPELLS // Scepter-less frost aura is nonlethal.

--- a/code/game/gamemodes/technomancer/spells/aura/shock_aura.dm
+++ b/code/game/gamemodes/technomancer/spells/aura/shock_aura.dm
@@ -1,7 +1,7 @@
 /datum/technomancer/spell/shock_aura
 	name = "Electric Aura"
 	desc = "Repeatively electrocutes enemies within four meters of you, as well as nearby electronics."
-	cost = 150
+	cost = 100
 	obj_path = /obj/item/weapon/spell/aura/shock
 	ability_icon_state = "tech_shockaura"
 	category = OFFENSIVE_SPELLS

--- a/code/game/gamemodes/technomancer/spells/blink.dm
+++ b/code/game/gamemodes/technomancer/spells/blink.dm
@@ -3,7 +3,7 @@
 	desc = "Force the target to teleport a short distance away.  This target could be anything from something lying on the ground, to someone trying to \
 	fight you, or even yourself.  Using this on someone next to you makes their potential distance after teleportation greater."
 	enhancement_desc = "Blink distance is increased greatly."
-	cost = 100
+	cost = 50
 	obj_path = /obj/item/weapon/spell/blink
 	category = UTILITY_SPELLS
 

--- a/code/game/gamemodes/technomancer/spells/control.dm
+++ b/code/game/gamemodes/technomancer/spells/control.dm
@@ -5,7 +5,7 @@
 	targets.  This function will have no effect on entities of higher intelligence, such as humans and similar alien species, as it's \
 	not true mind control, but merely pheromone synthesis for living animals, and electronic hacking for simple robots.  The green web \
 	around the entity is merely a hologram used to allow the user to know if the creature is safe or not."
-	cost = 200
+	cost = 100
 	obj_path = /obj/item/weapon/spell/control
 	category = UTILITY_SPELLS
 

--- a/code/game/gamemodes/technomancer/spells/energy_siphon.dm
+++ b/code/game/gamemodes/technomancer/spells/energy_siphon.dm
@@ -4,7 +4,7 @@
 	Every second, electricity is stolen until the link is broken by the target moving too far away, or having no more energy left.  \
 	Can drain from powercells, microbatteries, and other Cores.  The beam created by the siphoning is harmful to touch."
 	enhancement_desc = "Rate of siphoning is doubled."
-	cost = 150
+	cost = 100
 	obj_path = /obj/item/weapon/spell/energy_siphon
 	ability_icon_state = "tech_energysiphon"
 	category = UTILITY_SPELLS

--- a/code/game/gamemodes/technomancer/spells/flame_tongue.dm
+++ b/code/game/gamemodes/technomancer/spells/flame_tongue.dm
@@ -1,7 +1,7 @@
 /datum/technomancer/spell/flame_tongue
 	name = "Flame Tongue"
 	desc = "Using a miniturized flamethrower in your gloves, you can emit a flame strong enough to melt both your enemies and walls."
-	cost = 100
+	cost = 50
 	obj_path = /obj/item/weapon/spell/flame_tongue
 	ability_icon_state = "tech_flametongue"
 	category = OFFENSIVE_SPELLS

--- a/code/game/gamemodes/technomancer/spells/illusion.dm
+++ b/code/game/gamemodes/technomancer/spells/illusion.dm
@@ -2,7 +2,7 @@
 	name = "Illusion"
 	desc = "Allows you to create and control a holographic illusion, that can take the form of most object or entities."
 	enhancement_desc = "Illusions will be made of hard light, allowing the interception of attacks, appearing more realistic."
-	cost = 100
+	cost = 25
 	obj_path = /obj/item/weapon/spell/illusion
 	ability_icon_state = "tech_illusion"
 	category = UTILITY_SPELLS

--- a/code/game/gamemodes/technomancer/spells/insert/corona.dm
+++ b/code/game/gamemodes/technomancer/spells/insert/corona.dm
@@ -2,7 +2,7 @@
 	name = "Corona"
 	desc = "Causes the victim to glow very brightly, which while harmless in itself, makes it easier for them to be hit.  The \
 	bright glow also makes it very difficult to be stealthy.  The effect lasts for one minute."
-	cost = 100
+	cost = 50
 	obj_path = /obj/item/weapon/spell/insert/corona
 	ability_icon_state = "tech_corona"
 	category = SUPPORT_SPELLS

--- a/code/game/gamemodes/technomancer/spells/insert/mend_organs.dm
+++ b/code/game/gamemodes/technomancer/spells/insert/mend_organs.dm
@@ -2,7 +2,7 @@
 	name = "Mend Organs"
 	desc = "Heals the target's internal organs, both organic and robotic.  Instability is split between the target \
 	and technomancer, if seperate."
-	cost = 75
+	cost = 50
 	obj_path = /obj/item/weapon/spell/insert/mend_organs
 	ability_icon_state = "tech_mendwounds"
 	category = SUPPORT_SPELLS

--- a/code/game/gamemodes/technomancer/spells/insert/repel_missiles.dm
+++ b/code/game/gamemodes/technomancer/spells/insert/repel_missiles.dm
@@ -2,7 +2,7 @@
 	name = "Repel Missiles"
 	desc = "Places a repulsion field around you, which attempts to deflect incoming bullets and lasers, making them 30% less likely \
 	to hit you.  The field lasts for five minutes and can be granted to yourself or an ally."
-	cost = 60
+	cost = 25
 	obj_path = /obj/item/weapon/spell/insert/repel_missiles
 	ability_icon_state = "tech_repelmissiles"
 	category = SUPPORT_SPELLS

--- a/code/game/gamemodes/technomancer/spells/instability_tap.dm
+++ b/code/game/gamemodes/technomancer/spells/instability_tap.dm
@@ -2,7 +2,7 @@
 	name = "Instability Tap"
 	desc = "Creates a large sum of energy, at the cost of a very large amount of instability afflicting you."
 	enhancement_desc = "50% more energy gained, 20% less instability gained."
-	cost = 120
+	cost = 100
 	obj_path = /obj/item/weapon/spell/instability_tap
 	ability_icon_state = "tech_instabilitytap"
 	category = UTILITY_SPELLS

--- a/code/game/gamemodes/technomancer/spells/mark_recall.dm
+++ b/code/game/gamemodes/technomancer/spells/mark_recall.dm
@@ -3,7 +3,7 @@
 	desc = "This function places a specific 'mark' beacon under you, which is used by the Recall function as a destination.  \
 	Note that using Mark again will move the destination instead of creating a second destination, and only one destination \
 	can exist, regardless of who casted Mark."
-	cost = 50
+	cost = 25
 	obj_path = /obj/item/weapon/spell/mark
 	ability_icon_state = "tech_mark"
 	category = UTILITY_SPELLS
@@ -50,7 +50,7 @@
 	desc = "This function teleports you to where you placed a mark using the Mark function.  Without the Mark function, this \
 	function is useless.  Note that teleporting takes three seconds.  Being incapacitated while teleporting will cancel it."
 	enhancement_desc = "Recall takes two seconds instead of three."
-	cost = 50
+	cost = 25
 	obj_path = /obj/item/weapon/spell/recall
 	ability_icon_state = "tech_recall"
 	category = UTILITY_SPELLS

--- a/code/game/gamemodes/technomancer/spells/oxygenate.dm
+++ b/code/game/gamemodes/technomancer/spells/oxygenate.dm
@@ -2,7 +2,7 @@
 	name = "Oxygenate"
 	desc = "This function creates oxygen at a location of your chosing.  If used on a humanoid entity, it heals oxygen deprivation.  \
 	If casted on the envirnment, air (oxygen and nitrogen) is moved from a distant location to your target."
-	cost = 70
+	cost = 50
 	obj_path = /obj/item/weapon/spell/oxygenate
 	ability_icon_state = "oxygenate"
 	category = SUPPORT_SPELLS

--- a/code/game/gamemodes/technomancer/spells/phase_shift.dm
+++ b/code/game/gamemodes/technomancer/spells/phase_shift.dm
@@ -2,7 +2,7 @@
 	name = "Phase Shift"
 	desc = "Hides you in the safest possible place, where no harm can come to you.  Unfortunately you can only stay inside for a few moments before \
 	draining your powercell."
-	cost = 80
+	cost = 50
 	obj_path = /obj/item/weapon/spell/phase_shift
 	category = DEFENSIVE_SPELLS
 

--- a/code/game/gamemodes/technomancer/spells/projectile/beam.dm
+++ b/code/game/gamemodes/technomancer/spells/projectile/beam.dm
@@ -1,7 +1,7 @@
 /datum/technomancer/spell/beam
 	name = "Beam"
 	desc = "Fires a laser at your target.  Cheap, reliable, and a bit boring."
-	cost = 150
+	cost = 100
 	ability_icon_state = "tech_beam"
 	obj_path = /obj/item/weapon/spell/projectile/beam
 	category = OFFENSIVE_SPELLS

--- a/code/game/gamemodes/technomancer/spells/projectile/force_missile.dm
+++ b/code/game/gamemodes/technomancer/spells/projectile/force_missile.dm
@@ -2,7 +2,7 @@
 	name = "Force Missile"
 	desc = "This fires a missile at your target.  It's cheap to use, however the projectile itself moves and impacts in such a way \
 	that armor designed to protect from blunt force will mitigate this function as well."
-	cost = 100
+	cost = 50
 	obj_path = /obj/item/weapon/spell/projectile/force_missile
 	category = OFFENSIVE_SPELLS
 

--- a/code/game/gamemodes/technomancer/spells/projectile/overload.dm
+++ b/code/game/gamemodes/technomancer/spells/projectile/overload.dm
@@ -2,7 +2,7 @@
 	name = "Overload"
 	desc = "Fires a bolt of highly unstable energy, that does damaged equal to 1.5% of the technomancer's current reserve of energy.  \
 	This energy pierces all known armor."
-	cost = 150
+	cost = 100
 	obj_path = /obj/item/weapon/spell/projectile/overload
 	category = OFFENSIVE_SPELLS
 

--- a/code/game/gamemodes/technomancer/spells/projectile/projectile.dm
+++ b/code/game/gamemodes/technomancer/spells/projectile/projectile.dm
@@ -10,10 +10,9 @@
 	var/fire_sound = null
 
 /obj/item/weapon/spell/projectile/on_ranged_cast(atom/hit_atom, mob/living/user)
-	var/turf/T = get_turf(hit_atom)
 	if(set_up(hit_atom, user))
 		var/obj/item/projectile/new_projectile = new spell_projectile(get_turf(user))
-		new_projectile.launch(T)
+		new_projectile.launch(hit_atom)
 		if(fire_sound)
 			playsound(get_turf(src), fire_sound, 75, 1)
 		owner.adjust_instability(instability_per_shot)

--- a/code/game/gamemodes/technomancer/spells/radiance.dm
+++ b/code/game/gamemodes/technomancer/spells/radiance.dm
@@ -1,7 +1,7 @@
 /datum/technomancer/spell/radiance
 	name = "Radiance"
 	desc = "Causes you to be very radiant, glowing brightly in visible light, thermal energy, and deadly ionizing radiation."
-	cost = 180
+	cost = 100
 	obj_path = /obj/item/weapon/spell/radiance
 	category = OFFENSIVE_SPELLS
 

--- a/code/game/gamemodes/technomancer/spells/reflect.dm
+++ b/code/game/gamemodes/technomancer/spells/reflect.dm
@@ -1,7 +1,7 @@
 /datum/technomancer/spell/reflect
 	name = "Reflect"
 	desc = "Emits a protective shield fron your hand in front of you, which will reflect one attack back at the attacker."
-	cost = 120
+	cost = 100
 	obj_path = /obj/item/weapon/spell/reflect
 	ability_icon_state = "tech_reflect"
 	category = DEFENSIVE_SPELLS
@@ -22,7 +22,7 @@
 	spark_system = PoolOrNew(/datum/effect/effect/system/spark_spread)
 	spark_system.set_up(5, 0, src)
 	owner << "<span class='notice'>Your shield will expire in 3 seconds!</span>"
-	spawn(3 SECONDS)
+	spawn(5 SECONDS)
 		if(src)
 			owner << "<span class='danger'>Your shield expires!</span>"
 			qdel(src)
@@ -67,7 +67,7 @@
 
 				if(!reflecting)
 					reflecting = 1
-					spawn(1 SECOND) //To ensure that most or all of a burst fire cycle is reflected.
+					spawn(2 SECONDS) //To ensure that most or all of a burst fire cycle is reflected.
 						owner << "<span class='danger'>Your shield fades due being used up!</span>"
 						qdel(src)
 
@@ -87,7 +87,7 @@
 
 				if(!reflecting)
 					reflecting = 1
-					spawn(1 SECOND) //To ensure that most or all of a burst fire cycle is reflected.
+					spawn(2 SECONDS) //To ensure that most or all of a burst fire cycle is reflected.
 						owner << "<span class='danger'>Your shield fades due being used up!</span>"
 						qdel(src)
 		return 1

--- a/code/game/gamemodes/technomancer/spells/shield.dm
+++ b/code/game/gamemodes/technomancer/spells/shield.dm
@@ -2,7 +2,7 @@
 	name = "Shield"
 	desc = "Emits a protective shield fron your hand in front of you, which will protect you from almost anything able to harm \
 	you, so long as you can power it."
-	cost = 120
+	cost = 100
 	obj_path = /obj/item/weapon/spell/shield
 	ability_icon_state = "tech_shield"
 	category = DEFENSIVE_SPELLS

--- a/code/game/gamemodes/technomancer/spells/spawner/darkness.dm
+++ b/code/game/gamemodes/technomancer/spells/spawner/darkness.dm
@@ -1,7 +1,7 @@
 /datum/technomancer/spell/darkness
 	name = "Darkness"
 	desc = "Disrupts photons moving in a local area, causing darkness to shroud yourself or a position of your choosing."
-	cost = 30
+	cost = 25
 	obj_path = /obj/item/weapon/spell/spawner/darkness
 	category = UTILITY_SPELLS
 

--- a/code/game/gamemodes/technomancer/spells/spawner/pulsar.dm
+++ b/code/game/gamemodes/technomancer/spells/spawner/pulsar.dm
@@ -1,7 +1,7 @@
 /datum/technomancer/spell/pulsar
 	name = "Pulsar"
 	desc = "Emits electronic pulses to destroy, disable, or otherwise harm devices and machines.  Be sure to not hit yourself with this."
-	cost = 150
+	cost = 100
 	obj_path = /obj/item/weapon/spell/spawner/pulsar
 	category = OFFENSIVE_SPELLS
 

--- a/code/game/gamemodes/technomancer/spells/summon/summon_creature.dm
+++ b/code/game/gamemodes/technomancer/spells/summon/summon_creature.dm
@@ -6,7 +6,7 @@
 	The creatures take a few moments to be teleported to the targeted tile. Note that the creatures summoned are \
 	not inherently loyal to the technomancer, and that the creatures will be hurt slightly from being teleported to you."
 	enhancement_desc = "Summoned entities will never harm their summoner."
-	cost = 200
+	cost = 100
 	obj_path = /obj/item/weapon/spell/summon/summon_creature
 	category = UTILITY_SPELLS
 

--- a/code/game/gamemodes/technomancer/spells/summon/summon_ward.dm
+++ b/code/game/gamemodes/technomancer/spells/summon/summon_ward.dm
@@ -3,7 +3,7 @@
 	desc = "Teleports a prefabricated 'ward' drone to the target location, which will alert you and your allies when it sees entities \
 	moving around it, or when it is attacked.  They can see for up to five meters.  Wards expire in six minutes."
 	enhancement_desc = "Wards can detect invisibile entities, and are more specific in relaying information about what it sees."
-	cost = 100
+	cost = 25
 	obj_path = /obj/item/weapon/spell/summon/summon_ward
 	category = UTILITY_SPELLS
 
@@ -84,6 +84,9 @@
 			if(L.alpha <= 127)
 				continue // Too transparent, as a mercy to camo lings.
 
+		else
+			L.break_cloak()
+
 		// Warn the Technomancer when it sees a new mob.
 		if(!(L in seen_mobs))
 			seen_mobs.Add(L)
@@ -111,3 +114,7 @@
 		overlays.Cut()
 		var/image/I = image('icons/mob/critter.dmi',"ward_truesight")
 		overlays.Add(I)
+
+/mob/living/simple_animal/ward/invisible_detect
+	true_sight = 1
+	see_invisible = SEE_INVISIBLE_LEVEL_TWO

--- a/code/game/gamemodes/technomancer/spells/targeting_matrix.dm
+++ b/code/game/gamemodes/technomancer/spells/targeting_matrix.dm
@@ -2,7 +2,7 @@
 	name = "Targeting Matrix"
 	desc = "Automatically targets and fires a ranged weapon or function at a non-friendly target near a targeted tile.  \
 	Each target assisted attack costs some energy and instability."
-	cost = 150
+	cost = 50
 	ability_icon_state = "tech_targetingmatrix"
 	obj_path = /obj/item/weapon/spell/targeting_matrix
 	category = UTILITY_SPELLS

--- a/code/game/gamemodes/technomancer/spells/warp_strike.dm
+++ b/code/game/gamemodes/technomancer/spells/warp_strike.dm
@@ -1,7 +1,7 @@
 /datum/technomancer/spell/warp_strike
 	name = "Warp Strike"
 	desc = "Teleports you next to your target, and attacks them with whatever is in your off-hand, spell or object."
-	cost = 200
+	cost = 100
 	obj_path = /obj/item/weapon/spell/warp_strike
 	ability_icon_state = "tech_warpstrike"
 	category = OFFENSIVE_SPELLS


### PR DESCRIPTION
Cost for various spells and equipment adjusted greatly.  In general, things are cheaper, and everything should now be in multiples of 25, so no points are wasted.
The default jumpsuit for Technomancers is now heavily insulated, protecting them from tasers, batons, and perhaps unfortunate lightning strikes.
Instability between 31 and 50 made less harsh.
Wards made with a scepter of enhancement will break the cloak of anyone invisible that it can see.
Fire aura buffed, increased rate of heating as well as temperature cap for both non-scepter and scepter effects.
Reflect spell made more forgiving for the Technomancer, lasting longer before expiring.
Projectile spells should be able to hit people more reliably.