### PR TITLE
Allows people with debug access to restart easier.

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -184,7 +184,7 @@ var/list/admin_verbs_debug = list(
 	/client/proc/reload_admins,
 	/client/proc/reload_mentors,
 	/client/proc/restart_controller,
-	datum/admins/proc/restart,
+	/datum/admins/proc/restart,
 	/client/proc/print_random_map,
 	/client/proc/create_random_map,
 	/client/proc/apply_random_map,

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -184,6 +184,7 @@ var/list/admin_verbs_debug = list(
 	/client/proc/reload_admins,
 	/client/proc/reload_mentors,
 	/client/proc/restart_controller,
+	datum/admins/proc/restart,
 	/client/proc/print_random_map,
 	/client/proc/create_random_map,
 	/client/proc/apply_random_map,


### PR DESCRIPTION
For some reason, people with debug access don't have the "restart" proc even though they can restart it without the proc via advanced proccalls
See: https://i.imgur.com/b1gMxyU.gifv

This makes it so that people with debug access can restart it without having to jump through hoops when restarting is required.

Additionally: For the gif above, I had +POSSESS +BUILDMODE +FUN +DEBUG 