### PR TITLE
Nerfed Xenoarch Space Suit Slowdown

### DIFF
--- a/code/modules/xenoarcheaology/tools/equipment.dm
+++ b/code/modules/xenoarcheaology/tools/equipment.dm
@@ -19,6 +19,7 @@
 	item_state = "cespace_suit"
 	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 100, rad = 100)
 	allowed = list(/obj/item/device/flashlight,/obj/item/weapon/tank,/obj/item/device/suit_cooling_unit)
+	slowdown = 1
 
 /obj/item/clothing/head/helmet/space/anomaly
 	name = "Excavation hood"


### PR DESCRIPTION
Seriously, why the hell is this suit such a nightmare to move around in?
Mechanically, it has ZERO armor besides bio/radiation protection, and
the only real perk of it is that it's space worthy.

Xenoarcheology is just tedious and annoying with these dumb suits being
so clunky, so I've eliminated the slowdown to only slow you down as much
as voidsuits.

The slowdown is now 1, instead of 3.