### PR TITLE
24-round shotgun mag fixes + making it relevant.

### DIFF
--- a/code/datums/uplink/visible_weapons.dm
+++ b/code/datums/uplink/visible_weapons.dm
@@ -70,6 +70,11 @@
 	item_cost = 75
 	path = /obj/item/weapon/gun/projectile/automatic/sts35
 
+/datum/uplink_item/item/visible_weapons/automaticshotgun
+	name = "Automatic Shotgun (12g)"
+	item_cost = 100 //it's an automatic shotgun. Has a lot of potential for destruction.
+	path = /obj/item/weapon/gun/projectile/automatic/as24
+
 /*/datum/uplink_item/item/visible_weapons/bullpuprifle
 	name = "Assault Rifle (5.56mm)"
 	item_cost = 7

--- a/code/modules/projectiles/ammunition/magazines.dm
+++ b/code/modules/projectiles/ammunition/magazines.dm
@@ -467,7 +467,7 @@
 	icon_state = "12g"
 	mag_type = MAGAZINE
 	caliber = "12g"
-	matter = list(DEFAULT_WALL_MATERIAL = 2200)
+	matter = list(DEFAULT_WALL_MATERIAL = 13000) //did the math. now fixed the exploityness of this thing. Have fun!
 	ammo_type = /obj/item/ammo_casing/a12g
 	max_ammo = 24
 	multiple_sprites = 1


### PR DESCRIPTION
Adds the AS-24 Shotgun to the traitor uplink for 100 TCs, also makes automatic shotgun magazines (which spawn with shotgun slugs, as a note) costs the appropriate amount (13,000 metal up from 2200)