### PR TITLE
Removes Last Minute Autoantag

### DIFF
--- a/code/game/gamemodes/game_mode_latespawn.dm
+++ b/code/game/gamemodes/game_mode_latespawn.dm
@@ -31,6 +31,16 @@
 	if(emergency_shuttle.departed || !round_autoantag)
 		return
 
+	if(emergency_shuttle.shuttle && (emergency_shuttle.shuttle.moving_status == SHUTTLE_WARMUP || emergency_shuttle.shuttle.moving_status == SHUTTLE_INTRANSIT))
+		return // Don't do anything if the shuttle's coming.
+
+	var/mills = round_duration_in_ticks
+	var/mins = round((mills % 36000) / 600)
+	var/hours = round(mills / 36000)
+
+	if(hours >= 2 && mins >= 40) // Don't do anything in the last twenty minutes of the round, as well.
+		return
+
 	if(world.time < next_spawn)
 		return
 


### PR DESCRIPTION
Autotraitor and other latespawning modes that may exist in the future should no longer spawn an antag if the shuttle's warming up or in transit.
It will also not spawn antags in the last 20 minutes of the round.  If the round gets extended due to a vote, it'll start again until the last 20 minutes of that hour.