### PR TITLE
Further tweaks to Vox and their toys

### DIFF
--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -123,6 +123,7 @@
 	if(user.species.can_shred(user))
 		set_status(0)
 		user.do_attack_animation(src)
+		user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 		visible_message("<span class='warning'>\The [user] slashes at [src]!</span>")
 		playsound(src.loc, 'sound/weapons/slash.ogg', 100, 1)
 		add_hiddenprint(user)

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -160,6 +160,8 @@
 		if(H.species.can_shred(H))
 			playsound(src.loc, 'sound/effects/Glasshit.ogg', 75, 1)
 			visible_message("<span class='danger'>[user] smashes against the [src.name].</span>", 1)
+			user.do_attack_animation(src)
+			user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 			take_damage(25)
 			return
 	return src.attackby(user, user)

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -514,6 +514,7 @@
 		if(H.species.can_shred(user))
 			if(!prob(src.deflect_chance))
 				src.take_damage(15)
+				user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 				src.check_for_internal_damage(list(MECHA_INT_TEMP_CONTROL,MECHA_INT_TANK_BREACH,MECHA_INT_CONTROL_LOST))
 				playsound(src.loc, 'sound/weapons/slash.ogg', 50, 1, -1)
 				user << "<span class='danger'>You slash at the armored suit!</span>"

--- a/code/modules/clothing/spacesuits/alien.dm
+++ b/code/modules/clothing/spacesuits/alien.dm
@@ -34,6 +34,7 @@
 	item_flags = STOPPRESSUREDAMAGE | THICKMATERIAL | PHORONGUARD
 	allowed = list(/obj/item/weapon/gun,/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/weapon/melee/baton,/obj/item/weapon/melee/energy/sword,/obj/item/weapon/handcuffs,/obj/item/weapon/tank)
 	phoronproof = 1
+	slowdown = 2
 	armor = list(melee = 60, bullet = 50, laser = 40,energy = 15, bomb = 30, bio = 30, rad = 30)
 	siemens_coefficient = 0.2
 	heat_protection = UPPER_TORSO|LOWER_TORSO|LEGS|FEET|ARMS|HANDS

--- a/code/modules/clothing/spacesuits/rig/suits/alien.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/alien.dm
@@ -49,6 +49,9 @@
 	item_flags = THICKMATERIAL
 	siemens_coefficient = 0.2
 	phoronproof = 1
+	offline_slowdown = 5
+	slowdown = 2
+	allowed = list(/obj/item/weapon/gun,/obj/item/device/flashlight,/obj/item/weapon/tank,/obj/item/device/suit_cooling_unit)
 
 	air_type = /obj/item/weapon/tank/vox
 
@@ -108,7 +111,6 @@
 	icon_state = "voxstealth_rig"
 	armor = list(melee = 40, bullet = 30, laser = 30, energy = 15, bomb = 30, bio = 100, rad = 100)
 	emp_protection = 40 //change this to 30 if too high.
-	slowdown = 0
 	phoronproof = 1
 
 	req_access = list(access_syndicate)

--- a/code/modules/clothing/under/xenos/vox.dm
+++ b/code/modules/clothing/under/xenos/vox.dm
@@ -25,7 +25,7 @@
 	icon_state = "webbing-vox"
 	slot = "vox"
 
-	slots = 5
+	slots = 3
 
 /obj/item/clothing/accessory/storage/vox/New()
 	..()

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -701,6 +701,7 @@
 		var/mob/living/carbon/human/H = user
 
 		if(H.species.can_shred(H))
+			user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 			user.visible_message("<span call='warning'>[user.name] slashes at the [src.name]!</span>", "<span class='notice'>You slash at the [src.name]!</span>")
 			playsound(src.loc, 'sound/weapons/slash.ogg', 100, 1)
 

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -527,6 +527,7 @@
 	if(istype(user,/mob/living/carbon/human))
 		var/mob/living/carbon/human/H = user
 		if(H.species.can_shred(H))
+			user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 			for(var/mob/M in viewers(src))
 				M.show_message("\red [user.name] smashed the light!", 3, "You hear a tinkle of breaking glass", 2)
 			broken()

--- a/code/modules/projectiles/guns/vox.dm
+++ b/code/modules/projectiles/guns/vox.dm
@@ -57,6 +57,7 @@
 	icon_state = "darkcannon"
 	item_state = "darkcannon"
 	fire_sound = 'sound/weapons/eLuger.ogg'
+	w_class = ITEMSIZE_HUGE
 	charge_cost = 600
 	projectile_type = /obj/item/projectile/beam/darkmatter
 	self_recharge = 1
@@ -102,6 +103,7 @@
 	icon_state = "noise"
 	item_state = "noise"
 	fire_sound = 'sound/effects/basscannon.ogg'
+	w_class = ITEMSIZE_HUGE
 	self_recharge = 1
 	charge_cost = 600
 


### PR DESCRIPTION
- Shredding attacks now set attack cooldown.
- Vox spacesuits and hardsuits should now all have the same slowdown, was an issue with it making them too fast.
- Sonic and Darkmatter guns will now fit in Vox hardsuit suit storage, but are too large for backpacks.
- The Vox webbing can now hold three normal sized items, down from five.