### PR TITLE
Reduces TEG price.

### DIFF
--- a/code/datums/supplypacks/engineering.dm
+++ b/code/datums/supplypacks/engineering.dm
@@ -152,7 +152,7 @@
 /datum/supply_packs/eng/teg
 	contains = list(/obj/machinery/power/generator)
 	name = "Mark I Thermoelectric Generator"
-	cost = 50
+	cost = 40
 	containertype = /obj/structure/closet/crate/secure/large
 	containername = "Mk1 TEG crate"
 	access = access_engine
@@ -160,7 +160,7 @@
 /datum/supply_packs/eng/circulator
 	contains = list(/obj/machinery/atmospherics/binary/circulator)
 	name = "Binary atmospheric circulator"
-	cost = 50
+	cost = 20
 	containertype = /obj/structure/closet/crate/secure/large
 	containername = "Atmospheric circulator crate"
 	access = access_engine


### PR DESCRIPTION
Ordering a full replacement TEG from cargo costs 150 points, the same as a new supermatter core, which seems excessive. This reduces the total cost to 80 points which still seems a bit high, but is more reasonable.