### PR TITLE
Rename mecha power cell

### DIFF
--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -173,7 +173,7 @@
 		cell = C
 		return
 	cell = new(src)
-	cell.name = "high-capacity power cell"
+	cell.name = "mecha power cell"
 	cell.charge = 15000
 	cell.maxcharge = 15000
 


### PR DESCRIPTION
Sort of annoyng to have it named the same as an actual power cell, with a different max charge. If it's going to have a unique charge amount, it should have a unique name. High-cap cells are 10k, super are 20k, so this is some weird between-cell with 15k.