### PR TITLE
Area alarms should not fight each other for control of fire doors.

### DIFF
--- a/code/game/area/Space Station 13 areas.dm
+++ b/code/game/area/Space Station 13 areas.dm
@@ -49,7 +49,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	var/no_air = null
 //	var/list/lights				// list of all lights on this area
 	var/list/all_doors = list()		//Added by Strumpetplaya - Alarm Change - Contains a list of doors adjacent to this area
-	var/air_doors_activated = 0
+	var/firedoors_closed = 0
 	var/list/ambience = list('sound/ambience/ambigen1.ogg','sound/ambience/ambigen3.ogg','sound/ambience/ambigen4.ogg','sound/ambience/ambigen5.ogg','sound/ambience/ambigen6.ogg','sound/ambience/ambigen7.ogg','sound/ambience/ambigen8.ogg','sound/ambience/ambigen9.ogg','sound/ambience/ambigen10.ogg','sound/ambience/ambigen11.ogg','sound/ambience/ambigen12.ogg','sound/ambience/ambigen14.ogg')
 	var/list/forced_ambience = null
 	var/sound_env = STANDARD_STATION

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -53,22 +53,28 @@
 			danger_level = max(danger_level, AA.danger_level)
 
 	if(danger_level != atmosalm)
-		if (danger_level < 1 && atmosalm >= 1)
-			//closing the doors on red and opening on green provides a bit of hysteresis that will hopefully prevent fire doors from opening and closing repeatedly due to noise
-			air_doors_open()
-		else if (danger_level >= 2 && atmosalm < 2)
-			air_doors_close()
-
 		atmosalm = danger_level
+		//closing the doors on red and opening on green provides a bit of hysteresis that will hopefully prevent fire doors from opening and closing repeatedly due to noise
+		if (danger_level < 1 || danger_level >= 2)
+			firedoors_update()
+		
 		for (var/obj/machinery/alarm/AA in src)
 			AA.update_icon()
 
 		return 1
 	return 0
 
-/area/proc/air_doors_close()
-	if(!air_doors_activated)
-		air_doors_activated = 1
+// Either close or open firedoors depending on current alert statuses
+/area/proc/firedoors_update()
+	if(fire || party || atmosalm)
+		firedoors_close()
+	else
+		firedoors_open()
+
+// Close all firedoors in the area
+/area/proc/firedoors_close()
+	if(!firedoors_closed)
+		firedoors_closed = TRUE
 		for(var/obj/machinery/door/firedoor/E in all_doors)
 			if(!E.blocked)
 				if(E.operating)
@@ -77,9 +83,10 @@
 					spawn(0)
 						E.close()
 
-/area/proc/air_doors_open()
-	if(air_doors_activated)
-		air_doors_activated = 0
+// Open all firedoors in the area
+/area/proc/firedoors_open()
+	if(firedoors_closed)
+		firedoors_closed = FALSE
 		for(var/obj/machinery/door/firedoor/E in all_doors)
 			if(!E.blocked)
 				if(E.operating)
@@ -93,27 +100,13 @@
 	if(!fire)
 		fire = 1	//used for firedoor checks
 		updateicon()
-		mouse_opacity = 0
-		for(var/obj/machinery/door/firedoor/D in all_doors)
-			if(!D.blocked)
-				if(D.operating)
-					D.nextstate = FIREDOOR_CLOSED
-				else if(!D.density)
-					spawn()
-						D.close()
+		firedoors_update()
 
 /area/proc/fire_reset()
 	if (fire)
 		fire = 0	//used for firedoor checks
 		updateicon()
-		mouse_opacity = 0
-		for(var/obj/machinery/door/firedoor/D in all_doors)
-			if(!D.blocked)
-				if(D.operating)
-					D.nextstate = FIREDOOR_OPEN
-				else if(D.density)
-					spawn(0)
-					D.open()
+		firedoors_update()
 
 /area/proc/readyalert()
 	if(!eject)
@@ -131,21 +124,14 @@
 	if (!( party ))
 		party = 1
 		updateicon()
-		mouse_opacity = 0
+		firedoors_update()
 	return
 
 /area/proc/partyreset()
 	if (party)
 		party = 0
-		mouse_opacity = 0
 		updateicon()
-		for(var/obj/machinery/door/firedoor/D in src)
-			if(!D.blocked)
-				if(D.operating)
-					D.nextstate = FIREDOOR_OPEN
-				else if(D.density)
-					spawn(0)
-					D.open()
+		firedoors_update()
 	return
 
 /area/proc/updateicon()

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -719,9 +719,9 @@
 		if(href_list["atmos_unlock"])
 			switch(href_list["atmos_unlock"])
 				if("0")
-					alarm_area.air_doors_close()
+					alarm_area.firedoors_close()
 				if("1")
-					alarm_area.air_doors_open()
+					alarm_area.firedoors_open()
 			return 1
 
 		if(href_list["atmos_alarm"])

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -141,7 +141,7 @@
 
 	var/alarmed = lockdown
 	for(var/area/A in areas_added)		//Checks if there are fire alarms in any areas associated with that firedoor
-		if(A.fire || A.air_doors_activated)
+		if(A.firedoors_closed)
 			alarmed = 1
 
 	var/answer = alert(user, "Would you like to [density ? "open" : "close"] this [src.name]?[ alarmed && density ? "\nNote that by doing so, you acknowledge any damages from opening this\n[src.name] as being your own fault, and you will be held accountable under the law." : ""]",\
@@ -179,7 +179,7 @@
 		spawn(50)
 			alarmed = 0
 			for(var/area/A in areas_added)		//Just in case a fire alarm is turned off while the firedoor is going through an autoclose cycle
-				if(A.fire || A.air_doors_activated)
+				if(A.firedoors_closed)
 					alarmed = 1
 			if(alarmed)
 				nextstate = FIREDOOR_CLOSED

--- a/html/changelogs/Leshana - Firedoors.yml
+++ b/html/changelogs/Leshana - Firedoors.yml
@@ -1,0 +1,4 @@
+author: Leshana
+delete-after: True
+changes: 
+  - bugfix: "Resetting a fire alert will no longer open firedoors if atmos alert is in effect and vice versa"


### PR DESCRIPTION
* Instead of each individually controlling fire doors, setting or clearing alerts now simply calls firedoors_update() which considers both fire and atmos statuses before deciding to close or open the doors.
* Renamed air_doors_activated to firedoors_closed to be more intuitive.
* Preserved existing "party" alert status for posterity.
* Removed obsolete setting of mouse_opacity, it is always zero on areas.
* Fixes https://github.com/VOREStation/VOREStation/issues/1464