### PR TITLE
Fixes Cerulean slime enhancer

### DIFF
--- a/code/modules/xenobio/items/extracts.dm
+++ b/code/modules/xenobio/items/extracts.dm
@@ -756,7 +756,7 @@
 	result_amount = 1
 	required = /obj/item/slime_extract/cerulean
 
-/datum/chemical_reaction/slime/cerulean_enhance/on_reaction(var/datum/reagents/holder)
+/datum/chemical_reaction/slime/cerulean_enhancer/on_reaction(var/datum/reagents/holder)
 	new /obj/item/slimepotion/enhancer(get_turf(holder.my_atom))
 	..()
 


### PR DESCRIPTION
- Makes cerulean slime spawn the potion correctly when the reaction occurs.