### PR TITLE
Fix runtime in air_traffic.dm due to bad organizations in loremaster.

### DIFF
--- a/code/modules/busy_space/loremaster.dm
+++ b/code/modules/busy_space/loremaster.dm
@@ -9,5 +9,8 @@ var/datum/lore/loremaster/loremaster = new/datum/lore/loremaster
 
 	var/list/paths = typesof(/datum/lore/organization) - /datum/lore/organization
 	for(var/path in paths)
-		var/datum/lore/organization/instance = new path()
-		organizations[path] = instance
+		// Some intermediate paths are not real organizations (ex. /datum/lore/organization/mil). Only do ones with names
+		var/datum/lore/organization/instance = path
+		if(initial(instance.name))
+			instance = new path()
+			organizations[path] = instance


### PR DESCRIPTION
* Loremaster was loading all subtypes of /datum/lore/organization, but some intermediate subtypes are never meant to be used (such as /datum/lore/organization/mil)
* These intermediate subtypes have no names, and no ship_prefixes, so crash the ATC.
* Fix by not loading ones not meant to be loaded.  Detected by checking if they have a non-null name.
Fixes #3450 