### PR TITLE
Makes Syndie Toolboxes Special Again

### DIFF
--- a/code/datums/supplypacks/contraband.dm
+++ b/code/datums/supplypacks/contraband.dm
@@ -80,7 +80,7 @@
 					/obj/item/weapon/storage/box/syndie_kit/demolitions,
 					/obj/item/device/multitool/ai_detector,
 					/obj/item/weapon/plastique,
-					/obj/item/weapon/storage/toolbox/syndicate
+					/obj/item/weapon/storage/toolbox/syndicate/powertools
 					),
 			list( //the infiltrator,
 					/obj/item/weapon/gun/projectile/silenced,

--- a/code/datums/uplink/tools.dm
+++ b/code/datums/uplink/tools.dm
@@ -9,10 +9,15 @@
 	item_cost = 5
 	path = /obj/item/device/binoculars
 
-/datum/uplink_item/item/tools/toolbox
+/datum/uplink_item/item/tools/toolbox // Leaving the basic as an option since powertools are loud.
 	name = "Fully Loaded Toolbox"
-	item_cost = 10
+	item_cost = 5
 	path = /obj/item/weapon/storage/toolbox/syndicate
+
+/datum/uplink_item/item/tools/powertoolbox
+	name = "Fully Loaded Powertool Box"
+	item_cost = 10
+	path = /obj/item/weapon/storage/toolbox/syndicate/powertools
 
 /datum/uplink_item/item/tools/clerical
 	name = "Morphic Clerical Kit"

--- a/code/game/objects/items/weapons/storage/toolbox.dm
+++ b/code/game/objects/items/weapons/storage/toolbox.dm
@@ -69,14 +69,24 @@
 	origin_tech = list(TECH_COMBAT = 1, TECH_ILLEGAL = 1)
 	force = 14
 
-/obj/item/weapon/storage/toolbox/syndicate/New()
+/obj/item/weapon/storage/toolbox/syndicate/New() // This is found in maint, so it should have the basics, plus some gloves.
 	..()
 	new /obj/item/clothing/gloves/yellow(src)
+	new /obj/item/weapon/screwdriver(src)
+	new /obj/item/weapon/wrench(src)
+	new /obj/item/weapon/weldingtool(src)
+	new /obj/item/weapon/crowbar(src)
+	new /obj/item/weapon/wirecutters(src)
+	new /obj/item/device/multitool(src)
+
+/obj/item/weapon/storage/toolbox/syndicate/powertools/New() // Available in the uplink and is the 'real' syndie toolbox.
+	// ..() isn't called or else this box would contain the basic tools, power tools, and duplicate gloves.
+	new /obj/item/clothing/gloves/yellow(src)
 	new /obj/item/weapon/screwdriver/power(src)
-	new /obj/item/stack/cable_coil/random(src,30)
 	new /obj/item/weapon/weldingtool/experimental(src)
 	new /obj/item/weapon/crowbar/power(src)
 	new /obj/item/device/multitool(src)
+	new /obj/item/stack/cable_coil/random(src,30)
 	new /obj/item/device/analyzer(src)
 
 /obj/item/weapon/storage/toolbox/lunchbox


### PR DESCRIPTION
The syndie toolboxes have been split into two versions, one with the old contents pre-powertools and one with the current powertools. Both are in the uplink, however only the regular tool version of the syndie toolbox can be found in maint now. This is to make power tools less common, as there are several spots where syndie toolboxes are guaranteed to spawn at,  and it made the CE's tools less special.