### PR TITLE
Fixes dragging items with storage onto an occupied hand

### DIFF
--- a/code/game/objects/items/weapons/storage/internal.dm
+++ b/code/game/objects/items/weapons/storage/internal.dm
@@ -50,10 +50,10 @@
 		if (!( user.restrained() ) && !( user.stat ))
 			switch(over_object.name)
 				if("r_hand")
-					user.u_equip(master_item)
+					user.unEquip(master_item)
 					user.put_in_r_hand(master_item)
 				if("l_hand")
-					user.u_equip(master_item)
+					user.unEquip(master_item)
 					user.put_in_l_hand(master_item)
 			master_item.add_fingerprint(user)
 			return 0

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -77,10 +77,10 @@
 
 		switch(over_object.name)
 			if("r_hand")
-				usr.u_equip(src)
+				usr.unEquip(src)
 				usr.put_in_r_hand(src)
 			if("l_hand")
-				usr.u_equip(src)
+				usr.unEquip(src)
 				usr.put_in_l_hand(src)
 		src.add_fingerprint(usr)
 

--- a/code/modules/paperwork/clipboard.dm
+++ b/code/modules/paperwork/clipboard.dm
@@ -23,10 +23,10 @@
 		if(!M.restrained() && !M.stat)
 			switch(over_object.name)
 				if("r_hand")
-					M.u_equip(src)
+					M.unEquip(src)
 					M.put_in_r_hand(src)
 				if("l_hand")
-					M.u_equip(src)
+					M.unEquip(src)
 					M.put_in_l_hand(src)
 
 			add_fingerprint(usr)

--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -98,10 +98,10 @@ var/global/photo_count = 0
 		if((!( M.restrained() ) && !( M.stat ) && M.back == src))
 			switch(over_object.name)
 				if("r_hand")
-					M.u_equip(src)
+					M.unEquip(src)
 					M.put_in_r_hand(src)
 				if("l_hand")
-					M.u_equip(src)
+					M.unEquip(src)
 					M.put_in_l_hand(src)
 			add_fingerprint(usr)
 			return


### PR DESCRIPTION
* If you mouse-drag certain items onto a hand which is already holding something, the item goes into limbo.
* The reason this happens is that the standard code handling drags is directly calling usr.u_equip, despite the comment on that proc clearly saying never to do that.  So it just throws it to limbo and the next line attempting to put it in hand does nothing becuase the hand is occupied.   Better way is to call unEquip, so the item will drop on the ground if it fails.
* Fixes https://github.com/VOREStation/VOREStation/issues/394