### PR TITLE
Fixes a chameleon gun bug

### DIFF
--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -408,6 +408,7 @@
 	projectile_type = /obj/item/projectile/chameleon
 	charge_meter = 0
 	charge_cost = 48 //uses next to no power, since it's just holograms
+	battery_lock = 1
 
 	var/obj/item/projectile/copy_projectile
 	var/global/list/gun_choices


### PR DESCRIPTION
Easiest way to fix the bug was to just remove the ability to take out the cell.