### PR TITLE
Adds health analyzers to medkits missing them.

### DIFF
--- a/code/game/objects/items/weapons/storage/firstaid.dm
+++ b/code/game/objects/items/weapons/storage/firstaid.dm
@@ -102,13 +102,14 @@
 /obj/item/weapon/storage/firstaid/adv/New()
 	..()
 	if (empty) return
-	new /obj/item/weapon/reagent_containers/hypospray/autoinjector( src )
+	new /obj/item/weapon/reagent_containers/hypospray/autoinjector(src)
 	new /obj/item/stack/medical/advanced/bruise_pack(src)
 	new /obj/item/stack/medical/advanced/bruise_pack(src)
 	new /obj/item/stack/medical/advanced/bruise_pack(src)
 	new /obj/item/stack/medical/advanced/ointment(src)
 	new /obj/item/stack/medical/advanced/ointment(src)
 	new /obj/item/stack/medical/splint(src)
+	new /obj/item/device/healthanalyzer(src)
 	return
 
 /obj/item/weapon/storage/firstaid/combat
@@ -128,6 +129,7 @@
 	new /obj/item/weapon/storage/pill_bottle/spaceacillin(src)
 	new /obj/item/weapon/reagent_containers/hypospray/autoinjector/biginjector/clotting(src)
 	new /obj/item/stack/medical/splint(src)
+	new /obj/item/device/healthanalyzer(src)
 	return
 
 /obj/item/weapon/storage/firstaid/surgery


### PR DESCRIPTION
So, previously every 'basic' medkit - regular, oxy, toxin, burn - had a health analyzer... but the advanced and combat ones didn't. Now they do.

This PR adds a health analyzer to the advanced medkit and combat medkit. Boom.

* "Why? Doctors already have health analyzers." Sure, but the medkits didn't. Consistency.
* "Doesn't this add more health analyzers?" Yep. Not like we have them in almost infinite quantities anyway.
* "How about the combat medkit?" If you buy a combat medkit, you get your money's worth. That means a health analyzer.
* "Power creep!" More like consistency creep.