### PR TITLE
Fixes an issue with smes deconstruction

### DIFF
--- a/code/modules/power/smes_construction.dm
+++ b/code/modules/power/smes_construction.dm
@@ -345,7 +345,10 @@
 
 				usr << "\red You have disassembled the SMES cell!"
 				var/obj/structure/frame/M = new /obj/structure/frame(src.loc)
-				M.frame_type = "machine"
+				M.frame_type = new /datum/frame/frame_types/machine
+				M.anchored = 1
+				var/obj/item/weapon/circuitboard/C = new /obj/item/weapon/circuitboard/smes
+				M.circuit = C
 				M.state = 2
 				M.icon_state = "machine_1"
 				for(var/obj/I in component_parts)


### PR DESCRIPTION
Was runtiming due to the frame_type being a string and not a type.
Then also runtiming further upon deconstruction due to having a null circuit.