### PR TITLE
Removed crew non-xenos.

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station.dm
@@ -15,7 +15,6 @@
 	max_age = 110
 	health_hud_intensity = 1.5
 
-	spawn_flags = SPECIES_CAN_JOIN
 	appearance_flags = HAS_HAIR_COLOR | HAS_SKIN_TONE | HAS_LIPS | HAS_UNDERWEAR | HAS_EYE_COLOR
 
 /datum/species/human/get_bodytype(var/mob/living/carbon/human/H)


### PR DESCRIPTION
No. The discord is an useless metric. The approval of the memers is all I'm interested in.