### PR TITLE
Adds Z Coordinate to Suit Sensor Computer

### DIFF
--- a/maps/southern_cross/structures/closets/misc.dm
+++ b/maps/southern_cross/structures/closets/misc.dm
@@ -11,5 +11,5 @@
 	name = "rifle cabinet"
 	will_contain = list(
 		/obj/item/weapon/gun/projectile/shotgun/pump/rifle = 3,
-		/obj/item/ammo_magazine/clip/c762/hunting = 9
+		/obj/item/ammo_magazine/clip/c762/hunter = 9
 	)

--- a/nano/templates/crew_monitor.tmpl
+++ b/nano/templates/crew_monitor.tmpl
@@ -26,7 +26,7 @@ Used In File(s): \code\game\machinery\computer\crew.dm
 		{{else value.sensor_type == 2}}
 			<tr><td>{{:value.name}} ({{:value.assignment}})</td><td class='living'>{{:value.dead ? "<span class='bad'>Deceased</span>" : "<span class='good'>Living</span>"}} (<span class="oxyloss">{{:value.oxy}}</span>/<span class="toxin">{{:value.tox}}</span>/<span class="burn">{{:value.fire}}</span>/<span class="brute">{{:value.brute}}</span>)</td><td><span class="neutral">Not Available</td></td>{{if data.isAI}}<td class='tracking'>{{:helper.link('Track', null, {}, 'disabled')}}</td>{{/if}}</tr>
 		{{else value.sensor_type == 3}}
-			<tr><td>{{:value.name}} ({{:value.assignment}})</td><td class='living'>{{:value.dead ? "<span class='bad'>Deceased</span>" : "<span class='good'>Living</span>"}} (<span class="oxyloss">{{:value.oxy}}</span>/<span class="toxin">{{:value.tox}}</span>/<span class="burn">{{:value.fire}}</span>/<span class="brute">{{:value.brute}}</span>)</td><td>{{:value.area}}({{:value.x}}, {{:value.y}})</td>{{if data.isAI}}<td class='tracking'>{{:helper.link('Track', null, {'track' : value.ref})}}</td>{{/if}}</tr>
+			<tr><td>{{:value.name}} ({{:value.assignment}})</td><td class='living'>{{:value.dead ? "<span class='bad'>Deceased</span>" : "<span class='good'>Living</span>"}} (<span class="oxyloss">{{:value.oxy}}</span>/<span class="toxin">{{:value.tox}}</span>/<span class="burn">{{:value.fire}}</span>/<span class="brute">{{:value.brute}}</span>)</td><td>{{:value.area}}({{:value.x}}, {{:value.y}}, {{:value.z}})</td>{{if data.isAI}}<td class='tracking'>{{:helper.link('Track', null, {'track' : value.ref})}}</td>{{/if}}</tr>
 		{{/if}}
 	{{/for}}
 </tbody></table>


### PR DESCRIPTION
Fixes what I was was the computer not scanning across z-levels but was instead miscommunication on what was bugged, IE that the computer displays suit sensors for everyone on the station but gives no indication as to what deck they are on.
Bonus: Makes the map compile due to a path typo.