### PR TITLE
Adds a footstep volume modifier to shoes

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -447,6 +447,8 @@
 	var/water_speed = 0		//Speed boost/decrease in water, lower/negative values mean more speed
 	var/snow_speed = 0		//Speed boost/decrease on snow, lower/negative values mean more speed
 
+	var/step_volume_mod = 1	//How quiet or loud footsteps in this shoe are
+
 	permeability_coefficient = 0.50
 	slowdown = SHOES_SLOWDOWN
 	force = 2

--- a/code/modules/clothing/shoes/boots.dm
+++ b/code/modules/clothing/shoes/boots.dm
@@ -4,6 +4,7 @@
 	icon_state = "workboots"
 	force = 3
 	can_hold_knife = 1
+	step_volume_mod = 1.2
 
 /obj/item/clothing/shoes/boots/cowboy
 	name = "cowboy boots"
@@ -47,6 +48,7 @@
 	heat_protection = FEET|LEGS
 	max_heat_protection_temperature = SHOE_MAX_HEAT_PROTECTION_TEMPERATURE
 	snow_speed = -1
+	step_volume_mod = 0.8
 
 /obj/item/clothing/shoes/boots/winter/security
 	name = "security winter boots"

--- a/code/modules/clothing/shoes/leg_guards.dm
+++ b/code/modules/clothing/shoes/leg_guards.dm
@@ -5,6 +5,7 @@
 	slowdown = SHOES_SLOWDOWN+0.5
 	species_restricted = null	//Unathi and Taj can wear leg armor now
 	w_class = ITEMSIZE_NORMAL
+	step_volume_mod = 1.3
 
 /obj/item/clothing/shoes/leg_guard/mob_can_equip(var/mob/living/carbon/human/H, slot, disable_warning = 0)
 	if(..()) //This will only run if no other problems occured when equiping.

--- a/code/modules/clothing/shoes/magboots.dm
+++ b/code/modules/clothing/shoes/magboots.dm
@@ -13,6 +13,7 @@
 	action_button_name = "Toggle Magboots"
 	var/obj/item/clothing/shoes/shoes = null	//Undershoes
 	var/mob/living/carbon/human/wearer = null	//For shoe procs
+	step_volume_mod = 1.3
 
 /obj/item/clothing/shoes/magboots/proc/set_slowdown()
 	slowdown = shoes? max(SHOES_SLOWDOWN, shoes.slowdown): SHOES_SLOWDOWN	//So you can't put on magboots to make you walk faster.

--- a/code/modules/clothing/shoes/miscellaneous.dm
+++ b/code/modules/clothing/shoes/miscellaneous.dm
@@ -8,10 +8,12 @@
 	var/list/clothing_choices = list()
 	siemens_coefficient = 0.8
 	species_restricted = null
+	step_volume_mod = 0.5
 
 /obj/item/clothing/shoes/mime
 	name = "mime shoes"
 	icon_state = "white"
+	step_volume_mod = 0	//It's a mime
 
 /obj/item/clothing/shoes/galoshes
 	desc = "Rubber boots"
@@ -21,7 +23,6 @@
 	item_flags = NOSLIP
 	slowdown = SHOES_SLOWDOWN+1
 	species_restricted = null
-
 
 /obj/item/clothing/shoes/dress
 	name = "dress shoes"

--- a/code/modules/clothing/spacesuits/rig/suits/light.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/light.dm
@@ -26,6 +26,7 @@
 
 /obj/item/clothing/shoes/magboots/rig/light
 	name = "shoes"
+	step_volume_mod = 0.8
 
 /obj/item/clothing/head/helmet/space/rig/light
 	name = "hood"
@@ -82,6 +83,7 @@
 
 	chest_type = /obj/item/clothing/suit/space/rig/light/ninja
 	glove_type = /obj/item/clothing/gloves/gauntlets/rig/light/ninja
+	boot_type = /obj/item/clothing/shoes/magboots/rig/light/ninja
 	cell_type =  /obj/item/weapon/cell/hyper
 
 	req_access = list(access_syndicate)
@@ -106,6 +108,9 @@
 /obj/item/clothing/gloves/gauntlets/rig/light/ninja
 	name = "insulated gloves"
 	siemens_coefficient = 0
+
+/obj/item/clothing/shoes/magboots/rig/light/ninja
+	step_volume_mod = 0.25	//Not quite silent, but still damn quiet
 
 /obj/item/clothing/suit/space/rig/light/ninja
 	breach_threshold = 38 //comparable to regular hardsuits

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -186,6 +186,10 @@
 	// Reduce volume while walking or barefoot
 	if(!shoes || m_intent == "walk")
 		volume *= 0.5
+	else if(shoes)
+		var/obj/item/clothing/shoes/feet = shoes
+		if(feet)
+			volume *= feet.step_volume_mod
 
 	if(!has_organ(BP_L_FOOT) && !has_organ(BP_R_FOOT))
 		return // no feet = no footsteps


### PR DESCRIPTION
Footstep sounds are now modified by your shoes.
- Certain shoes will be louder, namely boots, magboots, and leg guards.
- Winter boots, mime shoes, traitor no-slip shoes, and ninja boots are quieter.
