### PR TITLE
Changes how IDscan works.

### DIFF
--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -442,7 +442,7 @@
 
 /obj/machinery/door/allowed(mob/M)
 	if(!requiresID())
-		return ..(null) //don't care who they are or what they have, act as if they're NOTHING
+		return 1 //If IDScan is disabled, anyone can come on through.
 	return ..(M)
 
 /obj/machinery/door/update_nearby_tiles(need_rebuild)


### PR DESCRIPTION
If you disable IDscan, rather than doing the same thing as bolting a door except shittier since they can just cut wires and crowbar it, it allows anyone through, giving it actual UTILITY for, as an example, emergency access.

Ported from Aurora.