### PR TITLE
Prevents halloss showing up as actual wounds on self examine

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -166,11 +166,13 @@
 				var/list/status = list()
 				var/brutedamage = org.brute_dam
 				var/burndamage = org.burn_dam
-				if(halloss > 0)
+				/*
+				if(halloss > 0) //Makes halloss show up as actual wounds on self examine.
 					if(prob(30))
 						brutedamage += halloss
 					if(prob(30))
 						burndamage += halloss
+				*/
 				switch(brutedamage)
 					if(1 to 20)
 						status += "bruised"


### PR DESCRIPTION
Fixes #577 by making halloss not show up as wounds on self examine.

Unsure if this removal is actually wanted anymore (Since the issue is from 2015.)

Pretty much all this PR does is stop halloss from making it appear like you have really severe wounds on self examine, as looking at yourself after being shot with a taser shouldn't appear like you have third degree burns all over.