### PR TITLE
Nuka cola effect fix.

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
@@ -1014,7 +1014,7 @@
 	glass_desc = "Don't cry, Don't raise your eye, It's only nuclear wasteland"
 	glass_special = list(DRINK_FIZZ)
 
-/datum/reagent/drink/nuka_cola/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed)
+/datum/reagent/drink/soda/nuka_cola/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed)
 	..()
 	M.add_chemical_effect(CE_SPEEDBOOST, 1)
 	M.make_jittery(20)

--- a/code/modules/reagents/reagent_containers/food/lunch.dm
+++ b/code/modules/reagents/reagent_containers/food/lunch.dm
@@ -58,7 +58,7 @@ var/list/lunchables_drink_reagents_ = list(/datum/reagent/drink/nothing,
                                            /datum/reagent/drink/dry_ramen,
                                            /datum/reagent/drink/hell_ramen,
                                            /datum/reagent/drink/hot_ramen,
-                                           /datum/reagent/drink/nuka_cola)
+                                           /datum/reagent/drink/soda/nuka_cola)
 
 // This default list is a bit different, it contains items we don't want
 var/list/lunchables_ethanol_reagents_ = list(/datum/reagent/ethanol/acid_spit,


### PR DESCRIPTION
-----------------------------------------**Nuka Cola Effect Fix**-------------------------------------------------

- Fixes Nuka Cola, making it properly apply all of it's effects.
- Adds the correct nuka cola path to lunch.dm

I was wondering why I didn't get all fucked up when I drank Nuka Cola and decided to look in the code. Turns out, the affect_ingest was listed as "reagent/drink/nuka_cola" instead of "reagent/drink/soda/nuka_cola"