### PR TITLE
Adds Reach Variable to Weapons

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -121,7 +121,7 @@
 	// A is a turf or is on a turf, or in something on a turf (pen in a box); but not something in something on a turf (pen in a box in a backpack)
 	sdepth = A.storage_depth_turf()
 	if(isturf(A) || isturf(A.loc) || (sdepth != -1 && sdepth <= 1))
-		if(A.Adjacent(src)) // see adjacent.dm
+		if(A.Adjacent(src) || (W && W.attack_can_reach(src, A, W.reach)) ) // see adjacent.dm
 			if(W)
 				// Return 1 in attackby() to prevent afterattack() effects (when safely moving items for example)
 				var/resolved = W.resolve_attackby(A,src)

--- a/code/game/gamemodes/changeling/changeling_powers.dm
+++ b/code/game/gamemodes/changeling/changeling_powers.dm
@@ -168,7 +168,8 @@ turf/proc/AdjacentTurfsRangedSting()
 		/obj/structure/target_stake,
 		/obj/structure/cable,
 		/obj/structure/disposalpipe,
-		/obj/machinery/
+		/obj/machinery,
+		/mob
 	)
 
 	var/L[] = new()

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -81,6 +81,7 @@
 
 	var/toolspeed = 1.0 // This is a multipler on how 'fast' a tool works.  e.g. setting this to 0.5 will make the tool work twice as fast.
 	var/attackspeed = DEFAULT_ATTACK_COOLDOWN // How long click delay will be when using this, in 1/10ths of a second. Checked in the user's get_attack_speed().
+	var/reach = 1 // Length of tiles it can reach, 1 is adjacent.
 	var/addblends // Icon overlay for ADD highlights when applicable.
 
 /obj/item/New()
@@ -641,3 +642,11 @@ modules/mob/living/carbon/human/life.dm if you die, you will be zoomed out.
 /obj/item/proc/pwr_drain()
 	return 0 // Process Kill
 
+// Used for non-adjacent melee attacks with specific weapons capable of reaching more than one tile.
+// This uses changeling range string A* but for this purpose its also applicable.
+/obj/item/proc/attack_can_reach(var/atom/us, var/atom/them, var/range)
+	if(us.Adjacent(them))
+		return TRUE // Already adjacent.
+	if(AStar(get_turf(us), get_turf(them), /turf/proc/AdjacentTurfsRangedSting, /turf/proc/Distance, max_nodes=25, max_node_depth=range))
+		return TRUE
+	return FALSE

--- a/code/game/objects/items/weapons/material/twohanded.dm
+++ b/code/game/objects/items/weapons/material/twohanded.dm
@@ -138,6 +138,7 @@
 	base_icon = "spearglass"
 	name = "spear"
 	desc = "A haphazardly-constructed yet still deadly weapon of ancient design."
+	description_info = "This weapon can strike from two tiles away, and over certain objects such as tables, or other people."
 	force = 10
 	w_class = ITEMSIZE_LARGE
 	slot_flags = SLOT_BACK
@@ -152,3 +153,5 @@
 	default_material = "glass"
 	applies_material_colour = 0
 	fragile = 1	//It's a haphazard thing of glass, wire, and steel
+	reach = 2 // Spears are long.
+	attackspeed = 14


### PR DESCRIPTION
Melee weapons can now potentially attack from farther away.
Obstacles are taken into account, so you cannot hit people through windows, but you can attack over specific things such as tables, or other people.
Currently only the spear can do this, with a range of two tiles, however the attack speed for the spear was reduced, so it may remain a situational weapon.
The intention for this is to make specific weapons feel different to each other besides 'does more damage', and I got ideas on other kinds of weapon adjustments later to make them feel a bit more unique.