### PR TITLE
Makes all synthetic brains radio-enabled.

### DIFF
--- a/code/game/machinery/telecomms/telecomunications.dm
+++ b/code/game/machinery/telecomms/telecomunications.dm
@@ -547,8 +547,7 @@ var/global/list/obj/machinery/telecomms/telecomms_list = list()
 					race = "[H.species.name]"
 					log.parameters["intelligible"] = 1
 				else if(isbrain(M))
-					var/mob/living/carbon/brain/B = M
-					race = "[B.species.name]"
+					race = "Brain"
 					log.parameters["intelligible"] = 1
 				else if(M.isMonkey())
 					race = "Monkey"

--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -317,6 +317,20 @@
 	item_state = "headset"
 	ks2type = /obj/item/device/encryptionkey/heads/hos
 
+/obj/item/device/radio/headset/mmi_radio
+	name = "brain-integrated radio"
+	desc = "MMIs and synthetic brains are often equipped with these."
+	icon = 'icons/obj/robot_component.dmi'
+	icon_state = "radio"
+	item_state = "headset"
+	var/mmiowner = null
+	var/radio_enabled = 1
+
+/obj/item/device/radio/headset/mmi_radio/receive_range(freq, level)
+	if (!radio_enabled || istype(src.loc.loc, /mob/living/silicon) || istype(src.loc.loc, /obj/item/organ/internal))
+		return -1 //Transciever Disabled.
+	return ..(freq, level, 1)
+
 /obj/item/device/radio/headset/attackby(obj/item/weapon/W as obj, mob/user as mob)
 //	..()
 	user.set_machine(src)

--- a/code/modules/mob/living/carbon/brain/MMI.dm
+++ b/code/modules/mob/living/carbon/brain/MMI.dm
@@ -16,6 +16,30 @@
 	var/mob/living/carbon/brain/brainmob = null//The current occupant.
 	var/obj/item/organ/internal/brain/brainobj = null	//The current brain organ.
 	var/obj/mecha = null//This does not appear to be used outside of reference in mecha.dm.
+	var/obj/item/device/radio/headset/mmi_radio/radio = null//Let's give it a radio.
+
+/obj/item/device/mmi/New()
+	radio = new(src)//Spawns a radio inside the MMI.
+
+/obj/item/device/mmi/verb/toggle_radio()
+	set name = "Toggle Brain Radio"
+	set desc = "Enables or disables the integrated brain radio, which is only usable outside of a body."
+	set category = "Object"
+	set src in usr
+	set popup_menu = 1
+	if(!usr.canmove || usr.stat || usr.restrained())
+		return 0
+
+	if (radio.radio_enabled == 1)
+		radio.radio_enabled = 0
+		to_chat (usr, "You have disabled the [src]'s radio.")
+		to_chat (brainmob, "Your radio has been disabled.")
+	else if (radio.radio_enabled == 0)
+		radio.radio_enabled = 1
+		to_chat (usr, "You have enabled the [src]'s radio.")
+		to_chat (brainmob, "Your radio has been enabled.")
+	else
+		to_chat (usr, "You were unable to toggle the [src]'s radio.")
 
 /obj/item/device/mmi/attackby(var/obj/item/O as obj, var/mob/user as mob)
 	if(istype(O,/obj/item/organ/internal/brain) && !brainmob) //Time to stick a brain in it --NEO
@@ -110,47 +134,14 @@
 	if(isrobot(loc))
 		var/mob/living/silicon/robot/borg = loc
 		borg.mmi = null
+	qdel_null(radio)
 	qdel_null(brainmob)
 	return ..()
 
 /obj/item/device/mmi/radio_enabled
 	name = "radio-enabled man-machine interface"
-	desc = "The Warrior's bland acronym, MMI, obscures the true horror of this monstrosity. This one comes with a built-in radio."
+	desc = "The Warrior's bland acronym, MMI, obscures the true horror of this monstrosity. This one comes with a built-in radio. Wait, don't they all?"
 	origin_tech = list(TECH_BIO = 4)
-
-	var/obj/item/device/radio/radio = null//Let's give it a radio.
-
-	New()
-		..()
-		radio = new(src)//Spawns a radio inside the MMI.
-		radio.broadcasting = 1//So it's broadcasting from the start.
-
-	verb//Allows the brain to toggle the radio functions.
-		Toggle_Broadcasting()
-			set name = "Toggle Broadcasting"
-			set desc = "Toggle broadcasting channel on or off."
-			set category = "MMI"
-			set src = usr.loc//In user location, or in MMI in this case.
-			set popup_menu = 0//Will not appear when right clicking.
-
-			if(brainmob.stat)//Only the brainmob will trigger these so no further check is necessary.
-				brainmob << "Can't do that while incapacitated or dead."
-
-			radio.broadcasting = radio.broadcasting==1 ? 0 : 1
-			brainmob << "<span class='notice'>Radio is [radio.broadcasting==1 ? "now" : "no longer"] broadcasting.</span>"
-
-		Toggle_Listening()
-			set name = "Toggle Listening"
-			set desc = "Toggle listening channel on or off."
-			set category = "MMI"
-			set src = usr.loc
-			set popup_menu = 0
-
-			if(brainmob.stat)
-				brainmob << "Can't do that while incapacitated or dead."
-
-			radio.listening = radio.listening==1 ? 0 : 1
-			brainmob << "<span class='notice'>Radio is [radio.listening==1 ? "now" : "no longer"] receiving broadcast.</span>"
 
 /obj/item/device/mmi/emp_act(severity)
 	if(!brainmob)
@@ -184,6 +175,7 @@
 	src.brainmob.container = src
 	src.brainmob.stat = 0
 	src.brainmob.silent = 0
+	radio = new(src)
 	dead_mob_list -= src.brainmob
 
 /obj/item/device/mmi/digital/attackby(var/obj/item/O as obj, var/mob/user as mob)

--- a/code/modules/mob/living/carbon/brain/say.dm
+++ b/code/modules/mob/living/carbon/brain/say.dm
@@ -22,7 +22,7 @@
 				verb="asks"
 
 		if(prob(emp_damage*4))
-			if(prob(10))//10% chane to drop the message entirely
+			if(prob(10))//10% chance to drop the message entirely
 				return
 			else
 				message = Gibberish(message, (emp_damage*6))//scrambles the message, gets worse when emp_damage is higher
@@ -31,8 +31,16 @@
 			speaking.broadcast(src,trim(message))
 			return
 
-		if(istype(container, /obj/item/device/mmi/radio_enabled))
-			var/obj/item/device/mmi/radio_enabled/R = container
-			if(R.radio)
-				spawn(0) R.radio.hear_talk(src, sanitize(message), verb, speaking)
 		..(trim(message), speaking, verb)
+
+/mob/living/carbon/brain/handle_message_mode(message_mode, message, verb, speaking, used_radios, alt_name)
+	..()
+	if(message_mode)
+		var/obj/item/device/mmi/R = container
+		if (R.radio && R.radio.radio_enabled)
+			if(message_mode == "general")
+				message_mode = null
+			return R.radio.talk_into(src,message,message_mode,verb,speaking)
+		else
+			src << "<span class='danger'>Your radio is disabled.</span>"
+			return 0

--- a/code/modules/research/designs.dm
+++ b/code/modules/research/designs.dm
@@ -755,16 +755,6 @@ other types of metals and chemistry for reagents).
 	category = "Misc"
 	sort_string = "VACBA"
 
-/datum/design/item/mmi_radio
-	name = "Radio-enabled man-machine interface"
-	id = "mmi_radio"
-	req_tech = list(TECH_DATA = 2, TECH_BIO = 4)
-	build_type = PROTOLATHE | PROSFAB
-	materials = list(DEFAULT_WALL_MATERIAL = 1200, "glass" = 500)
-	build_path = /obj/item/device/mmi/radio_enabled
-	category = "Misc"
-	sort_string = "VACBB"
-
 /datum/design/item/beacon
 	name = "Bluespace tracking beacon design"
 	id = "beacon"

--- a/html/changelogs/PrismaticGynoid-radioenabledbrains.yml
+++ b/html/changelogs/PrismaticGynoid-radioenabledbrains.yml
@@ -1,0 +1,6 @@
+author: PrismaticGynoid
+
+delete-after: True
+
+changes: 
+  - tweak: "Makes all MMIs, posibrains, and drone brains radio-enabled. Anyone holding the brain can also disable the radio for antag purposes."


### PR DESCRIPTION
Mostly because the old radio-enabled MMIs were almost never used. Changes all MMIs and their subtypes (posi and drone brains) to have a radio inside of them, which can only be used when the brain is outside of a body. This radio can be used to talk over the common channel, in case you get left on a table somewhere by an absent-minded roboticist. However, the radio can also be disabled, in case an antag has you and doesn't want to to scream for help.

Since this makes the old radio-enabled MMIs obsolete, they're no longer printable(although it's still defined in the code so I don't have to touch the map file). Also fixes a telecomms runtime with brains talking over the radio.