### PR TITLE
Adds expensive antag crate to Cargo

### DIFF
--- a/code/datums/supplypacks/contraband.dm
+++ b/code/datums/supplypacks/contraband.dm
@@ -7,7 +7,7 @@
 /datum/supply_packs/randomised/contraband
 	num_contained = 5
 	contains = list(
-		/obj/item/seeds/bloodtomatoseed,
+			/obj/item/seeds/bloodtomatoseed,
 			/obj/item/weapon/storage/pill_bottle/zoom,
 			/obj/item/weapon/storage/pill_bottle/happy,
 			/obj/item/weapon/reagent_containers/food/drinks/bottle/pwine
@@ -59,55 +59,55 @@
 	num_contained = 1
 	contains = list(
 				list( //the operator,
-					/obj/item/weapon/gun/projectile/shotgun/pump/combat,
-					/obj/item/clothing/suit/storage/vest/heavy/merc,
-					/obj/item/clothing/glasses/night,
-					/obj/item/weapon/storage/box/anti_photons,
-					/obj/item/ammo_magazine/clip/c12g/pellet,
-					/obj/item/ammo_magazine/clip/c12g
-					),
+				/obj/item/weapon/gun/projectile/shotgun/pump/combat,
+				/obj/item/clothing/suit/storage/vest/heavy/merc,
+				/obj/item/clothing/glasses/night,
+				/obj/item/weapon/storage/box/anti_photons,
+				/obj/item/ammo_magazine/clip/c12g/pellet,
+				/obj/item/ammo_magazine/clip/c12g
+				),
 				list( //the doc,
-					/obj/item/weapon/storage/firstaid/combat,
-					/obj/item/weapon/gun/projectile/dartgun,
-					/obj/item/weapon/reagent_containers/hypospray,
-					/obj/item/weapon/reagent_containers/glass/bottle/chloralhydrate,
-					/obj/item/weapon/reagent_containers/glass/bottle/cyanide,
-					/obj/item/ammo_magazine/chemdart
-					),
+				/obj/item/weapon/storage/firstaid/combat,
+				/obj/item/weapon/gun/projectile/dartgun,
+				/obj/item/weapon/reagent_containers/hypospray,
+				/obj/item/weapon/reagent_containers/glass/bottle/chloralhydrate,
+				/obj/item/weapon/reagent_containers/glass/bottle/cyanide,
+				/obj/item/ammo_magazine/chemdart
+				),
 				list( //the sapper,
-					/obj/item/weapon/melee/energy/sword/ionic_rapier,
-					/obj/item/weapon/storage/box/syndie_kit/space, //doesn't matter what species you are
-					/obj/item/weapon/storage/box/syndie_kit/demolitions,
-					/obj/item/device/multitool/ai_detector,
-					/obj/item/weapon/plastique,
-					/obj/item/weapon/storage/toolbox/syndicate
-					),
+				/obj/item/weapon/melee/energy/sword/ionic_rapier,
+				/obj/item/weapon/storage/box/syndie_kit/space, //doesn't matter what species you are
+				/obj/item/weapon/storage/box/syndie_kit/demolitions,
+				/obj/item/device/multitool/ai_detector,
+				/obj/item/weapon/plastique,
+				/obj/item/weapon/storage/toolbox/syndicate
+				),
 				list( //the infiltrator,
-					/obj/item/weapon/gun/projectile/silenced,
-					/obj/item/device/chameleon,
-					/obj/item/weapon/storage/box/syndie_kit/chameleon,
-					/obj/item/device/encryptionkey/syndicate,
-					/obj/item/weapon/card/id/syndicate,
-					/obj/item/clothing/mask/gas/voice
-					),
+				/obj/item/weapon/gun/projectile/silenced,
+				/obj/item/device/chameleon,
+				/obj/item/weapon/storage/box/syndie_kit/chameleon,
+				/obj/item/device/encryptionkey/syndicate,
+				/obj/item/weapon/card/id/syndicate,
+				/obj/item/clothing/mask/gas/voice
+				),
 				list( //the professional,
-					/obj/item/weapon/gun/projectile/silenced,
-					/obj/item/weapon/gun/energy/ionrifle/pistol,
-					/obj/item/clothing/glasses/thermal/syndi,
-					/obj/item/weapon/card/emag,
-					/obj/item/ammo_magazine/m45/ap,
-					/obj/item/weapon/material/hatchet/tacknife/combatknife,
-					/obj/item/clothing/mask/balaclava
-					),
+				/obj/item/weapon/gun/projectile/silenced,
+				/obj/item/weapon/gun/energy/ionrifle/pistol,
+				/obj/item/clothing/glasses/thermal/syndi,
+				/obj/item/weapon/card/emag,
+				/obj/item/ammo_magazine/m45/ap,
+				/obj/item/weapon/material/hatchet/tacknife/combatknife,
+				/obj/item/clothing/mask/balaclava
+				),
 				list( //the heavy,
-					/obj/item/weapon/rig/merc/empty,
-					/obj/item/rig_module/mounted/egun,
-					/obj/item/rig_module/maneuvering_jets,
-					/obj/item/rig_module/vision/thermal,
-					/obj/item/rig_module/device/plasmacutter,
-					/obj/item/weapon/cell/hyper
-					)
+				/obj/item/weapon/rig/merc/empty,
+				/obj/item/rig_module/mounted/egun,
+				/obj/item/rig_module/maneuvering_jets,
+				/obj/item/rig_module/vision/thermal,
+				/obj/item/rig_module/device/plasmacutter,
+				/obj/item/weapon/cell/hyper
 				)
+			)
 	cost = 250 //more than a hat crate!
 	contraband = 1
 	containertype = /obj/structure/largecrate

--- a/code/datums/supplypacks/contraband.dm
+++ b/code/datums/supplypacks/contraband.dm
@@ -55,7 +55,7 @@
  	containername = "Weapons crate"
 
 /datum/supply_packs/randomised/misc/telecrate //you get something awesome, a couple of decent things, and a few weak/filler things
-	name = "ERR_NULL_ENTRY"
+	name = "ERR_NULL_ENTRY" //null crate! also dream maker is hell,
 	num_contained = 1
 	contains = list(
 			list( //the operator,
@@ -74,7 +74,7 @@
 					),
 			list( //the sapper,
 					/obj/item/weapon/melee/energy/sword/ionic_rapier,
-					/obj/item/weapon/storage/box/syndie_kit/space, //doesn't matter what species you are
+					/obj/item/weapon/storage/box/syndie_kit/space, //doesn't matter what species you are,
 					/obj/item/weapon/storage/box/syndie_kit/demolitions,
 					/obj/item/device/multitool/ai_detector,
 					/obj/item/weapon/plastique,
@@ -106,7 +106,7 @@
 					/obj/item/weapon/cell/hyper
 					)
 			)
-	cost = 250 //more than a hat crate!
+	cost = 250 //more than a hat crate!,
 	contraband = 1
 	containertype = /obj/structure/largecrate
 	containername = "Suspicious crate"

--- a/code/datums/supplypacks/contraband.dm
+++ b/code/datums/supplypacks/contraband.dm
@@ -96,14 +96,6 @@
 					/obj/item/ammo_magazine/m45/ap,
 					/obj/item/weapon/material/hatchet/tacknife/combatknife,
 					/obj/item/clothing/mask/balaclava
-					),
-			list( //the heavy,
-					/obj/item/weapon/rig/merc/empty,
-					/obj/item/rig_module/mounted/egun,
-					/obj/item/rig_module/maneuvering_jets,
-					/obj/item/rig_module/vision/thermal,
-					/obj/item/rig_module/device/plasmacutter,
-					/obj/item/weapon/cell/hyper
 					)
 			)
 	cost = 250 //more than a hat crate!,

--- a/code/datums/supplypacks/contraband.dm
+++ b/code/datums/supplypacks/contraband.dm
@@ -7,7 +7,7 @@
 /datum/supply_packs/randomised/contraband
 	num_contained = 5
 	contains = list(
-			/obj/item/seeds/bloodtomatoseed,
+		/obj/item/seeds/bloodtomatoseed,
 			/obj/item/weapon/storage/pill_bottle/zoom,
 			/obj/item/weapon/storage/pill_bottle/happy,
 			/obj/item/weapon/reagent_containers/food/drinks/bottle/pwine
@@ -108,7 +108,6 @@
 					/obj/item/weapon/cell/hyper
 					)
 				)
-
 	cost = 250 //more than a hat crate!
 	contraband = 1
 	containertype = /obj/structure/largecrate

--- a/code/datums/supplypacks/contraband.dm
+++ b/code/datums/supplypacks/contraband.dm
@@ -53,3 +53,63 @@
  	contraband = 1
  	containertype = /obj/structure/closet/crate/secure/weapon
  	containername = "Weapons crate"
+
+/datum/supply_packs/randomised/misc/telecrate //you get something awesome, a couple of decent things, and a few weak/filler things
+	name = "ERR_NULL_ENTRY"
+	num_contained = 1
+	contains = list(
+				list( //the operator
+					/obj/item/weapon/gun/projectile/shotgun/pump/combat,
+					/obj/item/clothing/suit/storage/vest/heavy/merc,
+					/obj/item/clothing/glasses/night,
+					/obj/item/weapon/storage/box/anti_photons,
+					/obj/item/ammo_magazine/clip/c12g/pellet,
+					/obj/item/ammo_magazine/clip/c12g
+					),
+				list( //the doc
+					/obj/item/weapon/storage/firstaid/combat,
+					/obj/item/weapon/gun/projectile/dartgun,
+					/obj/item/weapon/reagent_containers/hypospray,
+					/obj/item/weapon/reagent_containers/glass/bottle/chloralhydrate,
+					/obj/item/weapon/reagent_containers/glass/bottle/cyanide,
+					/obj/item/ammo_magazine/chemdart
+					),
+				list( //the sapper
+					/obj/item/weapon/melee/energy/sword/ionic_rapier,
+					/obj/item/weapon/storage/box/syndie_kit/space, //doesn't matter what species you are
+					/obj/item/weapon/storage/box/syndie_kit/demolitions,
+					/obj/item/device/multitool/ai_detector,
+					/obj/item/weapon/plastique,
+					/obj/item/weapon/storage/toolbox/syndicate
+					),
+				list( //the infiltrator
+					/obj/item/weapon/gun/projectile/silenced,
+					/obj/item/device/chameleon,
+					/obj/item/weapon/storage/box/syndie_kit/chameleon,
+					/obj/item/device/encryptionkey/syndicate,
+					/obj/item/weapon/card/id/syndicate,
+					/obj/item/clothing/mask/gas/voice
+					),
+				list( //the professional
+					/obj/item/weapon/gun/projectile/silenced,
+					/obj/item/weapon/gun/energy/ionrifle/pistol,
+					/obj/item/clothing/glasses/thermal/syndi,
+					/obj/item/weapon/card/emag,
+					/obj/item/ammo_magazine/m45/ap,
+					/obj/item/weapon/material/hatchet/tacknife/combatknife,
+					/obj/item/clothing/mask/balaclava
+					),
+				list( //the heavy
+					/obj/item/weapon/rig/merc/empty,
+					/obj/item/rig_module/mounted/egun,
+					/obj/item/rig_module/maneuvering_jets,
+					/obj/item/rig_module/vision/thermal,
+					/obj/item/rig_module/device/plasmacutter,
+					/obj/item/weapon/cell/hyper
+					)
+				)
+
+	cost = 250 //more than a hat crate!
+	contraband = 1
+	containertype = /obj/structure/largecrate
+	containername = "Suspicious crate"

--- a/code/datums/supplypacks/contraband.dm
+++ b/code/datums/supplypacks/contraband.dm
@@ -58,7 +58,7 @@
 	name = "ERR_NULL_ENTRY"
 	num_contained = 1
 	contains = list(
-				list( //the operator
+				list( //the operator,
 					/obj/item/weapon/gun/projectile/shotgun/pump/combat,
 					/obj/item/clothing/suit/storage/vest/heavy/merc,
 					/obj/item/clothing/glasses/night,
@@ -66,7 +66,7 @@
 					/obj/item/ammo_magazine/clip/c12g/pellet,
 					/obj/item/ammo_magazine/clip/c12g
 					),
-				list( //the doc
+				list( //the doc,
 					/obj/item/weapon/storage/firstaid/combat,
 					/obj/item/weapon/gun/projectile/dartgun,
 					/obj/item/weapon/reagent_containers/hypospray,
@@ -74,7 +74,7 @@
 					/obj/item/weapon/reagent_containers/glass/bottle/cyanide,
 					/obj/item/ammo_magazine/chemdart
 					),
-				list( //the sapper
+				list( //the sapper,
 					/obj/item/weapon/melee/energy/sword/ionic_rapier,
 					/obj/item/weapon/storage/box/syndie_kit/space, //doesn't matter what species you are
 					/obj/item/weapon/storage/box/syndie_kit/demolitions,
@@ -82,7 +82,7 @@
 					/obj/item/weapon/plastique,
 					/obj/item/weapon/storage/toolbox/syndicate
 					),
-				list( //the infiltrator
+				list( //the infiltrator,
 					/obj/item/weapon/gun/projectile/silenced,
 					/obj/item/device/chameleon,
 					/obj/item/weapon/storage/box/syndie_kit/chameleon,
@@ -90,7 +90,7 @@
 					/obj/item/weapon/card/id/syndicate,
 					/obj/item/clothing/mask/gas/voice
 					),
-				list( //the professional
+				list( //the professional,
 					/obj/item/weapon/gun/projectile/silenced,
 					/obj/item/weapon/gun/energy/ionrifle/pistol,
 					/obj/item/clothing/glasses/thermal/syndi,
@@ -99,7 +99,7 @@
 					/obj/item/weapon/material/hatchet/tacknife/combatknife,
 					/obj/item/clothing/mask/balaclava
 					),
-				list( //the heavy
+				list( //the heavy,
 					/obj/item/weapon/rig/merc/empty,
 					/obj/item/rig_module/mounted/egun,
 					/obj/item/rig_module/maneuvering_jets,

--- a/code/datums/supplypacks/contraband.dm
+++ b/code/datums/supplypacks/contraband.dm
@@ -58,55 +58,53 @@
 	name = "ERR_NULL_ENTRY"
 	num_contained = 1
 	contains = list(
-				list( //the operator,
-				/obj/item/weapon/gun/projectile/shotgun/pump/combat,
-				/obj/item/clothing/suit/storage/vest/heavy/merc,
-				/obj/item/clothing/glasses/night,
-				/obj/item/weapon/storage/box/anti_photons,
-				/obj/item/ammo_magazine/clip/c12g/pellet,
-				/obj/item/ammo_magazine/clip/c12g
-				),
-				list( //the doc,
-				/obj/item/weapon/storage/firstaid/combat,
-				/obj/item/weapon/gun/projectile/dartgun,
-				/obj/item/weapon/reagent_containers/hypospray,
-				/obj/item/weapon/reagent_containers/glass/bottle/chloralhydrate,
-				/obj/item/weapon/reagent_containers/glass/bottle/cyanide,
-				/obj/item/ammo_magazine/chemdart
-				),
-				list( //the sapper,
-				/obj/item/weapon/melee/energy/sword/ionic_rapier,
-				/obj/item/weapon/storage/box/syndie_kit/space, //doesn't matter what species you are
-				/obj/item/weapon/storage/box/syndie_kit/demolitions,
-				/obj/item/device/multitool/ai_detector,
-				/obj/item/weapon/plastique,
-				/obj/item/weapon/storage/toolbox/syndicate
-				),
-				list( //the infiltrator,
-				/obj/item/weapon/gun/projectile/silenced,
-				/obj/item/device/chameleon,
-				/obj/item/weapon/storage/box/syndie_kit/chameleon,
-				/obj/item/device/encryptionkey/syndicate,
-				/obj/item/weapon/card/id/syndicate,
-				/obj/item/clothing/mask/gas/voice
-				),
-				list( //the professional,
-				/obj/item/weapon/gun/projectile/silenced,
-				/obj/item/weapon/gun/energy/ionrifle/pistol,
-				/obj/item/clothing/glasses/thermal/syndi,
-				/obj/item/weapon/card/emag,
-				/obj/item/ammo_magazine/m45/ap,
-				/obj/item/weapon/material/hatchet/tacknife/combatknife,
-				/obj/item/clothing/mask/balaclava
-				),
-				list( //the heavy,
-				/obj/item/weapon/rig/merc/empty,
-				/obj/item/rig_module/mounted/egun,
-				/obj/item/rig_module/maneuvering_jets,
-				/obj/item/rig_module/vision/thermal,
-				/obj/item/rig_module/device/plasmacutter,
-				/obj/item/weapon/cell/hyper
-				)
+			list( //the operator,
+					/obj/item/weapon/gun/projectile/shotgun/pump/combat,
+					/obj/item/clothing/suit/storage/vest/heavy/merc,
+					/obj/item/clothing/glasses/night,
+					/obj/item/weapon/storage/box/anti_photons,
+					/obj/item/ammo_magazine/clip/c12g/pellet,				/obj/item/ammo_magazine/clip/c12g
+					),
+			list( //the doc,
+					/obj/item/weapon/storage/firstaid/combat,
+					/obj/item/weapon/gun/projectile/dartgun,				/obj/item/weapon/reagent_containers/hypospray,
+					/obj/item/weapon/reagent_containers/glass/bottle/chloralhydrate,
+					/obj/item/weapon/reagent_containers/glass/bottle/cyanide,
+					/obj/item/ammo_magazine/chemdart
+					),
+			list( //the sapper,
+					/obj/item/weapon/melee/energy/sword/ionic_rapier,
+					/obj/item/weapon/storage/box/syndie_kit/space, //doesn't matter what species you are
+					/obj/item/weapon/storage/box/syndie_kit/demolitions,
+					/obj/item/device/multitool/ai_detector,
+					/obj/item/weapon/plastique,
+					/obj/item/weapon/storage/toolbox/syndicate
+					),
+			list( //the infiltrator,
+					/obj/item/weapon/gun/projectile/silenced,
+					/obj/item/device/chameleon,
+					/obj/item/weapon/storage/box/syndie_kit/chameleon,
+					/obj/item/device/encryptionkey/syndicate,
+					/obj/item/weapon/card/id/syndicate,
+					/obj/item/clothing/mask/gas/voice
+					),
+			list( //the professional,
+					/obj/item/weapon/gun/projectile/silenced,
+					/obj/item/weapon/gun/energy/ionrifle/pistol,
+					/obj/item/clothing/glasses/thermal/syndi,
+					/obj/item/weapon/card/emag,
+					/obj/item/ammo_magazine/m45/ap,
+					/obj/item/weapon/material/hatchet/tacknife/combatknife,
+					/obj/item/clothing/mask/balaclava
+					),
+			list( //the heavy,
+					/obj/item/weapon/rig/merc/empty,
+					/obj/item/rig_module/mounted/egun,
+					/obj/item/rig_module/maneuvering_jets,
+					/obj/item/rig_module/vision/thermal,
+					/obj/item/rig_module/device/plasmacutter,
+					/obj/item/weapon/cell/hyper
+					)
 			)
 	cost = 250 //more than a hat crate!
 	contraband = 1


### PR DESCRIPTION
Adds a 'null crate' to Cargo - ERR_NULL_ENTRY, 250 points under the misc section, and it doesn't appear without tampering with the console. When bought, it has a random one of six bundles...

1) Combat shotgun, merc vest, NVGs, anti-photon grenade, buckshot quick-loader, slug quick-loader
2) Combat first-aid kit, dartgun, hypospray, 30u chloral, 30u cyanide, some spare chemdarts
3) Ionic rapier, black and red softsuit, bomb-in-a-box, AI detecting multitool, C4, black and red toolbox
4) Silenced .45, chameleon projector, chameleon kit, encrypted radio key, agent ID, voice-changer
5) Silenced .45, ion pistol, thermal glasses, emag, .45 AP mag, combat knife, balaclava
6) Merc hardsuit with egun, thermals, plasma cutter and jetpack, and a hyper-cap cell

Disclaimer: you can get more stuff of about the same effectiveness for cheaper, but this is the only way you can get some of these items, and they come packaged together for convenience.