### PR TITLE
Changes AI holopad speech/emotes to use get_mobs_and_objs_in_view_fast()

### DIFF
--- a/code/modules/mob/living/silicon/say.dm
+++ b/code/modules/mob/living/silicon/say.dm
@@ -73,7 +73,7 @@
 
 		//Human-like, sorta, heard by those who understand humans.
 		var/rendered_a
-		//Speach distorted, heard by those who do not understand AIs.
+		//Speech distorted, heard by those who do not understand AIs.
 		var/message_stars = stars(message)
 		var/rendered_b
 
@@ -85,12 +85,21 @@
 			rendered_a = "<span class='game say'><span class='name'>[name]</span> [verb], <span class='message'>\"[message]\"</span></span>"
 			rendered_b = "<span class='game say'><span class='name'>[voice_name]</span> [verb], <span class='message'>\"[message_stars]\"</span></span>"
 			src << "<i><span class='game say'>Holopad transmitted, <span class='name'>[real_name]</span> [verb], <span class='message'><span class='body'>\"[message]\"</span></span></span></i>"//The AI can "hear" its own message.
-
-		for(var/mob/M in hearers(T.loc))//The location is the object, default distance.
-			if(M.say_understands(src))//If they understand AI speak. Humans and the like will be able to.
-				M.show_message(rendered_a, 2)
-			else//If they do not.
-				M.show_message(rendered_b, 2)
+		var/list/listeners = get_mobs_and_objs_in_view_fast(get_turf(T), world.view)
+		var/list/listening = listeners["mobs"]
+		var/list/listening_obj = listeners["objs"]
+		for(var/mob/M in listening)
+			spawn(0)
+				if(M.say_understands(src))//If they understand AI speak. Humans and the like will be able to.
+					M.show_message(rendered_a, 2)
+				else//If they do not.
+					M.show_message(rendered_b, 2)
+		for(var/obj/O in listening_obj)
+			if(O == T) //Don't recieve your own speech
+				continue
+			spawn(0)
+				if(O && src) //If we still exist, when the spawn processes
+					O.hear_talk(src, message, verb, speaking)
 		/*Radios "filter out" this conversation channel so we don't need to account for them.
 		This is another way of saying that we won't bother dealing with them.*/
 	else
@@ -112,8 +121,23 @@
 		var/rendered = "<span class='game say'><span class='name'>[name]</span> <span class='message'>[message]</span></span>"
 		src << "<i><span class='game say'>Holopad action relayed, <span class='name'>[real_name]</span> <span class='message'>[message]</span></span></i>"
 
-		for(var/mob/M in viewers(T.loc))
-			M.show_message(rendered, 2)
+		var/obj/effect/overlay/hologram = T.masters[src]
+		var/list/in_range = get_mobs_and_objs_in_view_fast(get_turf(hologram), world.view, 2) //Emotes are displayed from the hologram, not the pad
+		var/list/m_viewers = in_range["mobs"]
+		var/list/o_viewers = in_range["objs"]
+
+		for(var/mob/M in m_viewers)
+			spawn(0)
+				if(M)
+					M.show_message(rendered, 2)
+
+		for(var/obj/O in o_viewers)
+			if(O == T)
+				continue
+			spawn(0)
+				if(O)
+					O.see_emote(src, message)
+
 	else //This shouldn't occur, but better safe then sorry.
 		src << "No holopad connected."
 		return 0


### PR DESCRIPTION
Previously it just used normal byond viewers()/hearers(), this allows people in lockers or mechs to hear holopad speech, as well as objects like tape recorders.
This also allows ghosts with the relevant eyes/ears settings to hear holopads from wherever.
This also changes emotes sent through the holopad to be visible from the hologram itself, instead of the holopad.

Fixes #2013
Fixes #2648