### PR TITLE
Changes the old hyposprays to the new hyposprays.

### DIFF
--- a/code/datums/supplypacks/contraband.dm
+++ b/code/datums/supplypacks/contraband.dm
@@ -63,11 +63,13 @@
 					/obj/item/clothing/suit/storage/vest/heavy/merc,
 					/obj/item/clothing/glasses/night,
 					/obj/item/weapon/storage/box/anti_photons,
-					/obj/item/ammo_magazine/clip/c12g/pellet,				/obj/item/ammo_magazine/clip/c12g
+					/obj/item/ammo_magazine/clip/c12g/pellet,
+					/obj/item/ammo_magazine/clip/c12g
 					),
 			list( //the doc,
 					/obj/item/weapon/storage/firstaid/combat,
-					/obj/item/weapon/gun/projectile/dartgun,				/obj/item/weapon/reagent_containers/hypospray,
+					/obj/item/weapon/gun/projectile/dartgun,
+					/obj/item/weapon/reagent_containers/hypospray/vial,
 					/obj/item/weapon/reagent_containers/glass/bottle/chloralhydrate,
 					/obj/item/weapon/reagent_containers/glass/bottle/cyanide,
 					/obj/item/ammo_magazine/chemdart

--- a/code/datums/supplypacks/contraband.dm
+++ b/code/datums/supplypacks/contraband.dm
@@ -69,7 +69,7 @@
 			list( //the doc,
 					/obj/item/weapon/storage/firstaid/combat,
 					/obj/item/weapon/gun/projectile/dartgun,
-					/obj/item/weapon/reagent_containers/hypospray/vial,
+					/obj/item/weapon/reagent_containers/hypospray,
 					/obj/item/weapon/reagent_containers/glass/bottle/chloralhydrate,
 					/obj/item/weapon/reagent_containers/glass/bottle/cyanide,
 					/obj/item/ammo_magazine/chemdart

--- a/code/datums/supplypacks/medical.dm
+++ b/code/datums/supplypacks/medical.dm
@@ -119,7 +119,7 @@
 			/obj/item/weapon/storage/belt/medical,
 			/obj/item/device/radio/headset/heads/cmo,
 			/obj/item/clothing/under/rank/chief_medical_officer,
-			/obj/item/weapon/reagent_containers/hypospray,
+			/obj/item/weapon/reagent_containers/hypospray/vial,
 			/obj/item/clothing/accessory/stethoscope,
 			/obj/item/clothing/glasses/hud/health,
 			/obj/item/clothing/suit/storage/toggle/labcoat/cmo,

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -440,7 +440,7 @@ datum/objective/steal
 		"a chief medical officer's jumpsuit" = /obj/item/clothing/under/rank/chief_medical_officer,
 		"a head of security's jumpsuit" = /obj/item/clothing/under/rank/head_of_security,
 		"a head of personnel's jumpsuit" = /obj/item/clothing/under/rank/head_of_personnel,
-		"the hypospray" = /obj/item/weapon/reagent_containers/hypospray,
+		"the hypospray" = /obj/item/weapon/reagent_containers/hypospray/vial,
 		"the colony director's pinpointer" = /obj/item/weapon/pinpointer,
 		"an ablative armor vest" = /obj/item/clothing/suit/armor/laserproof,
 	)

--- a/code/game/objects/random/random.dm
+++ b/code/game/objects/random/random.dm
@@ -149,7 +149,7 @@
 				prob(6);/obj/item/weapon/reagent_containers/syringe/antitoxin,
 				prob(1);/obj/item/weapon/reagent_containers/syringe/antiviral,
 				prob(6);/obj/item/weapon/reagent_containers/syringe/inaprovaline,
-				prob(1);/obj/item/weapon/reagent_containers/hypospray,
+				prob(1);/obj/item/weapon/reagent_containers/hypospray/vial,
 				prob(1);/obj/item/weapon/storage/box/freezer,
 				prob(2);/obj/item/stack/nanopaste)
 

--- a/code/game/objects/random/random.dm
+++ b/code/game/objects/random/random.dm
@@ -149,7 +149,7 @@
 				prob(6);/obj/item/weapon/reagent_containers/syringe/antitoxin,
 				prob(1);/obj/item/weapon/reagent_containers/syringe/antiviral,
 				prob(6);/obj/item/weapon/reagent_containers/syringe/inaprovaline,
-				prob(1);/obj/item/weapon/reagent_containers/hypospray/vial,
+				prob(1);/obj/item/weapon/reagent_containers/hypospray,
 				prob(1);/obj/item/weapon/storage/box/freezer,
 				prob(2);/obj/item/stack/nanopaste)
 

--- a/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
@@ -204,7 +204,7 @@
 		new /obj/item/device/radio/headset/heads/cmo(src)
 		new /obj/item/device/radio/headset/heads/cmo/alt(src)
 		new /obj/item/device/flash(src)
-		new /obj/item/weapon/reagent_containers/hypospray(src)
+		new /obj/item/weapon/reagent_containers/hypospray/vial(src)
 		new /obj/item/clothing/suit/storage/hooded/wintercoat/medical(src)
 		new /obj/item/clothing/shoes/boots/winter/medical(src)
 		new /obj/item/weapon/storage/box/freezer(src)

--- a/maps/southern_cross/structures/closets/medical.dm
+++ b/maps/southern_cross/structures/closets/medical.dm
@@ -25,7 +25,7 @@
 		new /obj/item/clothing/gloves/sterile/latex(src)
 		new /obj/item/device/radio/headset/heads/cmo/alt(src)
 		new /obj/item/device/flash(src)
-		new /obj/item/weapon/reagent_containers/hypospray(src)
+		new /obj/item/weapon/reagent_containers/hypospray/vial(src)
 		new /obj/item/weapon/storage/box/freezer(src)
 		new /obj/item/clothing/mask/gas(src)
 		return


### PR DESCRIPTION
All instances that I could find of /obj/item/weapon/reagent_containers/hypospray (the old hypo) are now /obj/item/weapon/reagent_containers/hypospray/vial (the new hypo). This doesn't affect autoinjectors in any way. See #4192 for details.