### PR TITLE
Fixing runtimes, making things functional for the Xenobiology Console

### DIFF
--- a/code/modules/xenobio2/machinery/injector_computer.dm
+++ b/code/modules/xenobio2/machinery/injector_computer.dm
@@ -21,7 +21,6 @@
 
 /obj/machinery/computer/xenobio2/Destroy()
 	..()
-	injector.computer = null
 
 /obj/machinery/computer/xenobio2/attack_hand(mob/user)
 	if(..())
@@ -109,5 +108,5 @@
 
 /obj/item/weapon/circuitboard/xenobio2computer
 	name = T_BOARD("injector control console")
-	build_path = /obj/item/weapon/circuitboard/xenobio2computer
-	origin_tech = list()	//To be filled,
+	build_path = /obj/machinery/computer/xenobio2
+	origin_tech = list()	//To be filled


### PR DESCRIPTION
The old build path pointed towards a circuitboard instead of towards the
machine, meaning when you screwdrivered the frame twice, it would cause
frame.dm to runtime, and then not delete the frame, meaning you could
spam click the console with a screwdriver and spawn infinite boards, and
still be stuck with a non functional machine.

injector.computer = null was causing a runtime because it was attempting
to edit something that no longer existed on destruction.