### PR TITLE
Crawling

### DIFF
--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -68,7 +68,7 @@
 /atom/movable/proc/user_buckle_mob(mob/living/M, mob/user, var/forced = FALSE, var/silent = FALSE)
 	if(!ticker)
 		user << "<span class='warning'>You can't buckle anyone in before the game starts.</span>"
-	if(!user.Adjacent(M) || user.restrained() || user.lying || user.stat || istype(user, /mob/living/silicon/pai))
+	if(!user.Adjacent(M) || user.restrained() || user.stat || istype(user, /mob/living/silicon/pai))
 		return
 	if(M == buckled_mob)
 		return

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -84,6 +84,24 @@ turf/attackby(obj/item/weapon/W as obj, mob/user as mob)
 			S.gather_all(src, user)
 	return ..()
 
+/turf/MouseDrop_T(atom/movable/O as mob|obj, mob/user as mob)
+	var/turf/T = get_turf(user)
+	var/area/A = T.loc
+	if((istype(A) && !(A.has_gravity)) || (istype(T,/turf/space)))
+		return
+	if(istype(O, /obj/screen))
+		return
+	if(user.restrained() || user.stat || user.stunned || user.paralysis)
+		return
+	if((!(istype(O, /atom/movable)) || O.anchored || !Adjacent(user) || !Adjacent(O) || !user.Adjacent(O)))
+		return
+	if(!isturf(O.loc) || !isturf(user.loc))
+		return
+	if(isanimal(user) && O != user)
+		return
+	if (do_after(user, 25 + (5 * user.weakened)) && !(user.stat))
+		step_towards(O, src)
+
 /turf/Enter(atom/movable/mover as mob|obj, atom/forget as mob|obj|turf|area)
 	if(movement_disabled && usr.ckey != movement_disabled_exception)
 		usr << "<span class='warning'>Movement is admin-disabled.</span>" //This is to identify lag problems

--- a/html/changelogs/PrismaticGynoid-crawl.yml
+++ b/html/changelogs/PrismaticGynoid-crawl.yml
@@ -1,0 +1,5 @@
+author: PrismaticGynoid
+delete-after: True
+changes: 
+  - rscadd: "Adds the ability to 'crawl' to an adjacent turf by click-dragging yourself to it, after a delay. This can be used to move while unable to stand. You can also do this with other movable objects, if you really wanted to."
+  - tweak: "Conscious mobs lying on the ground can now buckle themselves to chairs/beds. This includes people missing legs."


### PR DESCRIPTION
Mobs now have the ability to "crawl" to an adjacent turf by click-dragging themselves to it. This would allow people unable to stand to still move around, though very slowly. You could also do this to other movable mobs or objects, if you really wanted to.

Moving this way takes about 2.5 seconds, plus half a second for each point of weakness you have. For a person missing a leg, this would take 5 seconds. It only works if the mob doing this is alive, conscious, unrestrained, not stunned or paralyzed, and in an area with gravity - no crawling through space.

Mobs lying on the ground are now able to buckle themselves to chairs or beds. For people missing legs or feet, this means no more being stuck helpless on the ground forever because Baldie McGreytide clicked on your wheelchair.

Tested in many different situations, and I've patched every bug that popped up.