### PR TITLE
Technomancer Bug Fixes & Tweaks

### DIFF
--- a/code/game/gamemodes/technomancer/core_obj.dm
+++ b/code/game/gamemodes/technomancer/core_obj.dm
@@ -86,6 +86,8 @@
 	if(wearer && wearer.mind)
 		if(!(technomancers.is_antagonist(wearer.mind))) // In case someone tries to wear a stolen core.
 			wearer.adjust_instability(20)
+	if(!wearer || wearer.stat == DEAD) // Unlock if we're dead or not worn.
+		canremove = TRUE
 
 /obj/item/weapon/technomancer_core/proc/regenerate()
 	energy = min(max(energy + regen_rate, 0), max_energy)
@@ -288,3 +290,11 @@
 /obj/item/weapon/technomancer_core/summoner/pay_dues()
 	if(summoned_mobs.len)
 		pay_energy( round(summoned_mobs.len) )
+
+/obj/item/weapon/technomancer_core/verb/toggle_lock()
+	set name = "Toggle Core Lock"
+	set category = "Object"
+	set desc = "Toggles the locking mechanism on your manipulation core."
+
+	canremove = !canremove
+	to_chat(usr, "<span class='notice'>You [canremove ? "de" : ""]activate the locking mechanism on \the [src].</span>")

--- a/code/game/gamemodes/technomancer/equipment.dm
+++ b/code/game/gamemodes/technomancer/equipment.dm
@@ -139,6 +139,7 @@
 	icon = 'icons/obj/technomancer.dmi'
 	icon_state = "scepter"
 	force = 15
+	slot_flags = SLOT_BELT
 
 /obj/item/weapon/scepter/attack_self(mob/living/carbon/human/user)
 	var/obj/item/item_to_test = user.get_other_hand(src)

--- a/code/game/gamemodes/technomancer/spells/aspect_aura.dm
+++ b/code/game/gamemodes/technomancer/spells/aspect_aura.dm
@@ -73,7 +73,7 @@
 		var/turf/location = get_turf(H)
 		location.hotspot_expose(1000, 50, 1)
 
-	owner.adjust_instability(1)
+	adjust_instability(1)
 
 /obj/item/weapon/spell/aura/frost
 	name = "chilling aura"
@@ -95,7 +95,7 @@
 		var/turf/location = get_turf(H)
 		location.hotspot_expose(1, 50, 1)
 
-	owner.adjust_instability(1)
+	adjust_instability(1)
 
 
 
@@ -128,7 +128,7 @@
 		for(var/mob/living/L in mobs_to_heal)
 			L.adjustBruteLoss(-5)
 			L.adjustFireLoss(-5)
-		owner.adjust_instability(2)
+		adjust_instability(2)
 
 /obj/item/weapon/spell/aura/biomed/on_use_cast(mob/living/user)
 	heal_allies_only = !heal_allies_only

--- a/code/game/gamemodes/technomancer/spells/audible_deception.dm
+++ b/code/game/gamemodes/technomancer/spells/audible_deception.dm
@@ -76,10 +76,10 @@
 	var/turf/T = get_turf(hit_atom)
 	if(selected_sound && pay_energy(200))
 		playsound(T, selected_sound, 80, 1, -1)
-		owner.adjust_instability(1)
+		adjust_instability(1)
 		// Air Horn time.
 		if(selected_sound == 'sound/items/AirHorn.ogg' && pay_energy(3800))
-			owner.adjust_instability(49) // Pay for your sins.
+			adjust_instability(49) // Pay for your sins.
 			for(var/mob/living/carbon/M in ohearers(6, T))
 				if(M.get_ear_protection() >= 2)
 					continue

--- a/code/game/gamemodes/technomancer/spells/aura/biomed_aura.dm
+++ b/code/game/gamemodes/technomancer/spells/aura/biomed_aura.dm
@@ -12,7 +12,7 @@
 	icon_state = "generic"
 	cast_methods = null
 	aspect = ASPECT_BIOMED
-	glow_color = "#0000FF"
+	glow_color = "#33CC33"
 	var/regen_tick = 0
 	var/heal_allies_only = 1
 
@@ -23,16 +23,16 @@
 	if(regen_tick % 5 == 0)
 		var/list/nearby_mobs = range(4,owner)
 		var/list/mobs_to_heal = list()
-		if(heal_allies_only)
-			for(var/mob/living/L in nearby_mobs)
+		for(var/mob/living/L in nearby_mobs)
+			if(heal_allies_only)
 				if(is_ally(L))
 					mobs_to_heal |= L
-		else
-			mobs_to_heal = nearby_mobs //Heal everyone!
+			else
+				mobs_to_heal |= L // Heal everyone!
 		for(var/mob/living/L in mobs_to_heal)
 			L.adjustBruteLoss(-2)
 			L.adjustFireLoss(-2)
-		owner.adjust_instability(2)
+		adjust_instability(2)
 
 /obj/item/weapon/spell/aura/biomed/on_use_cast(mob/living/user)
 	heal_allies_only = !heal_allies_only

--- a/code/game/gamemodes/technomancer/spells/aura/fire_aura.dm
+++ b/code/game/gamemodes/technomancer/spells/aura/fire_aura.dm
@@ -47,4 +47,4 @@
 				T.hotspot_expose(1000, 50, 1)
 				T.create_fire(fire_power)
 
-	owner.adjust_instability(1)
+	adjust_instability(1)

--- a/code/game/gamemodes/technomancer/spells/aura/frost_aura.dm
+++ b/code/game/gamemodes/technomancer/spells/aura/frost_aura.dm
@@ -36,4 +36,4 @@
 			var/cold_factor = abs(protection - 1)
 			H.bodytemperature = max( (H.bodytemperature - temp_change) * cold_factor, temp_cap)
 
-	owner.adjust_instability(1)
+	adjust_instability(1)

--- a/code/game/gamemodes/technomancer/spells/aura/shock_aura.dm
+++ b/code/game/gamemodes/technomancer/spells/aura/shock_aura.dm
@@ -39,4 +39,4 @@
 			L.electrocute_act(power, src, 1.0, BP_TORSO)
 
 
-	owner.adjust_instability(3)
+	adjust_instability(3)

--- a/code/game/gamemodes/technomancer/spells/aura/unstable_aura.dm
+++ b/code/game/gamemodes/technomancer/spells/aura/unstable_aura.dm
@@ -40,4 +40,4 @@
 				L << "<span class='danger'>You feel almost like you're melting from the inside!</span>"
 
 
-	owner.adjust_instability(2)
+	adjust_instability(2)

--- a/code/game/gamemodes/technomancer/spells/control.dm
+++ b/code/game/gamemodes/technomancer/spells/control.dm
@@ -150,7 +150,7 @@
 				attack \the [L].</span>"
 				//This is to stop someone from controlling beepsky and getting him to stun someone 5 times a second.
 				user.setClickCooldown(8)
-				owner.adjust_instability(controlled_mobs.len)
+				adjust_instability(controlled_mobs.len)
 
 	else if(isturf(hit_atom))
 		var/turf/T = hit_atom
@@ -159,7 +159,7 @@
 			return 0
 		if(pay_energy(50 * controlled_mobs.len))
 			move_all(T)
-			owner.adjust_instability(controlled_mobs.len)
+			adjust_instability(controlled_mobs.len)
 			user << "<span class='notice'>You command your [controlled_mobs.len > 1 ? "entities" : "[controlled_mobs[1]]"] to move \
 			towards \the [T].</span>"
 

--- a/code/game/gamemodes/technomancer/spells/flame_tongue.dm
+++ b/code/game/gamemodes/technomancer/spells/flame_tongue.dm
@@ -46,7 +46,7 @@
 			visible_message("<span class='danger'>\The [user] reaches out towards \the [L] with the flaming hand, and they ignite!</span>")
 			L << "<span class='danger'>You ignite!</span>"
 			L.fire_act()
-			owner.adjust_instability(12)
+			adjust_instability(12)
 	else
 		//This is needed in order for the welder to work, and works similarly to grippers.
 		welder.loc = user
@@ -54,7 +54,7 @@
 		if(!resolved && welder && hit_atom)
 			if(pay_energy(500))
 				welder.attack(hit_atom, user, def_zone)
-				owner.adjust_instability(4)
+				adjust_instability(4)
 		if(welder && user && (welder.loc == user))
 			welder.loc = src
 		else

--- a/code/game/gamemodes/technomancer/spells/insert/mend_burns.dm
+++ b/code/game/gamemodes/technomancer/spells/insert/mend_burns.dm
@@ -1,7 +1,6 @@
 /datum/technomancer/spell/mend_burns
 	name = "Mend Burns"
-	desc = "Heals minor burns, such as from exposure to flame, electric shock, or lasers.  \
-	Instability is split between the target and technomancer, if seperate."
+	desc = "Heals minor burns, such as from exposure to flame, electric shock, or lasers."
 	cost = 50
 	obj_path = /obj/item/weapon/spell/insert/mend_burns
 	ability_icon_state = "tech_mendburns"
@@ -20,10 +19,10 @@
 	spawn(1)
 		if(ishuman(host))
 			var/mob/living/carbon/human/H = host
+			var/heal_power = host == origin ? 10 : 30
+			origin.adjust_instability(10)
 			for(var/i = 0, i<5,i++)
 				if(H)
-					H.adjustFireLoss(-5)
-					H.adjust_instability(2.5)
-					origin.adjust_instability(2.5)
-					sleep(10)
+					H.adjustFireLoss(-heal_power / 5)
+					sleep(1 SECOND)
 		on_expire()

--- a/code/game/gamemodes/technomancer/spells/insert/mend_metal.dm
+++ b/code/game/gamemodes/technomancer/spells/insert/mend_metal.dm
@@ -1,6 +1,6 @@
 /datum/technomancer/spell/mend_metal
 	name = "Mend Metal"
-	desc = "Restores integrity to external robotic components.  Instability is split between the target and technomancer, if seperate."
+	desc = "Restores integrity to external robotic components."
 	cost = 50
 	obj_path = /obj/item/weapon/spell/insert/mend_metal
 	ability_icon_state = "tech_mendwounds"
@@ -19,14 +19,13 @@
 	spawn(1)
 		if(ishuman(host))
 			var/mob/living/carbon/human/H = host
+			var/heal_power = host == origin ? 10 : 30
+			origin.adjust_instability(10)
 			for(var/i = 0, i<5,i++)
 				if(H)
 					for(var/obj/item/organ/external/O in H.organs)
 						if(O.robotic < ORGAN_ROBOT) // Robot parts only.
 							continue
-						O.heal_damage(5, 0, internal = 1, robo_repair = 1)
-
-					H.adjust_instability(2.5)
-					origin.adjust_instability(2.5)
+						O.heal_damage(heal_power / 5, 0, internal = 1, robo_repair = 1)
 					sleep(1 SECOND)
 		on_expire()

--- a/code/game/gamemodes/technomancer/spells/insert/mend_organs.dm
+++ b/code/game/gamemodes/technomancer/spells/insert/mend_organs.dm
@@ -1,15 +1,15 @@
 /datum/technomancer/spell/mend_organs
-	name = "Mend Organs"
-	desc = "Heals the target's internal organs, both organic and robotic.  Instability is split between the target \
-	and technomancer, if seperate."
-	cost = 50
+	name = "Great Mend Wounds"
+	desc = "Greatly heals the target's wounds, both external and internal.  Restores internal organs to functioning states, even if \
+	robotic, reforms bones, patches internal bleeding, and restores missing blood."
+	cost = 100
 	obj_path = /obj/item/weapon/spell/insert/mend_organs
 	ability_icon_state = "tech_mendwounds"
 	category = SUPPORT_SPELLS
 
 /obj/item/weapon/spell/insert/mend_organs
-	name = "mend organs"
-	desc = "Now nobody will ever need surgery."
+	name = "great mend wounds"
+	desc = "A walking medbay is now you!"
 	icon_state = "mend_wounds"
 	cast_methods = CAST_MELEE
 	aspect = ASPECT_BIOMED
@@ -20,13 +20,33 @@
 	spawn(1)
 		if(ishuman(host))
 			var/mob/living/carbon/human/H = host
+			var/heal_power = host == origin ? 2 : 5
+			origin.adjust_instability(15)
+
 			for(var/i = 0, i<5,i++)
 				if(H)
 					for(var/obj/item/organ/O in H.internal_organs)
-						if(O.damage > 0)
-							O.damage = max(O.damage - 1, 0)
+						if(O.damage > 0) // Fix internal damage
+							O.damage = max(O.damage - (heal_power / 5), 0)
+						if(O.damage <= 5 && O.organ_tag == O_EYES) // Fix eyes
+							H.sdisabilities &= ~BLIND
 
-					H.adjust_instability(2.5)
-					origin.adjust_instability(2.5)
+					for(var/obj/item/organ/external/O in H.organs) // Fix limbs
+						if(!O.robotic < ORGAN_ROBOT) // No robot parts for this.
+							continue
+						O.heal_damage(0, heal_power / 5, internal = 1, robo_repair = 0)
+
+					for(var/obj/item/organ/E in H.bad_external_organs) // Fix bones
+						var/obj/item/organ/external/affected = E
+						if((affected.damage < affected.min_broken_damage * config.organ_health_multiplier) && (affected.status & ORGAN_BROKEN))
+							affected.status &= ~ORGAN_BROKEN
+
+						for(var/datum/wound/W in affected.wounds) // Fix IB
+							if(istype(W, /datum/wound/internal_bleeding))
+								affected.wounds -= W
+								affected.update_damages()
+
+					H.restore_blood() // Fix bloodloss
+
 					sleep(1 SECOND)
 		on_expire()

--- a/code/game/gamemodes/technomancer/spells/insert/mend_wires.dm
+++ b/code/game/gamemodes/technomancer/spells/insert/mend_wires.dm
@@ -1,7 +1,6 @@
 /datum/technomancer/spell/mend_wires
 	name = "Mend Wires"
-	desc = "Binds the internal wiring of robotic limbs and components over time.  \
-	Instability is split between the target and technomancer, if seperate."
+	desc = "Binds the internal wiring of robotic limbs and components over time."
 	cost = 50
 	obj_path = /obj/item/weapon/spell/insert/mend_wires
 	ability_icon_state = "tech_mendwounds"
@@ -20,14 +19,13 @@
 	spawn(1)
 		if(ishuman(host))
 			var/mob/living/carbon/human/H = host
+			var/heal_power = host == origin ? 10 : 30
+			origin.adjust_instability(10)
 			for(var/i = 0, i<5,i++)
 				if(H)
 					for(var/obj/item/organ/external/O in H.organs)
 						if(O.robotic < ORGAN_ROBOT) // Robot parts only.
 							continue
-						O.heal_damage(0, 5, internal = 1, robo_repair = 1)
-
-					H.adjust_instability(2.5)
-					origin.adjust_instability(2.5)
-					sleep(10)
+						O.heal_damage(0, heal_power / 5, internal = 1, robo_repair = 1)
+					sleep(1 SECOND)
 		on_expire()

--- a/code/game/gamemodes/technomancer/spells/insert/mend_wounds.dm
+++ b/code/game/gamemodes/technomancer/spells/insert/mend_wounds.dm
@@ -20,10 +20,10 @@
 	spawn(1)
 		if(ishuman(host))
 			var/mob/living/carbon/human/H = host
+			var/heal_power = host == origin ? 10 : 30
+			origin.adjust_instability(10)
 			for(var/i = 0, i<5,i++)
 				if(H)
-					H.adjustBruteLoss(-5)
-					H.adjust_instability(2.5)
-					origin.adjust_instability(2.5)
+					H.adjustBruteLoss(-heal_power / 5)
 					sleep(1 SECOND)
 		on_expire()

--- a/code/game/gamemodes/technomancer/spells/insert/purify.dm
+++ b/code/game/gamemodes/technomancer/spells/insert/purify.dm
@@ -1,7 +1,6 @@
 /datum/technomancer/spell/purify
 	name = "Purify"
-	desc = "Clenses the body of harmful impurities, such as toxins, radiation, viruses, genetic damage, and such.  \
-	Instability is split between the target and technomancer, if seperate."
+	desc = "Clenses the body of harmful impurities, such as toxins, radiation, viruses, genetic damage, and such."
 	cost = 25
 	obj_path = /obj/item/weapon/spell/insert/purify
 	ability_icon_state = "tech_purify"
@@ -24,12 +23,12 @@
 			H.disabilities = 0
 //			for(var/datum/disease/D in H.viruses)
 //				D.cure()
+			var/heal_power = host == origin ? 10 : 30
+			origin.adjust_instability(10)
 			for(var/i = 0, i<5,i++)
 				if(H)
-					H.adjustToxLoss(-5)
-					H.adjustCloneLoss(-5)
-					H.radiation = max(host.radiation - 10, 0)
-					H.adjust_instability(2.5)
-					origin.adjust_instability(2.5)
+					H.adjustToxLoss(-heal_power / 5)
+					H.adjustCloneLoss(-heal_power / 5)
+					H.radiation = max(host.radiation - ( (heal_power * 2) / 5), 0)
 					sleep(1 SECOND)
 		on_expire()

--- a/code/game/gamemodes/technomancer/spells/instability_tap.dm
+++ b/code/game/gamemodes/technomancer/spells/instability_tap.dm
@@ -20,8 +20,8 @@
 /obj/item/weapon/spell/instability_tap/on_use_cast(mob/user)
 	if(check_for_scepter())
 		core.give_energy(7500)
-		owner.adjust_instability(40)
+		adjust_instability(40)
 	else
 		core.give_energy(5000)
-		owner.adjust_instability(50)
+		adjust_instability(50)
 	qdel(src)

--- a/code/game/gamemodes/technomancer/spells/mark_recall.dm
+++ b/code/game/gamemodes/technomancer/spells/mark_recall.dm
@@ -37,7 +37,7 @@
 		else
 			mark_spell_ref.forceMove(get_turf(user))
 			user << "<span class='notice'>Your mark is moved from its old position to \the [get_turf(user)] under you.</span>"
-		owner.adjust_instability(5)
+		adjust_instability(5)
 		return 1
 	else
 		user << "<span class='warning'>You can't afford the energy cost!</span>"
@@ -99,7 +99,7 @@
 
 			playsound(old_turf, 'sound/effects/sparks2.ogg', 50, 1)
 
-			owner.adjust_instability(25)
+			adjust_instability(25)
 			qdel(src)
 			return 1
 	else

--- a/code/game/gamemodes/technomancer/spells/oxygenate.dm
+++ b/code/game/gamemodes/technomancer/spells/oxygenate.dm
@@ -20,7 +20,7 @@
 		var/mob/living/carbon/human/H = hit_atom
 		if(pay_energy(1500))
 			H.adjustOxyLoss(-35)
-			owner.adjust_instability(10)
+			adjust_instability(10)
 			return
 	else if(isturf(hit_atom))
 		var/turf/T = hit_atom
@@ -28,4 +28,4 @@
 			T.assume_gas("oxygen", 200)
 			T.assume_gas("nitrogen", 800)
 			playsound(src.loc, 'sound/effects/spray.ogg', 50, 1, -3)
-			owner.adjust_instability(10)
+			adjust_instability(10)

--- a/code/game/gamemodes/technomancer/spells/phase_shift.dm
+++ b/code/game/gamemodes/technomancer/spells/phase_shift.dm
@@ -15,6 +15,7 @@
 /obj/item/weapon/spell/phase_shift/New()
 	..()
 	set_light(3, 2, l_color = "#FA58F4")
+	processing_objects |= src
 
 /obj/effect/phase_shift
 	name = "rift"
@@ -32,7 +33,12 @@
 /obj/effect/phase_shift/Destroy()
 	for(var/atom/movable/AM in contents) //Eject everything out.
 		AM.forceMove(get_turf(src))
+	processing_objects -= src
 	..()
+
+/obj/effect/phase_shift/process()
+	for(var/mob/living/L in contents)
+		L.adjust_instability(2)
 
 /obj/effect/phase_shift/relaymove(mob/user as mob)
 	if(user.stat)

--- a/code/game/gamemodes/technomancer/spells/projectile/overload.dm
+++ b/code/game/gamemodes/technomancer/spells/projectile/overload.dm
@@ -36,7 +36,7 @@
 			P.damage = round(energy_before_firing * 0.004) // 4% of their current energy pool.
 		else
 			P.damage = round(energy_before_firing * 0.003) // 3% of their current energy pool.
-		owner.adjust_instability(instability_per_shot)
+		adjust_instability(instability_per_shot)
 		return 1
 
 

--- a/code/game/gamemodes/technomancer/spells/projectile/projectile.dm
+++ b/code/game/gamemodes/technomancer/spells/projectile/projectile.dm
@@ -13,9 +13,10 @@
 	if(set_up(hit_atom, user))
 		var/obj/item/projectile/new_projectile = new spell_projectile(get_turf(user))
 		new_projectile.launch(hit_atom)
+		log_and_message_admins("has casted [src] at \the [hit_atom].")
 		if(fire_sound)
 			playsound(get_turf(src), fire_sound, 75, 1)
-		owner.adjust_instability(instability_per_shot)
+		adjust_instability(instability_per_shot)
 		return 1
 	return 0
 
@@ -28,5 +29,8 @@
 				user.Stun(pre_shot_delay / 10)
 				sleep(pre_shot_delay)
 				qdel(target_image)
-			return 1
-	return 0
+				if(owner)
+					return TRUE
+				return FALSE // We got dropped before the firing occured.
+			return TRUE // No delay, no need to check.
+	return FALSE

--- a/code/game/gamemodes/technomancer/spells/radiance.dm
+++ b/code/game/gamemodes/technomancer/spells/radiance.dm
@@ -42,4 +42,4 @@
 		var/radius = max(get_dist(L, src), 1)
 		var/rads = (power / 10) * ( 1 / (radius**2) )
 		L.apply_effect(rads, IRRADIATE)
-	owner.adjust_instability(2)
+	adjust_instability(2)

--- a/code/game/gamemodes/technomancer/spells/resurrect.dm
+++ b/code/game/gamemodes/technomancer/spells/resurrect.dm
@@ -37,7 +37,7 @@
 				dead_mob_list -= SM
 				living_mob_list += SM
 				SM.icon_state = SM.icon_living
-				owner.adjust_instability(30)
+				adjust_instability(30)
 			else if(ishuman(L))
 				var/mob/living/carbon/human/H = L
 
@@ -57,7 +57,7 @@
 					H.timeofdeath = null
 					visible_message("<span class='danger'>\The [H]'s eyes open!</span>")
 					user << "<span class='notice'>It's alive!</span>"
-					owner.adjust_instability(100)
+					adjust_instability(100)
 				else
 					user << "<span class='warning'>The body of \the [H] doesn't seem to respond, perhaps you could try again?</span>"
-					owner.adjust_instability(10)
+					adjust_instability(10)

--- a/code/game/gamemodes/technomancer/spells/shared_burden.dm
+++ b/code/game/gamemodes/technomancer/spells/shared_burden.dm
@@ -24,5 +24,5 @@
 		if(pay_energy(500))
 			var/instability_to_drain = min(H.instability, 25)
 			user << "<span class='notice'>You draw instability away from \the [H] and towards you.</span>"
-			owner.adjust_instability(instability_to_drain)
+			adjust_instability(instability_to_drain)
 			H.adjust_instability(-instability_to_drain)

--- a/code/game/gamemodes/technomancer/spells/spawner/darkness.dm
+++ b/code/game/gamemodes/technomancer/spells/spawner/darkness.dm
@@ -15,7 +15,7 @@
 
 /obj/item/weapon/spell/spawner/darkness/on_ranged_cast(atom/hit_atom, mob/user)
 	if(pay_energy(500))
-		owner.adjust_instability(4)
+		adjust_instability(4)
 		..()
 
 /obj/item/weapon/spell/spawner/darkness/New()

--- a/code/game/gamemodes/technomancer/spells/spawner/fire_blast.dm
+++ b/code/game/gamemodes/technomancer/spells/spawner/fire_blast.dm
@@ -16,7 +16,7 @@
 
 /obj/item/weapon/spell/spawner/fire_blast/on_ranged_cast(atom/hit_atom, mob/user)
 	if(pay_energy(2000))
-		owner.adjust_instability(12)
+		adjust_instability(12)
 		..() // Makes the booms happen.
 
 /obj/effect/temporary_effect/fire_blast

--- a/code/game/gamemodes/technomancer/spells/spawner/pulsar.dm
+++ b/code/game/gamemodes/technomancer/spells/spawner/pulsar.dm
@@ -19,7 +19,7 @@
 
 /obj/item/weapon/spell/spawner/pulsar/on_ranged_cast(atom/hit_atom, mob/user)
 	if(pay_energy(4000))
-		owner.adjust_instability(8)
+		adjust_instability(8)
 		..()
 
 /obj/item/weapon/spell/spawner/pulsar/on_throw_cast(atom/hit_atom, mob/user)

--- a/code/game/gamemodes/technomancer/spells/summon/summon.dm
+++ b/code/game/gamemodes/technomancer/spells/summon/summon.dm
@@ -19,16 +19,17 @@
 		E.icon_state = "anom"
 		sleep(5 SECONDS)
 		qdel(E)
-		var/mob/living/L = new summoned_mob_type(T)
-		core.summoned_mobs |= L
-		L.summoned = 1
-		var/image/summon_underlay = image('icons/obj/objects.dmi',"anom")
-		summon_underlay.alpha = 127
-		L.underlays |= summon_underlay
-		on_summon(L)
-		user << "<span class='notice'>You've successfully teleported \a [L] to you!</span>"
-		visible_message("<span class='warning'>\A [L] appears from no-where!</span>")
-		user.adjust_instability(instability_cost)
+		if(owner) // We might've been dropped.
+			var/mob/living/L = new summoned_mob_type(T)
+			core.summoned_mobs |= L
+			L.summoned = 1
+			var/image/summon_underlay = image('icons/obj/objects.dmi',"anom")
+			summon_underlay.alpha = 127
+			L.underlays |= summon_underlay
+			on_summon(L)
+			user << "<span class='notice'>You've successfully teleported \a [L] to you!</span>"
+			visible_message("<span class='warning'>\A [L] appears from no-where!</span>")
+			user.adjust_instability(instability_cost)
 
 /obj/item/weapon/spell/summon/on_use_cast(mob/living/user)
 	if(summon_options.len)

--- a/code/game/gamemodes/technomancer/spells/summon/summon_ward.dm
+++ b/code/game/gamemodes/technomancer/spells/summon/summon_ward.dm
@@ -32,14 +32,23 @@
 	response_help   = "pets the"
 	response_disarm = "swats away"
 	response_harm   = "punches"
+	min_oxy = 0
+	max_oxy = 0
+	min_tox = 0
+	max_tox = 0
+	min_co2 = 0
+	max_co2 = 0
+	min_n2 = 0
+	max_n2 = 0
+	minbodytemp = 0
+	maxbodytemp = 0
+	unsuitable_atoms_damage = 0
+	heat_damage_per_tick = 0
+	cold_damage_per_tick = 0
+
 	var/true_sight = 0 // If true, detects more than what the Technomancer normally can't.
 	var/mob/living/carbon/human/creator = null
 	var/list/seen_mobs = list()
-
-/mob/living/simple_animal/ward/New()
-	..()
-	spawn(6 MINUTES)
-		expire()
 
 /mob/living/simple_animal/ward/death()
 	if(creator)

--- a/code/game/gamemodes/technomancer/spells/warp_strike.dm
+++ b/code/game/gamemodes/technomancer/spells/warp_strike.dm
@@ -49,7 +49,7 @@
 		var/new_dir = get_dir(user, chosen_target)
 		user.dir = new_dir
 		sparks.start()
-		owner.adjust_instability(12)
+		adjust_instability(12)
 
 		//Finally, we handle striking the victim with whatever's in the user's offhand.
 		var/obj/item/I = user.get_inactive_hand()

--- a/code/modules/mob/living/silicon/robot/life.dm
+++ b/code/modules/mob/living/silicon/robot/life.dm
@@ -11,6 +11,7 @@
 	clamp_values()
 	handle_regular_status_updates()
 	handle_actions()
+	handle_instability()
 
 	if(client)
 		handle_regular_hud_updates()

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -76,17 +76,16 @@
 	return	//immune
 
 /mob/living/silicon/electrocute_act(var/shock_damage, var/obj/source, var/siemens_coeff = 1.0)
-
-	if (istype(source, /obj/machinery/containment_field))
+	if(shock_damage > 0)
 		var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
 		s.set_up(5, 1, loc)
 		s.start()
 
 		shock_damage *= 0.75	//take reduced damage
 		take_overall_damage(0, shock_damage)
-		visible_message("\red [src] was shocked by \the [source]!", \
-			"\red <B>Energy pulse detected, system damaged!</B>", \
-			"\red You hear an electrical crack")
+		visible_message("<span class='warning'>[src] was shocked by \the [source]!</span>", \
+			"<span class='danger'>Energy pulse detected, system damaged!</span>", \
+			"<span class='warning'>You hear an electrical crack.</span>")
 		if(prob(20))
 			Stun(2)
 		return

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -398,6 +398,9 @@
 /mob/living/simple_animal/adjustBruteLoss(damage)
 	health = Clamp(health - damage, 0, maxHealth)
 
+/mob/living/simple_animal/adjustFireLoss(damage)
+	health = Clamp(health - damage, 0, maxHealth)
+
 /mob/living/simple_animal/proc/SA_attackable(target_mob)
 	if (isliving(target_mob))
 		var/mob/living/L = target_mob
@@ -637,3 +640,15 @@
 		spawn(10)
 			if(!src.stat)
 				horde()
+
+/mob/living/simple_animal/electrocute_act(var/shock_damage, var/obj/source, var/siemens_coeff = 1.0, var/def_zone = null)
+	shock_damage *= siemens_coeff
+	if (shock_damage < 1)
+		return 0
+
+	adjustFireLoss(shock_damage)
+	playsound(loc, "sparks", 50, 1, -1)
+
+	var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
+	s.set_up(5, 1, loc)
+	s.start()


### PR DESCRIPTION
- Cores can now be locked and unlocked by a verb.  Locked cores cannot be removed by anyone.  Cores automatically unlock if the wearer dies or otherwise stops existing for some reason.
- Healing spells now induce a flat instability cost on the healer instead of it being split between healer and healed.  The amount healed is greatly increased if used on someone besides the healer.  Between old system and this new one, instability cost is much cheaper as well, but heals for about the same as before if healing someone else.
- Mend Organs is now called Great Mend Wounds, and now heals broken bones, IB, eye damage, and blood loss in addition to internal organs.
- Radiating instability (the purple glow) now gives a warning to people afflicted.
- Instability discounts should start applying correctly for specific cores.
- Instability now affects all living mobs and not just humans.  This includes borgs and simple animals.
- Phase shift now adds ongoing instability while hiding inside the rift.
- Projectile spells should be logged now.
- Wards last forever, and should not die in vacuum now.
- Restoration aura is now green colored and not blue.
- Simple mobs and cyborgs are now harmed by lightning.