### PR TITLE
Blast Door repair & damage fix

### DIFF
--- a/code/game/machinery/doors/blast_door.dm
+++ b/code/game/machinery/doors/blast_door.dm
@@ -118,25 +118,8 @@
 				usr << "<span class='notice'>[src]'s motors resist your effort.</span>"
 			return
 
-		if(istype(C, /obj/item/stack/material) && C.get_material_name() == "plasteel") // Repairing.
-			var/amt = Ceiling((maxhealth - health)/150)
-			if(!amt)
-				usr << "<span class='notice'>\The [src] is already fully repaired.</span>"
-				return
-			var/obj/item/stack/P = C
-			if(P.amount < amt)
-				usr << "<span class='warning'>You don't have enough sheets to repair this! You need at least [amt] sheets.</span>"
-				return
-			usr << "<span class='notice'>You begin repairing [src]...</span>"
-			if(do_after(usr, 30))
-				if(P.use(amt))
-					usr << "<span class='notice'>You have repaired \The [src]</span>"
-					src.repair()
-				else
-					usr << "<span class='warning'>You don't have enough sheets to repair this! You need at least [amt] sheets.</span>"
 
-
-		else if(src.density)
+		else if(src.density && (user.a_intent == I_HURT)) //If we can't pry it open and it's a weapon, let's hit it.
 			var/obj/item/weapon/W = C
 			user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 			if(W.damtype == BRUTE || W.damtype == BURN)
@@ -147,8 +130,37 @@
 					user.visible_message("<span class='danger'>\The [user] forcefully strikes \the [src] with \the [W]!</span>")
 					playsound(src.loc, hitsound, 100, 1)
 					take_damage(W.force*0.35) //it's a blast door, it should take a while. -Luke
-			return
+				return
 
+	else if(istype(C, /obj/item/stack/material) && C.get_material_name() == "plasteel") // Repairing.
+		var/amt = Ceiling((maxhealth - health)/150)
+		if(!amt)
+			usr << "<span class='notice'>\The [src] is already fully repaired.</span>"
+			return
+		var/obj/item/stack/P = C
+		if(P.amount < amt)
+			usr << "<span class='warning'>You don't have enough sheets to repair this! You need at least [amt] sheets.</span>"
+			return
+		usr << "<span class='notice'>You begin repairing [src]...</span>"
+		if(do_after(usr, 30))
+			if(P.use(amt))
+				usr << "<span class='notice'>You have repaired \The [src]</span>"
+				src.repair()
+			else
+				usr << "<span class='warning'>You don't have enough sheets to repair this! You need at least [amt] sheets.</span>"
+
+	else if(src.density && (user.a_intent == I_HURT)) //If we can't pry it open and it's not a weapon.... Eh, let's attack it anyway.
+		var/obj/item/weapon/W = C
+		user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
+		if(W.damtype == BRUTE || W.damtype == BURN)
+			user.do_attack_animation(src)
+			if(W.force < min_force) //No actual non-weapon item shouls have a force greater than the min_force, but let's include this just in case.
+				user.visible_message("<span class='danger'>\The [user] hits \the [src] with \the [W] with no visible effect.</span>")
+			else
+				user.visible_message("<span class='danger'>\The [user] forcefully strikes \the [src] with \the [W]!</span>")
+				playsound(src.loc, hitsound, 100, 1)
+				take_damage(W.force*0.15) //If the item isn't a weapon, let's make this take longer than usual to break it down.
+			return
 
 // Proc: open()
 // Parameters: None


### PR DESCRIPTION
------------------------------------------------**Blast Door**---------------------------------------------------
- Fixes an indent error with blast doors that prevented them from being fixed with plasteel, as plasteel is a child of "/obj/item/stack/" not "/obj/item/weapon/"

- Fixes an indent error that prevented blast doors from being hit by an item.

- Modified the code so non-weapons can also be hit against the door, although it has a much harsher brute modifier (.15 compared to .35 that a weapon has) when attempting to break down the door. This should never come into effect, as no non item/weapon should have a damage above 20, but might as well just in case.

- Made it so you can actually hit the blast door with items that can pry open blast doors, if you so desire and are on harm intent.
--------------------------------------------------------------------------------------------------------------