### PR TITLE
Robobrains no longer drop real brains.

### DIFF
--- a/code/modules/mob/living/carbon/brain/robot.dm
+++ b/code/modules/mob/living/carbon/brain/robot.dm
@@ -10,6 +10,7 @@
 	..()
 	src.brainmob.name = "[pick(list("ADA","DOS","GNU","MAC","WIN"))]-[rand(1000, 9999)]"
 	src.brainmob.real_name = src.brainmob.name
+	src.name = "robotic intelligence circuit ([src.brainmob.name])"
 
 /obj/item/device/mmi/digital/robot/transfer_identity(var/mob/living/carbon/H)
 	..()
@@ -17,3 +18,6 @@
 		brainmob.mind.assigned_role = "Robotic Intelligence"
 	brainmob << "<span class='notify'>You feel slightly disoriented. That's normal when you're little more than a complex circuit.</span>"
 	return
+
+/obj/item/device/mmi/digital/robot/attack_self(mob/user as mob)
+	return //This object is technically a brain, and should not be dumping brains out of itself like its parent object does.

--- a/html/changelogs/Nerezza - DebrainsDronBrains.yml
+++ b/html/changelogs/Nerezza - DebrainsDronBrains.yml
@@ -1,0 +1,37 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Nerezza
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Digital FBP/Cyborg brains no longer drop brains."
+  - rscadd: "Digital FBP/Cyborg brains are tagged with their designation now."


### PR DESCRIPTION
This also makes them self-name with their designation like posibrains, so they're easier to identify.

Fixes #2698