### PR TITLE
Removes bad meme from hairstyle code

### DIFF
--- a/code/modules/mob/new_player/sprite_accessories.dm
+++ b/code/modules/mob/new_player/sprite_accessories.dm
@@ -324,7 +324,7 @@
 		name = "Overeye Long"
 		icon_state = "hair_longovereye"
 
-	fag
+	flowhair
 		name = "Flow Hair"
 		icon_state = "hair_f"
 


### PR DESCRIPTION
The "flow hair" hairstyle used to be called "fag" in the hairstyle code. It's now called "flowhair".