### PR TITLE
Spiders inject fewer spiderlings

### DIFF
--- a/code/game/objects/effects/spiders.dm
+++ b/code/game/objects/effects/spiders.dm
@@ -77,6 +77,8 @@
 	desc = "They seem to pulse slightly with an inner life"
 	icon_state = "eggs"
 	var/amount_grown = 0
+	var/spiders_min = 6
+	var/spiders_max = 24
 	New()
 		pixel_x = rand(3,-3)
 		pixel_y = rand(3,-3)
@@ -97,7 +99,7 @@
 /obj/effect/spider/eggcluster/process()
 	amount_grown += rand(0,2)
 	if(amount_grown >= 100)
-		var/num = rand(6,24)
+		var/num = rand(spiders_min, spiders_max)
 		var/obj/item/organ/external/O = null
 		if(istype(loc, /obj/item/organ/external))
 			O = loc
@@ -107,6 +109,10 @@
 			if(O)
 				O.implants += spiderling
 		qdel(src)
+
+/obj/effect/spider/eggcluster/small
+	spiders_min = 1
+	spiders_max = 3
 
 /obj/effect/spider/spiderling
 	name = "spiderling"

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -29,7 +29,7 @@
 	cold_damage_per_tick = 20
 	var/poison_per_bite = 5
 	var/poison_chance = 10
-	var/poison_type = "toxin"
+	var/poison_type = "spidertoxin"
 	faction = "spiders"
 	var/busy = 0
 	pass_flags = PASSTABLE
@@ -85,9 +85,14 @@
 		if(prob(5))
 			var/obj/item/organ/external/O = pick(H.organs)
 			if(!(O.robotic >= ORGAN_ROBOT))
-				var/eggs = PoolOrNew(/obj/effect/spider/eggcluster/, list(O, src))
-				O.implants += eggs
-				H << "<span class='warning'>The [src] injects something into your [O.name]!</span>"
+				var/eggcount
+				for(var/obj/I in O.implants)
+					if(istype(I, /obj/effect/spider/eggcluster))
+						eggcount ++
+				if(!eggcount)
+					var/eggs = PoolOrNew(/obj/effect/spider/eggcluster/small, list(O, src))
+					O.implants += eggs
+					H << "<span class='warning'>The [src] injects something into your [O.name]!</span>"
 
 /mob/living/simple_animal/hostile/giant_spider/Life()
 	..()


### PR DESCRIPTION
Nurse spiders implant smaller egg clusters, creating fewer spiderlings. Also won't inject clusters into limbs that already have implanted egg clusters.