### PR TITLE
Removed Shotgun's ability to use speedloaders.

### DIFF
--- a/code/modules/projectiles/guns/projectile/shotgun.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun.dm
@@ -10,7 +10,7 @@
 	slot_flags = SLOT_BACK
 	caliber = "12g"
 	origin_tech = list(TECH_COMBAT = 4, TECH_MATERIAL = 2)
-	load_method = SINGLE_CASING|SPEEDLOADER
+	load_method = SINGLE_CASING
 	ammo_type = /obj/item/ammo_casing/a12g/beanbag
 	handle_casings = HOLD_CASINGS
 	fire_sound = 'sound/weapons/shotgun.ogg'


### PR DESCRIPTION
- Makes no sense from a physics standpoint.
- It's bullshit from a balance stand point.
- Makes shotgun ammo boxes obsolete, which is dumb.

This doesn't get rid of shotgun speedloaders from the autolathe, it just means they are no longer possible to speed-reload your shotgun with. These were added with no ramification for the imbalance issues they cause. Allow me to elaborate:

- A shotgun clip holds 4 rounds, and is a small item. As such, it takes up the same amount of bag space as one box.
- One box can hold eight shotgun shells. Two clips can hold eight shotgun shells. But one box can hold four clips. You can fit **sixteen** shotgun shells into the space of one card board box, which is absurd.
- Clips can go into security belts, but boxes can't. More bullshit.

Seriously, shotguns should not be possible to speedload!

"Okay but Spades I don't want to go back to having to manually load shotgun shells one by one by hand during a crisis." Okay well you don't have to. Literally any cardboard box can be loaded with shells. If you load the box with shells, you can click a shotgun, and it will load the shotgun with shells automatically. This is far more balanced.