### PR TITLE
Fix mob.loc = X  on spawn

### DIFF
--- a/code/defines/obj.dm
+++ b/code/defines/obj.dm
@@ -11,8 +11,7 @@
 		switch(alert("Travel back to ss13?",,"Yes","No"))
 			if("Yes")
 				if(user.z != src.z)	return
-				user.loc.loc.Exited(user)
-				user.loc = pick(latejoin)
+				user.forceMove(pick(latejoin))
 			if("No")
 				return
 

--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -403,13 +403,13 @@ var/global/datum/controller/occupations/job_master
 			if(!S)
 				S = locate("start*[rank]") // use old stype
 			if(istype(S, /obj/effect/landmark/start) && istype(S.loc, /turf))
-				H.loc = S.loc
+				H.forceMove(S.loc)
 			else
 				LateSpawn(H, rank)
 
 			// Moving wheelchair if they have one
 			if(H.buckled && istype(H.buckled, /obj/structure/bed/chair/wheelchair))
-				H.buckled.loc = H.loc
+				H.buckled.forceMove(H.loc)
 				H.buckled.set_dir(H.dir)
 
 		// If they're head, give them the account info for their department
@@ -614,12 +614,12 @@ var/global/datum/controller/occupations/job_master
 
 	if(spawnpos && istype(spawnpos))
 		if(spawnpos.check_job_spawning(rank))
-			H.loc = pick(spawnpos.turfs)
+			H.forceMove(pick(spawnpos.turfs))
 			. = spawnpos.msg
 		else
 			H << "Your chosen spawnpoint ([spawnpos.display_name]) is unavailable for your chosen job. Spawning you at the Arrivals shuttle instead."
-			H.loc = pick(latejoin)
+			H.forceMove(pick(latejoin))
 			. = "has arrived on the station"
 	else
-		H.loc = pick(latejoin)
+		H.forceMove(pick(latejoin))
 		. = "has arrived on the station"


### PR DESCRIPTION
* When spawning into the game (both latejoin and normal join) the job controller used loc = X  to set location.  This meant that Enter() was never called for entering the spawn location, and all other associated problems.
* This bug screwed up the new jukebox music system because mob.lastarea is not set correctly.
* Fixed signpost teleporting for the same reason (nobody wants beach tunes playing forever)