### PR TITLE
Removes Ninja & Malf Voting

### DIFF
--- a/code/game/gamemodes/malfunction/malfunction.dm
+++ b/code/game/gamemodes/malfunction/malfunction.dm
@@ -10,3 +10,4 @@
 	auto_recall_shuttle = 0
 	antag_tags = list(MODE_MALFUNCTION)
 	disabled_jobs = list("AI")
+	votable = 0

--- a/code/game/gamemodes/ninja/ninja.dm
+++ b/code/game/gamemodes/ninja/ninja.dm
@@ -14,3 +14,4 @@
 	required_enemies = 1
 	end_on_antag_death = 0
 	antag_tags = list(MODE_NINJA)
+	votable = 0


### PR DESCRIPTION
Malf is a terrible gamemode, the code is unmaintained, and it's not very fun for the crew or the AI.  The AI can still be evil, and more effectively, as a traitor.  At some point I plan to give traitorAIs some malf powers, but the malf mode needs to go, and I meant to do this literally a year ago.

Ninja will no longer be votable, because one ninja cannot carry the round.  The age of solo-antags is coming to an end, because solo-antagonists have been proven to be ineffective, and place massive pressure on the person playing the antag.  It also makes it difficult to balance one person to be able to fight the whole station without it being shit for the station or shit for the antag.  To fix that, Ninja is no longer a solo-antag.  The other ninja modes like Intrigue and Visitors remain, as the ninja should have more breathing room, since other baddies exist.