### PR TITLE
Un-duplicates head marking cache generation.

### DIFF
--- a/code/modules/organs/organ_icon.dm
+++ b/code/modules/organs/organ_icon.dm
@@ -71,7 +71,7 @@ var/global/list/limb_icon_cache = list()
 		overlays |= lip_icon
 		mob_icon.Blend(lip_icon, ICON_OVERLAY)
 
-	//Head markings, duplicated (sadly) below.
+	//Head markings.
 	for(var/M in markings)
 		var/datum/sprite_accessory/marking/mark_style = markings[M]["datum"]
 		var/icon/mark_s = new/icon("icon" = mark_style.icon, "icon_state" = "[mark_style.icon_state]-[organ_tag]")
@@ -132,14 +132,15 @@ var/global/list/limb_icon_cache = list()
 				mob_icon = new /icon(species.get_icobase(owner, (status & ORGAN_MUTATED)), "[icon_name][gender ? "_[gender]" : ""]")
 				apply_colouration(mob_icon)
 
-			//Body markings, does not include head, duplicated (sadly) above.
-			for(var/M in markings)
-				var/datum/sprite_accessory/marking/mark_style = markings[M]["datum"]
-				var/icon/mark_s = new/icon("icon" = mark_style.icon, "icon_state" = "[mark_style.icon_state]-[organ_tag]")
-				mark_s.Blend(markings[M]["color"], ICON_ADD)
-				overlays |= mark_s //So when it's not on your body, it has icons
-				mob_icon.Blend(mark_s, ICON_OVERLAY) //So when it's on your body, it has icons
-				icon_cache_key += "[M][markings[M]["color"]]"
+			//Body markings, does not include head, that shit's above.
+			if(!istype(src,/obj/item/organ/external/head))
+				for(var/M in markings)
+					var/datum/sprite_accessory/marking/mark_style = markings[M]["datum"]
+					var/icon/mark_s = new/icon("icon" = mark_style.icon, "icon_state" = "[mark_style.icon_state]-[organ_tag]")
+					mark_s.Blend(markings[M]["color"], ICON_ADD)
+					overlays |= mark_s //So when it's not on your body, it has icons
+					mob_icon.Blend(mark_s, ICON_OVERLAY) //So when it's on your body, it has icons
+					icon_cache_key += "[M][markings[M]["color"]]"
 
 			if(body_hair && islist(h_col) && h_col.len >= 3)
 				var/cache_key = "[body_hair]-[icon_name]-[h_col[1]][h_col[2]][h_col[3]]"

--- a/code/modules/organs/organ_icon.dm
+++ b/code/modules/organs/organ_icon.dm
@@ -132,7 +132,7 @@ var/global/list/limb_icon_cache = list()
 				mob_icon = new /icon(species.get_icobase(owner, (status & ORGAN_MUTATED)), "[icon_name][gender ? "_[gender]" : ""]")
 				apply_colouration(mob_icon)
 
-			//Body markings, does not include head, that shit's above.
+			//Body markings, actually does not include head this time. Done separately above.
 			if(!istype(src,/obj/item/organ/external/head))
 				for(var/M in markings)
 					var/datum/sprite_accessory/marking/mark_style = markings[M]["datum"]


### PR DESCRIPTION
-Organ icon generation for heads no longer adds the markings list into the cache key twice.
-Actually does exclude heads from the parent caching for limb markings instead of counting on mere comment-format thoughts and prayers.
-Related to similar dismemberment crashes as the earlier organ cache issue fixes.