### PR TITLE
Turret Targetting Update

### DIFF
--- a/code/_helpers/mobs.dm
+++ b/code/_helpers/mobs.dm
@@ -24,6 +24,15 @@
 
 	return mobs
 
+/proc/mobs_in_xray_view(var/range, var/source)
+	var/list/mobs = list()
+	for(var/atom/movable/AM in orange(range, source))
+		var/M = AM.get_mob()
+		if(M)
+			mobs += M
+
+	return mobs
+
 proc/random_hair_style(gender, species = "Human")
 	var/h_style = "Bald"
 

--- a/code/game/machinery/turret_control.dm
+++ b/code/game/machinery/turret_control.dm
@@ -24,6 +24,7 @@
 	var/check_access = 1	//if this is active, the turret shoots everything that does not meet the access requirements
 	var/check_anomalies = 1	//checks if it can shoot at unidentified lifeforms (ie xenos)
 	var/check_synth = 0 	//if active, will shoot at anything not an AI or cyborg
+	var/check_all = 0		//If active, will shoot at anything.
 	var/ailock = 0 	//Silicons cannot use this
 
 	req_access = list(access_ai_upload)
@@ -130,6 +131,8 @@
 		settings[++settings.len] = list("category" = "Check Arrest Status", "setting" = "check_arrest", "value" = check_arrest)
 		settings[++settings.len] = list("category" = "Check Access Authorization", "setting" = "check_access", "value" = check_access)
 		settings[++settings.len] = list("category" = "Check misc. Lifeforms", "setting" = "check_anomalies", "value" = check_anomalies)
+		settings[++settings.len] = list("category" = "Neutralize All Entities", "setting" = "check_all", "value" = check_all)
+
 		data["settings"] = settings
 
 	ui = nanomanager.try_update_ui(user, src, ui_key, ui, data, force_open)
@@ -161,6 +164,8 @@
 			check_access = value
 		else if(href_list["command"] == "check_anomalies")
 			check_anomalies = value
+		else if(href_list["command"] == "check_all")
+			check_all = value
 
 		updateTurrets()
 		return 1
@@ -175,6 +180,7 @@
 	TC.check_arrest = check_arrest
 	TC.check_weapons = check_weapons
 	TC.check_anomalies = check_anomalies
+	TC.check_all = check_all
 	TC.ailock = ailock
 
 	if(istype(control_area))

--- a/code/game/objects/effects/chem/foam.dm
+++ b/code/game/objects/effects/chem/foam.dm
@@ -150,8 +150,10 @@
 /obj/structure/foamedmetal/ex_act(severity)
 	qdel(src)
 
-/obj/structure/foamedmetal/bullet_act()
-	if(metal == 1 || prob(50))
+/obj/structure/foamedmetal/bullet_act(var/obj/item/projectile/P)
+	if(istype(P, /obj/item/projectile/test))
+		return
+	else if(metal == 1 || prob(50))
 		qdel(src)
 
 /obj/structure/foamedmetal/attack_hand(var/mob/user)

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -410,6 +410,8 @@
 		return //cannot shoot yourself
 	if(istype(A, /obj/item/projectile))
 		return
+	if(istype(A, /obj/structure/foamedmetal)) //Turrets can detect through foamed metal, but will have to blast through it. Similar to windows, if someone runs behind it, a person should probably just not shoot.
+		return
 	if(istype(A, /mob/living) || istype(A, /obj/mecha) || istype(A, /obj/vehicle))
 		result = 2 //We hit someone, return 1!
 		return


### PR DESCRIPTION
Turret Update:
- Turrets are now able to be set to target anything, including synthetics, with 'Neutralize All Entities'. This overrides most other checks akin and including the Neutralize Non-Synthetics setting.
- Turrets sense targets through metal foam, and will blast through it over time in order to reach their target.
Helper addition:
- mobs_in_xray_view proc added, returning a list of mobs that are within the range of the source.
Test Projectile:
- Test projectile will now ignore metal foam tangentially, akin to windows, tables, and grilles.