### PR TITLE
Mutagenic chemicals tweak

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
@@ -315,8 +315,12 @@
 	if(istype(H) && (H.species.flags & NO_SCAN))
 		return
 
+//The original coder comment here wanted it to be "Approx. one mutation per 10 injected/20 ingested/30 touching units" 
+//The issue was, it was removed (.2) multiplied by .1, which resulted in a .02% chance per tick to have a mutation occur. Or more accurately, 5000 injected for a single mutation.
+//To honor their original idea, let's keep it as 10/20/30 as they wanted... For the most part.
+
 	if(M.dna)
-		if(prob(removed * 0.1)) // Approx. one mutation per 10 injected/20 ingested/30 touching units
+		if(prob(removed * 10)) // Removed is .2 per tick. Multiplying it by 10 makes it a 2% chance per tick. 10 units has 50 ticks, so 10 units injected should give a single good/bad mutation.
 			randmuti(M)
 			if(prob(98))
 				randmutb(M)
@@ -324,6 +328,9 @@
 				randmutg(M)
 			domutcheck(M, null)
 			M.UpdateAppearance()
+		if(prob(removed * 40)) //Additionally, let's make it so there's an 8% chance per tick for a random cosmetic/not guranteed good/bad mutation.
+			randmuti(M)//This should equate to 4 random cosmetic mutations per 10 injected/20 ingested/30 touching units
+			M << "<span class='warning'>You feel odd!</span>"
 	M.apply_effect(10 * removed, IRRADIATE, 0)
 
 /datum/reagent/slimejelly
@@ -600,7 +607,7 @@
 		return
 
 	if(M.dna)
-		if(prob(removed * 0.1))
+		if(prob(removed * 10))
 			randmuti(M)
 			if(prob(98))
 				randmutb(M)
@@ -608,6 +615,9 @@
 				randmutg(M)
 			domutcheck(M, null)
 			M.UpdateAppearance()
+		if(prob(removed * 40))
+			randmuti(M)
+			M << "<span class='warning'>You feel odd!</span>"
 	M.apply_effect(16 * removed, IRRADIATE, 0)
 
 /datum/reagent/aslimetoxin
@@ -627,7 +637,7 @@
 		return
 
 	if(M.dna)
-		if(prob(removed * 0.1))
+		if(prob(removed * 10))
 			randmuti(M)
 			if(prob(98))
 				randmutb(M)
@@ -635,4 +645,7 @@
 				randmutg(M)
 			domutcheck(M, null)
 			M.UpdateAppearance()
+		if(prob(removed * 40))
+			randmuti(M)
+			M << "<span class='warning'>You feel odd!</span>"
 	M.apply_effect(6 * removed, IRRADIATE, 0)


### PR DESCRIPTION
-------------------------------------**Mutagenic  Chemicals Tweak**--------------------------------------------

- Changes amount of mutagen/slimetoxin/aslimetoxin required for a good/bad mutation
- Adds an 8% chance per tick for a cosmetic mutation when you have  mutagen/slimetoxin/aslimetoxin in you. This equates to about 4 cosmetic mutations per 10 units injected.
- Documents the math and original coder's idea in coder comments.

Was doing some experimentation with unstable mutagen and was wondering why I was getting literally 0 mutations. Did the math (100/(0.2 * 0.1)) and found out that it would take _5000_ (!!!) units of mutagen to be injected for a single cosmetic & good/bad mutation.

Went ahead and fiddled around with the numbers for a while before changing it so that there is a 2% per tick for mutagenic chemicals to give a cosmetic & good/bad mutation, and an 8% chance per tick for a purely cosmetic mutation. 

I'm not sure if good/bad mutations are even enabled, but this ensures that if they are enabled then mutagen will actually be useful. This also makes it so it's useful for changing people cosmetically.