### PR TITLE
Removes a comma that allowed nuka_cola to spawn in flasks

### DIFF
--- a/code/modules/reagents/reagent_containers/food/lunch.dm
+++ b/code/modules/reagents/reagent_containers/food/lunch.dm
@@ -58,7 +58,7 @@ var/list/lunchables_drink_reagents_ = list(/datum/reagent/drink/nothing,
                                            /datum/reagent/drink/dry_ramen,
                                            /datum/reagent/drink/hell_ramen,
                                            /datum/reagent/drink/hot_ramen,
-                                           /datum/reagent/drink/nuka_cola,)
+                                           /datum/reagent/drink/nuka_cola)
 
 // This default list is a bit different, it contains items we don't want
 var/list/lunchables_ethanol_reagents_ = list(/datum/reagent/ethanol/acid_spit,


### PR DESCRIPTION
-------------------------------------------------**Nuka  Cola**--------------------------------------------------
- Removes a ~~cola~~ comma that allowed nuka_cola to spawn in things that use lunchables_drink_reagents, like vacuum flasks.