### PR TITLE
Fixes three advanced medscanner problems

### DIFF
--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -301,6 +301,15 @@
 
 			occupantData["reagents"] = reagentData
 
+			var/ingestedData[0]
+			if(H.ingested.reagent_list.len >= 1)
+				for(var/datum/reagent/R in H.ingested.reagent_list)
+					ingestedData[++ingestedData.len] = list("name" = R.name, "amount" = R.volume)
+			else
+				ingestedData = null
+
+			occupantData["ingested"] = ingestedData
+
 			var/extOrganData[0]
 			for(var/obj/item/organ/external/E in H.organs)
 				var/organData[0]
@@ -394,7 +403,7 @@
 			P.info += "<b>Time of scan:</b> [worldtime2stationtime(world.time)]<br><br>"
 			P.info += "[printing_text]"
 			P.info += "<br><br><b>Notes:</b><br>"
-			P.name = "Body Scan - [href_list["name"]]"
+			P.name = "Body Scan - [href_list["name"]] ([worldtime2stationtime(world.time)])"
 			printing = null
 			printing_text = null
 
@@ -457,8 +466,12 @@
 				dat += "[extra_font]\tBlood Level %: [blood_percent] ([blood_volume] units)</font><br>"
 
 			if(occupant.reagents)
-				for(var/datum/reagent/R in occupant.reagents)
+				for(var/datum/reagent/R in occupant.reagents.reagent_list)
 					dat += "Reagent: [R.name], Amount: [R.volume]<br>"
+
+			if(occupant.ingested)
+				for(var/datum/reagent/R in occupant.ingested.reagent_list)
+					dat += "Stomach: [R.name], Amount: [R.volume]<br>"
 
 			dat += "<hr><table border='1'>"
 			dat += "<tr>"

--- a/nano/templates/adv_med.tmpl
+++ b/nano/templates/adv_med.tmpl
@@ -94,7 +94,7 @@ Used In File(s): \code\game\machinery\adv_med.dm
 			<td class='itemContent' style='width: 10%;'>{{:data.occupant.blood.percent}}%</td>
 		</tr>
 	</table>
-	<h4>Reagents</h4>
+	<h4>Blood Reagents</h4>
 	{{if data.occupant.reagents}}
 		<table class='item'>
 			{{for data.occupant.reagents}}
@@ -105,7 +105,20 @@ Used In File(s): \code\game\machinery\adv_med.dm
 			{{/for}}
 		</table>
 	{{else}}
-		<div class='item'>No reagents detected.</div>
+		<div class='item'>No blood reagents detected.</div>
+	{{/if}}
+	<h4>Stomach Reagents</h4>
+	{{if data.occupant.ingested}}
+		<table class='item'>
+			{{for data.occupant.ingested}}
+				<tr>
+					<td class='itemLabel' style='width: 20%;'>{{:value.name}}:</td>
+					<td class='itemContent' style='width: 10%;'>{{:value.amount}}</td>
+				</tr>
+			{{/for}}
+		</table>
+	{{else}}
+		<div class='item'>No stomach reagents detected.</div>
 	{{/if}}
 	<h4><b>External Organs</b></h4>
 	<div class="itemGroup">


### PR DESCRIPTION
1) Printouts should have the time, otherwise it's awful in a filing cabinet when just looking at the paper names, to find anything.
2) Advandced scanner printouts don't read the correct thing for reagents and omit them entirely from printouts.
3) Advanced scanner (and in fact no medical tools) can tell you ingested reagents, leaving diagnosis of this a mystery, so now the advanced scanner shows stomach contents.