### PR TITLE
Gives cyborgs the ability to unbuckle things.

### DIFF
--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -11,6 +11,11 @@
 	if(can_buckle && buckled_mob)
 		user_unbuckle_mob(user)
 
+/obj/attack_robot(mob/living/user)
+	if(Adjacent(user) && buckled_mob) //Checks if what we're touching is adjacent to us and has someone buckled to it. This should prevent interacting with anti-robot manual valves among other things.
+		return attack_hand(user) //Process as if we're a normal person touching the object.
+	return ..() //Otherwise, treat this as an AI click like usual.
+
 /obj/MouseDrop_T(mob/living/M, mob/living/user)
 	. = ..()
 	if(can_buckle && istype(M))

--- a/html/changelogs/Nerezza - RoboBuckle.yml
+++ b/html/changelogs/Nerezza - RoboBuckle.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Nerezza
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "All cyborgs can now unbuckle people from beds/chairs. Just attack the structure with no module selected."


### PR DESCRIPTION
Checks if what they're attacking 'bare-handed' is adjacent to the cyborg, and has something buckled to it. If not, it passes the click on to AI click like usual.

Fixes #2703