### PR TITLE
Automates Changelog Button, Forever

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -15,7 +15,7 @@ datum/preferences
 	var/last_id
 
 	//game-preferences
-	var/lastchangelog = ""				//Saved changlog filesize to detect if there was a change
+	var/lastchangelog = ""				//Saved changlog SHA to detect if there was a change
 	var/ooccolor = "#010000"			//Whatever this is set to acts as 'reset' color and is thus unusable as an actual custom color
 	var/be_special = 0					//Special role selection
 	var/UI_style = "Midnight"
@@ -262,7 +262,7 @@ datum/preferences
 	if(be_random_name)
 		real_name = random_name(identifying_gender,species)
 
-	// Ask the preferences datums to apply their own settings to the new mob 
+	// Ask the preferences datums to apply their own settings to the new mob
 	player_setup.copy_to_mob(character)
 
 	if(icon_updates)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -393,31 +393,17 @@
 /client/verb/changes()
 	set name = "Changelog"
 	set category = "OOC"
-	getFiles(
-		'html/88x31.png',
-		'html/bug-minus.png',
-		'html/cross-circle.png',
-		'html/hard-hat-exclamation.png',
-		'html/image-minus.png',
-		'html/image-plus.png',
-		'html/map-pencil.png',
-		'html/music-minus.png',
-		'html/music-plus.png',
-		'html/tick-circle.png',
-		'html/wrench-screwdriver.png',
-		'html/spell-check.png',
-		'html/burn-exclamation.png',
-		'html/chevron.png',
-		'html/chevron-expand.png',
-		'html/changelog.css',
-		'html/changelog.js',
-		'html/changelog.html'
-		)
-	src << browse('html/changelog.html', "window=changes;size=675x650")
-	if(prefs.lastchangelog != changelog_hash)
-		prefs.lastchangelog = changelog_hash
-		prefs.save_preferences()
-		winset(src, "rpane.changelog", "background-color=none;font-style=;")
+
+	if(config.githuburl)
+		var/URL = "[config.githuburl]/pulse"
+		src << link(URL)
+
+		if(prefs.lastchangelog != changelog_hash)
+			prefs.lastchangelog = changelog_hash
+			prefs.save_preferences()
+			winset(src, "rpane.changelog", "background-color=none;font-style=;")
+	else
+		src << "<span class='danger'>The GitHub URL is not set in the server configuration.</span>"
 
 /mob/verb/observe()
 	set name = "Observe"

--- a/code/world.dm
+++ b/code/world.dm
@@ -43,7 +43,7 @@ var/global/datum/global_init/init = new ()
 	href_logfile = file("data/logs/[date_string] hrefs.htm")
 	diary = file("data/logs/[date_string].log")
 	diary << "[log_end]\n[log_end]\nStarting up. [time2text(world.timeofday, "hh:mm.ss")][log_end]\n---------------------[log_end]"
-	changelog_hash = md5('html/changelog.html')					//used for telling if the changelog has changed recently
+	changelog_hash = revdata.revision					//used for telling if the changelog has changed recently
 
 	if(byond_version < RECOMMENDED_VERSION)
 		world.log << "Your server's byond version does not meet the recommended requirements for this server. Please update BYOND"

--- a/interface/interface.dm
+++ b/interface/interface.dm
@@ -53,11 +53,11 @@
 
 /client/verb/github()
 	set name = "GitHub"
-	set desc = "Visit the GitHub"
+	set desc = "View Source Code Repository"
 	set hidden = 1
 
 	if(config.githuburl)
-		if(alert("This will open the GitHub in your browser. Are you sure?",,"Yes","No")=="No")
+		if(alert("This will open the GitHub Repository in your browser. Are you sure?",,"Yes","No")=="No")
 			return
 		src << link(config.githuburl)
 	else


### PR DESCRIPTION
Replaces the changelog button to point to the 'pulse' tab on GitHub, which will always give up to date information on what was added.  This relieves a fairly significant burden on the dev staff, and introduces a larger number of people to our code on GitHub.
The game will still bold the changelog button if the server's revision SHA is different from what they saw last time.