### PR TITLE
Fixes #4238.

### DIFF
--- a/code/modules/mob/living/carbon/alien/alien_attacks.dm
+++ b/code/modules/mob/living/carbon/alien/alien_attacks.dm
@@ -15,7 +15,7 @@
 		if (I_GRAB)
 			if (M == src)
 				return
-			var/obj/item/weapon/grab/G = new /obj/item/weapon/grab( M, M, src )
+			var/obj/item/weapon/grab/G = new /obj/item/weapon/grab( M, src )
 
 			M.put_in_active_hand(G)
 


### PR DESCRIPTION
This has got to be too good to be true...
Looks like there was a copy/paste error, or something. Had to replace `M, M, src` with `M, src`.