### PR TITLE
Makes Prometheans process various Toxins differently. Step One.

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
@@ -361,16 +361,17 @@
 /datum/reagent/slimejelly/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	if(alien == IS_DIONA)
 		return
-	if(prob(10) && alien != IS_SLIME) //Partially made of the stuff. Why would it hurt them?
-		M << "<span class='danger'>Your insides are burning!</span>"
-		M.adjustToxLoss(rand(100, 300) * removed)
-	else if(prob(40) || (alien == IS_SLIME && prob(75)))
-		if(alien == IS_SLIME) //Production of the stuff naturally slows as age increases. Added artificially later, it's like a stimpack. Though not all that effective if only one limb has the damage.
+	if(alien == IS_SLIME) //Partially made of the stuff. Why would it hurt them?
+		if(prob(75))
 			M.heal_overall_damage(25 * removed, 25 * removed)
 			M.adjustToxLoss(rand(-30, -10) * removed)
 			M.druggy = max(M.druggy, 10)
 			M.add_chemical_effect(CE_PAINKILLER, 60)
-		else
+	else
+		if(prob(10))
+			M << "<span class='danger'>Your insides are burning!</span>"
+			M.adjustToxLoss(rand(100, 300) * removed)
+		else if(prob(40))
 			M.heal_organ_damage(25 * removed, 0)
 
 /datum/reagent/soporific

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
@@ -14,6 +14,9 @@
 /datum/reagent/toxin/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	if(strength && alien != IS_DIONA)
 		if(issmall(M)) removed *= 2 // Small bodymass, more effect from lower volume.
+		if(alien == IS_SLIME)
+			removed *= 0.25 // Results in half the standard tox as normal. Prometheans are 'Small' for flaps.
+			M.nutrition += strength * removed
 		M.adjustToxLoss(strength * removed)
 
 /datum/reagent/toxin/plasticide
@@ -358,11 +361,17 @@
 /datum/reagent/slimejelly/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	if(alien == IS_DIONA)
 		return
-	if(prob(10))
+	if(prob(10) && alien != IS_SLIME) //Partially made of the stuff. Why would it hurt them?
 		M << "<span class='danger'>Your insides are burning!</span>"
 		M.adjustToxLoss(rand(100, 300) * removed)
-	else if(prob(40))
-		M.heal_organ_damage(25 * removed, 0)
+	else if(prob(40) || (alien == IS_SLIME && prob(75)))
+		if(alien == IS_SLIME) //Production of the stuff naturally slows as age increases. Added artificially later, it's like a stimpack. Though not all that effective if only one limb has the damage.
+			M.heal_overall_damage(25 * removed, 25 * removed)
+			M.adjustToxLoss(rand(-30, -10) * removed)
+			M.druggy = max(M.druggy, 10)
+			M.add_chemical_effect(CE_PAINKILLER, 60)
+		else
+			M.heal_organ_damage(25 * removed, 0)
 
 /datum/reagent/soporific
 	name = "Soporific"
@@ -382,6 +391,9 @@
 	if(alien == IS_SKRELL)
 		threshold = 1.2
 
+	if(alien == IS_SLIME)
+		threshold = 6	//Evens to 3 due to the fact they are considered 'small' for flaps.
+
 	var/effective_dose = dose
 	if(issmall(M))
 		effective_dose *= 2
@@ -396,7 +408,15 @@
 			M.Weaken(2)
 		M.drowsyness = max(M.drowsyness, 20)
 	else
-		M.sleeping = max(M.sleeping, 20)
+		if(alien == IS_SLIME) //They don't have eyes, and they don't really 'sleep'. Fumble their general senses.
+			M.eye_blurry = max(M.eye_blurry, 30)
+			if(prob(20))
+				M.ear_deaf = max(M.ear_deaf, 4)
+				M.Confuse(2)
+			else
+				M.Weaken(2)
+		else
+			M.sleeping = max(M.sleeping, 20)
 		M.drowsyness = max(M.drowsyness, 60)
 
 /datum/reagent/chloralhydrate
@@ -418,6 +438,9 @@
 	if(alien == IS_SKRELL)
 		threshold = 1.2
 
+	if(alien == IS_SLIME)
+		threshold = 6	//Evens to 3 due to the fact they are considered 'small' for flaps.
+
 	var/effective_dose = dose
 	if(issmall(M))
 		effective_dose *= 2
@@ -429,7 +452,14 @@
 		M.Weaken(30)
 		M.eye_blurry = max(M.eye_blurry, 10)
 	else
-		M.sleeping = max(M.sleeping, 30)
+		if(alien == IS_SLIME)
+			if(prob(30))
+				M.ear_deaf = max(M.ear_deaf, 4)
+			M.eye_blurry = max(M.eye_blurry, 60)
+			M.Weaken(30)
+			M.Confuse(40)
+		else
+			M.sleeping = max(M.sleeping, 30)
 
 	if(effective_dose > 1 * threshold)
 		M.adjustToxLoss(removed)
@@ -471,6 +501,9 @@
 	if(alien == IS_SKRELL)
 		drug_strength = drug_strength * 0.8
 
+	if(alien == IS_SLIME)
+		drug_strength = drug_strength * 1.2
+
 	M.druggy = max(M.druggy, drug_strength)
 	if(prob(10) && isturf(M.loc) && !istype(M.loc, /turf/space) && M.canmove && !M.restrained())
 		step(M, pick(cardinal))
@@ -508,8 +541,13 @@
 	if(alien == IS_DIONA)
 		return
 	var/drug_strength = 4
+
 	if(alien == IS_SKRELL)
 		drug_strength = drug_strength * 0.8
+
+	if(alien == IS_SLIME)
+		drug_strength = drug_strength * 1.2
+
 	M.make_dizzy(drug_strength)
 	M.Confuse(drug_strength * 5)
 
@@ -548,8 +586,13 @@
 		return
 
 	var/drug_strength = 100
+
 	if(alien == IS_SKRELL)
 		drug_strength *= 0.8
+
+	if(alien == IS_SLIME)
+		drug_strength *= 1.2
+
 	M.hallucination = max(M.hallucination, drug_strength)
 
 /datum/reagent/psilocybin
@@ -568,6 +611,9 @@
 	var/threshold = 1
 	if(alien == IS_SKRELL)
 		threshold = 1.2
+
+	if(alien == IS_SLIME)
+		threshold = 0.8
 
 	M.druggy = max(M.druggy, 30)
 


### PR DESCRIPTION
-Prometheans now take less toxin damage from base toxins, and gain nutrition from them. This includes fertilizers.
-Slime-jelly will now have a high chance to act as a general regenerative chemical for Prometheans, with the side effect of color distortion similar to mindbreaker. They do not have the chance of being poisoned by it, since it is part of their base body composition.
-Mindbreaker and Psilocybin now are more potent when used on Prometheans due to the entire surface of their body essentially acting as a sensory organ when required. That's a large amount of data to mess with.
-Soporific and Chloral Hydrate require greater amounts when used on, and no longer put Prometheans to sleep, instead keeping them inhibited (small chance to get up with confusion) or prone for the same duration respectively, with constant vision blurring and occasional deafness to act as an inhibited sensory state in both. This state is extended greatly for chloral hydrate.
-Tiny spacing changes to make reading the blocks easier.

Step one of probably only one of chemical variation-izing Prometheans. Probably. 