### PR TITLE
Communicator voices can understand speech with no default language.

### DIFF
--- a/code/modules/mob/living/voice/voice.dm
+++ b/code/modules/mob/living/voice/voice.dm
@@ -121,6 +121,17 @@
 
 	..(message, speaking, verb, alt_name, whispering) //mob/living/say() can do the actual talking.
 
+/mob/living/voice/say_understands(var/other,var/datum/language/speaking = null)
+	//These only pertain to common. Languages are handled by mob/say_understands()
+	if (!speaking)
+		if (istype(other, /mob/living/carbon))
+			return 1
+		if (istype(other, /mob/living/silicon))
+			return 1
+		if (istype(other, /mob/living/carbon/brain))
+			return 1
+	return ..()
+
 /mob/living/voice/custom_emote(var/m_type=1,var/message = null,var/range=world.view)
 	if(!comm) return
 	..(m_type,message,comm.video_range)


### PR DESCRIPTION
This includes speech from all silicon mobs, who do not have a language set by default, and speech that comes from sources other than a mob, such as the Arrivals Announcement Computer, Cryogenic Oversight, or the Supermatter Monitor.
Fixes #3479