### PR TITLE
Modifies Illegal Equipment Module

### DIFF
--- a/code/_onclick/hud/robot.dm
+++ b/code/_onclick/hud/robot.dm
@@ -243,7 +243,7 @@ var/obj/screen/robot_inventory
 		//Unfortunately adding the emag module to the list of modules has to be here. This is because a borg can
 		//be emagged before they actually select a module. - or some situation can cause them to get a new module
 		// - or some situation might cause them to get de-emagged or something.
-		if(r.emagged)
+		if(r.emagged || emag_items)
 			if(!(r.module.emag in r.module.modules))
 				r.module.modules.Add(r.module.emag)
 		else

--- a/code/_onclick/hud/robot.dm
+++ b/code/_onclick/hud/robot.dm
@@ -243,7 +243,7 @@ var/obj/screen/robot_inventory
 		//Unfortunately adding the emag module to the list of modules has to be here. This is because a borg can
 		//be emagged before they actually select a module. - or some situation can cause them to get a new module
 		// - or some situation might cause them to get de-emagged or something.
-		if(r.emagged || emag_items)
+		if(r.emagged || r.emag_items)
 			if(!(r.module.emag in r.module.modules))
 				r.module.modules.Add(r.module.emag)
 		else

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -157,7 +157,7 @@
 
 /obj/item/borg/upgrade/syndicate/
 	name = "scrambled equipment module"
-	desc = "Unlocks new and often deadly module specific items a robot"
+	desc = "Unlocks new and often deadly module specific items of a robot"
 	icon_state = "cyborg_upgrade3"
 	item_state = "cyborg_upgrade"
 	require_module = 1

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -156,8 +156,8 @@
 
 
 /obj/item/borg/upgrade/syndicate/
-	name = "illegal equipment module"
-	desc = "Unlocks the hidden, deadlier functions of a robot"
+	name = "scrambled equipment module"
+	desc = "Unlocks new and often deadly module specific items a robot"
 	icon_state = "cyborg_upgrade3"
 	item_state = "cyborg_upgrade"
 	require_module = 1
@@ -165,8 +165,8 @@
 /obj/item/borg/upgrade/syndicate/action(var/mob/living/silicon/robot/R)
 	if(..()) return 0
 
-	if(R.emagged == 1)
+	if(R.emag_items == 1)
 		return 0
 
-	R.emagged = 1
+	R.emag_items = 1
 	return 1

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -134,12 +134,12 @@
 	drill_verb = "drilling"
 
 /obj/item/weapon/pickaxe/borgdrill
-	name = "cyborg mining drill"
-	icon_state = "diamonddrill"
+	name = "enhanced sonic jackhammer"
+	icon_state = "jackhammer"
 	item_state = "jackhammer"
 	digspeed = 15
-	desc = ""
-	drill_verb = "drilling"
+	desc = "Cracks rocks with sonic blasts. This one seems like an improved design."
+	drill_verb = "hammering"
 
 /*****************************Shovel********************************/
 

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -63,6 +63,7 @@
 
 	var/opened = 0
 	var/emagged = 0
+	var/emag_items = 0
 	var/wiresexposed = 0
 	var/locked = 1
 	var/has_power = 1
@@ -737,7 +738,7 @@
 			dat += text("[obj]: <B>Activated</B><BR>")
 		else
 			dat += text("[obj]: <A HREF=?src=\ref[src];act=\ref[obj]>Activate</A><BR>")
-	if (emagged)
+	if (emagged || emag_items)
 		if(activated(module.emag))
 			dat += text("[module.emag]: <B>Activated</B><BR>")
 		else
@@ -1054,14 +1055,6 @@
 					src << "<b>Obey these laws:</b>"
 					laws.show_laws(src)
 					src << "<span class='danger'>ALERT: [user.real_name] is your new master. Obey your new laws and his commands.</span>"
-					if(src.module)
-						var/rebuild = 0
-						for(var/obj/item/weapon/pickaxe/borgdrill/D in src.module.modules)
-							qdel(D)
-							rebuild = 1
-						if(rebuild)
-							src.module.modules += new /obj/item/weapon/pickaxe/diamonddrill(src.module)
-							src.module.rebuild()
 					updateicon()
 			else
 				user << "You fail to hack [src]'s interface."

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -677,6 +677,7 @@ var/global/list/robot_modules = list(
 	src.modules += new /obj/item/weapon/gripper/miner(src)
 	src.modules += new /obj/item/weapon/mining_scanner(src)
 	src.emag = new /obj/item/weapon/pickaxe/plasmacutter(src)
+	src.emag = new /obj/item/weapon/pickaxe/diamonddrill(src)
 
 /obj/item/weapon/robot_module/robot/research
 	name = "research module"

--- a/html/changelogs/Nalarac - Robots.yml
+++ b/html/changelogs/Nalarac - Robots.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Nalarac
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Modifies the illegal equipment module for borgs to scrambled equipment module that only activates the special items and doesn't actually emag the borg"
+  - bugfix: "Mining cyborg diamond drill is now obtainable in a more sensible manner"
+  - tweak: "Click dragging has been added to the cryogenics tubes, cloning pod, and all methods of cryostorage"
+  - tweak: "Some quality of life changes for research, crisis, surgeon, and service cyborgs"
+  - bugfix: "Jumper cables readded"
+  - tweak: "Construction cyborgs merged back with engineering cyborgs"


### PR DESCRIPTION
+Illegal equipment module now scrambled equipment module
+Scrambled equipment module now unlocks emagged borg items without
actually emagging the borg, allowing for AI sync, law updates, and being
emagged.
+Makes the miner borg diamond drill appear in all cases of being
upgraded or emagged instead of only if emagged while the mining module
is equipped.

Changelog includes all my previous PRs as well for ease of access to the
changes by the general public. I can trim it down to just this PR if
requested.