### PR TITLE
Adds Vital Underwear Icon File Overriding

### DIFF
--- a/code/datums/underwear/underwear.dm
+++ b/code/datums/underwear/underwear.dm
@@ -67,7 +67,7 @@ datum/category_group/underwear/dd_SortValue()
 	if(!icon_state)
 		return
 
-	var/image/I = image(icon = 'icons/mob/human.dmi', icon_state = icon_state)
+	var/image/I = image(icon = icon, icon_state = icon_state)
 	for(var/datum/gear_tweak/gt in tweaks)
 		gt.tweak_item(I, metadata && metadata["[gt]"] ? metadata["[gt]"] : gt.get_default())
 	return I


### PR DESCRIPTION
Fixes nothing.
Part 4 of 4.

This change allows for multiple underwear icon files, either for easier expansion downstream or for admin shenanigans mid-round.