### PR TITLE
Re-fix for #2312

### DIFF
--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -413,7 +413,7 @@
 		if(istype(W,/obj/item/weapon/implant/health))
 			for(var/obj/machinery/computer/cloning/com in world)
 				for(var/datum/dna2/record/R in com.records)
-					if(R.implant == W)
+					if(locate(R.implant) == W)
 						qdel(R)
 						qdel(W)
 


### PR DESCRIPTION
The implant is stored as a string-reference, not an actual pointer, so you have to use locate() to resolve it into an actual pointer to see if that matches the implant we're removing.

Fixes #2312
Fixes https://github.com/VOREStation/VOREStation/issues/196