### PR TITLE
Shotgun Reloading Tweak

### DIFF
--- a/code/modules/projectiles/guns/projectile.dm
+++ b/code/modules/projectiles/guns/projectile.dm
@@ -141,6 +141,24 @@
 		user.visible_message("[user] inserts \a [C] into [src].", "<span class='notice'>You insert \a [C] into [src].</span>")
 		playsound(src.loc, 'sound/weapons/empty.ogg', 50, 1)
 
+	else if(istype(A, /obj/item/weapon/storage))
+		var/obj/item/weapon/storage/storage = A
+		if(!(load_method & SINGLE_CASING))
+			return //incompatible
+
+		user << "<span class='notice'>You start loading \the [src].</span>"
+		sleep(1 SECOND)
+		for(var/obj/item/ammo_casing/ammo in storage.contents)
+			if(caliber != ammo.caliber)
+				continue
+
+			load_ammo(ammo, user)
+
+			if(loaded.len >= max_shells)
+				user << "<span class='warning'>[src] is full.</span>"
+				break
+			sleep(1 SECOND)
+
 	update_icon()
 
 //attempts to unload src. If allow_dump is set to 0, the speedloader unloading method will be disabled


### PR DESCRIPTION
Adds ability to hit a shotgun or similar weapon with a container containing ammo, to load said ammo into the shotgun one at a time automatically, instead of having to play inventory tetris, as requested by some people.