### PR TITLE
Trait tweaks

### DIFF
--- a/code/modules/client/preference_setup/traits/trait_defines.dm
+++ b/code/modules/client/preference_setup/traits/trait_defines.dm
@@ -30,14 +30,14 @@
 	name = "Flimsy"
 	desc = "You're more fragile than most, and have less of an ability to endure harm."
 	modifier_type = /datum/modifier/trait/flimsy
-	muturally_exclusive = list(/datum/trait/modifier/physical/frail)
+	mutually_exclusive = list(/datum/trait/modifier/physical/frail)
 
 
 /datum/trait/modifier/physical/frail
 	name = "Frail"
 	desc = "Your body is very fragile, and has even less of an ability to endure harm."
 	modifier_type = /datum/modifier/trait/frail
-	muturally_exclusive = list(/datum/trait/modifier/physical/flimsy)
+	mutually_exclusive = list(/datum/trait/modifier/physical/flimsy)
 
 
 /datum/trait/modifier/physical/haemophilia
@@ -51,10 +51,19 @@
 	// If a species lacking blood is added, it is suggested to add a check for them here.
 	return ..()
 
+
 /datum/trait/modifier/physical/weak
 	name = "Weak"
 	desc = "A lack of physical strength causes a diminshed capability in close quarters combat."
 	modifier_type = /datum/modifier/trait/weak
+	mutually_exclusive = list(/datum/trait/modifier/physical/wimpy)
+
+
+/datum/trait/modifier/physical/wimpy
+	name = "Wimpy"
+	desc = "An extreme lack of physical strength causes a greatly diminished capability in close quarters combat."
+	modifier_type = /datum/modifier/trait/wimpy
+	mutually_exclusive = list(/datum/trait/modifier/physical/weak)
 
 
 /datum/trait/modifier/physical/inaccurate
@@ -68,6 +77,7 @@
 /datum/trait/modifier/physical/high_metabolism
 	name = "High Metabolism"
 	modifier_type = /datum/modifier/trait/high_metabolism
+	mutually_exclusive = list(/datum/trait/modifier/physical/low_metabolism)
 
 /datum/trait/modifier/physical/high_metabolism/test_for_invalidity(var/datum/category_item/player_setup_item/traits/setup)
 	if(setup.is_FBP())
@@ -78,6 +88,7 @@
 /datum/trait/modifier/physical/low_metabolism
 	name = "Low Metabolism"
 	modifier_type = /datum/modifier/trait/low_metabolism
+	mutually_exclusive = list(/datum/trait/modifier/physical/high_metabolism)
 
 /datum/trait/modifier/physical/low_metabolism/test_for_invalidity(var/datum/category_item/player_setup_item/traits/setup)
 	if(setup.is_FBP())
@@ -165,7 +176,7 @@
 	name = "Xenophobic"
 	desc = "The mind of the Alien is unknowable, and as such, their intentions cannot be known.  You always watch the xenos closely, as they most certainly are watching you \
 	closely, waiting to strike."
-	muturally_exclusive = list(
+	mutually_exclusive = list(
 		/datum/trait/modifier/mental/humanphobe,
 		/datum/trait/modifier/mental/skrellphobe,
 		/datum/trait/modifier/mental/tajaraphobe,
@@ -177,36 +188,36 @@
 /datum/trait/modifier/mental/humanphobe
 	name = "Human-phobic"
 	desc = "Boilerplate racism for monkeys goes here."
-	muturally_exclusive = list(/datum/trait/modifier/mental/xenophobe)
+	mutually_exclusive = list(/datum/trait/modifier/mental/xenophobe)
 
 /datum/trait/modifier/mental/skrellphobe
 	name = "Skrell-phobic"
 	desc = "Boilerplate racism for squid goes here."
-	muturally_exclusive = list(/datum/trait/modifier/mental/xenophobe)
+	mutually_exclusive = list(/datum/trait/modifier/mental/xenophobe)
 
 /datum/trait/modifier/mental/tajaraphobe
 	name = "Tajara-phobic"
 	desc = "Boilerplate racism for cats goes here."
-	muturally_exclusive = list(/datum/trait/modifier/mental/xenophobe)
+	mutually_exclusive = list(/datum/trait/modifier/mental/xenophobe)
 
 /datum/trait/modifier/mental/unathiphobe
 	name = "Unathi-phobic"
 	desc = "Boilerplate racism for lizards goes here."
-	muturally_exclusive = list(/datum/trait/modifier/mental/xenophobe)
+	mutually_exclusive = list(/datum/trait/modifier/mental/xenophobe)
 
 // Not sure why anyone would hate/fear these guys but for the sake of completeness here we are.
 /datum/trait/modifier/mental/dionaphobe
 	name = "Diona-phobic"
 	desc = "Boilerplate racism for trees goes here."
-	muturally_exclusive = list(/datum/trait/modifier/mental/xenophobe)
+	mutually_exclusive = list(/datum/trait/modifier/mental/xenophobe)
 
 /datum/trait/modifier/mental/teshariphobe
 	name = "Teshari-phobic"
 	desc = "Boilerplate racism for birds goes here."
-	muturally_exclusive = list(/datum/trait/modifier/mental/xenophobe)
+	mutually_exclusive = list(/datum/trait/modifier/mental/xenophobe)
 
 /datum/trait/modifier/mental/prometheanphobe
 	name = "Promethean-phobic"
 	desc = "Boilerplate racism for jellos goes here."
-	muturally_exclusive = list(/datum/trait/modifier/mental/xenophobe)
+	mutually_exclusive = list(/datum/trait/modifier/mental/xenophobe)
 */

--- a/code/modules/client/preference_setup/traits/traits.dm
+++ b/code/modules/client/preference_setup/traits/traits.dm
@@ -79,7 +79,7 @@ var/list/trait_categories = list() // The categories available for the trait men
 		if(invalidity)
 			invalid += "[invalidity]  "
 		if(conflicts)
-			invalid += "This trait is muturally exclusive with [conflicts]."
+			invalid += "This trait is mutually exclusive with [conflicts]."
 
 		. += "<td width = 75%><font size=2><i>[T.desc]</i>\
 		[invalid ? "<font color='#FF0000'><br>Cannot take trait.  Reason: [invalid]</font>":""]</font></td></tr>"
@@ -114,7 +114,7 @@ var/list/trait_categories = list() // The categories available for the trait men
 			var/conflicts = T.test_for_trait_conflict(pref.traits)
 			if(conflicts)
 				pref.traits -= trait_name
-				to_chat(preference_mob, "<span class='warning'>The [trait_name] trait is muturally exclusive with [conflicts].</span>")
+				to_chat(preference_mob, "<span class='warning'>The [trait_name] trait is mutually exclusive with [conflicts].</span>")
 
 /datum/category_item/player_setup_item/traits/OnTopic(href, href_list, user)
 	if(href_list["toggle_trait"])
@@ -129,7 +129,7 @@ var/list/trait_categories = list() // The categories available for the trait men
 
 			var/conflicts = T.test_for_trait_conflict(pref.traits)
 			if(conflicts)
-				to_chat(user, "<span class='warning'>The [T.name] trait is muturally exclusive with [conflicts].</span>")
+				to_chat(user, "<span class='warning'>The [T.name] trait is mutually exclusive with [conflicts].</span>")
 				return TOPIC_NOACTION
 
 			pref.traits += T.name
@@ -143,7 +143,7 @@ var/list/trait_categories = list() // The categories available for the trait men
 /datum/trait
 	var/name = null							// Name to show on UI
 	var/desc = null							// Description of what it does, also shown on UI.
-	var/list/muturally_exclusive = list()	// List of trait types which cannot be taken alongside this trait.
+	var/list/mutually_exclusive = list()	// List of trait types which cannot be taken alongside this trait.
 	var/category = null						// What section to place this trait inside.
 
 // Applies effects to the newly spawned mob.
@@ -156,16 +156,16 @@ var/list/trait_categories = list() // The categories available for the trait men
 /datum/trait/proc/test_for_invalidity(var/datum/category_item/player_setup_item/traits/setup)
 	return null
 
-// Checks muturally_exclusive.  current_traits needs to be a list of strings.
+// Checks mutually_exclusive.  current_traits needs to be a list of strings.
 // Returns null if everything is well, similar to the above proc.  Otherwise returns an english_list() of conflicting traits.
 /datum/trait/proc/test_for_trait_conflict(var/list/current_traits)
 	var/list/conflicts = list()
 	var/result
 
-	if(muturally_exclusive.len)
+	if(mutually_exclusive.len)
 		for(var/trait_name in current_traits)
 			var/datum/trait/T = trait_datums[trait_name]
-			if(T.type in muturally_exclusive)
+			if(T.type in mutually_exclusive)
 				conflicts.Add(T.name)
 
 	if(conflicts.len)

--- a/code/modules/mob/_modifiers/traits.dm
+++ b/code/modules/mob/_modifiers/traits.dm
@@ -24,6 +24,12 @@
 	name = "weak"
 	desc = "A lack of physical strength causes a diminshed capability in close quarters combat"
 
+	outgoing_melee_damage_percent = 0.8
+
+/datum/modifier/trait/wimpy
+	name = "wimpy"
+	desc = "An extreme lack of physical strength causes greatly diminished capability in close quarters combat."
+
 	outgoing_melee_damage_percent = 0.6
 
 /datum/modifier/trait/haemophilia


### PR DESCRIPTION
- High and Low Metabolism can no longer be taken together
- Weak trait is now -20% melee damage, up from -40%. Wimpy trait replaces old Weak trait, with -40% melee damage. These cannot be taken together.