### PR TITLE
Dead bodies are no longer perfect shields.

### DIFF
--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -235,9 +235,18 @@
 			//if they have a neck grab on someone, that person gets hit instead
 			var/obj/item/weapon/grab/G = locate() in M
 			if(G && G.state >= GRAB_NECK)
-				visible_message("<span class='danger'>\The [M] uses [G.affecting] as a shield!</span>")
-				if(Bump(G.affecting, forced=1))
-					return //If Bump() returns 0 (keep going) then we continue on to attack M.
+				if(G.affecting.stat == DEAD)
+					var/shield_chance = min(80, (30 * (M.mob_size / 10)))	//Small mobs have a harder time keeping a dead body as a shield than a human-sized one. Unathi would have an easier job, if they are made to be SIZE_LARGE in the future. -Mech
+					if(prob(shield_chance))
+						visible_message("<span class='danger'>\The [M] uses [G.affecting] as a shield!</span>")
+						if(Bump(G.affecting, forced=1))
+							return
+					else
+						visible_message("<span class='danger'>\The [M] tries to use [G.affecting] as a shield, but fails!</span>")
+				else
+					visible_message("<span class='danger'>\The [M] uses [G.affecting] as a shield!</span>")
+					if(Bump(G.affecting, forced=1))
+						return //If Bump() returns 0 (keep going) then we continue on to attack M.
 
 			passthrough = !attack_mob(M, distance)
 		else


### PR DESCRIPTION
Using a dead body as a shield is no longer a perfect defensive option, hovering near 60 percent block-rate for humans, and 30 for Teshari and Prometheans, because corpses are a lot of dead-weight for a small creature or jello creature to hold up. Prone-living persons are still counted as a meatshield, due to the fact that the hostage taker cannot force a hostage to stand, allowing the hostage to negate their risk-of-harm by lying down.
Edit: Fixes/Touches on https://github.com/PolarisSS13/Polaris/issues/4035