### PR TITLE
Using changeling fake death should work properly if self-respiration is on

### DIFF
--- a/code/game/gamemodes/changeling/powers/fake_death.dm
+++ b/code/game/gamemodes/changeling/powers/fake_death.dm
@@ -33,6 +33,9 @@
 	if(C.suiciding)
 		C.suiciding = 0
 
+	if(C.does_not_breathe)
+		C.does_not_breathe = 0	//This means they don't autoheal the oxy damage from the next step
+
 	if(C.stat != DEAD)
 		C.adjustOxyLoss(C.maxHealth * 2)
 


### PR DESCRIPTION
Fixes a rare bug in which lings wouldn't "die" properly when using their fake death.