### PR TITLE
Ports ghosts examining locker contents

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -315,6 +315,12 @@
 	if(!src.toggle())
 		usr << "<span class='notice'>It won't budge!</span>"
 
+/obj/structure/closet/attack_ghost(mob/ghost)
+	if(ghost.client && ghost.client.inquisitive_ghost)
+		ghost.examinate(src)
+		if (!src.opened)
+			to_chat(ghost, "It contains: [english_list(contents)].")
+
 /obj/structure/closet/verb/verb_toggleopen()
 	set src in oview(1)
 	set category = "Object"


### PR DESCRIPTION
A port of https://github.com/Baystation12/Baystation12/pull/19436. Ghosts clicking on a locker or crate to examine it can now see a list of its contents.
![ghostlocker](https://user-images.githubusercontent.com/16697591/33531477-7f744950-d842-11e7-95f6-599235d694fc.png)
