### PR TITLE
Fixes one player being able to hog every slot of a job alone.

### DIFF
--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -74,7 +74,7 @@ var/global/datum/controller/occupations/job_master
 
 	proc/FreeRole(var/rank)	//making additional slot on the fly
 		var/datum/job/job = GetJob(rank)
-		if(job && job.current_positions >= job.total_positions && job.total_positions != -1)
+		if(job && job.total_positions != -1)
 			job.total_positions++
 			return 1
 		return 0


### PR DESCRIPTION
-Apparently the FreeRole proc that is called when people cryo out and whatnot only frees up _**one**_ single slot and **_only_** if the job slots are already full. What this means is that say, we have a 3 slot job, and one person joins, leaves, and rejoins into the job 3 times, the one person will have filled up the entire job until they leave, which even then only reopens one slot. It doesn't even have to be the same person. Like 3 people join the job, fill the 3 slots, and then leave, only one slot opens, making the role only fit one player at a time beyond that point.
-Leaving does not deduct from the current_positions count (shown as the number on join menu before the "active" number, meaning it also counts the people who have already left and so on) and the FreeRole only pops a slot open if the person leaving took the last one.

Basically it's been like, 3 people join the job, 3 people leave the job, only one slot is opened. Or 3 people join, 2 people leave, and the remaining person will be taking up the whole rank, and after the last one is gone, the job will be restricted to 1 slot until intervention.