### PR TITLE
Fixes Welding

### DIFF
--- a/code/modules/clothing/spacesuits/spacesuits.dm
+++ b/code/modules/clothing/spacesuits/spacesuits.dm
@@ -17,7 +17,7 @@
 	species_restricted = list("exclude","Diona")
 	preserve_item = 1
 	phoronproof = 1
-	flash_protection = FLASH_PROTECTION_NONE
+	flash_protection = FLASH_PROTECTION_MAJOR
 
 	var/obj/machinery/camera/camera
 	var/list/camera_networks

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -715,8 +715,6 @@
 		add_clothing_protection(glasses)
 	if(istype(src.wear_mask, /obj/item/clothing/mask))
 		add_clothing_protection(wear_mask)
-	if(istype(back,/obj/item/weapon/rig))
-		add_clothing_protection(back)
 
 	return flash_protection
 


### PR DESCRIPTION
Welding in a RIG/spacesuit is currently broken. This PR fixes it. It was broken for two reasons.
First, the proc to get flash protection assumed the RIG was a clothing item, and as such thought it had variables it doesn't. So it would runtime.
Second, spacesuit helmets lost their flash protection for some reason. This has been reversed.