### PR TITLE
No longer shall ye burn from water

### DIFF
--- a/code/game/turfs/simulated/water.dm
+++ b/code/game/turfs/simulated/water.dm
@@ -44,7 +44,7 @@
 		L.update_water()
 		if(!istype(oldloc, /turf/simulated/floor/water))
 			to_chat(L, "<span class='warning'>You get drenched in water from entering \the [src]!</span>")
-	AM.water_act(5)
+	AM.water_act(-5)
 	..()
 
 /turf/simulated/floor/water/Exited(atom/movable/AM, atom/newloc)

--- a/code/game/turfs/simulated/water.dm
+++ b/code/game/turfs/simulated/water.dm
@@ -44,7 +44,7 @@
 		L.update_water()
 		if(!istype(oldloc, /turf/simulated/floor/water))
 			to_chat(L, "<span class='warning'>You get drenched in water from entering \the [src]!</span>")
-	AM.water_act(-5)
+	AM.water_act(5)
 	..()
 
 /turf/simulated/floor/water/Exited(atom/movable/AM, atom/newloc)
@@ -94,7 +94,7 @@
 	return
 
 /mob/living/water_act(amount)
-	adjust_fire_stacks(amount * 5)
+	adjust_fire_stacks(-amount * 5)
 	for(var/atom/movable/AM in contents)
 		AM.water_act(amount)
 

--- a/html/changelogs/Yoshax-HumanTorch.yml
+++ b/html/changelogs/Yoshax-HumanTorch.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Yoshax
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Water such as the pool will no longer apply fire stacks when you enter, meaning you will no longer be flammable from swimming."


### PR DESCRIPTION
Makes water apply negative fire stacks instead of actual fire stacks. Means you can still expand on it in the future to do like... Phoron liquids you can swim in or something just by doing `water_act(not_a_negative)`

Fixes #3320 