### PR TITLE
Revert "Enables unused cypherkey sprites."

### DIFF
--- a/code/game/objects/items/devices/radio/encryptionkey.dm
+++ b/code/game/objects/items/devices/radio/encryptionkey.dm
@@ -14,7 +14,7 @@
 /obj/item/device/encryptionkey/attackby(obj/item/weapon/W as obj, mob/user as mob)
 
 /obj/item/device/encryptionkey/syndicate
-	icon_state = "syn_cypherkey"
+	icon_state = "cypherkey"
 	channels = list("Mercenary" = 1)
 	origin_tech = list(TECH_ILLEGAL = 3)
 	syndie = 1//Signifies that it de-crypts Syndicate transmissions
@@ -26,7 +26,7 @@
 	syndie = 1
 
 /obj/item/device/encryptionkey/binary
-	icon_state = "bin_cypherkey"
+	icon_state = "cypherkey"
 	translate_binary = 1
 	origin_tech = list(TECH_ILLEGAL = 3)
 
@@ -123,5 +123,4 @@
 
 /obj/item/device/encryptionkey/ert
 	name = "\improper ERT radio encryption key"
-	icon_state = "cent_cypherkey"
 	channels = list("Response Team" = 1, "Science" = 1, "Command" = 1, "Medical" = 1, "Engineering" = 1, "Security" = 1, "Supply" = 1, "Service" = 1)


### PR DESCRIPTION
Reverts PolarisSS13/Polaris#3570

Those chips are actually supposed to look like the default one, for antaggy reasons.