### PR TITLE
Xenomorph Tweaks/Buffs.

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -61,6 +61,37 @@
 		return
 	..()
 
+/obj/machinery/door/airlock/attack_alien(var/mob/user) //Familiar, right? Doors. -Mechoid
+	if(istype(user, /mob/living/carbon/human))
+		var/mob/living/carbon/human/X = user
+		if(istype(X.species, /datum/species/xenos))
+			if(src.locked || src.welded)
+				visible_message("<span class='alium'>\The [user] begins digging into \the [src] internals!</span>")
+				src.do_animate("deny")
+				if(do_after(user,5 SECONDS,src))
+					visible_message("<span class='danger'>\The [user] forces \the [src] open, sparks flying from its electronics!</span>")
+					src.do_animate("spark")
+					playsound(src.loc, 'sound/machines/airlock_creaking.ogg', 100, 1)
+					src.locked = 0
+					src.welded = 0
+					update_icon()
+					open(1)
+					src.emag_act()
+			else if(src.density)
+				visible_message("<span class='alium'>\The [user] begins forcing \the [src] open!</span>")
+				if(do_after(user, 5 SECONDS,src))
+					playsound(src.loc, 'sound/machines/airlock_creaking.ogg', 100, 1)
+					visible_message("<span class='danger'>\The [user] forces \the [src] open!</span>")
+					open(1)
+			else
+				visible_message("<span class='danger'>\The [user] forces \the [src] closed!</span>")
+				close(1)
+		else
+			src.do_animate("deny")
+			visible_message("<span class='notice'>\The [user] strains fruitlessly to force \the [src] [density ? "open" : "closed"].</span>")
+			return
+	..()
+
 /obj/machinery/door/airlock/get_material()
 	if(mineral)
 		return get_material_by_name(mineral)
@@ -679,6 +710,12 @@ About the new airlock wires panel:
 		if(src.isElectrified())
 			if(src.shock(user, 100))
 				return
+
+	if(istype(user, /mob/living/carbon/human))
+		var/mob/living/carbon/human/X = user
+		if(istype(X.species, /datum/species/xenos))
+			src.attack_alien(user)
+			return
 
 	if(src.p_open)
 		user.set_machine(src)

--- a/code/game/machinery/doors/blast_door.dm
+++ b/code/game/machinery/doors/blast_door.dm
@@ -96,6 +96,17 @@
 	else
 		src.force_close()
 
+//Proc: attack_hand
+//Description: Attacked with empty hand. Only to allow special attack_bys.
+/obj/machinery/door/blast/attack_hand(mob/user as mob)
+	if(istype(user, /mob/living/carbon/human))
+		var/mob/living/carbon/human/X = user
+		if(istype(X.species, /datum/species/xenos))
+			src.attack_alien(user)
+			return
+	..()
+
+
 // Proc: attackby()
 // Parameters: 2 (C - Item this object was clicked with, user - Mob which clicked this object)
 // Description: If we are clicked with crowbar, wielded fire axe, or armblade, try to manually open the door.
@@ -161,6 +172,30 @@
 				playsound(src.loc, hitsound, 100, 1)
 				take_damage(W.force*0.15) //If the item isn't a weapon, let's make this take longer than usual to break it down.
 			return
+
+// Proc: attack_alien()
+// Parameters: Attacking Xeno mob.
+// Description: Forces open the door after a delay.
+/obj/machinery/door/blast/attack_alien(var/mob/user) //Familiar, right? Doors.
+	if(istype(user, /mob/living/carbon/human))
+		var/mob/living/carbon/human/X = user
+		if(istype(X.species, /datum/species/xenos))
+			if(src.density)
+				visible_message("<span class='alium'>\The [user] begins forcing \the [src] open!</span>")
+				if(do_after(user, 15 SECONDS,src))
+					playsound(src.loc, 'sound/machines/airlock_creaking.ogg', 100, 1)
+					visible_message("<span class='danger'>\The [user] forces \the [src] open!</span>")
+					force_open(1)
+			else
+				visible_message("<span class='alium'>\The [user] begins forcing \the [src] closed!</span>")
+				if(do_after(user, 5 SECONDS,src))
+					playsound(src.loc, 'sound/machines/airlock_creaking.ogg', 100, 1)
+					visible_message("<span class='danger'>\The [user] forces \the [src] closed!</span>")
+					force_close(1)
+		else
+			visible_message("<span class='notice'>\The [user] strains fruitlessly to force \the [src] [density ? "open" : "closed"].</span>")
+			return
+	..()
 
 // Proc: open()
 // Parameters: None

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -135,6 +135,12 @@
 	if(operating)
 		return//Already doing something.
 
+	if(istype(user, /mob/living/carbon/human))
+		var/mob/living/carbon/human/X = user
+		if(istype(X.species, /datum/species/xenos))
+			src.attack_alien(user)
+			return
+
 	if(blocked)
 		user << "<span class='warning'>\The [src] is welded solid!</span>"
 		return
@@ -184,6 +190,31 @@
 			if(alarmed)
 				nextstate = FIREDOOR_CLOSED
 				close()
+
+/obj/machinery/door/firedoor/attack_alien(var/mob/user) //Familiar, right? Doors.
+	if(istype(user, /mob/living/carbon/human))
+		var/mob/living/carbon/human/X = user
+		if(istype(X.species, /datum/species/xenos))
+			if(src.blocked)
+				visible_message("<span class='alium'>\The [user] begins digging into \the [src] internals!</span>")
+				if(do_after(user,5 SECONDS,src))
+					playsound(src.loc, 'sound/machines/airlock_creaking.ogg', 100, 1)
+					src.blocked = 0
+					update_icon()
+					open(1)
+			else if(src.density)
+				visible_message("<span class='alium'>\The [user] begins forcing \the [src] open!</span>")
+				if(do_after(user, 2 SECONDS,src))
+					playsound(src.loc, 'sound/machines/airlock_creaking.ogg', 100, 1)
+					visible_message("<span class='danger'>\The [user] forces \the [src] open!</span>")
+					open(1)
+			else
+				visible_message("<span class='danger'>\The [user] forces \the [src] closed!</span>")
+				close(1)
+		else
+			visible_message("<span class='notice'>\The [user] strains fruitlessly to force \the [src] [density ? "open" : "closed"].</span>")
+			return
+	..()
 
 /obj/machinery/door/firedoor/attackby(obj/item/weapon/C as obj, mob/user as mob)
 	add_fingerprint(user)

--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -11,6 +11,9 @@
 	if(can_buckle && buckled_mob)
 		user_unbuckle_mob(user)
 
+/obj/proc/attack_alien(mob/user as mob) //For calling in the event of Xenomorph or other alien checks.
+	return
+
 /obj/attack_robot(mob/living/user)
 	if(Adjacent(user) && buckled_mob) //Checks if what we're touching is adjacent to us and has someone buckled to it. This should prevent interacting with anti-robot manual valves among other things.
 		return attack_hand(user) //Process as if we're a normal person touching the object.

--- a/code/modules/mob/living/carbon/alien/larva/larva.dm
+++ b/code/modules/mob/living/carbon/alien/larva/larva.dm
@@ -7,6 +7,7 @@
 	language = "Hivemind"
 	maxHealth = 25
 	health = 25
+	faction = "xeno"
 
 /mob/living/carbon/alien/larva/New()
 	..()

--- a/code/modules/mob/living/carbon/alien/progression.dm
+++ b/code/modules/mob/living/carbon/alien/progression.dm
@@ -30,6 +30,9 @@
 
 	transfer_languages(src, adult)
 
+	if(src.faction != "neutral")
+		adult.faction = src.faction
+
 	if(mind)
 		mind.transfer_to(adult)
 		if (can_namepick_as_adult)

--- a/code/modules/mob/living/carbon/human/human_powers.dm
+++ b/code/modules/mob/living/carbon/human/human_powers.dm
@@ -38,7 +38,6 @@
 	if(prob(75))
 		T.Weaken(rand(0.5,3))
 	else
-		src.Weaken(rand(2,4))
 		failed = 1
 
 	playsound(loc, 'sound/weapons/pierce.ogg', 25, 1, -1)

--- a/code/modules/mob/living/carbon/human/species/species_attack.dm
+++ b/code/modules/mob/living/carbon/human/species/species_attack.dm
@@ -57,10 +57,21 @@
 	damage = 5
 	shredding = 1
 
+/datum/unarmed_attack/claws/strong/xeno
+	attack_verb = list("slashed", "gouged", "stabbed")
+	damage = 10
+
+/datum/unarmed_attack/claws/strong/xeno/queen
+	attack_verb = list("slashed", "gouged", "stabbed", "gored")
+	damage = 15
+
 /datum/unarmed_attack/bite/strong
 	attack_verb = list("mauled")
 	damage = 8
 	shredding = 1
+
+/datum/unarmed_attack/bite/strong/xeno
+	damage = 10
 
 /datum/unarmed_attack/slime_glomp
 	attack_verb = list("glomped")

--- a/code/modules/mob/living/carbon/human/species/xenomorphs/alien_powers.dm
+++ b/code/modules/mob/living/carbon/human/species/xenomorphs/alien_powers.dm
@@ -18,7 +18,7 @@
 		I.stored_plasma += amount
 	I.stored_plasma = max(0,min(I.stored_plasma,I.max_plasma))
 
-/mob/living/carbon/human/proc/check_alien_ability(var/cost,var/needs_foundation,var/needs_organ)
+/mob/living/carbon/human/proc/check_alien_ability(var/cost,var/needs_foundation,var/needs_organ)	//Returns 1 if the ability is clear for usage.
 
 	var/obj/item/organ/internal/xenos/plasmavessel/P = internal_organs_by_name[O_PLASMA]
 	if(!istype(P))
@@ -161,11 +161,11 @@
 	return
 
 /mob/living/carbon/human/proc/neurotoxin(mob/target as mob in oview())
-	set name = "Spit Neurotoxin (50)"
+	set name = "Spit Neurotoxin (40)"
 	set desc = "Spits neurotoxin at someone, paralyzing them for a short time if they are not wearing protective gear."
 	set category = "Abilities"
 
-	if(!check_alien_ability(50,0,O_ACID))
+	if(!check_alien_ability(40,0,O_ACID))
 		return
 
 	if(stat || paralysis || stunned || weakened || lying || restrained() || buckled)
@@ -175,6 +175,25 @@
 	visible_message("<span class='warning'>[src] spits neurotoxin at [target]!</span>", "<span class='alium'>You spit neurotoxin at [target].</span>")
 
 	var/obj/item/projectile/energy/neurotoxin/A = new(get_turf(src))
+	A.firer = src
+	A.launch(target)
+	return
+
+/mob/living/carbon/human/proc/acidspit(mob/target as mob in oview())
+	set name = "Spit Acid (50)"
+	set desc = "Spits a blob of acid at someone, burning them if they are not wearing protective gear."
+	set category = "Abilities"
+
+	if(!check_alien_ability(50,0,O_ACID))
+		return
+
+	if(stat || paralysis || stunned || weakened || lying || restrained() || buckled)
+		src << "You cannot spit acid in your current state."
+		return
+
+	visible_message("<span class='warning'>[src] spits acid at [target]!</span>", "<span class='alium'>You spit acid at [target].</span>")
+
+	var/obj/item/projectile/energy/acid/A = new(get_turf(src))
 	A.firer = src
 	A.launch(target)
 	return
@@ -239,7 +258,7 @@
 
 	src.visible_message("<span class='danger'>\The [src] leaps at [T]!</span>")
 	src.throw_at(get_step(get_turf(T),get_turf(src)), 4, 1, src)
-	playsound(src.loc, 'sound/voice/shriek1.ogg', 50, 1)
+	playsound(src.loc, 'sound/voice/hiss5.ogg', 50, 1)
 
 	sleep(5)
 

--- a/code/modules/mob/living/carbon/human/species/xenomorphs/alien_species.dm
+++ b/code/modules/mob/living/carbon/human/species/xenomorphs/alien_species.dm
@@ -5,7 +5,7 @@
 
 	default_language = "Xenomorph"
 	language = "Hivemind"
-	unarmed_types = list(/datum/unarmed_attack/claws/strong, /datum/unarmed_attack/bite/strong)
+	unarmed_types = list(/datum/unarmed_attack/claws/strong/xeno, /datum/unarmed_attack/bite/strong/xeno)
 	hud_type = /datum/hud_data/alien
 	rarity_value = 3
 
@@ -160,6 +160,7 @@
 	H.RemoveInfectionImages()
 	..()
 */
+
 /datum/species/xenos/drone
 	name = "Xenomorph Drone"
 	caste_name = "drone"
@@ -172,13 +173,13 @@
 	deform =  'icons/mob/human_races/xenos/r_xenos_drone.dmi'
 
 	has_organ = list(
-		O_HEART =           /obj/item/organ/internal/heart,
-		O_BRAIN =           /obj/item/organ/internal/brain/xeno,
-		O_PLASMA =   /obj/item/organ/internal/xenos/plasmavessel/queen,
-		O_ACID =      /obj/item/organ/internal/xenos/acidgland,
-		O_HIVE =       /obj/item/organ/internal/xenos/hivenode,
-		O_RESIN =   /obj/item/organ/internal/xenos/resinspinner,
-		O_NUTRIENT = /obj/item/organ/internal/diona/nutrients
+		O_HEART =		/obj/item/organ/internal/heart,
+		O_BRAIN =		/obj/item/organ/internal/brain/xeno,
+		O_PLASMA =		/obj/item/organ/internal/xenos/plasmavessel/queen,
+		O_ACID =		/obj/item/organ/internal/xenos/acidgland,
+		O_HIVE =		/obj/item/organ/internal/xenos/hivenode,
+		O_RESIN =		/obj/item/organ/internal/xenos/resinspinner,
+		O_NUTRIENT =	/obj/item/organ/internal/diona/nutrients
 		)
 
 	inherent_verbs = list(
@@ -232,7 +233,7 @@
 	weeds_plasma_rate = 10
 	caste_name = "sentinel"
 	slowdown = 0
-	total_health = 125
+	total_health = 200
 	tail = "xenos_sentinel_tail"
 
 	icobase = 'icons/mob/human_races/xenos/r_xenos_sentinel.dmi'
@@ -253,7 +254,8 @@
 		/mob/living/carbon/human/proc/regurgitate,
 		/mob/living/carbon/human/proc/transfer_plasma,
 		/mob/living/carbon/human/proc/corrosive_acid,
-		/mob/living/carbon/human/proc/neurotoxin
+		/mob/living/carbon/human/proc/neurotoxin,
+		/mob/living/carbon/human/proc/acidspit
 		)
 
 /datum/species/xenos/queen
@@ -269,6 +271,8 @@
 
 	icobase = 'icons/mob/human_races/xenos/r_xenos_queen.dmi'
 	deform =  'icons/mob/human_races/xenos/r_xenos_queen.dmi'
+
+	unarmed_types = list(/datum/unarmed_attack/claws/strong/xeno/queen, /datum/unarmed_attack/bite/strong/xeno)
 
 	has_organ = list(
 		O_HEART =    /obj/item/organ/internal/heart,
@@ -290,6 +294,7 @@
 		/mob/living/carbon/human/proc/transfer_plasma,
 		/mob/living/carbon/human/proc/corrosive_acid,
 		/mob/living/carbon/human/proc/neurotoxin,
+		/mob/living/carbon/human/proc/acidspit,
 		/mob/living/carbon/human/proc/resin
 		)
 

--- a/code/modules/mob/living/carbon/human/species/xenomorphs/xenomorphs.dm
+++ b/code/modules/mob/living/carbon/human/species/xenomorphs/xenomorphs.dm
@@ -9,18 +9,20 @@ proc/create_new_xenomorph(var/alien_caste,var/target)
 
 /mob/living/carbon/human/xdrone/New(var/new_loc)
 	h_style = "Bald"
+	faction = "xeno"
 	..(new_loc, "Xenomorph Drone")
 
 /mob/living/carbon/human/xsentinel/New(var/new_loc)
 	h_style = "Bald"
+	faction = "xeno"
 	..(new_loc, "Xenomorph Sentinel")
-
 /mob/living/carbon/human/xhunter/New(var/new_loc)
 	h_style = "Bald"
+	faction = "xeno"
 	..(new_loc, "Xenomorph Hunter")
-
 /mob/living/carbon/human/xqueen/New(var/new_loc)
 	h_style = "Bald"
+	faction = "xeno"
 	..(new_loc, "Xenomorph Queen")
 
 // I feel like we should generalize/condense down all the various icon-rendering antag procs.

--- a/code/modules/mob/living/simple_animal/aliens/alien.dm
+++ b/code/modules/mob/living/simple_animal/aliens/alien.dm
@@ -62,7 +62,7 @@
 	melee_damage_lower = 15
 	melee_damage_upper = 15
 	ranged = 1
-	projectiletype = /obj/item/projectile/neurotox
+	projectiletype = /obj/item/projectile/energy/neurotoxin/toxic
 	projectilesound = 'sound/weapons/pierce.ogg'
 
 
@@ -77,7 +77,7 @@
 	melee_damage_upper = 15
 	ranged = 1
 	move_to_delay = 3
-	projectiletype = /obj/item/projectile/neurotox
+	projectiletype = /obj/item/projectile/energy/neurotoxin/toxic
 	projectilesound = 'sound/weapons/pierce.ogg'
 	rapid = 1
 	status_flags = 0
@@ -91,10 +91,6 @@
 	move_to_delay = 4
 	maxHealth = 400
 	health = 400
-
-/obj/item/projectile/neurotox
-	damage = 30
-	icon_state = "toxin"
 
 /mob/living/simple_animal/hostile/alien/death()
 	..()

--- a/code/modules/projectiles/projectile/energy.dm
+++ b/code/modules/projectiles/projectile/energy.dm
@@ -111,13 +111,29 @@
 	name = "largebolt"
 	damage = 20
 
+/obj/item/projectile/energy/acid //Slightly up-gunned (Read: The thing does agony and checks bio resist) variant of the simple alien mob's projectile, for queens and sentinels.
+	name = "acidic spit"
+	icon_state = "neurotoxin"
+	damage = 30
+	damage_type = BURN
+	agony = 10
+	check_armour = "bio"
 
 /obj/item/projectile/energy/neurotoxin
-	name = "neuro"
+	name = "neurotoxic spit"
 	icon_state = "neurotoxin"
 	damage = 5
 	damage_type = TOX
-	weaken = 5
+	agony = 80
+	check_armour = "bio"
+
+/obj/item/projectile/energy/neurotoxin/toxic //New alien mob projectile to match the player-variant's projectiles.
+	name = "neurotoxic spit"
+	icon_state = "neurotoxin"
+	damage = 20
+	damage_type = TOX
+	agony = 20
+	check_armour = "bio"
 
 /obj/item/projectile/energy/phoron
 	name = "phoron bolt"

--- a/code/modules/tables/tables.dm
+++ b/code/modules/tables/tables.dm
@@ -159,6 +159,18 @@
 
 	return ..()
 
+/obj/structure/table/attack_hand(mob/user as mob)
+	if(istype(user, /mob/living/carbon/human))
+		var/mob/living/carbon/human/X = user
+		if(istype(X.species, /datum/species/xenos))
+			src.attack_alien(user)
+			return
+	..()
+
+/obj/structure/table/attack_alien(mob/user as mob)
+	visible_message("<span class='danger'>\The [user] tears apart \the [src]!</span>")
+	src.break_to_parts()
+
 /obj/structure/table/MouseDrop_T(obj/item/stack/material/what)
 	if(can_reinforce && isliving(usr) && (!usr.stat) && istype(what) && usr.get_active_hand() == what && Adjacent(usr))
 		reinforce_table(what, usr)


### PR DESCRIPTION
Simplemob:
--Projectile moved from simplemob file to projectiles.
--Projectile modified to be in line with the player xenomorphs, which check bio armor and deal toxin damage.

Player Xeno:
--Neurotoxin is no longer an instant stun, but does 80 agony and costs 40 phoron. Checks Bio armor.
--Added Acid Spit to Sentinels and Queens, which does burn damage and costs 50 phoron. Checks Bio armor.
--Ability to force open airlocks. Welded or bolted airlocks opened in this manner are broken.
--Ability to force open firelocks.
--Ability to force open blast doors after a considerable delay.
--Faction set to 'Xeno', so simple mob aliens do not attack them.
--Ability to smash tables and racks.
--Unarmed damage increased to 15 for drones, sentinels, and hunters.
--Unarmed damage increased to 20 for Queens.
--Leap sound changed to match other xenomorph sounds.
--Failing a tackle no longer weakens twice.

https://github.com/PolarisSS13/Polaris/issues/3768