### PR TITLE
Makes the CEs hardsuit and Engineering hardsuit temperature resistant

### DIFF
--- a/code/modules/clothing/spacesuits/rig/suits/station.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/station.dm
@@ -100,6 +100,7 @@
 
 	req_access = list()
 	req_one_access = list()
+	max_heat_protection_temperature = FIRE_HELMET_MAX_HEAT_PROTECTION_TEMPERATURE
 
 /obj/item/clothing/gloves/gauntlets/rig/eva
 	name = "insulated gauntlets"
@@ -135,6 +136,7 @@
 
 	req_access = list()
 	req_one_access = list()
+	max_heat_protection_temperature = FIRE_HELMET_MAX_HEAT_PROTECTION_TEMPERATURE
 
 /obj/item/clothing/gloves/gauntlets/rig/ce
 	name = "insulated gauntlets"


### PR DESCRIPTION
It's somewhat unfair and poor that you're punished for using these suits in response to certain scenarios. If an Atmos Tech, or the CE wishes to respond to a situation with a fire they should be fine using the possible hardsuits available to them.