### PR TITLE
Renames Infiltrator gamemode to Team Traitor

### DIFF
--- a/code/game/gamemodes/infiltrator/infiltrator.dm
+++ b/code/game/gamemodes/infiltrator/infiltrator.dm
@@ -1,5 +1,5 @@
 /datum/game_mode/infiltrator
-	name = "Infiltrator"
+	name = "Team Traitor"
 	round_description = "There are a group of shadowy infiltrators onboard!  Be careful!"
 	extended_round_description = "A team of secretative people have played the long con, and managed to obtain entry to \
 	the facility.  What their goals are, who their employers are, and why the individuals would work for them is a mystery, \


### PR DESCRIPTION
Changes the name to make it more obvious to players what the gamemode is, as I'm told that it might be confusing and make people think it's ninja+traitor.