### PR TITLE
Fixes "Death Commando" mask, changes its name

### DIFF
--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -104,9 +104,9 @@
 	flags_inv = HIDEEARS|HIDEFACE
 	item_state_slots = list(slot_r_hand_str = "mime", slot_l_hand_str = "mime")
 
-/obj/item/clothing/mask/gas/death_commando
-	name = "Death Commando Mask"
-	icon_state = "death_commando_mask"
+/obj/item/clothing/mask/gas/commando
+	name = "commando mask"
+	icon_state = "fullgas"
 	item_state_slots = list(slot_r_hand_str = "swat", slot_l_hand_str = "swat")
 	siemens_coefficient = 0.2
 


### PR DESCRIPTION
No use letting unused assets go to waste.

At first I thought this was a redundant mask but it actually serves a use, it's just coded wrongly.