### PR TITLE
Fixes Borg Lighting Conflicts

### DIFF
--- a/code/game/gamemodes/technomancer/instability.dm
+++ b/code/game/gamemodes/technomancer/instability.dm
@@ -274,8 +274,6 @@
 
 			L.receive_radiated_instability(outgoing_instability)
 
-	set_light(distance, distance * 4, l_color = "#660066") // #C26DDE
-
 // This should only be used for EXTERNAL sources of instability, such as from someone or something glowing.
 /mob/living/proc/receive_radiated_instability(amount)
 	// Energy armor like from the AMI RIG can protect from this.

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -12,6 +12,8 @@
 
 	handle_modifiers() // Do this early since it might affect other things later.
 
+	handle_light()
+
 	if(stat != DEAD)
 		//Breathing, if applicable
 		handle_breathing()
@@ -191,3 +193,19 @@
 
 /mob/living/proc/handle_hud_icons_health()
 	return
+
+/mob/living/proc/handle_light()
+	if(instability >= TECHNOMANCER_INSTABILITY_MIN_GLOW)
+		var/distance = round(sqrt(instability / 2))
+		if(distance)
+			set_light(distance, distance * 4, l_color = "#660066")
+			return TRUE
+
+	else if(on_fire)
+		set_light(light_range + 3, round(fire_stacks), l_color = "#FF9933")
+		return TRUE
+
+	else
+		set_light(0)
+		return FALSE
+

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -310,14 +310,14 @@
 /mob/living/proc/IgniteMob()
 	if(fire_stacks > 0 && !on_fire)
 		on_fire = 1
-		set_light(light_range + 3)
+		handle_light()
 		update_fire()
 
 /mob/living/proc/ExtinguishMob()
 	if(on_fire)
 		on_fire = 0
 		fire_stacks = 0
-		set_light(max(0, light_range - 3))
+		handle_light()
 		update_fire()
 
 /mob/living/proc/update_fire()

--- a/code/modules/mob/living/silicon/robot/life.dm
+++ b/code/modules/mob/living/silicon/robot/life.dm
@@ -12,6 +12,8 @@
 	handle_regular_status_updates()
 	handle_actions()
 	handle_instability()
+	// For some reason borg Life() doesn't call ..()
+	handle_light()
 
 	if(client)
 		handle_regular_hud_updates()
@@ -347,3 +349,10 @@
 /mob/living/silicon/robot/fire_act()
 	if(!on_fire) //Silicons don't gain stacks from hotspots, but hotspots can ignite them
 		IgniteMob()
+
+/mob/living/silicon/robot/handle_light()
+	. = ..()
+	if(. == FALSE) // If no other light sources are on.
+		if(lights_on)
+			set_light(integrated_light_power, integrated_light_power, "#FFFFFF")
+			return TRUE

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -347,10 +347,7 @@
 
 	lights_on = !lights_on
 	usr << "You [lights_on ? "enable" : "disable"] your integrated light."
-	if(lights_on)
-		set_light(integrated_light_power) // 1.5x luminosity of flashlight
-	else
-		set_light(0)
+	handle_light()
 
 /mob/living/silicon/robot/verb/self_diagnosis_verb()
 	set category = "Robot Commands"


### PR DESCRIPTION
Borg lights should be functional again.
Being on fire now makes you glow orange instead of white.  Intensity scales based on fire stacks.