### PR TITLE
Stasis Bag and Sleeper Changes

### DIFF
--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -534,7 +534,7 @@
 			time_entered = world.time
 			if(ishuman(M) && applies_stasis)
 				var/mob/living/carbon/human/H = M
-				H.in_stasis = 1
+				H.Stasis(1000)
 
 			// Book keeping!
 			var/turf/location = get_turf(src)
@@ -602,7 +602,7 @@
 		set_occupant(usr)
 		if(ishuman(usr) && applies_stasis)
 			var/mob/living/carbon/human/H = occupant
-			H.in_stasis = 1
+			H.Stasis(1000)
 
 		icon_state = occupied_icon_state
 
@@ -638,7 +638,7 @@
 	occupant.forceMove(get_turf(src))
 	if(ishuman(occupant) && applies_stasis)
 		var/mob/living/carbon/human/H = occupant
-		H.in_stasis = 0
+		H.Stasis(0)
 	set_occupant(null)
 
 	icon_state = base_icon_state

--- a/code/game/mecha/equipment/tools/medical_tools.dm
+++ b/code/game/mecha/equipment/tools/medical_tools.dm
@@ -7,7 +7,7 @@
 	energy_drain = 20
 	range = MELEE
 	equip_cooldown = 50
-	var/mob/living/carbon/occupant = null
+	var/mob/living/carbon/human/occupant = null
 	var/datum/global_iterator/pr_mech_sleeper
 	var/inject_amount = 10
 	required_type = /obj/mecha/medical
@@ -28,7 +28,7 @@
 	Exit(atom/movable/O)
 		return 0
 
-	action(var/mob/living/carbon/target)
+	action(var/mob/living/carbon/human/target)
 		if(!action_checks(target))
 			return
 		if(!istype(target))
@@ -56,6 +56,7 @@
 			target.forceMove(src)
 			occupant = target
 			target.reset_view(src)
+			occupant.Stasis(3)
 			/*
 			if(target.client)
 				target.client.perspective = EYE_PERSPECTIVE
@@ -80,6 +81,7 @@
 			occupant.client.eye = occupant.client.mob
 			occupant.client.perspective = MOB_PERSPECTIVE
 		*/
+		occupant.Stasis(0)
 		occupant = null
 		pr_mech_sleeper.stop()
 		set_ready_state(1)

--- a/code/game/objects/items/bodybag.dm
+++ b/code/game/objects/items/bodybag.dm
@@ -77,14 +77,14 @@
 /obj/structure/closet/body_bag/MouseDrop(over_object, src_location, over_location)
 	..()
 	if((over_object == usr && (in_range(src, usr) || usr.contents.Find(src))))
-		if(!ishuman(usr))	return
+		if(!ishuman(usr))	return 0
 		if(opened)	return 0
 		if(contents.len)	return 0
 		visible_message("[usr] folds up the [src.name]")
-		new item_path(get_turf(src))
+		var/folded = new item_path(get_turf(src))
 		spawn(0)
 			qdel(src)
-		return
+		return folded
 
 /obj/structure/closet/body_bag/proc/get_occupants()
 	var/list/occupants = list()
@@ -109,34 +109,43 @@
 
 /obj/item/bodybag/cryobag
 	name = "stasis bag"
-	desc = "A folded, non-reusable bag designed to prevent additional damage to an occupant, especially useful if short on time or in \
-	a hostile enviroment."
+	desc = "A non-reusable plastic bag designed to slow down bodily functions such as circulation and breathing, \
+	especially useful if short on time or in a hostile enviroment."
 	icon = 'icons/obj/cryobag.dmi'
 	icon_state = "bodybag_folded"
 	item_state = "bodybag_cryo_folded"
 	origin_tech = list(TECH_BIO = 4)
+	var/obj/item/weapon/reagent_containers/syringe/syringe
 
 /obj/item/bodybag/cryobag/attack_self(mob/user)
 	var/obj/structure/closet/body_bag/cryobag/R = new /obj/structure/closet/body_bag/cryobag(user.loc)
 	R.add_fingerprint(user)
+	if(syringe)
+		R.syringe = syringe
+		syringe = null
 	qdel(src)
 
 /obj/structure/closet/body_bag/cryobag
 	name = "stasis bag"
-	desc = "A non-reusable plastic bag designed to prevent additional damage to an occupant, especially useful if short on time or in \
-	a hostile enviroment."
+	desc = "A non-reusable plastic bag designed to slow down bodily functions such as circulation and breathing, \
+	especially useful if short on time or in a hostile enviroment."
 	icon = 'icons/obj/cryobag.dmi'
 	item_path = /obj/item/bodybag/cryobag
 	store_misc = 0
 	store_items = 0
 	var/used = 0
 	var/obj/item/weapon/tank/tank = null
+	var/stasis_level = 3 //Every 'this' life ticks are applied to the mob (when life_ticks%stasis_level == 1)
+	var/obj/item/weapon/reagent_containers/syringe/syringe
 
 /obj/structure/closet/body_bag/cryobag/New()
 	tank = new /obj/item/weapon/tank/emergency/oxygen(null) //It's in nullspace to prevent ejection when the bag is opened.
 	..()
 
 /obj/structure/closet/body_bag/cryobag/Destroy()
+	if(syringe)
+		qdel(syringe)
+		syringe = null
 	qdel(tank)
 	tank = null
 	..()
@@ -151,11 +160,19 @@
 		O.desc = "Pretty useless now.."
 		qdel(src)
 
+/obj/structure/closet/body_bag/cryobag/MouseDrop(over_object, src_location, over_location)
+	. = ..()
+	if(. && syringe)
+		var/obj/item/bodybag/cryobag/folded = .
+		folded.syringe = syringe
+		syringe = null
+
 /obj/structure/closet/body_bag/cryobag/Entered(atom/movable/AM)
 	if(ishuman(AM))
 		var/mob/living/carbon/human/H = AM
-		H.in_stasis = 1
+		H.Stasis(stasis_level)
 		src.used = 1
+		inject_occupant(H)
 
 	if(istype(AM, /obj/item/organ))
 		var/obj/item/organ/O = AM
@@ -167,7 +184,7 @@
 /obj/structure/closet/body_bag/cryobag/Exited(atom/movable/AM)
 	if(ishuman(AM))
 		var/mob/living/carbon/human/H = AM
-		H.in_stasis = 0
+		H.Stasis(0)
 
 	if(istype(AM, /obj/item/organ))
 		var/obj/item/organ/O = AM
@@ -181,10 +198,19 @@
 		return tank.air_contents
 	..()
 
+/obj/structure/closet/body_bag/cryobag/proc/inject_occupant(var/mob/living/carbon/human/H)
+	if(!syringe)
+		return
+
+	if(H.reagents)
+		syringe.reagents.trans_to_mob(H, 30, CHEM_BLOOD)
+
 /obj/structure/closet/body_bag/cryobag/examine(mob/user)
 	..()
 	if(Adjacent(user)) //The bag's rather thick and opaque from a distance.
 		user << "<span class='info'>You peer into \the [src].</span>"
+		if(syringe)
+			user << "<span class='info'>It has a syringe added to it.</span>"
 		for(var/mob/living/L in contents)
 			L.examine(user)
 
@@ -196,5 +222,28 @@
 			var/obj/item/device/healthanalyzer/analyzer = W
 			for(var/mob/living/L in contents)
 				analyzer.attack(L,user)
+
+		else if(istype(W,/obj/item/weapon/reagent_containers/syringe))
+			if(syringe)
+				to_chat(user,"<span class='warning'>\The [src] already has an injector! Remove it first.</span>")
+			else
+				var/obj/item/weapon/reagent_containers/syringe/syringe = W
+				to_chat(user,"<span class='info'>You insert \the [syringe] into \the [src], and it locks into place.</span>")
+				user.unEquip(syringe)
+				src.syringe = syringe
+				syringe.loc = null
+				for(var/mob/living/carbon/human/H in contents)
+					inject_occupant(H)
+					break
+
+		else if(istype(W,/obj/item/weapon/screwdriver))
+			if(syringe)
+				if(used)
+					to_chat(user,"<span class='warning'>The injector cannot be removed now that the stasis bag has been used!</span>")
+				else
+					syringe.forceMove(src.loc)
+					to_chat(user,"<span class='info'>You pry \the [syringe] out of \the [src].</span>")
+					syringe = null
+
 		else
 			..()

--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -153,6 +153,12 @@
 		wearing_rig.notify_ai("<span class='danger'>Warning: user consciousness failure. Mobility control passed to integrated intelligence system.</span>")
 	..()
 
+/mob/living/carbon/human/proc/Stasis(amount)
+	if((species.flags & NO_SCAN) || isSynthetic())
+		in_stasis = 0
+	else
+		in_stasis = amount
+
 /mob/living/carbon/human/getCloneLoss()
 	if((species.flags & NO_SCAN) || isSynthetic())
 		cloneloss = 0

--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -159,6 +159,20 @@
 	else
 		in_stasis = amount
 
+/mob/living/carbon/human/proc/getStasis()
+	if((species.flags & NO_SCAN) || isSynthetic())
+		return 0
+
+	return in_stasis
+
+//This determines if, RIGHT NOW, the life() tick is being skipped due to stasis
+/mob/living/carbon/human/proc/inStasisNow()
+	var/stasisValue = getStasis()
+	if(stasisValue && (life_tick % stasisValue))
+		return 1
+
+	return 0
+
 /mob/living/carbon/human/getCloneLoss()
 	if((species.flags & NO_SCAN) || isSynthetic())
 		cloneloss = 0

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -63,7 +63,10 @@
 	voice = GetVoice()
 
 	//No need to update all of these procs if the guy is dead.
-	if(stat != DEAD && !in_stasis)
+	if(stat != DEAD && (!in_stasis || life_tick % in_stasis == 1))
+		if(in_stasis > 2)
+			Sleeping(10)
+
 		//Updates the number of stored chemicals for powers
 		handle_changeling()
 
@@ -82,7 +85,6 @@
 		if(!client)
 			species.handle_npc(src)
 
-
 	if(!handle_some_updates())
 		return											//We go ahead and process them 5 times for HUD images and other stuff though.
 
@@ -97,7 +99,7 @@
 	return 1
 
 /mob/living/carbon/human/breathe()
-	if(!in_stasis)
+	if(!in_stasis || life_tick % in_stasis == 1)
 		..()
 
 // Calculate how vulnerable the human is to under- and overpressure.
@@ -207,7 +209,7 @@
 
 
 /mob/living/carbon/human/handle_mutations_and_radiation()
-	if(in_stasis)
+	if(in_stasis && life_tick % in_stasis != 1)
 		return
 
 	if(getFireLoss())
@@ -789,7 +791,7 @@
 
 /mob/living/carbon/human/handle_chemicals_in_body()
 
-	if(in_stasis)
+	if(in_stasis && life_tick % in_stasis != 1)
 		return
 
 	if(reagents)
@@ -1339,7 +1341,7 @@
 			if(!druggy && !seer)	see_invisible = SEE_INVISIBLE_LIVING
 
 /mob/living/carbon/human/handle_random_events()
-	if(in_stasis)
+	if(in_stasis && life_tick % in_stasis != 1)
 		return
 
 	// Puke if toxloss is too high

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -62,11 +62,12 @@
 
 	voice = GetVoice()
 
-	//No need to update all of these procs if the guy is dead.
-	if(stat != DEAD && (!in_stasis || life_tick % in_stasis == 1))
-		if(in_stasis > 2)
-			Sleeping(10)
+	var/stasis = inStasisNow()
+	if(getStasis() > 2)
+		Sleeping(20)
 
+	//No need to update all of these procs if the guy is dead.
+	if(stat != DEAD && !stasis)
 		//Updates the number of stored chemicals for powers
 		handle_changeling()
 
@@ -99,7 +100,7 @@
 	return 1
 
 /mob/living/carbon/human/breathe()
-	if(!in_stasis || life_tick % in_stasis == 1)
+	if(!inStasisNow())
 		..()
 
 // Calculate how vulnerable the human is to under- and overpressure.
@@ -209,7 +210,7 @@
 
 
 /mob/living/carbon/human/handle_mutations_and_radiation()
-	if(in_stasis && life_tick % in_stasis != 1)
+	if(inStasisNow())
 		return
 
 	if(getFireLoss())
@@ -791,7 +792,7 @@
 
 /mob/living/carbon/human/handle_chemicals_in_body()
 
-	if(in_stasis && life_tick % in_stasis != 1)
+	if(inStasisNow())
 		return
 
 	if(reagents)
@@ -1341,7 +1342,7 @@
 			if(!druggy && !seer)	see_invisible = SEE_INVISIBLE_LIVING
 
 /mob/living/carbon/human/handle_random_events()
-	if(in_stasis && life_tick % in_stasis != 1)
+	if(inStasisNow())
 		return
 
 	// Puke if toxloss is too high

--- a/code/modules/organs/blood.dm
+++ b/code/modules/organs/blood.dm
@@ -37,7 +37,7 @@ var/const/CE_STABLE_THRESHOLD = 0.5
 
 // Takes care blood loss and regeneration
 /mob/living/carbon/human/handle_blood()
-	if(in_stasis)
+	if(inStasisNow())
 		return
 
 	if(!should_have_organ(O_HEART))

--- a/html/changelogs/Arokha - Sleepers.yml
+++ b/html/changelogs/Arokha - Sleepers.yml
@@ -1,0 +1,39 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Arokha
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Sleepers now have a 'stasis' level setting, that will ignore varying numbers of life() ticks on the patient."
+  - tweak: "Stasis bags and Ody sleepers now use a fixed level of this new stasis system (ignore 2/3 life ticks)."
+  - tweak: "You can escape from being asleep in a sleeper, similar to escaping from a cryotube."
+  - rscadd: "You can now use grabs on sleepers to insert patients, same as scanners."

--- a/nano/templates/sleeper.tmpl
+++ b/nano/templates/sleeper.tmpl
@@ -88,4 +88,12 @@
 			</div>
 		</div>
 	{{/if}}
+	<div class="item">
+		<div class="itemLabel">
+			Stasis Level:
+		</div>
+		<div class="itemContent">
+			{{:helper.link(data.stasis, null, {'change_stasis' : 1})}}
+		</div>
+	</div>
 {{/if}}


### PR DESCRIPTION
This should add a little depth to these two rather shallow machines. Sure sleepers have some drugs and are the only way to do dialysis, but could probably benefit from being more useful, for being a bigass machine attached to the floor in the middle of medical. And stasis bags are a little silly considering they make the occupant completely immune to all harm from any source indefinitely.

**Sleepers:** These now actually deserve the name, and have an adjustable Stasis setting that has 0%, 50%, 80%, 90%, 99% settings. This can be read as "ignore 99% of life() ticks on this mob", or "ignore every other life() tick on this mob" (for the 50% setting), which is how the stasis bags function now (except they ignore every life tick). This allows you to buy time to treat someone, or have them process drugs more slowly so you can handle multiple patients. On the highest (99% slowdown) setting, it also slightly reduces time-of-death decay, and will allow the patient to be defibbed for longer. (Ody Sleeper: Has the same '30%' effects as a Stasis Bag, see below. No features removed.).

**Stasis Bag:** These act like the sleeper with a permanent fixed 66% setting, ignoring 2 out of 3 every life ticks. This is a direct nerf to their functionality, considering they can preserve someone indefinitely for now, without fail, against any harm. To try and make up for this, they now feature a built-in injector system, making them a sort of distant cousin to the sleepers. You can load a syringe with 15u of your favorite drugs and insert it into the cryobag in advance (then just re-fold it back up). Upon being used, the syringe will empty into the patient automatically (and the drugs will process at 30% speed, due to their slowed life() ticks). You can remove the syringe later with a screwdriver if you want to change it. If you're a completely crazy person, you could have a 'brute' stasis bag and a 'burn' stasis bag or something with different drugs.

So now the Sleeper, Ody Sleeper, and Stasis bag are basically tiers of the same concept:
- Stasis bag: Portable, but max 15u drug administration, fixed 33% metabolism rate, one time use (but fits in a pocket)
- Ody sleeper: Portable, advanced drug administration, fixed 30% metabolism rate
- Fixed sleeper: Fixed, advanced drug administration, dialysis, 0-100% metabolism rate, ToD decay delay

Edit: Forgot to mention, you can set the stasis level on a sleeper with no patient in it, it just applies to whoever gets in, so if you are dying and there's a sleeper in a first-aid station or something nearby, you can call for help, set stasis really high, and get in.