### PR TITLE
[DMN WIP] Adds support for two new movement types

### DIFF
--- a/code/__defines/mobs.dm
+++ b/code/__defines/mobs.dm
@@ -225,3 +225,9 @@
 #define SLIME_COMMAND_OBEY		1 // When disciplined.
 #define SLIME_COMMAND_FACTION	2 // When in the same 'faction'.
 #define SLIME_COMMAND_FRIEND	3 // When befriended with a slime friendship agent.
+
+// Movement states
+#define M_SPRINT	1
+#define M_RUN		2
+#define M_WALK		3
+#define M_STALK		4

--- a/code/_onclick/hud/alien_larva.dm
+++ b/code/_onclick/hud/alien_larva.dm
@@ -9,7 +9,7 @@
 	using.name = "mov_intent"
 	using.set_dir(SOUTHWEST)
 	using.icon = 'icons/mob/screen1_alien.dmi'
-	using.icon_state = (mymob.m_intent == "run" ? "running" : "walking")
+	using.icon_state = (mymob.m_intent == M_RUN ? "running" : "walking")
 	using.screen_loc = ui_acti
 	using.layer = 20
 	src.adding += using

--- a/code/_onclick/hud/human.dm
+++ b/code/_onclick/hud/human.dm
@@ -127,7 +127,7 @@
 		using = new /obj/screen()
 		using.name = "mov_intent"
 		using.icon = ui_style
-		using.icon_state = (mymob.m_intent == "run" ? "running" : "walking")
+		using.icon_state = (mymob.m_intent >= M_RUN ? "running" : "walking")
 		using.screen_loc = ui_movi
 		using.layer = 20
 		using.color = ui_color

--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -203,35 +203,35 @@
 				var/mob/living/carbon/C = usr
 				if(C.legcuffed)
 					C << "<span class='notice'>You are legcuffed! You cannot run until you get [C.legcuffed] removed!</span>"
-					C.m_intent = "walk"	//Just incase
+					C.m_intent = M_WALK	//Just incase
 					C.hud_used.move_intent.icon_state = "walking"
 					return 1
 				switch(usr.m_intent)
-					if("run")
-						usr.m_intent = "walk"
+					if(M_RUN)
+						usr.m_intent = M_WALK
 						usr.hud_used.move_intent.icon_state = "walking"
-					if("walk")
-						usr.m_intent = "run"
+					if(M_WALK)
+						usr.m_intent = M_RUN
 						usr.hud_used.move_intent.icon_state = "running"
 		if("m_intent")
 			if(!usr.m_int)
 				switch(usr.m_intent)
-					if("run")
+					if(M_RUN)
 						usr.m_int = "13,14"
-					if("walk")
+					if(M_WALK)
 						usr.m_int = "14,14"
 					if("face")
 						usr.m_int = "15,14"
 			else
 				usr.m_int = null
 		if("walk")
-			usr.m_intent = "walk"
+			usr.m_intent = M_WALK
 			usr.m_int = "14,14"
 		if("face")
 			usr.m_intent = "face"
 			usr.m_int = "15,14"
 		if("run")
-			usr.m_intent = "run"
+			usr.m_intent = M_RUN
 			usr.m_int = "13,14"
 		if("Reset Machine")
 			usr.unset_machine()

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -146,8 +146,10 @@ var/list/gamemode_cache = list()
 
 	//Used for modifying movement speed for mobs.
 	//Unversal modifiers
+	var/sprint_speed = 0
 	var/run_speed = 0
 	var/walk_speed = 0
+	var/stalk_speed = 0
 
 	//Mob specific modifiers. NOTE: These will affect different mob types in different ways
 	var/human_delay = 0
@@ -769,10 +771,14 @@ var/list/gamemode_cache = list()
 				if("limbs_can_break")
 					config.limbs_can_break = value
 
+				if("sprint_speed")
+					config.sprint_speed = value
 				if("run_speed")
 					config.run_speed = value
 				if("walk_speed")
 					config.walk_speed = value
+				if("stalk_speed")
+					config.stalk_speed = value
 
 				if("human_delay")
 					config.human_delay = value

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -224,7 +224,7 @@ var/list/mob/living/forced_ambiance_list = new
 		L.lastarea = get_area(L.loc)
 	var/area/newarea = get_area(L.loc)
 	var/area/oldarea = L.lastarea
-	if((oldarea.has_gravity == 0) && (newarea.has_gravity == 1) && (L.m_intent == "run")) // Being ready when you change areas gives you a chance to avoid falling all together.
+	if((oldarea.has_gravity == 0) && (newarea.has_gravity == 1) && (L.m_intent >= M_RUN)) // Being ready when you change areas gives you a chance to avoid falling all together.
 		thunk(L)
 		L.update_floating( L.Check_Dense_Object() )
 
@@ -275,7 +275,7 @@ var/list/mob/living/forced_ambiance_list = new
 		if(istype(H.shoes, /obj/item/clothing/shoes/magboots) && (H.shoes.item_flags & NOSLIP))
 			return
 
-		if(H.m_intent == "run")
+		if(H.m_intent >= M_RUN)
 			H.AdjustStunned(6)
 			H.AdjustWeakened(6)
 		else

--- a/code/game/gamemodes/changeling/powers/visible_camouflage.dm
+++ b/code/game/gamemodes/changeling/powers/visible_camouflage.dm
@@ -41,13 +41,13 @@
 			to_chat(src, "<span class='notice'>We may move at our normal speed while hidden.</span>")
 
 		if(must_walk)
-			H.set_m_intent("walk")
+			H.set_m_intent(M_WALK)
 
 		var/remain_cloaked = TRUE
 		while(remain_cloaked) //This loop will keep going until the player uncloaks.
 			sleep(1 SECOND) // Sleep at the start so that if something invalidates a cloak, it will drop immediately after the check and not in one second.
 
-			if(H.m_intent != "walk" && must_walk) // Moving too fast uncloaks you.
+			if(H.m_intent >= M_RUN && must_walk) // Moving too fast uncloaks you.
 				remain_cloaked = 0
 			if(!H.mind.changeling.cloaked)
 				remain_cloaked = 0
@@ -65,7 +65,7 @@
 		H.invisibility = initial(invisibility)
 		visible_message("<span class='warning'>[src] suddenly fades in, seemingly from nowhere!</span>",
 		"<span class='notice'>We revert our camouflage, revealing ourselves.</span>")
-		H.set_m_intent("run")
+		H.set_m_intent(M_RUN)
 		H.mind.changeling.cloaked = 0
 		H.mind.changeling.chem_recharge_rate = old_regen_rate
 

--- a/code/game/machinery/flasher.dm
+++ b/code/game/machinery/flasher.dm
@@ -98,7 +98,7 @@
 
 	if(istype(AM, /mob/living/carbon))
 		var/mob/living/carbon/M = AM
-		if((M.m_intent != "walk") && (anchored))
+		if((M.m_intent >= M_RUN) && (anchored))
 			flash()
 
 /obj/machinery/flasher/portable/attackby(obj/item/weapon/W as obj, mob/user as mob)

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -323,7 +323,7 @@
 /obj/item/toy/snappop/Crossed(H as mob|obj)
 	if((ishuman(H))) //i guess carp and shit shouldn't set them off
 		var/mob/living/carbon/M = H
-		if(M.m_intent == "run")
+		if(M.m_intent >= M_RUN)
 			M << "<span class='warning'>You step on the snap pop!</span>"
 
 			var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread

--- a/code/game/objects/items/weapons/traps.dm
+++ b/code/game/objects/items/weapons/traps.dm
@@ -99,7 +99,7 @@
 /obj/item/weapon/beartrap/Crossed(AM as mob|obj)
 	if(deployed && isliving(AM))
 		var/mob/living/L = AM
-		if(L.m_intent == "run")
+		if(L.m_intent >= M_RUN)
 			L.visible_message(
 				"<span class='danger'>[L] steps on \the [src].</span>",
 				"<span class='danger'>You step on \the [src]!</span>",

--- a/code/game/turfs/simulated.dm
+++ b/code/game/turfs/simulated.dm
@@ -107,7 +107,7 @@
 			if(H.shoes)
 				var/obj/item/clothing/shoes/S = H.shoes
 				if(istype(S))
-					S.handle_movement(src,(H.m_intent == "run" ? 1 : 0))
+					S.handle_movement(src,(H.m_intent >= M_RUN ? 1 : 0))
 					if(S.track_blood && S.blood_DNA)
 						bloodDNA = S.blood_DNA
 						bloodcolor=S.blood_color
@@ -128,7 +128,7 @@
 
 		if(src.wet)
 
-			if(M.buckled || (src.wet == 1 && M.m_intent == "walk"))
+			if(M.buckled || (src.wet == 1 && M.m_intent <= M_WALK))
 				return
 
 			var/slip_dist = 1

--- a/code/modules/assembly/mousetrap.dm
+++ b/code/modules/assembly/mousetrap.dm
@@ -86,7 +86,7 @@
 	if(armed)
 		if(ishuman(AM))
 			var/mob/living/carbon/H = AM
-			if(H.m_intent == "run")
+			if(H.m_intent >= M_RUN)
 				triggered(H)
 				H.visible_message("<span class='warning'>[H] accidentally steps on [src].</span>", \
 								  "<span class='warning'>You accidentally step on [src]</span>")

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -37,10 +37,15 @@
 	. = ..()
 	if(.)
 		if(src.nutrition && src.stat != 2)
-			src.nutrition -= DEFAULT_HUNGER_FACTOR/10
-			if(src.m_intent == "run")
+			if(src.m_intent == M_SPRINT)
+				src.nutrition -= DEFAULT_HUNGER_FACTOR
+			else if(src.m_intent == M_RUN)
+				src.nutrition -= DEFAULT_HUNGER_FACTOR/5
+			else if(src.m_intent == M_WALK)
 				src.nutrition -= DEFAULT_HUNGER_FACTOR/10
-		if((FAT in src.mutations) && src.m_intent == "run" && src.bodytemperature <= 360)
+			else
+				src.nutrition -= DEFAULT_HUNGER_FACTOR/20
+		if((FAT in src.mutations) && src.m_intent >= M_RUN && src.bodytemperature <= 360)
 			src.bodytemperature += 2
 
 		// Moving around increases germ_level faster

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -164,33 +164,20 @@
 
 // Handle footstep sounds
 /mob/living/carbon/human/handle_footstep(var/turf/T)
-	if(!config.footstep_volume || !T.footstep_sounds || !T.footstep_sounds.len)
+	if(!config.footstep_volume || !T.footstep_sounds || !T.footstep_sounds.len || m_intent == M_STALK)
 		return
-	// Future Upgrades - Multi species support
-	var/list/footstep_sounds = T.footstep_sounds["human"]
-	if(!footstep_sounds)
-		return
-
-	var/S = pick(footstep_sounds)
-	if(!S) return
 
 	// Play every 20 steps while walking, for the sneak
-	if(m_intent == "walk" && step_count++ % 20 != 0)
+	if(m_intent == M_WALK && step_count++ % 20 != 0)
 		return
 
 	// Play every other step while running
-	if(m_intent == "run" && step_count++ % 2 != 0)
+	if(m_intent == M_RUN && step_count++ % 5 != 0)
 		return
 
-	var/volume = config.footstep_volume
-
-	// Reduce volume while walking or barefoot
-	if(!shoes || m_intent == "walk")
-		volume *= 0.5
-	else if(shoes)
-		var/obj/item/clothing/shoes/feet = shoes
-		if(feet)
-			volume *= feet.step_volume_mod
+	// Play every other step while sprinting
+	if(m_intent == M_SPRINT && step_count++ % 2 != 0)
+		return
 
 	if(!has_organ(BP_L_FOOT) && !has_organ(BP_R_FOOT))
 		return // no feet = no footsteps
@@ -200,6 +187,25 @@
 
 	if(!has_gravity(src) && prob(75))
 		return // Far less likely to make noise in no gravity
+
+	// Future Upgrades - Multi species support
+	var/list/footstep_sounds = T.footstep_sounds["human"]
+	if(!footstep_sounds)
+		return
+
+	var/S = pick(footstep_sounds)
+	if(!S)
+		return
+
+	var/volume = config.footstep_volume
+
+	// Reduce volume while walking or barefoot
+	if(!shoes || m_intent <= M_WALK)
+		volume *= 0.5
+	else if(shoes)
+		var/obj/item/clothing/shoes/feet = shoes
+		if(feet)
+			volume *= feet.step_volume_mod
 
 	playsound(T, S, volume, FALSE)
 	return

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -941,8 +941,8 @@ var/global/list/damage_icon_parts = list()
 			standing = image("icon" = 'icons/mob/mob.dmi', "icon_state" = "legcuff1")
 		overlays_standing[LEGCUFF_LAYER] = standing
 
-		if(src.m_intent != "walk")
-			src.m_intent = "walk"
+		if(src.m_intent > M_WALK)
+			src.m_intent = M_WALK
 			if(src.hud_used && src.hud_used.move_intent)
 				src.hud_used.move_intent.icon_state = "walking"
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -124,7 +124,7 @@ default behaviour is:
 		spawn(0)
 			..()
 			if (!istype(AM, /atom/movable) || AM.anchored)
-				if(confused && prob(50) && m_intent=="run")
+				if(confused && prob(50) && m_intent >= M_RUN)
 					Weaken(2)
 					playsound(loc, "punch", 25, 1, -1)
 					visible_message("<span class='warning'>[src] [pick("ran", "slammed")] into \the [AM]!</span>")

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -119,7 +119,7 @@
 	var/shakecamera = 0
 	var/a_intent = I_HELP//Living
 	var/m_int = null//Living
-	var/m_intent = "run"//Living
+	var/m_intent = 3//Living
 	var/lastKnownIP = null
 	var/obj/buckled = null//Living
 

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -267,12 +267,18 @@
 		move_delay = world.time//set move delay
 
 		switch(mob.m_intent)
-			if("run")
+			if(M_SPRINT)
+				if(mob.drowsyness > 0)
+					move_delay += 6
+				move_delay += config.sprint_speed
+			if(M_RUN)
 				if(mob.drowsyness > 0)
 					move_delay += 6
 				move_delay += config.run_speed
-			if("walk")
+			if(M_WALK)
 				move_delay += config.walk_speed
+			if(M_STALK)
+				move_delay += config.stalk_speed
 		move_delay += mob.movement_delay()
 
 		var/tickcomp = 0 //moved this out here so we can use it for vehicles
@@ -309,10 +315,18 @@
 				//drunk wheelchair driving
 				else if(mob.confused)
 					switch(mob.m_intent)
-						if("run")
-							if(prob(50))	direct = turn(direct, pick(90, -90))
-						if("walk")
-							if(prob(25))	direct = turn(direct, pick(90, -90))
+						if(M_SPRINT)
+							if(prob(75))
+								direct = turn(direct, pick(90, -90))
+						if(M_RUN)
+							if(prob(50))
+								direct = turn(direct, pick(90, -90))
+						if(M_WALK)
+							if(prob(25))
+								direct = turn(direct, pick(90, -90))
+						if(M_STALK)
+							if(prob(13))
+								direct = turn(direct, pick(90, -90))
 				move_delay += 2
 				return mob.buckled.relaymove(mob,direct)
 
@@ -354,12 +368,20 @@
 		else
 			if(mob.confused)
 				switch(mob.m_intent)
-					if("run")
+					if(M_SPRINT)
 						if(prob(75))
 							direct = turn(direct, pick(90, -90))
 							n = get_step(mob, direct)
-					if("walk")
+					if(M_RUN)
+						if(prob(50))
+							direct = turn(direct, pick(90, -90))
+							n = get_step(mob, direct)
+					if(M_WALK)
 						if(prob(25))
+							direct = turn(direct, pick(90, -90))
+							n = get_step(mob, direct)
+					if(M_STALK)
+						if(prob(13))
 							direct = turn(direct, pick(90, -90))
 							n = get_step(mob, direct)
 			. = mob.SelfMove(n, direct)

--- a/code/modules/organs/internal/kidneys.dm
+++ b/code/modules/organs/internal/kidneys.dm
@@ -32,5 +32,5 @@
 	if (. >= 2)
 		if(prob(1))
 			owner.custom_pain("You feel extremely tired, like you can't move!",1)
-			owner.m_intent = "walk"
+			owner.m_intent = M_WALK
 			owner.hud_used.move_intent.icon_state = "walking"

--- a/code/modules/projectiles/targeting/targeting_mob.dm
+++ b/code/modules/projectiles/targeting/targeting_mob.dm
@@ -58,9 +58,9 @@
 		trigger_aiming(TARGET_CAN_MOVE)
 
 /mob/living/proc/set_m_intent(var/intent)
-	if (intent != "walk" && intent != "run")
+	if (intent != M_WALK && intent != M_RUN)
 		return 0
 	m_intent = intent
 	if(hud_used)
 		if (hud_used.move_intent)
-			hud_used.move_intent.icon_state = intent == "walk" ? "walking" : "running"
+			hud_used.move_intent.icon_state = intent == M_WALK ? "walking" : "running"

--- a/config/example/game_options.txt
+++ b/config/example/game_options.txt
@@ -44,9 +44,11 @@ REVIVAL_BRAIN_LIFE -1
 ## These values get directly added to values and totals in-game. To speed things up make the number negative, to slow things down, make the number positive.
 
 
-## These modify the run/walk speed of all mobs before the mob-specific modifiers are applied. 
+## These modify the run/walk speed of all mobs before the mob-specific modifiers are applied.
+SPRINT_SPEED 1
 RUN_SPEED 2
-WALK_SPEED 5
+WALK_SPEED 3.5
+STALK_SPEED 5
 
 
 ## The variables below affect the movement of specific mob types.


### PR DESCRIPTION
- Adds support for a "Sprint" walk mode and a "Stalk" walk mode. Sprint is faster than running; Stalk is a slow as current walking, but makes no footsteps.
- Swapped m_intent to a number, rather than a string. Higher numbers mean you're moving faster, so Stalk is 1, Walk is 2, Run is 3, and Sprint is 4. Seems to be working fine.
- Tweaks a whole bunch of related stuff, including (hopefully) optimizing footstep processing.

**TODO:**
- [ ] Needs to be discussed by the Staff
- [ ] Some way to limit the use of Sprint, possibly a Stamina tracker?
- [ ] Allow use of the other two walk modes
- [ ] Flip the Defines, Sprint should be 4