### PR TITLE
Reworks cryopod storage

### DIFF
--- a/code/game/gamemodes/nuclear/pinpointer.dm
+++ b/code/game/gamemodes/nuclear/pinpointer.dm
@@ -9,6 +9,7 @@
 	throw_speed = 4
 	throw_range = 20
 	matter = list(DEFAULT_WALL_MATERIAL = 500)
+	preserve_item = 1
 	var/obj/item/weapon/disk/nuclear/the_disk = null
 	var/active = 0
 

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -226,24 +226,6 @@
 	var/last_no_computer_message = 0
 	var/applies_stasis = 1
 
-	// These items are preserved when the process() despawn proc occurs.
-	var/list/preserve_items = list(
-		/obj/item/weapon/hand_tele,
-		/obj/item/weapon/card/id/captains_spare,
-		/obj/item/device/aicard,
-		/obj/item/device/paicard,
-		/obj/item/weapon/gun,
-		/obj/item/weapon/cell/device,
-		/obj/item/ammo_magazine,
-		/obj/item/ammo_casing,
-		/obj/item/weapon/pinpointer,
-		/obj/item/clothing/suit,
-		/obj/item/clothing/shoes/magboots,
-		/obj/item/blueprints,
-		/obj/item/clothing/head/helmet/space,
-		/obj/item/weapon/storage/internal
-	)
-
 /obj/machinery/cryopod/robot
 	name = "robotic storage unit"
 	desc = "A storage unit for robots."
@@ -407,12 +389,10 @@
 
 	for(var/obj/item/W in items)
 
-		var/preserve = null
+		var/preserve = 0
 
-		for(var/T in preserve_items)
-			if(istype(W,T))
-				preserve = 1
-				break
+		if(W.preserve_item)
+			preserve = 1
 
 		if(istype(W,/obj/item/weapon/implant/health))
 			for(var/obj/machinery/computer/cloning/com in world)

--- a/code/game/objects/items/blueprints.dm
+++ b/code/game/objects/items/blueprints.dm
@@ -4,6 +4,7 @@
 	icon = 'icons/obj/items.dmi'
 	icon_state = "blueprints"
 	attack_verb = list("attacked", "bapped", "hit")
+	preserve_item = 1
 	var/const/AREA_ERRNONE = 0
 	var/const/AREA_STATION = 1
 	var/const/AREA_SPACE =   2

--- a/code/game/objects/items/devices/aicard.dm
+++ b/code/game/objects/items/devices/aicard.dm
@@ -7,6 +7,7 @@
 	w_class = ITEMSIZE_NORMAL
 	slot_flags = SLOT_BELT
 	show_messages = 0
+	preserve_item = 1
 
 	var/flush = null
 	origin_tech = list(TECH_DATA = 4, TECH_MATERIAL = 4)

--- a/code/game/objects/items/devices/defib.dm
+++ b/code/game/objects/items/devices/defib.dm
@@ -11,6 +11,7 @@
 	slot_flags = SLOT_BACK
 	force = 5
 	throwforce = 6
+	preserve_item = 1
 	w_class = ITEMSIZE_LARGE
 	origin_tech = list(TECH_BIO = 4, TECH_POWER = 2)
 	action_button_name = "Remove/Replace Paddles"

--- a/code/game/objects/items/devices/paicard.dm
+++ b/code/game/objects/items/devices/paicard.dm
@@ -7,6 +7,7 @@
 	slot_flags = SLOT_BELT
 	origin_tech = list(TECH_DATA = 2)
 	show_messages = 0
+	preserve_item = 1
 
 	var/obj/item/device/radio/radio
 	var/looking_for_personality = 0

--- a/code/game/objects/items/weapons/AI_modules.dm
+++ b/code/game/objects/items/weapons/AI_modules.dm
@@ -18,6 +18,7 @@ AI MODULES
 	throw_speed = 3
 	throw_range = 15
 	origin_tech = list(TECH_DATA = 3)
+	preserve_item = 1
 	var/datum/ai_laws/laws = null
 
 /obj/item/weapon/aiModule/proc/install(var/atom/movable/AM, var/mob/living/user)

--- a/code/game/objects/items/weapons/RCD.dm
+++ b/code/game/objects/items/weapons/RCD.dm
@@ -15,6 +15,7 @@
 	w_class = ITEMSIZE_NORMAL
 	origin_tech = list(TECH_ENGINEERING = 4, TECH_MATERIAL = 2)
 	matter = list(DEFAULT_WALL_MATERIAL = 50000)
+	preserve_item = 1
 	var/datum/effect/effect/system/spark_spread/spark_system
 	var/stored_matter = 0
 	var/max_stored_matter = 30

--- a/code/game/objects/items/weapons/id cards/station_ids.dm
+++ b/code/game/objects/items/weapons/id cards/station_ids.dm
@@ -138,6 +138,7 @@
 	desc = "A golden card which shows power and might."
 	icon_state = "gold"
 	item_state = "gold_id"
+	preserve_item = 1
 
 /obj/item/weapon/card/id/gold/captain/New()
 	assignment = "Colony Director"
@@ -145,17 +146,11 @@
 	access = get_all_station_access()
 	..()
 
-/obj/item/weapon/card/id/captains_spare
+/obj/item/weapon/card/id/gold/captain/spare
 	name = "colony director's spare ID"
 	desc = "The spare ID of the High Lord himself."
-	icon_state = "gold"
-	item_state = "gold_id"
 	registered_name = "Colony Director"
 	assignment = "Colony Director"
-
-/obj/item/weapon/card/id/captains_spare/New()
-	access = get_all_station_access()
-	..()
 
 /obj/item/weapon/card/id/synthetic
 	name = "\improper Synthetic ID"

--- a/code/game/objects/items/weapons/power_cells.dm
+++ b/code/game/objects/items/weapons/power_cells.dm
@@ -34,6 +34,7 @@
 	throw_range = 7
 	maxcharge = 480
 	matter = list("metal" = 350, "glass" = 50)
+	preserve_item = 1
 
 /obj/item/weapon/cell/device/weapon
 	name = "weapon power cell"

--- a/code/game/objects/items/weapons/shields.dm
+++ b/code/game/objects/items/weapons/shields.dm
@@ -32,6 +32,7 @@
 /obj/item/weapon/shield
 	name = "shield"
 	var/base_block_chance = 50
+	preserve_item = 1
 	item_icons = list(
 				slot_l_hand_str = 'icons/mob/items/lefthand_melee.dmi',
 				slot_r_hand_str = 'icons/mob/items/righthand_melee.dmi',

--- a/code/game/objects/items/weapons/storage/internal.dm
+++ b/code/game/objects/items/weapons/storage/internal.dm
@@ -1,6 +1,7 @@
 //A storage item intended to be used by other items to provide storage functionality.
 //Types that use this should consider overriding emp_act() and hear_talk(), unless they shield their contents somehow.
 /obj/item/weapon/storage/internal
+	preserve_item = 1
 	var/obj/item/master_item
 
 /obj/item/weapon/storage/internal/New(obj/item/MI)

--- a/code/game/objects/items/weapons/storage/lockbox.dm
+++ b/code/game/objects/items/weapons/storage/lockbox.dm
@@ -9,6 +9,7 @@
 	max_w_class = ITEMSIZE_NORMAL
 	max_storage_space = ITEMSIZE_COST_NORMAL * 4 //The sum of the w_classes of all the items in this storage item.
 	req_access = list(access_armory)
+	preserve_item = 1
 	var/locked = 1
 	var/broken = 0
 	var/icon_locked = "lockbox+l"

--- a/code/game/objects/items/weapons/teleportation.dm
+++ b/code/game/objects/items/weapons/teleportation.dm
@@ -129,6 +129,7 @@ Frequency:
 	throw_range = 5
 	origin_tech = list(TECH_MAGNET = 1, TECH_BLUESPACE = 3)
 	matter = list(DEFAULT_WALL_MATERIAL = 10000)
+	preserve_item = 1
 
 /obj/item/weapon/hand_tele/attack_self(mob/user as mob)
 	var/turf/current_location = get_turf(user)//What turf is the user on?

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -12,6 +12,7 @@
 	var/damtype = "brute"
 	var/armor_penetration = 0
 	var/show_messages
+	var/preserve_item = 0 //whether this object is preserved when its owner goes into cryo-storage, gateway, etc
 
 /obj/Destroy()
 	processing_objects -= src

--- a/code/game/objects/random/random.dm
+++ b/code/game/objects/random/random.dm
@@ -973,7 +973,7 @@ var/list/multi_point_spawns
 /obj/random_multi/single_item/captains_spare_id
 	name = "Multi Point - Captain's Spare"
 	id = "Captain's spare id"
-	item_path = /obj/item/weapon/card/id/captains_spare
+	item_path = /obj/item/weapon/card/id/gold/captain/spare
 
 //Multiple Object Spawn
 

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -548,6 +548,7 @@
 	var/blood_overlay_type = "suit"
 	siemens_coefficient = 0.9
 	w_class = ITEMSIZE_NORMAL
+	preserve_item = 1
 
 	sprite_sheets = list(
 		"Teshari" = 'icons/mob/species/seromi/suit.dmi',

--- a/code/modules/clothing/shoes/magboots.dm
+++ b/code/modules/clothing/shoes/magboots.dm
@@ -7,6 +7,7 @@
 	force = 3
 	overshoes = 1
 	shoes_under_pants = -1	//These things are huge
+	preserve_item = 1
 	var/magpulse = 0
 	var/icon_base = "magboots"
 	action_button_name = "Toggle Magboots"

--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -24,6 +24,7 @@
 	siemens_coefficient = 0.2
 	permeability_coefficient = 0.1
 	unacidable = 1
+	preserve_item = 1
 
 	var/interface_path = "hardsuit.tmpl"
 	var/ai_interface_path = "hardsuit.tmpl"

--- a/code/modules/clothing/spacesuits/spacesuits.dm
+++ b/code/modules/clothing/spacesuits/spacesuits.dm
@@ -15,6 +15,7 @@
 	min_cold_protection_temperature = SPACE_HELMET_MIN_COLD_PROTECTION_TEMPERATURE
 	siemens_coefficient = 0.9
 	species_restricted = list("exclude","Diona")
+	preserve_item = 1
 
 	var/obj/machinery/camera/camera
 	var/list/camera_networks
@@ -59,6 +60,7 @@
 	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
 	siemens_coefficient = 0.9
 	species_restricted = list("exclude","Diona")
+	preserve_item = 1
 
 	var/list/supporting_limbs //If not-null, automatically splints breaks. Checked when removing the suit.
 

--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -7,6 +7,7 @@
 	slot_flags = SLOT_BELT | SLOT_EARS
 	throwforce = 1
 	w_class = ITEMSIZE_TINY
+	preserve_item = 1
 
 	var/leaves_residue = 1
 	var/caliber = ""					//Which kind of guns it can be loaded into
@@ -75,6 +76,7 @@
 	w_class = ITEMSIZE_SMALL
 	throw_speed = 4
 	throw_range = 10
+	preserve_item = 1
 
 	var/list/stored_ammo = list()
 	var/mag_type = SPEEDLOADER //ammo_magazines can only be used with compatible guns. This is not a bitflag, the load_method var on guns is.

--- a/code/modules/projectiles/ammunition/magnetic.dm
+++ b/code/modules/projectiles/ammunition/magnetic.dm
@@ -7,6 +7,7 @@
 	matter = list(DEFAULT_WALL_MATERIAL = 1800)
 	origin_tech = list(TECH_COMBAT = 1)
 	var/remaining = 9
+	preserve_item = 1
 
 /obj/item/weapon/magnetic_ammo/examine(mob/user)
 	. = ..()

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -46,6 +46,7 @@
 	throw_speed = 4
 	throw_range = 5
 	force = 5
+	preserve_item = 1
 	origin_tech = list(TECH_COMBAT = 1)
 	attack_verb = list("struck", "hit", "bashed")
 	zoomdevicename = "scope"

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -14,6 +14,7 @@
 	possible_transfer_amounts = null
 	flags = OPENCONTAINER
 	slot_flags = SLOT_BELT
+	preserve_item = 1
 	var/reusable = 1
 	var/used = 0
 	var/filled = 0
@@ -70,6 +71,7 @@
 	reusable = 0
 	filled = 1
 	filled_reagents = list("inaprovaline" = 5)
+	preserve_item = 0
 
 /obj/item/weapon/reagent_containers/hypospray/autoinjector/on_reagent_change()
 	..()

--- a/maps/northern_star/polaris-1.dmm
+++ b/maps/northern_star/polaris-1.dmm
@@ -5177,7 +5177,7 @@
 "bVC" = (/obj/machinery/ai_status_display{pixel_y = 32},/obj/machinery/atmospherics/unary/vent_scrubber/on{dir = 4},/turf/simulated/floor/wood,/area/crew_quarters/captain)
 "bVD" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{dir = 4},/turf/simulated/floor/wood,/area/crew_quarters/captain)
 "bVE" = (/obj/structure/table/woodentable,/obj/item/weapon/storage/secure/safe{pixel_x = 5; pixel_y = 28},/obj/machinery/recharger{pixel_y = 4},/turf/simulated/floor/wood,/area/crew_quarters/captain)
-"bVF" = (/obj/machinery/computer/card,/obj/item/weapon/card/id/captains_spare,/turf/simulated/floor/wood,/area/crew_quarters/captain)
+"bVF" = (/obj/machinery/computer/card,/obj/item/weapon/card/id/gold/captain/spare,/turf/simulated/floor/wood,/area/crew_quarters/captain)
 "bVG" = (/obj/machinery/computer/communications,/obj/machinery/status_display{pixel_x = 0; pixel_y = 32},/turf/simulated/floor/wood,/area/crew_quarters/captain)
 "bVH" = (/obj/machinery/keycard_auth{pixel_x = 0; pixel_y = 24},/turf/simulated/floor/wood,/area/crew_quarters/captain)
 "bVI" = (/obj/structure/table/rack,/obj/item/weapon/tank/jetpack/oxygen,/obj/item/clothing/mask/gas,/obj/item/clothing/suit/armor/captain,/obj/item/clothing/head/helmet/space/capspace,/obj/machinery/newscaster/security_unit{pixel_x = 32; pixel_y = 0},/turf/simulated/floor/wood,/area/crew_quarters/captain)

--- a/maps/northern_star/polaris-2.dmm
+++ b/maps/northern_star/polaris-2.dmm
@@ -1329,7 +1329,7 @@
 "zD" = (/obj/structure/bed/chair{dir = 8},/obj/effect/floor_decal/corner/white/diagonal,/turf/unsimulated/floor{icon_state = "steel"},/area/centcom/restaurant)
 "zE" = (/obj/machinery/door/airlock/centcom{name = "Bridge"; opacity = 1; req_access = list(109)},/turf/unsimulated/floor{icon_state = "steel"},/area/centcom/command)
 "zF" = (/obj/structure/table/reinforced,/obj/item/device/pda/captain,/turf/unsimulated/floor{icon_state = "steel"},/area/centcom/command)
-"zG" = (/obj/structure/table/reinforced,/obj/item/weapon/card/id/captains_spare,/turf/unsimulated/floor{icon_state = "steel"},/area/centcom/command)
+"zG" = (/obj/structure/table/reinforced,/obj/item/weapon/card/id/gold/captain/spare,/turf/unsimulated/floor{icon_state = "steel"},/area/centcom/command)
 "zH" = (/obj/structure/table/reinforced,/turf/unsimulated/floor{icon_state = "steel"},/area/centcom/command)
 "zI" = (/obj/structure/table/reinforced,/obj/machinery/recharger{pixel_y = 4},/turf/unsimulated/floor{icon_state = "steel"},/area/centcom/command)
 "zJ" = (/turf/simulated/shuttle/wall,/area/shuttle/transport1/centcom)


### PR DESCRIPTION
The cryo/residential/gateway storage system has been reworked; rather than being a list of objects in cryopod.dm, "this object is preserved" is now a variable that gets assigned to individual objects (default of 0/off). The list is as follows, with new additions bolded:

Station blueprints
intelliCore
**Defibrillator (including combat defib)** 
pAI card
**AI modules (Purge, Freeform, etc)**
Device and weapon power cells
Ammunition casings and magazines
**Flechettes**
**RCD, but not RCD ammo**
**Shields (riot, energy, telescopic)**
Hand tele
Colony Director's ID
**Lockboxes**
All oversuits (e.g. labcoats), including stored items
All spacesuits and helmets
Magboots
**RIG modules**
**CMO hyposprays, but not autoinjectors**
Pinpointers

If it's not on this list, it gets deleted. 
Additionally, the colony director's spare ID is now /obj/item/card/weapon/id/captain/spare, not /obj/item/weapon/id/captains_spare.  Maps have been updated to reflect this.

also fight me travis this one works