### PR TITLE
Fix runtimes in MouseDrop when dragging out of the screen

### DIFF
--- a/code/modules/clothing/clothing_accessories.dm
+++ b/code/modules/clothing/clothing_accessories.dm
@@ -40,7 +40,7 @@
 	return ..()
 
 /obj/item/clothing/MouseDrop(var/obj/over_object)
-	if (ishuman(usr) || issmall(usr))
+	if (over_object && (ishuman(usr) || issmall(usr)))
 		//makes sure that the clothing is equipped so that we can't drag it into our hand from miles away.
 		if (!(src.loc == usr))
 			return

--- a/code/modules/detectivework/tools/evidencebag.dm
+++ b/code/modules/detectivework/tools/evidencebag.dm
@@ -12,6 +12,8 @@
 /obj/item/weapon/evidencebag/MouseDrop(var/obj/item/I as obj)
 	if (!ishuman(usr))
 		return
+	if(!istype(I) || I.anchored)
+		return  ..()
 
 	var/mob/living/carbon/human/user = usr
 
@@ -35,9 +37,6 @@
 			user.drop_from_inventory(I)
 		else
 			return
-
-	if(!istype(I) || I.anchored)
-		return
 
 	if(istype(I, /obj/item/weapon/evidencebag))
 		user << "<span class='notice'>You find putting an evidence bag in another evidence bag to be slightly absurd.</span>"


### PR DESCRIPTION
* MouseDrop()'s over_object may be null if dropping over a stat panel or over other empty space. Fix runtimes from assuming it is not null.
* Fixes Runtime in clothing_accessories.dm,54: Cannot read null.name
* Fixes Runtime in evidencebag.dm,21: Cannot read null.loc
There may be more types for which this is an issue, but I did a quick search and didn't notice any obvious ones in code.

Resolves VOREStation/VOREStation/issues/2667