### PR TITLE
Dirt, hair, and underwear

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/prometheans.dm
+++ b/code/modules/mob/living/carbon/human/species/station/prometheans.dm
@@ -21,7 +21,7 @@ var/datum/species/shapeshifter/promethean/prometheans
 	swap_flags =       MONKEY|SLIME|SIMPLE_ANIMAL
 	push_flags =       MONKEY|SLIME|SIMPLE_ANIMAL
 	flags =            NO_SCAN | NO_SLIP | NO_MINOR_CUT
-	appearance_flags = HAS_SKIN_COLOR | HAS_EYE_COLOR | HAS_HAIR_COLOR | RADIATION_GLOWS
+	appearance_flags = HAS_SKIN_COLOR | HAS_EYE_COLOR | HAS_HAIR_COLOR | RADIATION_GLOWS | HAS_UNDERWEAR
 	spawn_flags		 = SPECIES_CAN_JOIN | SPECIES_IS_WHITELISTED
 	health_hud_intensity = 2
 	num_alternate_languages = 3
@@ -137,7 +137,12 @@ var/datum/species/shapeshifter/promethean/prometheans
 	if(istype(T))
 		var/obj/effect/decal/cleanable/C = locate() in T
 		if(C)
+			if(H.shoes || (H.wear_suit && (H.wear_suit.body_parts_covered & FEET)))
+				return
 			qdel(C)
+			if (istype(T, /turf/simulated))
+				var/turf/simulated/S = T
+				S.dirt = 0
 			H.nutrition += rand(15, 45)
 
 	// Heal remaining damage.

--- a/code/modules/mob/new_player/sprite_accessories.dm
+++ b/code/modules/mob/new_player/sprite_accessories.dm
@@ -29,7 +29,7 @@
 	var/gender = NEUTER
 
 	// Restrict some styles to specific species
-	var/list/species_allowed = list("Human")
+	var/list/species_allowed = list("Human","Promethean")
 
 	// Whether or not the accessory can be affected by colouration
 	var/do_colouration = 1
@@ -51,7 +51,7 @@
 		name = "Bald"
 		icon_state = "bald"
 		gender = MALE
-		species_allowed = list("Human","Unathi")
+		species_allowed = list("Human","Unathi","Promethean")
 
 	short
 		name = "Short Hair"	  // try to capatilize the names please~
@@ -632,7 +632,7 @@
 		name = "Shaved"
 		icon_state = "bald"
 		gender = NEUTER
-		species_allowed = list("Human","Unathi","Tajara","Skrell", "Machine","Teshari", "Vox")
+		species_allowed = list("Human","Unathi","Tajara","Skrell", "Machine","Teshari", "Vox","Promethean")
 
 	watson
 		name = "Watson Mustache"


### PR DESCRIPTION
Fixes #3786 - prometheans are no longer able to eat the same dirt repeatedly for infinite nutrition. The dirt now gets properly removed from the tile. Also, prometheans are no longer able to eat dirt and other messes off the floor unless their feet are uncovered.

Prometheans are now able to pick their hair in the character setup menu, and they're also able to have underwear (hopefully underwear that won't get dissolved accidentally).