### PR TITLE
Makes Icon Scaling Great

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -1,6 +1,6 @@
 /atom/movable
 	layer = 3
-	appearance_flags = TILE_BOUND
+	appearance_flags = TILE_BOUND|PIXEL_SCALE
 	var/last_move = null
 	var/anchored = 0
 	// var/elevation = 2    - not used anywhere
@@ -15,7 +15,7 @@
 	var/moved_recently = 0
 	var/mob/pulledby = null
 	var/item_state = null // Used to specify the item state for the on-mob overlays.
-
+	var/icon_scale = 1 // Used to scale icons up or down in update_transform().
 	var/auto_init = 1
 
 /atom/movable/New()
@@ -296,3 +296,12 @@
 		return null
 	return text2num(pickweight(candidates))
 
+/atom/movable/proc/update_transform()
+	var/matrix/M = matrix()
+	M.Scale(icon_scale)
+	src.transform = M
+
+// Use this to set the object's scale.
+/atom/movable/proc/adjust_scale(new_scale)
+	icon_scale = new_scale
+	update_transform()

--- a/code/modules/client/preference_setup/traits/trait_defines.dm
+++ b/code/modules/client/preference_setup/traits/trait_defines.dm
@@ -72,6 +72,25 @@
 	Regardless, you find it quite difficult to land shots where you wanted them to go."
 	modifier_type = /datum/modifier/trait/inaccurate
 
+/datum/trait/modifier/physical/smaller
+	name = "Smaller"
+	modifier_type = /datum/modifier/trait/smaller
+	mutually_exclusive = list(/datum/trait/modifier/physical/small, /datum/trait/modifier/physical/large, /datum/trait/modifier/physical/larger)
+
+/datum/trait/modifier/physical/small
+	name = "Small"
+	modifier_type = /datum/modifier/trait/small
+	mutually_exclusive = list(/datum/trait/modifier/physical/smaller, /datum/trait/modifier/physical/large, /datum/trait/modifier/physical/larger)
+
+/datum/trait/modifier/physical/large
+	name = "Large"
+	modifier_type = /datum/modifier/trait/large
+	mutually_exclusive = list(/datum/trait/modifier/physical/smaller, /datum/trait/modifier/physical/small, /datum/trait/modifier/physical/larger)
+
+/datum/trait/modifier/physical/larger
+	name = "Larger"
+	modifier_type = /datum/modifier/trait/larger
+	mutually_exclusive = list(/datum/trait/modifier/physical/smaller, /datum/trait/modifier/physical/small, /datum/trait/modifier/physical/large)
 
 // These two traits might be borderline, feel free to remove if they get abused.
 /datum/trait/modifier/physical/high_metabolism

--- a/code/modules/mob/_modifiers/modifiers.dm
+++ b/code/modules/mob/_modifiers/modifiers.dm
@@ -41,6 +41,7 @@
 	var/accuracy						// Positive numbers makes hitting things with guns easier, negatives make it harder.  Each point makes it 15% easier or harder, just like evasion.
 	var/accuracy_dispersion				// Positive numbers make gun firing cover a wider tile range, and therefore more inaccurate.  Negatives help negate dispersion penalties.
 	var/metabolism_percent				// Adjusts the mob's metabolic rate, which affects reagent processing.  Won't affect mobs without reagent processing.
+	var/icon_scale_percent				// Makes the holder's icon get scaled up or down.
 
 /datum/modifier/New(var/new_holder, var/new_origin)
 	holder = new_holder
@@ -62,6 +63,8 @@
 	holder.modifiers.Remove(src)
 	if(mob_overlay_state) // We do this after removing ourselves from the list so that the overlay won't remain.
 		holder.update_modifier_visuals()
+	if(icon_scale_percent) // Correct the scaling.
+		holder.update_transform()
 	qdel(src)
 
 // Override this for special effects when it gets removed.
@@ -117,6 +120,8 @@
 	modifiers.Add(mod)
 	if(mod.mob_overlay_state)
 		update_modifier_visuals()
+	if(mod.icon_scale_percent)
+		update_transform()
 
 	return mod
 
@@ -198,6 +203,8 @@
 		effects += "Your metabolism is [metabolism_percent > 1.0 ? "faster" : "slower"], \
 		causing reagents in your body to process, and hunger to occur [multipler_to_percentage(metabolism_percent, TRUE)] [metabolism_percent > 1.0 ? "faster" : "slower"]."
 
+	if(!isnull(icon_scale_percent))
+		effects += "Your appearance is [multipler_to_percentage(icon_scale_percent, TRUE)] [icon_scale_percent > 1 ? "larger" : "smaller"]."
 
 	return jointext(effects, "<br>")
 

--- a/code/modules/mob/_modifiers/traits.dm
+++ b/code/modules/mob/_modifiers/traits.dm
@@ -59,3 +59,27 @@
 
 	metabolism_percent = 0.5
 	incoming_healing_percent = 0.6
+
+/datum/modifier/trait/larger
+	name = "Larger"
+	desc = "Your body is larger than average."
+
+	icon_scale_percent = 1.2
+
+/datum/modifier/trait/large
+	name = "Large"
+	desc = "Your body is a bit larger than average."
+
+	icon_scale_percent = 1.1
+
+/datum/modifier/trait/small
+	name = "Small"
+	desc = "Your body is a bit smaller than average."
+
+	icon_scale_percent = 0.95
+
+/datum/modifier/trait/smaller
+	name = "Smaller"
+	desc = "Your body is smaller than average."
+
+	icon_scale_percent = 0.9

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1134,6 +1134,9 @@
 	if(species.default_language)
 		add_language(species.default_language)
 
+	if(species.icon_scale != 1)
+		update_transform()
+
 	if(species.base_color && default_colour)
 		//Apply colour.
 		r_skin = hex2num(copytext(species.base_color,2,4))

--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -29,7 +29,6 @@
 	var/g_synth							//Same as above
 	var/b_synth							//Same as above
 
-	var/size_multiplier = 1 //multiplier for the mob's icon size
 	var/damage_multiplier = 1 //multiplies melee combat damage
 	var/icon_update = 1 //whether icon updating shall take place
 

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -30,6 +30,8 @@
 	var/tail_animation                                   // If set, the icon to obtain tail animation states from.
 	var/tail_hair
 
+	var/icon_scale = 1                                   // Makes the icon larger/smaller.
+
 	var/race_key = 0       	                             // Used for mob icon cache string.
 	var/icon/icon_template                               // Used for mob icon generation for non-32x32 species.
 	var/mob_size	= MOB_MEDIUM

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -159,16 +159,29 @@ Please contact me on #coderbus IRC. ~Carn x
 				for(var/inner_entry in entry)
 					overlays += inner_entry
 
+	update_transform()
+
+/mob/living/carbon/human/update_transform()
+	// First, get the correct size.
+	var/desired_scale = icon_scale
+
+	desired_scale *= species.icon_scale
+
+	for(var/datum/modifier/M in modifiers)
+		if(!isnull(M.icon_scale_percent))
+			desired_scale *= M.icon_scale_percent
+
+	// Regular stuff again.
 	if(lying && !species.prone_icon) //Only rotate them if we're not drawing a specific icon for being prone.
 		var/matrix/M = matrix()
 		M.Turn(90)
-		M.Scale(size_multiplier)
+		M.Scale(desired_scale)
 		M.Translate(1,-6)
 		src.transform = M
 	else
 		var/matrix/M = matrix()
-		M.Scale(size_multiplier)
-		M.Translate(0, 16*(size_multiplier-1))
+		M.Scale(desired_scale)
+		M.Translate(0, 16*(desired_scale-1))
 		src.transform = M
 
 var/global/list/damage_icon_parts = list()

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1004,3 +1004,17 @@ default behaviour is:
 // Called by job_controller.
 /mob/living/proc/equip_post_job()
 	return
+
+
+/mob/living/update_transform()
+	// First, get the correct size.
+	var/desired_scale = icon_scale
+	for(var/datum/modifier/M in modifiers)
+		if(!isnull(M.icon_scale_percent))
+			desired_scale *= M.icon_scale_percent
+
+	// Now for the regular stuff.
+	var/matrix/M = matrix()
+	M.Scale(desired_scale)
+	M.Translate(0, 16*(desired_scale-1))
+	src.transform = M


### PR DESCRIPTION
Scaling wasn't great before so no Again.
Makes most icons not get blurry when scaled.
Makes all /atom/movable s able to be scaled with the adjust_scale() proc.
Adds ability for species to get scaled automatically.  Currently no species does this, but it is an option in the future.
Adds four traits to adjust your mob scale.  It is purely cosmetic at this time.
![Demo](https://i.imgur.com/zXUCR0b.png)
![Traits](https://puu.sh/ymbON/c6f89eac7b.png)