### PR TITLE
Emotes, sign language, and EAL no longer activate autohiss

### DIFF
--- a/code/modules/mob/living/autohiss.dm
+++ b/code/modules/mob/living/autohiss.dm
@@ -59,6 +59,8 @@
 /datum/species/proc/handle_autohiss(message, datum/language/lang, mode)
 	if(!autohiss_basic_map)
 		return message
+	if(lang.flags & NO_STUTTER)		// Currently prevents EAL, Sign language, and emotes from autohissing
+		return message
 	if(autohiss_exempt && (lang.name in autohiss_exempt))
 		return message
 

--- a/html/changelogs/Atermonera - Autohiss.yml
+++ b/html/changelogs/Atermonera - Autohiss.yml
@@ -1,0 +1,24 @@
+################################
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Atermonera
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+changes: 
+  - bugfix: "EAL, Sign language, and emotes will no longer use autohiss"


### PR DESCRIPTION
Since none of those stutter (NO_STUTTER = 1), any other speech artifacts like hissing also shouldn't be things. Fixes #3104 
Testing with various languages as a taj yielded these results:
Auto-hiss is now BASIC.
Cole Keppel says, "Rrrroll"
Cole Keppel mrowls, "Roll"
Cole Keppel enunciates, "Rrrroll"
Cole Keppel gestures, "Roll"
Cole Keppel whistles, "Roll"
Cole Keppel chirps, "Rrroll"
Cole Keppel warbles, "Rrrroll"

And no, Zane Keppel's brother is only sometimes transplanted into bodies, and usually exists as the cyborg Herodron