### PR TITLE
Fix server startup runtimes from uninitaizlied var

### DIFF
--- a/code/_helpers/names.dm
+++ b/code/_helpers/names.dm
@@ -16,7 +16,7 @@ var/church_name = null
 	return name
 
 /proc/command_name()
-	if (using_map.boss_name)
+	if(istype(using_map))
 		return using_map.boss_name
 
 /proc/change_command_name(var/name)


### PR DESCRIPTION
* That if statement wasn't heping anyone as it was.
* Strangely however, even an `if(using_map)` doesn't help, as using_map is in some crazy BYOND limbo state at that point in world init.  but checking istype() succeeds in figuring out its not real.