### PR TITLE
Removes hardsuit descriptions that name the station.

### DIFF
--- a/code/modules/clothing/spacesuits/spacesuits.dm
+++ b/code/modules/clothing/spacesuits/spacesuits.dm
@@ -62,10 +62,6 @@
 
 	var/list/supporting_limbs //If not-null, automatically splints breaks. Checked when removing the suit.
 
-/obj/item/clothing/suit/space/New()
-	..()
-	desc += " \"[using_map.station_short]\" is written in large block letters on the back."
-
 /obj/item/clothing/suit/space/equipped(mob/M)
 	check_limb_support(M)
 	..()


### PR DESCRIPTION
It's absurd for this to appear on Syndie suits, or NASA suits, or CentCom suits, or Vox suits, any other suits that don't explicitly belong to the station.

What if you wanna add SolGov suits one day? This will screw that up too.