### PR TITLE
Gripper Fixes, round one.

### DIFF
--- a/code/modules/mob/living/silicon/robot/drone/drone_items.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_items.dm
@@ -134,7 +134,8 @@
 
 	can_hold = list(
 		/obj/item/mecha_parts/part,
-		/obj/item/mecha_parts/mecha_equipment
+		/obj/item/mecha_parts/mecha_equipment,
+		/obj/item/mecha_parts/mecha_tracking
 		)
 
 /obj/item/weapon/gripper/no_use //Used when you want to hold and put items in other things, but not able to 'use' the item
@@ -177,9 +178,8 @@
 	wrapped = null
 	//update_icon()
 
-/obj/item/weapon/gripper/attack(mob/living/M as mob, mob/living/carbon/user as mob)
+/obj/item/weapon/gripper/attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob)
 	if(wrapped) 	//The force of the wrapped obj gets set to zero during the attack() and afterattack().
-		usr << "\blue Currently holding [wrapped.name]."
 		force_holder = wrapped.force
 		wrapped.force = 0.0
 		wrapped.attack(M,user)

--- a/code/modules/mob/living/silicon/robot/drone/drone_items.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_items.dm
@@ -177,12 +177,14 @@
 	wrapped = null
 	//update_icon()
 
-/obj/item/weapon/gripper/attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob)
+/obj/item/weapon/gripper/attack(mob/living/M as mob, mob/living/carbon/user as mob)
 	if(wrapped) 	//The force of the wrapped obj gets set to zero during the attack() and afterattack().
+		usr << "\blue Currently holding [wrapped.name]."
 		force_holder = wrapped.force
 		wrapped.force = 0.0
 		wrapped.attack(M,user)
-		if(deleted(wrapped))
+		M.attackby(wrapped, user)	//attackby reportedly gets procced by being clicked on, at least according to Anewbe.
+		if(deleted(wrapped) || wrapped.loc != src.loc)
 			wrapped = null
 		return 1
 	return 0

--- a/html/changelogs/Atermonera - GripperFixes.yml
+++ b/html/changelogs/Atermonera - GripperFixes.yml
@@ -1,0 +1,37 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Atermonera
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Science grippers can install and remove borg components"
+  - bugfix: "Exosuit grippers can install exosuit equipment"


### PR DESCRIPTION
Attackby() wasn't being called when wrapped.attack() happened, so I manually called it (Don't know if the order of the two particularly matters, if so then it's a quick fix). Fixes #2671 and allows exosuit grippers to function again. Tested.
#2609 is fixed by this.
#1998 might have been fixed, or was beforehand
#858 couldn't be reproduced when I was testing various stuff after making the fix.