### PR TITLE
Adds cyborg shield module and advanced armor plating

### DIFF
--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -173,3 +173,26 @@
 
 	R.emag_items = 1
 	return 1
+
+/obj/item/borg/upgrade/shield
+	name = "integrated shield module"
+	desc = "A shield generator array, made portable."
+	icon_state = "cyborg_upgrade3"
+	item_state = "cyborg_upgrade"
+	require_module = 1
+
+/obj/item/borg/upgrade/shield/action(var/mob/living/silicon/robot/R)
+	if(..()) return 0
+
+	var/obj/item/borg/combat/shield/S= locate() in R.module
+	if(!S)
+		S = locate() in R.module.contents
+	if(!S)
+		S = locate() in R.module.modules
+	if(!S)
+		R.module.modules += new /obj/item/borg/combat/shield(R)
+		return 1
+	if(S)
+		to_chat(R, "Upgrade mounting error!  No suitable hardpoint detected!")
+		to_chat(usr, "There's no mounting point for the module!")
+		return 0

--- a/code/modules/mob/living/silicon/robot/component.dm
+++ b/code/modules/mob/living/silicon/robot/component.dm
@@ -77,6 +77,10 @@
 	external_type = /obj/item/robot_parts/robot_component/armour
 	max_damage = 90
 
+/datum/robot_component/armour
+	name = "advanced armour plating"
+	external_type = /obj/item/robot_parts/robot_component/armour/advanced
+	max_damage = 150
 
 // ACTUATOR
 // Enables movement.
@@ -235,6 +239,9 @@
 	name = "armour plating"
 	icon_state = "armor"
 	icon_state_broken = "armor_broken"
+
+/obj/item/robot_parts/robot_component/armour/advanced
+	name = "advanced armour plating"
 
 /obj/item/robot_parts/robot_component/camera
 	name = "camera"

--- a/code/modules/research/prosfab_designs.dm
+++ b/code/modules/research/prosfab_designs.dm
@@ -249,6 +249,13 @@
 	id = "armour"
 	build_path = /obj/item/robot_parts/robot_component/armour
 
+/datum/design/item/prosfab/cyborg/component/armour_advanced
+	name = "Advanced armour plating"
+	id = "advanced_armour"
+	build_path = /obj/item/robot_parts/robot_component/armour/advanced
+	req_tech = list(TECH_COMBAT = 3, TECH_MATERIAL = 4, TECH_ENGINEERING = 3)
+	materials = list(DEFAULT_WALL_MATERIAL = 7500, "uranium" = 5000)
+
 
 //////////////////// Cyborg Modules ////////////////////
 /datum/design/item/prosfab/robot_upgrade
@@ -304,3 +311,11 @@
 	req_tech = list(TECH_COMBAT = 4, TECH_ILLEGAL = 3)
 	materials = list(DEFAULT_WALL_MATERIAL = 7500, "glass" = 11250, "diamond" = 7500)
 	build_path = /obj/item/borg/upgrade/syndicate
+
+/datum/design/item/prosfab/robot_upgrade/shield
+	name = "Integrated Shield module"
+	desc = "Allows cyborgs to use an energy shield."
+	id = "borg_shield_module"
+	req_tech = list(TECH_COMBAT = 5, TECH_MAGNET = 4, TECH_POWER = 6)
+	materials = list(DEFAULT_WALL_MATERIAL = 7500, "glass" = 11250, "phoron" = 11250, "uranium" = 15000)
+	build_path = /obj/item/borg/upgrade/shield


### PR DESCRIPTION
The **Advanced Armour Plating** component has 150 health, compared to the base component's 90.
- It requires TECH_COMBAT = 3, TECH_MATERIAL = 4, TECH_ENGINEERING = 3, 7500 Steel and 5000 Uranium

The **Shield Projector Module** is an upgrade item, that gives borgs the newly improved Borg Shield
- It requires TECH_COMBAT = 5, TECH_MAGNET = 4, TECH_POWER = 6, 7500 Steel, 11250 Glass, 11250 Phoron, and 11250 Uranium. Values are subject to change, in time.

**TO DO**
- [ ] Would be nice to have a unique sprite for the armor, even a fairly simple one.
- [ ] I need shield sprites for literally every borg sprite. Custom items will be adjusted based on their existing shield sprites, if this is completed and merged.