### PR TITLE
Removes passive APC destruction from hacked SMES

### DIFF
--- a/code/modules/power/smes_construction.dm
+++ b/code/modules/power/smes_construction.dm
@@ -85,7 +85,7 @@
 // Proc: process()
 // Parameters: None
 // Description: Uses parent process, but if grounding wire is cut causes sparks to fly around.
-// This also causes the SMES to quickly discharge, and has small chance of damaging output APCs.
+// This also causes the SMES to quickly discharge, and has small chance of breaking lights connected to APCs in the powernet.
 /obj/machinery/power/smes/buildable/process()
 	if(!grounding && (Percentage() > 5))
 		var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
@@ -93,7 +93,7 @@
 		s.start()
 		charge -= (output_level_max * SMESRATE)
 		if(prob(1)) // Small chance of overload occuring since grounding is disabled.
-			apcs_overload(5,10)
+			apcs_overload(0,10)
 
 	..()
 


### PR DESCRIPTION
This PR removes the ability for APCs to get killed passively by cutting a wire, but leaves the light bursting aspect in.  Why I'm doing this is explained below (warning: rant).

Currently when you cut a specific wire in a SMES, **every** APCs inside the powernet have a 5% chance to die every tick (~2 seconds), requiring an engineer to completely rebuild it to restore power.  Generally the overwhelming majority of APCs on the station are connected to the main SMES if substations weren't set, or if they were, those can be sabotaged as well.

You can also use the substations to stack the APC death pulse by inputting and outputting into the same powernet with the bypass active.  If you're a real bastard, you can also build a secret SMES somewhere to prevent engineering from fixing it for a long time, and by then it will have been too late.  It is capable of killing all the station's APCs sans the AI's fairly quickly due to the fact that every APC essentially rolls a d20 every two seconds, and if they roll a 1, RIP.

It's also really hard to determine whom caused this sabotage, due to the fact that most people don't actually know it's a thing, and that forensic evidence isn't really useful since insulated gloves are required to not die to hacking it, and engineers generally touch SMESes to configure them so their fibers being on the SMES doesn't look suspicious.

Repairing APCs is also time consuming and each one requires a power board, and plunging the station into perpetual blackout using this method is much stronger than simply snipping a cable or using a powersink, since the effect is permanent until an overworked engineer can go fix your APC and 50+ others which might not even be worth doing since it is easy to restart the APC death pulse or go subvert the substations into doing those as well.  Best part is that calling an evac can be made impossible due to the Bridge and CD's Office APCs being killed as well, if there isn't an AI.

The worst part is that doing this is fairly quiet if nobody is constantly monitoring the power or happens to be near the SMES.  By the time someone notices, it is likely that double digit amounts of APCs were killed, and even when fixed, the person who caused it can easily resume it while engineering is scrambling to undo the damage.

So this is a stealthy way for one person to essentially end the round but at the same time prevent the round from ending early if there's no AI, with no forewarning if engineering is understaffed or the only engineer is the saboteur, and with zero material cost.  It's not really hard for someone to do, but most people don't even know this exists.  Discovering who did this is also very unlikely.  It's an optimal strategy.  When more people find out, it will be a shitshow.

This is why I'm changing it to just blow the lights, which is **waaaaay** less detrimental to literally everyone else playing, and still remains fairly useful to do, if someone wants to sneak in the dark.  The janitor will cry, but its a lot better than what it currently does, in my opinion.