### PR TITLE
Fixes floor lighting bug

### DIFF
--- a/code/game/turfs/turf_changing.dm
+++ b/code/game/turfs/turf_changing.dm
@@ -85,3 +85,6 @@
 			lighting_build_overlays()
 		else
 			lighting_clear_overlays()
+	else
+		if(lighting_overlay)
+			lighting_overlay.update_overlay()


### PR DESCRIPTION
When a floor was created, it would always be dark at a distance until nearby light sources turned off and on again.  This should fix that problem by forcing the overlay to update upon turf being changed.