### PR TITLE
Fixes Bandage Spam Exploit

### DIFF
--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -75,11 +75,11 @@
 		var/obj/item/organ/external/affecting = H.get_organ(user.zone_sel.selecting)
 
 		if(affecting.open)
-			user << "<span class='notice'>The [affecting.name] is cut open, you'll need more than a bandage!</span>"
+			to_chat(user, "<span class='notice'>The [affecting.name] is cut open, you'll need more than a bandage!</span>")
 			return
 
 		if(affecting.is_bandaged())
-			user << "<span class='warning'>The wounds on [M]'s [affecting.name] have already been bandaged.</span>"
+			to_chat(user, "<span class='warning'>The wounds on [M]'s [affecting.name] have already been bandaged.</span>")
 			return 1
 		else
 			user.visible_message("<span class='notice'>\The [user] starts treating [M]'s [affecting.name].</span>", \
@@ -93,8 +93,12 @@
 				if(used == amount)
 					break
 				if(!do_mob(user, M, W.damage/5))
-					user << "<span class='notice'>You must stand still to bandage wounds.</span>"
+					to_chat(user, "<span class='notice'>You must stand still to bandage wounds.</span>")
 					break
+
+				if(affecting.is_bandaged()) // We do a second check after the delay, in case it was bandaged after the first check.
+					to_chat(user, "<span class='warning'>The wounds on [M]'s [affecting.name] have already been bandaged.</span>")
+					return 1
 
 				if (W.current_stage <= W.max_bleeding_stage)
 					user.visible_message("<span class='notice'>\The [user] bandages \a [W.desc] on [M]'s [affecting.name].</span>", \
@@ -111,9 +115,9 @@
 			affecting.update_damages()
 			if(used == amount)
 				if(affecting.is_bandaged())
-					user << "<span class='warning'>\The [src] is used up.</span>"
+					to_chat(user, "<span class='warning'>\The [src] is used up.</span>")
 				else
-					user << "<span class='warning'>\The [src] is used up, but there are more wounds to treat on \the [affecting.name].</span>"
+					to_chat(user, "<span class='warning'>\The [src] is used up, but there are more wounds to treat on \the [affecting.name].</span>")
 			use(used)
 
 /obj/item/stack/medical/ointment
@@ -135,17 +139,20 @@
 		var/obj/item/organ/external/affecting = H.get_organ(user.zone_sel.selecting)
 
 		if(affecting.open)
-			user << "<span class='notice'>The [affecting.name] is cut open, you'll need more than a bandage!</span>"
+			to_chat(user, "<span class='notice'>The [affecting.name] is cut open, you'll need more than a bandage!</span>")
 			return
 
 		if(affecting.is_salved())
-			user << "<span class='warning'>The wounds on [M]'s [affecting.name] have already been salved.</span>"
+			to_chat(user, "<span class='warning'>The wounds on [M]'s [affecting.name] have already been salved.</span>")
 			return 1
 		else
 			user.visible_message("<span class='notice'>\The [user] starts salving wounds on [M]'s [affecting.name].</span>", \
 					             "<span class='notice'>You start salving the wounds on [M]'s [affecting.name].</span>" )
 			if(!do_mob(user, M, 10))
-				user << "<span class='notice'>You must stand still to salve wounds.</span>"
+				to_chat(user, "<span class='notice'>You must stand still to salve wounds.</span>")
+				return 1
+			if(affecting.is_salved()) // We do a second check after the delay, in case it was bandaged after the first check.
+				to_chat(user, "<span class='warning'>The wounds on [M]'s [affecting.name] have already been salved.</span>")
 				return 1
 			user.visible_message("<span class='notice'>[user] salved wounds on [M]'s [affecting.name].</span>", \
 			                         "<span class='notice'>You salved wounds on [M]'s [affecting.name].</span>" )
@@ -169,11 +176,11 @@
 		var/obj/item/organ/external/affecting = H.get_organ(user.zone_sel.selecting)
 
 		if(affecting.open)
-			user << "<span class='notice'>The [affecting.name] is cut open, you'll need more than a bandage!</span>"
+			to_chat(user, "<span class='notice'>The [affecting.name] is cut open, you'll need more than a bandage!</span>")
 			return
 
 		if(affecting.is_bandaged() && affecting.is_disinfected())
-			user << "<span class='warning'>The wounds on [M]'s [affecting.name] have already been treated.</span>"
+			to_chat(user, "<span class='warning'>The wounds on [M]'s [affecting.name] have already been treated.</span>")
 			return 1
 		else
 			user.visible_message("<span class='notice'>\The [user] starts treating [M]'s [affecting.name].</span>", \
@@ -187,8 +194,11 @@
 				if(used == amount)
 					break
 				if(!do_mob(user, M, W.damage/5))
-					user << "<span class='notice'>You must stand still to bandage wounds.</span>"
+					to_chat(user, "<span class='notice'>You must stand still to bandage wounds.</span>")
 					break
+				if(affecting.is_bandaged() && affecting.is_disinfected()) // We do a second check after the delay, in case it was bandaged after the first check.
+					to_chat(user, "<span class='warning'>The wounds on [M]'s [affecting.name] have already been bandaged.</span>")
+					return 1
 				if (W.current_stage <= W.max_bleeding_stage)
 					user.visible_message("<span class='notice'>\The [user] cleans \a [W.desc] on [M]'s [affecting.name] and seals the edges with bioglue.</span>", \
 					                     "<span class='notice'>You clean and seal \a [W.desc] on [M]'s [affecting.name].</span>" )
@@ -205,9 +215,9 @@
 			affecting.update_damages()
 			if(used == amount)
 				if(affecting.is_bandaged())
-					user << "<span class='warning'>\The [src] is used up.</span>"
+					to_chat(user, "<span class='warning'>\The [src] is used up.</span>")
 				else
-					user << "<span class='warning'>\The [src] is used up, but there are more wounds to treat on \the [affecting.name].</span>"
+					to_chat(user, "<span class='warning'>\The [src] is used up, but there are more wounds to treat on \the [affecting.name].</span>")
 			use(used)
 
 /obj/item/stack/medical/advanced/ointment
@@ -228,16 +238,19 @@
 		var/obj/item/organ/external/affecting = H.get_organ(user.zone_sel.selecting)
 
 		if(affecting.open)
-			user << "<span class='notice'>The [affecting.name] is cut open, you'll need more than a bandage!</span>"
+			to_chat(user, "<span class='notice'>The [affecting.name] is cut open, you'll need more than a bandage!</span>")
 
 		if(affecting.is_salved())
-			user << "<span class='warning'>The wounds on [M]'s [affecting.name] have already been salved.</span>"
+			to_chat(user, "<span class='warning'>The wounds on [M]'s [affecting.name] have already been salved.</span>")
 			return 1
 		else
 			user.visible_message("<span class='notice'>\The [user] starts salving wounds on [M]'s [affecting.name].</span>", \
 					             "<span class='notice'>You start salving the wounds on [M]'s [affecting.name].</span>" )
 			if(!do_mob(user, M, 10))
-				user << "<span class='notice'>You must stand still to salve wounds.</span>"
+				to_chat(user, "<span class='notice'>You must stand still to salve wounds.</span>")
+				return 1
+			if(affecting.is_salved()) // We do a second check after the delay, in case it was bandaged after the first check.
+				to_chat(user, "<span class='warning'>The wounds on [M]'s [affecting.name] have already been salved.</span>")
 				return 1
 			user.visible_message( 	"<span class='notice'>[user] covers wounds on [M]'s [affecting.name] with regenerative membrane.</span>", \
 									"<span class='notice'>You cover wounds on [M]'s [affecting.name] with regenerative membrane.</span>" )
@@ -264,20 +277,23 @@
 		var/obj/item/organ/external/affecting = H.get_organ(user.zone_sel.selecting)
 		var/limb = affecting.name
 		if(!(affecting.organ_tag in splintable_organs))
-			user << "<span class='danger'>You can't use \the [src] to apply a splint there!</span>"
+			to_chat(user, "<span class='danger'>You can't use \the [src] to apply a splint there!</span>")
 			return
 		if(affecting.splinted)
-			user << "<span class='danger'>[M]'s [limb] is already splinted!</span>"
+			to_chat(user, "<span class='danger'>[M]'s [limb] is already splinted!</span>")
 			return
 		if (M != user)
 			user.visible_message("<span class='danger'>[user] starts to apply \the [src] to [M]'s [limb].</span>", "<span class='danger'>You start to apply \the [src] to [M]'s [limb].</span>", "<span class='danger'>You hear something being wrapped.</span>")
 		else
 			if(( !user.hand && (affecting.organ_tag in list(BP_R_ARM, BP_R_HAND)) || \
 				user.hand && (affecting.organ_tag in list(BP_L_ARM, BP_L_HAND)) ))
-				user << "<span class='danger'>You can't apply a splint to the arm you're using!</span>"
+				to_chat(user, "<span class='danger'>You can't apply a splint to the arm you're using!</span>")
 				return
 			user.visible_message("<span class='danger'>[user] starts to apply \the [src] to their [limb].</span>", "<span class='danger'>You start to apply \the [src] to your [limb].</span>", "<span class='danger'>You hear something being wrapped.</span>")
 		if(do_after(user, 50, M))
+			if(affecting.splinted)
+				to_chat(user, "<span class='danger'>[M]'s [limb] is already splinted!</span>")
+				return
 			if(M == user && prob(75))
 				user.visible_message("<span class='danger'>\The [user] fumbles [src].</span>", "<span class='danger'>You fumble [src].</span>", "<span class='danger'>You hear something being wrapped.</span>")
 				return


### PR DESCRIPTION
Removes ability to circumvent bandage limits by spamclicking someone. The check if its already bandaged is done twice, once at the start and once after the delay.
Should note this should not impede bandaging multiple wounds, rather it prevents bandaging the same wound if its already bandaged.
Replaces a lot of user << with to_chat().
Fixes #4263 
![Demo](https://i.imgur.com/dt3PDJS.png)