### PR TITLE
Might Fix Resource Lag

### DIFF
--- a/code/__defines/_compile_options.dm
+++ b/code/__defines/_compile_options.dm
@@ -1,2 +1,8 @@
 #define BACKGROUND_ENABLED 0    // The default value for all uses of set background. Set background can cause gradual lag and is recommended you only turn this on if necessary.
 								// 1 will enable set background. 0 will disable set background.
+
+#define PRELOAD_RSC 1			/*set to:
+								0 to allow using external resources or on-demand behaviour;
+								1 to use the default behaviour (preload compiled in recourses, not player uploaded ones);
+								2 for preloading absolutely everything;
+								*/

--- a/code/modules/client/client defines.dm
+++ b/code/modules/client/client defines.dm
@@ -49,6 +49,7 @@
 	var/related_accounts_ip = "Requires database"	//So admins know why it isn't working - Used to determine what other accounts previously logged in from this ip
 	var/related_accounts_cid = "Requires database"	//So admins know why it isn't working - Used to determine what other accounts previously logged in from this computer id
 
-	preload_rsc = 0 // This is 0 so we can set it to an URL once the player logs in and have them download the resources from a different server.
+	preload_rsc = PRELOAD_RSC
+
 	var/global/obj/screen/click_catcher/void
-	
+

--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -105,11 +105,6 @@
 		del(src)
 		return
 
-	// Change the way they should download resources.
-	if(config.resource_urls)
-		src.preload_rsc = pick(config.resource_urls)
-	else src.preload_rsc = 1 // If config.resource_urls is not set, preload like normal.
-
 	src << "<font color='red'>If the title screen is black, resources are still downloading. Please be patient until the title screen appears.</font>"
 
 


### PR DESCRIPTION
Removes the dynamic setting of preload_rsc, because BYOND does not appear to respect it if it's not compiled in, and the dynamic nature of it is unused to my knowledge. If you need to change it, you can change a define in _compile_options.dm
This should now properly set it to '1', which should load all the resources at once, which might make some significant slowdown when first connecting, but should be preferable to constantly getting mini-lags when moving to new areas or hearing new sounds (like when getting shot at!).