### PR TITLE
Ports the prescription kit from Virgo

### DIFF
--- a/code/defines/obj/weapon.dm
+++ b/code/defines/obj/weapon.dm
@@ -133,6 +133,49 @@
 		icon_state = "nullrod"
 		item_state = "foldcane"
 
+/obj/item/weapon/cane/concealed/hypo
+	var/concealed_hypo
+
+/obj/item/weapon/cane/concealed/hypo/New()
+	..()
+	var/obj/item/weapon/reagent_containers/hypospray/temp_hypo = new(src)
+	concealed_hypo = temp_hypo
+	temp_hypo.attack_self()
+
+/obj/item/weapon/cane/concealed/hypo/attack_self(var/mob/user)
+	if(concealed_hypo)
+		user.visible_message("<span class='warning'>[user] has unsheathed \a [concealed_hypo] from \his [src]!</span>", "You unsheathe \the [concealed_hypo] from \the [src].")
+		// Calling drop/put in hands to properly call item drop/pickup procs
+		playsound(user.loc, 'sound/weapons/flipblade.ogg', 50, 1)
+		user.drop_from_inventory(src)
+		user.put_in_hands(concealed_hypo)
+		user.put_in_hands(src)
+		user.update_inv_l_hand(0)
+		user.update_inv_r_hand()
+		concealed_hypo = null
+	else
+		..()
+
+/obj/item/weapon/cane/concealed/hypo/attackby(var/obj/item/weapon/reagent_containers/hypospray/W, var/mob/user)
+	if(!src.concealed_hypo && istype(W))
+		user.visible_message("<span class='warning'>[user] has sheathed \a [W] into \his [src]!</span>", "You sheathe \the [W] into \the [src].")
+		user.drop_from_inventory(W)
+		W.loc = src
+		src.concealed_hypo = W
+		update_icon()
+	else
+		..()
+
+/obj/item/weapon/cane/concealed/hypo/update_icon()
+	if(concealed_hypo)
+		name = initial(name)
+		icon_state = initial(icon_state)
+		item_state = initial(icon_state)
+	else
+		name = "cane shaft"
+		icon_state = "nullrod"
+		item_state = "foldcane"
+
 /obj/item/weapon/cane/whitecane
 	name = "white cane"
 	desc = "A cane used by the blind."

--- a/code/defines/obj/weapon.dm
+++ b/code/defines/obj/weapon.dm
@@ -133,49 +133,6 @@
 		icon_state = "nullrod"
 		item_state = "foldcane"
 
-/obj/item/weapon/cane/concealed/hypo
-	var/concealed_hypo
-
-/obj/item/weapon/cane/concealed/hypo/New()
-	..()
-	var/obj/item/weapon/reagent_containers/hypospray/temp_hypo = new(src)
-	concealed_hypo = temp_hypo
-	temp_hypo.attack_self()
-
-/obj/item/weapon/cane/concealed/hypo/attack_self(var/mob/user)
-	if(concealed_hypo)
-		user.visible_message("<span class='warning'>[user] has unsheathed \a [concealed_hypo] from \his [src]!</span>", "You unsheathe \the [concealed_hypo] from \the [src].")
-		// Calling drop/put in hands to properly call item drop/pickup procs
-		playsound(user.loc, 'sound/weapons/flipblade.ogg', 50, 1)
-		user.drop_from_inventory(src)
-		user.put_in_hands(concealed_hypo)
-		user.put_in_hands(src)
-		user.update_inv_l_hand(0)
-		user.update_inv_r_hand()
-		concealed_hypo = null
-	else
-		..()
-
-/obj/item/weapon/cane/concealed/hypo/attackby(var/obj/item/weapon/reagent_containers/hypospray/W, var/mob/user)
-	if(!src.concealed_hypo && istype(W))
-		user.visible_message("<span class='warning'>[user] has sheathed \a [W] into \his [src]!</span>", "You sheathe \the [W] into \the [src].")
-		user.drop_from_inventory(W)
-		W.loc = src
-		src.concealed_hypo = W
-		update_icon()
-	else
-		..()
-
-/obj/item/weapon/cane/concealed/hypo/update_icon()
-	if(concealed_hypo)
-		name = initial(name)
-		icon_state = initial(icon_state)
-		item_state = initial(icon_state)
-	else
-		name = "cane shaft"
-		icon_state = "nullrod"
-		item_state = "foldcane"
-
 /obj/item/weapon/cane/whitecane
 	name = "white cane"
 	desc = "A cane used by the blind."

--- a/code/modules/clothing/glasses_vr.dm
+++ b/code/modules/clothing/glasses_vr.dm
@@ -1,0 +1,58 @@
+/obj/item/clothing/glasses/proc/prescribe(var/mob/user)
+	prescription = !prescription
+
+	//Look it's really not that fancy. It's not ACTUALLY unique scrip data.
+	if(prescription)
+		name = "[initial(name)] (pr)"
+		user.visible_message("[user] replaces the lenses in \the [src] with a new prescription.")
+	else
+		name = "[initial(name)]"
+		user.visible_message("[user] replaces the prescription lenses in \the [src] with generics.")
+
+	playsound(user,'sound/items/screwdriver.ogg', 50, 1)
+
+//Prescription kit
+/obj/item/device/glasses_kit
+	name = "prescription glasses kit"
+	desc = "A kit containing all the needed tools and parts to develop and apply a prescription for someone."
+	icon = 'icons/obj/device.dmi'
+	icon_state = "modkit"
+	var/scrip_loaded = 0
+
+/obj/item/device/glasses_kit/afterattack(var/target, var/mob/living/carbon/human/user, var/proximity)
+	if(!proximity)
+		return
+	if(!istype(user))
+		return
+
+	//Too difficult
+	if(target == user)
+		user << "<span class='warning'>You can't use this on yourself. Get someone to help you.</span>"
+		return
+
+	//We're applying a prescription
+	if(istype(target,/obj/item/clothing/glasses))
+		var/obj/item/clothing/glasses/G = target
+		if(!scrip_loaded)
+			user << "<span class='warning'>You need to build a prescription from someone first! Use the kit on someone.</span>"
+			return
+
+		if(do_after(user,5 SECONDS))
+			G.prescribe(user)
+			scrip_loaded = 0
+
+	//We're getting a prescription
+	else if(ishuman(target))
+		var/mob/living/carbon/human/T = target
+		if(T.glasses || (T.head && T.head.flags_inv & HIDEEYES))
+			user << "<span class='warning'>The person's eyes can't be covered!</span>"
+			return
+
+		T.visible_message("[user] begins making measurements for prescription lenses for [target].","[user] begins measuring your eyes. Hold still!")
+		if(do_after(user,5 SECONDS,T))
+			T.flash_eyes()
+			scrip_loaded = 1
+			T.visible_message("[user] finishes making prescription lenses for [target].","<span class='warning'>Gah, that's bright!</span>")
+
+	else
+		..()


### PR DESCRIPTION
Direction for use:
1. Doctor holds the kit, uses it on the patient.
2. Doctor then uses the kit on whatever eye-wear that needs to be converted.
3. Tada, done.

Works with scanning goggles, mesons, sunglasses, HUD's, etc. 

This doesn't map it, so it still needs to be mapped into medical's equipment storage or secondary storage.