### PR TITLE
Removes binary from brains.

### DIFF
--- a/code/modules/mob/living/carbon/brain/MMI.dm
+++ b/code/modules/mob/living/carbon/brain/MMI.dm
@@ -177,7 +177,7 @@
 
 /obj/item/device/mmi/digital/New()
 	src.brainmob = new(src)
-	src.brainmob.add_language("Robot Talk")
+//	src.brainmob.add_language("Robot Talk")//No binary without a binary communication device
 	src.brainmob.add_language(LANGUAGE_GALCOM)
 	src.brainmob.add_language(LANGUAGE_EAL)
 	src.brainmob.loc = src
@@ -271,7 +271,7 @@
 	src.brainmob << "<b>You are a [src], brought into existence on [station_name()].</b>"
 	src.brainmob << "<b>As a synthetic intelligence, you answer to all crewmembers, as well as the AI.</b>"
 	src.brainmob << "<b>Remember, the purpose of your existence is to serve the crew and the station. Above all else, do no harm.</b>"
-	src.brainmob << "<b>Use say #b to speak to other artificial intelligences.</b>"
+//	src.brainmob << "<b>Use say #b to speak to other artificial intelligences.</b>"
 	src.brainmob.mind.assigned_role = "Synthetic Brain"
 
 	var/turf/T = get_turf_or_move(src.loc)

--- a/code/modules/mob/living/carbon/brain/brain.dm
+++ b/code/modules/mob/living/carbon/brain/brain.dm
@@ -60,5 +60,5 @@
 /mob/living/carbon/brain/isSynthetic()
 	return istype(loc, /obj/item/device/mmi)
 
-/mob/living/carbon/brain/binarycheck()
-	return isSynthetic()
+///mob/living/carbon/brain/binarycheck()//No binary without a binary communication device
+//	return isSynthetic()

--- a/html/changelogs/PrismaticGynoid-nonbinarybrains.yml
+++ b/html/changelogs/PrismaticGynoid-nonbinarybrains.yml
@@ -1,0 +1,5 @@
+author: PrismaticGynoid
+
+delete-after: True
+
+  - rscdel: "Brains are no longer able to hear binary (robot talk)."


### PR DESCRIPTION
This is being done because of the problem of MMI-type brains suddenly having access to a secure channel they can spy on when removed from a body - something they couldn't access before without a binary communication device or similar. This has been used several times against antags, usually antag AIs.