### PR TITLE
Additional Destroy proc fixes

### DIFF
--- a/code/game/gamemodes/technomancer/spells/flame_tongue.dm
+++ b/code/game/gamemodes/technomancer/spells/flame_tongue.dm
@@ -22,8 +22,7 @@
 	welder.setWelding(1)
 
 /obj/item/weapon/spell/flame_tongue/Destroy()
-	qdel(welder)
-	welder = null
+	qdel_null(welder)
 	return ..()
 
 /obj/item/weapon/weldingtool/spell

--- a/code/game/gamemodes/technomancer/spells/illusion.dm
+++ b/code/game/gamemodes/technomancer/spells/illusion.dm
@@ -62,8 +62,8 @@
 					illusion.emote(what_to_emote)
 
 /obj/item/weapon/spell/illusion/Destroy()
-	if(illusion)
-		qdel(illusion)
+	qdel_null(illusion)
+	copied = null
 	return ..()
 
 // Makes a tiny overlay of the thing the player has copied, so they can easily tell what they currently have.

--- a/code/game/gamemodes/technomancer/spells/phase_shift.dm
+++ b/code/game/gamemodes/technomancer/spells/phase_shift.dm
@@ -37,7 +37,7 @@
 	for(var/atom/movable/AM in contents) //Eject everything out.
 		AM.forceMove(get_turf(src))
 	processing_objects -= src
-	..()
+	return ..()
 
 /obj/effect/phase_shift/process()
 	for(var/mob/living/L in contents)

--- a/code/game/gamemodes/technomancer/spells/radiance.dm
+++ b/code/game/gamemodes/technomancer/spells/radiance.dm
@@ -25,7 +25,7 @@
 /obj/item/weapon/spell/radiance/Destroy()
 	processing_objects -= src
 	log_and_message_admins("has stopped maintaining [src].")
-	..()
+	return ..()
 
 /obj/item/weapon/spell/radiance/process()
 	var/turf/T = get_turf(src)

--- a/code/game/objects/items/antag_spawners.dm
+++ b/code/game/objects/items/antag_spawners.dm
@@ -12,7 +12,7 @@
 	sparks.attach(loc)
 
 /obj/item/weapon/antag_spawner/Destroy()
-	qdel(sparks)
+	qdel_null(sparks)
 	return ..()
 
 /obj/item/weapon/antag_spawner/proc/spawn_antag(client/C, turf/T)

--- a/code/game/objects/items/weapons/implants/implant.dm
+++ b/code/game/objects/items/weapons/implants/implant.dm
@@ -52,6 +52,7 @@
 /obj/item/weapon/implant/Destroy()
 	if(part)
 		part.implants.Remove(src)
+	part = null
 	return ..()
 
 /obj/item/weapon/implant/attackby(obj/item/I, mob/user)

--- a/code/game/objects/items/weapons/tanks/tanks.dm
+++ b/code/game/objects/items/weapons/tanks/tanks.dm
@@ -67,10 +67,10 @@ var/list/global/tank_gauge_cache = list()
 	return
 
 /obj/item/weapon/tank/Destroy()
-	qdel(air_contents)
+	qdel_null(air_contents)
 
 	processing_objects.Remove(src)
-	qdel(src.proxyassembly)
+	qdel_null(src.proxyassembly)
 
 	if(istype(loc, /obj/item/device/transfer_valve))
 		var/obj/item/device/transfer_valve/TTV = loc
@@ -609,6 +609,10 @@ var/list/global/tank_gauge_cache = list()
 /obj/item/device/tankassemblyproxy/receive_signal()	//This is mainly called by the sensor through sense() to the holder, and from the holder to here.
 	tank.ignite()	//boom (or not boom if you made shijwtty mix)
 
+/obj/item/device/tankassemblyproxy/Destroy()
+	. = ..()
+	tank = null
+	assembly = null
 
 /obj/item/weapon/tank/proc/assemble_bomb(W,user)	//Bomb assembly proc. This turns assembly+tank into a bomb
 	var/obj/item/device/assembly_holder/S = W

--- a/code/modules/integrated_electronics/core/assemblies.dm
+++ b/code/modules/integrated_electronics/core/assemblies.dm
@@ -53,11 +53,9 @@
 	processing_objects |= src
 
 /obj/item/device/electronic_assembly/Destroy()
-	battery = null
+	battery = null // It will be qdel'd by ..() if still in our contents
 	processing_objects -= src
-	for(var/atom/movable/AM in contents)
-		qdel(AM)
-	..()
+	return ..()
 
 /obj/item/device/electronic_assembly/process()
 	handle_idle_power()

--- a/code/modules/integrated_electronics/subtypes/manipulation.dm
+++ b/code/modules/integrated_electronics/subtypes/manipulation.dm
@@ -25,8 +25,8 @@
 	power_draw_per_use = 50 // The targeting mechanism uses this.  The actual gun uses its own cell for firing if it's an energy weapon.
 
 /obj/item/integrated_circuit/manipulation/weapon_firing/Destroy()
-	qdel(installed_gun)
-	..()
+	installed_gun = null // It will be qdel'd by ..() if still in our contents
+	return ..()
 
 /obj/item/integrated_circuit/manipulation/weapon_firing/attackby(var/obj/O, var/mob/user)
 	if(istype(O, /obj/item/weapon/gun))

--- a/code/modules/xenoarcheaology/tools/suspension_generator.dm
+++ b/code/modules/xenoarcheaology/tools/suspension_generator.dm
@@ -247,5 +247,5 @@
 
 /obj/effect/suspension_field/Destroy()
 	for(var/atom/movable/I in src)
-		I.loc = src.loc
-	..()
+		I.dropInto(loc)
+	return ..()


### PR DESCRIPTION
These procs needed to return a QDEL hint or make sure they nulled out their references.