### PR TITLE
Fixes layering issue with tree icons

### DIFF
--- a/code/game/objects/structures/flora.dm
+++ b/code/game/objects/structures/flora.dm
@@ -4,7 +4,6 @@
 	anchored = 1
 	density = 1
 	pixel_x = -16
-	layer = 9
 
 /obj/structure/flora/tree/pine
 	name = "pine tree"

--- a/code/game/objects/structures/flora.dm
+++ b/code/game/objects/structures/flora.dm
@@ -4,6 +4,7 @@
 	anchored = 1
 	density = 1
 	pixel_x = -16
+	layer = MOB_LAYER // You know what, let's play it safe.
 
 /obj/structure/flora/tree/pine
 	name = "pine tree"


### PR DESCRIPTION
I've discovered from using it on the tether map in Vorestation that it being on layer **9** is really unnecessary and it just looks absurd when layered over other things.

I don't think you actually use trees for anything right now, but whenever you do, you'll want this to prevent them from looking dumb.