### PR TITLE
Adds Submap (PoI) Seeding Procedure

### DIFF
--- a/code/__defines/map.dm
+++ b/code/__defines/map.dm
@@ -6,3 +6,6 @@
 #define MAP_LEVEL_SEALED		0x010 // Z-levels that don't allow random transit at edge
 #define MAP_LEVEL_EMPTY			0x020 // Empty Z-levels that may be used for various things (currently used by bluespace jump)
 #define MAP_LEVEL_CONSOLES		0x040 // Z-levels available to various consoles, such as the crew monitor (when that gets coded in). Defaults to station_levels if unset.
+
+// Misc map defines.
+#define SUBMAP_MAP_EDGE_PAD 15 // Automatically created submaps are forbidden from being this close to the main map's edge.

--- a/code/controllers/Processes/planet.dm
+++ b/code/controllers/Processes/planet.dm
@@ -51,9 +51,10 @@ var/datum/controller/process/planet/planet_controller = null
 			//Redraw weather icons
 			for(var/T in P.planet_floors)
 				var/turf/simulated/turf = T
-				turf.overlays -= turf.weather_overlay
+		//		turf.overlays -= turf.weather_overlay
 				turf.weather_overlay = new_overlay
-				turf.overlays += turf.weather_overlay
+		//		turf.overlays += turf.weather_overlay
+				turf.update_icon()
 				SCHECK
 
 		//Sun light needs changing

--- a/code/controllers/master.dm
+++ b/code/controllers/master.dm
@@ -540,10 +540,10 @@ var/datum/controller/master/Master = new()
 	stat("Byond:", "(FPS:[world.fps]) (TickCount:[world.time/world.tick_lag]) (TickDrift:[round(Master.tickdrift,1)]([round((Master.tickdrift/(world.time/world.tick_lag))*100,0.1)]%))")
 	stat("Master Controller:", statclick.update("(TickRate:[Master.processing]) (Iteration:[Master.iteration])"))
 
-/datum/controller/master/StartLoadingMap()
+/datum/controller/master/StartLoadingMap(var/quiet = TRUE)
 	if(map_loading)
 		admin_notice("<span class='danger'>Another map is attempting to be loaded before first map released lock.  Delaying.</span>", R_DEBUG)
-	else
+	else if(!quiet)
 		admin_notice("<span class='danger'>Map is now being built.  Locking.</span>", R_DEBUG)
 
 	//disallow more than one map to load at once, multithreading it will just cause race conditions
@@ -557,8 +557,9 @@ var/datum/controller/master/Master = new()
 	air_processing_killed = TRUE
 	map_loading = TRUE
 
-/datum/controller/master/StopLoadingMap(bounds = null)
-	admin_notice("<span class='danger'>Map is finished.  Unlocking.</span>", R_DEBUG)
+/datum/controller/master/StopLoadingMap(var/quiet = TRUE)
+	if(!quiet)
+		admin_notice("<span class='danger'>Map is finished.  Unlocking.</span>", R_DEBUG)
 	air_processing_killed = FALSE
 	map_loading = FALSE
 	for(var/S in subsystems)

--- a/code/controllers/subsystems/creation.dm
+++ b/code/controllers/subsystems/creation.dm
@@ -13,10 +13,10 @@ SUBSYSTEM_DEF(creation)
 
 	var/map_loading = FALSE
 
-/datum/controller/subsystem/creation/StartLoadingMap()
+/datum/controller/subsystem/creation/StartLoadingMap(var/quiet)
 	map_loading = TRUE
 
-/datum/controller/subsystem/creation/StopLoadingMap()
+/datum/controller/subsystem/creation/StopLoadingMap(var/quiet)
 	map_loading = FALSE
 
 /datum/controller/subsystem/creation/proc/initialize_late_atoms()

--- a/code/game/turfs/simulated/floor_icon.dm
+++ b/code/game/turfs/simulated/floor_icon.dm
@@ -5,6 +5,8 @@ var/list/flooring_cache = list()
 	if(lava)
 		return
 
+	overlays.Cut()
+
 	if(flooring)
 		// Set initial icon and strings.
 		name = flooring.name
@@ -20,7 +22,6 @@ var/list/flooring_cache = list()
 				flooring_override = icon_state
 
 		// Apply edges, corners, and inner corners.
-		overlays.Cut()
 		var/has_border = 0
 		if(flooring.flags & TURF_HAS_EDGES)
 			for(var/step_dir in cardinal)

--- a/code/game/turfs/simulated/outdoors/grass.dm
+++ b/code/game/turfs/simulated/outdoors/grass.dm
@@ -20,12 +20,12 @@ var/list/grass_types = list(
 	grass_chance = 0
 	var/tree_chance = 2
 
-/turf/simulated/floor/outdoors/grass/sif/New()
+/turf/simulated/floor/outdoors/grass/sif/initialize()
 	if(tree_chance && prob(tree_chance))
 		new /obj/structure/flora/tree/sif(src)
 	..()
 
-/turf/simulated/floor/outdoors/grass/New()
+/turf/simulated/floor/outdoors/grass/initialize()
 	if(prob(50))
 		icon_state += "2"
 		//edge_blending_priority++

--- a/code/game/turfs/simulated/outdoors/outdoors.dm
+++ b/code/game/turfs/simulated/outdoors/outdoors.dm
@@ -40,7 +40,10 @@ var/list/outdoor_turfs = list()
 
 /turf/simulated/proc/make_indoors()
 	outdoors = FALSE
-	planet_controller.unallocateTurf(src)
+	if(planet_controller)
+		planet_controller.unallocateTurf(src)
+	else // This is happening during map gen, if there's no planet_controller (hopefully).
+		outdoor_turfs -= src
 	qdel(weather_overlay)
 	update_icon()
 

--- a/code/game/turfs/simulated/water.dm
+++ b/code/game/turfs/simulated/water.dm
@@ -19,8 +19,8 @@
 	update_icon()
 
 /turf/simulated/floor/water/update_icon()
-	..() // To get the edges.  This also gets rid of other overlays so it needs to go first.
 	overlays.Cut()
+	..() // To get the edges.
 	icon_state = water_state
 	var/image/floorbed_sprite = image(icon = 'icons/turf/outdoors.dmi', icon_state = under_state)
 	underlays.Add(floorbed_sprite)

--- a/maps/southern_cross/southern_cross_defines.dm
+++ b/maps/southern_cross/southern_cross_defines.dm
@@ -65,9 +65,19 @@
 	else
 		return ..()
 
-/datum/map/northern_star/perform_map_generation()
+/datum/map/southern_cross/perform_map_generation()
+	// First, place a bunch of submaps. This comes before tunnel/forest generation as to not interfere with the submap.
+
+	// Cave submaps are first.
+	seed_submaps(list(Z_LEVEL_SURFACE_MINE), 100, /area/mine/unexplored, /datum/map_template/cave)
+	// Wilderness is next.
+	seed_submaps(list(Z_LEVEL_SURFACE_WILD), 100, /area/surface/outside/wilderness, /datum/map_template/surface)
+	// If Space submaps are made, add a line to make them here as well.
+
+	// Now for the tunnels.
 	new /datum/random_map/automata/cave_system(null, 1, 1, Z_LEVEL_SURFACE_MINE, world.maxx, world.maxy) // Create the mining Z-level.
 	new /datum/random_map/noise/ore(null, 1, 1, Z_LEVEL_SURFACE_MINE, 64, 64)         // Create the mining ore distribution map.
+	// Todo: Forest generation.
 	return 1
 
 /datum/map_z_level/southern_cross/station

--- a/maps/submaps/cave_submaps/cave.dm
+++ b/maps/submaps/cave_submaps/cave.dm
@@ -17,13 +17,16 @@
 	name = "Abandoned Relay"
 	desc = "An unregistered comms relay, abandoned to the elements."
 	mappath = 'maps/submaps/cave_submaps/deadBeacon.dmm'
+	cost = 10
 
 /datum/map_template/cave/prepper1
 	name = "Prepper Bunker"
 	desc = "A little hideaway for someone with more time and money than sense."
 	mappath = 'maps/submaps/cave_submaps/prepper1.dmm'
+	cost = 10
 
 /datum/map_template/cave/qshuttle
 	name = "Quarantined Shuttle"
 	desc = "An emergency landing turned viral outbreak turned tragedy."
 	mappath = 'maps/submaps/cave_submaps/quarantineshuttle.dmm'
+	cost = 20

--- a/maps/submaps/surface_submaps/forest.dm
+++ b/maps/submaps/surface_submaps/forest.dm
@@ -8,7 +8,7 @@
 
 /datum/map_template/surface
 	name = "Surface Content"
-	desc = "Used to make the surface by 17% less boring."
+	desc = "Used to make the surface be 17% less boring."
 
 // To be added: Templates for surface exploration when they are made.
 
@@ -16,8 +16,11 @@
 	name = "Farm 1"
 	desc = "A small farm tended by a farmbot."
 	mappath = 'maps/submaps/surface_submaps/farm1.dmm'
+	cost = 10
 
 /datum/map_template/surface/spider1
 	name = "Spider Nest 1"
 	desc = "A small spider nest, in the forest."
 	mappath = 'maps/submaps/surface_submaps/spider1.dmm'
+	allow_duplicates = TRUE
+	cost = 5


### PR DESCRIPTION
Mostly ports /tg/'s method of seeding submaps into specific z-levels. Note that submaps are spawned in before other map generation things, such as tunnels or trees spawning.
PoI spawning has several restrictions, firstly being restricted to a specific area. The cave PoIs only spawn in 'unexplored' sections, so there should be no risk of them blocking the outposts or the premade pathways. PoIs are also forbidden from being too close to the edge of the world, and the entire PoI must be contained in the same area, so it will not eat the outposts or another PoI.
Due to the low number of submaps present, all of the PoIs are guaranteed to spawn. As more are added, this should fix itself.
Fixes a few weather icon related bugs.