### PR TITLE
Tweaks cache_lifespan

### DIFF
--- a/code/world.dm
+++ b/code/world.dm
@@ -34,7 +34,7 @@ var/global/datum/global_init/init = new ()
 	turf = /turf/space
 	area = /area/space
 	view = "15x15"
-	cache_lifespan = 0	//stops player uploaded stuff from being kept in the rsc past the current session
+	cache_lifespan = 7
 
 
 


### PR DESCRIPTION
Changes the world var from 0 to 7, as it is what /tg/ uses and it might help reduce the amount of data one needs to download when connecting. Not sure if it will but it can't hurt.