### PR TITLE
Make cells show correct icon when they spawn

### DIFF
--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -5,9 +5,6 @@
 /obj/item/weapon/cell/New()
 	..()
 	charge = maxcharge
-
-/obj/item/weapon/cell/initialize()
-	..()
 	update_icon()
 
 /obj/item/weapon/cell/drain_power(var/drain_check, var/surge, var/power = 0)


### PR DESCRIPTION
Initialize is great for cells sitting on a counter or something when the map loads. But not really for cells in guns that R&D prints and stuff. Kinda needs to be in New(). Also the Initialize call was completely pointless, so, removed.