### PR TITLE
Modifies 1 time PAI sprite&speech selection.

### DIFF
--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -312,29 +312,26 @@
 	var/finalized = "No"
 	while(finalized == "No" && src.client)
 
-		choice = input(usr,"What would you like to use for your mobile chassis icon? This decision can only be made once.") as null|anything in possible_chassis
+		choice = input(usr,"What would you like to use for your mobile chassis icon?") as null|anything in possible_chassis
 		if(!choice) return
 
 		icon_state = possible_chassis[choice]
 		finalized = alert("Look at your sprite. Is this what you wish to use?",,"No","Yes")
 
 	chassis = possible_chassis[choice]
-	verbs -= /mob/living/silicon/pai/proc/choose_chassis
-	verbs += /mob/living/proc/hide
+	verbs |= /mob/living/proc/hide
 
 /mob/living/silicon/pai/proc/choose_verbs()
 	set category = "pAI Commands"
 	set name = "Choose Speech Verbs"
 
-	var/choice = input(usr,"What theme would you like to use for your speech verbs? This decision can only be made once.") as null|anything in possible_say_verbs
+	var/choice = input(usr,"What theme would you like to use for your speech verbs?") as null|anything in possible_say_verbs
 	if(!choice) return
 
 	var/list/sayverbs = possible_say_verbs[choice]
 	speak_statement = sayverbs[1]
 	speak_exclamation = sayverbs[(sayverbs.len>1 ? 2 : sayverbs.len)]
 	speak_query = sayverbs[(sayverbs.len>2 ? 3 : sayverbs.len)]
-
-	verbs -= /mob/living/silicon/pai/proc/choose_verbs
 
 /mob/living/silicon/pai/lay_down()
 	set name = "Rest"


### PR DESCRIPTION
This modifies the 1 time PAI chassis/speech verb selection and allows them to be used multiple times.

It was really unneeded to have it 1 time restricted. There's nothing to gain from changing your PAI sprite or your speech verbs other than aesthetic appeal. If someone picked, say, the cat sprite for a portion of the round and went "Eh, I want the parrot sprite and speech" later on in the round they'd be locked out of it, resulting in people just wiping their selves from the PAI and just being redownloaded to do so, completely making the 1 time restrictions irrelevant and null.