### PR TITLE
Buffs Bolt Action rifle damage to be less useless

### DIFF
--- a/code/modules/projectiles/guns/projectile/boltaction.dm
+++ b/code/modules/projectiles/guns/projectile/boltaction.dm
@@ -2,25 +2,25 @@
 
 /obj/item/weapon/gun/projectile/shotgun/pump/rifle
 	name = "bolt action rifle"
-	desc = "A reproduction of an almost ancient weapon design from the early 20th century. It's still popular among hunters and collectors due to its reliability. Uses 5.56mm rounds."
+	desc = "A reproduction of an almost ancient weapon design from the early 20th century. It's still popular among hunters and collectors due to its reliability. Uses 7.62mm rounds."
 	item_state = "boltaction"
 	icon_state = "boltaction"
 	fire_sound = 'sound/weapons/rifleshot.ogg'
 	max_shells = 5
-	caliber = "a556"
+	caliber = "a762"
 	origin_tech = list(TECH_COMBAT = 1)// Old as shit rifle doesn't have very good tech.
-	ammo_type = /obj/item/ammo_casing/a556
+	ammo_type = /obj/item/ammo_casing/a762
 	load_method = SINGLE_CASING|SPEEDLOADER
 	action_sound = 'sound/weapons/riflebolt.ogg'
 
 /obj/item/weapon/gun/projectile/shotgun/pump/rifle/practice // For target practice
 	desc = "A bolt-action rifle with a lightweight synthetic wood stock, designed for competitive shooting. Comes shipped with practice rounds pre-loaded into the gun. Popular among professional marksmen. Uses 5.56mm rounds."
-	ammo_type = /obj/item/ammo_casing/a556p
+	ammo_type = /obj/item/ammo_casing/a762p
 
 /obj/item/weapon/gun/projectile/shotgun/pump/rifle/ceremonial
 	name = "ceremonial bolt-action rifle"
 	desc = "A bolt-action rifle with a heavy, high-quality wood stock that has a beautiful finish. Clearly not intended to be used in combat. Uses 5.56mm rounds."
-	ammo_type = /obj/item/ammo_casing/a556/blank
+	ammo_type = /obj/item/ammo_casing/a762/blank
 
 /obj/item/weapon/gun/projectile/shotgun/pump/rifle/mosin
 	name = "\improper Mosin Nagant"

--- a/code/modules/projectiles/guns/projectile/boltaction.dm
+++ b/code/modules/projectiles/guns/projectile/boltaction.dm
@@ -14,7 +14,7 @@
 	action_sound = 'sound/weapons/riflebolt.ogg'
 
 /obj/item/weapon/gun/projectile/shotgun/pump/rifle/practice // For target practice
-	desc = "A bolt-action rifle with a lightweight synthetic wood stock, designed for competitive shooting. Comes shipped with practice rounds pre-loaded into the gun. Popular among professional marksmen. Uses 5.56mm rounds."
+	desc = "A bolt-action rifle with a lightweight synthetic wood stock, designed for competitive shooting. Comes shipped with practice rounds pre-loaded into the gun. Popular among professional marksmen. Uses 7.62mm rounds."
 	ammo_type = /obj/item/ammo_casing/a762p
 
 /obj/item/weapon/gun/projectile/shotgun/pump/rifle/ceremonial
@@ -24,7 +24,7 @@
 
 /obj/item/weapon/gun/projectile/shotgun/pump/rifle/mosin
 	name = "\improper Mosin Nagant"
-	desc = "Despite its age, the Mosin Nagant continues to be a favorite weapon among colonists, conscripts, and militias across the cosmos. Most today are built by Chen-Iltchenko Firearms, but it's hard to say who built this particular gun, considering the design has been ripped off by just about every arms manufacturer in the galaxy. Uses 5.56mm rounds."
+	desc = "Despite its age, the Mosin Nagant continues to be a favorite weapon among colonists, conscripts, and militias across the cosmos. Most today are built by Chen-Iltchenko Firearms, but it's hard to say who built this particular gun, considering the design has been ripped off by just about every arms manufacturer in the galaxy. Uses 7.62mm rounds."
 	icon_state = "mosin"
 	item_state = "mosin"
 


### PR DESCRIPTION
My reasoning behind this request is because, aside from a small armor pen value, a puny little .45 pistol is better in every other way to a bolt _rifle_, and that just doesn't make any sense, and isn't very fun.

It basically just exists as a cheap gimmick right now. This PR fixes that.

This PR makes it slightly less of a gimmick and more of a weapon people might actually use if they don't have many options. This weapon is especially popular during cult rounds when Cargo needs some kind of
guns.

Previously: The bolt action rifles had a total possible damage output of 125 with a full magazine.
This PR: The bolt action rifles have a total possible damage output of 150 with a full magazine.

Rate of fire is still same as a pump action shotgun. For comparison, a shotgun slug does 50 damage per hit, and can carry 8 of them. You do the math. This is worse than a shotgun still.

~~ToDo: Fix the Lever rifle to not have speedloader ability.~~ Nevermind, ammo boxes need that. Also, why does the Lever rifle already use 7.62 ammo? Did anyone know this?