### PR TITLE
Fix formatting of security and medical notes in PDA.

### DIFF
--- a/nano/css/shared.css
+++ b/nano/css/shared.css
@@ -212,6 +212,10 @@ h4 {
 	font-size: 10px;
 }
 
+.multiLine {
+    white-space: pre-wrap;
+}
+
 .noticePlaceholder {
     position: relative;
     font-size: 12px;

--- a/nano/templates/pai_medrecords.tmpl
+++ b/nano/templates/pai_medrecords.tmpl
@@ -75,7 +75,7 @@ code/modules/mob/living/silicon/pai/software_modules.dm
 	</div>
 	<div class="item">
 		<div class="itemLabel">Important Notes</div>
-		<div class="itemContent">{{:data.medical.notes}}</div>
+		<div class="itemContent multiLine">{{:data.medical.notes}}</div>
 	</div>
 {{/if}}
 

--- a/nano/templates/pai_secrecords.tmpl
+++ b/nano/templates/pai_secrecords.tmpl
@@ -65,7 +65,7 @@ code/modules/mob/living/silicon/pai/software_modules.dm
 	</div>
 	<div class="item">
 		<div class="itemLabel">Important Notes</div>
-		<div class="itemContent">{{:data.security.notes}}</div>
+		<div class="itemContent multiLine">{{:data.security.notes}}</div>
 	</div>
 {{/if}}
 

--- a/nano/templates/pda.tmpl
+++ b/nano/templates/pda.tmpl
@@ -591,7 +591,7 @@ Used In File(s): \code\game\objects\items\devices\PDA\PDA.dm
                         <span class="good">Details:		</span> <span class="average">{{:data.records.medical.alg_d}}	</span><br><br>
                         <span class="good">Current Disease:	</span> <span class="average">{{:data.records.medical.cdi}}		</span><br>
                         <span class="good">Details:		</span> <span class="average">{{:data.records.medical.alg_d}}	</span><br><br>
-                        <span class="good">Important Notes:	</span> <span class="average">{{:data.records.medical.notes}}	</span>
+                        <span class="good">Important Notes:	</span> <span class="average multiLine">{{:data.records.medical.notes}}	</span>
                     {{else}}
                         <span class="bad">
                             Medical Record Lost!
@@ -643,7 +643,7 @@ Used In File(s): \code\game\objects\items\devices\PDA\PDA.dm
                         <span class="good">Details:  </span><span class="average">{{:data.records.security.mi_crim_d}} </span><br><br>
                         <span class="good">Major Crimes:  </span><span class="average">{{:data.records.security.ma_crim}} </span><br>
                         <span class="good">Details:  </span><span class="average">{{:data.records.security.ma_crim_d}} </span><br><br>
-                        <span class="good">Important Notes:   </span><span class="average">{{:data.records.security.notes}} </span>
+                        <span class="good">Important Notes:   </span><span class="average multiLine">{{:data.records.security.notes}} </span>
                     {{else}}
                         <span class="bad">
                             Security Record Lost!<br><br>


### PR DESCRIPTION
* Line beaks were being smooshed becuase PDA nanoui uses HTML template.  Fixed by adding white-space: pre-wrap style.
Fixes https://github.com/VOREStation/VOREStation/issues/807

Before:
![issue 807 sec records pda before](https://cloud.githubusercontent.com/assets/14110581/23190853/72845646-f868-11e6-9aa5-d0517b61a5a5.PNG)

After:
![issue 807 sec records pda after](https://cloud.githubusercontent.com/assets/14110581/23190858/79138c66-f868-11e6-96b9-c64d00f08632.PNG)
