### PR TITLE
Lung popping happens at slightly lower pressure

### DIFF
--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -368,7 +368,7 @@
 			safe_pressure_min *= 1.5
 		else if(L.is_bruised())
 			safe_pressure_min *= 1.25
-		else if(breath.total_moles < BREATH_MOLES / 5 || breath.total_moles > BREATH_MOLES * 5)
+		else if(breath.total_moles < safe_pressure_min || breath.total_moles > BREATH_MOLES * 5)
 			if (prob(8))
 				rupture_lung()
 


### PR DESCRIPTION
Lungs will only pop if the breath inhaled is less than the lung's safe pressure

Fixes #2809 