### PR TITLE
Fixes a problem with advanced_who

### DIFF
--- a/code/game/verbs/advanced_who.dm
+++ b/code/game/verbs/advanced_who.dm
@@ -56,7 +56,7 @@
 			if(C.holder && C.holder.fakekey)
 				var/entry = "\t[C.key]"
 				var/mob/observer/dead/O = C.mob
-				entry += C.holder.fakekey
+				entry = C.holder.fakekey
 				if(isobserver(O))
 					entry += " - <font color='gray'>Observing</font>"
 				else if(istype(O,/mob/new_player))


### PR DESCRIPTION
Advanced who was making admins names show up when stealthed. 
(Testname represents Ckey, StealthTest represents stealth Ckey)
"Testname" for admins when unstealthed, which was good, but it was doing
"Testname(StealthTet)" when admins were stealthed.

This PR makes it start off as "Testname", then checks to see if they are stealthed. If so, it becomes their selected stealth name then adds in all the additional info (If they are observing, in lobby, or playing.)