### PR TITLE
Two bugfixes for recent saycode stuff

### DIFF
--- a/code/modules/mob/hear_say.dm
+++ b/code/modules/mob/hear_say.dm
@@ -94,7 +94,7 @@
 	var/list/valid_names = splittext(real_name, " ") // Should output list("John", "Doe") as an example.
 	valid_names += special_mentions()
 	for(var/name in valid_names)
-		if(findtext(message, name))
+		if(findtext(message, regex("\\b[name]\\b", "i"))) // This is to stop 'ai' from triggering if someone says 'wait'.
 			return TRUE
 	return FALSE
 
@@ -108,7 +108,7 @@
 // Converts specific characters, like *, /, and _ to formatted output.
 /mob/proc/say_emphasis(var/message)
 	message = encode_html_emphasis(message, "/", "i")
-	message = encode_html_emphasis(message, "*", "b")
+	message = encode_html_emphasis(message, "+", "b")
 	message = encode_html_emphasis(message, "_", "u")
 	return message
 


### PR DESCRIPTION
Makes the mention system more robust on name detection.
Changes * to + for bolding.
Should fix #3084 