### PR TITLE
Heavy Armor values reworked for FUN™

### DIFF
--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -394,14 +394,14 @@
 
 /obj/item/clothing/suit/armor/heavy
 	name = "heavy armor"
-	desc = "A heavily armored suit that protects against moderate damage."
+	desc = "An old military-grade suit of armor. Incredibly robust against brute force damage! However, it offers little protection from energy-based weapons, which, combined with its bulk, makes it woefully obsolete."
 	icon_state = "heavy"
 	item_state_slots = list(slot_r_hand_str = "swat", slot_l_hand_str = "swat")
-	armor = list(melee = 60, bullet = 60, laser = 60, energy = 40, bomb = 40, bio = 0, rad = 0)
-	w_class = ITEMSIZE_LARGE//bulky item
+	armor = list(melee = 90, bullet = 80, laser = 10, energy = 10, bomb = 80, bio = 0, rad = 0)
+	w_class = ITEMSIZE_HUGE // Very bulky, very heavy.
 	gas_transfer_coefficient = 0.90
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|FEET|ARMS|HANDS
-	slowdown = 3
+	slowdown = 5 // If you're a tank you're gonna move like a tank.
 	flags_inv = HIDEGLOVES|HIDESHOES|HIDEJUMPSUIT
 	siemens_coefficient = 0
 


### PR DESCRIPTION
Just to clarify, **I'm not talking about mercenary heavy armor vest.**
I'm talking about **/obj/item/clothing/suit/armor/heavy** which currently appears nowhere in the game, at all.

At one time, this armor had no values at all, because it was never used. Someone who noticed the thunderdome armors and this armor also had no values decided to copy the values from the merc heavy armor over to this--but this armor also has a slowdown, so why would you ever use it? Answer: You wouldn't.

So I made this heavy armor suit actually serve a purpose again--albeit imbalanced, and _that's okay_.


Well, okay, not totally imbalanced. I used to have this available in old Gateway missions on Vorestation. It was popular for fighting mobs but useless when you got back to the station. Here's what's new:

```
/obj/item/clothing/suit/armor/heavy
 name = "heavy armor"
 desc = "An old military-grade suit of armor. Incredibly robust against brute force damage! However, it offers little protection from energy-based weapons, which, combined with its bulk, makes it woefully obsolete."
 armor = list(melee = 90, bullet = 80, laser = 10, energy = 10, bomb = 80, bio = 0, rad = 0)
 w_class = ITEMSIZE_HUGE // Very bulky, very heavy.
 slowdown = 5 // If you're a tank you're gonna move like a tank.
```

As you can see, this is a very specialized armor.

Considering this armor can only be admin spawned, I say "Why not?" If used, it'd be interesting to see players adapt to fighting someone in this armor. Again, it's basically useless against energy weapons.

(Redo of https://github.com/PolarisSS13/Polaris/pull/2494 because Github fucked up during an internet outage.)

**Edit:** Although it resembles Thunderdome armor, it's not Thunderdome armor, neither as code or as a sprite. They just look similar, but if you compare the sprites, it is _not_ supposed to be uncolored Thunderdome armor.