### PR TITLE
Adds Telecomms Logging to EPv2

### DIFF
--- a/code/datums/EPv2.dm
+++ b/code/datums/EPv2.dm
@@ -112,23 +112,27 @@ var/global/list/all_exonet_connections = list()
 	return null
 
 // Proc: send_message()
-// Parameters: 3 (target_address - the desired address to send the message to, message - the message to send, text - the message text if message is of type "text")
-// Description: Sends the message to target_address, by calling receive_message() on the desired datum.
-/datum/exonet_protocol/proc/send_message(var/target_address, var/message, var/text)
+// Parameters: 3 (target_address - the desired address to send the message to, data_type - text stating what the content is meant to be used for,
+// 		content - the actual 'message' being sent to the address)
+// Description: Sends the message to target_address, by calling receive_message() on the desired datum.  Returns true if the message is recieved.
+/datum/exonet_protocol/proc/send_message(var/target_address, var/data_type, var/content)
 	if(!address)
-		return 0
+		return FALSE
+	var/obj/machinery/exonet_node/node = get_exonet_node()
+	if(!node) // Telecomms went boom, ion storm, etc.
+		return FALSE
 	for(var/datum/exonet_protocol/exonet in all_exonet_connections)
 		if(exonet.address == target_address)
-			exonet.receive_message(holder, address, message, text)
-			break
+			node.write_log(src.address, target_address, data_type, content)
+			return exonet.receive_message(holder, address, data_type, content)
 
 // Proc: receive_message()
-// Parameters: 4 (origin_atom - the origin datum's holder, origin_address - the address the message originated from, message - the message that was sent,
-//				  text - the message text if message is of type "text")
+// Parameters: 4 (origin_atom - the origin datum's holder, origin_address - the address the message originated from,
+// 		data_type - text stating what the content is meant to be used for, content - the actual 'message' being sent from origin_atom)
 // Description: Called when send_message() successfully reaches the intended datum.  By default, calls receive_exonet_message() on the holder atom.
-/datum/exonet_protocol/proc/receive_message(var/atom/origin_atom, var/origin_address, var/message, var/text)
-	holder.receive_exonet_message(origin_atom, origin_address, message, text)
-	return
+/datum/exonet_protocol/proc/receive_message(var/atom/origin_atom, var/origin_address, var/data_type, var/content)
+	holder.receive_exonet_message(origin_atom, origin_address, data_type, content)
+	return TRUE // for send_message()
 
 // Proc: receive_exonet_message()
 // Parameters: 3 (origin_atom - the origin datum's holder, origin_address - the address the message originated from, message - the message that was sent)

--- a/code/game/machinery/exonet_node.dm
+++ b/code/game/machinery/exonet_node.dm
@@ -15,6 +15,8 @@
 
 	var/opened = 0
 
+	var/list/logs = list() // Gets written to by exonet's send_message() function.
+
 // Proc: New()
 // Parameters: None
 // Description: Adds components to the machine for deconstruction.
@@ -60,6 +62,7 @@
 	else
 		on = 0
 		idle_power_usage = 0
+	update_icon()
 
 // Proc: emp_act()
 // Parameters: 1 (severity - how strong the EMP is, with lower numbers being stronger)
@@ -114,6 +117,7 @@
 	data["allowPDAs"] = allow_external_PDAs
 	data["allowCommunicators"] = allow_external_communicators
 	data["allowNewscasters"] = allow_external_newscasters
+	data["logs"] = logs
 
 
 	// update the ui if it exists, returns null if no ui is passed/found
@@ -171,3 +175,14 @@
 	for(var/obj/machinery/exonet_node/E in machines)
 		if(E.on)
 			return E
+
+// Proc: write_log()
+// Parameters: 4 (origin_address - Where the message is from, target_address - Where the message is going, data_type - Instructions on how to interpet content,
+// 		content - The actual message.
+// Description: This writes to the logs list, so that people can see what people are doing on the Exonet ingame.  Note that this is not an admin logging function.
+// 		Communicators are already logged seperately.
+/obj/machinery/exonet_node/proc/write_log(var/origin_address, var/target_address, var/data_type, var/content)
+	//var/timestamp = time2text(station_time_in_ticks, "hh:mm:ss")
+	var/timestamp = "[stationdate2text()] [stationtime2text()]"
+	var/msg = "[timestamp] | FROM [origin_address] TO [target_address] | TYPE: [data_type] | CONTENT: [content]"
+	logs.Add(msg)

--- a/nano/templates/exonet_node.tmpl
+++ b/nano/templates/exonet_node.tmpl
@@ -38,3 +38,12 @@ Used In File(s): code\game\machinery/exonet_node.dm
 		{{:helper.link('Open', 'check', {'toggle_newscaster_port' : 1}, data.allowNewscasters ? 'selected' : null)}}{{:helper.link('Close', 'close', {'toggle_newscaster_port' : 1}, data.allowNewscasters ? null : 'selected')}}
 	</div>
 </div>
+
+<H2>Logging</H2>
+<div class="statusDisplay" style="height: 250px; overflow: auto;">
+	{{for data.logs}}
+		<div class='item'>
+			{{:value}}
+		</div>
+	{{/for}}
+</div>


### PR DESCRIPTION
The Exonet Node now has a log window, showing all successful message transmissions that pass through it.  Each line contains information about the origin address, target address, the message type, and the contents of the message.
Changes the documentation for some procs to be more clear on what they're actually doing.
Also fixes icon bug with exonet node losing power not updating.
Image:
![log window](http://puu.sh/tdKOk/962265f764.png)