### PR TITLE
Use mutable_appearance for HUD health overlays.

### DIFF
--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -1211,8 +1211,9 @@
 				healths.icon_state = "health_numb"
 			else
 				// Generate a by-limb health display.
-				healths.icon_state = "blank"
-				healths.overlays = null
+				var/mutable_appearance/healths_ma = new(healths)
+				healths_ma.icon_state = "blank"
+				healths_ma.overlays = null
 
 				var/no_damage = 1
 				var/trauma_val = 0 // Used in calculating softcrit/hardcrit indicators.
@@ -1240,7 +1241,8 @@
 				else if(no_damage)
 					health_images += image('icons/mob/screen1_health.dmi',"fullhealth")
 
-				healths.overlays += health_images
+				healths_ma.overlays += health_images
+				healths.appearance = healths_ma
 
 		if(nutrition_icon)
 			switch(nutrition)


### PR DESCRIPTION
This improves the issue of player mobs using excessive CPU every Life() tick.
* Testing determined the worst performance was actually the manipulation of the "healths" HUD doll's overlays.
* Switching to using a mutable_appearance helps quite a bit for little effort.

Tested to ensure the health doll still worked after the change.  **On the test server player mob Life() time dropped by over 30% when idle.**