### PR TITLE
Fixes a-help being dis-colored.

### DIFF
--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -91,8 +91,8 @@ var/list/adminhelp_ignored_words = list("unknown","the","a","an","of","monkey","
 			//Options bar:  mob, details ( admin = 2, dev = 3, mentor = 4, character name (0 = just ckey, 1 = ckey and character name), link? (0 no don't make it a link, 1 do so),
 			//		highlight special roles (0 = everyone has same looking name, 1 = antags / special roles get a golden name)
 
-	var/mentor_msg = "<b><font color=red>Request for Help: </font><font color='blue'>[get_options_bar(mob, 4, 1, 1, 0)][ai_cl]:</b> [msg]</font>"
-	msg = "<b><font color=red>Request for Help:: </font><font color='blue'>[get_options_bar(mob, 2, 1, 1)][ai_cl]:</b> [msg]</font>"
+	var/mentor_msg = "<b><font color=red>Request for Help: </font></b><font color='blue'><b>[get_options_bar(mob, 4, 1, 1, 0)][ai_cl]:</b> [msg]</font>"
+	msg = "<b><font color=red>Request for Help: </font></b><font color='blue'><b>[get_options_bar(mob, 2, 1, 1)][ai_cl]</b> [msg]</font>"
 
 	var/admin_number_afk = 0
 


### PR DESCRIPTION
Apparantly you can't use bold between two different ```<font color>```'s

This fixes the text showing up an incorrect color. Also removes a : because there were two :'s

Tested and can confirm it works.