### PR TITLE
Uplink guns come DNA Lockable

### DIFF
--- a/code/datums/uplink/uplink_items.dm
+++ b/code/datums/uplink/uplink_items.dm
@@ -32,6 +32,7 @@ var/datum/uplink/uplink = new()
 	var/datum/uplink_category/category		// Item category
 	var/list/datum/antagonist/antag_roles	// Antag roles this item is displayed to. If empty, display to all.
 	var/blacklisted = 0
+	var/list/new_args = list()
 
 /datum/uplink_item/item
 	var/path = null
@@ -39,8 +40,6 @@ var/datum/uplink/uplink = new()
 /datum/uplink_item/New()
 	..()
 	antag_roles = list()
-
-
 
 /datum/uplink_item/proc/buy(var/obj/item/device/uplink/U, var/mob/user)
 	var/extra_args = extra_args(user)
@@ -132,7 +131,9 @@ datum/uplink_item/dd_SortValue()
 	return I
 
 /datum/uplink_item/item/get_goods(var/obj/item/device/uplink/U, var/loc)
-	var/obj/item/I = new path(loc)
+	var/list/input_args = new_args.Copy()
+	input_args.Insert(1, loc)
+	var/obj/item/I = new path(arglist(input_args))
 	return I
 
 /datum/uplink_item/item/description()

--- a/code/datums/uplink/visible_weapons.dm
+++ b/code/datums/uplink/visible_weapons.dm
@@ -4,6 +4,9 @@
 /datum/uplink_item/item/visible_weapons
 	category = /datum/uplink_category/visible_weapons
 
+/datum/uplink_item/item/visible_weapons/ranged
+	new_args = list(TRUE)
+
 /datum/uplink_item/item/visible_weapons/tactknife
 	name = "Tactical Knife"
 	item_cost = 10
@@ -19,53 +22,58 @@
 	item_cost = 40
 	path = /obj/item/weapon/melee/energy/sword
 
-/datum/uplink_item/item/visible_weapons/dartgun
-	name = "Dart Gun"
-	item_cost = 30
-	path = /obj/item/weapon/gun/projectile/dartgun
-
-/datum/uplink_item/item/visible_weapons/crossbow
-	name = "Energy Crossbow"
-	item_cost = 40
-	path = /obj/item/weapon/gun/energy/crossbow
-
-/datum/uplink_item/item/visible_weapons/silenced_45
-	name = "Silenced .45"
-	item_cost = 40
-	path = /obj/item/weapon/gun/projectile/silenced
-
 /datum/uplink_item/item/visible_weapons/riggedlaser
 	name = "Exosuit Rigged Laser"
 	item_cost = 60
 	path = /obj/item/mecha_parts/mecha_equipment/weapon/energy/riggedlaser
 
-/datum/uplink_item/item/visible_weapons/revolver
-	name = "Revolver"
-	item_cost = 70
-	path = /obj/item/weapon/gun/projectile/revolver
+/datum/uplink_item/item/visible_weapons/ranged/dartgun
+	name = "Dart Gun"
+	item_cost = 30
+	path = /obj/item/weapon/gun/projectile/dartgun
 
-/datum/uplink_item/item/visible_weapons/Derringer
+/datum/uplink_item/item/visible_weapons/ranged/crossbow
+	name = "Energy Crossbow"
+	item_cost = 40
+	path = /obj/item/weapon/gun/energy/crossbow
+
+/datum/uplink_item/item/visible_weapons/ranged/silenced_45
+	name = "Silenced .45"
+	item_cost = 40
+	path = /obj/item/weapon/gun/projectile/silenced
+
+/datum/uplink_item/item/visible_weapons/ranged/Derringer
 	name = ".357 Derringer Pistol"
 	item_cost = 40
 	path = /obj/item/weapon/gun/projectile/derringer
 
-/datum/uplink_item/item/visible_weapons/heavysniper
-	name = "Anti-Materiel Rifle (14.5mm)"
-	item_cost = DEFAULT_TELECRYSTAL_AMOUNT
-	path = /obj/item/weapon/gun/projectile/heavysniper
+/datum/uplink_item/item/visible_weapons/ranged/ionrifle
+	name = "Ion Rifle"
+	item_cost = 40
+	path = /obj/item/weapon/gun/energy/ionrifle
 
-/datum/uplink_item/item/visible_weapons/tommygun
+/datum/uplink_item/item/visible_weapons/ranged/tommygun
 	name = "Tommygun (.45)" // We're keeping this because it's CLASSY. -Spades
 	item_cost = 60
 	path = /obj/item/weapon/gun/projectile/automatic/tommygun
 
 //These are for traitors (or other antags, perhaps) to have the option of purchasing some merc gear.
-/datum/uplink_item/item/visible_weapons/submachinegun
+/datum/uplink_item/item/visible_weapons/ranged/submachinegun
 	name = "Submachine Gun (10mm)"
 	item_cost = 60
 	path = /obj/item/weapon/gun/projectile/automatic/c20r
 
-/datum/uplink_item/item/visible_weapons/assaultrifle
+/datum/uplink_item/item/visible_weapons/ranged/egun
+	name = "Energy Gun"
+	item_cost = 60
+	path = /obj/item/weapon/gun/energy/gun
+
+/datum/uplink_item/item/visible_weapons/ranged/lasercannon
+	name = "Laser Cannon"
+	item_cost = 60
+	path = /obj/item/weapon/gun/energy/lasercannon
+
+/datum/uplink_item/item/visible_weapons/ranged/assaultrifle
 	name = "Assault Rifle (7.62mm)"
 	item_cost = 75
 	path = /obj/item/weapon/gun/projectile/automatic/sts35
@@ -75,32 +83,27 @@
 	item_cost = 7
 	path = /obj/item/weapon/gun/projectile/automatic/carbine
 */
-/datum/uplink_item/item/visible_weapons/combatshotgun
+/datum/uplink_item/item/visible_weapons/ranged/combatshotgun
 	name = "Combat Shotgun"
 	item_cost = 75
 	path = /obj/item/weapon/gun/projectile/shotgun/pump/combat
-
-/datum/uplink_item/item/visible_weapons/egun
-	name = "Energy Gun"
-	item_cost = 60
-	path = /obj/item/weapon/gun/energy/gun
-
-/datum/uplink_item/item/visible_weapons/lasercannon
-	name = "Laser Cannon"
-	item_cost = 60
-	path = /obj/item/weapon/gun/energy/lasercannon
 
 /datum/uplink_item/item/visible_weapons/lasercarbine
 	name = "Laser Carbine"
 	item_cost = 75
 	path = /obj/item/weapon/gun/energy/laser
 
-/datum/uplink_item/item/visible_weapons/ionrifle
-	name = "Ion Rifle"
-	item_cost = 40
-	path = /obj/item/weapon/gun/energy/ionrifle
+/datum/uplink_item/item/visible_weapons/ranged/revolver
+	name = "Revolver"
+	item_cost = 70
+	path = /obj/item/weapon/gun/projectile/revolver
 
-/datum/uplink_item/item/visible_weapons/xray
+/datum/uplink_item/item/visible_weapons/ranged/xray
 	name = "Xray Gun"
 	item_cost = 85
 	path = /obj/item/weapon/gun/energy/xray
+
+/datum/uplink_item/item/visible_weapons/ranged/heavysniper
+	name = "Anti-Materiel Rifle (14.5mm)"
+	item_cost = DEFAULT_TELECRYSTAL_AMOUNT
+	path = /obj/item/weapon/gun/projectile/heavysniper

--- a/code/game/objects/items/devices/uplink_random_lists.dm
+++ b/code/game/objects/items/devices/uplink_random_lists.dm
@@ -53,14 +53,14 @@ var/datum/uplink_random_selection/all_uplink_selection = new/datum/uplink_random
 /datum/uplink_random_selection/default/New()
 	..()
 
-	items += new/datum/uplink_random_item(/datum/uplink_item/item/visible_weapons/silenced_45)
+	items += new/datum/uplink_random_item(/datum/uplink_item/item/visible_weapons/ranged/silenced_45)
 	items += new/datum/uplink_random_item(/datum/uplink_item/item/ammo/mc9mm)
-	items += new/datum/uplink_random_item(/datum/uplink_item/item/visible_weapons/revolver)
+	items += new/datum/uplink_random_item(/datum/uplink_item/item/visible_weapons/ranged/revolver)
 	items += new/datum/uplink_random_item(/datum/uplink_item/item/ammo/a357)
-	items += new/datum/uplink_random_item(/datum/uplink_item/item/visible_weapons/heavysniper, 15, 0)
+	items += new/datum/uplink_random_item(/datum/uplink_item/item/visible_weapons/ranged/heavysniper, 15, 0)
 	items += new/datum/uplink_random_item(/datum/uplink_item/item/ammo/sniperammo, 15, 0)
 	items += new/datum/uplink_random_item(/datum/uplink_item/item/grenades/emp, 50)
-	items += new/datum/uplink_random_item(/datum/uplink_item/item/visible_weapons/crossbow, 33)
+	items += new/datum/uplink_random_item(/datum/uplink_item/item/visible_weapons/ranged/crossbow, 33)
 	items += new/datum/uplink_random_item(/datum/uplink_item/item/visible_weapons/energy_sword, 75)
 
 	items += new/datum/uplink_random_item(/datum/uplink_item/item/stealthy_weapons/soap, 5, 100)

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -87,7 +87,7 @@
 
 	var/last_shot = 0			//records the last shot fired
 
-/obj/item/weapon/gun/New()
+/obj/item/weapon/gun/New(loc, dna_lock = 0)
 	..()
 	for(var/i in 1 to firemodes.len)
 		firemodes[i] = new /datum/firemode(src, firemodes[i])

--- a/html/changelogs/Yoshax-Ron.yml
+++ b/html/changelogs/Yoshax-Ron.yml
@@ -1,0 +1,37 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Yosh
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Guns purchases from the antag uplink will now come with the ability to be DNA Locked. There are several verbs pertaining to this, Give DNA, Remove DNA and Allow Samples. Give DNA gives the gun your DNA, Remove DNA removes all the DNA samples. The first person to give their DNA to the gun is the Primary Controller and can use the Allow Samples verb, which toggles whether or not the gun will accpet further DNA. A DNA locked gun when it has DNA cannot be fired by anyone who does not have their DNA stored in the gun."
+  - tweak: "For backend stuff, the antag uplink code has been expanded to allow for extra arguments to be given to the new() of the item being spawned."


### PR DESCRIPTION
- All guns purchases in the antag uplink now with come preinstalled with a DNA Locking chip, allowing them to be DNA Locked. Information further on this can be found in previous PRs, #1726 #2400
- Backend for uplink item spawning has been expanded to allow for extra args to be provided to the item's new. 
- Visible weapons has had /ranged/ added to allow for all of this to fully work
- Lot of changes in visible_weapons.dm due to moving the items into not ranged then ranged, and in TC order