### PR TITLE
Reduces effectiveness of tabling as opening combat move.

### DIFF
--- a/code/modules/tables/interactions.dm
+++ b/code/modules/tables/interactions.dm
@@ -85,6 +85,8 @@
 			if(occupied)
 				user << "<span class='danger'>There's \a [occupied] in the way.</span>"
 				return
+			if(!user.Adjacent(M))
+				return
 			if (G.state < 2)
 				if(user.a_intent == I_HURT)
 					if (prob(15))	M.Weaken(5)
@@ -106,9 +108,9 @@
 				else
 					user << "<span class='danger'>You need a better grip to do that!</span>"
 					return
-			else if(!M.Check_Shoegrip() && do_mob(user, M, 5+(M.getarmor(BP_TORSO,"melee")/4)))
+			else if(G.state > GRAB_AGGRESSIVE || world.time >= (G.last_action + UPGRADE_COOLDOWN))
 				M.forceMove(get_turf(src))
-				M.Weaken(round(5-(M.getarmor(null, "melee")/20)))
+				M.Weaken(5)
 				visible_message("<span class='danger'>[G.assailant] puts [G.affecting] on \the [src].</span>")
 			qdel(W)
 			return

--- a/code/modules/tables/interactions.dm
+++ b/code/modules/tables/interactions.dm
@@ -106,9 +106,9 @@
 				else
 					user << "<span class='danger'>You need a better grip to do that!</span>"
 					return
-			else
-				G.affecting.loc = src.loc
-				G.affecting.Weaken(5)
+			else if(!M.Check_Shoegrip() && do_mob(user, M, 5+(M.getarmor(BP_TORSO,"melee")/4)))
+				M.forceMove(get_turf(src))
+				M.Weaken(round(5-(M.getarmor(null, "melee")/20)))
 				visible_message("<span class='danger'>[G.assailant] puts [G.affecting] on \the [src].</span>")
 			qdel(W)
 			return

--- a/html/changelogs/Cyantime-Tabling.yml
+++ b/html/changelogs/Cyantime-Tabling.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Cyantime
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Tabling now requires a completed aggressive grab."


### PR DESCRIPTION
Tabling in its current form is an effectively instant stun with no real counters other then being about four tiles from any tables at all times, which can be extended indefinitely with minimal effort. This degenerates melee combat into "Grab, mash z, click table, push to ground, table again occasionally to reapply stun".

Tabling now requires a fully upgraded aggressive grab.

I was told to send this to here from a downstream fork.