### PR TITLE
Makes jumpsuits hide under space suits under right conditions.

### DIFF
--- a/code/game/gamemodes/cult/cult_items.dm
+++ b/code/game/gamemodes/cult/cult_items.dm
@@ -110,6 +110,7 @@
 	slowdown = 1
 	armor = list(melee = 60, bullet = 50, laser = 30, energy = 15, bomb = 30, bio = 30, rad = 30)
 	siemens_coefficient = 0
+	flags_inv = HIDEGLOVES|HIDEJUMPSUIT|HIDETAIL|HIDETIE|HIDEHOLSTER
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS|HANDS
 
 /obj/item/clothing/suit/space/cult/cultify()

--- a/code/modules/clothing/spacesuits/miscellaneous.dm
+++ b/code/modules/clothing/spacesuits/miscellaneous.dm
@@ -76,7 +76,7 @@
 	body_parts_covered = 0
 	siemens_coefficient = 0.9
 
-/obj/item/clothing/suit/space/pirate
+/obj/item/clothing/suit/space/pirate //Whhhhyyyyyyy???
 	name = "pirate coat"
 	desc = "Yarr."
 	icon_state = "pirate"
@@ -85,6 +85,7 @@
 	slowdown = 0
 	armor = list(melee = 60, bullet = 50, laser = 30,energy = 15, bomb = 30, bio = 30, rad = 30)
 	siemens_coefficient = 0.9
+	flags_inv = HIDETAIL|HIDEHOLSTER
 	body_parts_covered = UPPER_TORSO|ARMS
 
 //Orange emergency space suit

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -470,7 +470,7 @@ var/global/list/damage_icon_parts = list()
 //vvvvvv UPDATE_INV PROCS vvvvvv
 
 /mob/living/carbon/human/update_inv_w_uniform(var/update_icons=1)
-	if(w_uniform && istype(w_uniform, /obj/item/clothing/under) )
+	if( (w_uniform && istype(w_uniform, /obj/item/clothing/under)) && !(wear_suit && istype(wear_suit, /obj/item/clothing/suit/space) && wear_suit.flags_inv & HIDEJUMPSUIT && !istype(wear_suit, /obj/item/clothing/suit/space/rig) ))
 		w_uniform.screen_loc = ui_iclothing
 
 		//determine the icon to use
@@ -793,16 +793,15 @@ var/global/list/damage_icon_parts = list()
 				standing.overlays |= A.get_mob_overlay()
 
 		overlays_standing[SUIT_LAYER]	= standing
-		update_tail_showing(0)
 
 	else
 		overlays_standing[SUIT_LAYER]	= null
-		update_tail_showing(0)
 
+	//Hide/show other layers if necessary
 	update_collar(0)
-
-	//hide/show shoes if necessary
+	update_inv_w_uniform(0)
 	update_inv_shoes(0)
+	update_tail_showing(0)
 
 	if(update_icons)   update_icons()
 

--- a/html/changelogs/Nerezza - bulkyjumpsuits.yml
+++ b/html/changelogs/Nerezza - bulkyjumpsuits.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Nerezza
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Space suits now hide jumpsuits, so excessively bulky jumpsuits no longer peek through."


### PR DESCRIPTION
Mostly noticeable on tesh wearing voidsuits, bulky jumpsuits were overlayed by the voidsuit making the jumpsuit 'peek' around the latter's icons.

Now, spacesuits in general will outright hide jumpsuits with exception only to rigsuits. Yeah I'm looking at you rescue suit, you and your ****ed up icons =3=

----

This has been tested thoroughly, as in I put on every single /suit/space in game, and in doing so I found a conflict with the pirate jacket (WHY?) and an unrelated issue with a cult 'space suit', both fixed.

As said above, I'd love to take out the '!rigs' but their icons are weird and stuff.