### PR TITLE
Adjusts liver damage from alcohol

### DIFF
--- a/code/modules/organs/internal/liver.dm
+++ b/code/modules/organs/internal/liver.dm
@@ -39,10 +39,11 @@
 
 		// Do some reagent processing.
 		if(owner.chem_effects[CE_ALCOHOL_TOXIC])
+			take_damage(owner.chem_effects[CE_ALCOHOL_TOXIC] * 0.1 * PROCESS_ACCURACY, prob(1)) // Chance to warn them
+			if(filter_effect < 2)	//Liver is badly damaged, you're drinking yourself to death
+				owner.adjustToxLoss(owner.chem_effects[CE_ALCOHOL_TOXIC] * 0.2 * PROCESS_ACCURACY)
 			if(filter_effect < 3)
 				owner.adjustToxLoss(owner.chem_effects[CE_ALCOHOL_TOXIC] * 0.1 * PROCESS_ACCURACY)
-			else
-				take_damage(owner.chem_effects[CE_ALCOHOL_TOXIC] * 0.1 * PROCESS_ACCURACY, prob(1)) // Chance to warn them
 
 /obj/item/organ/internal/liver/handle_germ_effects()
 	. = ..() //Up should return an infection level as an integer


### PR DESCRIPTION
**Requires Discussion, Do Not Merge**

- Hitting the Alcohol Tox level will cause an uncapped amount of liver damage, because it currently stops at 10, and that's a bit wonky. We probably should have or need to make a proc for that, in the future.
- Hitting the Alcohol Tox level will cause Toxin damage if your liver is bruise, and additional Toxin damage if your liver is broken.
- Alcohol is still pretty survivable. In testing I gave a Skrell an entire bottle of special blend and they didn't die in the 10+ minutes I was running the tests. The other species take somewhere in the range of 19 toxloss and ~25 liver damage.

