### PR TITLE
Fixes Inability to use Say/LOOC/Other Things

### DIFF
--- a/code/_helpers/game.dm
+++ b/code/_helpers/game.dm
@@ -281,12 +281,15 @@
 
 	//A list of every mob with a client
 	for(var/mob in player_list)
+		if(!istype(mob, /mob))
+			crash_with("There is a null or non-mob reference inside player_list.")
+			continue
 		if(get_turf(mob) in hearturfs)
 			mobs |= mob
 			continue
 
 		var/mob/M = mob
-		if(M.stat == DEAD && !M.forbid_seeing_deadchat)
+		if(M && M.stat == DEAD && !M.forbid_seeing_deadchat)
 			switch(type)
 				if(1) //Audio messages use ghost_ears
 					if(M.is_preference_enabled(/datum/client_preference/ghost_ears))

--- a/code/modules/mob/living/carbon/brain/brain.dm
+++ b/code/modules/mob/living/carbon/brain/brain.dm
@@ -20,7 +20,7 @@
 			if(stat!=DEAD)	//If not dead.
 				death(1)	//Brains can die again. AND THEY SHOULD AHA HA HA HA HA HA
 			ghostize()		//Ghostize checks for key so nothing else is necessary.
-		..()
+		return ..()
 
 	say_understands(var/other)//Goddamn is this hackish, but this say code is so odd
 		if (istype(other, /mob/living/silicon/ai))


### PR DESCRIPTION
A null entry somehow got into ```player_list```, which caused an important proc called ```get_mobs_and_objs_in_view_fast()``` to fail.  The cause appeared to be a brain mob failing to qdel, then failing to ```logout()```, leaving a null entry in ```player_list```.
```get_mobs_and_objs_in_view_fast()``` now makes sure every entry it iterates over exists, and this should fix the qdel issue as well.