### PR TITLE
AI verbs are no longer hidden

### DIFF
--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -17,10 +17,6 @@ var/list/ai_verbs_default = list(
 	/mob/living/silicon/ai/proc/show_laws_verb,
 	/mob/living/silicon/ai/proc/toggle_acceleration,
 	/mob/living/silicon/ai/proc/toggle_hologram_movement,
-	/mob/living/silicon/ai/proc/toggle_hidden_verbs,
-)
-
-var/list/ai_verbs_hidden = list( // For why this exists, refer to https://xkcd.com/1172/,
 	/mob/living/silicon/ai/proc/ai_announcement,
 	/mob/living/silicon/ai/proc/ai_call_shuttle,
 	/mob/living/silicon/ai/proc/ai_camera_track,
@@ -794,17 +790,6 @@ var/list/ai_verbs_hidden = list( // For why this exists, refer to https://xkcd.c
 	var/obj/item/weapon/rig/rig = src.get_rig()
 	if(rig)
 		rig.force_rest(src)
-
-/mob/living/silicon/ai/proc/toggle_hidden_verbs()
-	set name = "Toggle Hidden Verbs"
-	set category = "AI Settings"
-
-	if(/mob/living/silicon/ai/proc/ai_announcement in verbs)
-		src << "Extra verbs toggled off."
-		verbs -= ai_verbs_hidden
-	else
-		src << "Extra verbs toggled on."
-		verbs |= ai_verbs_hidden
 
 #undef AI_CHECK_WIRELESS
 #undef AI_CHECK_RADIO

--- a/html/changelogs/Atermonera-AI_verbs.yml
+++ b/html/changelogs/Atermonera-AI_verbs.yml
@@ -1,0 +1,4 @@
+author: Atermonera
+delete-after: True
+changes: 
+  - bugfix: "AI verbs are no longer hidden on the tabs."


### PR DESCRIPTION
Hiding stuff from players is bad, mmmkay. #4251 
Tested:
![AI Commands](https://puu.sh/yjlOR/8550cfc0b8.png)
![AI IM](https://puu.sh/yjlPw/24876072f7.png)
![AI Settings](https://puu.sh/yjlQ2/06e5baa68f.png)

Didn't rearrange the verbs on the tabs at all.
