### PR TITLE
Eliminates one possible culprit behind dismemberment crashes.

### DIFF
--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -875,6 +875,8 @@ Note that amputating the affected organ does in fact remove the infection from t
 
 	switch(disintegrate)
 		if(DROPLIMB_EDGE)
+			if(appearance_flags >= PIXEL_SCALE)
+				appearance_flags -= PIXEL_SCALE
 			compile_icon()
 			add_blood(victim)
 			var/matrix/M = matrix()

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -875,8 +875,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 
 	switch(disintegrate)
 		if(DROPLIMB_EDGE)
-			if(appearance_flags >= PIXEL_SCALE)
-				appearance_flags -= PIXEL_SCALE
+			appearance_flags &= ~PIXEL_SCALE
 			compile_icon()
 			add_blood(victim)
 			var/matrix/M = matrix()


### PR DESCRIPTION
-Okay so. The dismemberment related crashing has decreased in the mob icon cache related cases, but another circumstance has been revealed pointing towards the severed limbs themselves.
-(Someone got splattered yesterday downstream and nuked half server into chain crashing lmao)
-Anyhow. I personally had completely forgotten to update my client last year from an awfully outdated pre-PIXEL_SCALING version, but I happened to do it way after people began crashing and cannot remember encountering a single crash myself from the before time for comparison.
-Which led to a theory that our poor little Byond simply has trouble adjusting to fresh features and occasionally gets overwhelmed by the task of tossing around a bunch of severed limbs inheriting their owner's visual properties while also having to randomly rotate each one.
-This thing just disables pixel scaling from severed limbs upon dismemberment.
-Because of the evil nature of the bug unpredictably manifesting in action and often leaving some witnesses un-crashed, I have no proof if this helps anything but I'll just toss it up and see if it sticks.