### PR TITLE
Removes an unused gas from the code

### DIFF
--- a/code/ATMOSPHERICS/components/trinary_devices/filter.dm
+++ b/code/ATMOSPHERICS/components/trinary_devices/filter.dm
@@ -40,7 +40,7 @@
 	..()
 	switch(filter_type)
 		if(0) //removing hydrocarbons
-			filtered_out = list("phoron", "oxygen_agent_b")
+			filtered_out = list("phoron")
 		if(1) //removing O2
 			filtered_out = list("oxygen")
 		if(2) //removing N2
@@ -95,10 +95,10 @@
 
 /obj/machinery/atmospherics/trinary/filter/process()
 	..()
-	
+
 	last_power_draw = 0
 	last_flow_rate = 0
-	
+
 	if((stat & (NOPOWER|BROKEN)) || !use_power)
 		return
 

--- a/code/defines/gases.dm
+++ b/code/defines/gases.dm
@@ -21,11 +21,11 @@
 /decl/xgm_gas/phoron
 	id = "phoron"
 	name = "Phoron"
-	
+
 	//Note that this has a significant impact on TTV yield.
 	//Because it is so high, any leftover phoron soaks up a lot of heat and drops the yield pressure.
 	specific_heat = 200	// J/(mol*K)
-	
+
 	//Hypothetical group 14 (same as carbon), period 8 element.
 	//Using multiplicity rule, it's atomic number is 162
 	//and following a N/Z ratio of 1.5, the molar mass of a monatomic gas is:
@@ -51,9 +51,3 @@
 
 	tile_overlay = "sleeping_agent"
 	overlay_limit = 1
-
-/decl/xgm_gas/oxygen_agent_b
-	id = "oxygen_agent_b"
-	name = "Oxygen Agent-B"	//what is this?
-	specific_heat = 300	// J/(mol*K)
-	molar_mass = 0.032	// kg/mol

--- a/code/game/machinery/atmoalter/scrubber.dm
+++ b/code/game/machinery/atmoalter/scrubber.dm
@@ -17,7 +17,7 @@
 	var/minrate = 0
 	var/maxrate = 10 * ONE_ATMOSPHERE
 
-	var/list/scrubbing_gas = list("phoron", "carbon_dioxide", "sleeping_agent", "oxygen_agent_b")
+	var/list/scrubbing_gas = list("phoron", "carbon_dioxide", "sleeping_agent")
 
 /obj/machinery/portable_atmospherics/powered/scrubber/New()
 	..()


### PR DESCRIPTION
Removes oxygen_agent_b from the code.

This gas has no use, is unobtainable in game (Even with admin powers you'd have to edit a preexisting gas, as there is no canister to spawn it in with,) doesn't do anything special, and there is pretty much no reason to even have it in the code. 

After some testing, everything appears to work as it should. Scrubbing, siphoning, and pressurizing with the vents all works as they should.