### PR TITLE
Capitalizing reagent name 'carthatoline' to 'Carthatoline' to be like everything else.

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -94,7 +94,7 @@
 		M.adjustToxLoss(-4 * removed)
 
 /datum/reagent/carthatoline
-	name = "carthatoline"
+	name = "Carthatoline"
 	id = "carthatoline"
 	description = "Carthatoline is strong evacuant used to treat severe poisoning."
 	reagent_state = LIQUID


### PR DESCRIPTION
The reagent name was lower cased- causing the reagent name in almost every GUI to be 'carthatoline' instead of 'Carthatoline' while every other reagent like tricordrazine would show expectantly as 'Tricordrazine'
Even chemistry master was caused to produce bottles that default to 'carthatoline' as a name.


Rawr. A seadragon has fixed this! Yaaay ^-^
This will cure some of the OCD with the medical staff.
I'm aware this PR is literally a 1 character fix, but a fix is a fix.
