### PR TITLE
Adjusts streamlined (Vey-Med) med voidsuits

### DIFF
--- a/code/datums/supplypacks/voidsuits.dm
+++ b/code/datums/supplypacks/voidsuits.dm
@@ -142,7 +142,7 @@
 			/obj/item/clothing/shoes/magboots = 2,
 			/obj/item/weapon/tank/oxygen = 2
 			)
-	cost = 50
+	cost = 60
 	containertype = "/obj/structure/closet/crate/secure"
 	containername = "Vey-Med Medical voidsuit crate"
 	access = access_medical_equip

--- a/code/modules/clothing/spacesuits/void/station.dm
+++ b/code/modules/clothing/spacesuits/void/station.dm
@@ -150,20 +150,21 @@
 	item_state_slots = list(slot_r_hand_str = "medical_voidsuit_bio", slot_l_hand_str = "medical_voidsuit_bio")
 	armor = list(melee = 45, bullet = 5, laser = 20, energy = 5, bomb = 15, bio = 100, rad = 75)
 
-//Medical Surplus Voidsuit
-/obj/item/clothing/head/helmet/space/void/medical/alt
-	name = "streamlined medical voidsuit helmet"
-	desc = "A trendy, lightly radiation-shielded voidsuit helmet trimmed in a fetching green."
-	icon_state = "rig0-medicalalt"
-	armor = list(melee = 30, bullet = 5, laser = 10,energy = 5, bomb = 5, bio = 100, rad = 60)
-	light_overlay = "helmet_light_dual_green"
+//Medical Streamlined Voidsuit
+	/obj/item/clothing/head/helmet/space/void/medical/alt
+		name = "streamlined medical voidsuit helmet"
+		desc = "A trendy, lightly radiation-shielded voidsuit helmet trimmed in a fetching green."
+		icon_state = "rig0-medicalalt"
+		armor = list(melee = 30, bullet = 5, laser = 20,energy = 5, bomb = 25, bio = 100, rad = 80)
+		light_overlay = "helmet_light_dual_green"
 
-/obj/item/clothing/suit/space/void/medical/alt
-	icon_state = "rig-medicalalt"
-	name = "streamlined medical voidsuit"
-	desc = "A more recent model of Vey-Med voidsuit, featuring the latest in radiation shielding technology, without sacrificing comfort or style."
-	allowed = list(/obj/item/device/flashlight,/obj/item/weapon/tank,/obj/item/device/suit_cooling_unit,/obj/item/weapon/storage/firstaid,/obj/item/device/healthanalyzer,/obj/item/stack/medical)
-	armor = list(melee = 30, bullet = 5, laser = 10,energy = 5, bomb = 5, bio = 100, rad = 60)
+	/obj/item/clothing/suit/space/void/medical/alt
+		icon_state = "rig-medicalalt"
+		name = "streamlined medical voidsuit"
+		desc = "A more recent model of Vey-Med voidsuit, featuring the latest in radiation shielding technology, without sacrificing comfort or style."
+		allowed = list(/obj/item/device/flashlight,/obj/item/weapon/tank,/obj/item/device/suit_cooling_unit,/obj/item/weapon/storage/firstaid,/obj/item/device/healthanalyzer,/obj/item/stack/medical,/obj/item/weapon/reagent_containers/hypospray,/obj/item/weapon/reagent_containers/glass,/obj/item/weapon/storage/pill_bottle,/obj/item/roller,/obj/item/bodybag/cryobag)
+		slowdown = 0
+		armor = list(melee = 30, bullet = 5, laser = 20,energy = 5, bomb = 25, bio = 100, rad = 80)
 
 //Security
 /obj/item/clothing/head/helmet/space/void/security

--- a/code/modules/clothing/spacesuits/void/station.dm
+++ b/code/modules/clothing/spacesuits/void/station.dm
@@ -151,20 +151,19 @@
 	armor = list(melee = 45, bullet = 5, laser = 20, energy = 5, bomb = 15, bio = 100, rad = 75)
 
 //Medical Streamlined Voidsuit
-	/obj/item/clothing/head/helmet/space/void/medical/alt
-		name = "streamlined medical voidsuit helmet"
-		desc = "A trendy, lightly radiation-shielded voidsuit helmet trimmed in a fetching green."
-		icon_state = "rig0-medicalalt"
-		armor = list(melee = 30, bullet = 5, laser = 20,energy = 5, bomb = 25, bio = 100, rad = 80)
-		light_overlay = "helmet_light_dual_green"
+/obj/item/clothing/head/helmet/space/void/medical/alt
+	name = "streamlined medical voidsuit helmet"
+	desc = "A trendy, lightly radiation-shielded voidsuit helmet trimmed in a fetching green."
+	icon_state = "rig0-medicalalt"
+	armor = list(melee = 30, bullet = 5, laser = 20,energy = 5, bomb = 25, bio = 100, rad = 80)
+	light_overlay = "helmet_light_dual_green"
 
-	/obj/item/clothing/suit/space/void/medical/alt
-		icon_state = "rig-medicalalt"
-		name = "streamlined medical voidsuit"
-		desc = "A more recent model of Vey-Med voidsuit, featuring the latest in radiation shielding technology, without sacrificing comfort or style."
-		allowed = list(/obj/item/device/flashlight,/obj/item/weapon/tank,/obj/item/device/suit_cooling_unit,/obj/item/weapon/storage/firstaid,/obj/item/device/healthanalyzer,/obj/item/stack/medical,/obj/item/weapon/reagent_containers/hypospray,/obj/item/weapon/reagent_containers/glass,/obj/item/weapon/storage/pill_bottle,/obj/item/roller,/obj/item/bodybag/cryobag)
-		slowdown = 0
-		armor = list(melee = 30, bullet = 5, laser = 20,energy = 5, bomb = 25, bio = 100, rad = 80)
+/obj/item/clothing/suit/space/void/medical/alt
+	icon_state = "rig-medicalalt"
+	name = "streamlined medical voidsuit"
+	desc = "A more recent model of Vey-Med voidsuit, featuring the latest in radiation shielding technology, without sacrificing comfort or style."
+	slowdown = 0
+	armor = list(melee = 30, bullet = 5, laser = 20,energy = 5, bomb = 25, bio = 100, rad = 80)
 
 //Security
 /obj/item/clothing/head/helmet/space/void/security


### PR DESCRIPTION
So, those streamlined voidsuits you can get from Cargo, the green ones made by Vey-Med? The 'streamlined' ones? They weren't streamlined. They're streamlined now.

- Slowdown removed! They're lighter and faster and, well, streamlined.
- Radiation shielding improved! It's in the examine text, after all. Still not 100% radproof, though.
- Marginally better at taking lasers and bomb impacts! Made of flexible, but durable, VeyMed materials.
- Costs 60 Cargo points, up from 50! They're better now, and actually worth buying.

Yeah, this means that streamlined voidsuits + clotting agent = 100 points = Medical's entire department budget.