### PR TITLE
Food fluff

### DIFF
--- a/code/modules/examine/descriptions/food.dm
+++ b/code/modules/examine/descriptions/food.dm
@@ -26,7 +26,7 @@
   description_fluff = "Originally Raisin Blend no. 4, 4noraisins obtained their current name in the Skadi Positronic Exclusion Crisis of 2442, where they were rebranded as part of the protests." //the exclusion crisis, presumably, involved positronic immigration being banned for no raisin
 
 /obj/item/weapon/reagent_containers/food/snacks/spacetwinkie
-  description_fluff = "Space Twinkies, a modification of a flagship product of one of Centauri Provision's predecessor corporations, are designed to withstand vacume, radiation, dehydration, and long periods of acceleration without losing their shape or taste. They're not great, but they have earned their names (and enormous revenue for their parent company)."
+  description_fluff = "Space Twinkies, a modification of a flagship product of one of Centauri Provision's predecessor corporations, are designed to withstand vacuum, radiation, dehydration, and long periods of acceleration without losing their shape or taste. They're not great, but they have earned their names (and enormous revenue for their parent company)."
   
 /obj/item/weapon/reagent_containers/food/snacks/cheesiehonkers
   description_fluff = "Cheesie Honkers, a previously niche line of cheese puffs from a subsidiary of a subsidiary of Centauri Provisions, rose to household-name status when their tell-tale orange dust was used as evidence to convict notorious positronic serial killer Etoid in 2404."

--- a/code/modules/examine/descriptions/food.dm
+++ b/code/modules/examine/descriptions/food.dm
@@ -1,7 +1,4 @@
 /obj/item/weapon/reagent_containers/food/snacks/candy
-  description_fluff = 
-
-/obj/item/weapon/reagent_containers/food/snacks/candy
   description_fluff = "The Candy Bar is a copylefted recipe designed by information freedom activists to bring the delicious taste of nougat to the masses. It's cheap, familiar, and easy to synthesize, so most food vendors stock it."
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/proteinbar

--- a/code/modules/examine/descriptions/food.dm
+++ b/code/modules/examine/descriptions/food.dm
@@ -2,7 +2,7 @@
   description_fluff = "The Candy Bar is a copylefted recipe designed by information freedom activists to bring the delicious taste of nougat to the masses. It's cheap, familiar, and easy to synthesize, so most food vendors stock it."
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/proteinbar
-	description_fluff = "The SWOLEMAX protien bar is the flagship product of SWOLEMAX, a health foods corporation recently independent of Centauri Provisions. It tastes like a brick of ashes."
+  description_fluff = "The SWOLEMAX protien bar is the flagship product of SWOLEMAX, a health foods corporation recently independent of Centauri Provisions. It tastes like a brick of ashes."
 
 /obj/item/weapon/reagent_containers/food/snacks/candy_corn
   description_fluff = "Nobody knows why Nanotrasen keeps making these waxy pieces of sugar and bone glue, but a handful of people swear by them. Purportedly popular with Skrell children, dubiously enough."
@@ -43,7 +43,7 @@
 /obj/item/weapon/reagent_containers/food/snacks/tastybread
   description_fluff = "This is the product that brought Centauri Provisions into the limelight. A product of the earliest extrasolar colony of Heaven, the Bread Tube, while bland, contains all the nutrients a spacer needs to get through the day and is decidedly edible when compared to some of its competitors."
   
-/obj/item/weapon/reagent_containers/food/snacks/skrellsnacks // fix proper desc too
+/obj/item/weapon/reagent_containers/food/snacks/skrellsnacks
   description_fluff = "A jerky product made of Go'moa mushrooms native to the Skrellian homeworld of Qerr'balak. SkrellSnaks are actually a product of Natuna, designed to welcome Ue-Katish refugees to their colony. The brand was recreated by Centauri Provisions after Natuna and SolGov broke off diplomatic relations."
   
 /obj/item/weapon/reagent_containers/food/snacks/unajerky

--- a/code/modules/examine/descriptions/food.dm
+++ b/code/modules/examine/descriptions/food.dm
@@ -1,0 +1,53 @@
+/obj/item/weapon/reagent_containers/food/snacks/candy
+  description_fluff = 
+
+/obj/item/weapon/reagent_containers/food/snacks/candy
+  description_fluff = "The Candy Bar is a copylefted recipe designed by information freedom activists to bring the delicious taste of nougat to the masses. It's cheap, familiar, and easy to synthesize, so most food vendors stock it."
+
+/obj/item/weapon/reagent_containers/food/snacks/candy/proteinbar
+	description_fluff = "The SWOLEMAX protien bar is the flagship product of SWOLEMAX, a health foods corporation recently independent of Centauri Provisions. It tastes like a brick of ashes."
+
+/obj/item/weapon/reagent_containers/food/snacks/candy_corn
+  description_fluff = "Nobody knows why Nanotrasen keeps making these waxy pieces of sugar and bone glue, but a handful of people swear by them. Purportedly popular with Skrell children, dubiously enough."
+
+/obj/item/weapon/reagent_containers/food/snacks/chips
+  description_fluff = "Actual potatos haven't been used in potato chips for centuries. They're mostly a denatured nutrient slurry pressed into a chip-shaped mold and salted. Still tastes the same."
+
+/obj/item/weapon/reagent_containers/food/snacks/donut
+  description_fluff = "These donuts claim to be made fresh daily in a boutique bakery in New Reykjavik and delivered to Nanotrasen's hardworking asset protection crew. They're probably synthesized."
+
+/obj/item/weapon/reagent_containers/food/snacks/donkpocket
+  description_fluff = "DONKpockets were originally a Nanotrasen product, an attempt to break into the food market controlled by Centauri Provisions. Somehow, Centauri wound up with the rights to the DONK brand, ending Nanotrasen's ambitions. They taste pretty okay."
+  
+/obj/item/weapon/reagent_containers/food/snacks/pie
+  description_fluff = "One of the more esoteric terms of the Nanotrasen-Centauri Noncompetition Agreement of 2545 was a requirement that Nanotrasen stock these pies on all their stations. They're calibrated for commedic value, not taste."
+
+/obj/item/weapon/reagent_containers/food/snacks/sosjerky
+  description_fluff = "Space Cows, here, being an affectionate name given by early colonists to the massive food synthesizers used to sustain independent outposts before the dominance of hydroponics. Tastes like cardboard rubbed in meat seasoning."
+  
+/obj/item/weapon/reagent_containers/food/snacks/no_raisin
+  description_fluff = "Originally Raisin Blend no. 4, 4noraisins obtained their current name in the Skadi Positronic Exclusion Crisis of 2442, where they were rebranded as part of the protests." //the exclusion crisis, presumably, involved positronic immigration being banned for no raisin
+
+/obj/item/weapon/reagent_containers/food/snacks/spacetwinkie
+  description_fluff = "Space Twinkies, a modification of a flagship product of one of Centauri Provision's predecessor corporations, are designed to withstand vacume, radiation, dehydration, and long periods of acceleration without losing their shape or taste. They're not great, but they have earned their names (and enormous revenue for their parent company)."
+  
+/obj/item/weapon/reagent_containers/food/snacks/cheesiehonkers
+  description_fluff = "Cheesie Honkers, a previously niche line of cheese puffs from a subsidiary of a subsidiary of Centauri Provisions, rose to household-name status when their tell-tale orange dust was used as evidence to convict notorious positronic serial killer Etoid in 2404."
+  
+/obj/item/weapon/reagent_containers/food/snacks/syndicake
+  description_fluff = "Due to ongoing litigation concerning the business practices of the Cakemakers' Syndicate, access to this product has been removed from all Centauri and Getmore vending machines. This is a shame, because Syndi-Cakes are generally regarded as the most appetizing thing in them."
+
+/obj/item/weapon/reagent_containers/food/snacks/twobread
+  description_fluff = "The most popular recipe from the Morpheus Cyberkinetics cookbook 'Calories for Organics'"
+  
+/obj/item/weapon/reagent_containers/food/snacks/liquidfood
+  description_fluff = "A survival food commonly packed onto short-distance bluespace shuttles and similar vessels. Tastes like chalk, but is packed full of nutrients and will keep you alive."
+  
+/obj/item/weapon/reagent_containers/food/snacks/tastybread
+  description_fluff = "This is the product that brought Centauri Provisions into the limelight. A product of the earliest extrasolar colony of Heaven, the Bread Tube, while bland, contains all the nutrients a spacer needs to get through the day and is decidedly edible when compared to some of its competitors."
+  
+/obj/item/weapon/reagent_containers/food/snacks/skrellsnacks // fix proper desc too
+  description_fluff = "A jerky product made of Go'moa mushrooms native to the Skrellian homeworld of Qerr'balak. SkrellSnaks are actually a product of Natuna, designed to welcome Ue-Katish refugees to their colony. The brand was recreated by Centauri Provisions after Natuna and SolGov broke off diplomatic relations."
+  
+/obj/item/weapon/reagent_containers/food/snacks/unajerky
+  description_fluff = "Removed from Getmore vendors pending approval from the SolGov Nutrition Council, Sissalik Jerky remains a popular snack for Unathi immigrants and daredevils looking for a meaty, spicy treat that makes Scaredy's look like tofu."

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -3460,7 +3460,7 @@
 
 /obj/item/weapon/reagent_containers/food/snacks/skrellsnacks
 	name = "\improper SkrellSnax"
-	desc = "Cured fungus shipped all the way from Jargon 4, almost like jerky! Almost."
+	desc = "Cured fungus shipped all the way from Qerr'balak, almost like jerky! Almost."
 	icon_state = "skrellsnacks"
 	filling_color = "#A66829"
 	center_of_mass = list("x"=15, "y"=12)

--- a/polaris.dme
+++ b/polaris.dme
@@ -1396,6 +1396,7 @@
 #include "code\modules\examine\descriptions\containers.dm"
 #include "code\modules\examine\descriptions\devices.dm"
 #include "code\modules\examine\descriptions\engineering.dm"
+#include "code\modules\examine\descriptions\food.dm"
 #include "code\modules\examine\descriptions\machines.dm"
 #include "code\modules\examine\descriptions\medical.dm"
 #include "code\modules\examine\descriptions\mobs.dm"


### PR DESCRIPTION
Gives fluff descriptions to everything in the Getmore vendor, also twobread.

Also removes the "Jargon 4" reference in the skrellsnaks description. I think that's a developmental legacy or something?

(god I hope this passes Travis)