### PR TITLE
Item placement tweaks

### DIFF
--- a/code/__defines/misc.dm
+++ b/code/__defines/misc.dm
@@ -191,3 +191,10 @@
 #define TSC_MORPH	"Morpheus"
 #define TSC_XION	"Xion" // Not really needed but consistancy I guess.
 #define TSC_GIL 	"Gilthari"
+
+//Grid for item placement
+#define CELLS 8								//Amount of cells per row/column in grid
+#define CELLSIZE (world.icon_size/CELLS)	//Size of a cell in pixels
+
+#define WORLD_ICON_SIZE 32
+#define PIXEL_MULTIPLIER WORLD_ICON_SIZE/32

--- a/code/_helpers/global_lists.dm
+++ b/code/_helpers/global_lists.dm
@@ -213,3 +213,28 @@ var/global/list/string_slot_flags = list(
 */
 //Hexidecimal numbers
 var/global/list/hexNums = list("0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "A", "B", "C", "D", "E", "F")
+
+
+
+var/global/list/paramslist_cache = list()
+
+#define cached_key_number_decode(key_number_data) cached_params_decode(key_number_data, /proc/key_number_decode)
+#define cached_number_list_decode(number_list_data) cached_params_decode(number_list_data, /proc/number_list_decode)
+
+/proc/cached_params_decode(var/params_data, var/decode_proc)
+	. = paramslist_cache[params_data]
+	if(!.)
+		. = call(decode_proc)(params_data)
+		paramslist_cache[params_data] = .
+
+/proc/key_number_decode(var/key_number_data)
+	var/list/L = params2list(key_number_data)
+	for(var/key in L)
+		L[key] = text2num(L[key])
+	return L
+
+/proc/number_list_decode(var/number_list_data)
+	var/list/L = params2list(number_list_data)
+	for(var/i in 1 to L.len)
+		L[i] = text2num(L[i])
+	return L

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -104,7 +104,7 @@
 	var/sdepth = A.storage_depth(src)
 	if((!isturf(A) && A == loc) || (sdepth != -1 && sdepth <= 1))
 		if(W)
-			var/resolved = W.resolve_attackby(A, src)
+			var/resolved = W.resolve_attackby(A, src, params)
 			if(!resolved && A && W)
 				W.afterattack(A, src, 1, params) // 1 indicates adjacency
 		else
@@ -125,7 +125,7 @@
 		if(A.Adjacent(src)) // see adjacent.dm
 			if(W)
 				// Return 1 in attackby() to prevent afterattack() effects (when safely moving items for example)
-				var/resolved = W.resolve_attackby(A,src)
+				var/resolved = W.resolve_attackby(A,src, params)
 				if(!resolved && A && W)
 					W.afterattack(A, src, 1, params) // 1: clicking something Adjacent
 			else

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -24,12 +24,12 @@ avoid code duplication. This includes items that may sometimes act as a standard
 	return
 
 //I would prefer to rename this to attack(), but that would involve touching hundreds of files.
-/obj/item/proc/resolve_attackby(atom/A, mob/user)
+/obj/item/proc/resolve_attackby(atom/A, mob/user, var/click_params)
 	add_fingerprint(user)
-	return A.attackby(src, user)
+	return A.attackby(src, user, click_params)
 
 // No comment
-/atom/proc/attackby(obj/item/W, mob/user)
+/atom/proc/attackby(obj/item/W, mob/user, var/click_params)
 	return
 
 /atom/movable/attackby(obj/item/W, mob/user)

--- a/code/defines/obj/weapon.dm
+++ b/code/defines/obj/weapon.dm
@@ -3,6 +3,7 @@
 	desc = "Should anything ever go wrong..."
 	icon = 'icons/obj/items.dmi'
 	icon_state = "red_phone"
+	randpixel = 0
 	flags = CONDUCT
 	force = 3.0
 	throwforce = 2.0
@@ -142,6 +143,7 @@
 /obj/item/weapon/disk
 	name = "disk"
 	icon = 'icons/obj/items.dmi'
+	randpixel = 5
 
 /obj/item/weapon/disk/nuclear
 	name = "nuclear authentication disk"
@@ -410,13 +412,9 @@
 	desc = "What?"
 	gender = PLURAL
 	icon = 'icons/obj/stock_parts.dmi'
+	randpixel = 5
 	w_class = ITEMSIZE_SMALL
 	var/rating = 1
-
-/obj/item/weapon/stock_parts/New()
-	src.pixel_x = rand(-5.0, 5)
-	src.pixel_y = rand(-5.0, 5)
-	..()
 
 //Rank 1
 

--- a/code/game/machinery/computer3/storage.dm
+++ b/code/game/machinery/computer3/storage.dm
@@ -173,8 +173,6 @@
 	New()
 		..()
 		icon_state = "datadisk[rand(0,6)]"
-		src.pixel_x = rand(-5, 5)
-		src.pixel_y = rand(-5, 5)
 		files = list()
 		if(istype(spawn_files))
 			for(var/typekey in spawn_files)

--- a/code/game/machinery/pipe/construction.dm
+++ b/code/game/machinery/pipe/construction.dm
@@ -66,6 +66,7 @@ Buildable meters
 	force = 7
 	icon = 'icons/obj/pipe-item.dmi'
 	icon_state = "simple"
+	randpixel = 5
 	item_state = "buildpipe"
 	w_class = ITEMSIZE_NORMAL
 	level = 2
@@ -215,8 +216,6 @@ Buildable meters
 			connect_types = CONNECT_TYPE_REGULAR|CONNECT_TYPE_SUPPLY|CONNECT_TYPE_SCRUBBER
 	//src.pipe_dir = get_pipe_dir()
 	update()
-	src.pixel_x = rand(-5, 5)
-	src.pixel_y = rand(-5, 5)
 
 //update the name and icon of the pipe item depending on the type
 

--- a/code/game/mecha/mecha_parts.dm
+++ b/code/game/mecha/mecha_parts.dm
@@ -16,6 +16,7 @@
 /obj/item/mecha_parts/chassis
 	name="Mecha Chassis"
 	icon_state = "backbone"
+	randpixel = 0
 	var/datum/construction/construct
 	flags = CONDUCT
 

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -4,6 +4,7 @@
 	w_class = ITEMSIZE_NORMAL
 
 	var/image/blood_overlay = null //this saves our blood splatter overlay, which will be processed not to go over the edges of the sprite
+	var/randpixel = 6
 	var/abstract = 0
 	var/r_speed = 1.0
 	var/health = null
@@ -85,6 +86,10 @@
 		else
 			embed_chance = force/(w_class*3)
 	..()
+	if(randpixel && (!pixel_x && !pixel_y)) //hopefully this will prevent us from messing with mapper-set pixel_x/y
+		pixel_x = rand(-randpixel, randpixel)
+		pixel_y = rand(-randpixel, 0) - randpixel //an idea borrowed from some of the older pixel_y randomizations. Intended to make items appear to drop at a character's feet
+
 
 /obj/item/equipped()
 	..()
@@ -195,7 +200,13 @@
 	else
 		if(isliving(src.loc))
 			return
-	user.put_in_active_hand(src)
+	if(user.put_in_active_hand(src))
+		if(randpixel)
+			pixel_x = rand(-randpixel, randpixel)
+			pixel_y = rand(-randpixel, 0) //an idea borrowed from some of the older pixel_y randomizations. Intended to make items appear to drop at a character's feet
+		else if(randpixel == 0)
+			pixel_x = 0
+			pixel_y = 0
 	return
 
 /obj/item/attack_ai(mob/user as mob)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -86,10 +86,12 @@
 		else
 			embed_chance = force/(w_class*3)
 	..()
+/*
 	if(randpixel && (!pixel_x && !pixel_y)) //hopefully this will prevent us from messing with mapper-set pixel_x/y
 		pixel_x = rand(-randpixel, randpixel)
 		pixel_y = rand(-randpixel, 0) - randpixel //an idea borrowed from some of the older pixel_y randomizations. Intended to make items appear to drop at a character's feet
-
+*/
+	//keeping this here if it's ever wanted.
 
 /obj/item/equipped()
 	..()

--- a/code/game/objects/items/devices/radio/intercom.dm
+++ b/code/game/objects/items/devices/radio/intercom.dm
@@ -2,6 +2,7 @@
 	name = "station intercom (General)"
 	desc = "Talk through this."
 	icon_state = "intercom"
+	randpixel = 0
 	anchored = 1
 	w_class = ITEMSIZE_LARGE
 	canhear_range = 2

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -753,6 +753,7 @@ var/global/list/default_medbay_channels = list(
 	broadcasting = 0
 	icon = 'icons/obj/items.dmi'
 	icon_state = "red_phone"
+	randpixel = 0
 	listening = 1
 	name = "phone"
 

--- a/code/game/objects/items/stacks/tiles/tile_types.dm
+++ b/code/game/objects/items/stacks/tiles/tile_types.dm
@@ -14,13 +14,9 @@
 	name = "tile"
 	singular_name = "tile"
 	desc = "A non-descript floor tile"
+	randpixel = 7
 	w_class = ITEMSIZE_NORMAL
 	max_amount = 60
-
-/obj/item/stack/tile/New()
-	..()
-	pixel_x = rand(-7, 7)
-	pixel_y = rand(-7, 7)
 
 /*
  * Grass

--- a/code/game/objects/items/weapons/cigs_lighters.dm
+++ b/code/game/objects/items/weapons/cigs_lighters.dm
@@ -356,14 +356,13 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	desc = "A manky old cigarette butt."
 	icon = 'icons/obj/clothing/masks.dmi'
 	icon_state = "cigbutt"
+	randpixel = 10
 	w_class = ITEMSIZE_TINY
 	slot_flags = SLOT_EARS
 	throwforce = 1
 
 /obj/item/weapon/cigbutt/New()
 	..()
-	pixel_x = rand(-10,10)
-	pixel_y = rand(-10,10)
 	transform = turn(transform,rand(0,360))
 
 /obj/item/weapon/cigbutt/cigarbutt

--- a/code/game/objects/items/weapons/gift_wrappaper.dm
+++ b/code/game/objects/items/weapons/gift_wrappaper.dm
@@ -13,11 +13,10 @@
 	icon = 'icons/obj/items.dmi'
 	icon_state = "gift1"
 	item_state = "gift1"
+	randpixel = 10
 
 /obj/item/weapon/a_gift/New()
 	..()
-	pixel_x = rand(-10,10)
-	pixel_y = rand(-10,10)
 	if(w_class > 0 && w_class < ITEMSIZE_LARGE)
 		icon_state = "gift[w_class]"
 	else

--- a/code/game/objects/items/weapons/material/ashtray.dm
+++ b/code/game/objects/items/weapons/material/ashtray.dm
@@ -4,6 +4,7 @@ var/global/list/ashtray_cache = list()
 	name = "ashtray"
 	icon = 'icons/obj/objects.dmi'
 	icon_state = "blank"
+	randpixel = 5
 	force_divisor = 0.1
 	thrown_force_divisor = 0.1
 	var/image/base_image
@@ -15,8 +16,6 @@ var/global/list/ashtray_cache = list()
 		qdel(src)
 		return
 	max_butts = round(material.hardness/10) //This is arbitrary but whatever.
-	src.pixel_y = rand(-5, 5)
-	src.pixel_x = rand(-6, 6)
 	update_icon()
 	return
 

--- a/code/game/objects/items/weapons/material/shards.dm
+++ b/code/game/objects/items/weapons/material/shards.dm
@@ -5,6 +5,7 @@
 	icon = 'icons/obj/shards.dmi'
 	desc = "Made of nothing. How does this even exist?" // set based on material, if this desc is visible it's a bug (shards default to being made of glass)
 	icon_state = "large"
+	randpixel=8
 	sharp = 1
 	edge = 1
 	w_class = ITEMSIZE_SMALL
@@ -27,8 +28,6 @@
 		return
 
 	icon_state = "[material.shard_icon][pick("large", "medium", "small")]"
-	pixel_x = rand(-8, 8)
-	pixel_y = rand(-8, 8)
 	update_icon()
 
 	if(material.shard_type)

--- a/code/game/objects/items/weapons/material/thrown.dm
+++ b/code/game/objects/items/weapons/material/thrown.dm
@@ -2,6 +2,7 @@
 	name = "shuriken"
 	desc = "A sharp, perfectly weighted piece of metal."
 	icon_state = "star"
+	randpixel = 12
 	force_divisor = 0.1 // 6 with hardness 60 (steel)
 	thrown_force_divisor = 0.75 // 15 with weight 20 (steel)
 	throw_speed = 10
@@ -11,8 +12,6 @@
 
 /obj/item/weapon/material/star/New()
 	..()
-	src.pixel_x = rand(-12, 12)
-	src.pixel_y = rand(-12, 12)
 
 /obj/item/weapon/material/star/throw_impact(atom/hit_atom)
 	..()

--- a/code/game/objects/structures/bedsheet_bin.dm
+++ b/code/game/objects/structures/bedsheet_bin.dm
@@ -9,6 +9,7 @@ LINEN BINS
 	desc = "A surprisingly soft linen bedsheet."
 	icon = 'icons/obj/items.dmi'
 	icon_state = "sheet"
+	randpixel = 0
 	slot_flags = SLOT_BACK
 	layer = 4.0
 	throwforce = 1

--- a/code/game/objects/structures/stool_bed_chair_nest/stools.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/stools.dm
@@ -6,6 +6,7 @@ var/global/list/stool_cache = list() //haha stool
 	desc = "Apply butt."
 	icon = 'icons/obj/furniture.dmi'
 	icon_state = "stool_preview" //set for the map
+	randpixel = 0
 	force = 10
 	throwforce = 10
 	w_class = ITEMSIZE_HUGE

--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -4,6 +4,7 @@
 	name = "fruit"
 	icon = 'icons/obj/hydroponics_products.dmi'
 	icon_state = "blank"
+	randpixel = 5
 	desc = "Nutritious! Probably."
 	slot_flags = SLOT_HOLSTER
 
@@ -16,8 +17,6 @@
 	..()
 	if(!dried_type)
 		dried_type = type
-	src.pixel_x = rand(-5.0, 5)
-	src.pixel_y = rand(-5.0, 5)
 
 	// Fill the object up with the appropriate reagents.
 	if(planttype)

--- a/code/modules/hydroponics/seed_machines.dm
+++ b/code/modules/hydroponics/seed_machines.dm
@@ -8,11 +8,6 @@
 	var/list/genes = list()
 	var/genesource = "unknown"
 
-/obj/item/weapon/disk/botany/New()
-	..()
-	pixel_x = rand(-5,5)
-	pixel_y = rand(-5,5)
-
 /obj/item/weapon/disk/botany/attack_self(var/mob/user as mob)
 	if(genes.len)
 		var/choice = alert(user, "Are you sure you want to wipe the disk?", "Xenobotany Data", "No", "Yes")

--- a/code/modules/materials/material_sheets.dm
+++ b/code/modules/materials/material_sheets.dm
@@ -7,6 +7,7 @@
 	throw_speed = 3
 	throw_range = 3
 	max_amount = 50
+	randpixel = 3
 	item_icons = list(
 		slot_l_hand_str = 'icons/mob/items/lefthand_material.dmi',
 		slot_r_hand_str = 'icons/mob/items/righthand_material.dmi',
@@ -17,10 +18,8 @@
 	var/perunit = SHEET_MATERIAL_AMOUNT
 	var/apply_colour //temp pending icon rewrite
 
-/obj/item/stack/material/New()
-	..()
-	pixel_x = rand(0,4)-4
-	pixel_y = rand(0,4)-4
+/obj/item/stack/material/New(atom/newloc, var/amount=null)
+	..(newloc, amount)
 
 	if(!default_type)
 		default_type = DEFAULT_WALL_MATERIAL

--- a/code/modules/mining/coins.dm
+++ b/code/modules/mining/coins.dm
@@ -4,6 +4,7 @@
 	icon = 'icons/obj/items.dmi'
 	name = "Coin"
 	icon_state = "coin"
+	randpixel = 8
 	flags = CONDUCT
 	force = 0.0
 	throwforce = 0.0
@@ -11,10 +12,6 @@
 	slot_flags = SLOT_EARS
 	var/string_attached
 	var/sides = 2
-
-/obj/item/weapon/coin/New()
-	pixel_x = rand(0,16)-8
-	pixel_y = rand(0,8)-8
 
 /obj/item/weapon/coin/gold
 	name = "gold coin"

--- a/code/modules/mining/ore.dm
+++ b/code/modules/mining/ore.dm
@@ -2,6 +2,7 @@
 	name = "small rock"
 	icon = 'icons/obj/mining.dmi'
 	icon_state = "ore2"
+	randpixel = 8
 	w_class = ITEMSIZE_SMALL
 	var/datum/geosample/geologic_data
 	var/material
@@ -82,10 +83,6 @@
 	desc = "Someone screwed up..."
 	icon_state = "slag"
 	material = null
-
-/obj/item/weapon/ore/New()
-	pixel_x = rand(0,16)-8
-	pixel_y = rand(0,8)-8
 
 /obj/item/weapon/ore/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	if(istype(W,/obj/item/device/core_sampler))

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -39,8 +39,6 @@
 
 /obj/item/weapon/paper/New()
 	..()
-	pixel_y = rand(-8, 8)
-	pixel_x = rand(-9, 9)
 	stamps = ""
 
 	if(name != "paper")

--- a/code/modules/paperwork/paper_bundle.dm
+++ b/code/modules/paperwork/paper_bundle.dm
@@ -4,6 +4,7 @@
 	icon = 'icons/obj/bureaucracy.dmi'
 	icon_state = "paper"
 	item_state = "paper"
+	randpixel = 8
 	throwforce = 0
 	w_class = ITEMSIZE_SMALL
 	throw_range = 2

--- a/code/modules/paperwork/paperbin.dm
+++ b/code/modules/paperwork/paperbin.dm
@@ -2,6 +2,7 @@
 	name = "paper bin"
 	icon = 'icons/obj/bureaucracy.dmi'
 	icon_state = "paper_bin1"
+	randpixel = 0
 	item_icons = list(
 			slot_l_hand_str = 'icons/mob/items/lefthand_material.dmi',
 			slot_r_hand_str = 'icons/mob/items/righthand_material.dmi',

--- a/code/modules/paperwork/papershredder.dm
+++ b/code/modules/paperwork/papershredder.dm
@@ -149,6 +149,7 @@
 	name = "shredded paper"
 	icon = 'icons/obj/bureaucracy.dmi'
 	icon_state = "shredp"
+	randpixel = 5
 	throwforce = 0
 	w_class = ITEMSIZE_TINY
 	throw_range = 3
@@ -156,8 +157,6 @@
 
 /obj/item/weapon/shreddedp/New()
 	..()
-	pixel_x = rand(-5,5)
-	pixel_y = rand(-5,5)
 	if(prob(65)) color = pick("#BABABA","#7F7F7F")
 
 /obj/item/weapon/shreddedp/attackby(var/obj/item/W as obj, var/mob/user)

--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -250,8 +250,6 @@
 	p.update_icon()
 	p.icon_state = "paper_words"
 	p.name = bundle.name
-	p.pixel_y = rand(-8, 8)
-	p.pixel_x = rand(-9, 9)
 	return p
 
 /obj/item/device/toner

--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -28,6 +28,7 @@ var/global/photo_count = 0
 	icon = 'icons/obj/items.dmi'
 	icon_state = "photo"
 	item_state = "paper"
+	randpixel = 10
 	w_class = ITEMSIZE_SMALL
 	var/id
 	var/icon/img	//Big photo image
@@ -293,8 +294,6 @@ var/global/photo_count = 0
 	p.tiny = pc
 	p.img = photoimage
 	p.desc = mobs
-	p.pixel_x = rand(-10, 10)
-	p.pixel_y = rand(-10, 10)
 	p.photo_size = size
 
 	return p

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -483,6 +483,7 @@ obj/structure/cable/proc/cableColor(var/colorC)
 	name = "cable coil"
 	icon = 'icons/obj/power.dmi'
 	icon_state = "coil"
+	randpixel = 2
 	amount = MAXCOIL
 	max_amount = MAXCOIL
 	color = COLOR_RED
@@ -518,8 +519,6 @@ obj/structure/cable/proc/cableColor(var/colorC)
 	src.amount = length
 	if (param_color) // It should be red by default, so only recolor it if parameter was specified.
 		color = param_color
-	pixel_x = rand(-2,2)
-	pixel_y = rand(-2,2)
 	update_icon()
 	update_wclass()
 
@@ -805,8 +804,6 @@ obj/structure/cable/proc/cableColor(var/colorC)
 /obj/item/stack/cable_coil/cut/New(loc)
 	..()
 	src.amount = rand(1,2)
-	pixel_x = rand(-2,2)
-	pixel_y = rand(-2,2)
 	update_icon()
 	update_wclass()
 

--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -3,6 +3,7 @@
 	desc = "A bullet casing."
 	icon = 'icons/obj/ammo.dmi'
 	icon_state = "s-casing"
+	randpixel = 10
 	flags = CONDUCT
 	slot_flags = SLOT_BELT | SLOT_EARS
 	throwforce = 1
@@ -18,8 +19,6 @@
 	..()
 	if(ispath(projectile_type))
 		BB = new projectile_type(src)
-	pixel_x = rand(-10, 10)
-	pixel_y = rand(-10, 10)
 
 //removes the projectile from the ammo casing
 /obj/item/ammo_casing/proc/expend()
@@ -91,8 +90,6 @@
 
 /obj/item/ammo_magazine/New()
 	..()
-	pixel_x = rand(-5, 5)
-	pixel_y = rand(-5, 5)
 	if(multiple_sprites)
 		initialize_magazine_icondata(src)
 

--- a/code/modules/reagents/Chemistry-Machinery.dm
+++ b/code/modules/reagents/Chemistry-Machinery.dm
@@ -233,8 +233,6 @@
 				var/obj/item/weapon/reagent_containers/pill/P = new/obj/item/weapon/reagent_containers/pill(src.loc)
 				if(!name) name = reagents.get_master_reagent_name()
 				P.name = "[name] pill"
-				P.pixel_x = rand(-7, 7) //random position
-				P.pixel_y = rand(-7, 7)
 				P.icon_state = "pill"+pillsprite
 				reagents.trans_to_obj(P,amount_per_pill)
 				if(src.loaded_pill_bottle)
@@ -247,8 +245,6 @@
 				var/obj/item/weapon/reagent_containers/glass/bottle/P = new/obj/item/weapon/reagent_containers/glass/bottle(src.loc)
 				if(!name) name = reagents.get_master_reagent_name()
 				P.name = "[name] bottle"
-				P.pixel_x = rand(-7, 7) //random position
-				P.pixel_y = rand(-7, 7)
 				P.icon_state = "bottle-"+bottlesprite
 				reagents.trans_to_obj(P,60)
 				P.update_icon()

--- a/code/modules/reagents/reagent_containers/food.dm
+++ b/code/modules/reagents/reagent_containers/food.dm
@@ -1,38 +1,8 @@
-#define CELLS 8
-#define CELLSIZE (32/CELLS)
-
 ////////////////////////////////////////////////////////////////////////////////
 /// Food.
 ////////////////////////////////////////////////////////////////////////////////
 /obj/item/weapon/reagent_containers/food
+	randpixel = 6
 	possible_transfer_amounts = null
 	volume = 50 //Sets the default container amount for all food items.
 	var/filling_color = "#FFFFFF" //Used by sandwiches.
-
-	var/list/center_of_mass = list() // Used for table placement
-
-/obj/item/weapon/reagent_containers/food/New()
-	..()
-	if (center_of_mass.len && !pixel_x && !pixel_y)
-		src.pixel_x = rand(-6.0, 6) //Randomizes postion
-		src.pixel_y = rand(-6.0, 6)
-
-/obj/item/weapon/reagent_containers/food/afterattack(atom/A, mob/user, proximity, params)
-	if(center_of_mass.len && proximity && params && istype(A, /obj/structure/table))
-		//Places the item on a grid
-		var/list/mouse_control = params2list(params)
-
-		var/mouse_x = text2num(mouse_control["icon-x"])
-		var/mouse_y = text2num(mouse_control["icon-y"])
-
-		if(!isnum(mouse_x) || !isnum(mouse_y))
-			return
-
-		var/cell_x = max(0, min(CELLS-1, round(mouse_x/CELLSIZE)))
-		var/cell_y = max(0, min(CELLS-1, round(mouse_y/CELLSIZE)))
-
-		pixel_x = (CELLSIZE * (0.5 + cell_x)) - center_of_mass["x"]
-		pixel_y = (CELLSIZE * (0.5 + cell_y)) - center_of_mass["y"]
-
-#undef CELLS
-#undef CELLSIZE

--- a/code/modules/reagents/reagent_containers/food/condiment.dm
+++ b/code/modules/reagents/reagent_containers/food/condiment.dm
@@ -10,6 +10,7 @@
 	desc = "Just your average condiment container."
 	icon = 'icons/obj/food.dmi'
 	icon_state = "emptycondiment"
+	randpixel = 10
 	flags = OPENCONTAINER
 	possible_transfer_amounts = list(1,5,10)
 	center_of_mass = list("x"=16, "y"=6)
@@ -174,5 +175,3 @@
 /obj/item/weapon/reagent_containers/food/condiment/flour/New()
 	..()
 	reagents.add_reagent("flour", 30)
-	src.pixel_x = rand(-10.0, 10)
-	src.pixel_y = rand(-10.0, 10)

--- a/code/modules/reagents/reagent_containers/glass/bottle.dm
+++ b/code/modules/reagents/reagent_containers/glass/bottle.dm
@@ -7,6 +7,7 @@
 	icon = 'icons/obj/chemical.dmi'
 	icon_state = null
 	item_state = "atoxinbottle"
+	randpixel = 7
 	amount_per_transfer_from_this = 10
 	possible_transfer_amounts = list(5,10,15,25,30,60)
 	flags = 0

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -7,6 +7,7 @@
 	icon = 'icons/obj/chemical.dmi'
 	icon_state = null
 	item_state = "pill"
+	randpixel = 7
 	possible_transfer_amounts = null
 	w_class = ITEMSIZE_TINY
 	slot_flags = SLOT_EARS

--- a/code/modules/research/research.dm
+++ b/code/modules/research/research.dm
@@ -222,10 +222,6 @@ research holder datum.
 	matter = list(DEFAULT_WALL_MATERIAL = 30, "glass" = 10)
 	var/datum/tech/stored
 
-/obj/item/weapon/disk/tech_disk/New()
-	pixel_x = rand(-5.0, 5)
-	pixel_y = rand(-5.0, 5)
-
 /obj/item/weapon/disk/design_disk
 	name = "component design disk"
 	desc = "A disk for storing device design data for construction in lathes."
@@ -235,7 +231,3 @@ research holder datum.
 	w_class = ITEMSIZE_SMALL
 	matter = list(DEFAULT_WALL_MATERIAL = 30, "glass" = 10)
 	var/datum/design/blueprint
-
-/obj/item/weapon/disk/design_disk/New()
-	pixel_x = rand(-5.0, 5)
-	pixel_y = rand(-5.0, 5)

--- a/code/modules/tables/interactions.dm
+++ b/code/modules/tables/interactions.dm
@@ -72,7 +72,7 @@
 	return
 
 
-/obj/structure/table/attackby(obj/item/W as obj, mob/user as mob)
+/obj/structure/table/attackby(obj/item/W as obj, mob/user as mob, var/click_params)
 	if (!W) return
 
 	// Handle harm intent grabbing/tabling.
@@ -140,7 +140,52 @@
 
 	if(item_place)
 		user.drop_item(src.loc)
+		auto_align(W, click_params)
 	return
 
 /obj/structure/table/attack_tk() // no telehulk sorry
 	return
+
+
+/obj/item/var/center_of_mass = "x=16;y=16" //can be null for no exact placement behaviour
+/obj/structure/table/proc/auto_align(obj/item/W, click_params)
+	if (!W.center_of_mass) // Clothing, material stacks, generally items with large sprites where exact placement would be unhandy.
+		W.pixel_x = rand(-W.randpixel, W.randpixel)
+		W.pixel_y = rand(-W.randpixel, W.randpixel)
+		W.pixel_z = 0
+		return
+
+	if (!click_params)
+		return
+
+	var/list/click_data = params2list(click_params)
+	if (!click_data["icon-x"] || !click_data["icon-y"])
+		return
+
+	// Calculation to apply new pixelshift.
+	var/mouse_x = text2num(click_data["icon-x"])-1 // Ranging from 0 to 31
+	var/mouse_y = text2num(click_data["icon-y"])-1
+
+	var/cell_x = Clamp(round(mouse_x/CELLSIZE), 0, CELLS-1) // Ranging from 0 to CELLS-1
+	var/cell_y = Clamp(round(mouse_y/CELLSIZE), 0, CELLS-1)
+
+	var/list/center = cached_key_number_decode(W.center_of_mass)
+
+	W.pixel_x = (CELLSIZE * (cell_x + 0.5)) - center["x"]
+	W.pixel_y = (CELLSIZE * (cell_y + 0.5)) - center["y"]
+	W.pixel_z = 0
+
+/obj/structure/table/rack/auto_align(obj/item/W, click_params)
+	if(W && !W.center_of_mass)
+		..(W)
+
+	var/i = -1
+	for (var/obj/item/I in get_turf(src))
+		if (I.anchored || !I.center_of_mass)
+			continue
+		i++
+		I.pixel_x = max(3-i*3, -3) + 1 // There's a sprite layering bug for 0/0 pixelshift, so we avoid it.
+		I.pixel_y = max(4-i*4, -4) + 1
+		I.pixel_z = 0
+
+

--- a/code/modules/tables/rack.dm
+++ b/code/modules/tables/rack.dm
@@ -12,6 +12,11 @@
 	verbs -= /obj/structure/table/verb/do_flip
 	verbs -= /obj/structure/table/proc/do_put
 
+
+/obj/structure/table/rack/initialize()
+	auto_align()
+	..()
+
 /obj/structure/table/rack/update_connections()
 	return
 

--- a/code/modules/xenoarcheaology/sampling.dm
+++ b/code/modules/xenoarcheaology/sampling.dm
@@ -2,6 +2,7 @@
 	name = "rock sliver"
 	desc = "It looks extremely delicate."
 	icon = 'icons/obj/xenoarchaeology.dmi'
+	randpixel = 8
 	icon_state = "sliver1"
 	w_class = ITEMSIZE_TINY
 	sharp = 1
@@ -9,8 +10,6 @@
 
 /obj/item/weapon/rocksliver/New()
 	icon_state = "sliver[rand(1, 3)]"
-	pixel_x = rand(-8, 8)
-	pixel_y = rand(-8 ,0)
 
 /datum/geosample
 	var/age = 0

--- a/html/changelogs/LorenLuke - TablePixels.yml
+++ b/html/changelogs/LorenLuke - TablePixels.yml
@@ -1,0 +1,37 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: LorenLuke
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Clicking any item, not just food, on a table will align it to the cursor."
+  - rscadd: "Adds a few parameter functions to be used (no idea what they do, but needed for the feature)."


### PR DESCRIPTION
Ported from Bay12.

- Allows items (not just food) to be placed where clicked on on tables.

- Randomises item placement when dropped or on spawn

- Adds a few param functions.

