### PR TITLE
Make planets more generic

### DIFF
--- a/code/controllers/Processes/planet.dm
+++ b/code/controllers/Processes/planet.dm
@@ -1,11 +1,16 @@
+var/datum/controller/process/planet/planet_controller = null
+
 /datum/controller/process/planet
 	var/list/planets = list()
 
 /datum/controller/process/planet/setup()
 	name = "planet"
+	planet_controller = src
 	schedule_interval = 600 // every minute
-	planet_sif = new()
-	planets.Add(planet_sif)
+	var/list/planet_datums = typesof(/datum/planet) - /datum/planet
+	for(var/P in planet_datums)
+		var/datum/planet/NP = new P()
+		planets.Add(NP)
 
 /datum/controller/process/planet/doWork()
 	for(var/datum/planet/P in planets)

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -977,7 +977,7 @@
 	if(!check_rights(R_DEBUG))
 		return
 
-	var/datum/planet/planet = input(usr, "Which planet do you want to modify the weather on?", "Change Weather") in list(planet_sif)
+	var/datum/planet/planet = input(usr, "Which planet do you want to modify the weather on?", "Change Weather") in planet_controller.planets
 	var/datum/weather/new_weather = input(usr, "What weather do you want to change to?", "Change Weather") as null|anything in planet.weather_holder.allowed_weather_types
 	if(new_weather)
 		planet.weather_holder.change_weather(new_weather)
@@ -993,7 +993,7 @@
 	if(!check_rights(R_DEBUG))
 		return
 
-	var/datum/planet/planet = input(usr, "Which planet do you want to modify time on?", "Change Time") in list(planet_sif)
+	var/datum/planet/planet = input(usr, "Which planet do you want to modify time on?", "Change Time") in planet_controller.planets
 
 	var/datum/time/current_time_datum = planet.current_time
 	var/new_hour = input(usr, "What hour do you want to change to?", "Change Time", text2num(current_time_datum.show_time("hh"))) as null|num

--- a/code/modules/planet/planet.dm
+++ b/code/modules/planet/planet.dm
@@ -36,7 +36,12 @@
 	if(weather_holder)
 		weather_holder.process()
 
-// Returns the time datum of Sif.
-/proc/get_sif_time()
-	if(planet_sif)
-		return planet_sif.current_time
+/datum/planet/proc/update_sun_deferred(var/new_range, var/new_brightness, var/new_color)
+	set background = 1
+	set waitfor = 0
+	var/i = 0
+	for(var/turf/simulated/floor/T in outdoor_turfs)
+		T.set_light(new_range, new_brightness, new_color)
+		i++
+		if(i % 30 == 0)
+			sleep(1)

--- a/code/modules/planet/sif.dm
+++ b/code/modules/planet/sif.dm
@@ -13,6 +13,7 @@ var/datum/planet/sif/planet_sif = null
 
 /datum/planet/sif/New()
 	..()
+	planet_sif = src
 	weather_holder = new /datum/weather_holder/sif(src) // Cold weather is also nice.
 
 // This code is horrible.
@@ -95,12 +96,11 @@ var/datum/planet/sif/planet_sif = null
 	spawn(1)
 		update_sun_deferred(2, new_brightness, new_color)
 
-/datum/planet/proc/update_sun_deferred(var/new_range, var/new_brightness, var/new_color)
-	set background = 1
-	set waitfor = 0
-	var/i = 0
-	for(var/turf/simulated/floor/T in outdoor_turfs)
-		T.set_light(new_range, new_brightness, new_color)
-		i++
-		if(i % 30 == 0)
-			sleep(1)
+// We're gonna pretend there are 32 hours in a Sif day instead of 32.64 for the purposes of not losing sanity.  We lose 38m 24s but the alternative is a path to madness.
+/datum/time/sif
+	seconds_in_day = 60 * 60 * 32 * 10 // 115,200 seconds.  If we did 32.64 hours/day it would be around 117,504 seconds instead.
+
+// Returns the time datum of Sif.
+/proc/get_sif_time()
+	if(planet_sif)
+		return planet_sif.current_time

--- a/code/modules/planet/time.dm
+++ b/code/modules/planet/time.dm
@@ -70,7 +70,3 @@
 	answer = replacetext(answer, "mm", minute_text)
 	answer = replacetext(answer, "ss", second_text)
 	return answer
-
-// We're gonna pretend there are 32 hours in a Sif day instead of 32.64 for the purposes of not losing sanity.  We lose 38m 24s but the alternative is a path to madness.
-/datum/time/sif
-	seconds_in_day = 60 * 60 * 32 * 10 // 115,200 seconds.  If we did 32.64 hours/day it would be around 117,504 seconds instead.


### PR DESCRIPTION
So that Sif doesn't have to be the only one!

Moves all the Sif-specific procs and functions into the sif.dm file, moves the non-Sif-specific procs and functions into their respective files, and makes the controller planet-name agnostic. If you need a global reference for your planet, define it at the top of your planet's dm and set it in the planet's new().