### PR TITLE
Sorta fixes the syntax on the *halt emote

### DIFF
--- a/code/modules/mob/living/silicon/robot/emote.dm
+++ b/code/modules/mob/living/silicon/robot/emote.dm
@@ -230,7 +230,7 @@
 
 		if("halt")
 			if (istype(module,/obj/item/weapon/robot_module/robot/security))
-				message = "<B>[src]</B>'s speakers skreech, \"Halt! Security!\"."
+				message = "<B>'s</B> speakers skreech, \"Halt! Security!\"."
 
 				playsound(src.loc, 'sound/voice/halt.ogg', 50, 0)
 				m_type = 2


### PR DESCRIPTION
There's a space in between the name and the 's that I can't fix afaik, but it no longer repeats the name.