### PR TITLE
Adds new Server News

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -160,7 +160,8 @@ var/list/admin_verbs_server = list(
 	/datum/admins/proc/toggle_space_ninja,
 	/client/proc/toggle_random_events,
 	/client/proc/check_customitem_activity,
-	/client/proc/nanomapgen_DumpImage
+	/client/proc/nanomapgen_DumpImage,
+	/client/proc/modify_server_news
 	)
 var/list/admin_verbs_debug = list(
 	/client/proc/getruntimelog,                     //allows us to access runtime logs to somebody,

--- a/code/modules/admin/news.dm
+++ b/code/modules/admin/news.dm
@@ -1,0 +1,42 @@
+#define NEWSFILE "data/news.sav"	//where the memos are saved
+
+/client/
+	var/last_news_hash = null // Stores a hash of the last news window it saw, which gets compared to the current one to see if it is different.
+
+// Returns true if news was updated since last seen.
+/client/proc/check_for_new_server_news()
+	var/savefile/F = get_server_news()
+	if(F)
+		if(md5(F["body"]) != last_news_hash)
+			return TRUE
+	return FALSE
+
+/client/proc/modify_server_news()
+	set name = "Modify Public News"
+	set category = "Server"
+
+	if(!check_rights(0))
+		return
+
+	var/savefile/F = new(NEWSFILE)
+	if(F)
+		var/title = F["title"]
+		var/body = F["body"]
+		var/new_title = sanitize(input(src,"Write a good title for the news update.  Note: HTML is NOT supported.","Write News", title) as null|text, extra = 0)
+		if(!new_title)
+			return
+		var/new_body = sanitize(input(src,"Write the body of the news update here. Note: HTML is NOT supported.","Write News", body) as null|message, extra = 0)
+		if(findtext(new_body,"<script",1,0) ) // Is this needed with santize()?
+			return
+		F["title"] << new_title
+		F["body"] << new_body
+		F["author"] << key
+		F["timestamp"] << time2text(world.realtime, "DDD, MMM DD YYYY")
+		message_admins("[key] modified the news to read:<br>[new_title]<br>[new_body]")
+
+/proc/get_server_news()
+	var/savefile/F = new(NEWSFILE)
+	if(F)
+		return F
+
+#undef NEWSFILE

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -60,6 +60,11 @@
 			else
 				output += "<p><a href='byond://?src=\ref[src];showpoll=1'>Show Player Polls</A></p>"
 
+	if(client.check_for_new_server_news())
+		output += "<p><b><a href='byond://?src=\ref[src];shownews=1'>Show News</A> (NEW!)</b></p>"
+	else
+		output += "<p><a href='byond://?src=\ref[src];shownews=1'>Show News</A></p>"
+
 	output += "</div>"
 
 	panel = new(src, "Welcome","Welcome", 210, 280, src)
@@ -276,6 +281,28 @@
 				for(var/optionid = id_min; optionid <= id_max; optionid++)
 					if(!isnull(href_list["option_[optionid]"]))	//Test if this optionid was selected
 						vote_on_poll(pollid, optionid, 1)
+
+	if(href_list["shownews"])
+		handle_server_news()
+		return
+
+/mob/new_player/proc/handle_server_news()
+	if(!client)
+		return
+	var/savefile/F = get_server_news()
+	if(F)
+		client.last_news_hash = md5(F["body"])
+
+		var/dat = "<html><body><center>"
+		dat += "<h1>[F["title"]]</h1>"
+		dat += "<br>"
+		dat += "[F["body"]]"
+		dat += "<br>"
+		dat += "<font size='2'><i>Last written by [F["author"]], on [F["timestamp"]].</i></font>"
+		dat += "</center></body></html>"
+		var/datum/browser/popup = new(src, "Server News", "Server News", 450, 300, src)
+		popup.set_content(dat)
+		popup.open()
 
 /mob/new_player/proc/IsJobAvailable(rank)
 	var/datum/job/job = job_master.GetJob(rank)

--- a/polaris.dme
+++ b/polaris.dme
@@ -1032,6 +1032,7 @@
 #include "code\modules\admin\IsBanned.dm"
 #include "code\modules\admin\map_capture.dm"
 #include "code\modules\admin\NewBan.dm"
+#include "code\modules\admin\news.dm"
 #include "code\modules\admin\player_notes.dm"
 #include "code\modules\admin\player_panel.dm"
 #include "code\modules\admin\topic.dm"


### PR DESCRIPTION
Adds ability for admins with R_SERVER perms to be able to set a persistant 'news' announcement that works similarly to admin memos, but for the public.  This is ideal for telling the public things such as when an event is scheduled, directing people to a forum thread, new lore changes, new policies, etc.
The news window allows to define a title, and the body of the text, using an admin verb.  The author and date are added automatically.
Any players can read the news window in the lobby.  The button will bold itself, and display (NEW!), if the player has not seen the news before.  This is done by comparing a hash of the body that the client remembers verses a hash the current news body.
Example image: ![Example](http://puu.sh/tgJMQ/2f5f0c0823.png)
It should be noted that only one news piece can exist at a time.