### PR TITLE
Hull shields and emergency shields check for outdoor turfs and drops

### DIFF
--- a/code/modules/shieldgen/emergency_shield.dm
+++ b/code/modules/shieldgen/emergency_shield.dm
@@ -139,6 +139,11 @@
 	var/check_delay = 60	//periodically recheck if we need to rebuild a shield
 	use_power = 0
 	idle_power_usage = 0
+	var/global/list/blockedturfs =  list(
+		/turf/space,
+		/turf/simulated/open,
+		/turf/simulated/floor/outdoors,
+	)
 
 /obj/machinery/shieldgen/Destroy()
 	collapse_shields()
@@ -169,7 +174,7 @@
 
 /obj/machinery/shieldgen/proc/create_shields()
 	for(var/turf/target_tile in range(2, src))
-		if (istype(target_tile,/turf/space) && !(locate(/obj/machinery/shield) in target_tile))
+		if (is_type_in_list(target_tile,blockedturfs) && !(locate(/obj/machinery/shield) in target_tile))
 			if (malfunction && prob(33) || !malfunction)
 				var/obj/machinery/shield/S = new/obj/machinery/shield(target_tile)
 				deployed_shields += S

--- a/code/modules/shieldgen/shield_gen_external.dm
+++ b/code/modules/shieldgen/shield_gen_external.dm
@@ -3,7 +3,11 @@
 
 /obj/machinery/shield_gen/external
 	name = "hull shield generator"
-
+	var/global/list/blockedturfs =  list(
+		/turf/space,
+		/turf/simulated/open,
+		/turf/simulated/floor/outdoors,
+	)
 /obj/machinery/shield_gen/external/New()
 	..()
 
@@ -18,7 +22,7 @@
 	for (var/x_offset = -field_radius; x_offset <= field_radius; x_offset++)
 		for (var/y_offset = -field_radius; y_offset <= field_radius; y_offset++)
 			T = locate(gen_turf.x + x_offset, gen_turf.y + y_offset, gen_turf.z)
-			if (istype(T, /turf/space))
+			if (is_type_in_list(T,blockedturfs))
 				//check neighbors of T
 				if (locate(/turf/simulated/) in orange(1, T))
 					out += T


### PR DESCRIPTION
This is more of a thing for planetside maps, especially those with funky atmospheric situations. Also includes support for multi-z.

tl;dr, instead of just placing shields on space turfs, the generator now blocks off outdoor areas as well so you can use the shield to keep yourself snug and warm on an arctic hellscape station or whatever else you want to use just as readily as you would one in space.