### PR TITLE
Tweaks some emotes

### DIFF
--- a/code/game/objects/items/weapons/implants/implant.dm
+++ b/code/game/objects/items/weapons/implants/implant.dm
@@ -508,7 +508,7 @@ the implant may become unstable and either pre-maturely inject the subject or si
 	qdel(src)
 
 /obj/item/weapon/implant/compressed/implanted(mob/source as mob)
-	src.activation_emote = input("Choose activation emote:") in list("blink", "blink_r", "eyebrow", "chuckle", "twitch_s", "frown", "nod", "blush", "giggle", "grin", "groan", "shrug", "smile", "pale", "sniff", "whimper", "wink")
+	src.activation_emote = input("Choose activation emote:") in list("blink", "blink_r", "eyebrow", "chuckle", "twitch", "frown", "nod", "blush", "giggle", "grin", "groan", "shrug", "smile", "pale", "sniff", "whimper", "wink")
 	if (source.mind)
 		source.mind.store_memory("Compressed matter implant can be activated by using the [src.activation_emote] emote, <B>say *[src.activation_emote]</B> to attempt to activate.", 0, 0)
 	source << "The implanted compressed matter implant can be activated by using the [src.activation_emote] emote, <B>say *[src.activation_emote]</B> to attempt to activate."

--- a/code/game/objects/items/weapons/implants/implantfreedom.dm
+++ b/code/game/objects/items/weapons/implants/implantfreedom.dm
@@ -9,7 +9,7 @@
 
 
 /obj/item/weapon/implant/freedom/New()
-	src.activation_emote = pick("blink", "blink_r", "eyebrow", "chuckle", "twitch_s", "frown", "nod", "blush", "giggle", "grin", "groan", "shrug", "smile", "pale", "sniff", "whimper", "wink")
+	src.activation_emote = pick("blink", "blink_r", "eyebrow", "chuckle", "twitch", "frown", "nod", "blush", "giggle", "grin", "groan", "shrug", "smile", "pale", "sniff", "whimper", "wink")
 	src.uses = rand(1, 5)
 	..()
 	return

--- a/code/game/objects/items/weapons/implants/implantuplink.dm
+++ b/code/game/objects/items/weapons/implants/implantuplink.dm
@@ -4,7 +4,7 @@
 	var/activation_emote = "chuckle"
 
 /obj/item/weapon/implant/uplink/New()
-	activation_emote = pick("blink", "blink_r", "eyebrow", "chuckle", "twitch_s", "frown", "nod", "blush", "giggle", "grin", "groan", "shrug", "smile", "pale", "sniff", "whimper", "wink")
+	activation_emote = pick("blink", "blink_r", "eyebrow", "chuckle", "twitch", "frown", "nod", "blush", "giggle", "grin", "groan", "shrug", "smile", "pale", "sniff", "whimper", "wink")
 	hidden_uplink = new(src)
 	//hidden_uplink.uses = 5
 	//Code currently uses a mind var for telecrystals, balancing is currently an issue. Will investigate.
@@ -12,7 +12,7 @@
 	return
 
 /obj/item/weapon/implant/uplink/implanted(mob/source)
-	activation_emote = input("Choose activation emote:") in list("blink", "blink_r", "eyebrow", "chuckle", "twitch_s", "frown", "nod", "blush", "giggle", "grin", "groan", "shrug", "smile", "pale", "sniff", "whimper", "wink")
+	activation_emote = input("Choose activation emote:") in list("blink", "blink_r", "eyebrow", "chuckle", "twitch", "frown", "nod", "blush", "giggle", "grin", "groan", "shrug", "smile", "pale", "sniff", "whimper", "wink")
 	source.mind.store_memory("Uplink implant can be activated by using the [src.activation_emote] emote, <B>say *[src.activation_emote]</B> to attempt to activate.", 0, 0)
 	source << "The implanted uplink implant can be activated by using the [src.activation_emote] emote, <B>say *[src.activation_emote]</B> to attempt to activate."
 	listening_objects |= src

--- a/code/modules/mob/living/carbon/alien/emote.dm
+++ b/code/modules/mob/living/carbon/alien/emote.dm
@@ -80,6 +80,9 @@
 			message = "<B>The [src.name]</B> sulks down sadly."
 			m_type = 1
 		if("twitch")
+			message = "<B>The [src.name]</B> twitches."
+			m_type = 1
+		if("twitch_v")
 			message = "<B>The [src.name]</B> twitches violently."
 			m_type = 1
 		if("dance")

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -188,11 +188,11 @@
 					m_type = 2
 
 		if ("twitch")
-			message = "twitches violently."
+			message = "twitches."
 			m_type = 1
 
-		if ("twitch_s")
-			message = "twitches."
+		if ("twitch_v")
+			message = "twitches violently."
 			m_type = 1
 
 		if ("faint")
@@ -590,6 +590,9 @@
 			src.animate_tail_stop()
 
 		if("vomit")
+			if(isSynthetic())
+				src << "<span class='warning'>You are unable to vomit.</span>"
+				return
 			vomit()
 			return
 
@@ -597,7 +600,7 @@
 			src << {"blink, blink_r, blush, bow-(none)/mob, burp, choke, chuckle, clap, collapse, cough, cry, custom, deathgasp, drool, eyebrow, fastsway/qwag,
 frown, gasp, giggle, glare-(none)/mob, grin, groan, grumble, handshake, hug-(none)/mob, laugh, look-(none)/mob, moan, mumble, nod, pale, point-atom,
 raise, salute, shake, shiver, shrug, sigh, signal-#1-10, smile, sneeze, sniff, snore, stare-(none)/mob, stopsway/swag, sway/wag, swish, tremble, twitch,
-twitch_s, vomit, whimper, wink, yawn"}
+twitch_v, vomit, whimper, wink, yawn"}
 
 		else
 			src << "\blue Unusable emote '[act]'. Say *help for a list."

--- a/code/modules/mob/living/silicon/robot/emote.dm
+++ b/code/modules/mob/living/silicon/robot/emote.dm
@@ -72,11 +72,11 @@
 				m_type = 2
 
 		if ("twitch")
-			message = "twitches violently."
+			message = "twitches."
 			m_type = 1
 
-		if ("twitch_s")
-			message = "twitches."
+		if ("twitch_v")
+			message = "twitches violently."
 			m_type = 1
 
 		if ("nod")

--- a/code/modules/mob/living/simple_animal/borer/borer.dm
+++ b/code/modules/mob/living/simple_animal/borer/borer.dm
@@ -86,7 +86,7 @@
 					host.adjustBrainLoss(0.1)
 
 				if(prob(host.brainloss/20))
-					host.say("*[pick(list("blink","blink_r","choke","aflap","drool","twitch","twitch_s","gasp"))]")
+					host.say("*[pick(list("blink","blink_r","choke","aflap","drool","twitch","twitch_v","gasp"))]")
 
 /mob/living/simple_animal/borer/Stat()
 	..()


### PR DESCRIPTION
 - FBPs can't voluntarily vomit anymore, it'd just drop them to the ground anyway.
 - The "twitch" emote is now a gentler twitch.
 - The old "twitch_s" emote has been replaced with "twitch_v", which has the same text as the old emote.