### PR TITLE
Adds Supply Shuttle Hook

### DIFF
--- a/code/controllers/hooks-defs.dm
+++ b/code/controllers/hooks-defs.dm
@@ -85,3 +85,12 @@
  * Parameters: var/obj/structure/closet/crate/sold, var/area/shuttle
  */
 /hook/sell_crate
+
+/**
+ * Supply Shuttle sold hook.
+ * Called in supplyshuttle.dm when the shuttle contents are sold.
+ * This hook is called _before_ the crates are processed for normal
+ * phoron/metal sale (and before the sell_crate hooks)
+ * Parameters: var/area/area_shuttle
+ */
+/hook/sell_shuttle

--- a/code/game/supplyshuttle.dm
+++ b/code/game/supplyshuttle.dm
@@ -184,6 +184,8 @@ var/list/mechtoys = list(
 		var/area/area_shuttle = shuttle.get_location_area()
 		if(!area_shuttle)	return
 
+		callHook("sell_shuttle", list(area_shuttle));
+
 		var/phoron_count = 0
 		var/plat_count = 0
 


### PR DESCRIPTION
* Adds a global hook for when the supply shuttle reaches centcom.  The existing sell_crate hook is too limited, as it only detects what is in crates, and is fired many times, making it hard to produce a summary for events that might want stuff shipped on the shuttle.

I think a variety of random events will want to involve the station producing things.  Lore already establishes that the station exports stuff via the supply shuttle, so its a good way to do it.  Having a hook makes it easy for such events to do it non-invasively.

I'm currently working on such an event, and it would be nice to have this infrastructure in place for it.