### PR TITLE
Examining FBPs now shows their braintype

### DIFF
--- a/code/__defines/mobs.dm
+++ b/code/__defines/mobs.dm
@@ -201,3 +201,8 @@
 #define TASTE_NORMAL 1 //anything below 15%
 #define TASTE_DULL 0.5 //anything below 30%
 #define TASTE_NUMB 0.1 //anything below 150%
+
+#define FBP_NONE	""
+#define FBP_CYBORG	"cyborg"
+#define FBP_POSI	"positronic"
+#define FBP_DRONE	"drone"

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -108,16 +108,24 @@
 
 	if(!(skipjumpsuit && skipface))
 		if(looks_synth)
-			var/use_gender = "a synthetic"
-			if(gender == MALE)
-				use_gender = "an android"
-			else if(gender == FEMALE)
-				use_gender = "a gynoid"
+			var/line
+			var/use_fbp = get_FBP_type()
+			var/use_gender = " synthetic"
 
-			msg += ", <b><font color='#555555'>[use_gender]!</font></b>"
+			if(gender == MALE)
+				use_gender = " android"
+			else if(gender == FEMALE)
+				use_gender = " gynoid"
+
+			// Cyborgs show their species instead of 'cyborg'
+			if(use_fbp == FBP_CYBORG)
+				use_fbp = species.get_examine_name()
+
+			line = "a [use_fbp][use_gender]!"
+			msg += ", <b><font color='#555555'>[line]</font></b>"
 
 		else if(species.name != "Human")
-			msg += ", <b><font color='[species.get_flesh_colour(src)]'>\a [species.get_examine_name()]!</font></b>"
+			msg += ", <b><font color='[species.get_flesh_colour(src)]'>a [species.get_examine_name()]!</font></b>"
 
 	var/extra_species_text = species.get_additional_examine_text(src)
 	if(extra_species_text)

--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -90,6 +90,24 @@
 
 	return 0
 
+// Returns a string based on what kind of brain the FBP has.
+/mob/living/carbon/human/proc/get_FBP_type()
+	if(!isSynthetic())
+		return FBP_NONE
+	var/obj/item/organ/internal/brain/B
+	B = internal_organs_by_name[O_BRAIN]
+	if(B) // Incase we lost our brain for some reason, like if we got decapped.
+		if(istype(B, /obj/item/organ/internal/mmi_holder))
+			var/obj/item/organ/internal/mmi_holder/mmi_holder = B
+			if(istype(mmi_holder.stored_mmi, /obj/item/device/mmi/digital/posibrain))
+				return FBP_POSI
+			else if(istype(mmi_holder.stored_mmi, /obj/item/device/mmi/digital/robot))
+				return FBP_DRONE
+			else if(istype(mmi_holder.stored_mmi, /obj/item/device/mmi)) // This needs to come last because inheritence.
+				return FBP_CYBORG
+
+	return FBP_NONE
+
 #undef HUMAN_EATING_NO_ISSUE
 #undef HUMAN_EATING_NO_MOUTH
 #undef HUMAN_EATING_BLOCKED_MOUTH


### PR DESCRIPTION
FBPs now will tell you what kind of brain is inside (assuming they have one) upon examination, with the format of 'This is X, a Positronic Android', as an example.
Cyborg FBPs show their species instead of 'cyborg' when examines, e.g. 'This is Y, a Skrell Gynoid'.
Vey-Med and future 'lifelike' FBP models are exempt from this, with the same rules as before.
Clothing such as spacesuits also hides this, as it did previously.

![Warble Borg](https://puu.sh/vo5iS/c32c5f12ff.png)
![Positronic Example](https://puu.sh/vo46x/c514556dca.png)