### PR TITLE
Nerfs the siemens on most hardsuits

### DIFF
--- a/code/modules/clothing/spacesuits/rig/suits/alien.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/alien.dm
@@ -13,7 +13,7 @@
 	offline_slowdown = 10
 	vision_restriction = 1
 	offline_vision_restriction = 2
-
+	siemens_coefficient = 0.75
 	chest_type = /obj/item/clothing/suit/space/rig/breacher
 	helm_type = /obj/item/clothing/head/helmet/space/rig/breacher
 	boot_type = /obj/item/clothing/shoes/magboots/rig/breacher
@@ -25,6 +25,7 @@
 	icon_state = "breacher_rig"
 	armor = list(melee = 90, bullet = 90, laser = 90, energy = 90, bomb = 90, bio = 100, rad = 80) //Takes TEN TIMES as much damage to stop someone in a breacher. In exchange, it's slow.
 	vision_restriction = 0
+	siemens_coefficient = 0.2
 
 /obj/item/clothing/head/helmet/space/rig/breacher
 	species_restricted = list("Unathi")

--- a/code/modules/clothing/spacesuits/rig/suits/ert.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/ert.dm
@@ -11,6 +11,7 @@
 	helm_type = /obj/item/clothing/head/helmet/space/rig/ert
 
 	req_access = list(access_cent_specops)
+	siemens_coefficient= 0.5
 
 	armor = list(melee = 60, bullet = 50, laser = 30,energy = 15, bomb = 30, bio = 100, rad = 100)
 	allowed = list(/obj/item/device/flashlight, /obj/item/weapon/tank, /obj/item/device/t_scanner, /obj/item/weapon/rcd, /obj/item/weapon/crowbar, \
@@ -30,7 +31,7 @@
 	suit_type = "ERT engineer"
 	icon_state = "ert_engineer_rig"
 	armor = list(melee = 60, bullet = 50, laser = 30,energy = 15, bomb = 30, bio = 100, rad = 100)
-	siemens_coefficient = 0
+	glove_type = /obj/item/clothing/gloves/gauntlets/rig/eva
 
 	initial_modules = list(
 		/obj/item/rig_module/ai_container,
@@ -71,6 +72,8 @@
 	suit_type = "heavy asset protection"
 	icon_state = "asset_protection_rig"
 	armor = list(melee = 60, bullet = 50, laser = 50,energy = 40, bomb = 40, bio = 100, rad = 100)
+	siemens_coefficient= 0.3
+	glove_type = /obj/item/clothing/gloves/gauntlets/rig/eva
 
 	initial_modules = list(
 		/obj/item/rig_module/ai_container,

--- a/code/modules/clothing/spacesuits/rig/suits/merc.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/merc.dm
@@ -11,7 +11,8 @@
 	slowdown = 1
 	offline_slowdown = 3
 	offline_vision_restriction = 1
-
+	siemens_coefficient = 0.3
+	glove_type = /obj/item/clothing/gloves/gauntlets/rig/eva
 	helm_type = /obj/item/clothing/head/helmet/space/rig/merc
 	allowed = list(/obj/item/device/flashlight,/obj/item/weapon/tank,/obj/item/device/suit_cooling_unit,/obj/item/weapon/gun,/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/weapon/melee/baton,/obj/item/weapon/melee/energy/sword,/obj/item/weapon/handcuffs)
 

--- a/code/modules/clothing/spacesuits/rig/suits/station.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/station.dm
@@ -65,6 +65,7 @@
 	offline_slowdown = 10
 	offline_vision_restriction = 2
 	emp_protection = -20
+	siemens_coefficient= 0.75
 
 	helm_type = /obj/item/clothing/head/helmet/space/rig/industrial
 
@@ -92,6 +93,7 @@
 	slowdown = 0
 	offline_slowdown = 1
 	offline_vision_restriction = 1
+	siemens_coefficient= 0.75
 
 	helm_type = /obj/item/clothing/head/helmet/space/rig/eva
 	glove_type = /obj/item/clothing/gloves/gauntlets/rig/eva
@@ -127,6 +129,7 @@
 	slowdown = 0
 	offline_slowdown = 0
 	offline_vision_restriction = 0
+	siemens_coefficient= 0.75
 
 	helm_type = /obj/item/clothing/head/helmet/space/rig/ce
 	glove_type = /obj/item/clothing/gloves/gauntlets/rig/ce
@@ -161,6 +164,7 @@
 	armor = list(melee = 45, bullet = 5, laser = 45, energy = 80, bomb = 60, bio = 100, rad = 100)
 	slowdown = 1
 	offline_vision_restriction = 1
+	siemens_coefficient= 0.75
 
 	helm_type = /obj/item/clothing/head/helmet/space/rig/hazmat
 
@@ -188,6 +192,7 @@
 	armor = list(melee = 30, bullet = 15, laser = 20, energy = 60, bomb = 30, bio = 100, rad = 100)
 	slowdown = 1
 	offline_vision_restriction = 1
+	siemens_coefficient= 0.75
 
 	helm_type = /obj/item/clothing/head/helmet/space/rig/medical
 
@@ -217,6 +222,7 @@
 	slowdown = 1
 	offline_slowdown = 3
 	offline_vision_restriction = 1
+	siemens_coefficient= 0.7
 
 	helm_type = /obj/item/clothing/head/helmet/space/rig/hazard
 


### PR DESCRIPTION
Hello. This is something I had never noticed. All hardsuits with siemens_coefficient undefined are inheriting from the parent which is siemens_coefficient = 0.2. This makes most of them take 20% agony from stuns, and various other implications.

I propose these changes:

Station:
Industrial - 0.75
EVA - 0.75 (Has 0.0 gloves)
CE - 0.75 (Has 0.0 gloves)
AMI - 0.75
Medical - 0.75
NT Breacher - 0.75

ERT:
Commander - 0.5
Medical - 0.5
Security - 0.5
Engineering - 0.5 (Has 0.0 gloves. This one actually had 0,0 across the board for all pieces.)
HAP - 0.3 (Has 0.0 gloves)

Other:
Merc - 0.5 (Has 0.0 gloves)

