### PR TITLE
Changes Spider meat back to Xeno meat

### DIFF
--- a/code/modules/food/recipes_microwave.dm
+++ b/code/modules/food/recipes_microwave.dm
@@ -105,7 +105,7 @@ I said no!
 /datum/recipe/xenoburger
 	items = list(
 		/obj/item/weapon/reagent_containers/food/snacks/bun,
-		/obj/item/weapon/reagent_containers/food/snacks/spidermeat	//	/obj/item/weapon/reagent_containers/food/snacks/xenomeat
+		/obj/item/weapon/reagent_containers/food/snacks/xenomeat
 	)
 	result = /obj/item/weapon/reagent_containers/food/snacks/xenoburger
 
@@ -224,9 +224,9 @@ I said no!
 		/obj/item/weapon/reagent_containers/food/snacks/dough,
 		/obj/item/weapon/reagent_containers/food/snacks/dough,
 		/obj/item/weapon/reagent_containers/food/snacks/dough,
-		/obj/item/weapon/reagent_containers/food/snacks/spidermeat,	//xenomeat,
-		/obj/item/weapon/reagent_containers/food/snacks/spidermeat,	//xenomeat,
-		/obj/item/weapon/reagent_containers/food/snacks/spidermeat,	//xenomeat,
+		/obj/item/weapon/reagent_containers/food/snacks/xenomeat,
+		/obj/item/weapon/reagent_containers/food/snacks/xenomeat,
+		/obj/item/weapon/reagent_containers/food/snacks/xenomeat,
 		/obj/item/weapon/reagent_containers/food/snacks/cheesewedge,
 		/obj/item/weapon/reagent_containers/food/snacks/cheesewedge,
 		/obj/item/weapon/reagent_containers/food/snacks/cheesewedge,

--- a/code/modules/mob/living/simple_animal/animals/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/animals/giant_spider.dm
@@ -36,7 +36,7 @@
 	speak_emote = list("chitters")
 	emote_hear = list("chitters")
 
-	meat_type = /obj/item/weapon/reagent_containers/food/snacks/spidermeat
+	meat_type = /obj/item/weapon/reagent_containers/food/snacks/xenomeat/spidermeat
 
 	var/busy = 0
 	var/poison_per_bite = 5

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -734,17 +734,17 @@
 	reagents.add_reagent("pacid",6)
 	src.bitesize = 6
 
-/obj/item/weapon/reagent_containers/food/snacks/spidermeat
-	name = "meat"
+/obj/item/weapon/reagent_containers/food/snacks/xenomeat/spidermeat // Substitute for recipes requiring xeno meat.
+	name = "spider meat"
 	desc = "A slab of green meat."
 	icon_state = "xenomeat"
 	filling_color = "#43DE18"
 	center_of_mass = list("x"=16, "y"=10)
 
-/obj/item/weapon/reagent_containers/food/snacks/spidermeat/New()
+/obj/item/weapon/reagent_containers/food/snacks/xenomeat/spidermeat/New()
 	..()
-	reagents.add_reagent("protein", 6)
 	reagents.add_reagent("spidertoxin",6)
+	reagents.remove_reagent("pacid",6)
 	src.bitesize = 6
 
 /obj/item/weapon/reagent_containers/food/snacks/meatball


### PR DESCRIPTION
But also changes a bad design choice and makes spider meat a viable alternative to recipes requiring Xeno meat.

Now, for those of us who do still use xenos for things, xeno meat isn't suddenly completely useless, while spiders still produce their own unique meat that is usable in these recipes.