### PR TITLE
Fixing issues with the Xenobiology Computer.

### DIFF
--- a/code/modules/xenobio2/machinery/injector_computer.dm
+++ b/code/modules/xenobio2/machinery/injector_computer.dm
@@ -21,7 +21,6 @@
 
 /obj/machinery/computer/xenobio2/Destroy()
 	..()
-	injector.computer = null
 
 /obj/machinery/computer/xenobio2/attack_hand(mob/user)
 	if(..())
@@ -109,5 +108,5 @@
 
 /obj/item/weapon/circuitboard/xenobio2computer
 	name = T_BOARD("injector control console")
-	build_path = /obj/item/weapon/circuitboard/xenobio2computer
-	origin_tech = list()	//To be filled,
+	build_path = /obj/machinery/computer/xenobio2
+	origin_tech = list()	//To be filled

--- a/code/modules/xenobio2/machinery/injector_computer.dm
+++ b/code/modules/xenobio2/machinery/injector_computer.dm
@@ -20,6 +20,7 @@
 	var/active
 
 /obj/machinery/computer/xenobio2/Destroy()
+	injector.computer = null
 	..()
 
 /obj/machinery/computer/xenobio2/attack_hand(mob/user)


### PR DESCRIPTION
injector.computer=null was being called after deletion, causing it to runtime. This resolves that issue by placing it inside the operation instead of outside.

The build_path for the computer was pointing towards the circuiboard as the end result instead of the machine, causing a runtime in frame.dm when you screwdrivered the console twice, the computer wasn't reconstructable.