### PR TITLE
Removes the military clothing from the loadout, repaths things

### DIFF
--- a/code/datums/outfits/military/sifguard.dm
+++ b/code/datums/outfits/military/sifguard.dm
@@ -1,22 +1,22 @@
 /decl/hierarchy/outfit/military/sifguard/pt
 	name = OUTFIT_MILITARY("SifGuard PT")
-	uniform = /obj/item/clothing/under/pt/expeditionary
+	uniform = /obj/item/clothing/under/pt/sifguard
 	shoes = /obj/item/clothing/shoes/black
 
 /decl/hierarchy/outfit/military/sifguard/utility
 	name = OUTFIT_MILITARY("SifGuard Utility")
-	uniform = /obj/item/clothing/under/utility/expeditionary
+	uniform = /obj/item/clothing/under/utility/sifguard
 	shoes = /obj/item/clothing/shoes/boots/jackboots
 
 /decl/hierarchy/outfit/military/sifguard/service
 	name = OUTFIT_MILITARY("SifGuard Service")
-	uniform = /obj/item/clothing/under/utility/expeditionary
+	uniform = /obj/item/clothing/under/utility/sifguard
 	shoes = /obj/item/clothing/shoes/boots/jackboots
-	suit = /obj/item/clothing/suit/storage/service/expeditionary
+	suit = /obj/item/clothing/suit/storage/service/sifguard
 
 /decl/hierarchy/outfit/military/sifguard/dress
 	name = OUTFIT_MILITARY("SifGuard Dress")
-	uniform = /obj/item/clothing/under/mildress/expeditionary
+	uniform = /obj/item/clothing/under/mildress/sifguard
 	shoes = /obj/item/clothing/shoes/dress
 	suit = /obj/item/clothing/suit/dress/expedition
 	gloves = /obj/item/clothing/gloves/white

--- a/code/modules/client/preference_setup/loadout/loadout_suit.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_suit.dm
@@ -384,18 +384,6 @@
 	display_name = "denim vest, corporate"
 	path = /obj/item/clothing/suit/storage/toggle/denim_jacket/nanotrasen/sleeveless
 
-/datum/gear/suit/service
-	display_name = "service jacket selection"
-	path = /obj/item/clothing/suit/storage/service
-
-/datum/gear/suit/service/New()
-	..()
-	var/list/services = list()
-	for(var/service_style in typesof(/obj/item/clothing/suit/storage/service))
-		var/obj/item/clothing/suit/storage/service/service = service_style
-		services[initial(service.name)] = service
-	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(services))
-
 /datum/gear/suit/miscellaneous/kimono
 	display_name = "kimono"
 	path = /obj/item/clothing/suit/kimono

--- a/code/modules/client/preference_setup/loadout/loadout_uniform.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_uniform.dm
@@ -371,30 +371,17 @@
 	display_name = "sexy maid uniform"
 	path = /obj/item/clothing/under/dress/sexymaid
 
-/datum/gear/uniform/pt
-	display_name = "pt uniform"
-	path = /obj/item/clothing/under/pt
-
-/datum/gear/uniform/pt/expeditionary
-	display_name = "pt uniform, sifguard"
-	path = /obj/item/clothing/under/pt/expeditionary
-
-/datum/gear/uniform/pt/fleet
-	display_name = "pt uniform, fleet"
-	path = /obj/item/clothing/under/pt/fleet
-
 /datum/gear/uniform/utility
 	display_name = "utility, black"
 	path = /obj/item/clothing/under/utility
-	cost = 2
 
-/datum/gear/uniform/utility/fleet
-	display_name = "utility, navy"
-	path = /obj/item/clothing/under/utility/fleet
+/datum/gear/uniform/utility/blue
+	display_name = "utility, blue"
+	path = /obj/item/clothing/under/utility/blue
 
-/datum/gear/uniform/utility/marine
+/datum/gear/uniform/utility/grey
 	display_name = "utility, grey"
-	path = /obj/item/clothing/under/utility/marine
+	path = /obj/item/clothing/under/utility/grey
 
 /datum/gear/uniform/sweater
 	display_name = "sweater, grey"

--- a/code/modules/clothing/suits/solgov.dm
+++ b/code/modules/clothing/suits/solgov.dm
@@ -12,47 +12,47 @@
 	siemens_coefficient = 0.9
 	allowed = list(/obj/item/weapon/tank/emergency/oxygen,/obj/item/device/flashlight,/obj/item/weapon/pen,/obj/item/clothing/head/soft,/obj/item/clothing/head/beret,/obj/item/weapon/storage/fancy/cigarettes,/obj/item/weapon/flame/lighter,/obj/item/device/taperecorder,/obj/item/device/analyzer,/obj/item/device/radio,/obj/item/taperoll)
 
-/obj/item/clothing/suit/storage/service/expeditionary
+/obj/item/clothing/suit/storage/service/sifguard
 	name = "\improper SifGuard jacket"
 	desc = "A uniform service jacket belonging to the Sif Defense Force. It has silver buttons."
 	icon_state = "blackservice_crew"
 
-/obj/item/clothing/suit/storage/service/expeditionary/medical
+/obj/item/clothing/suit/storage/service/sifguard/medical
 	name = "\improper SifGuard medical jacket"
 	desc = "A uniform service jacket belonging to the Sif Defense Force. It has silver buttons and blue trim."
 	icon_state = "blackservice_med"
 
-/obj/item/clothing/suit/storage/service/expeditionary/medical/command
+/obj/item/clothing/suit/storage/service/sifguard/medical/command
 	name = "\improper SifGuard medical command jacket"
 	desc = "A uniform service jacket belonging to the Sif Defense Force. It has gold buttons and blue trim."
 	icon_state = "blackservice_medcom"
 
-/obj/item/clothing/suit/storage/service/expeditionary/engineering
+/obj/item/clothing/suit/storage/service/sifguard/engineering
 	name = "\improper SifGuard engineering jacket"
 	desc = "A uniform service jacket belonging to the Sif Defense Force. It has silver buttons and orange trim."
 	icon_state = "blackservice_eng"
 
-/obj/item/clothing/suit/storage/service/expeditionary/engineering/command
+/obj/item/clothing/suit/storage/service/sifguard/engineering/command
 	name = "\improper SifGuard engineering command jacket"
 	desc = "A uniform service jacket belonging to the Sif Defense Force. It has gold buttons and orange trim."
 	icon_state = "blackservice_engcom"
 
-/obj/item/clothing/suit/storage/service/expeditionary/supply
+/obj/item/clothing/suit/storage/service/sifguard/supply
 	name = "\improper SifGuard supply jacket"
 	desc = "A uniform service jacket belonging to the Sif Defense Force. It has silver buttons and brown trim."
 	icon_state = "blackservice_sup"
 
-/obj/item/clothing/suit/storage/service/expeditionary/security
+/obj/item/clothing/suit/storage/service/sifguard/security
 	name = "\improper SifGuard security jacket"
 	desc = "A uniform service jacket belonging to the Sif Defense Force. It has silver buttons and red trim."
 	icon_state = "blackservice_sec"
 
-/obj/item/clothing/suit/storage/service/expeditionary/security/command
+/obj/item/clothing/suit/storage/service/sifguard/security/command
 	name = "\improper SifGuard security command jacket"
 	desc = "A uniform service jacket belonging to the Sif Defense Force. It has gold buttons and red trim."
 	icon_state = "blackservice_seccom"
 
-/obj/item/clothing/suit/storage/service/expeditionary/command
+/obj/item/clothing/suit/storage/service/sifguard/command
 	name = "\improper SifGuard command jacket"
 	desc = "A uniform service jacket belonging to the Sif Defense Force. It has gold buttons and gold trim."
 	icon_state = "blackservice_com"

--- a/code/modules/clothing/under/accessories/armor.dm
+++ b/code/modules/clothing/under/accessories/armor.dm
@@ -150,16 +150,16 @@
 //Decorative attachments
 /obj/item/clothing/accessory/armor/tag
 	name = "\improper SCG Flag"
-	desc = "An emblem depicting the Sol Central Government's flag."
+	desc = "An emblem depicting the Solar Confederate Government's flag."
 	icon_override = 'icons/mob/modular_armor.dmi'
 	icon = 'icons/obj/clothing/modular_armor.dmi'
 //	accessory_icons = list(slot_tie_str = 'icons/mob/modular_armor.dmi', slot_wear_suit_str = 'icons/mob/modular_armor.dmi')
 	icon_state = "solflag"
 	slot = ACCESSORY_SLOT_ARMOR_M
 
-/obj/item/clothing/accessory/armor/tag/ec
-	name = "\improper Expeditionary Corps crest"
-	desc = "An emblem depicting the crest of the SCG Expeditionary Corps."
+/obj/item/clothing/accessory/armor/tag/sifguard
+	name = "\improper Sif Defense Force crest"
+	desc = "An emblem depicting the crest of the Sif Defense Force."
 	icon_state = "ecflag"
 
 /obj/item/clothing/accessory/armor/tag/sec
@@ -169,7 +169,7 @@
 
 /obj/item/clothing/accessory/armor/tag/com
 	name = "\improper SCG tag"
-	desc = "An armor tag with the words SOL CENTRAL GOVERNMENT printed in gold lettering on it."
+	desc = "An armor tag with the words SOLAR CONFEDERATE GOVERNMENT printed in gold lettering on it."
 	icon_state = "comtag"
 
 /obj/item/clothing/accessory/armor/tag/nt

--- a/code/modules/clothing/under/solgov.dm
+++ b/code/modules/clothing/under/solgov.dm
@@ -10,7 +10,7 @@
 	siemens_coefficient = 0.9
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO
 
-/obj/item/clothing/under/pt/expeditionary
+/obj/item/clothing/under/pt/sifguard
 	name = "\improper SifGuard pt uniform"
 	desc = "A baggy shirt bearing the seal of the Sif Defense Force and some dorky looking blue shorts."
 	icon_state = "expeditionpt"
@@ -30,7 +30,7 @@
 
 
 //Utility
-
+//These are just colored
 /obj/item/clothing/under/utility
 	name = "utility uniform"
 	desc = "A comfortable turtleneck and black utility trousers."
@@ -39,56 +39,69 @@
 	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 0, rad = 0)
 	siemens_coefficient = 0.9
 
-/obj/item/clothing/under/utility/expeditionary
+/obj/item/clothing/under/utility/blue
+	name = "utility uniform"
+	desc = "A comfortable blue utility jumpsuit."
+	icon_state = "navyutility"
+	worn_state = "navyutility"
+
+/obj/item/clothing/under/utility/grey
+	name = "utility uniform"
+	desc = "A comfortable grey utility jumpsuit."
+	icon_state = "greyutility"
+	worn_state = "greyutility"
+
+//Here's the real ones
+/obj/item/clothing/under/utility/sifguard
 	name = "\improper SifGuard uniform"
 	desc = "The utility uniform of the Sif Defense Force, made from biohazard resistant material. This one has silver trim."
 	icon_state = "blackutility_crew"
 	worn_state = "blackutility_crew"
 	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 10, rad = 10)
 
-/obj/item/clothing/under/utility/expeditionary/medical
+/obj/item/clothing/under/utility/sifguard/medical
 	name = "\improper SifGuard medical uniform"
 	desc = "The utility uniform of the Sif Defense Force, made from biohazard resistant material. This one has silver trim and blue blazes."
 	icon_state = "blackutility_med"
 	worn_state = "blackutility_med"
 
-/obj/item/clothing/under/utility/expeditionary/medical/command
+/obj/item/clothing/under/utility/sifguard/medical/command
 	name = "\improper SifGuard medical command uniform"
 	desc = "The utility uniform of the Sif Defense Force, made from biohazard resistant material. This one has gold trim and blue blazes."
 	icon_state = "blackutility_medcom"
 	worn_state = "blackutility_medcom"
 
-/obj/item/clothing/under/utility/expeditionary/engineering
+/obj/item/clothing/under/utility/sifguard/engineering
 	name = "\improper SifGuard engineering uniform"
 	desc = "The utility uniform of the Sif Defense Force, made from biohazard resistant material. This one has silver trim and organge blazes."
 	icon_state = "blackutility_eng"
 	worn_state = "blackutility_eng"
 
-/obj/item/clothing/under/utility/expeditionary/engineering/command
+/obj/item/clothing/under/utility/sifguard/engineering/command
 	name = "\improper SifGuard engineering command uniform"
 	desc = "The utility uniform of the Sif Defense Force, made from biohazard resistant material. This one has gold trim and organge blazes."
 	icon_state = "blackutility_engcom"
 	worn_state = "blackutility_engcom"
 
-/obj/item/clothing/under/utility/expeditionary/supply
+/obj/item/clothing/under/utility/sifguard/supply
 	name = "\improper SifGuard supply uniform"
 	desc = "The utility uniform of the Sif Defense Force, made from biohazard resistant material. This one has silver trim and brown blazes."
 	icon_state = "blackutility_sup"
 	worn_state = "blackutility_sup"
 
-/obj/item/clothing/under/utility/expeditionary/security
+/obj/item/clothing/under/utility/sifguard/security
 	name = "\improper SifGuard security uniform"
 	desc = "The utility uniform of the Sif Defense Force, made from biohazard resistant material. This one has silver trim and red blazes."
 	icon_state = "blackutility_sec"
 	worn_state = "blackutility_sec"
 
-/obj/item/clothing/under/utility/expeditionary/security/command
+/obj/item/clothing/under/utility/sifguard/security/command
 	name = "\improper SifGuard security command uniform"
 	desc = "The utility uniform of the Sif Defense Force, made from biohazard resistant material. This one has gold trim and red blazes."
 	icon_state = "blackutility_seccom"
 	worn_state = "blackutility_seccom"
 
-/obj/item/clothing/under/utility/expeditionary/command
+/obj/item/clothing/under/utility/sifguard/command
 	name = "\improper SifGuard command uniform"
 	desc = "The utility uniform of the Sif Defense Force, made from biohazard resistant material. This one has gold trim and gold blazes."
 	icon_state = "blackutility_com"
@@ -220,13 +233,13 @@
 	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 0, rad = 0)
 	siemens_coefficient = 0.9
 
-/obj/item/clothing/under/mildress/expeditionary
+/obj/item/clothing/under/mildress/sifguard
 	name = "\improper SifGuard dress uniform"
 	desc = "The dress uniform of the Sif Defense Force in silver trim."
 	icon_state = "greydress"
 	worn_state = "greydress"
 
-/obj/item/clothing/under/mildress/expeditionary/command
+/obj/item/clothing/under/mildress/sifguard/command
 	name = "\improper SifGuard command dress uniform"
 	desc = "The dress uniform of the Sif Defense Force in gold trim."
 	icon_state = "greydress_com"


### PR DESCRIPTION
- Removes the Fleet, Marine, and SifGuard PT uniforms from the loadout. Left the underwear in place.
- Removes the Fleet and Marine Utility uniforms from the loadout. Replaced them with statless versions with the same sprites.
- Removes Service Jackets from the loadout.
- Repaths a bunch of stuff that was still /expeditionary