### PR TITLE
BlockHeadHair doesn't make players bald.

### DIFF
--- a/code/modules/clothing/head/jobs.dm
+++ b/code/modules/clothing/head/jobs.dm
@@ -34,7 +34,7 @@
 	desc = "It's hood that covers the head. It keeps you warm during the space winters."
 	icon_state = "chaplain_hood"
 	item_state_slots = list(slot_r_hand_str = "beret_black", slot_l_hand_str = "beret_black")
-	flags_inv = BLOCKHAIR
+	flags_inv = BLOCKHEADHAIR
 	body_parts_covered = HEAD
 
 //Chaplain
@@ -43,7 +43,7 @@
 	desc = "Maximum piety in this star system."
 	icon_state = "nun_hood"
 	item_state_slots = list(slot_r_hand_str = "beret_black", slot_l_hand_str = "beret_black")
-	flags_inv = BLOCKHAIR
+	flags_inv = BLOCKHEADHAIR
 	body_parts_covered = HEAD
 
 //Mime

--- a/code/modules/clothing/head/misc.dm
+++ b/code/modules/clothing/head/misc.dm
@@ -81,7 +81,7 @@
 	desc = "It's unspeakably stylish"
 	icon_state = "hasturhood"
 	item_state_slots = list(slot_r_hand_str = "enginering_beret", slot_l_hand_str = "enginering_beret")
-	flags_inv = BLOCKHAIR
+	flags_inv = BLOCKHEADHAIR
 	body_parts_covered = HEAD|FACE|EYES
 
 /obj/item/clothing/head/nursehat

--- a/code/modules/clothing/spacesuits/miscellaneous.dm
+++ b/code/modules/clothing/spacesuits/miscellaneous.dm
@@ -44,8 +44,7 @@
 	icon_state = "beret_badge"
 	item_state_slots = list(slot_r_hand_str = "beret", slot_l_hand_str = "beret")
 	armor = list(melee = 65, bullet = 55, laser = 35,energy = 20, bomb = 30, bio = 30, rad = 30)
-	item_flags = STOPPRESSUREDAMAGE
-	flags_inv = BLOCKHAIR
+	flags_inv = BLOCKHEADHAIR
 	siemens_coefficient = 0.9
 
 //Space santa outfit suit

--- a/code/modules/clothing/suits/miscellaneous.dm
+++ b/code/modules/clothing/suits/miscellaneous.dm
@@ -688,7 +688,7 @@
 	icon_state = "generic_hood"
 	body_parts_covered = HEAD
 	cold_protection = HEAD
-	flags_inv = HIDEEARS | BLOCKHEADHAIR
+	flags_inv = HIDEEARS | BLOCKHAIR
 	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
 
 /obj/item/clothing/suit/storage/hooded/wintercoat/captain

--- a/code/modules/clothing/suits/miscellaneous.dm
+++ b/code/modules/clothing/suits/miscellaneous.dm
@@ -688,7 +688,7 @@
 	icon_state = "generic_hood"
 	body_parts_covered = HEAD
 	cold_protection = HEAD
-	flags_inv = HIDEEARS | BLOCKHAIR
+	flags_inv = HIDEEARS | BLOCKHEADHAIR
 	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
 
 /obj/item/clothing/suit/storage/hooded/wintercoat/captain

--- a/code/modules/clothing/suits/utility.dm
+++ b/code/modules/clothing/suits/utility.dm
@@ -78,7 +78,7 @@
 	name = "Radiation Hood"
 	icon_state = "rad"
 	desc = "A hood with radiation protective properties. Label: Made with lead, do not eat insulation"
-	flags_inv = BLOCKHAIR
+	flags_inv = BLOCKHEADHAIR
 	body_parts_covered = HEAD|FACE|EYES
 	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 60, rad = 100)
 

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -363,31 +363,7 @@ var/global/list/damage_icon_parts = list()
 		if(update_icons)   update_icons()
 		return
 
-	//base icons
-	var/icon/face_standing	= new /icon('icons/mob/human_face.dmi',"bald_s")
-
-	if(f_style)
-		var/datum/sprite_accessory/facial_hair_style = facial_hair_styles_list[f_style]
-		if(facial_hair_style && facial_hair_style.species_allowed && (src.species.get_bodytype(src) in facial_hair_style.species_allowed))
-			var/icon/facial_s = new/icon("icon" = facial_hair_style.icon, "icon_state" = "[facial_hair_style.icon_state]_s")
-			if(facial_hair_style.do_colouration)
-				facial_s.Blend(rgb(r_facial, g_facial, b_facial), ICON_ADD)
-
-			face_standing.Blend(facial_s, ICON_OVERLAY)
-
-	if(h_style && !(head && (head.flags_inv & BLOCKHEADHAIR)))
-		var/datum/sprite_accessory/hair_style = hair_styles_list[h_style]
-		if(hair_style && (src.species.get_bodytype(src) in hair_style.species_allowed))
-			var/icon/hair_s = new/icon("icon" = hair_style.icon, "icon_state" = "[hair_style.icon_state]_s")
-			if(hair_style.do_colouration)
-				hair_s.Blend(rgb(r_hair, g_hair, b_hair), ICON_ADD)
-
-			face_standing.Blend(hair_s, ICON_OVERLAY)
-
-	if(head_organ.nonsolid)
-		face_standing += rgb(,,,120)
-
-	overlays_standing[HAIR_LAYER]	= image(face_standing)
+	overlays_standing[HAIR_LAYER]	= head_organ.get_hair_icon()
 
 	if(update_icons)   update_icons()
 

--- a/code/modules/mob/new_player/sprite_accessories.dm
+++ b/code/modules/mob/new_player/sprite_accessories.dm
@@ -51,8 +51,8 @@
 	bald
 		name = "Bald"
 		icon_state = "bald"
-		species_allowed = list("Human","Unathi")
 		gender = MALE
+		species_allowed = list("Human","Unathi")
 		veryshort=1
 
 	short
@@ -544,7 +544,7 @@
 	tightbun
 		name = "Tight Bun"
 		icon_state = "hair_tightbun"
-		gender= FEMALE
+		gender = FEMALE
 
 	coffeehouse
 		name = "Coffee House Cut"

--- a/code/modules/mob/new_player/sprite_accessories.dm
+++ b/code/modules/mob/new_player/sprite_accessories.dm
@@ -52,6 +52,7 @@
 		name = "Bald"
 		icon_state = "bald"
 		species_allowed = list("Human","Unathi")
+		gender = MALE
 		veryshort=1
 
 	short
@@ -401,6 +402,7 @@
 	balding
 		name = "Balding Hair"
 		icon_state = "hair_e"
+		gender = MALE
 		veryshort=1
 
 	familyman
@@ -502,6 +504,7 @@
 	lowfade
 		name = "Low Fade"
 		icon_state = "hair_lowfade"
+		gender = MALE
 		veryshort=1
 
 	medfade
@@ -512,11 +515,13 @@
 	highfade
 		name = "High Fade"
 		icon_state = "hair_highfade"
+		gender = MALE
 		veryshort=1
 
 	baldfade
 		name = "Balding Fade"
 		icon_state = "hair_baldfade"
+		gender = MALE
 		veryshort=1
 
 	nofade
@@ -527,28 +532,34 @@
 	trimflat
 		name = "Trimmed Flat Top"
 		icon_state = "hair_trimflat"
+		gender = MALE
 		veryshort=1
 
 	trimmed
 		name = "Trimmed"
 		icon_state = "hair_trimmed"
+		gender = MALE
 		veryshort=1
 
 	tightbun
 		name = "Tight Bun"
 		icon_state = "hair_tightbun"
+		gender= FEMALE
 
 	coffeehouse
 		name = "Coffee House Cut"
 		icon_state = "hair_coffeehouse"
+		gender = MALE
 
 	undercut
 		name = "Undercut"
 		icon_state = "hair_undercut"
+		gender = MALE
 
 	partfade
 		name = "Parted Fade"
 		icon_state = "hair_shavedpart"
+		gender = MALE
 
 
 /*
@@ -568,6 +579,7 @@
 		name = "Shaved"
 		icon_state = "bald"
 		species_allowed = list("Human","Unathi","Tajara","Skrell", "Machine","Teshari", "Vox")
+		gender = NEUTER
 
 	watson
 		name = "Watson Mustache"

--- a/code/modules/mob/new_player/sprite_accessories.dm
+++ b/code/modules/mob/new_player/sprite_accessories.dm
@@ -46,16 +46,19 @@
 /datum/sprite_accessory/hair
 
 	icon = 'icons/mob/Human_face.dmi'	  // default icon for all hairs
+	var/veryshort
 
 	bald
 		name = "Bald"
 		icon_state = "bald"
 		gender = MALE
 		species_allowed = list("Human","Unathi")
+		veryshort=1
 
 	short
 		name = "Short Hair"	  // try to capatilize the names please~
 		icon_state = "hair_a" // you do not need to define _s or _l sub-states, game automatically does this for you
+		veryshort=1
 
 	short2
 		name = "Short Hair 2"
@@ -96,10 +99,12 @@
 	halfbang
 		name = "Half-banged Hair"
 		icon_state = "hair_halfbang"
+		veryshort=1
 
 	halfbangalt
 		name = "Half-banged Hair Alt"
 		icon_state = "hair_halfbang_alt"
+		veryshort=1
 
 	ponytail1
 		name = "Ponytail 1"
@@ -167,6 +172,7 @@
 	sleeze
 		name = "Sleeze"
 		icon_state = "hair_sleeze"
+		veryshort=1
 
 	quiff
 		name = "Quiff"
@@ -217,31 +223,38 @@
 	bowl
 		name = "Bowl"
 		icon_state = "hair_bowlcut"
+		veryshort=1
 
 	buzz
 		name = "Buzzcut"
 		icon_state = "hair_buzzcut"
 		species_allowed = list("Human","Unathi")
+		veryshort=1
 
 	shavehair
 		name = "Shaved Hair"
 		icon_state = "hair_shaved"
+		veryshort=1
 
 	crew
 		name = "Crewcut"
 		icon_state = "hair_crewcut"
+		veryshort=1
 
 	combover
 		name = "Combover"
 		icon_state = "hair_combover"
+		veryshort=1
 
 	father
 		name = "Father"
 		icon_state = "hair_father"
+		veryshort=1
 
 	reversemohawk
 		name = "Reverse Mohawk"
 		icon_state = "hair_reversemohawk"
+		veryshort=1
 
 	devillock
 		name = "Devil Lock"
@@ -270,14 +283,17 @@
 	rows
 		name = "Rows"
 		icon_state = "hair_rows1"
+		veryshort=1
 
 	rows2
 		name = "Rows 2"
 		icon_state = "hair_rows2"
+		veryshort=1
 
 	sargeant
 		name = "Flat Top"
 		icon_state = "hair_sargeant"
+		veryshort=1
 
 	emo
 		name = "Emo"
@@ -314,6 +330,7 @@
 	fag
 		name = "Flow Hair"
 		icon_state = "hair_f"
+		veryshort=1
 
 	feather
 		name = "Feather"
@@ -380,11 +397,13 @@
 	skinhead
 		name = "Skinhead"
 		icon_state = "hair_skinhead"
+		veryshort=1
 
 	balding
 		name = "Balding Hair"
 		icon_state = "hair_e"
 		gender = MALE // turnoff!
+		veryshort=1
 
 	familyman
 		name = "The Family Man"
@@ -464,6 +483,7 @@
 	shortbangs
 		name = "Short Bangs"
 		icon_state = "hair_shortbangs"
+		veryshort=1
 
 	halfshaved
 		name = "Half-Shaved Emo"
@@ -484,21 +504,22 @@
 	lowfade
 		name = "Low Fade"
 		icon_state = "hair_lowfade"
-		gender = MALE
+		veryshort=1
 
 	medfade
 		name = "Medium Fade"
 		icon_state = "hair_medfade"
+		veryshort=1
 
 	highfade
 		name = "High Fade"
 		icon_state = "hair_highfade"
-		gender = MALE
+		veryshort=1
 
 	baldfade
 		name = "Balding Fade"
 		icon_state = "hair_baldfade"
-		gender = MALE
+		veryshort=1
 
 	nofade
 		name = "Regulation Cut"
@@ -508,32 +529,28 @@
 	trimflat
 		name = "Trimmed Flat Top"
 		icon_state = "hair_trimflat"
-		gender = MALE
+		veryshort=1
 
 	trimmed
 		name = "Trimmed"
 		icon_state = "hair_trimmed"
-		gender = MALE
+		veryshort=1
 
 	tightbun
 		name = "Tight Bun"
 		icon_state = "hair_tightbun"
-		gender = FEMALE
 
 	coffeehouse
 		name = "Coffee House Cut"
 		icon_state = "hair_coffeehouse"
-		gender = MALE
 
 	undercut
 		name = "Undercut"
 		icon_state = "hair_undercut"
-		gender = MALE
 
 	partfade
 		name = "Parted Fade"
 		icon_state = "hair_shavedpart"
-		gender = MALE
 
 
 /*
@@ -547,12 +564,10 @@
 /datum/sprite_accessory/facial_hair
 
 	icon = 'icons/mob/Human_face.dmi'
-	gender = MALE // barf (unless you're a dorf, dorfs dig chix /w beards :P)
 
 	shaved
 		name = "Shaved"
 		icon_state = "bald"
-		gender = NEUTER
 		species_allowed = list("Human","Unathi","Tajara","Skrell", "Machine","Teshari", "Vox")
 
 	watson

--- a/code/modules/mob/new_player/sprite_accessories.dm
+++ b/code/modules/mob/new_player/sprite_accessories.dm
@@ -562,6 +562,7 @@
 /datum/sprite_accessory/facial_hair
 
 	icon = 'icons/mob/Human_face.dmi'
+	gender = MALE // barf (unless you're a dorf, dorfs dig chix /w beards :P)
 
 	shaved
 		name = "Shaved"

--- a/code/modules/mob/new_player/sprite_accessories.dm
+++ b/code/modules/mob/new_player/sprite_accessories.dm
@@ -51,7 +51,6 @@
 	bald
 		name = "Bald"
 		icon_state = "bald"
-		gender = MALE
 		species_allowed = list("Human","Unathi")
 		veryshort=1
 
@@ -402,7 +401,6 @@
 	balding
 		name = "Balding Hair"
 		icon_state = "hair_e"
-		gender = MALE // turnoff!
 		veryshort=1
 
 	familyman
@@ -733,15 +731,14 @@
 	skr_tentacle_m
 		name = "Skrell Male Tentacles"
 		icon_state = "skrell_hair_m"
-		species_allowed = list("Skrell")
 		gender = MALE
+		species_allowed = list("Skrell")
 
 	skr_tentacle_f
 		name = "Skrell Female Tentacles"
 		icon_state = "skrell_hair_f"
-		species_allowed = list("Skrell")
 		gender = FEMALE
-
+		species_allowed = list("Skrell")
 //Tajaran hairstyles
 	taj_ears
 		name = "Tajaran Ears"

--- a/code/modules/organs/organ_icon.dm
+++ b/code/modules/organs/organ_icon.dm
@@ -65,23 +65,33 @@ var/global/list/limb_icon_cache = list()
 		overlays |= lip_icon
 		mob_icon.Blend(lip_icon, ICON_OVERLAY)
 
+	overlays |= get_hair_icon()
+
+	return mob_icon
+
+/obj/item/organ/external/head/proc/get_hair_icon()
+	var/image/res = image('icons/mob/human_face.dmi',"bald_s")
 	if(owner.f_style)
 		var/datum/sprite_accessory/facial_hair_style = facial_hair_styles_list[owner.f_style]
-		if(facial_hair_style && facial_hair_style.species_allowed && (species.get_bodytype(owner) in facial_hair_style.species_allowed))
+		if(facial_hair_style && facial_hair_style.species_allowed && (species.get_bodytype() in facial_hair_style.species_allowed))
 			var/icon/facial_s = new/icon("icon" = facial_hair_style.icon, "icon_state" = "[facial_hair_style.icon_state]_s")
 			if(facial_hair_style.do_colouration)
 				facial_s.Blend(rgb(owner.r_facial, owner.g_facial, owner.b_facial), ICON_ADD)
-			overlays |= facial_s
+			res.overlays |= facial_s
 
-	if(owner.h_style && !(owner.head && (owner.head.flags_inv & BLOCKHEADHAIR)))
-		var/datum/sprite_accessory/hair_style = hair_styles_list[owner.h_style]
-		if(hair_style && (species.get_bodytype(owner) in hair_style.species_allowed))
+	if(owner.h_style)
+		var/style = owner.h_style
+		var/datum/sprite_accessory/hair/hair_style = hair_styles_list[style]
+		if(owner.head && (owner.head.flags_inv & BLOCKHEADHAIR))
+			if(!hair_style.veryshort)
+				hair_style = hair_styles_list["Short Hair"]
+		if(hair_style && (species.get_bodytype() in hair_style.species_allowed))
 			var/icon/hair_s = new/icon("icon" = hair_style.icon, "icon_state" = "[hair_style.icon_state]_s")
 			if(hair_style.do_colouration && islist(h_col) && h_col.len >= 3)
 				hair_s.Blend(rgb(h_col[1], h_col[2], h_col[3]), ICON_ADD)
-			overlays |= hair_s
+			res.overlays |= hair_s
+	return res
 
-	return mob_icon
 
 /obj/item/organ/external/proc/get_icon(var/skeletal)
 

--- a/code/modules/xenoarcheaology/tools/equipment.dm
+++ b/code/modules/xenoarcheaology/tools/equipment.dm
@@ -11,6 +11,7 @@
 	icon_state = "engspace_helmet"
 	item_state = "engspace_helmet"
 	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 100, rad = 100)
+	flags_inv = BLOCKHEADHAIR
 
 /obj/item/clothing/suit/space/anomaly
 	name = "Excavation suit"
@@ -27,3 +28,4 @@
 	icon_state = "cespace_helmet"
 	item_state = "cespace_helmet"
 	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 100, rad = 100)
+	flags_inv = BLOCKHEADHAIR

--- a/html/changelogs/nachomeep - HEADHAIR.yml
+++ b/html/changelogs/nachomeep - HEADHAIR.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: nachomeep
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Helmets and other items with the BLOCKHEADHAIR tag now replace the style with shorthair rather than causing balding."


### PR DESCRIPTION
Instead, it replaces their hairstyle with short hair [unless their hair was already short enough to not have any clipping issues]. Also replaces a lot of 'BLOCKHAIR' tags with 'BLOCKHEADHAIR', because chaplains should have beards visible when their hoods are on.

Tested. It works. No clipping issues found. Point out any other hair that should be allowed and any that should be disallowed, and any items that need tag updates regarding BLOCKHAIR and BLOCKHEADHAIR.

Mostly ported from - https://github.com/Baystation12/Baystation12/pull/14239