### PR TITLE
Allow turbolift specific-floor delays

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ language: c
 sudo: false
 
 env:
-  BYOND_MAJOR="510"
-  BYOND_MINOR="1346"
-  MACRO_COUNT=986
+  BYOND_MAJOR="511"
+  BYOND_MINOR="1381"
+  MACRO_COUNT=875
 
 cache:
   directories:

--- a/code/modules/turbolift/turbolift.dm
+++ b/code/modules/turbolift/turbolift.dm
@@ -108,7 +108,7 @@
 	current_floor = next_floor
 	control_panel_interior.visible_message("The elevator [moving_upwards ? "rises" : "descends"] smoothly.")
 
-	return 1
+	return (next_floor.delay_time || move_delay || 30)
 
 /datum/turbolift/proc/queue_move_to(var/datum/turbolift_floor/floor)
 	if(!floor || !(floor in floors) || (floor in queued_floors))

--- a/code/modules/turbolift/turbolift_areas.dm
+++ b/code/modules/turbolift/turbolift_areas.dm
@@ -9,3 +9,4 @@
 	var/lift_floor_name = null
 	var/lift_announce_str = "Ding!"
 	var/arrival_sound = 'sound/machines/ding.ogg'
+	var/delay_time

--- a/code/modules/turbolift/turbolift_console.dm
+++ b/code/modules/turbolift/turbolift_console.dm
@@ -123,7 +123,7 @@
 	dat += "<a href='?src=\ref[src];emergency_stop=1'>Emergency Stop</a>"
 	dat += "<hr></body></html>"
 
-	var/datum/browser/popup = new(user, "turbolift_panel", "Lift Panel", 230, 260)
+	var/datum/browser/popup = new(user, "turbolift_panel", "Lift Panel", 250, 320)
 	popup.set_content(jointext(dat, null))
 	popup.open()
 	return

--- a/code/modules/turbolift/turbolift_floor.dm
+++ b/code/modules/turbolift/turbolift_floor.dm
@@ -5,6 +5,7 @@
 	var/name
 	var/announce_str
 	var/arrival_sound
+	var/delay_time
 
 	var/list/doors = list()
 	var/obj/structure/lift/button/ext_panel
@@ -20,6 +21,7 @@
 	name = A.lift_floor_name ? A.lift_floor_name : A.name
 	announce_str = A.lift_announce_str
 	arrival_sound = A.arrival_sound
+	delay_time = A.delay_time
 
 //called when a lift has queued this floor as a destination
 /datum/turbolift_floor/proc/pending_move(var/datum/turbolift/lift)

--- a/code/modules/turbolift/turbolift_process.dm
+++ b/code/modules/turbolift/turbolift_process.dm
@@ -20,16 +20,17 @@ var/datum/controller/process/turbolift/turbolift_controller
 			continue
 		spawn(0)
 			lift.busy = 1
-			if(!lift.do_move())
+			var/floor_delay
+			if(!(floor_delay = lift.do_move()))
 				moving_lifts[liftref] = null
 				moving_lifts -= liftref
 				if(lift.target_floor)
 					lift.target_floor.ext_panel.reset()
 					lift.target_floor = null
 			else
-				lift_is_moving(lift)
+				lift_is_moving(lift,floor_delay)
 			lift.busy = 0
 		SCHECK
 
-/datum/controller/process/turbolift/proc/lift_is_moving(var/datum/turbolift/lift)
-	moving_lifts["\ref[lift]"] = world.time + lift.move_delay
+/datum/controller/process/turbolift/proc/lift_is_moving(var/datum/turbolift/lift,var/floor_delay)
+	moving_lifts["\ref[lift]"] = world.time + floor_delay


### PR DESCRIPTION
If one floor is 'taller' than the others, or otherwise takes longer to traverse, you can set delay_time on the area to have it wait a different time there. Or, wait even less time, though less than 1 second isn't possible since the controller only fires every second.

Also makes the default elevator panel nanoui window sliiightly bigger. It often had scrollbars for me after a few floors.