### PR TITLE
FBP/Synth wound sprite updater

### DIFF
--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -675,6 +675,9 @@ Note that amputating the affected organ does in fact remove the infection from t
 		for(var/datum/wound/W in wounds) //Repaired wounds disappear though
 			if(W.damage <= 0)  //and they disappear right away
 				wounds -= W    //TODO: robot wounds for robot limbs
+				src.update_damages()
+				if (update_icon())
+					owner.UpdateDamageIcon(1)
 		return
 
 	for(var/datum/wound/W in wounds)


### PR DESCRIPTION
It returned before it got to the bottom with robotic limb repair, which would leave the wound sprites on them unless an admin forced an icon update on them. So now we update them just like we do for organics a few lines below when wound levels change.