### PR TITLE
Fix step_trigger teleporters to use forceMove()

### DIFF
--- a/code/game/objects/effects/step_triggers.dm
+++ b/code/game/objects/effects/step_triggers.dm
@@ -95,10 +95,8 @@
 
 	Trigger(var/atom/movable/A)
 		if(teleport_x && teleport_y && teleport_z)
-
-			A.x = teleport_x
-			A.y = teleport_y
-			A.z = teleport_z
+			var/turf/T = locate(teleport_x, teleport_y, teleport_z)
+			A.forceMove(T)
 
 /* Random teleporter, teleports atoms to locations ranging from teleport_x - teleport_x_offset, etc */
 
@@ -110,8 +108,5 @@
 	Trigger(var/atom/movable/A)
 		if(teleport_x && teleport_y && teleport_z)
 			if(teleport_x_offset && teleport_y_offset && teleport_z_offset)
-
-				A.x = rand(teleport_x, teleport_x_offset)
-				A.y = rand(teleport_y, teleport_y_offset)
-				A.z = rand(teleport_z, teleport_z_offset)
-
+				var/turf/T = locate(rand(teleport_x, teleport_x_offset), rand(teleport_y, teleport_y_offset), rand(teleport_z, teleport_z_offset))
+				A.forceMove(T)


### PR DESCRIPTION
* They previously just updated your coordinates, skipping all those things which forceMove() was invented for and causing all the same problems that `mob.loc = X` caused.
* Fixes https://github.com/VOREStation/VOREStation/issues/1364 and tested using those steps to reproduce.