### PR TITLE
Fixes Oversight with Scrambled Equipment Module

### DIFF
--- a/code/modules/research/prosfab_designs.dm
+++ b/code/modules/research/prosfab_designs.dm
@@ -290,7 +290,7 @@
 	build_path = /obj/item/borg/upgrade/jetpack
 
 /datum/design/item/prosfab/robot_upgrade/syndicate
-	name = "Illegal upgrade"
+	name = "Scrambled equipment module"
 	desc = "Allows for the construction of lethal upgrades for cyborgs."
 	id = "borg_syndicate_module"
 	req_tech = list(TECH_COMBAT = 4, TECH_ILLEGAL = 3)


### PR DESCRIPTION
I had assumed the prosthetics fabricator took the name of the items for
its lists, but that wasn't the case.