### PR TITLE
Update values after equalizing gas mixtures.

### DIFF
--- a/code/modules/xgm/xgm_gas_mixture.dm
+++ b/code/modules/xgm/xgm_gas_mixture.dm
@@ -110,6 +110,9 @@
 		temperature = ((temperature * our_heatcap) + (sharer.temperature * share_heatcap)) / (our_heatcap + share_heatcap)
 	sharer.temperature = temperature
 
+	update_values()
+	sharer.update_values()
+
 	return 1
 
 


### PR DESCRIPTION
Fixes https://github.com/VOREStation/VOREStation/issues/1192
* If we do not do this, zones are left with the wrong total_moles (and therefore the wrong **pressure readout**) after equalizing.
* Equalizing happens when two connected zones get close enough to suspend processing. Thus the effect of this bug would be wrong pressure readings on rooms that are no longer being updated, thus locking in the wrong value!