### PR TITLE
Make jukebox controllable by its wires

### DIFF
--- a/code/datums/wires/jukebox.dm
+++ b/code/datums/wires/jukebox.dm
@@ -1,7 +1,7 @@
 /datum/wires/jukebox
 	random = 1
 	holder_type = /obj/machinery/media/jukebox
-	wire_count = 7
+	wire_count = 11
 
 var/const/WIRE_POWER = 1
 var/const/WIRE_HACK = 2
@@ -10,6 +10,10 @@ var/const/WIRE_SPEEDDOWN = 8
 var/const/WIRE_REVERSE = 16
 var/const/WIRE_NOTHING1 = 32
 var/const/WIRE_NOTHING2 = 64
+var/const/WIRE_START = 128
+var/const/WIRE_STOP = 256
+var/const/WIRE_PREV = 512
+var/const/WIRE_NEXT = 1024
 
 /datum/wires/jukebox/CanUse(var/mob/living/L)
 	var/obj/machinery/media/jukebox/A = holder
@@ -40,6 +44,14 @@ var/const/WIRE_NOTHING2 = 64
 			holder.visible_message("<span class='notice'>\icon[holder] The speakers squeaks.</span>")
 		if(WIRE_SPEEDDOWN)
 			holder.visible_message("<span class='notice'>\icon[holder] The speakers rumble.</span>")
+		if(WIRE_START)
+			A.StartPlaying()
+		if(WIRE_STOP)
+			A.StopPlaying()
+		if(WIRE_PREV)
+			A.PrevTrack()
+		if(WIRE_NEXT)
+			A.NextTrack()
 		else
 			A.shock(usr, 10) // The nothing wires give a chance to shock just for fun
 

--- a/code/game/machinery/jukebox.dm
+++ b/code/game/machinery/jukebox.dm
@@ -270,3 +270,23 @@ datum/track/New(var/title_name, var/audio)
 	playing = 1
 	update_use_power(2)
 	update_icon()
+
+// Advance to the next track - Don't start playing it unless we were already playing
+/obj/machinery/media/jukebox/proc/NextTrack()
+	if(!tracks.len) return
+	var/curTrackIndex = max(1, tracks.Find(current_track))
+	var/newTrackIndex = (curTrackIndex % tracks.len) + 1  // Loop back around if past end
+	current_track = tracks[newTrackIndex]
+	if(playing)
+		StartPlaying()
+	updateDialog()
+
+// Advance to the next track - Don't start playing it unless we were already playing
+/obj/machinery/media/jukebox/proc/PrevTrack()
+	if(!tracks.len) return
+	var/curTrackIndex = max(1, tracks.Find(current_track))
+	var/newTrackIndex = curTrackIndex == 1 ? tracks.len : curTrackIndex - 1
+	current_track = tracks[newTrackIndex]
+	if(playing)
+		StartPlaying()
+	updateDialog()


### PR DESCRIPTION
#### More jukebox enhancements!
Added four extra hacking wires to the jukebox for Play, Stop, Next, and Prev.  A resourceful bartender could now remote control their jukebox.