### PR TITLE
Gives not equal gate the correct icon_state

### DIFF
--- a/code/modules/integrated_electronics/subtypes/logic.dm
+++ b/code/modules/integrated_electronics/subtypes/logic.dm
@@ -60,7 +60,7 @@
 /obj/item/integrated_circuit/logic/binary/not_equals
 	name = "not equal gate"
 	desc = "This gate compares two values, and outputs the number one if both are different."
-	icon_state = "not equal"
+	icon_state = "not_equal"
 	spawn_flags = IC_SPAWN_DEFAULT|IC_SPAWN_RESEARCH
 
 /obj/item/integrated_circuit/logic/binary/not_equals/do_compare(var/datum/integrated_io/A, var/datum/integrated_io/B)


### PR DESCRIPTION
Gives the not equal gate a correct icon_state. Icon state was set to"not equal"

 In the electronic_assemblies.dmi it is actually "not_equal"

This gives it the correct icon_state

Solves #2999 