### PR TITLE
Fixes an issue preventing spiderbots from ventcrawling

### DIFF
--- a/code/modules/ventcrawl/ventcrawl.dm
+++ b/code/modules/ventcrawl/ventcrawl.dm
@@ -10,6 +10,7 @@ var/list/ventcrawl_machinery = list(
 	/obj/item/weapon/holder,
 	/obj/machinery/camera,
 	/mob/living/simple_animal/borer,
+	/obj/item/device/mmi,
 	)
 
 /mob/living/var/list/icon/pipes_shown = list()


### PR DESCRIPTION
Someone sent this ahelp as a spiderbot::
When attempting to ventcrawl as a spiderbot, I get the message "You can't carry the positronic brain (HIU-303) while ventcrawling!"

Looked at the code and saw

```c
/mob/living/simple_animal/spiderbot/is_allowed_vent_crawl_item(var/obj/item/carried_item)
    if(carried_item == held_item)
        return 1
    return ..()

//Which that ..() goes to

/mob/living/proc/is_allowed_vent_crawl_item(var/obj/item/carried_item)
    if(carried_item == ability_master)
        return 1

    var/list/allowed = list()
    for(var/type in can_enter_vent_with)
        var/list/types = typesof(type)
        allowed += types

    if(carried_item.type in allowed)
        if(get_inventory_slot(carried_item) == 0)
            return 1
```

This should allow spiderbots to ventcrawl once more.