### PR TITLE
Loadout tweaks + accessory path improvements

### DIFF
--- a/code/game/objects/items/weapons/gift_wrappaper.dm
+++ b/code/game/objects/items/weapons/gift_wrappaper.dm
@@ -103,7 +103,7 @@
 		/obj/item/device/paicard,
 		/obj/item/device/violin,
 		/obj/item/weapon/storage/belt/utility/full,
-		/obj/item/clothing/accessory/horrible)
+		/obj/item/clothing/accessory/tie/horrible)
 
 	if(!ispath(gift_type,/obj/item))	return
 

--- a/code/game/objects/structures/railing.dm
+++ b/code/game/objects/structures/railing.dm
@@ -1,7 +1,7 @@
 // Based on railing.dmi from https://github.com/Endless-Horizon/CEV-Eris
 /obj/structure/railing
 	name = "railing"
-	desc = "A standard steel railing.  Play stupid games win stupid prizes."
+	desc = "A standard steel railing.  Play stupid games, win stupid prizes."
 	icon = 'icons/obj/railing.dmi'
 	density = 1
 	throwpass = 1

--- a/code/modules/client/preference_setup/loadout/loadout.dm
+++ b/code/modules/client/preference_setup/loadout/loadout.dm
@@ -14,7 +14,8 @@ var/list/gear_datums = list()
 	//create a list of gear datums to sort
 	for(var/geartype in typesof(/datum/gear)-/datum/gear)
 		var/datum/gear/G = geartype
-
+		if(initial(G.type_category) == geartype)
+			continue
 		var/use_name = initial(G.display_name)
 		var/use_category = initial(G.sort_category)
 
@@ -205,6 +206,7 @@ var/list/gear_datums = list()
 	var/sort_category = "General"
 	var/list/gear_tweaks = list() //List of datums which will alter the item after it has been spawned.
 	var/exploitable = 0		//Does it go on the exploitable information list?
+	var/type_category = null
 
 /datum/gear/New()
 	..()

--- a/code/modules/client/preference_setup/loadout/loadout_accessories.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_accessories.dm
@@ -2,6 +2,7 @@
 	slot = slot_tie
 	sort_category = "Accessories"
 	type_category = /datum/gear/accessory
+	cost = 1
 
 /datum/gear/accessory/armband
 	display_name = "armband selection"

--- a/code/modules/client/preference_setup/loadout/loadout_accessories.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_accessories.dm
@@ -1,50 +1,25 @@
 /datum/gear/accessory/
-	display_name = "armband selection"
-	path = /obj/item/clothing/accessory/armband
 	slot = slot_tie
 	sort_category = "Accessories"
+	type_category = /datum/gear/accessory
 
-/datum/gear/accessory/New()
+/datum/gear/accessory/armband
+	display_name = "armband selection"
+	path = /obj/item/clothing/accessory/armband
+
+/datum/gear/accessory/armband/New()
 	..()
 	var/list/armbands = list()
-	for(var/armband in typesof(/obj/item/clothing/accessory/armband))
+	for(var/armband in (typesof(/obj/item/clothing/accessory/armband) - typesof(/obj/item/clothing/accessory/armband/med/color)))
 		var/obj/item/clothing/accessory/armband_type = armband
 		armbands[initial(armband_type.name)] = armband_type
 	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(armbands))
 
-/datum/gear/accessory/cargo
-	display_name = "armband, cargo"
-	path = /obj/item/clothing/accessory/armband/cargo
-
-/datum/gear/accessory/emt
-	display_name = "armband, EMT"
-	path = /obj/item/clothing/accessory/armband/medblue
-
-/datum/gear/accessory/engineering
-	display_name = "armband, engineering"
-	path = /obj/item/clothing/accessory/armband/engine
-
-/datum/gear/accessory/hydroponics
-	display_name = "armband, hydroponics"
-	path = /obj/item/clothing/accessory/armband/hydro
-
-/datum/gear/accessory/medical
-	display_name = "armband, medical"
-	path = /obj/item/clothing/accessory/armband/med
-
-/datum/gear/accessory/medical/cross
-	display_name = "armband, medic"
-	path = /obj/item/clothing/accessory/armband/med/cross
-
-/datum/gear/accessory/science
-	display_name = "armband, science"
-	path = /obj/item/clothing/accessory/armband/science
-
-/datum/gear/accessory/colored
+/datum/gear/accessory/armband/colored
 	display_name = "armband"
 	path = /obj/item/clothing/accessory/armband/med/color
 
-/datum/gear/accessory/colored/New()
+/datum/gear/accessory/armband/colored/New()
 	..()
 	gear_tweaks = list(gear_tweak_free_color_choice)
 

--- a/code/modules/client/preference_setup/loadout/loadout_accessories.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_accessories.dm
@@ -1,8 +1,16 @@
-/datum/gear/accessory
-	display_name = "armband, red"
+/datum/gear/accessory/
+	display_name = "armband selection"
 	path = /obj/item/clothing/accessory/armband
 	slot = slot_tie
 	sort_category = "Accessories"
+
+/datum/gear/accessory/New()
+	..()
+	var/list/armbands = list()
+	for(var/armband in typesof(/obj/item/clothing/accessory/armband))
+		var/obj/item/clothing/accessory/armband_type = armband
+		armbands[initial(armband_type.name)] = armband_type
+	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(armbands))
 
 /datum/gear/accessory/cargo
 	display_name = "armband, cargo"

--- a/code/modules/client/preference_setup/loadout/loadout_accessories.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_accessories.dm
@@ -1,4 +1,6 @@
-/datum/gear/accessory/
+/datum/gear/accessory
+	display_name = "accessory"
+	path = /obj/item/accessory/
 	slot = slot_tie
 	sort_category = "Accessories"
 	type_category = /datum/gear/accessory

--- a/code/modules/client/preference_setup/loadout/loadout_accessories.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_accessories.dm
@@ -74,209 +74,102 @@
 	..()
 	gear_tweaks = list(gear_tweak_free_color_choice)
 
-
 /datum/gear/accessory/wcoat
-	display_name = "waistcoat"
+	display_name = "waistcoat selection"
 	path = /obj/item/clothing/accessory/wcoat
 	cost = 1
 
-/datum/gear/accessory/wcoat/red
-	display_name = "waistcoat, red"
-	path = /obj/item/clothing/accessory/wcoat/red
-
-/datum/gear/accessory/wcoat/grey
-	display_name = "waistcoat, grey"
-	path = /obj/item/clothing/accessory/wcoat/grey
-
-/datum/gear/accessory/wcoat/brown
-	display_name = "waistcoat, brown"
-	path = /obj/item/clothing/accessory/wcoat/brown
-
-/datum/gear/accessory/swvest
-	display_name = "sweatervest, black"
-	path = /obj/item/clothing/accessory/wcoat/swvest
-	cost = 1
-
-/datum/gear/accessory/swvest/blue
-	display_name = "sweatervest, blue"
-	path = /obj/item/clothing/accessory/wcoat/swvest/blue
-
-/datum/gear/accessory/swvest/red
-	display_name = "sweatervest, red"
-	path = /obj/item/clothing/accessory/wcoat/swvest/red
+/datum/gear/accessory/wcoat/New()
+	..()
+	var/list/wcoats = list()
+	for(var/wcoat in typesof(/obj/item/clothing/accessory/wcoat))
+		var/obj/item/clothing/accessory/wcoat_type = wcoat
+		wcoats[initial(wcoat_type.name)] = wcoat_type
+	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(wcoats))
 
 /datum/gear/accessory/holster
-	display_name = "holster, armpit"
-	path = /obj/item/clothing/accessory/holster/armpit
+	display_name = "holster selection (Security, CD, HoP)"
+	path = /obj/item/clothing/accessory/holster
 	allowed_roles = list("Colony Director", "Head of Personnel", "Security Officer", "Warden", "Head of Security","Detective")
 
-/datum/gear/accessory/holster/hip
-	display_name = "holster, hip"
-	path = /obj/item/clothing/accessory/holster/hip
-
-/datum/gear/accessory/holster/leg
-	display_name = "holster, leg"
-	path = /obj/item/clothing/accessory/holster/leg
-
-/datum/gear/accessory/holster/waist
-	display_name = "holster, waist"
-	path = /obj/item/clothing/accessory/holster/waist
+/datum/gear/accessory/holster/New()
+	..()
+	var/list/holsters = list()
+	for(var/holster in typesof(/obj/item/clothing/accessory/holster))
+		var/obj/item/clothing/accessory/holster_type = holster
+		holsters[initial(holster_type.name)] = holster_type
+	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(holsters))
 
 /datum/gear/accessory/tie
-	display_name = "tie, black"
-	path = /obj/item/clothing/accessory/black
+	display_name = "tie selection"
+	path = /obj/item/clothing/accessory/tie
+	cost = 1
 
-/datum/gear/accessory/tie/blue
-	display_name = "tie, blue"
-	path = /obj/item/clothing/accessory/blue
-
-/datum/gear/accessory/tie/blue_clip
-	display_name = "tie, blue with clip"
-	path = /obj/item/clothing/accessory/blue_clip
-
-/datum/gear/accessory/tie/blue_long
-	display_name = "tie, blue long"
-	path = /obj/item/clothing/accessory/blue_long
-
-/datum/gear/accessory/tie/red
-	display_name = "tie, red"
-	path = /obj/item/clothing/accessory/red
-
-/datum/gear/accessory/tie/red_clip
-	display_name = "tie, red with clip"
-	path = /obj/item/clothing/accessory/red_clip
-
-/datum/gear/accessory/tie/red_long
-	display_name = "tie, red long"
-	path = /obj/item/clothing/accessory/red_long
-
-/datum/gear/accessory/tie/yellow
-	display_name = "tie, yellow"
-	path = /obj/item/clothing/accessory/yellow
-
-/datum/gear/accessory/tie/navy
-	display_name = "tie, navy blue"
-	path = /obj/item/clothing/accessory/navy
-
-/datum/gear/accessory/tie/white
-	display_name = "tie, white"
-	path = /obj/item/clothing/accessory/white
-
-/datum/gear/accessory/tie/horrible
-	display_name = "tie, socially disgraceful"
-	path = /obj/item/clothing/accessory/horrible
+/datum/gear/accessory/tie/New()
+	..()
+	var/list/ties = list()
+	for(var/tie in typesof(/obj/item/clothing/accessory/tie))
+		var/obj/item/clothing/accessory/tie_type = tie
+		ties[initial(tie_type.name)] = tie_type
+	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(ties))
 
 /datum/gear/accessory/scarf
-	display_name = "scarf"
+	display_name = "scarf selection"
 	path = /obj/item/clothing/accessory/scarf
+	cost = 1
 
-/datum/gear/accessory/scarf/red
-	display_name = "scarf, red"
-	path = /obj/item/clothing/accessory/scarf/red
+/datum/gear/accessory/scarf/New()
+	..()
+	var/list/scarfs = list()
+	for(var/scarf in typesof(/obj/item/clothing/accessory/scarf))
+		var/obj/item/clothing/accessory/scarf_type = scarf
+		scarfs[initial(scarf_type.name)] = scarf_type
+	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(scarfs))
 
-/datum/gear/accessory/scarf/green
-	display_name = "scarf, green"
-	path = /obj/item/clothing/accessory/scarf/green
+/datum/gear/accessory/jacket
+	display_name = "suit jacket selection"
+	path = /obj/item/clothing/accessory/jacket
+	cost = 1
 
-/datum/gear/accessory/scarf/darkblue
-	display_name = "scarf, dark blue"
-	path = /obj/item/clothing/accessory/scarf/darkblue
-
-/datum/gear/accessory/scarf/purple
-	display_name = "scarf, purple"
-	path = /obj/item/clothing/accessory/scarf/purple
-
-/datum/gear/accessory/scarf/yellow
-	display_name = "scarf, yellow"
-	path = /obj/item/clothing/accessory/scarf/yellow
-
-/datum/gear/accessory/scarf/orange
-	display_name = "scarf, orange"
-	path = /obj/item/clothing/accessory/scarf/orange
-
-/datum/gear/accessory/scarf/lightblue
-	display_name = "scarf, light blue"
-	path = /obj/item/clothing/accessory/scarf/lightblue
-
-/datum/gear/accessory/scarf/white
-	display_name = "scarf, white"
-	path = /obj/item/clothing/accessory/scarf/white
-
-/datum/gear/accessory/scarf/black
-	display_name = "scarf, black"
-	path = /obj/item/clothing/accessory/scarf/black
-
-/datum/gear/accessory/scarf/zebra
-	display_name = "scarf, zebra"
-	path = /obj/item/clothing/accessory/scarf/zebra
-
-/datum/gear/accessory/scarf/christmas
-	display_name = "scarf, christmas"
-	path = /obj/item/clothing/accessory/scarf/christmas
-
-/datum/gear/accessory/scarf/stripedred
-	display_name = "scarf, striped red"
-	path = /obj/item/clothing/accessory/stripedredscarf
-
-/datum/gear/accessory/scarf/stripedgreen
-	display_name = "scarf, striped green"
-	path = /obj/item/clothing/accessory/stripedgreenscarf
-
-/datum/gear/accessory/scarf/stripedblue
-	display_name = "scarf, striped blue"
-	path = /obj/item/clothing/accessory/stripedbluescarf
-
-/datum/gear/accessory/suitjacket
-	display_name = "suit jacket, tan"
-	path = /obj/item/clothing/accessory/tan_jacket
-
-/datum/gear/accessory/suitjacket/charcoal
-	display_name = "suit jacket, charcoal"
-	path = /obj/item/clothing/accessory/charcoal_jacket
-
-/datum/gear/accessory/suitjacket/navy
-	display_name = "suit jacket, navy blue"
-	path = /obj/item/clothing/accessory/navy_jacket
-
-/datum/gear/accessory/suitjacket/burgundy
-	display_name = "suit jacket, burgundy"
-	path = /obj/item/clothing/accessory/burgundy_jacket
-
-/datum/gear/accessory/suitjacket/checkered
-	display_name = "suit jacket, checkered"
-	path = /obj/item/clothing/accessory/checkered_jacket
+/datum/gear/accessory/jacket/New()
+	..()
+	var/list/jackets = list()
+	for(var/jacket in typesof(/obj/item/clothing/accessory/jacket))
+		var/obj/item/clothing/accessory/jacket_type = jacket
+		jackets[initial(jacket_type.name)] = jacket_type
+	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(jackets))
 
 /datum/gear/accessory/suitvest
 	display_name = "suit vest"
 	path = /obj/item/clothing/accessory/vest
 
 /datum/gear/accessory/brown_vest
-	display_name = "webbing, engineering"
+	display_name = "webbing, brown"
 	path = /obj/item/clothing/accessory/storage/brown_vest
 	allowed_roles = list("Station Engineer","Atmospheric Technician","Chief Engineer","Security Officer","Detective","Head of Security","Warden","Paramedic","Chief Medical Officer","Medical Doctor")
 
 /datum/gear/accessory/black_vest
-	display_name = "webbing, security"
+	display_name = "webbing, black"
 	path = /obj/item/clothing/accessory/storage/black_vest
 	allowed_roles = list("Station Engineer","Atmospheric Technician","Chief Engineer","Security Officer","Detective","Head of Security","Warden","Paramedic","Chief Medical Officer","Medical Doctor")
 
 /datum/gear/accessory/white_vest
-	display_name = "webbing, medical"
+	display_name = "webbing, white"
 	path = /obj/item/clothing/accessory/storage/white_vest
 	allowed_roles = list("Station Engineer","Atmospheric Technician","Chief Engineer","Security Officer","Detective","Head of Security","Warden","Paramedic","Chief Medical Officer","Medical Doctor")
 
 /datum/gear/accessory/brown_drop_pouches
-	display_name = "drop pouches, engineering"
+	display_name = "drop pouches, brown"
 	path = /obj/item/clothing/accessory/storage/brown_drop_pouches
 	allowed_roles = list("Station Engineer","Atmospheric Technician","Chief Engineer","Security Officer","Detective","Head of Security","Warden","Paramedic","Chief Medical Officer","Medical Doctor")
 
 /datum/gear/accessory/black_drop_pouches
-	display_name = "drop pouches, security"
+	display_name = "drop pouches, black"
 	path = /obj/item/clothing/accessory/storage/black_drop_pouches
 	allowed_roles = list("Station Engineer","Atmospheric Technician","Chief Engineer","Security Officer","Detective","Head of Security","Warden","Paramedic","Chief Medical Officer","Medical Doctor")
 
 /datum/gear/accessory/white_drop_pouches
-	display_name = "drop pouches, medical"
+	display_name = "drop pouches, white"
 	path = /obj/item/clothing/accessory/storage/white_drop_pouches
 	allowed_roles = list("Station Engineer","Atmospheric Technician","Chief Engineer","Security Officer","Detective","Head of Security","Warden","Paramedic","Chief Medical Officer","Medical Doctor")
 

--- a/code/modules/client/preference_setup/loadout/loadout_eyes.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_eyes.dm
@@ -53,7 +53,7 @@
 /datum/gear/eyes/medical
 	display_name = "Medical HUD (Medical)"
 	path = /obj/item/clothing/glasses/hud/health
-	allowed_roles = list("Medical Doctor","Chief Medical Officer","Chemist","Paramedic","Geneticist")
+	allowed_roles = list("Medical Doctor","Chief Medical Officer","Chemist","Paramedic","Geneticist", "Psychiatrist")
 
 /datum/gear/eyes/medical/prescriptionmed
 	display_name = "Medical HUD, prescription (Medical)"
@@ -68,9 +68,9 @@
 	path = /obj/item/clothing/glasses/sunglasses/medhud/aviator/prescription
 
 /datum/gear/eyes/meson
-	display_name = "Optical Meson Scanners (Engineering)"
+	display_name = "Optical Meson Scanners (Engineering, Science)"
 	path = /obj/item/clothing/glasses/meson
-	allowed_roles = list("Station Engineer","Chief Engineer","Atmospheric Technician")
+	allowed_roles = list("Station Engineer","Chief Engineer","Atmospheric Technician", "Scientist", "Research Director")
 
 /datum/gear/eyes/meson/prescription
 	display_name = "Optical Meson Scanners, prescription (Engineering)"
@@ -115,4 +115,3 @@
 /datum/gear/eyes/sun/prescriptionsun
 	display_name = "sunglasses, presciption (Security/Command)"
 	path = /obj/item/clothing/glasses/sunglasses/prescription
-	cost = 2

--- a/code/modules/client/preference_setup/loadout/loadout_eyes.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_eyes.dm
@@ -53,7 +53,7 @@
 /datum/gear/eyes/medical
 	display_name = "Medical HUD (Medical)"
 	path = /obj/item/clothing/glasses/hud/health
-	allowed_roles = list("Medical Doctor","Chief Medical Officer","Chemist","Paramedic","Geneticist", "Psychiatrist")
+	allowed_roles = list("Medical Doctor","Chief Medical Officer","Chemist","Paramedic","Geneticist")
 
 /datum/gear/eyes/medical/prescriptionmed
 	display_name = "Medical HUD, prescription (Medical)"

--- a/code/modules/client/preference_setup/loadout/loadout_gloves.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_gloves.dm
@@ -68,7 +68,7 @@
 	cost = 3
 
 /datum/gear/gloves/forensic
-	display_name = "gloves, forensic"
+	display_name = "gloves, forensic (Detective)"
 	path = /obj/item/clothing/gloves/forensic
 	allowed_roles = list("Detective")
 

--- a/code/modules/client/preference_setup/loadout/loadout_head.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_head.dm
@@ -136,7 +136,6 @@
 /datum/gear/head/cowboy
 	display_name = "cowboy, rodeo"
 	path = /obj/item/clothing/head/cowboy_hat
-	cost = 3
 
 /datum/gear/head/cowboy/black
 	display_name = "cowboy, black"
@@ -267,6 +266,11 @@
 /datum/gear/head/taqiyah/New()
 	..()
 	gear_tweaks = list(gear_tweak_free_color_choice)
+
+
+/datum/gear/head/kitty
+	display_name = "kitty ears"
+	path = /obj/item/clothing/head/kitty
 
 /datum/gear/head/beanie
 	display_name = "beanie"

--- a/code/modules/client/preference_setup/loadout/loadout_shoes.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_shoes.dm
@@ -195,6 +195,10 @@
 	..()
 	gear_tweaks = list(gear_tweak_free_color_choice)
 
+/datum/gear/shoes/slippers
+	display_name = "bunny slippers"
+	path = /obj/item/clothing/shoes/slippers
+
 /datum/gear/shoes/boots/winter
 	display_name = "winter boots"
 	path = /obj/item/clothing/shoes/boots/winter
@@ -227,7 +231,7 @@
 /datum/gear/shoes/boots/winter/medical
 	display_name = "medical winter boots"
 	path = /obj/item/clothing/shoes/boots/winter/medical
-	allowed_roles = list("Medical Doctor","Chief Medical Officer","Chemist","Paramedic","Geneticist")
+	allowed_roles = list("Medical Doctor","Chief Medical Officer","Chemist","Paramedic","Geneticist", "Psychiatrist")
 
 /datum/gear/shoes/boots/winter/mining
 	display_name = "mining winter boots"

--- a/code/modules/client/preference_setup/loadout/loadout_suit.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_suit.dm
@@ -149,7 +149,7 @@
 /datum/gear/suit/labcoat/emt
 	display_name = "labcoat, EMT (Medical)"
 	path = /obj/item/clothing/suit/storage/toggle/labcoat/emt
-	allowed_roles = list("Medical Doctor","Chief Medical Officer","Chemist","Paramedic","Geneticist")
+	allowed_roles = list("Medical Doctor","Chief Medical Officer","Chemist","Paramedic","Geneticist", "Psychiatrist")
 
 /datum/gear/suit/roles/surgical_apron
 	display_name = "surgical apron"
@@ -182,7 +182,7 @@
 /datum/gear/suit/roles/poncho/medical
 	display_name = "poncho, medical"
 	path = /obj/item/clothing/accessory/poncho/roles/medical
-	allowed_roles = list("Medical Doctor","Chief Medical Officer","Chemist","Paramedic","Geneticist")
+	allowed_roles = list("Medical Doctor","Chief Medical Officer","Chemist","Paramedic","Geneticist", "Psychiatrist")
 
 /datum/gear/suit/roles/poncho/engineering
 	display_name = "poncho, engineering"
@@ -292,7 +292,7 @@
 /datum/gear/suit/wintercoat/medical
 	display_name = "winter coat, medical"
 	path = /obj/item/clothing/suit/storage/hooded/wintercoat/medical
-	allowed_roles = list("Medical Doctor","Chief Medical Officer","Chemist","Paramedic","Geneticist")
+	allowed_roles = list("Medical Doctor","Chief Medical Officer","Chemist","Paramedic","Geneticist", "Psychiatrist")
 
 /datum/gear/suit/wintercoat/science
 	display_name = "winter coat, science"
@@ -445,7 +445,7 @@
 /datum/gear/suit/snowsuit/medical
 	display_name = "snowsuit, medical"
 	path = /obj/item/clothing/suit/storage/snowsuit/medical
-	allowed_roles = list("Medical Doctor","Chief Medical Officer","Chemist","Paramedic","Geneticist")
+	allowed_roles = list("Medical Doctor","Chief Medical Officer","Chemist","Paramedic","Geneticist", "Psychiatrist")
 
 /datum/gear/suit/snowsuit/science
 	display_name = "snowsuit, science"
@@ -461,3 +461,8 @@
 	display_name = "snowsuit, supply"
 	path = /obj/item/clothing/suit/storage/snowsuit/cargo
 	allowed_roles = list("Quartermaster","shaft Miner","Cargo Technician","Head of Personnel")
+
+/datum/gear/suit/ianshirt
+	display_name = "worn shirt, Ian (HoP)"
+	path = /obj/item/clothing/suit/ianshirt
+	allowed_roles = list("Head of Personnel")

--- a/code/modules/client/preference_setup/loadout/loadout_suit.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_suit.dm
@@ -461,8 +461,3 @@
 	display_name = "snowsuit, supply"
 	path = /obj/item/clothing/suit/storage/snowsuit/cargo
 	allowed_roles = list("Quartermaster","shaft Miner","Cargo Technician","Head of Personnel")
-
-/datum/gear/suit/ianshirt
-	display_name = "worn shirt, Ian (HoP)"
-	path = /obj/item/clothing/suit/ianshirt
-	allowed_roles = list("Head of Personnel")

--- a/code/modules/client/preference_setup/loadout/loadout_uniform.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_uniform.dm
@@ -243,7 +243,6 @@
 /datum/gear/uniform/scrub
 	display_name = "scrubs selection"
 	path = /obj/item/clothing/under/rank/medical/scrubs
-	allowed_roles = list("Medical Doctor","Chief Medical Officer","Chemist","Paramedic","Geneticist", "Roboticist")
 
 /datum/gear/uniform/scrub/New()
 	..()
@@ -455,3 +454,7 @@
 /datum/gear/uniform/red_swept_dress
 	display_name = "red swept dress"
 	path = /obj/item/clothing/under/dress/red_swept_dress
+
+/datum/gear/uniform/bathrobe
+	display_name = "bathrobe"
+	path = /obj/item/clothing/under/bathrobe

--- a/code/modules/clothing/under/accessories/accessory.dm
+++ b/code/modules/clothing/under/accessories/accessory.dm
@@ -237,11 +237,8 @@
 //Scarves
 
 /obj/item/clothing/accessory/scarf
-	name = "scarf"
-	desc = "A stylish scarf. The perfect winter accessory for those with a keen fashion sense, and those who just can't handle a cold breeze on their necks."
-
-/obj/item/clothing/accessory/scarf/red
 	name = "red scarf"
+	desc = "A stylish scarf. The perfect winter accessory for those with a keen fashion sense, and those who just can't handle a cold breeze on their necks."
 	icon_state = "redscarf"
 
 /obj/item/clothing/accessory/scarf/green

--- a/code/modules/clothing/under/accessories/accessory.dm
+++ b/code/modules/clothing/under/accessories/accessory.dm
@@ -80,51 +80,51 @@
 		return	//we aren't an object on the ground so don't call parent
 	..()
 
-/obj/item/clothing/accessory/blue
+/obj/item/clothing/accessory/tie
 	name = "blue tie"
 	icon_state = "bluetie"
 
-/obj/item/clothing/accessory/red
+/obj/item/clothing/accessory/tie/red
 	name = "red tie"
 	icon_state = "redtie"
 
-/obj/item/clothing/accessory/blue_clip
+/obj/item/clothing/accessory/tie/blue_clip
 	name = "blue tie with a clip"
 	icon_state = "bluecliptie"
 
-/obj/item/clothing/accessory/blue_long
+/obj/item/clothing/accessory/tie/blue_long
 	name = "blue long tie"
 	icon_state = "bluelongtie"
 
-/obj/item/clothing/accessory/red_clip
+/obj/item/clothing/accessory/tie/red_clip
 	name = "red tie with a clip"
 	icon_state = "redcliptie"
 
-/obj/item/clothing/accessory/red_long
+/obj/item/clothing/accessory/tie/red_long
 	name = "red long tie"
 	icon_state = "redlongtie"
 
-/obj/item/clothing/accessory/black
+/obj/item/clothing/accessory/tie/black
 	name = "black tie"
 	icon_state = "blacktie"
 
-/obj/item/clothing/accessory/darkgreen
+/obj/item/clothing/accessory/tie/darkgreen
 	name = "dark green tie"
 	icon_state = "dgreentie"
 
-/obj/item/clothing/accessory/yellow
+/obj/item/clothing/accessory/tie/yellow
 	name = "yellow tie"
 	icon_state = "yellowtie"
 
-/obj/item/clothing/accessory/navy
+/obj/item/clothing/accessory/tie/navy
 	name = "navy tie"
 	icon_state = "navytie"
 
-/obj/item/clothing/accessory/white
+/obj/item/clothing/accessory/tie/white
 	name = "white tie"
 	icon_state = "whitetie"
 
-/obj/item/clothing/accessory/horrible
+/obj/item/clothing/accessory/tie/horrible
 	name = "horrible tie"
 	desc = "A neosilk clip-on tie. This one is disgusting."
 	icon_state = "horribletie"
@@ -284,14 +284,14 @@
 	name = "christmas scarf"
 	icon_state = "christmasscarf"
 
-/obj/item/clothing/accessory/stripedredscarf
+/obj/item/clothing/accessory/scarf/stripedred
 	name = "striped red scarf"
 	icon_state = "stripedredscarf"
 
-/obj/item/clothing/accessory/stripedgreenscarf
+/obj/item/clothing/accessory/scarf/stripedgreen
 	name = "striped green scarf"
 	icon_state = "stripedgreenscarf"
 
-/obj/item/clothing/accessory/stripedbluescarf
+/obj/item/clothing/accessory/scarf/stripedblue
 	name = "striped blue scarf"
 	icon_state = "stripedbluescarf"

--- a/code/modules/clothing/under/accessories/clothing.dm
+++ b/code/modules/clothing/under/accessories/clothing.dm
@@ -3,27 +3,27 @@
 	desc = "Slick black suit vest."
 	icon_state = "det_vest"
 
-/obj/item/clothing/accessory/tan_jacket
+/obj/item/clothing/accessory/jacket/
 	name = "tan suit jacket"
 	desc = "Cozy suit jacket."
 	icon_state = "tan_jacket"
 
-/obj/item/clothing/accessory/charcoal_jacket
+/obj/item/clothing/accessory/jacket/charcoal
 	name = "charcoal suit jacket"
 	desc = "Strict suit jacket."
 	icon_state = "charcoal_jacket"
 
-/obj/item/clothing/accessory/navy_jacket
+/obj/item/clothing/accessory/jacket/navy
 	name = "navy suit jacket"
 	desc = "Official suit jacket."
 	icon_state = "navy_jacket"
 
-/obj/item/clothing/accessory/burgundy_jacket
+/obj/item/clothing/accessory/jacket/burgundy
 	name = "burgundy suit jacket"
 	desc = "Expensive suit jacket."
 	icon_state = "burgundy_jacket"
 
-/obj/item/clothing/accessory/checkered_jacket
+/obj/item/clothing/accessory/jacket/checkered
 	name = "checkered suit jacket"
 	desc = "Lucky suit jacket."
 	icon_state = "checkered_jacket"

--- a/code/modules/clothing/under/jobs/civilian.dm
+++ b/code/modules/clothing/under/jobs/civilian.dm
@@ -101,7 +101,7 @@
 	icon_state = "internalaffairs"
 	item_state_slots = list(slot_r_hand_str = "ba_suit", slot_l_hand_str = "ba_suit")
 	rolled_sleeves = 0
-	starting_accessories = list(/obj/item/clothing/accessory/black)
+	starting_accessories = list(/obj/item/clothing/accessory/tie/black)
 
 /obj/item/clothing/under/rank/internalaffairs/skirt
 	desc = "The plain, professional attire of an Internal Affairs Agent. The top button is sewn shut."
@@ -156,7 +156,7 @@
 	desc = "A classy suit."
 	icon_state = "bluesuit"
 	item_state_slots = list(slot_r_hand_str = "lawyer_blue", slot_l_hand_str = "lawyer_blue")
-	starting_accessories = list(/obj/item/clothing/accessory/red)
+	starting_accessories = list(/obj/item/clothing/accessory/tie/red)
 
 /obj/item/clothing/under/lawyer/bluesuit/skirt
 	name = "blue skirt suit"

--- a/code/modules/clothing/under/jobs/security.dm
+++ b/code/modules/clothing/under/jobs/security.dm
@@ -73,7 +73,7 @@
 	armor = list(melee = 10, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 0, rad = 0)
 	siemens_coefficient = 0.9
 	rolled_sleeves = 0
-	starting_accessories = list(/obj/item/clothing/accessory/blue_clip)
+	starting_accessories = list(/obj/item/clothing/accessory/tie/blue_clip)
 
 /*
 /obj/item/clothing/under/det/verb/rollup()
@@ -89,13 +89,13 @@
 /obj/item/clothing/under/det/grey
 	icon_state = "detective2"
 	desc = "A serious-looking tan dress shirt paired with freshly-pressed black slacks."
-	starting_accessories = list(/obj/item/clothing/accessory/red_long)
+	starting_accessories = list(/obj/item/clothing/accessory/tie/red_long)
 
 /obj/item/clothing/under/det/black
 	icon_state = "detective3"
 	item_state_slots = list(slot_r_hand_str = "sl_suit", slot_l_hand_str = "sl_suit")
 	desc = "An immaculate white dress shirt, paired with a pair of dark grey dress pants, a red tie, and a charcoal vest."
-	starting_accessories = list(/obj/item/clothing/accessory/red_long, /obj/item/clothing/accessory/vest)
+	starting_accessories = list(/obj/item/clothing/accessory/tie/red_long, /obj/item/clothing/accessory/vest)
 
 /obj/item/clothing/under/det/corporate
 	name = "detective's jumpsuit"
@@ -106,12 +106,12 @@
 /obj/item/clothing/under/det/waistcoat
 	icon_state = "detective"
 	desc = "A rumpled white dress shirt paired with well-worn grey slacks, complete with a blue striped tie, faux-gold tie clip, and waistcoat."
-	starting_accessories = list(/obj/item/clothing/accessory/blue_clip, /obj/item/clothing/accessory/wcoat)
+	starting_accessories = list(/obj/item/clothing/accessory/tie/blue_clip, /obj/item/clothing/accessory/wcoat)
 
 /obj/item/clothing/under/det/grey/waistcoat
 	icon_state = "detective2"
 	desc = "A serious-looking tan dress shirt paired with freshly-pressed black slacks, complete with a red striped tie and waistcoat."
-	starting_accessories = list(/obj/item/clothing/accessory/red_long, /obj/item/clothing/accessory/wcoat)
+	starting_accessories = list(/obj/item/clothing/accessory/tie/red_long, /obj/item/clothing/accessory/wcoat)
 
 /obj/item/clothing/under/det/skirt
 	name = "detective's skirt"

--- a/code/modules/clothing/under/miscellaneous.dm
+++ b/code/modules/clothing/under/miscellaneous.dm
@@ -101,7 +101,7 @@
 	icon_state = "greensuit"
 	item_state_slots = list(slot_r_hand_str = "centcom", slot_l_hand_str = "centcom")
 	rolled_sleeves = 0
-	starting_accessories = list(/obj/item/clothing/accessory/darkgreen)
+	starting_accessories = list(/obj/item/clothing/accessory/tie/darkgreen)
 
 /obj/item/clothing/under/gov/skirt
 	name = "Green formal skirt uniform"
@@ -161,7 +161,7 @@
 	icon_state = "gentlesuit"
 	item_state_slots = list(slot_r_hand_str = "grey", slot_l_hand_str = "grey")
 	rolled_sleeves = 0
-	starting_accessories = list(/obj/item/clothing/accessory/white, /obj/item/clothing/accessory/wcoat/gentleman)
+	starting_accessories = list(/obj/item/clothing/accessory/tie/white, /obj/item/clothing/accessory/wcoat/gentleman)
 
 /obj/item/clothing/under/gentlesuit/skirt
 	name = "lady's suit"
@@ -472,7 +472,7 @@
 	desc = "A charcoal suit and red tie. Very professional."
 	icon_state = "charcoal_suit"
 	item_state_slots = list(slot_r_hand_str = "lawyer_black", slot_l_hand_str = "lawyer_black")
-	starting_accessories = list(/obj/item/clothing/accessory/navy, /obj/item/clothing/accessory/charcoal_jacket)
+	starting_accessories = list(/obj/item/clothing/accessory/tie/navy, /obj/item/clothing/accessory/jacket/charcoal)
 
 /obj/item/clothing/under/suit_jacket/charcoal/skirt
 	name = "charcoal skirt"
@@ -483,7 +483,7 @@
 	desc = "A navy suit and red tie, intended for the station's finest."
 	icon_state = "navy_suit"
 	item_state_slots = list(slot_r_hand_str = "lawyer_blue", slot_l_hand_str = "lawyer_blue")
-	starting_accessories = list(/obj/item/clothing/accessory/red, /obj/item/clothing/accessory/navy_jacket)
+	starting_accessories = list(/obj/item/clothing/accessory/tie/red, /obj/item/clothing/accessory/jacket/navy)
 
 /obj/item/clothing/under/suit_jacket/navy/skirt
 	name = "navy skirt"
@@ -494,7 +494,7 @@
 	desc = "A burgundy suit and black tie. Somewhat formal."
 	icon_state = "burgundy_suit"
 	item_state_slots = list(slot_r_hand_str = "lawyer_red", slot_l_hand_str = "lawyer_red")
-	starting_accessories = list(/obj/item/clothing/accessory/black, /obj/item/clothing/accessory/burgundy_jacket)
+	starting_accessories = list(/obj/item/clothing/accessory/tie/black, /obj/item/clothing/accessory/jacket/burgundy)
 
 /obj/item/clothing/under/suit_jacket/burgundy/skirt
 	name = "burgundy skirt"
@@ -505,7 +505,7 @@
 	desc = "That's a very nice suit you have there. Shame if something were to happen to it, eh?"
 	icon_state = "checkered_suit"
 	item_state_slots = list(slot_r_hand_str = "lawyer_black", slot_l_hand_str = "lawyer_black")
-	starting_accessories = list(/obj/item/clothing/accessory/black, /obj/item/clothing/accessory/checkered_jacket)
+	starting_accessories = list(/obj/item/clothing/accessory/tie/black, /obj/item/clothing/accessory/jacket/checkered)
 
 /obj/item/clothing/under/suit_jacket/checkered/skirt
 	name = "checkered skirt"
@@ -516,7 +516,7 @@
 	desc = "A tan suit. Smart, but casual."
 	icon_state = "tan_suit"
 	item_state_slots = list(slot_r_hand_str = "tan_suit", slot_l_hand_str = "tan_suit")
-	starting_accessories = list(/obj/item/clothing/accessory/yellow, /obj/item/clothing/accessory/tan_jacket)
+	starting_accessories = list(/obj/item/clothing/accessory/tie/yellow, /obj/item/clothing/accessory/jacket)
 
 /obj/item/clothing/under/suit_jacket/tan/skirt
 	name = "tan skirt"

--- a/code/modules/mining/abandonedcrates.dm
+++ b/code/modules/mining/abandonedcrates.dm
@@ -54,7 +54,7 @@
 		if(46 to 50)
 			new/obj/item/clothing/under/chameleon(src)
 			for(var/i = 0, i < 7, i++)
-				new/obj/item/clothing/accessory/horrible(src)
+				new/obj/item/clothing/accessory/tie/horrible(src)
 		if(51 to 52) // Uncommon, 2% each
 			new/obj/item/weapon/melee/classic_baton(src)
 		if(53 to 54)


### PR DESCRIPTION
- Ties are now /accessory/tie, not /accessory.
- Fixed a typo in railing.dm
- Armbands, waistcoats, holsters, jackets, ties and scarves now come in selection menus (declutters loadout).
- Renamed webbing and drop pouches to black/brown/white in the loadout, since it's not job-restricted to specific departments.
- Psychiatrists can now take medical boots, winter coat, EMT labcoat, and the medical poncho, like the rest of medical. Still can't have MedHUDs from the loadout, though.
- Scientists and Research Directors can now take mesons.
- Scrubs are now no longer limited to medical staff; pregnant Tajaran can take them too.
- Added the bathrobe, bunny slippers, kitty ears to the loadout.
- Only Detectives can take forensic gloves - this has been clarified.
- Cowboy hats are now worth the same as every other hat.
- Prescription Command sunglasses are now worth the same as regular Command sunglasses.

Fixes #3542 by letting Scientists and RD take mesons.