### PR TITLE
fixes exterior shields putting shields EVERYWHERE

### DIFF
--- a/code/modules/shieldgen/emergency_shield.dm
+++ b/code/modules/shieldgen/emergency_shield.dm
@@ -141,7 +141,6 @@
 	idle_power_usage = 0
 	var/global/list/blockedturfs =  list(
 		/turf/space,
-		/turf/simulated/open,
 		/turf/simulated/floor/outdoors,
 	)
 

--- a/code/modules/shieldgen/shield_gen_external.dm
+++ b/code/modules/shieldgen/shield_gen_external.dm
@@ -5,7 +5,6 @@
 	name = "hull shield generator"
 	var/global/list/blockedturfs =  list(
 		/turf/space,
-		/turf/simulated/open,
 		/turf/simulated/floor/outdoors,
 	)
 /obj/machinery/shield_gen/external/New()
@@ -24,6 +23,8 @@
 			T = locate(gen_turf.x + x_offset, gen_turf.y + y_offset, gen_turf.z)
 			if (is_type_in_list(T,blockedturfs))
 				//check neighbors of T
-				if (locate(/turf/simulated/) in orange(1, T))
-					out += T
+				for(var/i in orange(1, T))
+					if(istype(i, /turf/simulated) && !is_type_in_list(i,blockedturfs))
+						out += T
+						break
 	return out


### PR DESCRIPTION
My last shield PR screwed up 'cause it didn't check neighbours properly, resulting in literally every "blocked" turf in range getting a hexagon slapped on it regardless of whether there was an adjacent station turf or not. This fixes that.

Also takes open space off the list because it breaks stairs whoops