### PR TITLE
Symbols make sprite accessories freak out

### DIFF
--- a/code/modules/mob/new_player/sprite_accessories.dm
+++ b/code/modules/mob/new_player/sprite_accessories.dm
@@ -1034,17 +1034,17 @@
 		body_parts = list(BP_L_FOOT,BP_R_FOOT,BP_L_LEG,BP_R_LEG,BP_L_ARM,BP_R_ARM,BP_L_HAND,BP_R_HAND)
 
 	paw_socks_belly
-		name = "Socks+Belly Coloration (Generic)"
+		name = "Socks,Belly Coloration (Generic)"
 		icon_state = "pawsocksbelly"
 		body_parts = list(BP_L_FOOT,BP_R_FOOT,BP_L_LEG,BP_R_LEG,BP_L_ARM,BP_R_ARM,BP_L_HAND,BP_R_HAND,BP_GROIN,BP_TORSO)
 
 	belly_hands_feet
-		name = "Hands/Feet/Belly Color (Minor)"
+		name = "Hands,Feet,Belly Color (Minor)"
 		icon_state = "bellyhandsfeetsmall"
 		body_parts = list(BP_L_FOOT,BP_R_FOOT,BP_L_LEG,BP_R_LEG,BP_L_ARM,BP_R_ARM,BP_L_HAND,BP_R_HAND,BP_GROIN,BP_TORSO)
 
 	hands_feet_belly_full
-		name = "Hands/Feet/Belly Color (Major)"
+		name = "Hands,Feet,Belly Color (Major)"
 		icon_state = "bellyhandsfeet"
 		body_parts = list(BP_L_FOOT,BP_R_FOOT,BP_L_LEG,BP_R_LEG,BP_L_ARM,BP_R_ARM,BP_L_HAND,BP_R_HAND,BP_GROIN,BP_TORSO)
 


### PR DESCRIPTION
Like plus or ampersand or single or escaped quotes in the name, it goes crazy. You can't remove Socks+Belly because it has a plus, once you've added it. I have no idea why. But here's a quick fix. (The ones with slashes weren't problematic but I'm a sucker for consistency. The only broken one was the one with the plus sign).