### PR TITLE
Small Window Damage Tweak

### DIFF
--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -13,6 +13,7 @@
 	var/maximal_heat = T0C + 100 		// Maximal heat before this window begins taking damage from fire
 	var/damage_per_fire_tick = 2.0 		// Amount of damage per fire tick. Regular windows are not fireproof so they might as well break quickly.
 	var/health
+	var/force_threshold = 0
 	var/ini_dir = null
 	var/state = 2
 	var/reinf = 0
@@ -313,9 +314,9 @@
 	return
 
 /obj/structure/window/proc/hit(var/damage, var/sound_effect = 1)
-	if(reinf) damage *= 0.5
-	if(damage < 5)
+	if(damage < force_threshold || force_threshold < 0)
 		return
+	if(reinf) damage *= 0.5
 	take_damage(damage)
 	return
 
@@ -452,13 +453,14 @@
 
 
 /obj/structure/window/basic
-	desc = "It looks thin and flimsy. A few knocks with... anything, really should shatter it."
+	desc = "It looks thin and flimsy. A few knocks with... almost anything, really should shatter it."
 	icon_state = "window"
 	basestate = "window"
 	glasstype = /obj/item/stack/material/glass
 	maximal_heat = T0C + 100
 	damage_per_fire_tick = 2.0
 	maxhealth = 12.0
+	force_threshold = 3
 
 /obj/structure/window/phoronbasic
 	name = "phoron window"
@@ -470,6 +472,7 @@
 	maximal_heat = T0C + 2000
 	damage_per_fire_tick = 1.0
 	maxhealth = 40.0
+	force_threshold = 5
 
 /obj/structure/window/phoronbasic/full
 	dir = SOUTHWEST
@@ -486,6 +489,7 @@
 	maximal_heat = T0C + 4000
 	damage_per_fire_tick = 1.0 // This should last for 80 fire ticks if the window is not damaged at all. The idea is that borosilicate windows have something like ablative layer that protects them for a while.
 	maxhealth = 80.0
+	force_threshold = 10
 
 /obj/structure/window/phoronreinforced/full
 	dir = SOUTHWEST
@@ -501,6 +505,7 @@
 	maximal_heat = T0C + 750
 	damage_per_fire_tick = 2.0
 	glasstype = /obj/item/stack/material/glass/reinforced
+	force_threshold = 6
 
 
 /obj/structure/window/New(Loc, constructed=0)
@@ -528,6 +533,7 @@
 	icon_state = "fwindow"
 	basestate = "fwindow"
 	maxhealth = 30
+	force_threshold = 5
 
 /obj/structure/window/shuttle
 	name = "shuttle window"
@@ -539,6 +545,7 @@
 	reinf = 1
 	basestate = "w"
 	dir = 5
+	force_threshold = 7
 
 /obj/structure/window/reinforced/polarized
 	name = "electrochromic window"


### PR DESCRIPTION
This PR modifies the recent glass damage immunity values, with the aim of making things a little fairer on players, and also to eliminate the hard coded numeric values.
It's also possible now for maps to contain specialized windows. For instance, sections of Centcom or other out-of-round areas could have glass with a resistance of -1, making them functionally immune to being struck by objects.

The new values in this pull are designed to reflect the following considerations:
- Basic glass is used primarily as a "Break Glass in case of Emergency" material, and should be breakable by almost anything. In particular, the previous value prevented emergency oxygen internals from breaking this glass, which to me seemed like the obvious item to grab in an emergency.
- Reinforced glass was completely immune to damage from the very tools required to de-construct it, the most notable of which was the crowbar, a tool often used to destroy smaller building materials such as window panes in lieu of a tool such as a hammer.
- Borosilicate glass, as a rarer material, struck me as being generally sturdier than it's regular counterparts.