### PR TITLE
Fixes medium screen circuit bug

### DIFF
--- a/code/modules/integrated_electronics/subtypes/input_output.dm
+++ b/code/modules/integrated_electronics/subtypes/input_output.dm
@@ -477,7 +477,7 @@
 	var/list/nearby_things = range(0, get_turf(src))
 	for(var/mob/M in nearby_things)
 		var/obj/O = assembly ? assembly : src
-		visible_message("<span class='notice'>\icon[O] [stuff_to_display]</span>")
+		to_chat(M, "<span class='notice'>\icon[O] [stuff_to_display]</span>")
 
 /obj/item/integrated_circuit/output/screen/large
 	name = "large screen"


### PR DESCRIPTION
Medium screens should only show to the person holding the assembly now, instead of everyone seeing it.  That's what the large screen is for.