### PR TITLE
Redoes how gloves prevent fingerprints

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -298,10 +298,9 @@ its easier to just keep the beam vertical.
 
 		//Deal with gloves the pass finger/palm prints.
 		if(!ignoregloves)
-			if(H.gloves != src)
-				if(prob(75) && istype(H.gloves, /obj/item/clothing/gloves/sterile))
-					return 0
-				else if(H.gloves && !istype(H.gloves, /obj/item/clothing/gloves/sterile))
+			if(H.gloves && H.gloves != src)
+				var/obj/item/clothing/gloves/G = H.gloves
+				if(!prob(G.fingerprint_chance))
 					return 0
 
 		//More adminstuffz

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -184,6 +184,7 @@
 	var/wired = 0
 	var/obj/item/weapon/cell/cell = 0
 	var/overgloves = 0
+	var/fingerprint_chance = 0	//How likely the glove is to let fingerprints through
 	body_parts_covered = HANDS
 	slot_flags = SLOT_GLOVES
 	attack_verb = list("challenged")

--- a/code/modules/clothing/gloves/color.dm
+++ b/code/modules/clothing/gloves/color.dm
@@ -87,3 +87,4 @@ obj/item/clothing/gloves/fingerless
 	desc = "A pair of gloves that don't actually cover the fingers."
 	name = "fingerless gloves"
 	icon_state = "fingerlessgloves"
+	fingerprint_chance = 100

--- a/code/modules/clothing/gloves/miscellaneous.dm
+++ b/code/modules/clothing/gloves/miscellaneous.dm
@@ -56,6 +56,7 @@
 	siemens_coefficient = 1.0 //thin latex gloves, much more conductive than fabric gloves (basically a capacitor for AC)
 	permeability_coefficient = 0.01
 	germ_level = 0
+	fingerprint_chance = 25
 //	var/balloonPath = /obj/item/latexballon
 
 //TODO: Make inflating gloves a thing


### PR DESCRIPTION
Fingerprint code now checks a var on the gloves before it leaves prints, instead of having a hardcoded list in atoms.dm

Additionally, fingerless gloves no longer prevent fingerprints.