### PR TITLE
Fix supply shuttle overflow

### DIFF
--- a/code/game/supplyshuttle.dm
+++ b/code/game/supplyshuttle.dm
@@ -247,6 +247,7 @@ var/list/mechtoys = list(
 			var/i = rand(1,clear_turfs.len)
 			var/turf/pickedloc = clear_turfs[i]
 			clear_turfs.Cut(i,i+1)
+			shoppinglist -= S
 
 			var/datum/supply_order/SO = S
 			var/datum/supply_packs/SP = SO.object
@@ -298,5 +299,4 @@ var/list/mechtoys = list(
 				slip.info += "</ul><br>"
 				slip.info += "CHECK CONTENTS AND STAMP BELOW THE LINE TO CONFIRM RECEIPT OF GOODS<hr>"
 
-		shoppinglist.Cut()
 		return


### PR DESCRIPTION
Fixes #2437 

Supply shuttle will now only remove an order from the shopping list once it has found a place on the shuttle. Any excess orders will be left on the shopping list for the next time the shuttle is called in.