### PR TITLE
Prevent lighting_overlay objects from being moved around.

### DIFF
--- a/code/modules/lighting/lighting_overlay.dm
+++ b/code/modules/lighting/lighting_overlay.dm
@@ -112,6 +112,15 @@
 /atom/movable/lighting_overlay/singularity_pull()
 	return
 
+/atom/movable/lighting_overlay/forceMove()
+	return 0 //should never move
+
+/atom/movable/lighting_overlay/Move()
+	return 0
+
+/atom/movable/lighting_overlay/throw_at()
+	return 0
+
 /atom/movable/lighting_overlay/Destroy()
 	total_lighting_overlays--
 	global.lighting_update_overlays     -= src


### PR DESCRIPTION
 * lighting_overlay objects belong to a turf. Turfs never move. Neither should the lighting_overlay, even of an overzealous shuttle controller thinks they should.

Or this: 
![image](https://cloud.githubusercontent.com/assets/14110581/26079961/96c27c34-3992-11e7-84e4-33543d603555.png)
