### PR TITLE
Nanopaste Tweaks

### DIFF
--- a/code/game/objects/items/stacks/nanopaste.dm
+++ b/code/game/objects/items/stacks/nanopaste.dm
@@ -6,6 +6,7 @@
 	icon_state = "nanopaste"
 	origin_tech = list(TECH_MATERIAL = 4, TECH_ENGINEERING = 3)
 	amount = 10
+	toolspeed = 0.75 //Used in surgery, shouldn't be the same speed as a normal screwdriver on mechanical organ repair.
 	w_class = ITEMSIZE_SMALL
 	no_variants = FALSE
 
@@ -14,12 +15,13 @@
 		return 0
 	if (istype(M,/mob/living/silicon/robot))	//Repairing cyborgs
 		var/mob/living/silicon/robot/R = M
-		if (R.getBruteLoss() || R.getFireLoss() )
-			R.adjustBruteLoss(-15)
-			R.adjustFireLoss(-15)
-			R.updatehealth()
-			use(1)
-			user.visible_message("<span class='notice'>\The [user] applied some [src] on [R]'s damaged areas.</span>",\
+		if (R.getBruteLoss() || R.getFireLoss())
+			if(do_after(user,7 * toolspeed))
+				R.adjustBruteLoss(-15)
+				R.adjustFireLoss(-15)
+				R.updatehealth()
+				use(1)
+				user.visible_message("<span class='notice'>\The [user] applied some [src] on [R]'s damaged areas.</span>",\
 				"<span class='notice'>You apply some [src] at [R]'s damaged areas.</span>")
 		else
 			user << "<span class='notice'>All [R]'s systems are nominal.</span>"
@@ -28,14 +30,17 @@
 		var/mob/living/carbon/human/H = M
 		var/obj/item/organ/external/S = H.get_organ(user.zone_sel.selecting)
 
-		if(S.open >= 2)
-			if (S && (S.robotic >= ORGAN_ROBOT))
-				if(!S.get_damage())
-					user << "<span class='notice'>Nothing to fix here.</span>"
-				else if(can_use(1))
-					user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
-					S.heal_damage(15, 15, robo_repair = 1)
-					H.updatehealth()
-					use(1)
-					user.visible_message("<span class='notice'>\The [user] applies some nanite paste on [user != M ? "[M]'s [S.name]" : "[S]"] with [src].</span>",\
-					"<span class='notice'>You apply some nanite paste on [user == M ? "your" : "[M]'s"] [S.name].</span>")
+		if (S && (S.robotic >= ORGAN_ROBOT))
+			if(!S.get_damage())
+				user << "<span class='notice'>Nothing to fix here.</span>"
+			else if(can_use(1))
+				user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
+				if(S.open >= 2)
+					if(do_after(user,5 * toolspeed))
+						S.heal_damage(20, 20, robo_repair = 1)
+				else if(do_after(user,5 * toolspeed))
+					S.heal_damage(10,10, robo_repair =1)
+				H.updatehealth()
+				use(1)
+				user.visible_message("<span class='notice'>\The [user] applies some nanite paste on [user != M ? "[M]'s [S.name]" : "[S]"] with [src].</span>",\
+				"<span class='notice'>You apply some nanite paste on [user == M ? "your" : "[M]'s"] [S.name].</span>")


### PR DESCRIPTION
Nanopaste now functions as an advanced damage kit for FBPs. Again.
Nanopaste now repairs 20 burn/brute in open-repair, double the normal 10/10 repair.
Nanopaste ignores the damage limit of welders and cable coils, but is still more effective when used as a surgical repair.
Nanopaste is now faster than a screwdriver when repairing robotic organs, since it isn't the person doing the repair, it's nanites.
Nanopaste now has a minor use delay, most noticeable for borgs.