### PR TITLE
Adds medical tape

### DIFF
--- a/code/game/objects/items/weapons/policetape.dm
+++ b/code/game/objects/items/weapons/policetape.dm
@@ -59,6 +59,18 @@ var/list/tape_roll_applications = list()
 		hazard_overlays["[WEST]"]	= new/image('icons/effects/warning_stripes.dmi', icon_state = "W")
 	update_icon()
 
+/obj/item/taperoll/medical
+	name = "medical tape"
+	desc = "A roll of medical tape used to block off patients from the public."
+	tape_type = /obj/item/tape/medical
+	color = COLOR_WHITE
+
+/obj/item/tape/medical
+	name = "medical tape"
+	desc = "A length of medical tape.  Do not cross."
+	req_access = list(access_medical)
+	color = COLOR_WHITE
+
 /obj/item/taperoll/police
 	name = "police tape"
 	desc = "A roll of police tape used to block off crime scenes from the public."

--- a/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
@@ -154,6 +154,7 @@
 		new /obj/item/weapon/extinguisher/mini(src)
 		new /obj/item/weapon/storage/box/freezer(src)
 		new /obj/item/clothing/accessory/storage/white_vest(src)
+		new /obj/item/taperoll/medical(src)
 		return
 
 /obj/structure/closet/secure_closet/CMO
@@ -208,6 +209,7 @@
 		new /obj/item/clothing/shoes/boots/winter/medical(src)
 		new /obj/item/weapon/storage/box/freezer(src)
 		new /obj/item/clothing/mask/gas(src)
+		new /obj/item/taperoll/medical(src)
 		return
 
 


### PR DESCRIPTION
- Adds medical tape for medical to block off areas when treating patients
- Adds medical tape to paramedic and CMO lockers.

This makes it so paramedics can block off an area when they are treating patients, so they aren't bumped into while injecting chemicals or applying medications.

Tested and it just shows up as plain, white tape when put down, as intended.
https://i.imgur.com/gNp90Sb.png