### PR TITLE
Increases maximum stored camera locations

### DIFF
--- a/code/game/machinery/camera/tracking.dm
+++ b/code/game/machinery/camera/tracking.dm
@@ -2,7 +2,7 @@
 #define TRACKING_NO_COVERAGE 1
 #define TRACKING_TERMINATE 2
 
-/mob/living/silicon/ai/var/max_locations = 10
+/mob/living/silicon/ai/var/max_locations = 30
 /mob/living/silicon/ai/var/stored_locations[0]
 
 /proc/InvalidPlayerTurf(turf/T as turf)

--- a/html/changelogs/PrismaticGynoid-storemoreplaces.yml
+++ b/html/changelogs/PrismaticGynoid-storemoreplaces.yml
@@ -1,0 +1,4 @@
+author: PrismaticGynoid
+delete-after: True
+changes: 
+  - tweak: "Adjusts the amount of camera locations the AI can store from 10 to 30."


### PR DESCRIPTION
This increases the number of stored camera locations the AI can have at one time, from 10 to 30. This is mostly a quality-of-life update in preparation for the new map, as its multiple floors make navigating around the station as the AI more difficult.