### PR TITLE
Fixes Autoantag Assigning to Invalid Mobs

### DIFF
--- a/code/game/antagonist/antagonist.dm
+++ b/code/game/antagonist/antagonist.dm
@@ -111,9 +111,6 @@
 		else if(config.use_age_restriction_for_antags && player.current.client.player_age < minimum_player_age)
 			candidates -= player
 			log_debug("[key_name(player)] is not eligible to become a [role_text]: Is only [player.current.client.player_age] day\s old, has to be [minimum_player_age] day\s!")
-		else if(istype(player.current, /mob/living/voice))
-			candidates -= player
-			log_debug("[key_name(player)] is not eligible to become a [role_text]: They are only a communicator voice. They have been removed from the draft.")
 		else if(player.special_role)
 			candidates -= player
 			log_debug("[key_name(player)] is not eligible to become a [role_text]: They already have a special role ([player.special_role])! They have been removed from the draft.")

--- a/code/game/antagonist/antagonist_helpers.dm
+++ b/code/game/antagonist/antagonist_helpers.dm
@@ -1,12 +1,16 @@
 /datum/antagonist/proc/can_become_antag(var/datum/mind/player, var/ignore_role)
-	if(player.current && jobban_isbanned(player.current, bantype))
-		return 0
+	if(player.current)
+		if(jobban_isbanned(player.current, bantype))
+			return FALSE
+		if(!isnewplayer(player.current) && !isobserver(player.current))
+			if(!player.current.can_be_antagged) // Stop autotraitoring pAIs!
+				return FALSE
 	if(!ignore_role)
 		if(player.assigned_role in restricted_jobs)
-			return 0
+			return FALSE
 		if(config.protect_roles_from_antagonist && (player.assigned_role in protected_jobs))
-			return 0
-	return 1
+			return FALSE
+	return TRUE
 
 /datum/antagonist/proc/antags_are_dead()
 	for(var/datum/mind/antag in current_antagonists)

--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -95,3 +95,5 @@
 	var/identifying_gender // In case the human identifies as another gender than it's biological
 
 	var/step_count = 0 // Track how many footsteps have been taken to know when to play footstep sounds
+
+	can_be_antagged = TRUE

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -90,6 +90,8 @@ var/list/ai_verbs_hidden = list( // For why this exists, refer to https://xkcd.c
 	var/custom_sprite 	= 0 					// Whether the selected icon is custom
 	var/carded
 
+	can_be_antagged = TRUE
+
 /mob/living/silicon/ai/proc/add_ai_verbs()
 	src.verbs |= ai_verbs_default
 	src.verbs |= silicon_subsystems

--- a/code/modules/mob/living/silicon/robot/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone.dm
@@ -58,6 +58,8 @@ var/list/mob_hat_cache = list()
 
 	holder_type = /obj/item/weapon/holder/drone
 
+	can_be_antagged = FALSE
+
 /mob/living/silicon/robot/drone/Destroy()
 	if(hat)
 		hat.loc = get_turf(src)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -22,6 +22,8 @@
 	var/integrated_light_power = 6
 	var/datum/wires/robot/wires
 
+	can_be_antagged = TRUE
+
 //Icon stuff
 
 	var/icontype 				//Persistent icontype tracking allows for cleaner icon updates

--- a/code/modules/mob/living/simple_animal/borer/borer.dm
+++ b/code/modules/mob/living/simple_animal/borer/borer.dm
@@ -32,6 +32,8 @@
 	var/has_reproduced
 	var/roundstart
 
+	can_be_antagged = TRUE
+
 /mob/living/simple_animal/borer/roundstart
 	roundstart = 1
 

--- a/code/modules/mob/living/simple_animal/constructs/constructs.dm
+++ b/code/modules/mob/living/simple_animal/constructs/constructs.dm
@@ -35,6 +35,8 @@
 
 	var/list/construct_spells = list()
 
+	can_be_antagged = TRUE
+
 /mob/living/simple_animal/construct/cultify()
 	return
 

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -154,6 +154,8 @@
 
 	var/faction = "neutral" //Used for checking whether hostile simple animals will attack you, possibly more stuff later
 
+	var/can_be_antagged = FALSE // To prevent pAIs/mice/etc from getting antag in autotraitor and future auto- modes. Uses inheritance instead of a bunch of typechecks.
+
 //Generic list for proc holders. Only way I can see to enable certain verbs/procs. Should be modified if needed.
 	var/proc_holder_list[] = list()//Right now unused.
 	//Also unlike the spell list, this would only store the object in contents, not an object in itself.


### PR DESCRIPTION
Uses a mob var to determine antag validity instead of typechecks, since I believe this will work out better in the long term.  Inheritance can automatically make new mobs we make be invalid by default.