### PR TITLE
Ports a few fixes to multi-z and related code from Bay

### DIFF
--- a/code/_macros.dm
+++ b/code/_macros.dm
@@ -42,6 +42,8 @@
 
 #define isxeno(A) istype(A, /mob/living/simple_animal/xeno)
 
+#define isopenspace(A) istype(A, /turf/simulated/open)
+
 #define isweakref(A) istype(A, /weakref)
 
 #define RANDOM_BLOOD_TYPE pick(4;"O-", 36;"O+", 3;"A-", 28;"A+", 1;"B-", 20;"B+", 1;"AB-", 5;"AB+")

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -115,12 +115,7 @@
 	else if(isturf(hit_atom))
 		src.throwing = 0
 		var/turf/T = hit_atom
-		if(T.density)
-			spawn(2)
-				step(src, turn(src.last_move, 180))
-			if(istype(src,/mob/living))
-				var/mob/living/M = src
-				M.turf_collision(T, speed)
+		T.hitby(src,speed)
 
 //decided whether a movable atom being thrown can pass through the turf it is in.
 /atom/movable/proc/hit_check(var/speed)

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -243,3 +243,11 @@ var/const/enterloopsanity = 100
 /turf/proc/update_blood_overlays()
 	return
 
+// Called when turf is hit by a thrown object
+/turf/hitby(atom/movable/AM as mob|obj, var/speed)
+	if(src.density)
+		spawn(2)
+			step(AM, turn(AM.last_move, 180))
+		if(isliving(AM))
+			var/mob/living/M = AM
+			M.turf_collision(src, speed)

--- a/code/modules/multiz/basic.dm
+++ b/code/modules/multiz/basic.dm
@@ -11,25 +11,35 @@ var/z_levels = 0 // Each bit represents a connection between adjacent levels.  S
 	qdel(src)
 
 // The storage of connections between adjacent levels means some bitwise magic is needed.
-proc/HasAbove(var/z)
+/proc/HasAbove(var/z)
 	if(z >= world.maxz || z > 16 || z < 1)
 		return 0
 	return z_levels & (1 << (z - 1))
 
-proc/HasBelow(var/z)
+/proc/HasBelow(var/z)
 	if(z > world.maxz || z > 17 || z < 2)
 		return 0
 	return z_levels & (1 << (z - 2))
 
 // Thankfully, no bitwise magic is needed here.
-proc/GetAbove(var/atom/atom)
+/proc/GetAbove(var/atom/atom)
 	var/turf/turf = get_turf(atom)
 	if(!turf)
 		return null
 	return HasAbove(turf.z) ? get_step(turf, UP) : null
 
-proc/GetBelow(var/atom/atom)
+/proc/GetBelow(var/atom/atom)
 	var/turf/turf = get_turf(atom)
 	if(!turf)
 		return null
 	return HasBelow(turf.z) ? get_step(turf, DOWN) : null
+
+/proc/GetConnectedZlevels(z)
+	. = list(z)
+	for(var/level = z, HasBelow(level), level--)
+		. |= level-1
+	for(var/level = z, HasAbove(level), level++)
+		. |= level+1
+
+proc/AreConnectedZLevels(var/zA, var/zB)
+	return zA == zB || (zB in GetConnectedZlevels(zA))

--- a/code/modules/multiz/movement.dm
+++ b/code/modules/multiz/movement.dm
@@ -3,34 +3,38 @@
 	set category = "IC"
 
 	if(zMove(UP))
-		to_chat(usr, "<span class='notice'>You move upwards.</span>")
+		to_chat(src, "<span class='notice'>You move upwards.</span>")
 
 /mob/verb/down()
 	set name = "Move Down"
 	set category = "IC"
 
 	if(zMove(DOWN))
-		to_chat(usr, "<span class='notice'>You move down.</span>")
+		to_chat(src, "<span class='notice'>You move down.</span>")
 
 /mob/proc/zMove(direction)
 	if(eyeobj)
 		return eyeobj.zMove(direction)
 	if(!can_ztravel())
-		to_chat(usr, "<span class='warning'>You lack means of travel in that direction.</span>")
+		to_chat(src, "<span class='warning'>You lack means of travel in that direction.</span>")
 		return
 
+	var/turf/start = loc
+	if(!istype(start))
+		to_chat(src, "<span class='notice'>You are unable to move from here.</span>")
+		return 0
+		
 	var/turf/destination = (direction == UP) ? GetAbove(src) : GetBelow(src)
-
 	if(!destination)
-		to_chat(usr, "<span class='notice'>There is nothing of interest in this direction.</span>")
+		to_chat(src, "<span class='notice'>There is nothing of interest in this direction.</span>")
+		return 0
+	
+	if(!start.CanZPass(src, direction))
+		to_chat(src, "<span class='warning'>\The [start] is in the way.</span>")
 		return 0
 
-	var/turf/start = get_turf(src)
-	if(!start.CanZPass(src, direction))
-		to_chat(usr, "<span class='warning'>\The [start] is in the way.</span>")
-		return 0
 	if(!destination.CanZPass(src, direction))
-		to_chat(usr, "<span class='warning'>\The [destination] blocks your way.</span>")
+		to_chat(src, "<span class='warning'>\The [destination] blocks your way.</span>")
 		return 0
 
 	var/area/area = get_area(src)
@@ -46,12 +50,12 @@
 				to_chat(src, "<span class='warning'>You gave up on pulling yourself up.</span>")
 				return 0
 		else
-			to_chat(usr, "<span class='warning'>Gravity stops you from moving upward.</span>")
+			to_chat(src, "<span class='warning'>Gravity stops you from moving upward.</span>")
 			return 0
 
 	for(var/atom/A in destination)
 		if(!A.CanPass(src, start, 1.5, 0))
-			to_chat(usr, "<span class='warning'>\The [A] blocks you.</span>")
+			to_chat(src, "<span class='warning'>\The [A] blocks you.</span>")
 			return 0
 	Move(destination)
 	return 1
@@ -61,14 +65,14 @@
 	if(destination)
 		forceMove(destination)
 	else
-		to_chat(usr, "<span class='notice'>There is nothing of interest in this direction.</span>")
+		to_chat(src, "<span class='notice'>There is nothing of interest in this direction.</span>")
 
 /mob/observer/eye/zMove(direction)
 	var/turf/destination = (direction == UP) ? GetAbove(src) : GetBelow(src)
 	if(destination)
 		setLoc(destination)
 	else
-		to_chat(usr, "<span class='notice'>There is nothing of interest in this direction.</span>")
+		to_chat(src, "<span class='notice'>There is nothing of interest in this direction.</span>")
 
 /mob/proc/can_ztravel()
 	return 0

--- a/code/modules/multiz/pipes.dm
+++ b/code/modules/multiz/pipes.dm
@@ -13,6 +13,9 @@ obj/machinery/atmospherics/pipe/zpipe
 		dir = SOUTH
 		initialize_directions = SOUTH
 
+		// node1 is the connection on the same Z
+		// node2 is the connection on the other Z
+
 		var/minimum_temperature_difference = 300
 		var/thermal_conductivity = 0 //WALL_HEAT_TRANSFER_COEFFICIENT No
 

--- a/code/modules/multiz/structures.dm
+++ b/code/modules/multiz/structures.dm
@@ -122,10 +122,6 @@
 	allowed_directions = UP|DOWN
 	icon_state = "ladder11"
 
-
-
-
-
 /obj/structure/stairs
 	name = "Stairs"
 	desc = "Stairs leading to another deck.  Not too useful if the gravity goes out."

--- a/code/modules/multiz/turf.dm
+++ b/code/modules/multiz/turf.dm
@@ -82,7 +82,7 @@
 			return
 		var/obj/item/stack/rods/R = C
 		if (R.use(1))
-			user << "<span class='notice'>Constructing support lattice ...</span>"
+			to_chat(user, "<span class='notice'>Constructing support lattice ...</span>")
 			playsound(src, 'sound/weapons/Genhit.ogg', 50, 1)
 			ReplaceWithLattice()
 		return
@@ -99,7 +99,7 @@
 			ChangeTurf(/turf/simulated/floor/airless)
 			return
 		else
-			user << "<span class='warning'>The plating is going to need some support.</span>"
+			to_chat(user, "<span class='warning'>The plating is going to need some support.</span>")
 
 	//To lay cable.
 	if(istype(C, /obj/item/stack/cable_coil))

--- a/code/modules/multiz/turf.dm
+++ b/code/modules/multiz/turf.dm
@@ -36,6 +36,11 @@
 	..()
 	mover.fall()
 
+// Called when thrown object lands on this turf.
+/turf/simulated/open/hitby(var/atom/movable/AM, var/speed)
+	. = ..()
+	AM.fall()
+
 /turf/simulated/open/proc/update()
 	below = GetBelow(src)
 	turf_changed_event.register(below, src, /turf/simulated/open/update_icon)

--- a/code/modules/turbolift/turbolift_map.dm
+++ b/code/modules/turbolift/turbolift_map.dm
@@ -221,7 +221,7 @@
 	var/turf/T = locate(int_panel_x, int_panel_y, uz)
 	lift.control_panel_interior = new(T, lift)
 	lift.control_panel_interior.set_dir(udir)
-	lift.current_floor = lift.floors[uz]
+	lift.current_floor = lift.floors[1]
 
 	lift.open_doors()
 


### PR DESCRIPTION
Ports:
https://github.com/Baystation12/Baystation12/pull/16653
https://github.com/Baystation12/Baystation12/pull/16941
https://github.com/Baystation12/Baystation12/pull/16942

#### Can no longer move up/down from non-turf locations. ##

#### Multi-Z code formatting and utilities.
* Global procs should start with /proc
* Use to_chat() macro
* Added utility to find all z-levels are connected (transitively adjacent) and utility to test if two levels are connected.

#### Fix crash in turbolifts built on any z-level other than "1"
* Turbolift auto-mapping code assumed that all lift's first floor would be on z=1.  Fixed so it picks the first floor instead of the zth floor from the floor list.

#### De-snowflake thrown objects hitting turfs.
* Actually tell turfs when a thrown object hits them, and let them decide what to do about it!
  * We do this by calling hitby(), which is how it already works for obj and mob, so this makes behavior consistent.
* This allows us to cleanly solve the problem of a thrown object landing on open space without falling.


P.S. Yes, I am porting my own bay PR's to here... It was good to get their input too.
