### PR TITLE
Prevent returning null from get_authentification_rank()

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -261,7 +261,7 @@
 	var/obj/item/device/pda/pda = wear_id
 	if (istype(pda))
 		if (pda.id)
-			return pda.id.rank
+			return pda.id.rank ? pda.id.rank : if_no_job
 		else
 			return pda.ownrank
 	else


### PR DESCRIPTION
Make sure we return the no job value if they have an id without a rank that is in a PDA.
Should fix https://github.com/PolarisSS13/Polaris/issues/3486