### PR TITLE
Makes galoshes not conduct electricity

### DIFF
--- a/code/modules/clothing/shoes/miscellaneous.dm
+++ b/code/modules/clothing/shoes/miscellaneous.dm
@@ -20,6 +20,7 @@
 	name = "galoshes"
 	icon_state = "galoshes"
 	permeability_coefficient = 0.05
+	siemens_coefficient = 0 //They're thick rubber boots! Of course they won't conduct electricity!
 	item_flags = NOSLIP
 	slowdown = SHOES_SLOWDOWN+1
 	species_restricted = null


### PR DESCRIPTION
They're thick rubber boots! Of course they won't conduct electricity

Really not too big of a game changer. You could argue this _slightly_ makes the janitor stronger since his  boots won't cause him to be shocked if he gets shot in the feet, but... Who shoots at the feet anyways?

They'll still take damage from tasers/shocks, just not tasers/shocks that target only the feet.