### PR TITLE
Fix zpipes losing color in-game.

### DIFF
--- a/code/modules/multiz/pipes.dm
+++ b/code/modules/multiz/pipes.dm
@@ -97,6 +97,7 @@ obj/machinery/atmospherics/pipe/zpipe/pipeline_expansion()
 	return list(node1, node2)
 
 obj/machinery/atmospherics/pipe/zpipe/update_icon()
+	color = pipe_color
 	return
 
 obj/machinery/atmospherics/pipe/zpipe/disconnect(obj/machinery/atmospherics/reference)


### PR DESCRIPTION
* Colored zpipes (like scrubbers or supply for example) would always lose color in game becuase atmospherics machinery sets color = null since most pipes use overlays and the icon cache.  For better or worse, zpipes don't, they just use a normal icon_state, so they need color set.

![image](https://cloud.githubusercontent.com/assets/14110581/25462298/209a14c0-2abc-11e7-922a-48ad1c493acc.png)
