### PR TITLE
Fix two extra robust bugs

### DIFF
--- a/code/game/objects/items/weapons/trays.dm
+++ b/code/game/objects/items/weapons/trays.dm
@@ -17,7 +17,7 @@
 	var/max_carry = 10
 
 /obj/item/weapon/tray/attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob)
-
+	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 	// Drop all the things. All of them.
 	overlays.Cut()
 	for(var/obj/item/I in carrying)

--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -133,7 +133,7 @@
 			user  << "<span class='notice'>\The [src] already has someone buckled to it.</span>"
 			return
 		user.visible_message("<span class='notice'>[user] attempts to buckle [affecting] into \the [src]!</span>")
-		if(do_after(user, 20))
+		if(do_after(user, 20, G.affecting))
 			affecting.loc = loc
 			spawn(0)
 				if(buckle_mob(affecting))


### PR DESCRIPTION
Trays have no attack cooldown because they have this crazy-long snowflake code for attacks.

Beds (and children like chairs) don't track target for grab-buckle do_after, letting them run away and get teleported back to the chair and buckled regardless of their efforts.