### PR TITLE
Balance adjustment for CE_SPEEDBOOST effects

### DIFF
--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -13,9 +13,6 @@
 	if(force_max_speed)
 		return -3 // Returning -1 will actually result in a slowdown for Teshari.
 
-	if(CE_SPEEDBOOST in chem_effects)
-		return -3
-
 	var/health_deficiency = (maxHealth - health)
 	if(health_deficiency >= 40) tally += (health_deficiency / 25)
 
@@ -78,6 +75,11 @@
 	if(pulling && istype(pulling, /obj/item))
 		var/obj/item/pulled = pulling
 		tally += max(pulled.slowdown, 0)
+
+	if(CE_SPEEDBOOST in chem_effects)
+		if (tally >= 0)	// cut any penalties in half
+			tally = tally/2
+		tally -= 1	// give 'em a buff on top.
 
 	return (tally+config.human_delay)
 


### PR DESCRIPTION
Adjusts CE_SPEEDBOOST and thus the effects of all chems that use it, most notably hyperzine and stimm.

Previously, having the effect meant movement_delay() would return -3 regardless of species, equipment, injuries, hunger, _whether you have legs_, or any other factors. The code comments note that it used to be -1 but that had the effect of slowing down teshari.

The new check takes place at the _end_ of the proc, after penalties for race, gear, injury, etc have been calculated, cuts said penalties in half, then applies a -1 buff.

Tested it with a selection of races running around the station.
Tajara and Teshari on new-hyperzine are still pretty sanic, but at least they can be slowed down if you tase the lil' buggers now.
Unathi and humans, the buff is definitely noticeable, reasonable sanicitude but a lil' slower than maxspeed.
Diona become actually bearable to play (and effectively get the biggest buff in terms of raw numbers).

Reason for this change is rather than the existing nerf of piling tox damage and such onto the chem to discourage the supersanic unslowable hyperspeed that was a problem, it addresses the mechanic that was causing the problem in the first place because people were just loading up on dylovene and continuing to sanic around.

If this is merged we could probably justify removing/reducing the toxic effects as it'll be an actual beneficial chem without being OP, or create a "hyperzine plus" chemical or something that is restricted in some other way than causing damage (such as requiring cooperation between chemistry and botany, like "hyperzine + some plant chem + phoron as catalyst" or similar).