### PR TITLE
Prevent falling from sudden gravity restoration if buckled.

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -266,9 +266,11 @@ var/list/mob/living/forced_ambiance_list = new
 
 	if(istype(mob,/mob/living/carbon/human/))
 		var/mob/living/carbon/human/H = mob
+		if(H.buckled)
+			return // Being buckled to something solid keeps you in place.
 		if(istype(H.shoes, /obj/item/clothing/shoes/magboots) && (H.shoes.item_flags & NOSLIP))
 			return
-
+		
 		if(H.m_intent == "run")
 			H.AdjustStunned(6)
 			H.AdjustWeakened(6)

--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -42,6 +42,7 @@
 	M.facing_dir = null
 	M.set_dir(buckle_dir ? buckle_dir : dir)
 	M.update_canmove()
+	M.update_floating( M.Check_Dense_Object() )
 	buckled_mob = M
 
 	post_buckle_mob(M)
@@ -53,6 +54,7 @@
 		buckled_mob.buckled = null
 		buckled_mob.anchored = initial(buckled_mob.anchored)
 		buckled_mob.update_canmove()
+		buckled_mob.update_floating( buckled_mob.Check_Dense_Object() )
 		buckled_mob = null
 
 		post_buckle_mob(.)

--- a/html/changelogs/Leshana-gravity-thunk.yml
+++ b/html/changelogs/Leshana-gravity-thunk.yml
@@ -1,0 +1,4 @@
+author: Leshana
+delete-after: True
+changes: 
+  - tweak: "During the gravity failure event, you can now buckle yourself to a chair to prevent falling when gravity returns."


### PR DESCRIPTION
* Also stops the floating animation while you're buckled, so you know.
* Resolves https://github.com/VOREStation/VOREStation/issues/1458