### PR TITLE
Inflatable QoL tweaks

### DIFF
--- a/code/game/objects/structures/inflatable.dm
+++ b/code/game/objects/structures/inflatable.dm
@@ -4,14 +4,20 @@
 	icon = 'icons/obj/inflatable.dmi'
 	icon_state = "folded_wall"
 	w_class = ITEMSIZE_NORMAL
+	var/deploy_path = /obj/structure/inflatable
 
-	attack_self(mob/user)
-		playsound(loc, 'sound/items/zip.ogg', 75, 1)
-		user << "<span class='notice'>You inflate [src].</span>"
-		var/obj/structure/inflatable/R = new /obj/structure/inflatable(user.loc)
-		src.transfer_fingerprints_to(R)
-		R.add_fingerprint(user)
-		qdel(src)
+/obj/item/inflatable/attack_self(mob/user)
+	inflate(user,user.loc)
+
+/obj/item/inflatable/afterattack(var/atom/A, var/mob/user)
+	..(A, user)
+	if(!user)
+		return
+	if(!user.Adjacent(A))
+		to_chat(user,"You can't reach!")
+		return
+	if(istype(A, /turf))
+		inflate(user,A)
 
 /obj/structure/inflatable
 	name = "inflatable wall"
@@ -82,6 +88,17 @@
 	if(health <= 0)
 		deflate(1)
 
+/obj/structure/inflatable/CtrlClick()
+	hand_deflate()
+
+/obj/item/inflatable/proc/inflate(var/mob/user,var/location)
+	playsound(location, 'sound/items/zip.ogg', 75, 1)
+	to_chat(user,"<span class='notice'>You inflate [src].</span>")
+	var/obj/structure/inflatable/R = new deploy_path(location)
+	src.transfer_fingerprints_to(R)
+	R.add_fingerprint(user)
+	qdel(src)
+
 /obj/structure/inflatable/proc/deflate(var/violent=0)
 	playsound(loc, 'sound/machines/hiss.ogg', 75, 1)
 	if(violent)
@@ -102,7 +119,7 @@
 	set category = "Object"
 	set src in oview(1)
 
-	if(isobserver(usr)) //to stop ghosts from deflating
+	if(isobserver(usr) || usr.restrained() || !usr.Adjacent(src))
 		return
 
 	verbs -= /obj/structure/inflatable/verb/hand_deflate
@@ -123,14 +140,7 @@
 	desc = "A folded membrane which rapidly expands into a simple door on activation."
 	icon = 'icons/obj/inflatable.dmi'
 	icon_state = "folded_door"
-
-	attack_self(mob/user)
-		playsound(loc, 'sound/items/zip.ogg', 75, 1)
-		user << "<span class='notice'>You inflate [src].</span>"
-		var/obj/structure/inflatable/door/R = new /obj/structure/inflatable/door(user.loc)
-		src.transfer_fingerprints_to(R)
-		R.add_fingerprint(user)
-		qdel(src)
+	deploy_path = /obj/structure/inflatable/door
 
 /obj/structure/inflatable/door //Based on mineral door code
 	name = "inflatable door"
@@ -165,7 +175,6 @@
 	if(isSwitchingStates) return
 	if(ismob(user))
 		var/mob/M = user
-		if(world.time - user.last_bumped <= 60) return //NOTE do we really need that?
 		if(M.client)
 			if(iscarbon(M))
 				var/mob/living/carbon/C = M

--- a/html/changelogs/Nerezza - inflatablechanges.yml
+++ b/html/changelogs/Nerezza - inflatablechanges.yml
@@ -1,0 +1,38 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Nerezza
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Inflatables can be deflated using ctrl-click."
+  - rscadd: "Inflatables can be deployed on adjacent tiles by clicking them."
+  - bugfix: "Bumping into closed inflatable doors will no longer freeze them for a few moments."


### PR DESCRIPTION
Features:
- Ctrl-click can deflate inflatables now.
- Using inflatables on adjacent tiles deploys them to that tile. Currently this doesn't care about objects in the way, ie computers or welding tanks, but it does respect glass and imo it works fine this way.

Bugfix:
- Bumping an inflatable door no longer freezes it closed for a few moments.
----
inflatables.dm is a mess so I'll probably look into cleaning it up to be more like Bay's sometime after Thanksgiving.

I'm also probably going to port the robot inflatables dispenser if Yosh doesn't do that, so engiborgs and crisis borgs can deploy airlocks where needed. However, I don't think the engineering derpartment should get dispensers like in Bay, hence the turf-deploy in this PR.

Edit: Oh and, this was tested.