### PR TITLE
Make blood loss/heart removal make sense

### DIFF
--- a/code/modules/organs/blood.dm
+++ b/code/modules/organs/blood.dm
@@ -109,12 +109,14 @@ var/const/BLOOD_VOLUME_SURVIVE = 40
 			if(prob(15))
 				var/word = pick("dizzy","woosey","faint")
 				src << "\red You feel extremely [word]"
-		else
-			// There currently is a strange bug here. If the mob is not below -100 health
-			// when death() is called, apparently they will be just fine, and this way it'll
-			// spam deathgasp. Adjusting toxloss ensures the mob will stay dead.
-			toxloss += 300 // just to be safe!
-			death()
+		else //Not enough blood to survive (usually)
+			if(!pale)
+				pale = 1
+				update_body()
+			eye_blurry = max(eye_blurry,6)
+			Paralyse(3)
+			toxloss += 3
+			oxyloss += 75 // 15 more than dexp fixes (also more than dex+dexp+tricord)
 
 		// Without enough blood you slowly go hungry.
 		if(blood_volume < BLOOD_VOLUME_SAFE)

--- a/html/changelogs/Arokha-Blood.yml
+++ b/html/changelogs/Arokha-Blood.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Arokha
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+   tweak: "Having less than 30% blood (as a result of literally having that little blood, or a broken heart) causes 75 oxyloss per tick rather than 300 toxins and instant death, to allow for heart transplants."


### PR DESCRIPTION
Right now it gives you 300 toxin damage "to be sure" you die. That's a little odd. Especially on health scanners after someone has bled to death. And you can't do heart transplants. We can do heart transplants now in 2017. 3500 per year. Pretty sure they won't forget how by 2561 or whatever.

This makes having no heart or too little blood do 75 oxyloss per tick. Enough to kill you eight seconds if you have no special care. It becomes 15 per tick with dexP which is fast enough to kill you "pretty fastly" and slow enough you can swap out a heart in surgery.

With dexP+dex+tric it becomes a meager 10ish per tick, but an inevitable 10 per tick as they are literally now full of every oxyloss removing drug in the game. So you can survive a part of a minute, max, with not enough blood. You're still paralyzed and eye_blurry for most of it. You should probably be in surgery.