### PR TITLE
Merges xenobiologist job with scientist.

### DIFF
--- a/code/game/jobs/job/science.dm
+++ b/code/game/jobs/job/science.dm
@@ -49,52 +49,20 @@
 	department = "Science"
 	department_flag = MEDSCI
 	faction = "Station"
-	total_positions = 5
+	total_positions = 7
 	spawn_positions = 3
 	supervisors = "the research director"
 	selection_color = "#633D63"
 	idtype = /obj/item/weapon/card/id/science
 	economic_modifier = 7
-	access = list(access_robotics, access_tox, access_tox_storage, access_research, access_xenobiology, access_xenoarch)
-	minimal_access = list(access_tox, access_tox_storage, access_research, access_xenoarch)
-	alt_titles = list("Xenoarcheologist", "Anomalist", "Phoron Researcher")
+	access = list(access_robotics, access_tox, access_tox_storage, access_research, access_xenobiology, access_xenoarch, access_hydroponics)
+	minimal_access = list(access_tox, access_tox_storage, access_research, access_xenoarch, access_xenobiology, access_hydroponics)
+	alt_titles = list("Xenoarcheologist", "Anomalist", "Phoron Researcher", "Xenobiologist", "Xenobotanist")
 
 	minimal_player_age = 14
 
 /datum/job/scientist/equip(var/mob/living/carbon/human/H, var/alt_title)
 	if(!H)	return 0
-	H.equip_to_slot_or_del(new /obj/item/device/radio/headset/headset_sci(H), slot_l_ear)
-	H.equip_to_slot_or_del(new /obj/item/clothing/under/rank/scientist(H), slot_w_uniform)
-	H.equip_to_slot_or_del(new /obj/item/clothing/shoes/white(H), slot_shoes)
-	H.equip_to_slot_or_del(new /obj/item/device/pda/science(H), slot_belt)
-	switch(H.backbag)
-		if(2) H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/toxins(H), slot_back)
-		if(3) H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/satchel/tox(H), slot_back)
-		if(4) H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/satchel(H), slot_back)
-		if(5) H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/messenger/tox(H), slot_back)
-	H.equip_to_slot_or_del(new /obj/item/clothing/suit/storage/toggle/labcoat/science(H), slot_wear_suit)
-	return 1
-
-/datum/job/xenobiologist
-	title = "Xenobiologist"
-	flag = XENOBIOLOGIST
-	department = "Science"
-	department_flag = MEDSCI
-	faction = "Station"
-	total_positions = 3
-	spawn_positions = 2
-	supervisors = "the research director"
-	selection_color = "#633D63"
-	idtype = /obj/item/weapon/card/id/science
-	economic_modifier = 7
-	access = list(access_robotics, access_tox, access_tox_storage, access_research, access_xenobiology, access_hydroponics)
-	minimal_access = list(access_research, access_xenobiology, access_hydroponics, access_tox_storage)
-	alt_titles = list("Xenobotanist")
-
-	minimal_player_age = 14
-
-/datum/job/xenobiologist/equip(var/mob/living/carbon/human/H, var/alt_title)
-	if(!H) return 0
 	H.equip_to_slot_or_del(new /obj/item/device/radio/headset/headset_sci(H), slot_l_ear)
 	H.equip_to_slot_or_del(new /obj/item/clothing/under/rank/scientist(H), slot_w_uniform)
 	H.equip_to_slot_or_del(new /obj/item/clothing/shoes/white(H), slot_shoes)

--- a/code/game/jobs/jobs.dm
+++ b/code/game/jobs/jobs.dm
@@ -82,8 +82,7 @@ var/list/science_positions = list(
 	"Research Director",
 	"Scientist",
 	"Geneticist",	//Part of both medical and science
-	"Roboticist",
-	"Xenobiologist"
+	"Roboticist"
 )
 
 //BS12 EDIT

--- a/code/game/jobs/jobs.dm
+++ b/code/game/jobs/jobs.dm
@@ -24,8 +24,7 @@ var/const/GENETICIST		=(1<<5)
 var/const/VIROLOGIST		=(1<<6)
 var/const/PSYCHIATRIST		=(1<<7)
 var/const/ROBOTICIST		=(1<<8)
-var/const/XENOBIOLOGIST		=(1<<9)
-var/const/PARAMEDIC			=(1<<10)
+var/const/PARAMEDIC			=(1<<9)
 
 
 var/const/CIVILIAN			=(1<<2)

--- a/code/modules/client/preference_setup/loadout/loadout_shoes.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_shoes.dm
@@ -242,4 +242,4 @@
 /datum/gear/shoes/boots/winter/hydro
 	display_name = "hydroponics winter boots"
 	path = /obj/item/clothing/shoes/boots/winter/hydro
-	allowed_roles = list("Botanist", "Xenobiologist")
+	allowed_roles = list("Botanist", "Scientist")

--- a/code/modules/client/preference_setup/loadout/loadout_suit.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_suit.dm
@@ -192,7 +192,7 @@
 /datum/gear/suit/roles/poncho/science
 	display_name = "poncho, science"
 	path = /obj/item/clothing/accessory/poncho/roles/science
-	allowed_roles = list("Research Director","Scientist", "Roboticist", "Xenobiologist")
+	allowed_roles = list("Research Director","Scientist", "Roboticist")
 
 /datum/gear/suit/roles/poncho/cargo
 	display_name = "poncho, cargo"
@@ -262,7 +262,7 @@
 /datum/gear/suit/wintercoat/science
 	display_name = "winter coat, science"
 	path = /obj/item/clothing/suit/storage/hooded/wintercoat/science
-	allowed_roles = list("Research Director","Scientist", "Roboticist", "Xenobiologist")
+	allowed_roles = list("Research Director","Scientist", "Roboticist")
 
 /datum/gear/suit/wintercoat/engineering
 	display_name = "winter coat, engineering"
@@ -277,7 +277,7 @@
 /datum/gear/suit/wintercoat/hydro
 	display_name = "winter coat, hydroponics"
 	path = /obj/item/clothing/suit/storage/hooded/wintercoat/hydro
-	allowed_roles = list("Botanist", "Xenobiologist")
+	allowed_roles = list("Botanist", "Scientist")
 
 /datum/gear/suit/wintercoat/cargo
 	display_name = "winter coat, cargo"
@@ -415,7 +415,7 @@
 /datum/gear/suit/snowsuit/science
 	display_name = "snowsuit, science"
 	path = /obj/item/clothing/suit/storage/snowsuit/science
-	allowed_roles = list("Research Director","Scientist", "Roboticist", "Xenobiologist")
+	allowed_roles = list("Research Director","Scientist", "Roboticist")
 
 /datum/gear/suit/snowsuit/engineering
 	display_name = "snowsuit, engineering"

--- a/code/modules/client/preference_setup/loadout/loadout_uniform.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_uniform.dm
@@ -134,7 +134,7 @@
 /datum/gear/uniform/job_skirt/sci
 	display_name = "skirt, scientist"
 	path = /obj/item/clothing/under/rank/scientist/skirt
-	allowed_roles = list("Research Director","Scientist", "Xenobiologist")
+	allowed_roles = list("Research Director","Scientist")
 
 /datum/gear/uniform/job_skirt/cargo
 	display_name = "skirt, cargo"

--- a/nano/css/icons.css
+++ b/nano/css/icons.css
@@ -337,10 +337,6 @@
 }
 .mapIcon16.rank-roboticist {
     background-position: -128px -128px;
-}
-.mapIcon16.rank-xenobiologist {
-    background-position: -128px -128px;
-}
 
 /* Security Positions */
 .mapIcon16.rank-warden {


### PR DESCRIPTION
With the new slime update and new xenobio, I took a look at what xenobio had special compared to scientists. To make a long story short: Absolutely nothing except for having access to hydroponics. 
They were exactly identical for all intents and purposes. Bumped scientist job up by 2 to compensate.

- Merges xenobiologist job with scientist
- Adds xenobiologist & xenobotanist alt titles to scientists.
- Bumps up scientist job by 2 to compensate.
- Gives scientists hydroponics access since xenobiologists had them. This can be removed if needed, since science/xenobio should really stick to their own area instead of going to a civillian one, but I digress.

Xenobio/Scientist comparison:
Sci access: access = list(access_robotics, access_tox, access_tox_storage, access_research, access_xenobiology, access_xenoarch)

Bio access: access = list(access_robotics, access_tox, access_tox_storage, access_research, access_xenobiology, access_hydroponics)

Eco modifier of 7 for both, same department (MEDSCI), same spawning clothing, etc.

The only difference was that xenobio had hydroponics access, while scientist had xenoarch access instead. Which isn't that big of a difference that it requires it's entire own job.

