### PR TITLE
Weak attacks no longer can damage windows

### DIFF
--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -164,7 +164,7 @@
 		update_verbs()
 		update_nearby_icons()
 		step(src, get_dir(AM, src))
-	if(tforce < 10)
+	if(tforce < 5)
 		return
 	take_damage(tforce)
 

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -164,6 +164,8 @@
 		update_verbs()
 		update_nearby_icons()
 		step(src, get_dir(AM, src))
+	if(tforce < 10)
+		return
 	take_damage(tforce)
 
 /obj/structure/window/attack_tk(mob/user as mob)

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -164,8 +164,6 @@
 		update_verbs()
 		update_nearby_icons()
 		step(src, get_dir(AM, src))
-	if(tforce < 5)
-		return
 	take_damage(tforce)
 
 /obj/structure/window/attack_tk(mob/user as mob)
@@ -293,6 +291,8 @@
 
 /obj/structure/window/proc/hit(var/damage, var/sound_effect = 1)
 	if(reinf) damage *= 0.5
+	if(damage < 5)
+		return
 	take_damage(damage)
 	return
 


### PR DESCRIPTION
Attacks with a force less than 5 for normal windows, or 10 for reinforced windows, no longer does any damage to the glass.

The exact number can change, just the goal of this is to stop (especially prisoners) from slapping a pane of glass with a pair of shoes until it shatters. Go ahead. Smack a pane of reinforced glass as many times as you want IRL with your sneaker. You're generally not going to damage it in the course of a day.

We already can't damage windows by punching them for obvious reasons. If your weapon does around the same or less damage than a punch, it shouldn't hurt the window either.