### PR TITLE
Brain transplants, synthetics, and languages

### DIFF
--- a/code/game/machinery/computer/ai_core.dm
+++ b/code/game/machinery/computer/ai_core.dm
@@ -176,6 +176,8 @@
 					var/mob/living/silicon/ai/A = new /mob/living/silicon/ai ( loc, laws, brain )
 					if(A) //if there's no brain, the mob is deleted and a structure/AIcore is created
 						A.rename_self("ai", 1)
+						for(var/datum/language/L in brain.brainmob.languages)
+							A.add_language(L.name)
 				feedback_inc("cyborg_ais_created",1)
 				qdel(src)
 

--- a/code/game/objects/items/robot/robot_parts.dm
+++ b/code/game/objects/items/robot/robot_parts.dm
@@ -208,6 +208,9 @@
 
 			O.job = "Cyborg"
 
+			for(var/datum/language/L in M.brainmob.languages)
+				O.add_language(L.name)
+
 			O.cell = chest.cell
 			O.cell.loc = O
 			W.loc = O//Should fix cybros run time erroring when blown up. It got deleted before, along with the frame.

--- a/code/modules/mob/language/generic.dm
+++ b/code/modules/mob/language/generic.dm
@@ -121,3 +121,7 @@
 	colour = "say_quote"
 	key = "s"
 	flags = SIGNLANG|NO_STUTTER|NONVERBAL
+
+/datum/language/sign/can_speak_special(var/mob/speaker)
+	var/obj/item/organ/external/hand/hands = locate() in speaker //you can't sign without hands
+	return (hands || !iscarbon(speaker))

--- a/code/modules/mob/living/carbon/brain/MMI.dm
+++ b/code/modules/mob/living/carbon/brain/MMI.dm
@@ -177,6 +177,7 @@
 /obj/item/device/mmi/digital/New()
 	src.brainmob = new(src)
 	src.brainmob.add_language("Robot Talk")
+	src.brainmob.add_language(LANGUAGE_GALCOM)
 	src.brainmob.add_language(LANGUAGE_EAL)
 	src.brainmob.loc = src
 	src.brainmob.container = src

--- a/code/modules/mob/living/carbon/brain/brain.dm
+++ b/code/modules/mob/living/carbon/brain/brain.dm
@@ -58,7 +58,7 @@
 	return canmove
 
 /mob/living/carbon/brain/isSynthetic()
-	return istype(loc, /obj/item/device/mmi/digital)
+	return istype(loc, /obj/item/device/mmi)
 
 /mob/living/carbon/brain/binarycheck()
 	return isSynthetic()

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -102,6 +102,7 @@
 	spark_system.attach(src)
 
 	add_language("Robot Talk", 1)
+	add_language(LANGUAGE_GALCOM, 1)
 	add_language(LANGUAGE_EAL, 1)
 
 	wires = new(src)
@@ -219,6 +220,12 @@
 		var/turf/T = get_turf(loc)//To hopefully prevent run time errors.
 		if(T)	mmi.loc = T
 		if(mmi.brainmob)
+			var/obj/item/weapon/robot_module/M = locate() in contents
+			if(M)
+				mmi.brainmob.languages = M.original_languages
+			else
+				mmi.brainmob.languages = languages
+			mmi.brainmob.remove_language("Robot Talk")
 			mind.transfer_to(mmi.brainmob)
 		else
 			src << "<span class='danger'>Oops! Something went very wrong, your MMI was unable to receive your mind. You have been ghosted. Please make a bug report so we can fix this bug.</span>"

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -232,7 +232,7 @@
 				default_str = " - <a href='byond://?src=\ref[src];default_lang=\ref[L]'>set default</a>"
 
 			var/synth = (L in speech_synthesizer_langs)
-			dat += "<b>[L.name] (:[L.key])</b>[synth ? default_str : null]<br/>Speech Synthesizer: <i>[synth ? "YES" : "NOT SUPPORTED"]</i><br/>[L.desc]<br/><br/>"
+			dat += "<b>[L.name] ([get_language_prefix()][L.key])</b>[synth ? default_str : null]<br/>Speech Synthesizer: <i>[synth ? "YES" : "NOT SUPPORTED"]</i><br/>[L.desc]<br/><br/>"
 
 	src << browse(dat, "window=checklanguage")
 	return

--- a/code/modules/mob/living/simple_animal/animals/spiderbot.dm
+++ b/code/modules/mob/living/simple_animal/animals/spiderbot.dm
@@ -149,6 +149,7 @@
 		src.mind.key = M.brainmob.key
 		src.ckey = M.brainmob.ckey
 		src.name = "spider-bot ([M.brainmob.name])"
+		src.languages = M.brainmob.languages
 
 /mob/living/simple_animal/spiderbot/proc/explode() //When emagged.
 	src.visible_message("<span class='danger'>\The [src] makes an odd warbling noise, fizzles, and explodes!</span>")

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -77,6 +77,11 @@
 	else
 		O.key = key
 
+	if(O.client && O.client.prefs)
+		var/datum/preferences/B = O.client.prefs
+		for(var/language in B.alternate_languages)
+			O.add_language(language)
+
 	if(move)
 		var/obj/loc_landmark
 		for(var/obj/effect/landmark/start/sloc in landmarks_list)
@@ -153,6 +158,11 @@
 			O.mmi = new /obj/item/device/mmi(O)
 
 		O.mmi.transfer_identity(src)
+
+	if(O.client && O.client.prefs)
+		var/datum/preferences/B = O.client.prefs
+		for(var/language in B.alternate_languages)
+			O.add_language(language)
 
 	callHook("borgify", list(O))
 	O.Namepick()

--- a/code/modules/organs/internal/brain.dm
+++ b/code/modules/organs/internal/brain.dm
@@ -82,6 +82,8 @@
 	if(H.mind)
 		H.mind.transfer_to(brainmob)
 
+	brainmob.languages = H.languages
+
 	brainmob << "<span class='notice'>You feel slightly disoriented. That's normal when you're just \a [initial(src.name)].</span>"
 	callHook("debrain", list(brainmob))
 

--- a/code/modules/organs/subtypes/machine.dm
+++ b/code/modules/organs/subtypes/machine.dm
@@ -62,6 +62,8 @@
 	stored_mmi.icon_state = "mmi_full"
 	icon_state = stored_mmi.icon_state
 
+	stored_mmi.brainmob.languages = owner.languages
+
 	if(owner && owner.stat == DEAD)
 		owner.stat = 0
 		dead_mob_list -= owner
@@ -91,6 +93,8 @@
 	stored_mmi.icon_state = "posibrain-occupied"
 	icon_state = stored_mmi.icon_state
 
+	stored_mmi.brainmob.languages = owner.languages
+
 /obj/item/organ/internal/mmi_holder/robot
 	name = "digital brain interface"
 	brain_type = /obj/item/device/mmi/digital/robot
@@ -100,3 +104,5 @@
 	..()
 	stored_mmi.icon_state = "mainboard"
 	icon_state = stored_mmi.icon_state
+
+	stored_mmi.brainmob.languages = owner.languages

--- a/code/modules/surgery/robotics.dm
+++ b/code/modules/surgery/robotics.dm
@@ -421,6 +421,7 @@
 
 		if(M.brainmob && M.brainmob.mind)
 			M.brainmob.mind.transfer_to(target)
+			target.languages = M.brainmob.languages
 
 		spawn(0) //Name yourself on your own damn time
 			var/new_name = ""

--- a/html/changelogs/PrismaticGynoid-forgottenlanguages.yml
+++ b/html/changelogs/PrismaticGynoid-forgottenlanguages.yml
@@ -1,0 +1,7 @@
+author: PrismaticGynoid
+delete-after: True
+changes: 
+  - tweak: "You now keep your languages when removed from/transplanted into a body."
+  - tweak: "AIs and borgs load languages from preferences when spawning."
+  - bugfix: "Fixed sign language being usable while lacking both hands."
+


### PR DESCRIPTION
Brains now retain languages from the mob they were removed from, rather than forgetting them. Languages are also retained when a brain is transplanted into a new body.

AIs, as well as cyborgs/robots/drones, will load languages from your currently-active preferences when they spawn (just like humanoid mobs do). Brains removed from cyborgs/robots/drones will retain their original languages regardless of the current module.

Brains in MMIs can now speak EAL if they know it, and additionally fixes #2832 - sign language will no longer be usable when lacking both hands. Also fixes silicons being told the wrong language prefix by the known languages window, as it was still showing ':', leading to much confusion among new borg players.

Known issues:
AIs who can use sign language can use it even without a holopad - I'm not sure how to have it check for that. This could be seen as a non-issue, as signs could conceivably be displayed on the AI's screen.

AIs signing over holopad will also have the language verbs overridden by the synth speech verbs (states/queries/declares). I'm pretty sure this has something to do with the already-existing bug that all languages can be understood by everyone when an AI speaks them over holopad.