### PR TITLE
Adds AOOC functionality for antags.

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -490,6 +490,8 @@
 			world.log << "## DEBUG: mind_initialize(): No ticker ready yet! Please inform Carn"
 	if(!mind.name)	mind.name = real_name
 	mind.current = src
+	if(player_is_antag(mind))
+		src.client.verbs += /client/proc/aooc
 
 //HUMAN
 /mob/living/carbon/human/mind_initialize()

--- a/code/game/antagonist/antagonist.dm
+++ b/code/game/antagonist/antagonist.dm
@@ -79,6 +79,8 @@
 		Think through your actions and make the roleplay immersive! <b>Please remember all \
 		rules aside from those without explicit exceptions apply to antagonists.</b>"
 
+	var/can_use_aooc = TRUE                // If true, will be given the AOOC verb, along with the ability to use it.
+
 /datum/antagonist/New()
 	..()
 	cur_max = hard_cap

--- a/code/game/antagonist/antagonist_add.dm
+++ b/code/game/antagonist/antagonist_add.dm
@@ -36,6 +36,9 @@
 			and it otherwise has no bearing on your round.</span>"
 	player.current.verbs |= /mob/living/proc/write_ambition
 
+	if(can_use_aooc)
+		player.current.client.verbs += /client/proc/aooc
+
 	// Handle only adding a mind and not bothering with gear etc.
 	if(nonstandard_role_type)
 		faction_members |= player
@@ -58,6 +61,7 @@
 		BITSET(player.current.hud_updateflag, SPECIALROLE_HUD)
 		if(!is_special_character(player))
 			player.current.verbs -= /mob/living/proc/write_ambition
+			player.current.client.verbs -= /client/proc/aooc
 			player.ambitions = ""
 		return 1
 	return 0

--- a/code/game/antagonist/outsider/ert.dm
+++ b/code/game/antagonist/outsider/ert.dm
@@ -25,6 +25,8 @@ var/datum/antagonist/ert/ert
 	initial_spawn_req = 5
 	initial_spawn_target = 7
 
+	can_use_aooc = FALSE // They're the good guys.
+
 /datum/antagonist/ert/create_default(var/mob/source)
 	var/mob/living/carbon/human/M = ..()
 	if(istype(M)) M.age = rand(25,45)

--- a/code/game/antagonist/outsider/trader.dm
+++ b/code/game/antagonist/outsider/trader.dm
@@ -24,6 +24,8 @@ var/datum/antagonist/trader/traders
 	initial_spawn_req = 5
 	initial_spawn_target = 7
 
+	can_use_aooc = FALSE // They're not real antags.
+
 /datum/antagonist/trader/create_default(var/mob/source)
 	var/mob/living/carbon/human/M = ..()
 	if(istype(M)) M.age = rand(25,45)

--- a/code/game/antagonist/station/renegade.dm
+++ b/code/game/antagonist/station/renegade.dm
@@ -59,6 +59,8 @@ var/datum/antagonist/renegade/renegades
 		list(/obj/item/weapon/gun/projectile/luger,/obj/item/weapon/gun/projectile/luger/brown)
 		)
 
+	can_use_aooc = FALSE // They aren't 'true' antags.
+
 /datum/antagonist/renegade/New()
 	..()
 	renegades = src

--- a/code/modules/admin/verbs/antag-ooc.dm
+++ b/code/modules/admin/verbs/antag-ooc.dm
@@ -3,17 +3,40 @@
 	set name = "AOOC"
 	set desc = "Antagonist OOC"
 
-	if(!check_rights(R_ADMIN|R_MOD))	return
+	var/is_admin = check_rights(R_ADMIN|R_MOD, show_msg = 0)
+	var/is_antag = usr.mind && usr.mind.special_role
+
+	if(!is_antag && !is_admin) // Non-antagonists and non-admins have no business using this.
+		to_chat(usr, "<span class='warning'>Sorry, but only certain antagonists or administrators can use this verb.</span>")
+		return
+
+	else if(is_antag && !is_admin) // Is an antag, and not an admin, meaning we need to check if their antag type allows AOOC.
+		var/datum/antagonist/A = get_antag_data(usr.mind.special_role)
+		if(!A || !A.can_use_aooc)
+			to_chat(usr, "<span class='warning'>Sorry, but your antagonist type is not allowed to speak in AOOC.</span>")
+			return
 
 	msg = sanitize(msg)
-	if(!msg)	return
+	if(!msg)
+		return
 
+	// Name shown to admins.
 	var/display_name = src.key
-	if(holder && holder.fakekey)
-		display_name = holder.fakekey
+	if(holder)
+		if(holder.fakekey)
+			display_name = usr.client.holder.fakekey
+
+	// Name shown to other players.  Admins whom are not also antags have their rank displayed.
+	var/player_display = (is_admin && !is_antag) ? "[display_name]([usr.client.holder.rank])" : display_name
 
 	for(var/mob/M in mob_list)
-		if((M.mind && M.mind.special_role && M.client) || check_rights((R_ADMIN|R_MOD), 0, M))
-			M << "<font color='#960018'><span class='ooc'>" + create_text_tag("aooc", "Antag-OOC:", M.client) + " <EM>[display_name]:</EM> <span class='message'>[msg]</span></span></font>"
+		if(check_rights(R_ADMIN|R_MOD, 0, M)) // Staff can see AOOC unconditionally, and with more details.
+			to_chat(M, "<span class='ooc'><span class='aooc'>[create_text_tag("aooc", "Antag-OOC:", M.client)] <EM>[get_options_bar(src, 0, 1, 1)]([admin_jump_link(usr, M.client.holder)]):</EM> <span class='message'>[msg]</span></span></span>")
+		else if(M.client) // Players can only see AOOC if observing, or if they are an antag type allowed to use AOOC.
+			var/datum/antagonist/A = null
+			if(M.mind) // Observers don't have minds, but they should still see AOOC.
+				A = get_antag_data(M.mind.special_role)
+			if((M.mind && M.mind.special_role && A && A.can_use_aooc) || isobserver(M)) // Antags must have their type be allowed to AOOC to see AOOC.  This prevents, say, ERT from seeing AOOC.
+				to_chat(M, "<span class='ooc'><span class='aooc'>[create_text_tag("aooc", "Antag-OOC:", M.client)] <EM>[player_display]:</EM> <span class='message'>[msg]</span></span></span>")
 
 	log_ooc("(ANTAG) [key] : [msg]")

--- a/code/stylesheet.dm
+++ b/code/stylesheet.dm
@@ -24,6 +24,7 @@ em						{font-style: normal;font-weight: bold;}
 .ooc .moderator			{color: #184880;}
 .ooc .developer			{color: #1b521f;}
 .ooc .admin				{color: #b82e00;}
+.ooc .aooc				{color: #960018;}
 
 /* Admin: Private Messages */
 .pm  .howto				{color: #ff0000;	font-weight: bold;		font-size: 200%;}


### PR DESCRIPTION
Borrows some code from Bay's variant of AOOC.
AOOC can be granted on a per-antag type basis.  If the type has ```can_use_aooc``` equal to true, they can both use and see AOOC.  It is true by default to allow for the upcoming Infiltrator type to automatically be able to use it.
The types disallowed from AOOC are ERT, Traders, and Renegades.  This means admins can now use AOOC to talk to the real antags and not the ERT by mistake.
Ghosts will be able to see AOOC now, as well.

![Normal version](https://puu.sh/wt8yD/27bf853698.png)
![Admin version](https://puu.sh/wt8AE/61bad3af51.png)