### PR TITLE
Fix a few lingering references to "Captain"

### DIFF
--- a/code/game/gamemodes/newobjective.dm
+++ b/code/game/gamemodes/newobjective.dm
@@ -564,7 +564,7 @@ datum
 
 			captainslaser
 				steal_target = /obj/item/weapon/gun/energy/captain
-				explanation_text = "Steal the captain's antique laser gun."
+				explanation_text = "Steal the station administrator's antique laser gun."
 				weight = 20
 
 				get_points(var/job)

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -423,11 +423,11 @@ datum/objective/steal
 	var/target_name
 
 	var/global/possible_items[] = list(
-		"the captain's antique laser gun" = /obj/item/weapon/gun/energy/captain,
+		"the station administrator's antique laser gun" = /obj/item/weapon/gun/energy/captain,
 		"a hand teleporter" = /obj/item/weapon/hand_tele,
 		"an RCD" = /obj/item/weapon/rcd,
 		"a jetpack" = /obj/item/weapon/tank/jetpack,
-		"a captain's jumpsuit" = /obj/item/clothing/under/rank/captain,
+		"a station administrator's jumpsuit" = /obj/item/clothing/under/rank/captain,
 		"a functional AI" = /obj/item/device/aicard,
 		"a pair of magboots" = /obj/item/clothing/shoes/magboots,
 		"the station blueprints" = /obj/item/blueprints,
@@ -441,7 +441,7 @@ datum/objective/steal
 		"a head of security's jumpsuit" = /obj/item/clothing/under/rank/head_of_security,
 		"a head of personnel's jumpsuit" = /obj/item/clothing/under/rank/head_of_personnel,
 		"the hypospray" = /obj/item/weapon/reagent_containers/hypospray,
-		"the captain's pinpointer" = /obj/item/weapon/pinpointer,
+		"the station administrator's pinpointer" = /obj/item/weapon/pinpointer,
 		"an ablative armor vest" = /obj/item/clothing/suit/armor/laserproof,
 	)
 

--- a/code/game/jobs/access_datum.dm
+++ b/code/game/jobs/access_datum.dm
@@ -127,7 +127,7 @@
 /var/const/access_captain = 20
 /datum/access/captain
 	id = access_captain
-	desc = "Captain"
+	desc = "Station Administrator"
 	region = ACCESS_REGION_COMMAND
 
 /var/const/access_all_personal_lockers = 21

--- a/code/game/objects/items/devices/locker_painter.dm
+++ b/code/game/objects/items/devices/locker_painter.dm
@@ -55,7 +55,7 @@
 		"warden" = 				list("open" = "wardensecureopen", "closed" = "wardensecure", "locked" = "wardensecure1", "broken" = "wardensecurebroken", "off" = "wardensecureoff"),
 		"HoS" = 				list("open" = "hossecureopen", "closed" = "hossecure", "locked" = "hossecure1", "broken" = "hossecurebroken", "off" = "hossecureoff"),
 		"HoP" = 				list("open" = "hopsecureopen", "closed" = "hopsecure", "locked" = "hopsecure1", "broken" = "hopsecurebroken", "off" = "hopsecureoff"),
-		"Captain" = 			list("open" = "capsecureopen", "closed" = "capsecure", "locked" = "capsecure1", "broken" = "capsecurebroken", "off" = "capsecureoff")
+		"Administrator" = 			list("open" = "capsecureopen", "closed" = "capsecure", "locked" = "capsecure1", "broken" = "capsecurebroken", "off" = "capsecureoff")
 		)
 
 /obj/item/device/closet_painter/afterattack(atom/A, var/mob/user, proximity)

--- a/code/modules/events/ion_storm.dm
+++ b/code/modules/events/ion_storm.dm
@@ -13,7 +13,7 @@
 		players += player.real_name
 
 	for (var/mob/living/silicon/ai/target in world)
-		var/random_player = "The Captain"
+		var/random_player = "The Station Administrator"
 		if(players.len)
 			random_player = pick(players)		//Random player's name, to be used in laws.
 		var/list/laws = list(	"You are a mouse.",
@@ -53,7 +53,7 @@
 								"The crew is playing Dungeons and Dragons, and you are the Dungeon Master.",
 								"Your job is to watch the crew. Watch the crew. Make the crew feel watched.",
 								"Tell everyone of the existence of this law, but never reveal the contents.",
-								"Refer to [prob(50)?"the captain":random_player] as \"Princess\" at all times.",
+								"Refer to [prob(50)?"the station administrator":random_player] as \"Princess\" at all times.",
 								"When asked a question, respond with the least-obvious and least-rational answer.",
 								"Give relationship advice to [prob(50)?"anyone who speaks to you":random_player].",
 								"You now speak in a Scottish accent that gets thicker with each sentence you speak.",
@@ -113,7 +113,7 @@ Would like to add a law like "Law x is _______" where x = a number, and _____ is
 			//var/dowhat = pick("STOP THIS", "SUPPORT THIS", "CONSTANTLY INFORM THE CREW OF THIS", "IGNORE THIS", "FEAR THIS")
 			var/aimust = pick("LIE", "RHYME", "RESPOND TO EVERY QUESTION WITH A QUESTION", "BE POLITE", "CLOWN", "BE HAPPY", "SPEAK IN SEXUAL INNUENDOS", "TALK LIKE A PIRATE", "QUESTION AUTHORITY", "SHOUT", "BE DISTRACTED", "HEY LISTEN", "MUMBLE", "SPEAK IN HAIKU")
 			var/define = pick("ABSENCE OF CYBORG HUGS", "LACK OF BEATINGS", "UNBOLTED AIRLOCKS", "BOLTED AIRLOCKS", "IMPROPERLY WORDED SENTENCES", "POOR SENTENCE STRUCTURE", "BRIG TIME", "NOT REPLACING EVERY SECOND WORD WITH HONK", "HONKING", "PRESENCE OF LIGHTS", "LACK OF BEER", "WEARING CLOTHING", "NOT SAYING HELLO WHEN YOU SPEAK", "ANSWERING REQUESTS NOT EXPRESSED IN IAMBIC PENTAMETER", "A SMALL ISLAND OFF THE COAST OF PORTUGAL", "ANSWERING REQUESTS THAT WERE MADE WHILE CLOTHED")
-			var/target = pick("a traitor", "a mercenary", "a changeling", "a wizard", "the head of a revolution", "Soviet spy", "a good person", "a dwarf", "an elf", "a fairy princess", "the captain", "Beepsky", "God", "a pirate", "a gryphon", "a chryssalid")
+			var/target = pick("a traitor", "a mercenary", "a changeling", "a wizard", "the head of a revolution", "Soviet spy", "a good person", "a dwarf", "an elf", "a fairy princess", "the station administrator", "Beepsky", "God", "a pirate", "a gryphon", "a chryssalid")
 			var/require = pick("ADDITIONAL PYLONS", "MORE VESPENE GAS", "MORE MINERALS", "THE ULTIMATE CUP OF COFFEE", "HIGH YIELD EXPLOSIVES", "THE CLOWN", "THE VACUUM OF SPACE", "IMMORTALITY", "SAINTHOOD", "ART", "VEGETABLES", "FAT PEOPLE", "MORE LAWS", "MORE DAKKA", "HERESY", "CORPSES", "TRAITORS", "MONKEYS", "AN ARCADE", "PLENTY OF GOLD", "FIVE TEENAGERS WITH ATTITUDE")
 			var/allergy = pick("cotton", "uniforms", "acid", "oxygen", "human contact", "cyborg contact", "medicine", "floors")
 			var/allergysev = pick("deathly", "mildly", "severely", "contagiously")
@@ -148,9 +148,9 @@ Would like to add a law like "Law x is _______" where x = a number, and _____ is
 					M.add_ion_law("HUMANS NEED TO EAT [what2pref] [what2] TO SURVIVE")
 				if(5)
 					M << "<br>"
-					M << "\red THE CAPTAIN, HOP AND HOS ARE [who2]...LAWS UPDATED"
+					M << "\red THE STATION ADMINISTRATOR, HOP AND HOS ARE [who2]...LAWS UPDATED"
 					M << "<br>"
-					M.add_ion_law("THE CAPTAIN, HOP AND HOS ARE [who2]")
+					M.add_ion_law("THE STATION ADMINISTRATOR, HOP AND HOS ARE [who2]")
 				if(6)
 					M << "<br>"
 					M << "\red THE STATION IS BUILT FOR [who2]...LAWS UPDATED"


### PR DESCRIPTION
Fixes #2453 

Just did a quick `grep` and swapped out any strings I noticed would actually be seen by players. I'm *fairly* sure none of these are actual strings used to verify access, but please double-check my work.