### PR TITLE
XGM init() and lazy list optimization

### DIFF
--- a/code/ZAS/Turf.dm
+++ b/code/ZAS/Turf.dm
@@ -5,9 +5,9 @@
 /turf/var/datum/gas_mixture/air
 
 /turf/simulated/proc/update_graphic(list/graphic_add = null, list/graphic_remove = null)
-	if(graphic_add && graphic_add.len)
+	if(LAZYLEN(graphic_add))
 		overlays += graphic_add
-	if(graphic_remove && graphic_remove.len)
+	if(LAZYLEN(graphic_remove))
 		overlays -= graphic_remove
 
 /turf/proc/update_air_properties()

--- a/code/ZAS/Zone.dm
+++ b/code/ZAS/Zone.dm
@@ -77,7 +77,8 @@ Class Procs:
 		fire_tiles.Add(T)
 		air_master.active_fire_zones |= src
 		if(fuel) fuel_objs += fuel
-	T.update_graphic(air.graphic)
+	if(air.graphic)
+		T.update_graphic(air.graphic)
 
 /zone/proc/remove(turf/simulated/T)
 #ifdef ZASDBG
@@ -92,7 +93,8 @@ Class Procs:
 		var/obj/effect/decal/cleanable/liquid_fuel/fuel = locate() in T
 		fuel_objs -= fuel
 	T.zone = null
-	T.update_graphic(graphic_remove = air.graphic)
+	if(air.graphic)
+		T.update_graphic(graphic_remove = air.graphic)
 	if(contents.len)
 		air.group_multiplier = contents.len
 	else
@@ -106,9 +108,11 @@ Class Procs:
 	ASSERT(!into.invalid)
 #endif
 	c_invalidate()
+	var/list/air_graphic = air.graphic // Cache for sanic speed
 	for(var/turf/simulated/T in contents)
 		into.add(T)
-		T.update_graphic(graphic_remove = air.graphic)
+		if(air_graphic)
+			T.update_graphic(graphic_remove = air_graphic)
 		#ifdef ZASDBG
 		T.dbg(merged)
 		#endif
@@ -131,8 +135,10 @@ Class Procs:
 /zone/proc/rebuild()
 	if(invalid) return //Short circuit for explosions where rebuild is called many times over.
 	c_invalidate()
+	var/list/air_graphic = air.graphic // Cache for sanic speed
 	for(var/turf/simulated/T in contents)
-		T.update_graphic(graphic_remove = air.graphic) //we need to remove the overlays so they're not doubled when the zone is rebuilt
+		if(air_graphic)
+			T.update_graphic(graphic_remove = air_graphic) //we need to remove the overlays so they're not doubled when the zone is rebuilt
 		//T.dbg(invalid_zone)
 		T.needs_air_update = 0 //Reset the marker so that it will be added to the list.
 		air_master.mark_for_update(T)

--- a/code/modules/xgm/xgm_gas_mixture.dm
+++ b/code/modules/xgm/xgm_gas_mixture.dm
@@ -18,7 +18,6 @@
 /datum/gas_mixture/New(vol = CELL_VOLUME)
 	volume = vol
 	gas = list()
-	graphic = list()
 
 //Takes a gas string and the amount of moles to adjust by.  Calls update_values() if update isn't 0.
 /datum/gas_mixture/proc/adjust_gas(gasid, moles, update = 1)
@@ -331,27 +330,24 @@
 //Rechecks the gas_mixture and adjusts the graphic list if needed.
 //Two lists can be passed by reference if you need know specifically which graphics were added and removed.
 /datum/gas_mixture/proc/check_tile_graphic(list/graphic_add = null, list/graphic_remove = null)
+	var/list/cur_graphic = graphic // Cache for sanic speed
 	for(var/g in gas_data.overlay_limit)
-		if(graphic.Find(gas_data.tile_overlay[g]))
+		if(cur_graphic && cur_graphic.Find(gas_data.tile_overlay[g]))
 			//Overlay is already applied for this gas, check if it's still valid.
 			if(gas[g] <= gas_data.overlay_limit[g])
-				if(!graphic_remove)
-					graphic_remove = list()
-				graphic_remove += gas_data.tile_overlay[g]
+				LAZYADD(graphic_remove, gas_data.tile_overlay[g])
 		else
 			//Overlay isn't applied for this gas, check if it's valid and needs to be added.
 			if(gas[g] > gas_data.overlay_limit[g])
-				if(!graphic_add)
-					graphic_add = list()
-				graphic_add += gas_data.tile_overlay[g]
+				LAZYADD(graphic_add, gas_data.tile_overlay[g])
 
 	. = 0
 	//Apply changes
-	if(graphic_add && graphic_add.len)
-		graphic += graphic_add
+	if(LAZYLEN(graphic_add))
+		LAZYADD(graphic, graphic_add)
 		. = 1
-	if(graphic_remove && graphic_remove.len)
-		graphic -= graphic_remove
+	if(LAZYLEN(graphic_remove))
+		LAZYREMOVE(graphic, graphic_remove)
 		. = 1
 
 

--- a/code/modules/xgm/xgm_gas_mixture.dm
+++ b/code/modules/xgm/xgm_gas_mixture.dm
@@ -1,7 +1,7 @@
 /datum/gas_mixture
 	//Associative list of gas moles.
 	//Gases with 0 moles are not tracked and are pruned by update_values()
-	var/list/gas = list()
+	var/list/gas
 	//Temperature in Kelvin of this gas mix.
 	var/temperature = 0
 
@@ -13,10 +13,12 @@
 	var/group_multiplier = 1
 
 	//List of active tile overlays for this gas_mixture.  Updated by check_tile_graphic()
-	var/list/graphic = list()
+	var/list/graphic
 
 /datum/gas_mixture/New(vol = CELL_VOLUME)
 	volume = vol
+	gas = list()
+	graphic = list()
 
 //Takes a gas string and the amount of moles to adjust by.  Calls update_values() if update isn't 0.
 /datum/gas_mixture/proc/adjust_gas(gasid, moles, update = 1)


### PR DESCRIPTION
###  Eliminate init() proc from /datum/gas_mixture
* Initializing a list in the type definition (of any type) incurs a hidden proc call ("init").   Simply by moving the init of the lists to /New() we speed up creation of /datum/gas_mixtures (which happens *often*)
* The list variables still get initialized by the time the instance is created, so this has zero impact on other code, its just starightup faster with no downsides.
### Converts /datum/gas_mixture/var/graphic to a lazy list. 
* The vast majority of gas mixtures _never_ use their `graphic` list.  Prime candidate for making a lazy init list.
* While we are here, add nullchecks to ZAS's use of the graphic list a bit.  /turf/update_graphics was technically already null safe, but its even better to not bother calling it at all right?