### PR TITLE
Reworks ranged changeling stings

### DIFF
--- a/code/game/gamemodes/changeling/changeling_powers.dm
+++ b/code/game/gamemodes/changeling/changeling_powers.dm
@@ -153,6 +153,46 @@ var/global/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","E
 	//STINGS//	//They get a pretty header because there's just so fucking many of them ;_;
 	//////////
 
+turf/proc/AdjacentTurfsRangedSting()
+	//Yes this is snowflakey, but I couldn't get it to work any other way.. -Luke
+	var/list/allowed = list(
+		/obj/structure/table,
+		/obj/structure/closet,
+		/obj/structure/frame,
+		/obj/structure/target_stake,
+		/obj/structure/cable,
+		/obj/structure/disposalpipe,
+		/obj/machinery/
+	)
+
+	var/L[] = new()
+	for(var/turf/simulated/t in oview(src,1))
+		var/add = 1
+		if(t.density)
+			add = 0
+		if(add && LinkBlocked(src,t))
+			add = 0
+		if(add && TurfBlockedNonWindow(t))
+			add = 0
+			for(var/obj/O in t)
+				if(!O.density)
+					add = 1
+					break
+				if(istype(O, /obj/machinery/door))
+					//not sure why this doesn't fire on LinkBlocked()
+					add = 0
+					break
+				for(var/type in allowed)
+					if (istype(O, type))
+						add = 1
+						break
+				if(!add)
+					break
+		if(add)
+			L.Add(t)
+	return L
+
+
 /mob/proc/sting_can_reach(mob/M as mob, sting_range = 1)
 	if(M.loc == src.loc)
 		return 1 //target and source are in the same thing
@@ -160,7 +200,7 @@ var/global/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","E
 		src << "<span class='warning'>We cannot reach \the [M] with a sting!</span>"
 		return 0 //One is inside, the other is outside something.
 	// Maximum queued turfs set to 25; I don't *think* anything raises sting_range above 2, but if it does the 25 may need raising
-	if(!AStar(src.loc, M.loc, /turf/proc/AdjacentTurfs, /turf/proc/Distance, max_nodes=25, max_node_depth=sting_range)) //If we can't find a path, fail
+	if(!AStar(src.loc, M.loc, /turf/proc/AdjacentTurfsRangedSting, /turf/proc/Distance, max_nodes=25, max_node_depth=sting_range)) //If we can't find a path, fail
 		src << "<span class='warning'>We cannot find a path to sting \the [M] by!</span>"
 		return 0
 	return 1

--- a/code/game/gamemodes/changeling/powers/boost_range.dm
+++ b/code/game/gamemodes/changeling/powers/boost_range.dm
@@ -18,11 +18,11 @@
 	if(!changeling)
 		return 0
 	changeling.chem_charges -= 10
-	src << "<span class='notice'>Your throat adjusts to launch the sting.</span>"
+	to_chat(src, "<span class='notice'>Your throat adjusts to launch the sting.</span>")
 	var/range = 2
 	if(src.mind.changeling.recursive_enhancement)
 		range = range + 3
-		src << "<span class='notice'>We can fire our next sting from five squares away.</span>"
+		to_chat(src, "<span class='notice'>We can fire our next sting from five squares away.</span>")
 	changeling.sting_range = range
 	src.verbs -= /mob/proc/changeling_boost_range
 	spawn(5)

--- a/html/changelogs/LorenLuke - ChangelingSting.yml
+++ b/html/changelogs/LorenLuke - ChangelingSting.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: LorenLuke
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Refactors changeling ranged stings not passing over tables. Can now pass over tables, any machinery (except doors), machine frames, and past closet subtypes."


### PR DESCRIPTION
Also, changes a few << to to_chat()

Stings bypass the following and their subtypes:
		/obj/structure/table,
		/obj/structure/closet,
		/obj/structure/frame,
		/obj/structure/target_stake,
		/obj/structure/cable,
		/obj/structure/disposalpipe,
		/obj/machinery/

with the exception being /obj/machinery/door and its subtypes.
