### PR TITLE
Sundry Runtime Fixes

### DIFF
--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -206,7 +206,7 @@
 		user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 		if (W.force >= src.toughness)
 			user.do_attack_animation(src)
-			visible_message("<span class='warning'><b>[src] has been [pick(W.attack_verb)] with [W] by [user]!</b></span>")
+			visible_message("<span class='warning'><b>[src] has been [W.attack_verb.len? pick(W.attack_verb) : "attacked"] with [W] by [user]!</b></span>")
 			if (istype(W, /obj/item)) //is it even possible to get into attackby() with non-items?
 				var/obj/item/I = W
 				if (I.hitsound)

--- a/code/game/objects/structures/lattice.dm
+++ b/code/game/objects/structures/lattice.dm
@@ -37,7 +37,7 @@
 	if(istype(loc, /turf/simulated/open))
 		var/turf/simulated/open/O = loc
 		spawn(1)
-			if(O) // If we built a new floor with the lattice, the open turf won't exist anymore.
+			if(istype(O)) // If we built a new floor with the lattice, the open turf won't exist anymore.
 				O.update() // This lattice may be supporting things on top of it.  If it's being deleted, they need to fall down.
 	..()
 

--- a/code/modules/mob/new_player/preferences_setup.dm
+++ b/code/modules/mob/new_player/preferences_setup.dm
@@ -224,12 +224,14 @@
 			var/datum/gear/G = gear_datums[thing]
 			if(G)
 				var/permitted = 0
-				if(G.allowed_roles)
+				if(!G.allowed_roles)
+					permitted = 1
+				else if(!previewJob)
+					permitted = 0
+				else
 					for(var/job_name in G.allowed_roles)
 						if(previewJob.title == job_name)
 							permitted = 1
-				else
-					permitted = 1
 
 				if(G.whitelisted && (G.whitelisted != mannequin.species.name))
 					permitted = 0


### PR DESCRIPTION
* Fixes Runtime in camera.dm,214: pick() from empty list
* Fixes Runtime in preferences_setup.dm,230: Cannot read null.title
* Fixes Runtime in lattice.dm,41: undefined proc or verb /turf/simulated/floor/airless/update().