### PR TITLE
Makes artifact_harvesters have a detection delay on spawn

### DIFF
--- a/code/modules/xenoarcheaology/tools/artifact_harvester.dm
+++ b/code/modules/xenoarcheaology/tools/artifact_harvester.dm
@@ -15,10 +15,10 @@
 
 /obj/machinery/artifact_harvester/New()
 	..()
-	//connect to a nearby scanner pad
-	owned_scanner = locate(/obj/machinery/artifact_scanpad) in get_step(src, dir)
-	if(!owned_scanner)
-		owned_scanner = locate(/obj/machinery/artifact_scanpad) in orange(1, src)
+	spawn(50) //Delay so the scan pad has time to actually spawn in
+		owned_scanner = locate(/obj/machinery/artifact_scanpad) in get_step(src, dir) //connect to a nearby scanner pad
+		if(!owned_scanner)
+			owned_scanner = locate(/obj/machinery/artifact_scanpad) in orange(1, src)
 
 /obj/machinery/artifact_harvester/attackby(var/obj/I as obj, var/mob/user as mob)
 	if(istype(I,/obj/item/weapon/anobattery))


### PR DESCRIPTION
-------------------------------------------**Artifact_Harvester**-------------------------------------------------
- Adds a small delay when the artifact_harvester spawns in before looking for an artifact_scanpad.

Without this delay, the artifact_harvester can spawn first, (depending on the map layout) look for the artifact_scanpad, not find it and give up. Afterwards, the artifact_scanpad spawns but can't be linked, as the artifact_harvester already looked and gave up.

Example:

- Without the delay: https://i.gyazo.com/cb96fe8a563f5868231e968d4ab6c0c5.png
- With the delay: https://i.gyazo.com/548ea3b6521c9c9612ac95cdd7993b0a.png
--------------------------------------------------------------------------------------------------------------