### PR TITLE
Allows in-round flavortext updating with verb

### DIFF
--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -346,3 +346,16 @@ client/verb/character_setup()
 	set category = "Preferences"
 	if(prefs)
 		prefs.ShowChoices(usr)
+
+client/verb/update_flavors()
+	set name = "Reapply Flavortext"
+	set category = "Preferences"
+	set desc = "Updates the on-mob flavortext with current, as defined in character setup"
+
+	if(prefs && prefs.player_setup && isliving(mob))
+		var/datum/category_group/player_setup_category/general_preferences/gpc = prefs.player_setup.categories_by_name["General"]
+		var/datum/category_item/player_setup_item/general/flavor/flav = gpc.items_by_name["Flavor"]
+		flav.copy_to_mob(mob)
+		src << "<span class='notice'>Flavortext re-applied!</span>"
+	else
+		src << "<span class='warning'>You can't update your flavortext right now!</span>"


### PR DESCRIPTION
This adds a verb in the Preferences tab that reapplies flavortext from character setup to your mob, so if you have changed it, you can push that down to the mob to update it (lost an arm, got a scar, whatever).

To be honest, I don't know how important this is to you. It comes up fairly often for us as people update (E)RP prefs and flavortexts during our longer rounds for various reasons. It won't hurt anything to give it, though.