### PR TITLE
Blood can be put into dead bodies.

### DIFF
--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -17,8 +17,7 @@
 		//Mutations and radiation
 		handle_mutations_and_radiation()
 
-		//Chemicals in the body
-		handle_chemicals_in_body()
+
 
 		//Blood
 		handle_blood()
@@ -27,6 +26,9 @@
 		handle_random_events()
 
 		. = 1
+
+	//Chemicals in the body, this is moved over here so that blood can be added after death
+	handle_chemicals_in_body()
 
 	//Handle temperature/pressure differences between body and environment
 	if(environment)

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Core.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Core.dm
@@ -5,6 +5,7 @@
 	reagent_state = LIQUID
 	metabolism = REM * 5
 	mrate_static = TRUE
+	affects_dead = 1 //so you can pump blood into someone before defibbing them
 	color = "#C80000"
 
 	glass_name = "tomato juice"

--- a/html/changelogs/MagmaRam-Blood.yml
+++ b/html/changelogs/MagmaRam-Blood.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: N3X15
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Corpses will now process a select few chemicals, meaning you can now add blood into people who bled out before defibbing them."

--- a/html/changelogs/MagmaRam-Blood.yml
+++ b/html/changelogs/MagmaRam-Blood.yml
@@ -22,7 +22,7 @@
 #################################
 
 # Your name.  
-author: N3X15
+author: MagmaRam
 
 # Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
 delete-after: True


### PR DESCRIPTION
Right now we're doing this because blood can't be put into dead people, which makes Medical's job aggravating if they try to defib someone who died of blood loss.

Most reagents are still skipped, but blood is, importantly, not.
This needs to be discussed further, as apparently the reason this was this way is because of lag. I could try doing something that, if they're dead, only moves blood from bloodstr to vessel, but this is an easier and cleaner fix.