### PR TITLE
Makes species bleed out faster or slower

### DIFF
--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -39,6 +39,7 @@
 	var/virus_immune
 	var/short_sighted                                    // Permanent weldervision.
 	var/blood_volume = 560                               // Initial blood volume.
+	var/bloodloss_rate = 1								 // Multiplier for how fast a species bleeds out. Higher = Faster
 	var/hunger_factor = 0.05                             // Multiplier for hunger.
 
 	var/taste_sensitivity = TASTE_NORMAL                 // How sensitive the species is to minute tastes.

--- a/code/modules/mob/living/carbon/human/species/station/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station.dm
@@ -35,12 +35,14 @@
 	ambiguous_genders = TRUE
 	gluttonous = 1
 	slowdown = 0.5
+	total_health = 125
 	brute_mod = 0.85
 	burn_mod = 0.85
 	metabolic_rate = 0.85
 	item_slowdown_mod = 0.5
 	mob_size = MOB_LARGE
 	blood_volume = 840
+	bloodloss_rate = 0.75
 	num_alternate_languages = 3
 	secondary_langs = list(LANGUAGE_UNATHI)
 	name_language = LANGUAGE_UNATHI
@@ -234,6 +236,8 @@
 	darksight = 4
 	flash_mod = 1.2
 	chemOD_mod = 0.9
+
+	bloodloss_rate = 1.5
 
 	ambiguous_genders = TRUE
 

--- a/code/modules/organs/blood.dm
+++ b/code/modules/organs/blood.dm
@@ -143,6 +143,9 @@ var/const/CE_STABLE_THRESHOLD = 0.5
 		var/blood_max = 0
 		var/blood_loss_divisor = 30	//lower factor = more blood loss
 
+		// Some species bleed out differently
+		blood_loss_divisor /= species.bloodloss_rate
+
 		// Some modifiers can make bleeding better or worse.  Higher multiplers = more bleeding.
 		var/blood_loss_modifier_multiplier = 1.0
 		for(var/datum/modifier/M in modifiers)


### PR DESCRIPTION
- Adds a var to let species bleed out faster or slower.
- Skrell bleed out a bit faster.
- Unathi bleed out a bit slower.
- Also makes Unathi have a bit more health, because I was in the file ~~and no one plays them anyway~~.