### PR TITLE
Allows Prometheans to mimic the appearance of Vatborn.

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/prometheans.dm
+++ b/code/modules/mob/living/carbon/human/species/station/prometheans.dm
@@ -85,7 +85,7 @@ var/datum/species/shapeshifter/promethean/prometheans
 		/mob/living/carbon/human/proc/regenerate
 		)
 
-	valid_transform_species = list("Human", "Unathi", "Tajara", "Skrell", "Diona", "Teshari", "Monkey")
+	valid_transform_species = list("Human", "Vatborn", "Unathi", "Tajara", "Skrell", "Diona", "Teshari", "Monkey")
 	monochromatic = 1
 
 	var/heal_rate = 0.5 // Temp. Regen per tick.


### PR DESCRIPTION
On the tin. 
Permits the use of Vatborn sprites, which for the female icons, is thin enough to be considerable as a 'base' Promethean.
