### PR TITLE
Weapon Cell Oversight fixes

### DIFF
--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -167,7 +167,7 @@
 
 //secborg stun baton module
 /obj/item/weapon/melee/baton/robot
-	hitcost = 120
+	hitcost = 500
 
 /obj/item/weapon/melee/baton/robot/attack_self(mob/user)
 	//try to find our power cell

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -103,8 +103,8 @@
 	if(power_supply)
 		user.put_in_hands(power_supply)
 		power_supply.update_icon()
-		power_supply = null
 		user.visible_message("[user] removes [power_supply] from [src].", "<span class='notice'>You remove [power_supply] from [src].</span>")
+		power_supply = null
 		playsound(src.loc, 'sound/weapons/empty.ogg', 50, 1)
 		update_icon()
 		update_held_icon()

--- a/html/changelogs/Anewbe - Battery Oversights.yml
+++ b/html/changelogs/Anewbe - Battery Oversights.yml
@@ -1,0 +1,37 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: N3X15
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Unloading an energy weapon should now correctly show what was unloaded."
+  - tweak: "Borg stun baton is back to the old cost, for balance reasons."


### PR DESCRIPTION
Unloading an energy weapon should now correctly show what was unloaded.
Borg stun baton is back to the old cost, for balance reasons.