### PR TITLE
Cloning machine now auto process meat

### DIFF
--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -172,9 +172,13 @@
 //Grow clones to maturity then kick them out.  FREELOADERS
 /obj/machinery/clonepod/process()
 
+	var/visible_message = 0
 	for(var/obj/item/weapon/reagent_containers/food/snacks/meat in range(1, src))
 		qdel(meat)
 		biomass += 50
+		visible_message = 1 // Prevent chatspam when multiple meat are near
+
+	if(visible_message)
 		visible_message("[src] sucks in and processes the nearby biomass.")
 
 	if(stat & NOPOWER) //Autoeject if power is lost

--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -172,6 +172,11 @@
 //Grow clones to maturity then kick them out.  FREELOADERS
 /obj/machinery/clonepod/process()
 
+	for(var/obj/item/weapon/reagent_containers/food/snacks/meat in range(1, src))
+		qdel(meat)
+		biomass += 50
+		visible_message("[src] sucks in and processes the nearby biomass.")
+
 	if(stat & NOPOWER) //Autoeject if power is lost
 		if(occupant)
 			locked = 0

--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -179,7 +179,7 @@
 		visible_message = 1 // Prevent chatspam when multiple meat are near
 
 	if(visible_message)
-		visible_message("[src] sucks in and processes the nearby biomass.")
+		visible_message("<span class = 'notice'>[src] sucks in and processes the nearby biomass.</span>")
 
 	if(stat & NOPOWER) //Autoeject if power is lost
 		if(occupant)


### PR DESCRIPTION
As per title. This port in the feature from Paracode (look i'm not gonna check where) where cloningpod sucks in meat automatically (for 50 biomass each.)

Any meat will work, alongside meatpie, meatsteak and meatball due to similar looking typepath. Shouldn't cause an issue though, no one's gonna feed meatpie to a cloning pod. 

Probably.

Mandatory testing screenie: 
![](https://i.imgur.com/O9akbrF.png)