### PR TITLE
Extend Station Blueprints to consider outdoor mining areas as "space"

### DIFF
--- a/code/game/objects/items/blueprints.dm
+++ b/code/game/objects/items/blueprints.dm
@@ -19,6 +19,23 @@
 	var/const/ROOM_ERR_SPACE = -1
 	var/const/ROOM_ERR_TOOLARGE = -2
 
+	var/static/list/SPACE_AREA_TYPES = list(
+		/area/space,
+		/area/mine
+	)
+	var/static/list/SPECIAL_AREA_TYPES = list(
+		/area/shuttle,
+		/area/admin,
+		/area/arrival,
+		/area/centcom,
+		/area/asteroid,
+		/area/tdome,
+		/area/syndicate_station,
+		/area/wizard_station,
+		/area/prison
+		// /area/derelict //commented out, all hail derelict-rebuilders!
+	)
+
 /obj/item/blueprints/attack_self(mob/M as mob)
 	if (!istype(M,/mob/living/carbon/human))
 		M << "This stack of blue paper means nothing to you." //monkeys cannot into projecting
@@ -79,22 +96,11 @@ move an amendment</a> to the drawing.</p>
 	return A
 
 /obj/item/blueprints/proc/get_area_type(var/area/A = get_area())
-	if(istype(A, /area/space))
-		return AREA_SPACE
-	var/list/SPECIALS = list(
-		/area/shuttle,
-		/area/admin,
-		/area/arrival,
-		/area/centcom,
-		/area/asteroid,
-		/area/tdome,
-		/area/syndicate_station,
-		/area/wizard_station,
-		/area/prison
-		// /area/derelict //commented out, all hail derelict-rebuilders!
-	)
-	for (var/type in SPECIALS)
-		if ( istype(A,type) )
+	for(var/type in SPACE_AREA_TYPES)
+		if(istype(A, type))
+			return AREA_SPACE
+	for (var/type in SPECIAL_AREA_TYPES)
+		if(istype(A, type))
 			return AREA_SPECIAL
 	return AREA_STATION
 


### PR DESCRIPTION
* Allows constructing new rooms out of the asteroid!  Previously blueprint couldn't because it wasn't technically "/area/space"
* Also moved the list of what area types count as space or protected to variables so its not a list embedded in the middle of a proc...

The only actual change here is adding /area/mine to the list of "space" area types.  The other changes are just code style improvements.
Long story short, on northern star most of the station is surrounded by asteroid instead of "space"   Its effectively still "outside" but because its not exactly /area/space blueprints don't work to create rooms out of it even if you perfectly enclose it. 