### PR TITLE
Fixes the severed legs crashing?

### DIFF
--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -293,6 +293,8 @@ var/global/list/damage_icon_parts = list()
 		base_icon = chest.get_icon()
 
 		for(var/obj/item/organ/external/part in organs)
+			if(isnull(part) || part.is_stump())
+				continue
 			var/icon/temp = part.get_icon(skeleton)
 			//That part makes left and right legs drawn topmost and lowermost when human looks WEST or EAST
 			//And no change in rendering for other parts (they icon_position is 0, so goes to 'else' part)


### PR DESCRIPTION
-Hopefully finally yes.
-Got no properly reliable environment to test if it actually fixes the thing, but extensive troubleshooting and pinpointing has eliminated the issue to the rendering of leg icons, which apparently had nothing in it to skip missing ones.
-Thing affects both, living mobs and ghosts alike, and being a cached icon generation also explains why it only happens once and not after the victims have rejoined.