### PR TITLE
Oxyphoron change proposal

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
@@ -64,8 +64,10 @@
 /datum/reagent/toxin/hydrophoron/touch_turf(var/turf/simulated/T)
 	if(!istype(T))
 		return
-	T.assume_gas("oxygen", ceil(volume/2), T20C)
 	T.assume_gas("phoron", ceil(volume/2), T20C)
+	var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
+	s.set_up(1, 1, T)
+	s.start()
 	remove_self(volume)
 
 /datum/reagent/toxin/spidertoxin

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
@@ -45,23 +45,23 @@
 
 //R-UST port
 // Produced during deuterium synthesis. Super poisonous, SUPER flammable (doesn't need oxygen to burn).
-/datum/reagent/toxin/phoroxygen
-	name = "Oxyphoron"
-	id = "oxyphoron"
+/datum/reagent/toxin/hydrophoron
+	name = "Hydrophoron"
+	id = "hydrophoron"
 	description = "An exceptionally flammable molecule formed from deuterium synthesis."
 	strength = 80
 	var/fire_mult = 30
 
-/datum/reagent/toxin/phoroxygen/touch_mob(var/mob/living/L, var/amount)
+/datum/reagent/toxin/hydrophoron/touch_mob(var/mob/living/L, var/amount)
 	if(istype(L))
 		L.adjust_fire_stacks(amount / fire_mult)
 
-/datum/reagent/toxin/phoroxygen/affect_touch(var/mob/living/carbon/M, var/alien, var/removed)
-	M.take_organ_damage(0, removed * 0.1) //being splashed directly with oxyphoron causes minor chemical burns
+/datum/reagent/toxin/hydrophoron/affect_touch(var/mob/living/carbon/M, var/alien, var/removed)
+	M.take_organ_damage(0, removed * 0.1) //being splashed directly with hydrophoron causes minor chemical burns
 	if(prob(10 * fire_mult))
 		M.pl_effects()
 
-/datum/reagent/toxin/phoroxygen/touch_turf(var/turf/simulated/T)
+/datum/reagent/toxin/hydrophoron/touch_turf(var/turf/simulated/T)
 	if(!istype(T))
 		return
 	T.assume_gas("oxygen", ceil(volume/2), T20C)
@@ -340,7 +340,7 @@
 	if(istype(H) && (H.species.flags & NO_SCAN))
 		return
 
-//The original coder comment here wanted it to be "Approx. one mutation per 10 injected/20 ingested/30 touching units" 
+//The original coder comment here wanted it to be "Approx. one mutation per 10 injected/20 ingested/30 touching units"
 //The issue was, it was removed (.2) multiplied by .1, which resulted in a .02% chance per tick to have a mutation occur. Or more accurately, 5000 injected for a single mutation.
 //To honor their original idea, let's keep it as 10/20/30 as they wanted... For the most part.
 

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
@@ -65,9 +65,9 @@
 	if(!istype(T))
 		return
 	T.assume_gas("phoron", ceil(volume/2), T20C)
-	var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
-	s.set_up(1, 1, T)
-	s.start()
+	for(var/turf/simulated/floor/target_tile in range(0,T))
+		target_tile.assume_gas("volatile_fuel", volume, 400+T0C)
+		spawn (0) target_tile.hotspot_expose(700, 400)
 	remove_self(volume)
 
 /datum/reagent/toxin/spidertoxin

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
@@ -66,7 +66,7 @@
 		return
 	T.assume_gas("phoron", ceil(volume/2), T20C)
 	for(var/turf/simulated/floor/target_tile in range(0,T))
-		target_tile.assume_gas("volatile_fuel", volume, 400+T0C)
+		target_tile.assume_gas("volatile_fuel", volume/2, 400+T0C)
 		spawn (0) target_tile.hotspot_expose(700, 400)
 	remove_self(volume)
 

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -1948,11 +1948,12 @@
 	result_amount = 2
 
 //R-UST Port
-/datum/chemical_reaction/oxyphoron
-	name = "Oxyphoron"
-	id = "oxyphoron"
-	result = "oxyphoron"
-	required_reagents = list("water" = 1, "phoron" = 1)
+/datum/chemical_reaction/hyrdophoron
+	name = "Hydrophoron"
+	id = "hydrophoron"
+	result = "hydrophoron"
+	required_reagents = list("hydrogen" = 1, "phoron" = 1)
+	inhibitors = list("nitrogen" = 1) //So it doesn't mess with lexorin
 	result_amount = 2
 
 /datum/chemical_reaction/deuterium
@@ -1960,7 +1961,7 @@
 	id = "deuterium"
 	result = null
 	required_reagents = list("water" = 10)
-	catalysts = list("oxyphoron" = 5)
+	catalysts = list("hydrophoron" = 5)
 	result_amount = 1
 
 /datum/chemical_reaction/deuterium/on_reaction(var/datum/reagents/holder, var/created_volume)


### PR DESCRIPTION
So, water + phoron messes with a lot of stuff. My bad. 

However, hardly any medicines/toxins/etc use both hydrogen and phoron! Even stuff that uses hydrogen + more complicated chemicals, like methyldrate (or whatever the ADD med is called exactly), none of the stuff that's required uses both phoron and hydrogen. So my proposal is that oxyphoron becomes hydrophoron, as well as have an inhibitor of nitrogen so that it doesn't mess with the lexorin recipe, which is the only thing I managed to find that uses hydrogen and phoron. 

This also has an added benefit of being /slightly/ more realistic. It could possibly be fluffed that hydrophoron + water makes heavy water, and that's where the deuterium comes from. We're using a magical chemical already (phoron) so some suspension of disbelief is still required, but... you know. 