### PR TITLE
Decapitation now stops defibrillation

### DIFF
--- a/code/game/objects/items/devices/defib.dm
+++ b/code/game/objects/items/devices/defib.dm
@@ -284,7 +284,7 @@
 		return "buzzes, \"Resuscitation failed - Excessive neural degeneration. Further attempts futile.\""
 
 	H.updatehealth()
-	if(H.health + H.getOxyLoss() <= config.health_threshold_dead || (HUSK in H.mutations))
+	if(H.health + H.getOxyLoss() <= config.health_threshold_dead || (HUSK in H.mutations) || (!H.isSynthetic() && !H.can_defib))
 		return "buzzes, \"Resuscitation failed - Severe tissue damage makes recovery of patient impossible via defibrillator. Further attempts futile.\""
 
 	var/bad_vital_organ = check_vital_organs(H)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -15,6 +15,8 @@
 	var/spit_name = null //String
 	var/last_spit = 0 //Timestamp.
 
+	var/can_defib = 1	//Horrible damage (like beheadings) will prevent defibbing organics.
+
 /mob/living/carbon/human/New(var/new_loc, var/new_species = null)
 
 	if(!dna)

--- a/code/modules/organs/subtypes/standard.dm
+++ b/code/modules/organs/subtypes/standard.dm
@@ -279,6 +279,8 @@
 		spawn(1)
 			owner.update_hair()
 	get_icon()
+	if(vital)	//This is just in case we ever add something that both a) Doesn't need a head to live, and b) Can be defibbed
+		owner.can_defib = 0
 	..()
 
 /obj/item/organ/external/head/take_damage(brute, burn, sharp, edge, used_weapon = null, list/forbidden_limbs = list())


### PR DESCRIPTION
As per the title, decapitating an organic victim will prevent them from being defibbed.
Synthetics should still be fine, if a little worse for wear