### PR TITLE
Fixes Runtime in Prosthetics Fabricator

### DIFF
--- a/code/game/mecha/mech_prosthetics.dm
+++ b/code/game/mecha/mech_prosthetics.dm
@@ -256,10 +256,10 @@
 	for(var/M in D.materials)
 		materials[M] = max(0, materials[M] - D.materials[M] * mat_efficiency)
 	if(D.build_path)
-		var/obj/new_item = D.Fabricate(get_step(get_turf(src), src.dir), src)
+		var/obj/new_item = D.Fabricate(get_step(get_turf(src), src.dir), src) // Sometimes returns a mob. Beware!
 		visible_message("\The [src] pings, indicating that \the [D] is complete.", "You hear a ping.")
 		if(mat_efficiency != 1)
-			if(new_item.matter && new_item.matter.len > 0)
+			if(istype(new_item, /obj/) && new_item.matter && new_item.matter.len > 0)
 				for(var/i in new_item.matter)
 					new_item.matter[i] = new_item.matter[i] * mat_efficiency
 	remove_from_queue(1)


### PR DESCRIPTION
Fixes #2129
Atomised version, part 2 of 4.

Prosthetics Fabricators no longer produce infinite FBP torsos (and in turn, runtimes), when their material efficiency has been upgraded.