### PR TITLE
Stops MMIs created with a ghosted brain from being put into cyborgs.

### DIFF
--- a/code/game/objects/items/robot/robot_parts.dm
+++ b/code/game/objects/items/robot/robot_parts.dm
@@ -178,7 +178,7 @@
 					for(var/mob/observer/dead/G in player_list)
 						if(G.can_reenter_corpse && G.mind == M.brainmob.mind)
 							ghost_can_reenter = 1 //May come in use again at another point.
-							to_chat(user, "<span class='notice'>\The [W] is completely unresponsive; though it may be able to auto-recussitate.</span>") //Jamming a ghosted brain into a borg is likely not good, and may result in some upsetness.
+							to_chat(user, "<span class='notice'>\The [W] is completely unresponsive; though it may be able to auto-resuscitate.</span>") //Jamming a ghosted brain into a borg is likely detrimental, and may result in some problems.
 							return
 				if(!ghost_can_reenter)
 					user << "<span class='notice'>\The [W] is completely unresponsive; there's no point.</span>"

--- a/code/game/objects/items/robot/robot_parts.dm
+++ b/code/game/objects/items/robot/robot_parts.dm
@@ -177,8 +177,9 @@
 				if(M.brainmob.mind)
 					for(var/mob/observer/dead/G in player_list)
 						if(G.can_reenter_corpse && G.mind == M.brainmob.mind)
-							ghost_can_reenter = 1
-							break
+							ghost_can_reenter = 1 //May come in use again at another point.
+							to_chat(user, "<span class='notice'>\The [W] is completely unresponsive; though it may be able to auto-recussitate.</span>") //Jamming a ghosted brain into a borg is likely not good, and may result in some upsetness.
+							return
 				if(!ghost_can_reenter)
 					user << "<span class='notice'>\The [W] is completely unresponsive; there's no point.</span>"
 					return


### PR DESCRIPTION
On the Tin. I didn't completely overwrite the check for safety reasons, and it may be usable at a later point.