### PR TITLE
Make wingrille spawners usable

### DIFF
--- a/code/game/objects/structures/window_spawner.dm
+++ b/code/game/objects/structures/window_spawner.dm
@@ -22,6 +22,9 @@
 /obj/effect/wingrille_spawn/attack_generic()
 	activate()
 
+/obj/effect/wingrille_spawn/CanPass(atom/movable/mover, turf/target, height=1.5, air_group = 0)
+	return FALSE
+
 /obj/effect/wingrille_spawn/initialize()
 	..()
 	if(!win_path)


### PR DESCRIPTION
Makes the spawner object itself block air and prevent active edges before the game starts, so you can actually use these in maps now without creating tons of active edge warnings and making ZAS zones merge everywhere. Should save a loooot of time for mappers picking those window directions.