### PR TITLE
Allows communicators to be made by RnD, shows ghosts communicator IMs

### DIFF
--- a/code/game/objects/items/devices/communicator/communicator.dm
+++ b/code/game/objects/items/devices/communicator/communicator.dm
@@ -429,6 +429,13 @@ var/global/list/obj/item/device/communicator/all_communicators = list()
 			exonet.send_message(their_address, "text", text)
 			im_list += list(list("address" = exonet.address, "to_address" = their_address, "im" = text))
 			log_pda("[usr] (COMM: [src]) sent \"[text]\" to [exonet.get_atom_from_address(their_address)]")
+			for(var/mob/M in player_list)
+				if(M.stat == DEAD && M.is_preference_enabled(/datum/client_preference/ghost_ears))
+					if(istype(M, /mob/new_player) || M.forbid_seeing_deadchat)
+						continue
+					if(exonet.get_atom_from_address(their_address) == M)
+						continue
+					M.show_message("Comm IM - [src] -> [exonet.get_atom_from_address(their_address)]: [text]")
 
 	if(href_list["disconnect"])
 		var/name_to_disconnect = href_list["disconnect"]
@@ -988,6 +995,14 @@ var/global/list/obj/item/device/communicator/all_communicators = list()
 			src << "<span class='notice'>You have sent '[text_message]' to [chosen_communicator].</span>"
 			exonet_messages.Add("<b>To [chosen_communicator]:</b><br>[text_message]")
 			log_pda("[usr] (COMM: [src]) sent \"[text_message]\" to [chosen_communicator]")
+			for(var/mob/M in player_list)
+				if(M.stat == DEAD && M.is_preference_enabled(/datum/client_preference/ghost_ears))
+					if(istype(M, /mob/new_player) || M.forbid_seeing_deadchat)
+						continue
+					if(M == src)
+						continue
+					M.show_message("Comm IM - [src] -> [chosen_communicator]: [text_message]")
+
 
 
 // Verb: show_text_messages()

--- a/code/modules/research/designs.dm
+++ b/code/modules/research/designs.dm
@@ -742,6 +742,14 @@ other types of metals and chemistry for reagents).
 	build_path = /obj/item/device/paicard
 	sort_string = "VABAI"
 
+/datum/design/item/communicator
+	name = "Communcator"
+	id = "communicator"
+	req_tech = list(TECH_DATA = 2, TECH_MAGNET = 2)
+	materials = list(DEFAULT_WALL_MATERIAL = 500, "glass" = 500)
+	build_path = /obj/item/device/communicator
+	sort_string = "VABAJ"
+
 /datum/design/item/intellicard
 	name = "'intelliCore', AI preservation and transportation system"
 	desc = "Allows for the construction of an intelliCore."


### PR DESCRIPTION
Adds a design datum for building communicators from the protolathe.
Shows communicator IMs to ghosts in the same way as PDA messages.