### PR TITLE
Fixes unfoldable boxes.

### DIFF
--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -592,8 +592,9 @@
 
 /obj/item/weapon/storage/attack_self(mob/user as mob)
 	if((user.get_active_hand() == src) || (isrobot(user)) && allow_quick_empty)
-		src.quick_empty()
-		return 1 // Is this return even needed?
+		if(src.verbs.Find(/obj/item/weapon/storage/verb/quick_empty))
+			src.quick_empty()
+			return 1
 
 //Returns the storage depth of an atom. This is the number of storage items the atom is contained in before reaching toplevel (the area).
 //Returns -1 if the atom was not found on container.


### PR DESCRIPTION
-Apparently storage proc for this thing was changed to return 1 regardless if the item had the quick empty verb or not, which in turn triggered the very first nope of the box specific code.
-Boxes can be quick emptied but lack the actual verb apparently?
```
/obj/item/weapon/storage/box/attack_self(mob/user as mob)
	if(..()) return
```