### PR TITLE
Slightly reworks the way spiders inject poison

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -28,6 +28,7 @@
 	heat_damage_per_tick = 20
 	cold_damage_per_tick = 20
 	var/poison_per_bite = 5
+	var/poison_chance = 10
 	var/poison_type = "toxin"
 	faction = "spiders"
 	var/busy = 0
@@ -45,7 +46,7 @@
 	health = 40
 	melee_damage_lower = 5
 	melee_damage_upper = 10
-	poison_per_bite = 10
+	poison_per_bite = 7
 	var/atom/cocoon_target
 	poison_type = "stoxin"
 	var/fed = 0
@@ -72,16 +73,16 @@
 	if(isliving(.))
 		var/mob/living/L = .
 		if(L.reagents)
-			L.reagents.add_reagent("toxin", poison_per_bite)
-			if(prob(poison_per_bite))
-				L << "<span class='warning'>You feel a tiny prick.</span>" 
-				L.reagents.add_reagent(poison_type, 5)
+			L.reagents.add_reagent(poison_type, poison_per_bite)
+			if(prob(poison_chance))
+				L << "<span class='warning'>You feel a tiny prick.</span>"
+				L.reagents.add_reagent(poison_type, poison_per_bite)
 
 /mob/living/simple_animal/hostile/giant_spider/nurse/AttackingTarget()
 	. = ..()
 	if(ishuman(.))
 		var/mob/living/carbon/human/H = .
-		if(prob(poison_per_bite))
+		if(prob(poison_chance))
 			var/obj/item/organ/external/O = pick(H.organs)
 			if(!(O.robotic >= ORGAN_ROBOT))
 				var/eggs = PoolOrNew(/obj/effect/spider/eggcluster/, list(O, src))


### PR DESCRIPTION
Gives them a var called poison_chance that decides how often a bite will inject extra toxins.
The poison_per_bite var is now only for the amount of toxin injected per bit.
Toxin injection checks poison_type, so nurse spiders don't poison the prey to death.