### PR TITLE
Allows individuals to have multiple custom Borg Sprite-Sets.

### DIFF
--- a/code/modules/mob/living/silicon/robot/custom_sprites.dm
+++ b/code/modules/mob/living/silicon/robot/custom_sprites.dm
@@ -1,7 +1,7 @@
 
 //list(ckey = real_name,)
 //Since the ckey is used as the icon_state, the current system will only permit a single custom robot sprite per ckey.
-//While it might be possible for a ckey to use that custom sprite for several real_names, it seems rather pointless to support it.
+//While it might be possible for a ckey to use that custom sprite for several real_names, it seems rather pointless to support it. ~Mech: We found it wasn't pointless.
 var/list/robot_custom_icons
 
 /hook/startup/proc/load_robot_custom_sprites()
@@ -11,20 +11,22 @@ var/list/robot_custom_icons
 	robot_custom_icons = list()
 	for(var/line in lines)
 		//split entry into ckey and real_name
-		var/split_idx = findtext(line, "-") //this works if ckey cannot contain dashes, and findtext starts from the beginning
-		if(!split_idx || split_idx == length(line))
+		var/list/split_idx = splittext(line, "-") //this works if ckeys and borg names cannot contain dashes, and splittext starts from the beginning ~Mech
+		if(!split_idx || !split_idx.len)
 			continue //bad entry
 
-		var/ckey = copytext(line, 1, split_idx)
-		var/real_name = copytext(line, split_idx+1)
+		var/ckey = split_idx[1]
+		//Prevents the CKEY from being considered a borg name / being processed into the name list. ~Mech
+		split_idx.Remove(ckey)
 
-		robot_custom_icons[ckey] = real_name
+		for(var/name in split_idx)
+			robot_custom_icons[name] = ckey
 	return 1
 
 /mob/living/silicon/robot/proc/set_custom_sprite()
-	var/rname = robot_custom_icons[ckey]
-	if(rname && rname == real_name)
+	var/sprite_owner = robot_custom_icons[real_name]
+	if(sprite_owner && sprite_owner == ckey)
 		custom_sprite = 1
 		icon = CUSTOM_ITEM_SYNTH
 		if(icon_state == "robot")
-			icon_state = "[ckey]-Standard"
+			icon_state = "[ckey]-[name]-Standard" //Compliant with robot.dm line 236 ~Mech

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -233,7 +233,7 @@
 		module_sprites = new_sprites.Copy()
 		//Custom_sprite check and entry
 		if (custom_sprite == 1)
-			module_sprites["Custom"] = "[src.ckey]-[modtype]"
+			module_sprites["Custom"] = "[ckey]-[name]-[modtype]" //Made compliant with custom_sprites.dm line 32. (src.) was apparently redundant as it's implied. ~Mech
 			icontype = "Custom"
 		else
 			icontype = module_sprites[1]


### PR DESCRIPTION
-Custom Borg config setup tweak, format expanded to allow multiple names, "ckey-Name1-Name2", seperated by -'s as before.
-Small modification of robot.dm to make both custom sprite set-ings compliant with one-another.

Neerti = Hero I needed but probably didn't deserve.
' https://github.com/PolarisSS13/Custom-Items/pull/21 ' Should be merged afterward, if this is.