### PR TITLE
Cryotoxin should no longer be as fast or powerful

### DIFF
--- a/code/game/gamemodes/changeling/powers/cryo_sting.dm
+++ b/code/game/gamemodes/changeling/powers/cryo_sting.dm
@@ -31,19 +31,3 @@
 		src << "<span class='notice'>Our cryogenic string is ready to be used once more.</span>"
 		src.verbs |= /mob/proc/changeling_cryo_sting
 	return 1
-
-/datum/reagent/cryotoxin //A much more potent version of frost oil.
-	name = "Cryotoxin"
-	id = "cryotoxin"
-	description = "Rapidly lowers the body's internal temperature."
-	reagent_state = LIQUID
-	color = "#B31008"
-
-/datum/reagent/cryotoxin/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
-	if(alien == IS_DIONA)
-		return
-	M.bodytemperature = max(M.bodytemperature - 30 * TEMPERATURE_DAMAGE_COEFFICIENT, 0)
-	if(prob(3))
-		M.emote("shiver")
-	..()
-	return

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
@@ -284,12 +284,20 @@
 /datum/reagent/frostoil/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	if(alien == IS_DIONA)
 		return
-	M.bodytemperature = max(M.bodytemperature - 10 * TEMPERATURE_DAMAGE_COEFFICIENT, 0)
+	M.bodytemperature = max(M.bodytemperature - 10 * TEMPERATURE_DAMAGE_COEFFICIENT, 215)
 	if(prob(1))
 		M.emote("shiver")
 	if(istype(M, /mob/living/simple_animal/slime))
 		M.bodytemperature = max(M.bodytemperature - rand(10,20), 0)
 	holder.remove_reagent("capsaicin", 5)
+
+/datum/reagent/frostoil/cryotoxin //A longer lasting version of frost oil.
+	name = "Cryotoxin"
+	id = "cryotoxin"
+	description = "Lowers the body's internal temperature."
+	reagent_state = LIQUID
+	color = "#B31008"
+	metabolism = REM * 0.5
 
 /datum/reagent/capsaicin
 	name = "Capsaicin Oil"


### PR DESCRIPTION
- Frost oil has been given a temperature cap, it shouldn't lower body temp below 215. This puts most species into the first level of cold damage.
- Cryotoxin is now a subtype of frost oil, it lasts twice as long, which means twice as much cold damage.