### PR TITLE
Resolves an uplink issue

### DIFF
--- a/code/game/objects/items/devices/uplink.dm
+++ b/code/game/objects/items/devices/uplink.dm
@@ -218,7 +218,7 @@
 // implant uplink (not the implant tool) and a preset headset uplink.
 
 /obj/item/device/radio/uplink/New()
-	hidden_uplink = new(src)
+	hidden_uplink = new(src, usr.mind, DEFAULT_TELECRYSTAL_AMOUNT)
 	icon_state = "radio"
 
 /obj/item/device/radio/uplink/attack_self(mob/user as mob)


### PR DESCRIPTION
Fixes a runtime within new() of the base uplink item due to line 27 (as seen below) where owner was null, causing the line below it (line 28) to never be executed.
```uses = owner.tcrystals```