### PR TITLE
Greases up get_blahblah_fast

### DIFF
--- a/code/_helpers/game.dm
+++ b/code/_helpers/game.dm
@@ -271,20 +271,22 @@
 	var/list/hear = dview(range,T,INVISIBILITY_MAXIMUM)
 	var/list/hearturfs = list()
 
-	for(var/atom/movable/AM in hear)
-		if(ismob(AM))
-			mobs += AM
-			hearturfs += AM.locs[1]
-		else if(isobj(AM))
-			objs += AM
-			hearturfs += AM.locs[1]
+	for(var/thing in hear)
+		if(istype(thing,/obj))
+			objs += thing
+			hearturfs += get_turf(thing)
+		else if(istype(thing,/mob))
+			mobs += thing
+			hearturfs += get_turf(thing)
 
 	//A list of every mob with a client
-	for(var/mob/M in player_list)
-		if(M.loc && M.locs[1] in hearturfs)
-			mobs |= M
+	for(var/mob in player_list)
+		if(get_turf(mob) in hearturfs)
+			mobs |= mob
+			continue
 
-		else if(M.stat == DEAD && !M.forbid_seeing_deadchat)
+		var/mob/M = mob
+		if(M.stat == DEAD && !M.forbid_seeing_deadchat)
 			switch(type)
 				if(1) //Audio messages use ghost_ears
 					if(M.is_preference_enabled(/datum/client_preference/ghost_ears))
@@ -294,9 +296,9 @@
 						mobs |= M
 
 	//For objects below the top level who still want to hear
-	for(var/obj/O in listening_objects)
-		if(O.loc && O.locs[1] in hearturfs)
-			objs |= O
+	for(var/obj in listening_objects)
+		if(get_turf(obj) in hearturfs)
+			objs |= obj
 
 	return list("mobs" = mobs, "objs" = objs)
 

--- a/code/modules/mob/emote.dm
+++ b/code/modules/mob/emote.dm
@@ -34,11 +34,14 @@
 		var/list/m_viewers = in_range["mobs"]
 		var/list/o_viewers = in_range["objs"]
 
-		for(var/mob/M in m_viewers)
+		for(var/mob in m_viewers)
+			var/mob/M = mob
 			spawn(0) // It's possible that it could be deleted in the meantime, or that it runtimes.
 				if(M)
 					M.show_message(message, m_type)
-		for(var/obj/O in o_viewers)
+
+		for(var/obj in o_viewers)
+			var/obj/O = obj
 			spawn(0)
 				if(O)
 					O.see_emote(src, message, m_type)


### PR DESCRIPTION
Untypes lists, obj is more likely so it goes first, uses get_turf now that get_turf uses the get_step witchcraft method.

Tested == yes