### PR TITLE
Fix internal bleeding on adv med scanners

### DIFF
--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -335,16 +335,15 @@
 					organStatus["bleeding"] = 1
 				if(E.status & ORGAN_DEAD)
 					organStatus["dead"] = 1
+				for(var/datum/wound/W in E.wounds)
+					if(W.internal)
+						organStatus["internalBleeding"] = 1
+						break
 
 				organData["status"] = organStatus
 
 				if(istype(E, /obj/item/organ/external/chest) && H.is_lung_ruptured())
 					organData["lungRuptured"] = 1
-
-				for(var/datum/wound/W in E.wounds)
-					if(W.internal)
-						organData["internalBleeding"] = 1
-						break
 
 				extOrganData.Add(list(organData))
 


### PR DESCRIPTION
The nanoui template expects "internalBleeding" to be in the organStatus list, not in the organData list. I agree with this expectation, as this is also where normal "bleeding" is stored, so I updated the adv_med.dm file rather than changing the template.