### PR TITLE
Removes RNG from emagging APCs and robots.

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -1024,15 +1024,11 @@
 /mob/living/silicon/robot/emag_act(var/remaining_charges, var/mob/user)
 	if(!opened)//Cover is closed
 		if(locked)
-			if(prob(90))
-				user << "You emag the cover lock."
-				locked = 0
-			else
-				user << "You fail to emag the cover lock."
-				src << "Hack attempt detected."
+			to_chat(user,"You emag the cover lock.")
+			locked = 0
 			return 1
 		else
-			user << "The cover is already unlocked."
+			to_chat(user,"The cover is already unlocked.")
 		return
 
 	if(opened)//Cover is open

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -681,13 +681,10 @@
 		else
 			flick("apc-spark", src)
 			if (do_after(user,6))
-				if(prob(50))
-					emagged = 1
-					locked = 0
-					to_chat(user,"<span class='notice'>You emag the APC interface.</span>")
-					update_icon()
-				else
-					to_chat(user,"<span class='warning'>The APC interface refused to unlock.</span>")
+				emagged = 1
+				locked = 0
+				to_chat(user,"<span class='notice'>You emag the APC interface.</span>")
+				update_icon()
 				return 1
 
 /obj/machinery/power/apc/attack_hand(mob/user)


### PR DESCRIPTION
>get emag
>have a drone captured in your cave
>swipe your emag once
>it fails
>swipe it again
>it fails
>try three more times
>you're out of charge
>the drone has PDA'd the HoS in this time
>the HoS kicks down the door and throws in a flashbang
>you shut down your PC