### PR TITLE
Fixes water-coolers.

### DIFF
--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -212,8 +212,8 @@
 	cups = 10
 
 /obj/structure/reagent_dispensers/water_cooler/New()
+	..()
 	if(bottle)
-		..()
 		reagents.add_reagent("water",120)
 	update_icon()
 


### PR DESCRIPTION
Creating a water-cooler either through admin spawn or by construction currently doesn't initiate it's reagents list, causing the thing to throw a runtime when you try to add or remove water to it.
These runtimes can then be exploited to duplicate the water containers, which can be turned back into glass at an autolathe.

Figured that this might just about be a big enough issue to warrant a one-line PR.