### PR TITLE
Allows the dumping of drinks & beaker spill tweak

### DIFF
--- a/code/modules/reagents/reagent_containers/drinkingglass/drinkingglass.dm
+++ b/code/modules/reagents/reagent_containers/drinkingglass/drinkingglass.dm
@@ -150,10 +150,18 @@
 /obj/item/weapon/reagent_containers/food/drinks/glass2/afterattack(var/obj/target, var/mob/user, var/proximity)
 	if(user.a_intent == I_HURT) //We only want splashing to be done if they are on harm intent.
 		if(!is_open_container() || !proximity)
-			return
+			return 1
 		if(standard_splash_mob(user, target))
-			return
+			return 1
 		if(reagents && reagents.total_volume) //They are on harm intent, aka wanting to spill it.
 			user << "<span class='notice'>You splash the solution onto [target].</span>"
 			reagents.splash(target, reagents.total_volume)
-			return
+			return 1
+	else
+		return
+
+/obj/item/weapon/reagent_containers/food/drinks/glass2/standard_feed_mob(var/mob/user, var/mob/target)
+	if(afterattack()) //Check to see if harm intent & splash.
+		return
+	else
+		..() //If they're splashed, no need to do anything else.

--- a/code/modules/reagents/reagent_containers/drinkingglass/drinkingglass.dm
+++ b/code/modules/reagents/reagent_containers/drinkingglass/drinkingglass.dm
@@ -146,3 +146,14 @@
 			underlays += I
 		else continue
 		side = "right"
+
+/obj/item/weapon/reagent_containers/food/drinks/glass2/afterattack(var/obj/target, var/mob/user, var/proximity)
+	if(user.a_intent == I_HURT) //We only want splashing to be done if they are on harm intent.
+		if(!is_open_container() || !proximity)
+			return
+		if(standard_splash_mob(user, target))
+			return
+		if(reagents && reagents.total_volume) //They are on harm intent, aka wanting to spill it.
+			user << "<span class='notice'>You splash the solution onto [target].</span>"
+			reagents.splash(target, reagents.total_volume)
+			return

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -78,24 +78,26 @@
 
 /obj/item/weapon/reagent_containers/glass/afterattack(var/obj/target, var/mob/user, var/proximity)
 
-	if(!is_open_container() || !proximity)
-		return
+	if(!is_open_container() || !proximity) //Is the container open & are they next to whatever they're clicking?
+		return //If not, do nothing.
 
-	for(var/type in can_be_placed_into)
+	for(var/type in can_be_placed_into) //Is it something it can be placed into?
 		if(istype(target, type))
 			return
 
-	if(standard_splash_mob(user, target))
-		return
-	if(standard_dispenser_refill(user, target))
-		return
-	if(standard_pour_into(user, target))
+	if(standard_dispenser_refill(user, target)) //Are they clicking a water tank/some dispenser?
 		return
 
-	if(reagents && reagents.total_volume)
-		user << "<span class='notice'>You splash the solution onto [target].</span>"
-		reagents.splash(target, reagents.total_volume)
+	if(standard_pour_into(user, target)) //Pouring into another beaker?
 		return
+
+	if(user.a_intent == I_HURT) //Harm intent?
+		if(standard_splash_mob(user, target)) //If harm intent and can splash a mob, go ahead.
+			return
+		if(reagents && reagents.total_volume) //Otherwise? Splash the floor.
+			user << "<span class='notice'>You splash the solution onto [target].</span>"
+			reagents.splash(target, reagents.total_volume)
+			return
 
 /obj/item/weapon/reagent_containers/glass/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	if(istype(W, /obj/item/weapon/pen) || istype(W, /obj/item/device/flashlight/pen))


### PR DESCRIPTION
- Allows you to splash your drink if on harm intent
- Requires you to be on harm intent in order to spill beakers or other glass/ variants.

This can be used by lazy bartenders to empty glasses, ~~since there seems to be no other way to do so.~~ Apparently you can use the sink.

Also allows people to dump a drink the bartender gives you incorrectly, just to be rude.