### PR TITLE
Fix custom items appearing in random space turfs

### DIFF
--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -335,7 +335,6 @@
 	var/mob/living/character = create_character()	//creates the human and transfers vars and mind
 	character = job_master.EquipRank(character, rank, 1)					//equips the human
 	UpdateFactionList(character)
-	equip_custom_items(character)
 
 	// AIs don't need a spawnpoint, they must spawn at an empty core
 	if(character.mind.assigned_role == "AI")
@@ -357,6 +356,8 @@
 
 	//Find our spawning point.
 	var/join_message = job_master.LateSpawn(character, rank)
+	// Equip our custom items only AFTER deploying to spawn points eh?
+	equip_custom_items(character)
 
 	character.lastarea = get_area(loc)
 	// Moving wheelchair if they have one


### PR DESCRIPTION
* If a custom item can't be equipped to a character's inventory it is dropped on the ground.  For late join characters, equip_custom_item() was called *before* the mob was placed at their starting locations; their coordinates were still 1,1,1.   Which is the edge of a map so the dropped items get bounced to another z level.
* Fix: Equip custom items AFTER job_master.LateSpawn places the mob at the starting location, so it flows in same order as roundstart join characters.