### PR TITLE
Fix Runtimes

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -341,6 +341,7 @@
 		var/mob/living/carbon/C = usr
 		C.swap_hand()
 	else
-		var/turf/T = screen_loc2turf("screen-loc", get_turf(usr))
-		T.Click(location, control, params)
+		var/turf/T = screen_loc2turf(screen_loc, get_turf(usr))
+		if(T)
+			T.Click(location, control, params)
 	. = 1

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1452,6 +1452,7 @@
 
 	if(stat) return
 	var/datum/category_group/underwear/UWC = input(usr, "Choose underwear:", "Show/hide underwear") as null|anything in global_underwear.categories
+	if(!UWC) return
 	var/datum/category_item/underwear/UWI = all_underwear[UWC.name]
 	if(!UWI || UWI.name == "None")
 		src << "<span class='notice'>You do not have [UWC.gender==PLURAL ? "[UWC.display_name]" : "\a [UWC.display_name]"].</span>"

--- a/code/modules/paperwork/paper_bundle.dm
+++ b/code/modules/paperwork/paper_bundle.dm
@@ -180,7 +180,7 @@
 			update_icon()
 	else
 		usr << "<span class='notice'>You need to hold it in hands!</span>"
-	if (istype(src.loc, /mob) ||istype(src.loc.loc, /mob))
+	if (src.loc && istype(src.loc, /mob) ||istype(src.loc.loc, /mob))
 		src.attack_self(usr)
 		updateUsrDialog()
 


### PR DESCRIPTION
click.dm fixes:
[09:46:49] Runtime in unsorted.dm,1293: list index out of bounds
  proc name: screen loc2turf (/proc/screen_loc2turf)
[09:46:49] Runtime in click.dm,345: Cannot execute null.Click().
  proc name: Click (/obj/screen/click_catcher/Click)
paper_bundle.dm fixes:
[10:30:21] Runtime in paper_bundle.dm,183: Cannot read null.loc
  proc name: Topic (/obj/item/weapon/paper_bundle/Topic)
human.dm fixes:
12:27:51] Runtime in human.dm,1476: Cannot read null.name
  proc name: Toggle Underwear (/mob/living/carbon/human/verb/toggle_underwear)