### PR TITLE
Dropper and bloodpack improvements

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -202,6 +202,32 @@
 		M.heal_organ_damage(30 * removed, 30 * removed)
 		M.adjustToxLoss(-30 * removed)
 
+/datum/reagent/saline
+	name = "Saline"
+	id = "saline"
+	description = "A mixture of sodium chloride in water, saline can be used to treat minor eye and brain trauma. It's really just salt-water."
+	taste_description = "salt"
+	reagent_state = LIQUID
+	color = "#F4F4F4"
+	scannable = 1
+
+/datum/reagent/saline/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
+	if(alien == IS_DIONA)
+		return
+	M.adjustBrainLoss(-1 * removed)
+	M.eye_blurry = max(M.eye_blurry - 1, 0)
+	M.AdjustBlinded(-1)
+	if(ishuman(M))
+		var/mob/living/carbon/human/H = M
+		var/obj/item/organ/internal/eyes/E = H.internal_organs_by_name[O_EYES]
+		if(istype(E))
+			if(E.robotic >= ORGAN_ROBOT)
+				return
+			if(E.damage > 0)
+				E.damage = max(E.damage - 1 * removed, 0)
+			if(E.damage <= 1 && E.organ_tag == O_EYES)
+				H.sdisabilities &= ~BLIND
+
 /* Painkillers */
 
 /datum/reagent/paracetamol

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -202,32 +202,6 @@
 		M.heal_organ_damage(30 * removed, 30 * removed)
 		M.adjustToxLoss(-30 * removed)
 
-/datum/reagent/saline
-	name = "Saline"
-	id = "saline"
-	description = "A mixture of sodium chloride in water, saline can be used to treat minor eye and brain trauma. It's really just salt-water."
-	taste_description = "salt"
-	reagent_state = LIQUID
-	color = "#F4F4F4"
-	scannable = 1
-
-/datum/reagent/saline/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
-	if(alien == IS_DIONA)
-		return
-	M.adjustBrainLoss(-1 * removed)
-	M.eye_blurry = max(M.eye_blurry - 1, 0)
-	M.AdjustBlinded(-1)
-	if(ishuman(M))
-		var/mob/living/carbon/human/H = M
-		var/obj/item/organ/internal/eyes/E = H.internal_organs_by_name[O_EYES]
-		if(istype(E))
-			if(E.robotic >= ORGAN_ROBOT)
-				return
-			if(E.damage > 0)
-				E.damage = max(E.damage - 1 * removed, 0)
-			if(E.damage <= 1 && E.organ_tag == O_EYES)
-				H.sdisabilities &= ~BLIND
-
 /* Painkillers */
 
 /datum/reagent/paracetamol

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -410,13 +410,6 @@
 	catalysts = list("phoron" = 5)
 	result_amount = 2
 
-/datum/chemical_reaction/saline
-	name = "Saline"
-	id = "saline"
-	result = "saline"
-	required_reagents = list("sodiumchloride" = 1, "water" = 3)
-	result_amount = 4
-
 /datum/chemical_reaction/spaceacillin
 	name = "Spaceacillin"
 	id = "spaceacillin"

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -410,6 +410,13 @@
 	catalysts = list("phoron" = 5)
 	result_amount = 2
 
+/datum/chemical_reaction/saline
+	name = "Saline"
+	id = "saline"
+	result = "saline"
+	required_reagents = list("sodiumchloride" = 1, "water" = 3)
+	result_amount = 4
+
 /datum/chemical_reaction/spaceacillin
 	name = "Spaceacillin"
 	id = "spaceacillin"
@@ -2172,7 +2179,7 @@
 	result = "mojito"
 	required_reagents = list("rum" = 3, "limejuice" = 1, "mint" = 1)
 	result_amount = 5
-	
+
 /datum/chemical_reaction/drinks/piscosour
 	name = "Pisco Sour"
 	id = "piscosour"
@@ -2186,8 +2193,8 @@
 	result = "coldfront"
 	required_reagents = list("icecoffee" = 1, "whiskey" = 1, "mint" = 1)
 	result_amount = 3
-	
-	
+
+
 //R-UST Port
 /datum/chemical_reaction/hyrdophoron
 	name = "Hydrophoron"

--- a/code/modules/reagents/reagent_containers/blood_pack.dm
+++ b/code/modules/reagents/reagent_containers/blood_pack.dm
@@ -14,19 +14,25 @@
 		new /obj/item/weapon/reagent_containers/blood/empty(src)
 
 /obj/item/weapon/reagent_containers/blood
-	name = "BloodPack"
-	desc = "Contains blood used for transfusion."
+	name = "IV pack"
+	var/base_name = " "
+	desc = "Holds liquids used for transfusion."
+	var/base_desc = " "
 	icon = 'icons/obj/bloodpack.dmi'
 	icon_state = "empty"
 	item_state = "bloodpack_empty"
 	volume = 200
+	var/label_text = ""
 
 	var/blood_type = null
 
 /obj/item/weapon/reagent_containers/blood/New()
 	..()
+	base_name = name
+	base_desc = desc
 	if(blood_type != null)
-		name = "BloodPack [blood_type]"
+		label_text = "[blood_type]"
+		update_iv_label()
 		reagents.add_reagent("blood", 200, list("donor"=null,"viruses"=null,"blood_DNA"=null,"blood_type"=blood_type,"resistances"=null,"trace_chem"=null))
 		update_icon()
 
@@ -44,6 +50,30 @@
 	else if(percent >= 51 && percent < INFINITY)
 		icon_state = "full"
 		item_state = "bloodpack_full"
+
+/obj/item/weapon/reagent_containers/blood/attackby(obj/item/weapon/W as obj, mob/user as mob)
+	if(istype(W, /obj/item/weapon/pen) || istype(W, /obj/item/device/flashlight/pen))
+		var/tmp_label = sanitizeSafe(input(user, "Enter a label for [name]", "Label", label_text), MAX_NAME_LEN)
+		if(length(tmp_label) > 50)
+			to_chat(user, "<span class='notice'>The label can be at most 50 characters long.</span>")
+		else if(length(tmp_label) > 10)
+			to_chat(user, "<span class='notice'>You set the label.</span>")
+			label_text = tmp_label
+			update_iv_label()
+		else
+			to_chat(user, "<span class='notice'>You set the label to \"[tmp_label]\".</span>")
+			label_text = tmp_label
+			update_iv_label()
+
+/obj/item/weapon/reagent_containers/blood/proc/update_iv_label()
+	if(label_text == "")
+		name = base_name
+	else if(length(label_text) > 10)
+		var/short_label_text = copytext(label_text, 1, 11)
+		name = "[base_name] ([short_label_text]...)"
+	else
+		name = "[base_name] ([label_text])"
+	desc = "[base_desc] It is labeled \"[label_text]\"."
 
 /obj/item/weapon/reagent_containers/blood/APlus
 	blood_type = "A+"


### PR DESCRIPTION
* Improves droppers - rather than splashing half their reagents onto the target, injecting a quarter into the bloodstream, and retaining a quarter in the dropper, they actually... work now. You can also use less than the entire dropper - e.g. one or two drops.
* Improves IV packs - you can label them with a pen now, and their default blood type is their default label. If you're feeling traitorous, label all the O- blood as AB+, and vice versa.