### PR TITLE
Better T-Ray Scanners

### DIFF
--- a/code/game/objects/items/devices/t_scanner.dm
+++ b/code/game/objects/items/devices/t_scanner.dm
@@ -132,4 +132,19 @@
 /obj/item/device/t_scanner/dropped(mob/user)
 	set_user_client(null)
 
+/obj/item/device/t_scanner/upgraded
+	name = "Upgraded T-ray Scanner"
+	desc = "An upgraded version of the terahertz-ray emitter and scanner used to detect underfloor objects such as cables and pipes."
+	matter = list(DEFAULT_WALL_MATERIAL = 500, PHORON = 150)
+	origin_tech = list(TECH_MAGNET = 4, TECH_ENGINEERING = 5)
+	scan_range = 3
+
+/obj/item/device/t_scanner/advanced
+	name = "Advanced T-ray Scanner"
+	desc = "An advanced version of the terahertz-ray emitter and scanner used to detect underfloor objects such as cables and pipes."
+	matter = list(DEFAULT_WALL_MATERIAL = 1500, PHORON = 200, SILVER = 250)
+	origin_tech = list(TECH_MAGNET = 7, TECH_ENGINEERING = 7, TECH_MATERIAL = 6)
+	scan_range = 7
+
+
 #undef OVERLAY_CACHE_LEN


### PR DESCRIPTION
Name one of the most useless tools in the game? If you guessed the T-Ray, you'd probably be right. It's way easier to just crowbar up the floor than to have to worry about waiting two seconds to only see one tile below you. I thought it would be a good idea to add upgraded TScanners, because, TScanners are shit. That's why.