### PR TITLE
Make Flashes Great Again

### DIFF
--- a/code/game/objects/items/devices/flash.dm
+++ b/code/game/objects/items/devices/flash.dm
@@ -96,7 +96,7 @@
 						H.eye_blind = max(H.eye_blind, flash_strength)
 						H.eye_blurry = max(H.eye_blurry, flash_strength + 5)
 						H.flash_eyes()
-						H.adjustHalLoss(halloss_per_flash) // Should take four flashes to stun.
+						H.adjustHalLoss(halloss_per_flash * (flash_strength / 5)) // Should take four flashes to stun.
 
 			else
 				flashfail = 1

--- a/code/game/objects/items/devices/flash.dm
+++ b/code/game/objects/items/devices/flash.dm
@@ -13,6 +13,8 @@
 	var/times_used = 0 //Number of times it's been used.
 	var/broken = 0     //Is the flash burnt out?
 	var/last_used = 0 //last world.time it was used.
+	var/max_flashes = 10 // How many times the flash can be used before needing to self recharge.
+	var/halloss_per_flash = 30
 
 /obj/item/device/flash/proc/clown_check(var/mob/user)
 	if(user && (CLUMSY in user.mutations) && prob(50))
@@ -22,14 +24,35 @@
 	return 1
 
 /obj/item/device/flash/proc/flash_recharge()
-	//capacitor recharges over time
-	for(var/i=0, i<3, i++)
-		if(last_used+600 > world.time)
+	//Every ten seconds the flash doesn't get used, the times_used variable goes down by one, making the flash less likely to burn out,
+	// as well as being able to flash more before reaching max_flashes cap.
+	for(var/i=0, i < max_flashes, i++)
+		if(last_used + 10 SECONDS > world.time)
 			break
-		last_used += 600
-		times_used -= 2
+		last_used += 10 SECONDS
+		times_used--
 	last_used = world.time
 	times_used = max(0,round(times_used)) //sanity
+
+// Returns true if the device can flash.
+/obj/item/device/flash/proc/check_capacitor(var/mob/user)
+	//spamming the flash before it's fully charged (60 seconds) increases the chance of it breaking
+	//It will never break on the first use.
+	if(times_used <= max_flashes)
+		last_used = world.time
+		if(prob( round(times_used / 2) ))	//if you use it 10 times in a minute it has a 5% chance to break.
+			broken = 1
+			if(user)
+				user << "<span class='warning'>The bulb has burnt out!</span>"
+			icon_state = "flashburnt"
+			return FALSE
+		else
+			times_used++
+			return TRUE
+	else	//can only use it 10 times a minute
+		if(user)
+			user << "<span class='warning'>*click* *click*</span>"
+		return FALSE
 
 //attack_as_weapon
 /obj/item/device/flash/attack(mob/living/M, mob/living/user, var/target_zone)
@@ -49,20 +72,8 @@
 
 	flash_recharge()
 
-	//spamming the flash before it's fully charged (60seconds) increases the chance of it  breaking
-	//It will never break on the first use.
-	switch(times_used)
-		if(0 to 5)
-			last_used = world.time
-			if(prob(times_used))	//if you use it 5 times in a minute it has a 10% chance to break!
-				broken = 1
-				user << "<span class='warning'>The bulb has burnt out!</span>"
-				icon_state = "flashburnt"
-				return
-			times_used++
-		else	//can only use it  5 times a minute
-			user << "<span class='warning'>*click* *click*</span>"
-			return
+	if(!check_capacitor(user))
+		return
 
 	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 	user.do_attack_animation(M)
@@ -71,12 +82,13 @@
 	var/flashfail = 0
 
 	if(iscarbon(M))
-		if(M.stat!=DEAD)
-			var/safety = M:eyecheck()
+		var/mob/living/carbon/C = M
+		if(C.stat != DEAD)
+			var/safety = C.eyecheck()
 			if(safety <= 0)
 				var/flash_strength = 5
-				if(ishuman(M))
-					var/mob/living/carbon/human/H = M
+				if(ishuman(C))
+					var/mob/living/carbon/human/H = C
 					flash_strength *= H.species.flash_mod
 
 					if(flash_strength > 0)
@@ -84,6 +96,7 @@
 						H.eye_blind = max(H.eye_blind, flash_strength)
 						H.eye_blurry = max(H.eye_blurry, flash_strength + 5)
 						H.flash_eyes()
+						H.adjustHalLoss(halloss_per_flash) // Should take four flashes to stun.
 
 			else
 				flashfail = 1
@@ -132,19 +145,9 @@
 
 	flash_recharge()
 
-	//spamming the flash before it's fully charged (60seconds) increases the chance of it  breaking
-	//It will never break on the first use.
-	switch(times_used)
-		if(0 to 5)
-			if(prob(2*times_used))	//if you use it 5 times in a minute it has a 10% chance to break!
-				broken = 1
-				user << "<span class='warning'>The bulb has burnt out!</span>"
-				icon_state = "flashburnt"
-				return
-			times_used++
-		else	//can only use it  5 times a minute
-			user.show_message("<span class='warning'>*click* *click*</span>", 2)
-			return
+	if(!check_capacitor(user))
+		return
+
 	playsound(src.loc, 'sound/weapons/flash.ogg', 100, 1)
 	flick("flash2", src)
 	if(user && isrobot(user))
@@ -158,32 +161,29 @@
 			sleep(5)
 			qdel(animation)
 
-	for(var/mob/living/carbon/M in oviewers(3, null))
-		var/safety = M:eyecheck()
+	for(var/mob/living/carbon/C in oviewers(3, null))
+		var/safety = C.eyecheck()
 		if(!safety)
-			if(!M.blinded)
-				M.flash_eyes()
+			if(!C.blinded)
+				C.flash_eyes()
 
 	return
 
 /obj/item/device/flash/emp_act(severity)
 	if(broken)	return
 	flash_recharge()
-	switch(times_used)
-		if(0 to 5)
-			if(prob(2*times_used))
-				broken = 1
-				icon_state = "flashburnt"
-				return
-			times_used++
-			if(istype(loc, /mob/living/carbon))
-				var/mob/living/carbon/M = loc
-				var/safety = M.eyecheck()
-				if(safety <= 0)
-					M.Weaken(10)
-					M.flash_eyes()
-					for(var/mob/O in viewers(M, null))
-						O.show_message("<span class='disarm'>[M] is blinded by the flash!</span>")
+	if(!check_capacitor())
+		return
+
+	if(istype(loc, /mob/living/carbon))
+		var/mob/living/carbon/C = loc
+		var/safety = C.eyecheck()
+		if(safety <= 0)
+			C.adjustHalLoss(halloss_per_flash)
+			//C.Weaken(10)
+			C.flash_eyes()
+			for(var/mob/M in viewers(C, null))
+				M.show_message("<span class='disarm'>[C] is blinded by the flash!</span>")
 	..()
 
 /obj/item/device/flash/synthetic

--- a/code/modules/projectiles/projectile/energy.dm
+++ b/code/modules/projectiles/projectile/energy.dm
@@ -33,7 +33,7 @@
 					H.confused = max(H.confused, flash_strength + 5)
 					H.eye_blind = max(H.eye_blind, flash_strength)
 					H.eye_blurry = max(H.eye_blurry, flash_strength + 5)
-					H.adjustHalLoss(22) // Five flashes to stun.  Bit weaker than melee flashes due to being ranged.
+					H.adjustHalLoss(22 * (flash_strength / 5)) // Five flashes to stun.  Bit weaker than melee flashes due to being ranged.
 
 	//snap pop
 	playsound(src, 'sound/effects/snap.ogg', 50, 1)

--- a/code/modules/projectiles/projectile/energy.dm
+++ b/code/modules/projectiles/projectile/energy.dm
@@ -33,7 +33,7 @@
 					H.confused = max(H.confused, flash_strength + 5)
 					H.eye_blind = max(H.eye_blind, flash_strength)
 					H.eye_blurry = max(H.eye_blurry, flash_strength + 5)
-
+					H.adjustHalLoss(22) // Five flashes to stun.  Bit weaker than melee flashes due to being ranged.
 
 	//snap pop
 	playsound(src, 'sound/effects/snap.ogg', 50, 1)

--- a/html/changelogs/Neerti-Flashes.yml
+++ b/html/changelogs/Neerti-Flashes.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Neerti
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Hand-held flashes and flash rounds will now stun upon repeated applications, similar to stun batons."


### PR DESCRIPTION
Hand-held flashes now do 30 halloss per flash, if the person lacks flash protection.
Hand-held flashes now can be used 10 times per minute instead of five, due to needing ~4 flashes to down someone.
Flash rounds do 20 halloss if the mob hit lacks flash protection.
Cleans up the hand-held flash code, removes copypasta, removes colons.