### PR TITLE
Borg Custom-sprite Fix: Panels

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -689,7 +689,7 @@
 		overlays += "eyes-[module_sprites[icontype]]"
 
 	if(opened)
-		var/panelprefix = custom_sprite ? src.ckey : "ov"
+		var/panelprefix = custom_sprite ? "[src.ckey]-[src.name]" : "ov"
 		if(wiresexposed)
 			overlays += "[panelprefix]-openpanel +w"
 		else if(cell)


### PR DESCRIPTION
Borg custom sprites previously could only use one panel sprite. This is an issue for borgs of differing / changing heights among multiple sets per one person.

Framework would now be " ckey-Borgname-openpanel +w/+c/-c " to match the form of the sprites themselves.