### PR TITLE
Adds sensor preferences!

### DIFF
--- a/code/_helpers/global_lists.dm
+++ b/code/_helpers/global_lists.dm
@@ -58,6 +58,7 @@ var/datum/category_collection/underwear/global_underwear = new()
 	//Backpacks
 var/global/list/backbaglist = list("Nothing", "Backpack", "Satchel", "Satchel Alt", "Messenger Bag")
 var/global/list/pdachoicelist = list("Default", "Slim", "Old", "Rugged")
+var/global/list/sensorpreflist = list("Off", "Binary", "Vitals", "Tracking", "No Preference")
 var/global/list/exclude_jobs = list(/datum/job/ai,/datum/job/cyborg)
 
 // Visual nets

--- a/code/modules/client/preference_setup/general/04_equipment.dm
+++ b/code/modules/client/preference_setup/general/04_equipment.dm
@@ -11,12 +11,14 @@
 	S["all_underwear_metadata"] >> pref.all_underwear_metadata
 	S["backbag"]	>> pref.backbag
 	S["pdachoice"]	>> pref.pdachoice
+	S["sensorpref"]	>> pref.sensorpref
 
 /datum/category_item/player_setup_item/general/equipment/save_character(var/savefile/S)
 	S["all_underwear"] << pref.all_underwear
 	S["all_underwear_metadata"] << pref.all_underwear_metadata
-	S["backbag"]	<< pref.backbag
-	S["pdachoice"]	<< pref.pdachoice
+	S["backbag"]				<< pref.backbag
+	S["pdachoice"]				<< pref.pdachoice
+	S["sensorpref"]				<< pref.sensorpref
 
 // Moved from /datum/preferences/proc/copy_to()
 /datum/category_item/player_setup_item/general/equipment/copy_to_mob(var/mob/living/carbon/human/character)
@@ -41,6 +43,10 @@
 	if(pref.pdachoice > 4 || pref.pdachoice < 1)
 		pref.pdachoice = 1
 	character.pdachoice = pref.pdachoice
+
+	if(pref.sensorpref > 5 || pref.sensorpref < 1)
+		pref.sensorpref = 5
+	character.sensorpref = pref.sensorpref
 
 /datum/category_item/player_setup_item/general/equipment/sanitize_character()
 	if(!islist(pref.gear)) pref.gear = list()
@@ -71,6 +77,7 @@
 			pref.all_underwear_metadata -= underwear_metadata
 	pref.backbag	= sanitize_integer(pref.backbag, 1, backbaglist.len, initial(pref.backbag))
 	pref.pdachoice	= sanitize_integer(pref.pdachoice, 1, pdachoicelist.len, initial(pref.pdachoice))
+	pref.sensorpref	= sanitize_integer(pref.sensorpref, 1, sensorpreflist.len, initial(pref.sensorpref))
 
 /datum/category_item/player_setup_item/general/equipment/content()
 	. = list()
@@ -86,6 +93,7 @@
 		. += "<br>"
 	. += "Backpack Type: <a href='?src=\ref[src];change_backpack=1'><b>[backbaglist[pref.backbag]]</b></a><br>"
 	. += "PDA Type: <a href='?src=\ref[src];change_pda=1'><b>[pdachoicelist[pref.pdachoice]]</b></a><br>"
+	. += "Sensor Preferences: <a href='?src=\ref[src];sensorpref=1'>[sensorpreflist[pref.sensorpref]]</a><br>"
 
 	return jointext(.,null)
 
@@ -117,6 +125,12 @@
 		var/new_pdachoice = input(user, "Choose your character's style of PDA:", "Character Preference", pdachoicelist[pref.pdachoice]) as null|anything in pdachoicelist
 		if(!isnull(new_pdachoice) && CanUseTopic(user))
 			pref.pdachoice = pdachoicelist.Find(new_pdachoice)
+			return TOPIC_REFRESH
+
+	else if(href_list["sensorpref"])
+		var/new_sensorpref = input(user, "Choose your character's sensor preferences:", "Character Preference", sensorpreflist[pref.sensorpref]) as null|anything in sensorpreflist
+		if(!isnull(new_sensorpref) && CanUseTopic(user))
+			pref.sensorpref = sensorpreflist.Find(new_sensorpref)
 			return TOPIC_REFRESH
 
 	else if(href_list["change_underwear"])

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -31,6 +31,7 @@ datum/preferences
 	var/b_type = "A+"					//blood type (not-chooseable)
 	var/backbag = 2						//backpack type
 	var/pdachoice = 1					//PDA type
+	var/sensorpref = 5					//Sensor preferences
 	var/h_style = "Bald"				//Hair type
 	var/r_hair = 0						//Hair color
 	var/g_hair = 0						//Hair color

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -582,7 +582,8 @@
 	show_messages = 1
 
 	var/has_sensor = 1 //For the crew computer 2 = unable to change mode
-	var/sensor_mode = 0
+	var/sensor_mode = 3
+	var/sensorpref = 5
 		/*
 		1 = Report living/dead
 		2 = Report detailed damages
@@ -805,6 +806,15 @@
 	update_clothing_icon()
 
 
-/obj/item/clothing/under/rank/New()
-	sensor_mode = pick(0,1,2,3)
+/obj/item/clothing/under/New(var/mob/living/carbon/human/H)
 	..()
+	sensorpref = isnull(H) ? 1 : (ishuman(H) ? H.sensorpref : 1)
+	switch(sensorpref)
+		if(1) sensor_mode = 0 //off
+		if(2) sensor_mode = 1 //binary
+		if(3) sensor_mode = 2 //vitals
+		if(4) sensor_mode = 3 //tracking
+		if(5) sensor_mode = pick(0,1,2,3) //random
+		else
+			sensor_mode = pick(0,1,2,3)
+			log_debug("Invalid switch for suit sensors, defaulting to random. [sensorpref] chosen.")

--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -43,6 +43,7 @@
 	var/list/hide_underwear = list()
 	var/backbag = 2		//Which backpack type the player has chosen. Nothing, Satchel or Backpack.
 	var/pdachoice = 1	//Which PDA type the player has chosen. Default, Slim, Old, or Rugged.
+	var/sensorpref = 5	//What suit sensor pref the player has chosen. Off, Binary, Vitals, Tracking or No Preference
 
 	// General information
 	var/home_system = ""

--- a/code/modules/mob/new_player/preferences_setup.dm
+++ b/code/modules/mob/new_player/preferences_setup.dm
@@ -31,6 +31,7 @@
 
 	backbag = rand(1,5)
 	pdachoice = rand(1,4)
+	sensorpref = rand(1,5)
 	age = rand(current_species.min_age, current_species.max_age)
 	b_type = RANDOM_BLOOD_TYPE
 	if(H)


### PR DESCRIPTION
Adds an option in the general tab of character setup, under the equipment section (same as PDA style, backpack/satchel/neither, etc) - _sensor preferences_. You can select a mode of suit sensors - off, binary, vitals, tracking - or no preference - and that mode will always be enabled at roundstart for you.

So if you set your sensor preferences to tracking, you'll always start with sensors to tracking.
If you set your sensors to off, you'll always start with sensors disabled.
It defaults to 'no preference', which is the current setting - randomly generated, 25% chance each for off/binary/vitals/tracking.

Bonus, it's different for each character. Do you have a sensible character and a paranoid character? No problem - you could set your sensor prefs to 'tracking' and 'binary' respectively, if you wanted to.

"This doesn't affect me, I don't want it." You don't have to use it! Defaults to 'no preference'.

Tested, and it works, and also Travis fight me.

Edit: pretty sure Travis failed 'cause of SC test
Edit 2: did it again now the test is over