### PR TITLE
Makes sure female executive suit has different name

### DIFF
--- a/code/modules/clothing/under/miscellaneous.dm
+++ b/code/modules/clothing/under/miscellaneous.dm
@@ -206,7 +206,7 @@
 	icon_state = "really_black_suit_skirt"
 
 /obj/item/clothing/under/suit_jacket/female
-	name = "executive suit"
+	name = "female executive suit"
 	desc = "A formal trouser suit for women, intended for the station's finest."
 	icon_state = "black_suit_fem"
 	item_state_slots = list(slot_r_hand_str = "lawyer_black", slot_l_hand_str = "lawyer_black")


### PR DESCRIPTION
The modular suit selection looked for all suits under /obj/item/clothing/under/suit_jacket
As both /obj/item/clothing/under/suit_jacket/female and /obj/item/clothing/under/suit_jacket/really_black were named "executive suit" it only showed one of them, which happens to be the female only. By renaming the female one to "female executive suit" it allows both the /female and /really_black to show up under the modular suit selection

- Corrects the name of an outfit to allow both suits of the previous same name to be selected by the modular suit selector.