### PR TITLE
Service Borg 2: Drink Synthesizer and Rapid Service Fab changes.

### DIFF
--- a/code/game/objects/items/weapons/RSF.dm
+++ b/code/game/objects/items/weapons/RSF.dm
@@ -39,7 +39,7 @@ RSF
 	playsound(src.loc, 'sound/effects/pop.ogg', 50, 0)
 	if (mode == 1)
 		mode = 2
-		user << "Changed dispensing mode to 'Drinking Glass'"
+		user << "Changed dispensing mode to 'Drinking Glass:Pint'"
 		return
 	if (mode == 2)
 		mode = 3
@@ -82,7 +82,7 @@ RSF
 			product = new /obj/item/clothing/mask/smokable/cigarette()
 			used_energy = 10
 		if(2)
-			product = new /obj/item/weapon/reagent_containers/food/drinks/glass2()
+			product = new /obj/item/weapon/reagent_containers/food/drinks/glass2/pint()
 			used_energy = 50
 		if(3)
 			product = new /obj/item/weapon/paper()

--- a/code/modules/reagents/reagent_containers/borghydro.dm
+++ b/code/modules/reagents/reagent_containers/borghydro.dm
@@ -121,7 +121,7 @@
 	recharge_time = 3
 	volume = 60
 	possible_transfer_amounts = list(5, 10, 20, 30)
-	reagent_ids = list("beer", "kahlua", "whiskey", "specialwhiskey", "wine", "vodka", "gin", "rum", "tequilla", "vermouth", "cognac", "ale", "mead", "water", "sugar", "ice", "tea", "icetea", "cola", "spacemountainwind", "dr_gibb", "space_up", "tonic", "sodawater", "lemon_lime", "orangejuice", "limejuice", "watermelonjuice")
+	reagent_ids = list("ale", "beer", "berryjuice", "coffee", "cognac", "cola", "dr_gibb", "egg", "gin", "hot_coco", "ice", "icetea", "kahlua", "lemonjuice", "lemon_lime", "limejuice", "mead", "milk", "mint", "orangejuice", "rum", "sodawater", "soymilk", "space_up", "spacemountainwind", "specialwhiskey", "sugar", "tea", "tequilla", "tomatojuice", "tonic", "vermouth", "vodka", "water", "watermelonjuice", "whiskey", "wine")
 
 /obj/item/weapon/reagent_containers/borghypo/service/attack(var/mob/M, var/mob/user)
 	return


### PR DESCRIPTION
Alphabetizes the mess that was the borg drink synthesizer's list.
Adds multiple things to make it both on-par/slightly better than the multiple drink dispensers.
Adds egg-stuff to the synthesizer as they can't get eggs out of their cartons because they're containers.

Also changes the Rapid Service Fabricator to use a glass, not its parent.