### PR TITLE
Skrell Language Color Change-

### DIFF
--- a/code/stylesheet.dm
+++ b/code/stylesheet.dm
@@ -87,7 +87,7 @@ h1.alert, h2.alert		{color: #000000;}
 .alien					{color: #543354;}
 .tajaran				{color: #803B56;}
 .tajaran_signlang		{color: #941C1C;}
-.skrell					{color: #00CED1;}
+.skrell					{color: #00B0B3;}
 .soghun					{color: #228B22;}
 .solcom					{color: #22228B;}
 .changeling				{color: #800080;}


### PR DESCRIPTION
The Skrell Language color has always seemed a bit too bright and hard to read, so I thought it would be a fine idea to darken the color just a little so that it was easier to see, and didn't strain your eyes.