### PR TITLE
Fixes Issue #2982 - Deconstruction of Fax Machine

### DIFF
--- a/code/game/machinery/computer/aifixer.dm
+++ b/code/game/machinery/computer/aifixer.dm
@@ -10,6 +10,7 @@
 	var/active = 0
 
 /obj/machinery/computer/aifixer/New()
+	..()
 	update_icon()
 
 /obj/machinery/computer/aifixer/proc/load_ai(var/mob/living/silicon/ai/transfer, var/obj/item/device/aicard/card, var/mob/user)

--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -16,6 +16,7 @@
 	var/maxcopies = 10	//how many copies can be copied at once- idea shamelessly stolen from bs12's copier!
 
 /obj/machinery/photocopier/New()
+	..()
 	component_parts = list()
 	component_parts += new /obj/item/weapon/stock_parts/scanning_module(src)
 	component_parts += new /obj/item/weapon/stock_parts/motor(src)


### PR DESCRIPTION
* Fax machine's New() was not calling `..()` and therefore `circuit` was not being changed from a type to an instance.  Thus when deconstruct proc tries to read it's properties it can't.
* A search thru code found the aifixer had the same problem. Fixed it there too.