### PR TITLE
Fix the runtime on server boot caused by uninitialized using_map

### DIFF
--- a/code/modules/busy_space/organizations.dm
+++ b/code/modules/busy_space/organizations.dm
@@ -89,10 +89,11 @@
 
 /datum/lore/organization/tsc/nanotrasen/New()
 	..()
-	// Get rid of the current map from the list, so ships flying in don't say they're coming to the current map.
-	var/string_to_test = "[using_map.station_name] in [using_map.starsys_name]"
-	if(string_to_test in destination_names)
-		destination_names.Remove(string_to_test)
+	spawn(1) // BYOND shenanigans means using_map is not initialized yet.  Wait a tick.
+		// Get rid of the current map from the list, so ships flying in don't say they're coming to the current map.
+		var/string_to_test = "[using_map.station_name] in [using_map.starsys_name]"
+		if(string_to_test in destination_names)
+			destination_names.Remove(string_to_test)
 
 
 


### PR DESCRIPTION
This is the same basic issue that caused the other on-boot runtime a month ago.  I just don't want it to print every time I start a server anymore.