### PR TITLE
Fix lung rupture while drowning in water.

### DIFF
--- a/code/game/turfs/simulated/water.dm
+++ b/code/game/turfs/simulated/water.dm
@@ -35,7 +35,16 @@
 			water_breath.temperature = above_air.temperature
 			return water_breath
 		else
-			return null // Lying down means they're submerged, which means no air.
+			var/gasid = "carbon_dioxide"
+			if(ishuman(L))
+				var/mob/living/carbon/human/H = L
+				if(H.species && H.species.exhale_type)
+					gasid = H.species.exhale_type
+			var/datum/gas_mixture/water_breath = new()
+			var/datum/gas_mixture/above_air = return_air()
+			water_breath.adjust_gas(gasid, BREATH_MOLES) // They have no oxygen, but non-zero moles and temp
+			water_breath.temperature = above_air.temperature
+			return water_breath
 	return return_air() // Otherwise their head is above the water, so get the air from the atmosphere instead.
 
 /turf/simulated/floor/water/Entered(atom/movable/AM, atom/oldloc)


### PR DESCRIPTION
* When water returned null from return_air_for_internal_lifeform() the life code treats that as vacuum.  Instead we must return a mixture containing at least some gas.
* It will attempt to use the exhale type for the species, or fall back to carbon_dioxide if it can't find that info.