### PR TITLE
Fixes supplypacks.dm invalid group

### DIFF
--- a/code/datums/supplypacks/supplypacks.dm
+++ b/code/datums/supplypacks/supplypacks.dm
@@ -34,7 +34,7 @@ var/list/all_supply_groups = list("Atmospherics",
 	var/access = null
 	var/hidden = 0
 	var/contraband = 0
-	var/group = "Operations"
+	var/group = "Miscellaneous"
 
 /datum/supply_packs/New()
 	manifest += "<ul>"


### PR DESCRIPTION
Operations doesn't exist anymore. It shouldn't be the default class.