### PR TITLE
Adds the Vial-Based Hypospray

### DIFF
--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -60,7 +60,57 @@
 		used = !used
 
 	return
+//A vial-loaded hypospray. Cartridge-based!
+/obj/item/weapon/reagent_containers/hypospray/vial
+	name = "hypospray mkII"
+	desc = "A new development from DeForest Medical, this new hypospray takes 30-unit vials as the drug supply for easy swapping."
+	var/obj/item/weapon/reagent_containers/glass/beaker/vial/loaded_vial //Wow, what a name.
+	volume = 0
 
+/obj/item/weapon/reagent_containers/hypospray/vial/New()
+	..()
+	loaded_vial = new /obj/item/weapon/reagent_containers/glass/beaker/vial(src) //Comes with an empty vial
+	volume = loaded_vial.volume
+	reagents.maximum_volume = loaded_vial.reagents.maximum_volume
+
+/obj/item/weapon/reagent_containers/hypospray/vial/attack_hand(mob/user as mob)
+	if(user.get_inactive_hand() == src)
+		if(loaded_vial)
+			reagents.trans_to_holder(loaded_vial.reagents,volume)
+			reagents.maximum_volume = 0
+			loaded_vial.update_icon()
+			user.put_in_hands(loaded_vial)
+			loaded_vial = null
+			user << "<span class='notice'>You remove the vial from the [src].</span>"
+			update_icon()
+			playsound(src.loc, 'sound/weapons/flipblade.ogg', 50, 1)
+			return
+		..()
+	else
+		return ..()
+
+/obj/item/weapon/reagent_containers/hypospray/vial/attackby(obj/item/weapon/W, mob/user as mob)
+	if(istype(W, /obj/item/weapon/reagent_containers/glass/beaker/vial))
+		if(!loaded_vial)
+			user.visible_message("<span class='notice'>[user] begins loading [W] into \the [src].</span>","<span class='notice'>You start loading [W] into \the [src].</span>")
+			if(!do_after(user,30) || loaded_vial || !(W in user))
+				return 0
+			if(W.is_open_container())
+				W.flags ^= OPENCONTAINER
+				W.update_icon()
+			user.drop_item()
+			W.loc = src
+			loaded_vial = W
+			reagents.maximum_volume = loaded_vial.reagents.maximum_volume
+			loaded_vial.reagents.trans_to_holder(reagents,volume)
+			user.visible_message("<span class='notice'>[user] has loaded [W] into \the [src].</span>","<span class='notice'>You have loaded [W] into \the [src].</span>")
+			update_icon()
+			playsound(src.loc, 'sound/weapons/empty.ogg', 50, 1)
+		else
+			user << "<span class='notice'>\The [src] already has a vial.</span>"
+	else
+		..()
+		
 /obj/item/weapon/reagent_containers/hypospray/autoinjector
 	name = "autoinjector"
 	desc = "A rapid and safe way to administer small amounts of drugs by untrained or trained personnel."


### PR DESCRIPTION
Better hypospray. Instead of an internal container, this new hypospray uses vials. I recommend replacing all hyposprays with this one.

Pros:
- Allows for easy emptying and reloading, so a CMO may have various mixes preloaded into vials, they can switch to whatever they need at a moment's notice. 
- Also, lets you empty a hypo without having to use a syringe or inject yourself.
- Let's you check how much you have in the hypo by simply removing the vial and examining it.
- Also, comes with its own vial
- "But Tempest, I don't _want_ these fancy vial-hypo's! I prefer loading mine with a direct transfer from a beaker or a syringe!" - That's perfectly fine, these hypo's retain that use, so if you don't like it, you can simply use it exactly like you would the old ones and leave the vial inside the entire round, refilling it via beaker/syringe!

Cons:
- Only comes with the 1 vial, additional boxes of vials will need to be added to the CMO Locker and the Medical Locker, or at least in Secondary Storage and Chemistry so Chemists.
- There's a 3-second delay for the action of inserting a new vial into the hypo. _Removing_ a vial is instant. 

