### PR TITLE
Syndicate ID changes

### DIFF
--- a/code/game/objects/items/weapons/cards_ids_syndicate.dm
+++ b/code/game/objects/items/weapons/cards_ids_syndicate.dm
@@ -1,28 +1,21 @@
-var/list/syndicate_ids = list()
-
 /obj/item/weapon/card/id/syndicate
 	name = "agent card"
 	icon_state = "syndicate"
 	assignment = "Agent"
 	origin_tech = list(TECH_ILLEGAL = 3)
 	var/electronic_warfare = 1
-	var/registered_user = null
+	var/mob/registered_user = null
 
 /obj/item/weapon/card/id/syndicate/New(mob/user as mob)
 	..()
-	syndicate_ids += src
 	access = syndicate_access.Copy()
 
-/obj/item/weapon/card/id/syndicate/Destroy()
-	syndicate_ids -= src
-	registered_user = null
-	return ..()
+/obj/item/weapon/card/id/syndicate/station_access/New()
+	..() // Same as the normal Syndicate id, only already has all station access
+	access |= get_all_station_access()
 
-// On mob destruction, ensure any references are cleared
-/mob/Destroy()
-	for(var/obj/item/weapon/card/id/syndicate/SID in syndicate_ids)
-		if(SID.registered_user == src)
-			SID.registered_user = null
+/obj/item/weapon/card/id/syndicate/Destroy()
+	unset_registered_user(registered_user)
 	return ..()
 
 /obj/item/weapon/card/id/syndicate/prevent_tracking()
@@ -37,9 +30,8 @@ var/list/syndicate_ids = list()
 			user << "<span class='notice'>The microscanner activates as you pass it over the ID, copying its access.</span>"
 
 /obj/item/weapon/card/id/syndicate/attack_self(mob/user as mob)
-	if(!registered_user)
-		registered_user = user
-		user.set_id_info(src)
+	// We use the fact that registered_name is not unset should the owner be vaporized, to ensure the id doesn't magically become unlocked.
+	if(!registered_user && register_user(user))
 		user << "<span class='notice'>The microscanner marks you as its owner, preventing others from accessing its internals.</span>"
 	if(registered_user == user)
 		switch(alert("Would you like edit the ID, or show it?","Show or Edit?", "Edit","Show"))
@@ -71,6 +63,21 @@ var/list/syndicate_ids = list()
 		ui = new(user, src, ui_key, "agent_id_card.tmpl", "Fake ID", 600, 400)
 		ui.set_initial_data(data)
 		ui.open()
+
+/obj/item/weapon/card/id/syndicate/proc/register_user(var/mob/user)
+	if(!istype(user) || user == registered_user)
+		return FALSE
+	unset_registered_user()
+	registered_user = user
+	user.set_id_info(src)
+	user.register(OBSERVER_EVENT_DESTROY, src, /obj/item/weapon/card/id/syndicate/proc/unset_registered_user)
+	return TRUE
+
+/obj/item/weapon/card/id/syndicate/proc/unset_registered_user(var/mob/user)
+	if(!registered_user || (user && user != registered_user))
+		return
+	registered_user.unregister(OBSERVER_EVENT_DESTROY, src)
+	registered_user = null
 
 /obj/item/weapon/card/id/syndicate/CanUseTopic(mob/user)
 	if(user != registered_user)
@@ -172,7 +179,7 @@ var/list/syndicate_ids = list()
 					icon_state = initial(icon_state)
 					name = initial(name)
 					registered_name = initial(registered_name)
-					registered_user = null
+					unset_registered_user()
 					sex = initial(sex)
 					user << "<span class='notice'>All information has been deleted from \the [src].</span>"
 					. = 1

--- a/html/changelogs/Woodrat-SyndIDs.yml
+++ b/html/changelogs/Woodrat-SyndIDs.yml
@@ -1,0 +1,37 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Woodrat
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Added a Syndicate ID with all access (admin spawn only)."
+  - tweak: "Port of 'Syndicate id cards now listen for owner destruction' from Bay."


### PR DESCRIPTION
- Added a Syndicate ID with all access (admin spawn only).
- Port of 'Syndicate id cards now listen for owner destruction' from Bay. Link https://github.com/Baystation12/Baystation12/pull/11563