### PR TITLE
Do NOT qdel() all client.screen objects

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -9,8 +9,6 @@
 		for(var/obj/screen/movable/spell_master/spell_master in spell_masters)
 			qdel(spell_master)
 		remove_screen_obj_references()
-		for(var/atom/movable/AM in client.screen)
-			qdel(AM)
 		client.screen = list()
 	if(mind && mind.current == src)
 		spellremove(src)


### PR DESCRIPTION
Global singletons are added to this list. Deleting them with qdel() deletes them for EVERYONE when they are eventually garbage collected.

For example, when someone with a welding helmet down or a Teshari is ~~digested~~ deleted, their client.screen contains the `global_hud` list `darkMask`. The next GC cycle, `darkMask` is deleted from `global_hud` which has some unfortunate side effects:
- Welder overlay broken for the rest of the round
- Cameras lose their overlays
- Teshari can no longer spawn correctly (runtimes while spawning them when trying to add `darkMask`)

It is fairly simple to test if you want to test it. Just start a server, join as a Teshari or spawn yourself a welder mask so you have an overlay on the screen, and delete your own mob. Wait until next GC cycle. You will see many TESTING messages in world.log about how it was unable to GC many "/obj/screen" objects and they have been deleted. That WAS the global singleton `darkMask`.

From that point forward, the above issues will be present until next round.