### PR TITLE
Corrects the Shotgun Sawing Procedure 

### DIFF
--- a/code/modules/projectiles/guns/projectile/shotgun.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun.dm
@@ -90,10 +90,11 @@
 	if(istype(A, /obj/item/weapon/circular_saw) || istype(A, /obj/item/weapon/melee/energy) || istype(A, /obj/item/weapon/pickaxe/plasmacutter))
 		user << "<span class='notice'>You begin to shorten the barrel of \the [src].</span>"
 		if(loaded.len)
-			for(var/i in 1 to max_shells)
-				afterattack(user, user)	//will this work? //it will. we call it twice, for twice the FUN
-				playsound(user, fire_sound, 50, 1)
+			var/burstsetting = burst
+			burst = 2
 			user.visible_message("<span class='danger'>The shotgun goes off!</span>", "<span class='danger'>The shotgun goes off in your face!</span>")
+			Fire_userless(user)
+			burst = burstsetting
 			return
 		if(do_after(user, 30))	//SHIT IS STEALTHY EYYYYY
 			icon_state = "sawnshotgun"


### PR DESCRIPTION
Fixes #2340 and #1829
Part 3 of 4.

Finally puts an end to "You refrain from _accidentally_ shooting yourself in the face, since your intent is set to help."
As stated previously, it's not perfect but it fixes the issue.