### PR TITLE
Gripper Fixes and Updates

### DIFF
--- a/code/game/machinery/computer/card.dm
+++ b/code/game/machinery/computer/card.dm
@@ -59,7 +59,7 @@
 	if(!istype(id_card))
 		return ..()
 
-	if(!scan && (access_change_ids in id_card.access) && user.unEquip(id_card))
+	if(!scan && (access_change_ids in id_card.access) && (user.unEquip(id_card) || (id_card.loc == user && istype(user,/mob/living/silicon/robot)))) //Grippers. Again. ~Mechoid
 		user.drop_item()
 		id_card.forceMove(src)
 		scan = id_card

--- a/code/game/machinery/computer/computer.dm
+++ b/code/game/machinery/computer/computer.dm
@@ -99,5 +99,14 @@
 	if(computer_deconstruction_screwdriver(user, I))
 		return
 	else
+		if(istype(I,/obj/item/weapon/gripper)) //Behold, Grippers and their horribleness. If ..() is called by any computers' attackby() now or in the future, this should let grippers work with them appropriately.
+			var/obj/item/weapon/gripper/B = I	//B, for Borg.
+			if(!B.wrapped)
+				user << "\The [B] is not holding anything."
+				return
+			else
+				var/B_held = B.wrapped
+				user << "You use \the [B] to use \the [B_held] with \the [src]."
+			return
 		attack_hand(user)
 		return

--- a/code/game/machinery/kitchen/smartfridge.dm
+++ b/code/game/machinery/kitchen/smartfridge.dm
@@ -252,6 +252,16 @@
 			if(P.contents.len > 0)
 				user << "<span class='notice'>Some items are refused.</span>"
 
+	else if(istype(O, /obj/item/weapon/gripper)) // Grippers. ~Mechoid.
+		var/obj/item/weapon/gripper/B = O	//B, for Borg.
+		if(!B.wrapped)
+			user << "\The [B] is not holding anything."
+			return
+		else
+			var/B_held = B.wrapped
+			user << "You use \the [B] to put \the [B_held] into \the [src]."
+		return
+
 	else
 		user << "<span class='notice'>\The [src] smartly refuses [O].</span>"
 		return 1

--- a/code/modules/reagents/Chemistry-Machinery.dm
+++ b/code/modules/reagents/Chemistry-Machinery.dm
@@ -362,6 +362,17 @@
 		src.updateUsrDialog()
 		return 0
 
+	if(istype(O,/obj/item/weapon/gripper))
+		var/obj/item/weapon/gripper/B = O	//B, for Borg.
+		if(!B.wrapped)
+			user << "\The [B] is not holding anything."
+			return 0
+		else
+			var/B_held = B.wrapped
+			user << "You use \the [B] to load \the [src] with \the [B_held]."
+
+		return 0
+
 	if(!sheet_reagents[O.type] && (!O.reagents || !O.reagents.total_volume))
 		user << "\The [O] is not suitable for blending."
 		return 1


### PR DESCRIPTION
Grippers can now interface with smart-fridges, grinders and kitchen machinery. 
Testing was done incrementally as I fixed machine interactions.

New or current computers that need gripper interaction and call ..() in their attackby proc should be functional with them as well. I didn't touch the base machine instead, because it has no strict attackby, and I didn't want to touch it and cause un-forseen consequences.

I can guarantee there are more machines that need gripper interaction checks, that I didn't recall/fix, but I will fix them as I am informed when I get a new list going.

**Fixes: **
-Clerical borgs' grippers can interface with both ID console card slots again. The transition to NanoUI overlooked this.
-Borgs can't teleport food to them from the oven, fryer, grill, etc. in the kitchen anymore, despite the comedy involved.