### PR TITLE
Corrects Borg Light Intensity

### DIFF
--- a/code/modules/mob/living/silicon/robot/life.dm
+++ b/code/modules/mob/living/silicon/robot/life.dm
@@ -354,5 +354,5 @@
 	. = ..()
 	if(. == FALSE) // If no other light sources are on.
 		if(lights_on)
-			set_light(integrated_light_power, integrated_light_power, "#FFFFFF")
+			set_light(integrated_light_power, 1, "#FFFFFF")
 			return TRUE


### PR DESCRIPTION
Apparently default intensity before the handle_light() change is 1 and not the range repeated, so now it's 1 again.