### PR TITLE
Makes the 'Spawn Character' verb include custom items

### DIFF
--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -471,8 +471,10 @@ Traitors and the like can also be revived with the previous role mostly intact.
 		antag_data.place_mob(new_character)
 
 	//If desired, apply equipment.
-	if(equipment && charjob)
-		job_master.EquipRank(new_character, charjob, 1)
+	if(equipment)
+		if(charjob)
+			job_master.EquipRank(new_character, charjob, 1)
+		equip_custom_items(new_character)
 
 	//If desired, add records.
 	if(records)


### PR DESCRIPTION
Only really works if you pick the option to put them in the mob, because the proc that spawns custom items is based on that, and I don't really want to rework the custom items system for such a small fix.