### PR TITLE
Fixes 'The data cable retracts rapidly into its spool.' times a billion.

### DIFF
--- a/code/defines/obj/weapon.dm
+++ b/code/defines/obj/weapon.dm
@@ -388,6 +388,10 @@
 
 	var/obj/machinery/machine
 
+/obj/item/weapon/pai_cable/Destroy()
+		machine = null
+		return ..()
+
 ///////////////////////////////////////Stock Parts /////////////////////////////////
 
 /obj/item/weapon/storage/part_replacer

--- a/code/modules/mob/living/silicon/pai/life.dm
+++ b/code/modules/mob/living/silicon/pai/life.dm
@@ -9,6 +9,7 @@
 			for (var/mob/M in viewers(T))
 				M.show_message("<font color='red'>The data cable rapidly retracts back into its spool.</font>", 3, "<font color='red'>You hear a click and the sound of wire spooling rapidly.</font>", 2)
 			qdel(src.cable)
+			src.cable = null
 
 	handle_regular_hud_updates()
 


### PR DESCRIPTION
On the tin. Also makes the cable's Destroy() cleaner.
There are no time police.