### PR TITLE
Removes Anti-Bird mechanisms from Defibs

### DIFF
--- a/code/game/objects/items/devices/defib.dm
+++ b/code/game/objects/items/devices/defib.dm
@@ -230,7 +230,7 @@
 
 /obj/item/weapon/shockpaddles/update_held_icon()
 	var/mob/living/M = loc
-	if(istype(M) && !issmall(M) && M.item_is_in_hands(src) && !M.hands_are_full())
+	if(istype(M) && M.item_is_in_hands(src) && !M.hands_are_full())
 		wielded = 1
 		name = "[initial(name)] (wielded)"
 	else


### PR DESCRIPTION
For some reason, small mobs, which include Teshari and Prometheans (and monkeys) cannot use the defib unit.  They can wear the unit but can't actually 'hold' the paddles in both hands, which seems a bit inconsistent and I'd rather just remove the 'no birds allowed' code.