### PR TITLE
Changes the formatting for attack logs for reflex shots.

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -284,7 +284,10 @@
 			if(one_handed_penalty >= 2)
 				user << "<span class='warning'>You struggle to keep \the [src] pointed at the correct position with just one hand!</span>"
 
-	admin_attack_log(usr, attacker_message="Fired [src]", admin_message="fired a gun ([src]) (MODE: [src.mode_name]) [reflex ? "by reflex" : "manually"].")
+	if(reflex)
+		admin_attack_log(user, target, attacker_message = "fired [src] by reflex.", victim_message = "triggered a reflex shot from [src].", admin_message = "shot [target], who triggered gunfire ([src]) by reflex)")
+	else
+		admin_attack_log(usr, attacker_message="Fired [src]", admin_message="fired a gun ([src]) (MODE: [src.mode_name]) [reflex ? "by reflex" : "manually"].")
 
 	//update timing
 	user.setClickCooldown(DEFAULT_QUICK_COOLDOWN)

--- a/code/modules/projectiles/targeting/targeting_triggers.dm
+++ b/code/modules/projectiles/targeting/targeting_triggers.dm
@@ -26,4 +26,4 @@
 	owner.visible_message("<span class='danger'>\The [owner] pulls the trigger reflexively!</span>")
 	var/obj/item/weapon/gun/G = aiming_with
 	if(istype(G))
-		G.Fire(aiming_at, owner)
+		G.Fire(aiming_at, owner, reflex = 1)


### PR DESCRIPTION
When someone triggers reflex fire, it'll note it in their attack logs. It'll also note in the shooter's attack logs that the gunfire was reflex and not manual. In addition, the attack logs that admins get will be changed to something in the format of "[shooter] shot [victim], who triggered gunfire [weapon] by reflex.

Fixes #2806, since that's my own reminder about this.