### PR TITLE
Fix runtimes in radiation controller

### DIFF
--- a/code/datums/repositories/radiation.dm
+++ b/code/datums/repositories/radiation.dm
@@ -23,11 +23,14 @@ var/global/repository/radiation/radiation_repository = new()
 	. = ..()
 
 /datum/radiation_source/proc/update_rad_power(var/new_power = null)
-	if(new_power != null && new_power != rad_power)
+	if(new_power == null || new_power == rad_power)
+		return // No change
+	else if(new_power <= 0)
+		qdel(src) // Decayed to nothing
+	else
 		rad_power = new_power
-		. = 1
-	if(. && !flat)
-		range = min(round(sqrt(rad_power / config.radiation_lower_limit)), 31)  // R = rad_power / dist**2 - Solve for dist
+		if(!flat)
+			range = min(round(sqrt(rad_power / config.radiation_lower_limit)), 31)  // R = rad_power / dist**2 - Solve for dist
 
 // Ray trace from all active radiation sources to T and return the strongest effect.
 /repository/radiation/proc/get_rads_at_turf(var/turf/T)
@@ -65,6 +68,8 @@ var/global/repository/radiation/radiation_repository = new()
 
 // Add a radiation source instance to the repository.  It will override any existing source on the same turf.
 /repository/radiation/proc/add_source(var/datum/radiation_source/S)
+	if(!isturf(S.source_turf))
+		return
 	var/datum/radiation_source/existing = sources_assoc[S.source_turf]
 	if(existing)
 		qdel(existing)


### PR DESCRIPTION
Ports https://github.com/Baystation12/Baystation12/pull/17446
* Fixes Baystation12/Baystation12/issues/17443 - Runtime in radiation.dm,30: illegal: sqrt(-2.857143)
  * Updating radiation power to below zero should simply delete the source.
* Fixes at least one cause of Runtime in radiation.dm,41: Cannot read null.z in an effort to fix Baystation12/Baystation12/issues/17411
  * Prevent radiation sources without a source_turf from being added to the repository.