### PR TITLE
Removes second definition of katana

### DIFF
--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -287,6 +287,7 @@
 	desc = "Woefully underpowered in D20."
 	icon = 'icons/obj/weapons.dmi'
 	icon_state = "katana"
+	item_state = "katana"
 	item_icons = list(
 		slot_l_hand_str = 'icons/mob/items/lefthand_material.dmi',
 		slot_r_hand_str = 'icons/mob/items/righthand_material.dmi',
@@ -696,19 +697,6 @@
 	name = "Emergency Response Team Commander action figure"
 	desc = "A \"Space Life\" brand Emergency Response Team Commander action figure."
 	icon_state = "ert"
-
-/obj/item/toy/katana
-	name = "replica katana"
-	desc = "Woefully underpowered in D20."
-	icon = 'icons/obj/weapons.dmi'
-	icon_state = "katana"
-	item_state = "katana"
-	flags = CONDUCT
-	slot_flags = SLOT_BELT | SLOT_BACK
-	force = 5
-	throwforce = 5
-	w_class = ITEMSIZE_NORMAL
-	attack_verb = list("attacked", "slashed", "stabbed", "sliced")
 
 /obj/item/toy/therapy_red
 	name = "red therapy doll"


### PR DESCRIPTION
- Removes a duplicate "toy/katana"
Was defined twice for some reason.