### PR TITLE
Fix runtimes in controllers

### DIFF
--- a/code/controllers/Processes/mob.dm
+++ b/code/controllers/Processes/mob.dm
@@ -14,7 +14,7 @@
 /datum/controller/process/mob/doWork()
 	for(last_object in mob_list)
 		var/mob/M = last_object
-		if(isnull(M.gcDestroyed))
+		if(M && isnull(M.gcDestroyed))
 			try
 				M.Life()
 			catch(var/exception/e)

--- a/code/controllers/Processes/obj.dm
+++ b/code/controllers/Processes/obj.dm
@@ -11,7 +11,7 @@
 /datum/controller/process/obj/doWork()
 	for(last_object in processing_objects)
 		var/datum/O = last_object
-		if(isnull(O.gcDestroyed))
+		if(O && isnull(O.gcDestroyed))
 			try
 				O:process()
 			catch(var/exception/e)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -341,7 +341,7 @@
 	if ((stat != 2 || !( ticker )))
 		usr << "<span class='notice'><B>You must be dead to use this!</B></span>"
 		return
-	if (ticker.mode.deny_respawn) //BS12 EDIT
+	if (ticker.mode && ticker.mode.deny_respawn) //BS12 EDIT
 		usr << "<span class='notice'>Respawn is disabled for this roundtype.</span>"
 		return
 	else


### PR DESCRIPTION
##### Fix runtime in mob controller loop.
* Any nulls present in the mob_list would cause a runtime when checked if they are gcDestroyed.  Add a null check.
* Noticed that the object controller has the same bug, might as well fix now too.
##### Fix another runtime when trying to respawn before roundstart.
* If you observe, then want to respawn before the round starts, it runtimes.  Lets prevent this.