### PR TITLE
Fixes runtime in inventory.dm

### DIFF
--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -48,6 +48,8 @@ var/list/slot_equipment_priority = list( \
 //set disable_warning to disable the 'you are unable to equip that' warning.
 //unset redraw_mob to prevent the mob from being redrawn at the end.
 /mob/proc/equip_to_slot_if_possible(obj/item/W as obj, slot, del_on_fail = 0, disable_warning = 0, redraw_mob = 1)
+	if(!W)
+		return 0
 	if(!W.mob_can_equip(src, slot))
 		if(del_on_fail)
 			qdel(W)


### PR DESCRIPTION
Clicking an inventory slot with nothing in your active hand would runtime. Now it checks to make sure you have something in your active hand, and if not it returns 0.