### PR TITLE
Fix nanopaste item size

### DIFF
--- a/code/game/objects/items/stacks/nanopaste.dm
+++ b/code/game/objects/items/stacks/nanopaste.dm
@@ -6,7 +6,7 @@
 	icon_state = "tube"
 	origin_tech = list(TECH_MATERIAL = 4, TECH_ENGINEERING = 3)
 	amount = 10
-
+	w_class = ITEMSIZE_SMALL
 
 /obj/item/stack/nanopaste/attack(mob/living/M as mob, mob/user as mob)
 	if (!istype(M) || !istype(user))


### PR DESCRIPTION
I'm pretty sure this is an oversight, rather than a balance thing. Nanopaste is too big to fit in boxes or anywhere else, but seems to be identical to all other 10-stack items like medical stacks in other regards. It should probably be the same size as the other 10-stack items.

Even the icon seems to suggest this, since right now it is just as big as an entire box, though the icon seems to be more like toothpaste-tube and looks awkward sitting in the huge backdrop inventory space.