### PR TITLE
Brain type is shown on all records

### DIFF
--- a/code/__defines/mobs.dm
+++ b/code/__defines/mobs.dm
@@ -207,3 +207,9 @@
 #define TASTE_NORMAL 1 //anything below 15%
 #define TASTE_DULL 0.5 //anything below 30%
 #define TASTE_NUMB 0.1 //anything below 150%
+
+// If they're in an FBP, what braintype.
+#define FBP_NONE	""
+#define FBP_CYBORG	"Cyborg"
+#define FBP_POSI	"Positronic"
+#define FBP_DRONE	"Drone"

--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -184,6 +184,10 @@
 		G.fields["real_rank"]	= H.mind.assigned_role
 		G.fields["rank"]		= assignment
 		G.fields["age"]			= H.age
+		if(H.get_FBP_type())
+			G.fields["brain_type"] = H.get_FBP_type()
+		else
+			G.fields["brain_type"] = "Organic"
 		G.fields["fingerprint"]	= md5(H.dna.uni_identity)
 		G.fields["p_stat"]		= "Active"
 		G.fields["m_stat"]		= "Stable"
@@ -201,11 +205,19 @@
 		M.fields["b_type"]		= H.b_type
 		M.fields["b_dna"]		= H.dna.unique_enzymes
 		M.fields["id_gender"]	= gender2text(H.identifying_gender)
+		if(H.get_FBP_type())
+			M.fields["brain_type"] = H.get_FBP_type()
+		else
+			M.fields["brain_type"] = "Organic"
 		if(H.med_record && !jobban_isbanned(H, "Records"))
 			M.fields["notes"] = H.med_record
 
 		//Security Record
 		var/datum/data/record/S = CreateSecurityRecord(H.real_name, id)
+		if(H.get_FBP_type())
+			S.fields["brain_type"] = H.get_FBP_type()
+		else
+			S.fields["brain_type"] = "Organic"
 		if(H.sec_record && !jobban_isbanned(H, "Records"))
 			S.fields["notes"] = H.sec_record
 
@@ -218,6 +230,10 @@
 		L.fields["fingerprint"]	= md5(H.dna.uni_identity)
 		L.fields["sex"]			= gender2text(H.gender)
 		L.fields["id_gender"]	= gender2text(H.identifying_gender)
+		if(H.get_FBP_type())
+			L.fields["brain_type"] = H.get_FBP_type()
+		else
+			L.fields["brain_type"] = "Organic"
 		L.fields["b_type"]		= H.b_type
 		L.fields["b_dna"]		= H.dna.unique_enzymes
 		L.fields["enzymes"]		= H.dna.SE // Used in respawning
@@ -426,6 +442,7 @@
 	G.fields["real_rank"] = "Unassigned"
 	G.fields["sex"] = "Unknown"
 	G.fields["age"] = "Unknown"
+	G.fields["brain_type"] = "Unknown"
 	G.fields["fingerprint"] = "Unknown"
 	G.fields["p_stat"] = "Active"
 	G.fields["m_stat"] = "Stable"
@@ -447,6 +464,7 @@
 	R.name = "Security Record #[id]"
 	R.fields["name"] = name
 	R.fields["id"] = id
+	R.fields["brain_type"] = "Unknown"
 	R.fields["criminal"]	= "None"
 	R.fields["mi_crim"]		= "None"
 	R.fields["mi_crim_d"]	= "No minor crime convictions."
@@ -467,6 +485,7 @@
 	M.fields["b_type"]		= "AB+"
 	M.fields["b_dna"]		= md5(name)
 	M.fields["id_gender"]	= "Unknown"
+	M.fields["brain_type"]	= "Unknown"
 	M.fields["mi_dis"]		= "None"
 	M.fields["mi_dis_d"]	= "No minor disabilities have been declared."
 	M.fields["ma_dis"]		= "None"

--- a/code/game/machinery/computer/medical.dm
+++ b/code/game/machinery/computer/medical.dm
@@ -85,6 +85,7 @@
 					if ((istype(src.active1, /datum/data/record) && data_core.general.Find(src.active1)))
 						dat += "<table><tr><td>Name: [active1.fields["name"]] \
 								ID: [active1.fields["id"]]<BR>\n	\
+								Entity Classification: <A href='?src=\ref[src];field=brain_type'>[active1.fields["brain_type"]]</A><BR>\n	\
 								Sex: <A href='?src=\ref[src];field=sex'>[active1.fields["sex"]]</A><BR>\n"
 						if ((istype(src.active2, /datum/data/record) && data_core.medical.Find(src.active2)))
 							dat += "Gender identity: <A href='?src=\ref[src];field=id_gender'>[active2.fields["id_gender"]]</A><BR>"

--- a/code/game/machinery/computer/security.dm
+++ b/code/game/machinery/computer/security.dm
@@ -127,6 +127,7 @@
 						dat += text("<table><tr><td>	\
 						Name: <A href='?src=\ref[src];choice=Edit Field;field=name'>[active1.fields["name"]]</A><BR> \
 						ID: <A href='?src=\ref[src];choice=Edit Field;field=id'>[active1.fields["id"]]</A><BR>\n \
+						Entity Classification: <A href='?src=\ref[src];field=brain_type'>[active1.fields["brain_type"]]</A><BR>\n	\
 						Sex: <A href='?src=\ref[src];choice=Edit Field;field=sex'>[active1.fields["sex"]]</A><BR>\n	\
 						Age: <A href='?src=\ref[src];choice=Edit Field;field=age'>[active1.fields["age"]]</A><BR>\n	\
 						Rank: <A href='?src=\ref[src];choice=Edit Field;field=rank'>[active1.fields["rank"]]</A><BR>\n	\

--- a/code/game/machinery/computer/skills.dm
+++ b/code/game/machinery/computer/skills.dm
@@ -93,6 +93,7 @@
 						dat += text("<table><tr><td>	\
 						Name: <A href='?src=\ref[src];choice=Edit Field;field=name'>[active1.fields["name"]]</A><BR> \
 						ID: <A href='?src=\ref[src];choice=Edit Field;field=id'>[active1.fields["id"]]</A><BR>\n	\
+						Entity Classification: <A href='?src=\ref[src];field=brain_type'>[active1.fields["brain_type"]]</A><BR>\n	\
 						Sex: <A href='?src=\ref[src];choice=Edit Field;field=sex'>[active1.fields["sex"]]</A><BR>\n	\
 						Age: <A href='?src=\ref[src];choice=Edit Field;field=age'>[active1.fields["age"]]</A><BR>\n	\
 						Rank: <A href='?src=\ref[src];choice=Edit Field;field=rank'>[active1.fields["rank"]]</A><BR>\n	\

--- a/code/game/machinery/computer3/computers/medical.dm
+++ b/code/game/machinery/computer3/computers/medical.dm
@@ -95,6 +95,7 @@
 
 							dat += "<table><tr><td>Name: [active1.fields["name"]] \
 									ID: [active1.fields["id"]]<BR>\n	\
+									Entity Classification: <A href='?src=\ref[src];field=brain_type'>[active1.fields["brain_type"]]</A><BR>\n	\
 									Sex: <A href='?src=\ref[src];field=sex'>[active1.fields["sex"]]</A><BR>\n	\
 									Age: <A href='?src=\ref[src];field=age'>[active1.fields["age"]]</A><BR>\n	\
 									Fingerprint: <A href='?src=\ref[src];field=fingerprint'>[active1.fields["fingerprint"]]</A><BR>\n	\

--- a/code/game/machinery/computer3/computers/security.dm
+++ b/code/game/machinery/computer3/computers/security.dm
@@ -134,6 +134,7 @@
 							dat += text("<table><tr><td>	\
 							Name: <A href='?src=\ref[src];choice=Edit Field;field=name'>[active1.fields["name"]]</A><BR> \
 							ID: <A href='?src=\ref[src];choice=Edit Field;field=id'>[active1.fields["id"]]</A><BR>\n	\
+							Entity Classification: <A href='?src=\ref[src];field=brain_type'>[active1.fields["brain_type"]]</A><BR>\n	\
 							Sex: <A href='?src=\ref[src];choice=Edit Field;field=sex'>[active1.fields["sex"]]</A><BR>\n	\
 							Age: <A href='?src=\ref[src];choice=Edit Field;field=age'>[active1.fields["age"]]</A><BR>\n	\
 							Rank: <A href='?src=\ref[src];choice=Edit Field;field=rank'>[active1.fields["rank"]]</A><BR>\n	\

--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -90,6 +90,24 @@
 
 	return 0
 
+// Returns a string based on what kind of brain the FBP has.
+/mob/living/carbon/human/proc/get_FBP_type()
+	if(!isSynthetic())
+		return FBP_NONE
+	var/obj/item/organ/internal/brain/B
+	B = internal_organs_by_name[O_BRAIN]
+	if(B) // Incase we lost our brain for some reason, like if we got decapped.
+		if(istype(B, /obj/item/organ/internal/mmi_holder))
+			var/obj/item/organ/internal/mmi_holder/mmi_holder = B
+			if(istype(mmi_holder.stored_mmi, /obj/item/device/mmi/digital/posibrain))
+				return FBP_POSI
+			else if(istype(mmi_holder.stored_mmi, /obj/item/device/mmi/digital/robot))
+				return FBP_DRONE
+			else if(istype(mmi_holder.stored_mmi, /obj/item/device/mmi)) // This needs to come last because inheritence.
+				return FBP_CYBORG
+
+	return FBP_NONE
+
 #undef HUMAN_EATING_NO_ISSUE
 #undef HUMAN_EATING_NO_MOUTH
 #undef HUMAN_EATING_BLOCKED_MOUTH

--- a/html/changelogs/Atermonera - Records.yml
+++ b/html/changelogs/Atermonera - Records.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Atermonera
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Brain type (Organic, cyborg, posi, or drone) is now displayed in all records."

--- a/nano/templates/pai_medrecords.tmpl
+++ b/nano/templates/pai_medrecords.tmpl
@@ -20,6 +20,10 @@ code/modules/mob/living/silicon/pai/software_modules.dm
 		<div class="itemContent">{{:data.general.id}}</div>
 	</div>
 	<div class="item">
+		<div class="itemLabel">Entity Classification</div>
+		<div class=itemContent">{{:data.general.brain_type}}</div>
+	</div>
+	<div class="item">
 		<div class="itemLabel">Sex</div>
 		<div class="itemContent">{{:data.general.sex}}</div>
 	</div>

--- a/nano/templates/pai_secrecords.tmpl
+++ b/nano/templates/pai_secrecords.tmpl
@@ -20,6 +20,10 @@ code/modules/mob/living/silicon/pai/software_modules.dm
 		<div class="itemContent">{{:data.general.id}}</div>
 	</div>
 	<div class="item">
+		<div class="itemLabel">Entity Classification</div>
+		<div class=itemContent">{{:data.general.brain_type}}</div>
+	</div>
+	<div class="item">
 		<div class="itemLabel">Sex</div>
 		<div class="itemContent">{{:data.general.sex}}</div>
 	</div>

--- a/nano/templates/pda.tmpl
+++ b/nano/templates/pda.tmpl
@@ -568,6 +568,7 @@ Used In File(s): \code\game\objects\items\devices\PDA\PDA.dm
                 <div class="itemContent" style="width: 100%;">
                     {{if data.records.general_exists == 1}}
                         <span class="good">Name:		</span> <span class="average">{{:data.records.general.name}}	</span><br>
+						<span class="good">Entity Class:	</span> <span class="average">{{:data.records.general.brain_type}}	</span><br>
                         <span class="good">Sex:			</span> <span class="average">{{:data.records.general.sex}}		</span><br>
                         <span class="good">Species:		</span> <span class="average">{{:data.records.general.species}}	</span><br>
                         <span class="good">Age:			</span> <span class="average">{{:data.records.general.age}}		</span><br>


### PR DESCRIPTION
When Neerti (Or someone) adds Drone ID cards, sec can punish those drones that toss theirs and try to claim to be posis or something.

Med and sec huds will NOT display brain type, because some people didn't want it, and I couldn't figure out where it was writing the records to chat.

Testing:
[pAI](https://puu.sh/vt4YG/c2d3b81875.png)
[PDA](https://puu.sh/vt4VU/4711035e49.png)
[Laptops](https://puu.sh/vt3Nw/6688f099ad.mp4)
[Consoles](https://puu.sh/vt2U6/c5d3262687.png) (Shifted to beneath name and ID)