### PR TITLE
Slime Update

### DIFF
--- a/code/__defines/mobs.dm
+++ b/code/__defines/mobs.dm
@@ -219,3 +219,8 @@
 #define SA_ANIMAL	2
 #define SA_ROBOTIC	3
 #define SA_HUMANOID	4
+
+// For slime commanding.  Higher numbers allow for more actions.
+#define SLIME_COMMAND_OBEY		1 // When disciplined.
+#define SLIME_COMMAND_FACTION	2 // When in the same 'faction'.
+#define SLIME_COMMAND_FRIEND	3 // When befriended with a slime friendship agent.

--- a/code/game/gamemodes/technomancer/spells/modifier/mend_synthetic.dm
+++ b/code/game/gamemodes/technomancer/spells/modifier/mend_synthetic.dm
@@ -29,17 +29,22 @@
 	stacks = MODIFIER_STACK_EXTEND
 
 /datum/modifier/technomancer/mend_synthetic/tick()
-	if(!holder.isSynthetic()) // Don't heal biologicals!
-		expire()
-		return
-	if(!holder.getBruteLoss() && !holder.getFireLoss()) // No point existing if the spell can't heal.
+//	if(!holder.isSynthetic()) // Don't heal biologicals!
+//		expire()
+//		return
+	if(!holder.getActualBruteLoss() && !holder.getActualFireLoss()) // No point existing if the spell can't heal.
 		expire()
 		return
 	if(ishuman(holder))
 		var/mob/living/carbon/human/H = holder
 		for(var/obj/item/organ/external/E in H.organs)
 			var/obj/item/organ/external/O = E
-			O.heal_damage(4 * spell_power, 4 * spell_power, 0, 1)
+			if(O.robotic >= ORGAN_ROBOT)
+				O.heal_damage(4 * spell_power, 4 * spell_power, 0, 1)
+	else
+		holder.adjustBruteLoss(-4 * spell_power) // Should heal roughly 20 burn/brute over 10 seconds, as tick() is run every 2 seconds.
+		holder.adjustFireLoss(-4 * spell_power) // Ditto.
+
 	holder.adjust_instability(1)
 	if(origin)
 		var/mob/living/L = origin.resolve()

--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -80,6 +80,12 @@
 		amount += O.brute_dam
 	return amount
 
+/mob/living/carbon/human/getActualBruteLoss()
+	var/amount = 0
+	for(var/obj/item/organ/external/O in organs) // Unlike the above, robolimbs DO count.
+		amount += O.brute_dam
+	return amount
+
 /mob/living/carbon/human/getFireLoss()
 	var/amount = 0
 	for(var/obj/item/organ/external/O in organs)
@@ -93,6 +99,12 @@
 	for(var/obj/item/organ/external/O in organs)
 		if(O.robotic >= ORGAN_ROBOT)
 			continue //robot limbs don't count towards shock and crit
+		amount += O.burn_dam
+	return amount
+
+/mob/living/carbon/human/getActualFireLoss()
+	var/amount = 0
+	for(var/obj/item/organ/external/O in organs) // Unlike the above, robolimbs DO count.
 		amount += O.burn_dam
 	return amount
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -218,6 +218,9 @@ default behaviour is:
 /mob/living/proc/getShockBruteLoss()	//Only checks for things that'll actually hurt (not robolimbs)
 	return bruteloss
 
+/mob/living/proc/getActualBruteLoss()	// Mostly for humans with robolimbs.
+	return getBruteLoss()
+
 /mob/living/proc/adjustBruteLoss(var/amount)
 	if(status_flags & GODMODE)	return 0	//godmode
 
@@ -285,6 +288,9 @@ default behaviour is:
 
 /mob/living/proc/getShockFireLoss()	//Only checks for things that'll actually hurt (not robolimbs)
 	return fireloss
+
+/mob/living/proc/getActualFireLoss()	// Mostly for humans with robolimbs.
+	return getBruteLoss()
 
 /mob/living/proc/adjustFireLoss(var/amount)
 	if(status_flags & GODMODE)	return 0	//godmode

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -994,6 +994,7 @@
 //Follow a target (and don't attempt to murder it horribly)
 /mob/living/simple_animal/proc/FollowTarget()
 	ai_log("FollowTarget() [follow_mob]",1)
+	stop_automated_movement = 1
 	//If we were chasing someone and we can't anymore, give up.
 	if(!follow_mob || follow_mob.stat)
 		ai_log("FollowTarget() Losing follow at top",2)
@@ -1324,6 +1325,7 @@
 //Forget a follow mode
 /mob/living/simple_animal/proc/LoseFollow()
 	ai_log("LoseFollow() [target_mob]",2)
+	stop_automated_movement = 0
 	follow_mob = null
 	handle_stance(STANCE_IDLE)
 	GiveUpMoving()

--- a/code/modules/mob/living/simple_animal/slime/ai.dm
+++ b/code/modules/mob/living/simple_animal/slime/ai.dm
@@ -1,11 +1,16 @@
 /mob/living/simple_animal/slime/FindTarget()
 	if(victim) // Don't worry about finding another target if we're eatting someone.
 		return
-//	if(!will_hunt())
-//		return
+	if(follow_mob && can_command(follow_mob)) // If following someone, don't attack until the leader says so, something hits you, or the leader is no longer worthy.
+		return
 	..()
 
 /mob/living/simple_animal/slime/special_target_check(mob/living/L)
+	if(L.faction == faction && !attack_same)
+		return FALSE
+	if(L in friends)
+		return FALSE
+
 	if(istype(L, /mob/living/simple_animal/slime))
 		var/mob/living/simple_animal/slime/buddy = L
 		if(buddy.slime_color == src.slime_color || discipline || unity || buddy.unity)
@@ -47,12 +52,3 @@
 		return
 	else
 		..()
-
-/*
-/mob/living/simple_animal/slime/proc/will_hunt() // Check for being stopped from feeding and chasing
-	if(nutrition <= get_starve_nutrition() || rabid)
-		return TRUE
-	if(nutrition <= get_hunger_nutrition() || prob(25))
-		return TRUE
-	return FALSE
-*/

--- a/code/modules/mob/living/simple_animal/slime/slime.dm
+++ b/code/modules/mob/living/simple_animal/slime/slime.dm
@@ -297,6 +297,24 @@
 
 	if(is_adult)
 		if(amount_grown >= 10)
+			// Check if there's enough 'room' to split.
+			var/list/nearby_things = orange(1, src)
+			var/free_tiles = 0
+			for(var/turf/T in nearby_things)
+				var/free = TRUE
+				if(T.density) // No walls.
+					continue
+				for(var/atom/movable/AM in T)
+					if(AM.density)
+						free = FALSE
+						break
+
+				if(free)
+					free_tiles++
+
+			if(free_tiles < 3) // Three free tiles are needed, as four slimes are made and the 4th tile is from the center tile that the current slime occupies.
+				to_chat(src, "<span class='warning'>It is too cramped here to reproduce...</span>")
+				return
 
 			var/list/babies = list()
 			for(var/i = 1 to 4)
@@ -352,13 +370,13 @@
 	if(rabid)
 		return FALSE
 	if(docile)
-		return TRUE
+		return SLIME_COMMAND_OBEY
 	if(commander in friends)
-		return TRUE
+		return SLIME_COMMAND_FRIEND
 	if(faction == commander.faction)
-		return TRUE
+		return SLIME_COMMAND_FACTION
 	if(discipline > resentment && obedience >= 5)
-		return TRUE
+		return SLIME_COMMAND_OBEY
 	return FALSE
 
 /mob/living/simple_animal/slime/proc/give_hat(var/obj/item/clothing/head/new_hat, var/mob/living/user)

--- a/code/modules/mob/living/simple_animal/slime/subtypes.dm
+++ b/code/modules/mob/living/simple_animal/slime/subtypes.dm
@@ -200,11 +200,14 @@
 			var/cold_factor = abs(protection - 1)
 			var/delta = -20
 			delta *= cold_factor
-			L.bodytemperature = max(50, delta)
+			L.bodytemperature = max(50, L.bodytemperature + delta)
 	var/turf/T = get_turf(src)
 	var/datum/gas_mixture/env = T.return_air()
 	if(env)
 		env.add_thermal_energy(-10 * 1000)
+
+/mob/living/simple_animal/slime/dark_blue/get_cold_protection()
+	return 1 // This slime is immune to cold.
 
 
 /mob/living/simple_animal/slime/silver
@@ -513,8 +516,16 @@
 /datum/modifier/slime_heal/tick()
 	if(holder.stat == DEAD) // Required or else simple animals become immortal.
 		expire()
-	holder.adjustBruteLoss(-2)
-	holder.adjustFireLoss(-2)
+
+	if(ishuman(holder)) // Robolimbs need this code sadly.
+		var/mob/living/carbon/human/H = holder
+		for(var/obj/item/organ/external/E in H.organs)
+			var/obj/item/organ/external/O = E
+			O.heal_damage(2, 2, 0, 1)
+	else
+		holder.adjustBruteLoss(-2)
+		holder.adjustFireLoss(-2)
+
 	holder.adjustToxLoss(-2)
 	holder.adjustOxyLoss(-2)
 	holder.adjustCloneLoss(-1)


### PR DESCRIPTION
Pink Slime Aura and Mend Synthetic (technomancer) should now fix FBPs again.
Adds procs to get the 'real' number of damage from humans, including limb damage on prosthetic limbs.
Slime following made a bit more robust, slimes (and other simple animals) stop wandering when following.
Slimes following a leader that passes the can_command() check will refrain from attacking things if not attacked first.
Slime kill command implemented, requires the slime to be in your faction or be the slime's friend, and not just obedient.  This can be accomplished with end-game slime agents.
Slimes require three 'free' tiles to split, which should prevent super overcrowed cells and by extension avoid Amber Tide from crashing the mob controller.
Dark Blue Cold Aura now properly adjusts temperature based on protection gradually instead of instantly setting to the lowest value.
Fixes #3834 
Fixes #3835 