### PR TITLE
Generalises shoe storage

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -380,7 +380,10 @@
 	var/can_hold_item
 	var/obj/item/holding
 	var/list/item_holding_blacklist = list(/obj/item/weapon/forensics/swab, /obj/item/weapon/reagent_containers/spray/luminol, /obj/item/device/uv_light,
-										/obj/item/weapon/sample, /obj/item/weapon/forensics/sample_kit, /obj/item/weapon/storage/box, /obj/item/clothing/shoes) //no you can't boots with boots in your boots
+										/obj/item/weapon/sample, /obj/item/weapon/forensics/sample_kit) //no you can't boots with boots in your boots
+	var/list/item_holding_whitelist = list(/obj/item/weapon/material/butterfly, /obj/item/weapon/material/butterfly/switchblade, /obj/item/weapon/material/knife,
+											/obj/item/weapon/material/kitchen/utensil, /obj/item/weapon/material/hatchet/unathiknife, /obj/item/weapon/material/hatchet/tacknife/combatknife,
+											/obj/item/weapon/gun/projectile/derringer, /obj/item/weapon/melee/telebaton, /obj/item/weapon/melee/energy/sword)
 
 	permeability_coefficient = 0.50
 	slowdown = SHOES_SLOWDOWN
@@ -419,16 +422,17 @@
 
 
 /obj/item/clothing/shoes/attackby(var/obj/item/I, var/mob/user)
-	if(can_hold_item && !is_type_in_list(I, item_holding_blacklist) && I.w_class <= ITEMSIZE_SMALL)
-		if(holding)
-			user << "<span class='warning'>\The [src] is already holding \a [holding].</span>"
-			return
-		user.unEquip(I)
-		I.forceMove(src)
-		holding = I
-		user.visible_message("<span class='notice'>\The [user] shoves \the [I] into \the [src].</span>")
-		verbs |= /obj/item/clothing/shoes/proc/withdraw_item
-		update_icon()
+	if(can_hold_item && !is_type_in_list(I, item_holding_blacklist))
+		if(I.w_class <= ITEMSIZE_TINY || is_type_in_list(I,item_holding_whitelist))
+			if(holding)
+				user << "<span class='warning'>\The [src] is already holding \a [holding].</span>"
+				return
+			user.unEquip(I)
+			I.forceMove(src)
+			holding = I
+			user.visible_message("<span class='notice'>\The [user] shoves \the [I] into \the [src].</span>")
+			verbs |= /obj/item/clothing/shoes/proc/withdraw_item
+			update_icon()
 	else
 		return ..()
 

--- a/code/modules/clothing/shoes/jobs.dm
+++ b/code/modules/clothing/shoes/jobs.dm
@@ -6,6 +6,7 @@
 	item_flags = NOSLIP
 	slowdown = SHOES_SLOWDOWN+1
 	species_restricted = null
+	can_hold_item = 1
 
 /obj/item/clothing/shoes/jackboots
 	name = "jackboots"
@@ -14,7 +15,7 @@
 	force = 3
 	armor = list(melee = 30, bullet = 10, laser = 10, energy = 15, bomb = 20, bio = 0, rad = 0)
 	siemens_coefficient = 0.7
-	can_hold_knife = 1
+	can_hold_item = 1
 
 /obj/item/clothing/shoes/jackboots/toeless
 	name = "toe-less jackboots"
@@ -29,7 +30,7 @@
 	icon_state = "workboots"
 	armor = list(melee = 40, bullet = 0, laser = 0, energy = 15, bomb = 20, bio = 0, rad = 20)
 	siemens_coefficient = 0.7
-	can_hold_knife = 1
+	can_hold_item = 1
 
 /obj/item/clothing/shoes/workboots/toeless
 	name = "toe-less workboots"

--- a/code/modules/clothing/shoes/leg_guards.dm
+++ b/code/modules/clothing/shoes/leg_guards.dm
@@ -5,6 +5,7 @@
 	slowdown = SHOES_SLOWDOWN+0.5
 	species_restricted = null	//Unathi and Taj can wear leg armor now
 	w_class = ITEMSIZE_NORMAL
+	can_hold_item = 1
 
 /obj/item/clothing/shoes/leg_guard/mob_can_equip(var/mob/living/carbon/human/H, slot, disable_warning = 0)
 	if(..()) //This will only run if no other problems occured when equiping.

--- a/code/modules/clothing/shoes/magboots.dm
+++ b/code/modules/clothing/shoes/magboots.dm
@@ -11,6 +11,7 @@
 	action_button_name = "Toggle Magboots"
 	var/obj/item/clothing/shoes/shoes = null	//Undershoes
 	var/mob/living/carbon/human/wearer = null	//For shoe procs
+	can_hold_item = 1
 
 /obj/item/clothing/shoes/magboots/proc/set_slowdown()
 	slowdown = shoes? max(SHOES_SLOWDOWN, shoes.slowdown): SHOES_SLOWDOWN	//So you can't put on magboots to make you walk faster.

--- a/code/modules/clothing/shoes/miscellaneous.dm
+++ b/code/modules/clothing/shoes/miscellaneous.dm
@@ -61,36 +61,7 @@
 	item_state_slots = list(slot_r_hand_str = "jackboots", slot_l_hand_str = "jackboots")
 	armor = list(melee = 80, bullet = 60, laser = 50,energy = 25, bomb = 50, bio = 10, rad = 0)
 	siemens_coefficient = 0.6
-	var/obj/item/weapon/material/hatchet/tacknife
-
-/obj/item/clothing/shoes/marine/attack_hand(var/mob/living/M)
-	if(tacknife)
-		tacknife.loc = get_turf(src)
-		if(M.put_in_active_hand(tacknife))
-			M << "<span class='notice'>You slide \the [tacknife] out of [src].</span>"
-			playsound(M, 'sound/weapons/flipblade.ogg', 40, 1)
-			tacknife = null
-			update_icon()
-		return
-	..()
-
-/obj/item/clothing/shoes/marine/attackby(var/obj/item/I, var/mob/living/M)
-	if(istype(I, /obj/item/weapon/material/hatchet/tacknife))
-		if(tacknife)
-			return
-		M.drop_item()
-		tacknife = I
-		I.loc = src
-		M << "<span class='notice'>You slide the [I] into [src].</span>"
-		playsound(M, 'sound/weapons/flipblade.ogg', 40, 1)
-		update_icon()
-	..()
-
-/obj/item/clothing/shoes/marine/update_icon()
-	if(tacknife)
-		icon_state = "jackboots_1"
-	else
-		icon_state = initial(icon_state)
+	can_hold_item = 1
 
 /obj/item/clothing/shoes/combat //Basically SWAT shoes combined with galoshes.
 	name = "combat boots"
@@ -100,6 +71,7 @@
 	armor = list(melee = 80, bullet = 60, laser = 50,energy = 25, bomb = 50, bio = 10, rad = 0)
 	item_flags = NOSLIP
 	siemens_coefficient = 0.6
+	can_hold_item = 1
 
 	cold_protection = FEET
 	min_cold_protection_temperature = SHOE_MIN_COLD_PROTECTION_TEMPERATURE
@@ -147,6 +119,7 @@
 	item_state_slots = list(slot_r_hand_str = "cult", slot_l_hand_str = "cult")
 	force = 2
 	siemens_coefficient = 0.7
+	can_hold_item = 1
 
 	cold_protection = FEET
 	min_cold_protection_temperature = SHOE_MIN_COLD_PROTECTION_TEMPERATURE
@@ -200,6 +173,7 @@
 	min_cold_protection_temperature = SHOE_MIN_COLD_PROTECTION_TEMPERATURE
 	heat_protection = FEET|LEGS
 	max_heat_protection_temperature = SHOE_MAX_HEAT_PROTECTION_TEMPERATURE
+	can_hold_item = 1
 
 /obj/item/clothing/shoes/flipflop
 	name = "flip flops"

--- a/html/changelogs/Yoshax-Booties.yml
+++ b/html/changelogs/Yoshax-Booties.yml
@@ -1,0 +1,37 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Yoshax
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "No longer are you stuck only being able to put knifes into your boots. Now you can put any small item or smaller. In addition, you can now simply click your boots to draw the item rather than having to fiddle with a right click menu and/or verb."
+  - tweak: "Many more shoe items have the ability to store items as above."

--- a/html/changelogs/Yoshax-Booties.yml
+++ b/html/changelogs/Yoshax-Booties.yml
@@ -33,5 +33,5 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes: 
-  - tweak: "No longer are you stuck only being able to put knifes into your boots. Now you can put any small item or smaller. In addition, you can now simply click your boots to draw the item rather than having to fiddle with a right click menu and/or verb."
+  - tweak: "No longer are you stuck only being able to put knifes into your boots. Now you can put any tiny item or smaller, as well as some small items such as knives. In addition, you can now simply click your boots to draw the item rather than having to fiddle with a right click menu and/or verb."
   - tweak: "Many more shoe items have the ability to store items as above."


### PR DESCRIPTION
No longer can you only put knifes into your boots. Any shoe that can hold items can now hold any small or smaller item. This operates on a blacklist, with only a few things currently blacklisted, including forensics stuff, and boxes, since I believe those are small (I may be wrong.).

Some old code has been gutted and/or cleaned up, including the removal of the buggy overlay for having a knife in your boot.

Lastly, some more shoes have the ability to hold items, like the leg armor, magboots and galoshes.