### PR TITLE
Grid checker is now dense and anchored

### DIFF
--- a/code/modules/power/grid_checker.dm
+++ b/code/modules/power/grid_checker.dm
@@ -4,6 +4,8 @@
 	than the alternative."
 	icon_state = "gridchecker_on"
 	circuit = /obj/item/weapon/circuitboard/grid_checker
+	density = 1
+	anchored = 1
 	var/power_failing = FALSE // Turns to TRUE when the grid check event is fired by the Game Master, or perhaps a cheeky antag.
 	// Wire stuff below.
 	var/datum/wires/grid_checker/wires


### PR DESCRIPTION
Per request ( @MisterLayne ). It's that big blue box engineers can mess with to fix the grid check random event, apparently. Definitely [looks like it should be dense and anchored](https://cdn.discordapp.com/attachments/176163422751293441/377598902062546944/unknown.png).