### PR TITLE
Prepare Atmospherics Machinery for SSatoms

### DIFF
--- a/code/ATMOSPHERICS/atmospherics.dm
+++ b/code/ATMOSPHERICS/atmospherics.dm
@@ -10,9 +10,6 @@ Pipelines + Other Objects -> Pipe network
 
 */
 /obj/machinery/atmospherics
-
-	auto_init = 0
-
 	anchored = 1
 	idle_power_usage = 0
 	active_power_usage = 0
@@ -47,6 +44,14 @@ Pipelines + Other Objects -> Pipe network
 
 // This is used to set up what directions pipes will connect to.  Should be called inside New() and whenever a dir changes.
 /obj/machinery/atmospherics/proc/init_dir()
+	return
+
+// Initializes nodes by looking at neighboring atmospherics machinery to connect to.
+// When we're being constructed at runtime, atmos_init() is called by the construction code.
+// When dynamically loading a map atmos_init is called by the maploader (initTemplateBounds proc)
+// But during initial world creation its called by the master_controller.
+// TODO - Consolidate these different ways of being called once SSatoms is created.
+/obj/machinery/atmospherics/proc/atmos_init()
 	return
 
 /obj/machinery/atmospherics/attackby(atom/A, mob/user as mob)

--- a/code/ATMOSPHERICS/atmospherics.dm
+++ b/code/ATMOSPHERICS/atmospherics.dm
@@ -33,6 +33,7 @@ Pipelines + Other Objects -> Pipe network
 	var/obj/machinery/atmospherics/node2
 
 /obj/machinery/atmospherics/New()
+	..()
 	if(!icon_manager)
 		icon_manager = new()
 
@@ -42,7 +43,11 @@ Pipelines + Other Objects -> Pipe network
 
 	if(!pipe_color_check(pipe_color))
 		pipe_color = null
-	..()
+	init_dir()
+
+// This is used to set up what directions pipes will connect to.  Should be called inside New() and whenever a dir changes.
+/obj/machinery/atmospherics/proc/init_dir()
+	return
 
 /obj/machinery/atmospherics/attackby(atom/A, mob/user as mob)
 	if(istype(A, /obj/item/device/pipe_painter))

--- a/code/ATMOSPHERICS/components/binary_devices/binary_atmos_base.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/binary_atmos_base.dm
@@ -57,7 +57,7 @@
 	node1 = null
 	node2 = null
 
-/obj/machinery/atmospherics/binary/initialize()
+/obj/machinery/atmospherics/binary/atmos_init()
 	if(node1 && node2)
 		return
 

--- a/code/ATMOSPHERICS/components/binary_devices/binary_atmos_base.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/binary_atmos_base.dm
@@ -61,20 +61,16 @@
 	if(node1 && node2)
 		return
 
-	init_dir()
-
 	var/node2_connect = dir
 	var/node1_connect = turn(dir, 180)
 
 	for(var/obj/machinery/atmospherics/target in get_step(src,node1_connect))
-		target.init_dir()
 		if(target.initialize_directions & get_dir(target,src))
 			if (check_connect_types(target,src))
 				node1 = target
 				break
 
 	for(var/obj/machinery/atmospherics/target in get_step(src,node2_connect))
-		target.init_dir()
 		if(target.initialize_directions & get_dir(target,src))
 			if (check_connect_types(target,src))
 				node2 = target

--- a/code/ATMOSPHERICS/components/binary_devices/circulator.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/circulator.dm
@@ -101,13 +101,13 @@
 			else if(dir & (EAST|WEST))
 				initialize_directions = EAST|WEST
 
-			initialize()
+			atmos_init()
 			build_network()
 			if (node1)
-				node1.initialize()
+				node1.atmos_init()
 				node1.build_network()
 			if (node2)
-				node2.initialize()
+				node2.atmos_init()
 				node2.build_network()
 		else
 			if(node1)

--- a/code/ATMOSPHERICS/components/binary_devices/passive_gate.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/passive_gate.dm
@@ -166,7 +166,7 @@
 		return
 	src.add_fingerprint(usr)
 	if(!src.allowed(user))
-		user << "<span class='warning'>Access denied.</span>"
+		to_chat(user, "<span class='warning'>Access denied.</span>")
 		return
 	usr.set_machine(src)
 	ui_interact(user)
@@ -240,14 +240,14 @@
 	if (!istype(W, /obj/item/weapon/wrench))
 		return ..()
 	if (unlocked)
-		user << "<span class='warning'>You cannot unwrench \the [src], turn it off first.</span>"
+		to_chat(user, "<span class='warning'>You cannot unwrench \the [src], turn it off first.</span>")
 		return 1
 	if(!can_unwrench())
 		to_chat(user, "<span class='warning'>You cannot unwrench \the [src], it too exerted due to internal pressure.</span>")
 		add_fingerprint(user)
 		return 1
 	playsound(src, W.usesound, 50, 1)
-	user << "<span class='notice'>You begin to unfasten \the [src]...</span>"
+	to_chat(user, "<span class='notice'>You begin to unfasten \the [src]...</span>")
 	if (do_after(user, 40 * W.toolspeed))
 		user.visible_message( \
 			"<span class='notice'>\The [user] unfastens \the [src].</span>", \

--- a/code/ATMOSPHERICS/components/binary_devices/pipeturbine.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/pipeturbine.dm
@@ -87,7 +87,7 @@
 		if(istype(W, /obj/item/weapon/wrench))
 			anchored = !anchored
 			playsound(src, W.usesound, 50, 1)
-			user << "<span class='notice'>You [anchored ? "secure" : "unsecure"] the bolts holding \the [src] to the floor.</span>"
+			to_chat(user, "<span class='notice'>You [anchored ? "secure" : "unsecure"] the bolts holding \the [src] to the floor.</span>")
 
 			if(anchored)
 				if(dir & (NORTH|SOUTH))
@@ -260,7 +260,7 @@
 			anchored = !anchored
 			playsound(src, W.usesound, 50, 1)
 			turbine = null
-			user << "<span class='notice'>You [anchored ? "secure" : "unsecure"] the bolts holding \the [src] to the floor.</span>"
+			to_chat(user, "<span class='notice'>You [anchored ? "secure" : "unsecure"] the bolts holding \the [src] to the floor.</span>")
 			updateConnection()
 		else
 			..()

--- a/code/ATMOSPHERICS/components/binary_devices/pipeturbine.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/pipeturbine.dm
@@ -95,13 +95,13 @@
 				else if(dir & (EAST|WEST))
 					initialize_directions = NORTH|SOUTH
 
-				initialize()
+				atmos_init()
 				build_network()
 				if (node1)
-					node1.initialize()
+					node1.atmos_init()
 					node1.build_network()
 				if (node2)
-					node2.initialize()
+					node2.atmos_init()
 					node2.build_network()
 			else
 				if(node1)
@@ -153,7 +153,7 @@
 
 		return null
 
-	initialize()
+	atmos_init()
 		if(node1 && node2) return
 
 		var/node2_connect = turn(dir, -90)

--- a/code/ATMOSPHERICS/components/binary_devices/pump.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/pump.dm
@@ -183,7 +183,7 @@ Thus, the two variables affect pump operation are set in New():
 		return
 	src.add_fingerprint(usr)
 	if(!src.allowed(user))
-		user << "<span class='warning'>Access denied.</span>"
+		to_chat(user, "<span class='warning'>Access denied.</span>")
 		return
 	usr.set_machine(src)
 	ui_interact(user)
@@ -219,14 +219,14 @@ Thus, the two variables affect pump operation are set in New():
 	if (!istype(W, /obj/item/weapon/wrench))
 		return ..()
 	if (!(stat & NOPOWER) && use_power)
-		user << "<span class='warning'>You cannot unwrench this [src], turn it off first.</span>"
+		to_chat(user, "<span class='warning'>You cannot unwrench this [src], turn it off first.</span>")
 		return 1
 	if(!can_unwrench())
 		to_chat(user, "<span class='warning'>You cannot unwrench this [src], it too exerted due to internal pressure.</span>")
 		add_fingerprint(user)
 		return 1
 	playsound(src, W.usesound, 50, 1)
-	user << "<span class='notice'>You begin to unfasten \the [src]...</span>"
+	to_chat(user, "<span class='notice'>You begin to unfasten \the [src]...</span>")
 	if (do_after(user, 40 * W.toolspeed))
 		user.visible_message( \
 			"<span class='notice'>\The [user] unfastens \the [src].</span>", \

--- a/code/ATMOSPHERICS/components/omni_devices/_omni_extras.dm
+++ b/code/ATMOSPHERICS/components/omni_devices/_omni_extras.dm
@@ -40,10 +40,10 @@
 /datum/omni_port/proc/connect()
 	if(node)
 		return
-	master.initialize()
+	master.atmos_init()
 	master.build_network()
 	if(node)
-		node.initialize()
+		node.atmos_init()
 		node.build_network()
 
 /datum/omni_port/proc/disconnect()

--- a/code/ATMOSPHERICS/components/omni_devices/omni_base.dm
+++ b/code/ATMOSPHERICS/components/omni_devices/omni_base.dm
@@ -86,7 +86,7 @@
 		to_chat(user, "<span class='warning'>You cannot unwrench \the [src], it is too exerted due to internal pressure.</span>")
 		add_fingerprint(user)
 		return 1
-	user << "<span class='notice'>You begin to unfasten \the [src]...</span>"
+	to_chat(user, "<span class='notice'>You begin to unfasten \the [src]...</span>")
 	playsound(src, W.usesound, 50, 1)
 	if(do_after(user, 40 * W.toolspeed))
 		user.visible_message( \

--- a/code/ATMOSPHERICS/components/omni_devices/omni_base.dm
+++ b/code/ATMOSPHERICS/components/omni_devices/omni_base.dm
@@ -245,9 +245,9 @@
 			qdel(P.network)
 			P.node = null
 
-	..()
+	. = ..()
 
-/obj/machinery/atmospherics/omni/initialize()
+/obj/machinery/atmospherics/omni/atmos_init()
 	for(var/datum/omni_port/P in ports)
 		if(P.node || P.mode == 0)
 			continue

--- a/code/ATMOSPHERICS/components/omni_devices/omni_base.dm
+++ b/code/ATMOSPHERICS/components/omni_devices/omni_base.dm
@@ -252,7 +252,6 @@
 		if(P.node || P.mode == 0)
 			continue
 		for(var/obj/machinery/atmospherics/target in get_step(src, P.dir))
-			target.init_dir()
 			if(target.initialize_directions & get_dir(target,src))
 				if (check_connect_types(target,src))
 					P.node = target

--- a/code/ATMOSPHERICS/components/portables_connector.dm
+++ b/code/ATMOSPHERICS/components/portables_connector.dm
@@ -70,7 +70,7 @@
 
 	node = null
 
-/obj/machinery/atmospherics/portables_connector/initialize()
+/obj/machinery/atmospherics/portables_connector/atmos_init()
 	if(node)
 		return
 

--- a/code/ATMOSPHERICS/components/portables_connector.dm
+++ b/code/ATMOSPHERICS/components/portables_connector.dm
@@ -21,10 +21,6 @@
 /obj/machinery/atmospherics/portables_connector/init_dir()
 	initialize_directions = dir
 
-/obj/machinery/atmospherics/portables_connector/New()
-	init_dir()
-	..()
-
 /obj/machinery/atmospherics/portables_connector/update_icon()
 	icon_state = "connector"
 
@@ -78,12 +74,9 @@
 	if(node)
 		return
 
-	init_dir()
-
 	var/node_connect = dir
 
 	for(var/obj/machinery/atmospherics/target in get_step(src,node_connect))
-		target.init_dir()
 		if(target.initialize_directions & get_dir(target,src))
 			if (check_connect_types(target,src))
 				node = target

--- a/code/ATMOSPHERICS/components/portables_connector.dm
+++ b/code/ATMOSPHERICS/components/portables_connector.dm
@@ -138,7 +138,7 @@
 	if (!istype(W, /obj/item/weapon/wrench))
 		return ..()
 	if (connected_device)
-		user << "<span class='warning'>You cannot unwrench \the [src], dettach \the [connected_device] first.</span>"
+		to_chat(user, "<span class='warning'>You cannot unwrench \the [src], dettach \the [connected_device] first.</span>")
 		return 1
 	if (locate(/obj/machinery/portable_atmospherics, src.loc))
 		return 1
@@ -147,7 +147,7 @@
 		add_fingerprint(user)
 		return 1
 	playsound(src, W.usesound, 50, 1)
-	user << "<span class='notice'>You begin to unfasten \the [src]...</span>"
+	to_chat(user, "<span class='notice'>You begin to unfasten \the [src]...</span>")
 	if (do_after(user, 40 * W.toolspeed))
 		user.visible_message( \
 			"<span class='notice'>\The [user] unfastens \the [src].</span>", \

--- a/code/ATMOSPHERICS/components/trinary_devices/filter.dm
+++ b/code/ATMOSPHERICS/components/trinary_devices/filter.dm
@@ -247,9 +247,7 @@ obj/machinery/atmospherics/trinary/atmos_filter/m_filter/init_dir()
 		if(WEST)
 			initialize_directions = WEST|SOUTH|EAST
 
-/obj/machinery/atmospherics/trinary/atmos_filter/m_filter/initialize()
-	set_frequency(frequency)
-
+/obj/machinery/atmospherics/trinary/atmos_filter/m_filter/atmos_init()
 	if(node1 && node2 && node3) return
 
 	var/node1_connect = turn(dir, -180)

--- a/code/ATMOSPHERICS/components/trinary_devices/filter.dm
+++ b/code/ATMOSPHERICS/components/trinary_devices/filter.dm
@@ -136,7 +136,7 @@
 		add_fingerprint(user)
 		return 1
 	playsound(src, W.usesound, 50, 1)
-	user << "<span class='notice'>You begin to unfasten \the [src]...</span>"
+	to_chat(user, "<span class='notice'>You begin to unfasten \the [src]...</span>")
 	if (do_after(user, 40 * W.toolspeed))
 		user.visible_message( \
 			"<span class='notice'>\The [user] unfastens \the [src].</span>", \
@@ -151,7 +151,7 @@
 		return
 
 	if(!src.allowed(user))
-		user << "<span class='warning'>Access denied.</span>"
+		to_chat(user, "<span class='warning'>Access denied.</span>")
 		return
 
 	var/dat

--- a/code/ATMOSPHERICS/components/trinary_devices/mixer.dm
+++ b/code/ATMOSPHERICS/components/trinary_devices/mixer.dm
@@ -192,7 +192,7 @@ obj/machinery/atmospherics/trinary/mixer/t_mixer/init_dir()
 		if(WEST)
 			initialize_directions = WEST|NORTH|SOUTH
 
-obj/machinery/atmospherics/trinary/mixer/t_mixer/initialize()
+obj/machinery/atmospherics/trinary/mixer/t_mixer/atmos_init()
 	..()
 	if(node1 && node2 && node3) return
 
@@ -237,7 +237,7 @@ obj/machinery/atmospherics/trinary/mixer/m_mixer/init_dir()
 		if(WEST)
 			initialize_directions = WEST|SOUTH|EAST
 
-obj/machinery/atmospherics/trinary/mixer/m_mixer/initialize()
+obj/machinery/atmospherics/trinary/mixer/m_mixer/atmos_init()
 	..()
 	if(node1 && node2 && node3) return
 

--- a/code/ATMOSPHERICS/components/trinary_devices/mixer.dm
+++ b/code/ATMOSPHERICS/components/trinary_devices/mixer.dm
@@ -111,7 +111,7 @@
 		add_fingerprint(user)
 		return 1
 	playsound(src, W.usesound, 50, 1)
-	user << "<span class='notice'>You begin to unfasten \the [src]...</span>"
+	to_chat(user, "<span class='notice'>You begin to unfasten \the [src]...</span>")
 	if (do_after(user, 40 * W.toolspeed))
 		user.visible_message( \
 			"<span class='notice'>\The [user] unfastens \the [src].</span>", \
@@ -125,7 +125,7 @@
 		return
 	src.add_fingerprint(usr)
 	if(!src.allowed(user))
-		user << "<span class='warning'>Access denied.</span>"
+		to_chat(user, "<span class='warning'>Access denied.</span>")
 		return
 	usr.set_machine(src)
 	var/dat = {"<b>Power: </b><a href='?src=\ref[src];power=1'>[use_power?"On":"Off"]</a><br>

--- a/code/ATMOSPHERICS/components/trinary_devices/trinary_base.dm
+++ b/code/ATMOSPHERICS/components/trinary_devices/trinary_base.dm
@@ -15,7 +15,6 @@
 
 /obj/machinery/atmospherics/trinary/New()
 	..()
-	init_dir()
 
 	air1 = new
 	air2 = new
@@ -75,27 +74,22 @@
 	if(node1 && node2 && node3)
 		return
 
-	init_dir()
-
 	var/node1_connect = turn(dir, -180)
 	var/node2_connect = turn(dir, -90)
 	var/node3_connect = dir
 
 	for(var/obj/machinery/atmospherics/target in get_step(src,node1_connect))
-		target.init_dir()
 		if(target.initialize_directions & get_dir(target,src))
 			if (check_connect_types(target,src))
 				node1 = target
 				break
 
 	for(var/obj/machinery/atmospherics/target in get_step(src,node2_connect))
-		target.init_dir()
 		if(target.initialize_directions & get_dir(target,src))
 			if (check_connect_types(target,src))
 				node2 = target
 				break
 	for(var/obj/machinery/atmospherics/target in get_step(src,node3_connect))
-		target.init_dir()
 		if(target.initialize_directions & get_dir(target,src))
 			if (check_connect_types(target,src))
 				node3 = target

--- a/code/ATMOSPHERICS/components/trinary_devices/trinary_base.dm
+++ b/code/ATMOSPHERICS/components/trinary_devices/trinary_base.dm
@@ -70,7 +70,7 @@
 	node2 = null
 	node3 = null
 
-/obj/machinery/atmospherics/trinary/initialize()
+/obj/machinery/atmospherics/trinary/atmos_init()
 	if(node1 && node2 && node3)
 		return
 

--- a/code/ATMOSPHERICS/components/tvalve.dm
+++ b/code/ATMOSPHERICS/components/tvalve.dm
@@ -179,7 +179,7 @@
 
 	return
 
-/obj/machinery/atmospherics/tvalve/initialize()
+/obj/machinery/atmospherics/tvalve/atmos_init()
 	var/node1_dir
 	var/node2_dir
 	var/node3_dir
@@ -375,7 +375,7 @@
 		if(WEST)
 			initialize_directions = EAST|WEST|SOUTH
 
-/obj/machinery/atmospherics/tvalve/mirrored/initialize()
+/obj/machinery/atmospherics/tvalve/mirrored/atmos_init()
 	var/node1_dir
 	var/node2_dir
 	var/node3_dir

--- a/code/ATMOSPHERICS/components/tvalve.dm
+++ b/code/ATMOSPHERICS/components/tvalve.dm
@@ -46,10 +46,6 @@
 /obj/machinery/atmospherics/tvalve/hide(var/i)
 	update_underlays()
 
-/obj/machinery/atmospherics/tvalve/New()
-	init_dir()
-	..()
-
 /obj/machinery/atmospherics/tvalve/init_dir()
 	switch(dir)
 		if(NORTH)
@@ -188,26 +184,21 @@
 	var/node2_dir
 	var/node3_dir
 
-	init_dir()
-
 	node1_dir = turn(dir, 180)
 	node2_dir = turn(dir, -90)
 	node3_dir = dir
 
 	for(var/obj/machinery/atmospherics/target in get_step(src,node1_dir))
-		target.init_dir()
 		if(target.initialize_directions & get_dir(target,src))
 			if (check_connect_types(target,src))
 				node1 = target
 				break
 	for(var/obj/machinery/atmospherics/target in get_step(src,node2_dir))
-		target.init_dir()
 		if(target.initialize_directions & get_dir(target,src))
 			if (check_connect_types(target,src))
 				node2 = target
 				break
 	for(var/obj/machinery/atmospherics/target in get_step(src,node3_dir))
-		target.init_dir()
 		if(target.initialize_directions & get_dir(target,src))
 			if (check_connect_types(target,src))
 				node3 = target

--- a/code/ATMOSPHERICS/components/tvalve.dm
+++ b/code/ATMOSPHERICS/components/tvalve.dm
@@ -308,7 +308,7 @@
 	if(!powered())
 		return
 	if(!src.allowed(user))
-		user << "<span class='warning'>Access denied.</span>"
+		to_chat(user, "<span class='warning'>Access denied.</span>")
 		return
 	..()
 
@@ -350,14 +350,14 @@
 	if (!istype(W, /obj/item/weapon/wrench))
 		return ..()
 	if (istype(src, /obj/machinery/atmospherics/tvalve/digital))
-		user << "<span class='warning'>You cannot unwrench \the [src], it's too complicated.</span>"
+		to_chat(user, "<span class='warning'>You cannot unwrench \the [src], it's too complicated.</span>")
 		return 1
 	if(!can_unwrench())
 		to_chat(user, "<span class='warnng'>You cannot unwrench \the [src], it too exerted due to internal pressure.</span>")
 		add_fingerprint(user)
 		return 1
 	playsound(src, W.usesound, 50, 1)
-	user << "<span class='notice'>You begin to unfasten \the [src]...</span>"
+	to_chat(user, "<span class='notice'>You begin to unfasten \the [src]...</span>")
 	if (do_after(user, 40 * W.toolspeed))
 		user.visible_message( \
 			"<span class='notice'>\The [user] unfastens \the [src].</span>", \
@@ -446,7 +446,7 @@
 	if(!powered())
 		return
 	if(!src.allowed(user))
-		user << "<span class='warning'>Access denied.</span>"
+		to_chat(user, "<span class='warning'>Access denied.</span>")
 		return
 	..()
 

--- a/code/ATMOSPHERICS/components/unary/cold_sink.dm
+++ b/code/ATMOSPHERICS/components/unary/cold_sink.dm
@@ -23,7 +23,6 @@
 
 /obj/machinery/atmospherics/unary/freezer/New()
 	..()
-	initialize_directions = dir
 	component_parts = list()
 	component_parts += new /obj/item/weapon/stock_parts/matter_bin(src)
 	component_parts += new /obj/item/weapon/stock_parts/capacitor(src)
@@ -32,7 +31,7 @@
 	component_parts += new /obj/item/stack/cable_coil(src, 2)
 	RefreshParts()
 
-/obj/machinery/atmospherics/unary/freezer/initialize()
+/obj/machinery/atmospherics/unary/freezer/atmos_init()
 	if(node)
 		return
 

--- a/code/ATMOSPHERICS/components/unary/heat_exchanger.dm
+++ b/code/ATMOSPHERICS/components/unary/heat_exchanger.dm
@@ -18,7 +18,7 @@
 
 		return
 
-	initialize()
+	atmos_init()
 		if(!partner)
 			var/partner_connect = turn(dir,180)
 

--- a/code/ATMOSPHERICS/components/unary/heat_exchanger.dm
+++ b/code/ATMOSPHERICS/components/unary/heat_exchanger.dm
@@ -70,14 +70,14 @@
 			return ..()
 		var/turf/T = src.loc
 		if (level==1 && isturf(T) && !T.is_plating())
-			user << "<span class='warning'>You must remove the plating first.</span>"
+			to_chat(user, "<span class='warning'>You must remove the plating first.</span>")
 			return 1
 		if (!can_unwrench())
-			user << "<span class='warning'>You cannot unwrench \the [src], it is too exerted due to internal pressure.</span>"
+			to_chat(user, "<span class='warning'>You cannot unwrench \the [src], it is too exerted due to internal pressure.</span>")
 			add_fingerprint(user)
 			return 1
 		playsound(src, W.usesound, 50, 1)
-		user << "<span class='notice'>You begin to unfasten \the [src]...</span>"
+		to_chat(user, "<span class='notice'>You begin to unfasten \the [src]...</span>")
 		if (do_after(user, 40 * W.toolspeed))
 			user.visible_message( \
 				"<span class='notice'>\The [user] unfastens \the [src].</span>", \

--- a/code/ATMOSPHERICS/components/unary/heat_source.dm
+++ b/code/ATMOSPHERICS/components/unary/heat_source.dm
@@ -23,7 +23,6 @@
 
 /obj/machinery/atmospherics/unary/heater/New()
 	..()
-	initialize_directions = dir
 	component_parts = list()
 	component_parts += new /obj/item/weapon/stock_parts/matter_bin(src)
 	component_parts += new /obj/item/weapon/stock_parts/capacitor(src)
@@ -32,7 +31,7 @@
 
 	RefreshParts()
 
-/obj/machinery/atmospherics/unary/heater/initialize()
+/obj/machinery/atmospherics/unary/heater/atmos_init()
 	if(node)
 		return
 

--- a/code/ATMOSPHERICS/components/unary/unary_base.dm
+++ b/code/ATMOSPHERICS/components/unary/unary_base.dm
@@ -41,7 +41,7 @@
 
 	node = null
 
-/obj/machinery/atmospherics/unary/initialize()
+/obj/machinery/atmospherics/unary/atmos_init()
 	if(node)
 		return
 

--- a/code/ATMOSPHERICS/components/unary/unary_base.dm
+++ b/code/ATMOSPHERICS/components/unary/unary_base.dm
@@ -13,7 +13,6 @@
 
 /obj/machinery/atmospherics/unary/New()
 	..()
-	init_dir()
 	air_contents = new
 
 	air_contents.volume = 200
@@ -46,12 +45,9 @@
 	if(node)
 		return
 
-	init_dir()
-
 	var/node_connect = dir
 
 	for(var/obj/machinery/atmospherics/target in get_step(src,node_connect))
-		target.init_dir()
 		if(target.initialize_directions & get_dir(target,src))
 			if (check_connect_types(target,src))
 				node = target

--- a/code/ATMOSPHERICS/components/unary/vent_pump.dm
+++ b/code/ATMOSPHERICS/components/unary/vent_pump.dm
@@ -357,7 +357,7 @@
 	if(istype(W, /obj/item/weapon/weldingtool))
 		var/obj/item/weapon/weldingtool/WT = W
 		if (WT.remove_fuel(0,user))
-			user << "<span class='notice'>Now welding the vent.</span>"
+			to_chat(user, "<span class='notice'>Now welding the vent.</span>")
 			if(do_after(user, 20 * WT.toolspeed))
 				if(!src || !WT.isOn()) return
 				playsound(src.loc, WT.usesound, 50, 1)
@@ -370,9 +370,9 @@
 					welded = 0
 					update_icon()
 			else
-				user << "<span class='notice'>The welding tool needs to be on to start this task.</span>"
+				to_chat(user, "<span class='notice'>The welding tool needs to be on to start this task.</span>")
 		else
-			user << "<span class='warning'>You need more welding fuel to complete this task.</span>"
+			to_chat(user, "<span class='warning'>You need more welding fuel to complete this task.</span>")
 			return 1
 	else
 		..()
@@ -395,18 +395,18 @@
 	if (!istype(W, /obj/item/weapon/wrench))
 		return ..()
 	if (!(stat & NOPOWER) && use_power)
-		user << "<span class='warning'>You cannot unwrench \the [src], turn it off first.</span>"
+		to_chat(user, "<span class='warning'>You cannot unwrench \the [src], turn it off first.</span>")
 		return 1
 	var/turf/T = src.loc
 	if (node && node.level==1 && isturf(T) && !T.is_plating())
-		user << "<span class='warning'>You must remove the plating first.</span>"
+		to_chat(user, "<span class='warning'>You must remove the plating first.</span>")
 		return 1
 	if(!can_unwrench())
 		to_chat(user, "<span class='warning'>You cannot unwrench \the [src], it is too exerted due to internal pressure.</span>")
 		add_fingerprint(user)
 		return 1
 	playsound(src, W.usesound, 50, 1)
-	user << "<span class='notice'>You begin to unfasten \the [src]...</span>"
+	to_chat(user, "<span class='notice'>You begin to unfasten \the [src]...</span>")
 	if (do_after(user, 40 * W.toolspeed))
 		user.visible_message( \
 			"<span class='notice'>\The [user] unfastens \the [src].</span>", \

--- a/code/ATMOSPHERICS/components/unary/vent_scrubber.dm
+++ b/code/ATMOSPHERICS/components/unary/vent_scrubber.dm
@@ -266,18 +266,18 @@
 	if (!istype(W, /obj/item/weapon/wrench))
 		return ..()
 	if (!(stat & NOPOWER) && use_power)
-		user << "<span class='warning'>You cannot unwrench \the [src], turn it off first.</span>"
+		to_chat(user, "<span class='warning'>You cannot unwrench \the [src], turn it off first.</span>")
 		return 1
 	var/turf/T = src.loc
 	if (node && node.level==1 && isturf(T) && !T.is_plating())
-		user << "<span class='warning'>You must remove the plating first.</span>"
+		to_chat(user, "<span class='warning'>You must remove the plating first.</span>")
 		return 1
 	if(!can_unwrench())
 		to_chat(user, "<span class='warning'>You cannot unwrench \the [src], it is too exerted due to internal pressure.</span>")
 		add_fingerprint(user)
 		return 1
 	playsound(src, W.usesound, 50, 1)
-	user << "<span class='notice'>You begin to unfasten \the [src]...</span>"
+	to_chat(user, "<span class='notice'>You begin to unfasten \the [src]...</span>")
 	if (do_after(user, 40 * W.toolspeed))
 		user.visible_message( \
 			"<span class='notice'>\The [user] unfastens \the [src].</span>", \

--- a/code/ATMOSPHERICS/components/valve.dm
+++ b/code/ATMOSPHERICS/components/valve.dm
@@ -141,7 +141,6 @@
 	return
 
 /obj/machinery/atmospherics/valve/initialize()
-	init_dir()
 	normalize_dir()
 
 	var/node1_dir
@@ -155,13 +154,11 @@
 				node2_dir = direction
 
 	for(var/obj/machinery/atmospherics/target in get_step(src,node1_dir))
-		target.init_dir()
 		if(target.initialize_directions & get_dir(target,src))
 			if (check_connect_types(target,src))
 				node1 = target
 				break
 	for(var/obj/machinery/atmospherics/target in get_step(src,node2_dir))
-		target.init_dir()
 		if(target.initialize_directions & get_dir(target,src))
 			if (check_connect_types(target,src))
 				node2 = target

--- a/code/ATMOSPHERICS/components/valve.dm
+++ b/code/ATMOSPHERICS/components/valve.dm
@@ -140,7 +140,7 @@
 
 	return
 
-/obj/machinery/atmospherics/valve/initialize()
+/obj/machinery/atmospherics/valve/atmos_init()
 	normalize_dir()
 
 	var/node1_dir

--- a/code/ATMOSPHERICS/components/valve.dm
+++ b/code/ATMOSPHERICS/components/valve.dm
@@ -239,7 +239,7 @@
 	if(!powered())
 		return
 	if(!src.allowed(user))
-		user << "<span class='warning'>Access denied.</span>"
+		to_chat(user, "<span class='warning'>Access denied.</span>")
 		return
 	..()
 
@@ -292,14 +292,14 @@
 	if (!istype(W, /obj/item/weapon/wrench))
 		return ..()
 	if (istype(src, /obj/machinery/atmospherics/valve/digital) && !src.allowed(user))
-		user << "<span class='warning'>Access denied.</span>"
+		to_chat(user, "<span class='warning'>Access denied.</span>")
 		return 1
 	if(!can_unwrench())
 		to_chat(user, "<span class='warning'>You cannot unwrench \the [src], it is too exerted due to internal pressure.</span>")
 		add_fingerprint(user)
 		return 1
 	playsound(src, W.usesound, 50, 1)
-	user << "<span class='notice'>You begin to unfasten \the [src]...</span>"
+	to_chat(user, "<span class='notice'>You begin to unfasten \the [src]...</span>")
 	if (do_after(user, 40 * W.toolspeed))
 		user.visible_message( \
 			"<span class='notice'>\The [user] unfastens \the [src].</span>", \

--- a/code/ATMOSPHERICS/he_pipes.dm
+++ b/code/ATMOSPHERICS/he_pipes.dm
@@ -19,7 +19,6 @@
 	// BubbleWrap
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging/New()
 	..()
-	init_dir()
 // BubbleWrap END
 	color = "#404040" //we don't make use of the fancy overlay system for colours, use this to set the default.
 
@@ -28,7 +27,6 @@
 	initialize_directions_he = initialize_directions	// The auto-detection from /pipe is good enough for a simple HE pipe
 
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging/initialize()
-	init_dir()
 	normalize_dir()
 	var/node1_dir
 	var/node2_dir
@@ -41,12 +39,10 @@
 				node2_dir = direction
 
 	for(var/obj/machinery/atmospherics/pipe/simple/heat_exchanging/target in get_step(src,node1_dir))
-		target.init_dir()
 		if(target.initialize_directions_he & get_dir(target,src))
 			node1 = target
 			break
 	for(var/obj/machinery/atmospherics/pipe/simple/heat_exchanging/target in get_step(src,node2_dir))
-		target.init_dir()
 		if(target.initialize_directions_he & get_dir(target,src))
 			node2 = target
 			break
@@ -137,14 +133,11 @@
 
 
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction/initialize()
-	init_dir()
 	for(var/obj/machinery/atmospherics/target in get_step(src,initialize_directions))
-		target.init_dir()
 		if(target.initialize_directions & get_dir(target,src))
 			node1 = target
 			break
 	for(var/obj/machinery/atmospherics/pipe/simple/heat_exchanging/target in get_step(src,initialize_directions_he))
-		target.init_dir()
 		if(target.initialize_directions_he & get_dir(target,src))
 			node2 = target
 			break

--- a/code/ATMOSPHERICS/mainspipe.dm
+++ b/code/ATMOSPHERICS/mainspipe.dm
@@ -101,7 +101,7 @@ obj/machinery/atmospherics/mains_pipe
 		disconnect()
 		..()
 
-	initialize()
+	atmos_init()
 		for(var/i = 1 to nodes.len)
 			var/obj/machinery/atmospherics/mains_pipe/node = nodes[i]
 			if(node)
@@ -155,7 +155,7 @@ obj/machinery/atmospherics/mains_pipe/simple
 			var/have_node2 = nodes[2]?1:0
 			icon_state = "exposed[have_node1][have_node2][invisibility ? "-f" : "" ]"
 
-	initialize()
+	atmos_init()
 		normalize_dir()
 		var/node1_dir
 		var/node2_dir
@@ -203,7 +203,7 @@ obj/machinery/atmospherics/mains_pipe/manifold
 		..()
 		initialize_mains_directions = (NORTH|SOUTH|EAST|WEST) & ~dir
 
-	initialize()
+	atmos_init()
 		var/connect_directions = initialize_mains_directions
 
 		for(var/direction in cardinal)
@@ -267,7 +267,7 @@ obj/machinery/atmospherics/mains_pipe/manifold4w
 		nodes.len = 4
 		..()
 
-	initialize()
+	atmos_init()
 		for(var/obj/machinery/atmospherics/mains_pipe/target in get_step(src,NORTH))
 			if(target.initialize_mains_directions & get_dir(target,src))
 				nodes[1] = target
@@ -319,7 +319,7 @@ obj/machinery/atmospherics/mains_pipe/split
 		initialize_mains_directions = turn(dir, 90) | turn(dir, -90)
 		initialize_directions = dir // actually have a normal connection too
 
-	initialize()
+	atmos_init()
 		var/node1_dir
 		var/node2_dir
 		var/node3_dir
@@ -420,7 +420,7 @@ obj/machinery/atmospherics/mains_pipe/split3
 		initialize_mains_directions = dir
 		initialize_directions = cardinal & ~dir // actually have a normal connection too
 
-	initialize()
+	atmos_init()
 		var/node1_dir
 		var/supply_node_dir
 		var/scrubbers_node_dir
@@ -514,7 +514,7 @@ obj/machinery/atmospherics/mains_pipe/cap
 	update_icon()
 		icon_state = "cap[invisibility ? "-f" : ""]"
 
-	initialize()
+	atmos_init()
 		for(var/obj/machinery/atmospherics/mains_pipe/target in get_step(src,dir))
 			if(target.initialize_mains_directions & get_dir(target,src))
 				nodes[1] = target

--- a/code/ATMOSPHERICS/mainspipe.dm
+++ b/code/ATMOSPHERICS/mainspipe.dm
@@ -647,7 +647,7 @@ obj/machinery/atmospherics/mains_pipe/valve
 
 		attack_hand(mob/user as mob)
 			if(!src.allowed(user))
-				user << "<span class='warning'>Access denied.</span>"
+				to_chat(user, "<span class='warning'>Access denied.</span>")
 				return
 			..()
 

--- a/code/ATMOSPHERICS/pipes.dm
+++ b/code/ATMOSPHERICS/pipes.dm
@@ -84,14 +84,14 @@
 		return ..()
 	var/turf/T = src.loc
 	if (level==1 && isturf(T) && !T.is_plating())
-		user << "<span class='warning'>You must remove the plating first.</span>"
+		to_chat(user, "<span class='warning'>You must remove the plating first.</span>")
 		return 1
 	if(!can_unwrench())
 		to_chat(user, "<span class='warning'>You cannot unwrench \the [src], it is too exerted due to internal pressure.</span>")
 		add_fingerprint(user)
 		return 1
 	playsound(src, W.usesound, 50, 1)
-	user << "<span class='notice'>You begin to unfasten \the [src]...</span>"
+	to_chat(user, "<span class='notice'>You begin to unfasten \the [src]...</span>")
 	if (do_after(user, 40 * W.toolspeed))
 		user.visible_message( \
 			"<span class='notice'>\The [user] unfastens \the [src].</span>", \

--- a/code/ATMOSPHERICS/pipes.dm
+++ b/code/ATMOSPHERICS/pipes.dm
@@ -266,7 +266,7 @@
 /obj/machinery/atmospherics/pipe/simple/update_underlays()
 	return
 
-/obj/machinery/atmospherics/pipe/simple/initialize()
+/obj/machinery/atmospherics/pipe/simple/atmos_init()
 	normalize_dir()
 	var/node1_dir
 	var/node2_dir
@@ -541,7 +541,7 @@
 	..()
 	update_icon()
 
-/obj/machinery/atmospherics/pipe/manifold/initialize()
+/obj/machinery/atmospherics/pipe/manifold/atmos_init()
 	var/connect_directions = (NORTH|SOUTH|EAST|WEST)&(~dir)
 
 	for(var/direction in cardinal)
@@ -818,7 +818,7 @@
 		invisibility = i ? 101 : 0
 	update_icon()
 
-/obj/machinery/atmospherics/pipe/manifold4w/initialize()
+/obj/machinery/atmospherics/pipe/manifold4w/atmos_init()
 
 	for(var/obj/machinery/atmospherics/target in get_step(src,1))
 		if(target.initialize_directions & 2)
@@ -1002,7 +1002,7 @@
 	overlays.Cut()
 	overlays += icon_manager.get_atmos_icon("pipe", , pipe_color, "cap")
 
-/obj/machinery/atmospherics/pipe/cap/initialize()
+/obj/machinery/atmospherics/pipe/cap/atmos_init()
 	for(var/obj/machinery/atmospherics/target in get_step(src, dir))
 		if(target.initialize_directions & get_dir(target,src))
 			if (check_connect_types(target,src))
@@ -1111,7 +1111,7 @@
 /obj/machinery/atmospherics/pipe/tank/hide()
 	update_underlays()
 
-/obj/machinery/atmospherics/pipe/tank/initialize()
+/obj/machinery/atmospherics/pipe/tank/atmos_init()
 	var/connect_direction = dir
 
 	for(var/obj/machinery/atmospherics/target in get_step(src,connect_direction))
@@ -1279,7 +1279,7 @@
 	else
 		icon_state = "exposed"
 
-/obj/machinery/atmospherics/pipe/vent/initialize()
+/obj/machinery/atmospherics/pipe/vent/atmos_init()
 	var/connect_direction = dir
 
 	for(var/obj/machinery/atmospherics/target in get_step(src,connect_direction))

--- a/code/ATMOSPHERICS/pipes.dm
+++ b/code/ATMOSPHERICS/pipes.dm
@@ -34,10 +34,6 @@
 
 	return 1
 
-// This is used to set up what directions pipes will connect to.  Called inside New(), initialize(), and when pipes look at another pipe, incase they didn't get to initialize() yet.
-/obj/machinery/atmospherics/proc/init_dir()
-	return
-
 /obj/machinery/atmospherics/pipe/return_air()
 	if(!parent)
 		parent = new /datum/pipeline()
@@ -170,10 +166,6 @@
 	icon = null
 	alpha = 255
 
-	init_dir()
-
-
-
 /obj/machinery/atmospherics/pipe/simple/hide(var/i)
 	if(istype(loc, /turf/simulated))
 		invisibility = i ? 101 : 0
@@ -275,7 +267,6 @@
 	return
 
 /obj/machinery/atmospherics/pipe/simple/initialize()
-	init_dir()
 	normalize_dir()
 	var/node1_dir
 	var/node2_dir
@@ -288,13 +279,11 @@
 				node2_dir = direction
 
 	for(var/obj/machinery/atmospherics/target in get_step(src,node1_dir))
-		target.init_dir()
 		if(target.initialize_directions & get_dir(target,src))
 			if (check_connect_types(target,src))
 				node1 = target
 				break
 	for(var/obj/machinery/atmospherics/target in get_step(src,node2_dir))
-		target.init_dir()
 		if(target.initialize_directions & get_dir(target,src))
 			if (check_connect_types(target,src))
 				node2 = target
@@ -444,8 +433,6 @@
 	alpha = 255
 	icon = null
 
-	init_dir()
-
 /obj/machinery/atmospherics/pipe/manifold/init_dir()
 	switch(dir)
 		if(NORTH)
@@ -555,13 +542,11 @@
 	update_icon()
 
 /obj/machinery/atmospherics/pipe/manifold/initialize()
-	init_dir()
 	var/connect_directions = (NORTH|SOUTH|EAST|WEST)&(~dir)
 
 	for(var/direction in cardinal)
 		if(direction&connect_directions)
 			for(var/obj/machinery/atmospherics/target in get_step(src,direction))
-				target.init_dir()
 				if(target.initialize_directions & get_dir(target,src))
 					if (check_connect_types(target,src))
 						node1 = target
@@ -574,7 +559,6 @@
 	for(var/direction in cardinal)
 		if(direction&connect_directions)
 			for(var/obj/machinery/atmospherics/target in get_step(src,direction))
-				target.init_dir()
 				if(target.initialize_directions & get_dir(target,src))
 					if (check_connect_types(target,src))
 						node2 = target
@@ -587,7 +571,6 @@
 	for(var/direction in cardinal)
 		if(direction&connect_directions)
 			for(var/obj/machinery/atmospherics/target in get_step(src,direction))
-				target.init_dir()
 				if(target.initialize_directions & get_dir(target,src))
 					if (check_connect_types(target,src))
 						node3 = target
@@ -838,28 +821,24 @@
 /obj/machinery/atmospherics/pipe/manifold4w/initialize()
 
 	for(var/obj/machinery/atmospherics/target in get_step(src,1))
-		target.init_dir()
 		if(target.initialize_directions & 2)
 			if (check_connect_types(target,src))
 				node1 = target
 				break
 
 	for(var/obj/machinery/atmospherics/target in get_step(src,2))
-		target.init_dir()
 		if(target.initialize_directions & 1)
 			if (check_connect_types(target,src))
 				node2 = target
 				break
 
 	for(var/obj/machinery/atmospherics/target in get_step(src,4))
-		target.init_dir()
 		if(target.initialize_directions & 8)
 			if (check_connect_types(target,src))
 				node3 = target
 				break
 
 	for(var/obj/machinery/atmospherics/target in get_step(src,8))
-		target.init_dir()
 		if(target.initialize_directions & 4)
 			if (check_connect_types(target,src))
 				node4 = target
@@ -975,10 +954,6 @@
 
 	var/obj/machinery/atmospherics/node
 
-/obj/machinery/atmospherics/pipe/cap/New()
-	..()
-	init_dir()
-
 /obj/machinery/atmospherics/pipe/cap/init_dir()
 	initialize_directions = dir
 
@@ -1028,9 +1003,7 @@
 	overlays += icon_manager.get_atmos_icon("pipe", , pipe_color, "cap")
 
 /obj/machinery/atmospherics/pipe/cap/initialize()
-	init_dir()
 	for(var/obj/machinery/atmospherics/target in get_step(src, dir))
-		target.init_dir()
 		if(target.initialize_directions & get_dir(target,src))
 			if (check_connect_types(target,src))
 				node = target
@@ -1106,7 +1079,6 @@
 
 /obj/machinery/atmospherics/pipe/tank/New()
 	icon_state = "air"
-	init_dir()
 	..()
 
 /obj/machinery/atmospherics/pipe/tank/init_dir()
@@ -1140,11 +1112,9 @@
 	update_underlays()
 
 /obj/machinery/atmospherics/pipe/tank/initialize()
-	init_dir()
 	var/connect_direction = dir
 
 	for(var/obj/machinery/atmospherics/target in get_step(src,connect_direction))
-		target.init_dir()
 		if(target.initialize_directions & get_dir(target,src))
 			if (check_connect_types(target,src))
 				node1 = target
@@ -1272,10 +1242,6 @@
 
 	var/build_killswitch = 1
 
-/obj/machinery/atmospherics/pipe/vent/New()
-	init_dir()
-	..()
-
 /obj/machinery/atmospherics/pipe/vent/init_dir()
 	initialize_directions = dir
 
@@ -1314,11 +1280,9 @@
 		icon_state = "exposed"
 
 /obj/machinery/atmospherics/pipe/vent/initialize()
-	init_dir()
 	var/connect_direction = dir
 
 	for(var/obj/machinery/atmospherics/target in get_step(src,connect_direction))
-		target.init_dir()
 		if(target.initialize_directions & get_dir(target,src))
 			if (check_connect_types(target,src))
 				node1 = target

--- a/code/controllers/master_controller.dm
+++ b/code/controllers/master_controller.dm
@@ -86,6 +86,11 @@ datum/controller/game_controller/proc/setup_objects()
 		CHECK_SLEEP_MASTER
 	sleep(1)
 
+	admin_notice("<span class='danger'>Initializing atmos machinery connections.</span>", R_DEBUG)
+	for(var/obj/machinery/atmospherics/machine in machines)
+		machine.atmos_init()
+		CHECK_SLEEP_MASTER
+
 	admin_notice("<span class='danger'>Initializing pipe networks</span>", R_DEBUG)
 	for(var/obj/machinery/atmospherics/machine in machines)
 		machine.build_network()

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -25,6 +25,12 @@
 	//Detective Work, used for the duplicate data points kept in the scanners
 	var/list/original_atom
 
+//atom creation method that preloads variables at creation
+/atom/New()
+	// Don't call ..() unless /datum/New() ever exists
+	if(use_preloader && (src.type == _preloader.target_path))//in case the instanciated atom is creating other atoms in New()
+		_preloader.load(src)
+
 /atom/proc/reveal_blood()
 	return
 

--- a/code/game/machinery/pipe/construction.dm
+++ b/code/game/machinery/pipe/construction.dm
@@ -491,16 +491,16 @@ Buildable meters
 			P.initialize_directions = pipe_dir
 			var/turf/T = P.loc
 			P.level = !T.is_plating() ? 2 : 1
-			P.initialize()
+			P.atmos_init()
 			if (QDELETED(P))
 				usr << pipefailtext
 				return 1
 			P.build_network()
 			if (P.node1)
-				P.node1.initialize()
+				P.node1.atmos_init()
 				P.node1.build_network()
 			if (P.node2)
-				P.node2.initialize()
+				P.node2.atmos_init()
 				P.node2.build_network()
 
 		if(PIPE_SUPPLY_STRAIGHT, PIPE_SUPPLY_BENT)
@@ -510,16 +510,16 @@ Buildable meters
 			P.initialize_directions = pipe_dir
 			var/turf/T = P.loc
 			P.level = !T.is_plating() ? 2 : 1
-			P.initialize()
+			P.atmos_init()
 			if (QDELETED(P))
 				usr << pipefailtext
 				return 1
 			P.build_network()
 			if (P.node1)
-				P.node1.initialize()
+				P.node1.atmos_init()
 				P.node1.build_network()
 			if (P.node2)
-				P.node2.initialize()
+				P.node2.atmos_init()
 				P.node2.build_network()
 
 		if(PIPE_SCRUBBERS_STRAIGHT, PIPE_SCRUBBERS_BENT)
@@ -529,16 +529,16 @@ Buildable meters
 			P.initialize_directions = pipe_dir
 			var/turf/T = P.loc
 			P.level = !T.is_plating() ? 2 : 1
-			P.initialize()
+			P.atmos_init()
 			if (QDELETED(P))
 				usr << pipefailtext
 				return 1
 			P.build_network()
 			if (P.node1)
-				P.node1.initialize()
+				P.node1.atmos_init()
 				P.node1.build_network()
 			if (P.node2)
-				P.node2.initialize()
+				P.node2.atmos_init()
 				P.node2.build_network()
 
 		if(PIPE_UNIVERSAL)
@@ -548,16 +548,16 @@ Buildable meters
 			P.initialize_directions = pipe_dir
 			var/turf/T = P.loc
 			P.level = !T.is_plating() ? 2 : 1
-			P.initialize()
+			P.atmos_init()
 			if (QDELETED(P))
 				usr << pipefailtext
 				return 1
 			P.build_network()
 			if (P.node1)
-				P.node1.initialize()
+				P.node1.atmos_init()
 				P.node1.build_network()
 			if (P.node2)
-				P.node2.initialize()
+				P.node2.atmos_init()
 				P.node2.build_network()
 
 		if(PIPE_HE_STRAIGHT, PIPE_HE_BENT)
@@ -565,16 +565,16 @@ Buildable meters
 			P.set_dir(src.dir)
 			P.initialize_directions = pipe_dir //this var it's used to know if the pipe is bent or not
 			P.initialize_directions_he = pipe_dir
-			P.initialize()
+			P.atmos_init()
 			if (QDELETED(P))
 				usr << pipefailtext
 				return 1
 			P.build_network()
 			if (P.node1)
-				P.node1.initialize()
+				P.node1.atmos_init()
 				P.node1.build_network()
 			if (P.node2)
-				P.node2.initialize()
+				P.node2.atmos_init()
 				P.node2.build_network()
 
 		if(PIPE_CONNECTOR)		// connector
@@ -585,10 +585,10 @@ Buildable meters
 				C.name = pipename
 			var/turf/T = C.loc
 			C.level = !T.is_plating() ? 2 : 1
-			C.initialize()
+			C.atmos_init()
 			C.build_network()
 			if (C.node)
-				C.node.initialize()
+				C.node.atmos_init()
 				C.node.build_network()
 
 
@@ -600,19 +600,19 @@ Buildable meters
 			//M.New()
 			var/turf/T = M.loc
 			M.level = !T.is_plating() ? 2 : 1
-			M.initialize()
+			M.atmos_init()
 			if (QDELETED(M))
 				usr << pipefailtext
 				return 1
 			M.build_network()
 			if (M.node1)
-				M.node1.initialize()
+				M.node1.atmos_init()
 				M.node1.build_network()
 			if (M.node2)
-				M.node2.initialize()
+				M.node2.atmos_init()
 				M.node2.build_network()
 			if (M.node3)
-				M.node3.initialize()
+				M.node3.atmos_init()
 				M.node3.build_network()
 
 		if(PIPE_SUPPLY_MANIFOLD)		//manifold
@@ -623,19 +623,19 @@ Buildable meters
 			//M.New()
 			var/turf/T = M.loc
 			M.level = !T.is_plating() ? 2 : 1
-			M.initialize()
+			M.atmos_init()
 			if (!M)
 				usr << "There's nothing to connect this manifold to! (with how the pipe code works, at least one end needs to be connected to something, otherwise the game deletes the segment)"
 				return 1
 			M.build_network()
 			if (M.node1)
-				M.node1.initialize()
+				M.node1.atmos_init()
 				M.node1.build_network()
 			if (M.node2)
-				M.node2.initialize()
+				M.node2.atmos_init()
 				M.node2.build_network()
 			if (M.node3)
-				M.node3.initialize()
+				M.node3.atmos_init()
 				M.node3.build_network()
 
 		if(PIPE_SCRUBBERS_MANIFOLD)		//manifold
@@ -646,19 +646,20 @@ Buildable meters
 			//M.New()
 			var/turf/T = M.loc
 			M.level = !T.is_plating() ? 2 : 1
-			M.initialize()
+			M.atmos_init()
 			if (!M)
 				usr << "There's nothing to connect this manifold to! (with how the pipe code works, at least one end needs to be connected to something, otherwise the game deletes the segment)"
 				return 1
 			M.build_network()
 			if (M.node1)
-				M.node1.initialize()
+				M.node1.atmos_init()
 				M.node1.build_network()
 			if (M.node2)
-				M.node2.initialize()
+				M.node2.atmos_init()
 				M.node2.build_network()
 			if (M.node3)
-				M.node3.initialize()
+				M.node3.atmos_init()
+				M.node3.build_network()
 				M.node3.build_network()
 
 		if(PIPE_MANIFOLD4W)		//4-way manifold
@@ -669,22 +670,22 @@ Buildable meters
 			//M.New()
 			var/turf/T = M.loc
 			M.level = !T.is_plating() ? 2 : 1
-			M.initialize()
+			M.atmos_init()
 			if (QDELETED(M))
 				usr << pipefailtext
 				return 1
 			M.build_network()
 			if (M.node1)
-				M.node1.initialize()
+				M.node1.atmos_init()
 				M.node1.build_network()
 			if (M.node2)
-				M.node2.initialize()
+				M.node2.atmos_init()
 				M.node2.build_network()
 			if (M.node3)
-				M.node3.initialize()
+				M.node3.atmos_init()
 				M.node3.build_network()
 			if (M.node4)
-				M.node4.initialize()
+				M.node4.atmos_init()
 				M.node4.build_network()
 
 		if(PIPE_SUPPLY_MANIFOLD4W)		//4-way manifold
@@ -696,22 +697,22 @@ Buildable meters
 			//M.New()
 			var/turf/T = M.loc
 			M.level = !T.is_plating() ? 2 : 1
-			M.initialize()
+			M.atmos_init()
 			if (!M)
 				usr << "There's nothing to connect this manifold to! (with how the pipe code works, at least one end needs to be connected to something, otherwise the game deletes the segment)"
 				return 1
 			M.build_network()
 			if (M.node1)
-				M.node1.initialize()
+				M.node1.atmos_init()
 				M.node1.build_network()
 			if (M.node2)
-				M.node2.initialize()
+				M.node2.atmos_init()
 				M.node2.build_network()
 			if (M.node3)
-				M.node3.initialize()
+				M.node3.atmos_init()
 				M.node3.build_network()
 			if (M.node4)
-				M.node4.initialize()
+				M.node4.atmos_init()
 				M.node4.build_network()
 
 		if(PIPE_SCRUBBERS_MANIFOLD4W)		//4-way manifold
@@ -723,22 +724,22 @@ Buildable meters
 			//M.New()
 			var/turf/T = M.loc
 			M.level = !T.is_plating() ? 2 : 1
-			M.initialize()
+			M.atmos_init()
 			if (!M)
 				usr << "There's nothing to connect this manifold to! (with how the pipe code works, at least one end needs to be connected to something, otherwise the game deletes the segment)"
 				return 1
 			M.build_network()
 			if (M.node1)
-				M.node1.initialize()
+				M.node1.atmos_init()
 				M.node1.build_network()
 			if (M.node2)
-				M.node2.initialize()
+				M.node2.atmos_init()
 				M.node2.build_network()
 			if (M.node3)
-				M.node3.initialize()
+				M.node3.atmos_init()
 				M.node3.build_network()
 			if (M.node4)
-				M.node4.initialize()
+				M.node4.atmos_init()
 				M.node4.build_network()
 
 		if(PIPE_JUNCTION)
@@ -746,16 +747,16 @@ Buildable meters
 			P.set_dir(src.dir)
 			P.initialize_directions = src.get_pdir()
 			P.initialize_directions_he = src.get_hdir()
-			P.initialize()
+			P.atmos_init()
 			if (QDELETED(P))
 				usr << pipefailtext //"There's nothing to connect this pipe to! (with how the pipe code works, at least one end needs to be connected to something, otherwise the game deletes the segment)"
 				return 1
 			P.build_network()
 			if (P.node1)
-				P.node1.initialize()
+				P.node1.atmos_init()
 				P.node1.build_network()
 			if (P.node2)
-				P.node2.initialize()
+				P.node2.atmos_init()
 				P.node2.build_network()
 
 		if(PIPE_UVENT)		//unary vent
@@ -766,10 +767,10 @@ Buildable meters
 				V.name = pipename
 			var/turf/T = V.loc
 			V.level = !T.is_plating() ? 2 : 1
-			V.initialize()
+			V.atmos_init()
 			V.build_network()
 			if (V.node)
-				V.node.initialize()
+				V.node.atmos_init()
 				V.node.build_network()
 
 		if(PIPE_MVALVE)		//manual valve
@@ -780,15 +781,15 @@ Buildable meters
 				V.name = pipename
 			var/turf/T = V.loc
 			V.level = !T.is_plating() ? 2 : 1
-			V.initialize()
+			V.atmos_init()
 			V.build_network()
 			if (V.node1)
 //					world << "[V.node1.name] is connected to valve, forcing it to update its nodes."
-				V.node1.initialize()
+				V.node1.atmos_init()
 				V.node1.build_network()
 			if (V.node2)
 //					world << "[V.node2.name] is connected to valve, forcing it to update its nodes."
-				V.node2.initialize()
+				V.node2.atmos_init()
 				V.node2.build_network()
 
 		if(PIPE_PUMP)		//gas pump
@@ -799,13 +800,13 @@ Buildable meters
 				P.name = pipename
 			var/turf/T = P.loc
 			P.level = !T.is_plating() ? 2 : 1
-			P.initialize()
+			P.atmos_init()
 			P.build_network()
 			if (P.node1)
-				P.node1.initialize()
+				P.node1.atmos_init()
 				P.node1.build_network()
 			if (P.node2)
-				P.node2.initialize()
+				P.node2.atmos_init()
 				P.node2.build_network()
 
 		if(PIPE_GAS_FILTER)		//gas filter
@@ -816,16 +817,16 @@ Buildable meters
 				P.name = pipename
 			var/turf/T = P.loc
 			P.level = !T.is_plating() ? 2 : 1
-			P.initialize()
+			P.atmos_init()
 			P.build_network()
 			if (P.node1)
-				P.node1.initialize()
+				P.node1.atmos_init()
 				P.node1.build_network()
 			if (P.node2)
-				P.node2.initialize()
+				P.node2.atmos_init()
 				P.node2.build_network()
 			if (P.node3)
-				P.node3.initialize()
+				P.node3.atmos_init()
 				P.node3.build_network()
 
 		if(PIPE_GAS_MIXER)		//gas mixer
@@ -836,16 +837,16 @@ Buildable meters
 				P.name = pipename
 			var/turf/T = P.loc
 			P.level = !T.is_plating() ? 2 : 1
-			P.initialize()
+			P.atmos_init()
 			P.build_network()
 			if (P.node1)
-				P.node1.initialize()
+				P.node1.atmos_init()
 				P.node1.build_network()
 			if (P.node2)
-				P.node2.initialize()
+				P.node2.atmos_init()
 				P.node2.build_network()
 			if (P.node3)
-				P.node3.initialize()
+				P.node3.atmos_init()
 				P.node3.build_network()
 
 		if(PIPE_GAS_FILTER_M)		//gas filter mirrored
@@ -856,16 +857,16 @@ Buildable meters
 				P.name = pipename
 			var/turf/T = P.loc
 			P.level = !T.is_plating() ? 2 : 1
-			P.initialize()
+			P.atmos_init()
 			P.build_network()
 			if (P.node1)
-				P.node1.initialize()
+				P.node1.atmos_init()
 				P.node1.build_network()
 			if (P.node2)
-				P.node2.initialize()
+				P.node2.atmos_init()
 				P.node2.build_network()
 			if (P.node3)
-				P.node3.initialize()
+				P.node3.atmos_init()
 				P.node3.build_network()
 
 		if(PIPE_GAS_MIXER_T)		//gas mixer-t
@@ -876,16 +877,16 @@ Buildable meters
 				P.name = pipename
 			var/turf/T = P.loc
 			P.level = !T.is_plating() ? 2 : 1
-			P.initialize()
+			P.atmos_init()
 			P.build_network()
 			if (P.node1)
-				P.node1.initialize()
+				P.node1.atmos_init()
 				P.node1.build_network()
 			if (P.node2)
-				P.node2.initialize()
+				P.node2.atmos_init()
 				P.node2.build_network()
 			if (P.node3)
-				P.node3.initialize()
+				P.node3.atmos_init()
 				P.node3.build_network()
 
 		if(PIPE_GAS_MIXER_M)		//gas mixer mirrored
@@ -896,16 +897,16 @@ Buildable meters
 				P.name = pipename
 			var/turf/T = P.loc
 			P.level = !T.is_plating() ? 2 : 1
-			P.initialize()
+			P.atmos_init()
 			P.build_network()
 			if (P.node1)
-				P.node1.initialize()
+				P.node1.atmos_init()
 				P.node1.build_network()
 			if (P.node2)
-				P.node2.initialize()
+				P.node2.atmos_init()
 				P.node2.build_network()
 			if (P.node3)
-				P.node3.initialize()
+				P.node3.atmos_init()
 				P.node3.build_network()
 
 		if(PIPE_SCRUBBER)		//scrubber
@@ -916,10 +917,10 @@ Buildable meters
 				S.name = pipename
 			var/turf/T = S.loc
 			S.level = !T.is_plating() ? 2 : 1
-			S.initialize()
+			S.atmos_init()
 			S.build_network()
 			if (S.node)
-				S.node.initialize()
+				S.node.atmos_init()
 				S.node.build_network()
 
 		if(PIPE_INSULATED_STRAIGHT, PIPE_INSULATED_BENT)
@@ -928,16 +929,16 @@ Buildable meters
 			P.initialize_directions = pipe_dir
 			var/turf/T = P.loc
 			P.level = !T.is_plating() ? 2 : 1
-			P.initialize()
+			P.atmos_init()
 			if (QDELETED(P))
 				usr << pipefailtext
 				return 1
 			P.build_network()
 			if (P.node1)
-				P.node1.initialize()
+				P.node1.atmos_init()
 				P.node1.build_network()
 			if (P.node2)
-				P.node2.initialize()
+				P.node2.atmos_init()
 				P.node2.build_network()
 
 		if(PIPE_MTVALVE)		//manual t-valve
@@ -948,16 +949,16 @@ Buildable meters
 				V.name = pipename
 			var/turf/T = V.loc
 			V.level = !T.is_plating() ? 2 : 1
-			V.initialize()
+			V.atmos_init()
 			V.build_network()
 			if (V.node1)
-				V.node1.initialize()
+				V.node1.atmos_init()
 				V.node1.build_network()
 			if (V.node2)
-				V.node2.initialize()
+				V.node2.atmos_init()
 				V.node2.build_network()
 			if (V.node3)
-				V.node3.initialize()
+				V.node3.atmos_init()
 				V.node3.build_network()
 
 		if(PIPE_MTVALVEM)		//manual t-valve
@@ -968,46 +969,46 @@ Buildable meters
 				V.name = pipename
 			var/turf/T = V.loc
 			V.level = !T.is_plating() ? 2 : 1
-			V.initialize()
+			V.atmos_init()
 			V.build_network()
 			if (V.node1)
-				V.node1.initialize()
+				V.node1.atmos_init()
 				V.node1.build_network()
 			if (V.node2)
-				V.node2.initialize()
+				V.node2.atmos_init()
 				V.node2.build_network()
 			if (V.node3)
-				V.node3.initialize()
+				V.node3.atmos_init()
 				V.node3.build_network()
 
 		if(PIPE_CAP)
 			var/obj/machinery/atmospherics/pipe/cap/C = new(src.loc)
 			C.set_dir(dir)
 			C.initialize_directions = pipe_dir
-			C.initialize()
+			C.atmos_init()
 			C.build_network()
 			if(C.node)
-				C.node.initialize()
+				C.node.atmos_init()
 				C.node.build_network()
 
 		if(PIPE_SUPPLY_CAP)
 			var/obj/machinery/atmospherics/pipe/cap/hidden/supply/C = new(src.loc)
 			C.set_dir(dir)
 			C.initialize_directions = pipe_dir
-			C.initialize()
+			C.atmos_init()
 			C.build_network()
 			if(C.node)
-				C.node.initialize()
+				C.node.atmos_init()
 				C.node.build_network()
 
 		if(PIPE_SCRUBBERS_CAP)
 			var/obj/machinery/atmospherics/pipe/cap/hidden/scrubbers/C = new(src.loc)
 			C.set_dir(dir)
 			C.initialize_directions = pipe_dir
-			C.initialize()
+			C.atmos_init()
 			C.build_network()
 			if(C.node)
-				C.node.initialize()
+				C.node.atmos_init()
 				C.node.build_network()
 
 		if(PIPE_PASSIVE_GATE)		//passive gate
@@ -1018,13 +1019,13 @@ Buildable meters
 				P.name = pipename
 			var/turf/T = P.loc
 			P.level = !T.is_plating() ? 2 : 1
-			P.initialize()
+			P.atmos_init()
 			P.build_network()
 			if (P.node1)
-				P.node1.initialize()
+				P.node1.atmos_init()
 				P.node1.build_network()
 			if (P.node2)
-				P.node2.initialize()
+				P.node2.atmos_init()
 				P.node2.build_network()
 
 		if(PIPE_VOLUME_PUMP)		//volume pump
@@ -1035,13 +1036,13 @@ Buildable meters
 				P.name = pipename
 			var/turf/T = P.loc
 			P.level = !T.is_plating() ? 2 : 1
-			P.initialize()
+			P.atmos_init()
 			P.build_network()
 			if (P.node1)
-				P.node1.initialize()
+				P.node1.atmos_init()
 				P.node1.build_network()
 			if (P.node2)
-				P.node2.initialize()
+				P.node2.atmos_init()
 				P.node2.build_network()
 
 		if(PIPE_HEAT_EXCHANGE)		// heat exchanger
@@ -1052,10 +1053,10 @@ Buildable meters
 				C.name = pipename
 			var/turf/T = C.loc
 			C.level = !T.is_plating() ? 2 : 1
-			C.initialize()
+			C.atmos_init()
 			C.build_network()
 			if (C.node)
-				C.node.initialize()
+				C.node.atmos_init()
 				C.node.build_network()
 
 		if(PIPE_DVALVE)		//digital valve
@@ -1070,13 +1071,13 @@ Buildable meters
 				V.name = pipename
 			var/turf/T = V.loc
 			V.level = !T.is_plating() ? 2 : 1
-			V.initialize()
+			V.atmos_init()
 			V.build_network()
 			if (V.node1)
-				V.node1.initialize()
+				V.node1.atmos_init()
 				V.node1.build_network()
 			if (V.node2)
-				V.node2.initialize()
+				V.node2.atmos_init()
 				V.node2.build_network()
 
 		if(PIPE_DTVALVE)		//digital t-valve
@@ -1091,16 +1092,16 @@ Buildable meters
 				V.name = pipename
 			var/turf/T = V.loc
 			V.level = !T.is_plating() ? 2 : 1
-			V.initialize()
+			V.atmos_init()
 			V.build_network()
 			if (V.node1)
-				V.node1.initialize()
+				V.node1.atmos_init()
 				V.node1.build_network()
 			if (V.node2)
-				V.node2.initialize()
+				V.node2.atmos_init()
 				V.node2.build_network()
 			if (V.node3)
-				V.node3.initialize()
+				V.node3.atmos_init()
 				V.node3.build_network()
 
 		if(PIPE_DTVALVEM)		//mirrored digital t-valve
@@ -1115,16 +1116,16 @@ Buildable meters
 				V.name = pipename
 			var/turf/T = V.loc
 			V.level = !T.is_plating() ? 2 : 1
-			V.initialize()
+			V.atmos_init()
 			V.build_network()
 			if (V.node1)
-				V.node1.initialize()
+				V.node1.atmos_init()
 				V.node1.build_network()
 			if (V.node2)
-				V.node2.initialize()
+				V.node2.atmos_init()
 				V.node2.build_network()
 			if (V.node3)
-				V.node3.initialize()
+				V.node3.atmos_init()
 				V.node3.build_network()
 
 ///// Z-Level stuff
@@ -1136,13 +1137,13 @@ Buildable meters
 				P.name = pipename
 			var/turf/T = P.loc
 			P.level = !T.is_plating() ? 2 : 1
-			P.initialize()
+			P.atmos_init()
 			P.build_network()
 			if (P.node1)
-				P.node1.initialize()
+				P.node1.atmos_init()
 				P.node1.build_network()
 			if (P.node2)
-				P.node2.initialize()
+				P.node2.atmos_init()
 				P.node2.build_network()
 		if(PIPE_DOWN)
 			var/obj/machinery/atmospherics/pipe/zpipe/down/P = new(src.loc)
@@ -1152,13 +1153,13 @@ Buildable meters
 				P.name = pipename
 			var/turf/T = P.loc
 			P.level = !T.is_plating() ? 2 : 1
-			P.initialize()
+			P.atmos_init()
 			P.build_network()
 			if (P.node1)
-				P.node1.initialize()
+				P.node1.atmos_init()
 				P.node1.build_network()
 			if (P.node2)
-				P.node2.initialize()
+				P.node2.atmos_init()
 				P.node2.build_network()
 		if(PIPE_SUPPLY_UP)
 			var/obj/machinery/atmospherics/pipe/zpipe/up/supply/P = new(src.loc)
@@ -1168,13 +1169,13 @@ Buildable meters
 				P.name = pipename
 			var/turf/T = P.loc
 			P.level = !T.is_plating() ? 2 : 1
-			P.initialize()
+			P.atmos_init()
 			P.build_network()
 			if (P.node1)
-				P.node1.initialize()
+				P.node1.atmos_init()
 				P.node1.build_network()
 			if (P.node2)
-				P.node2.initialize()
+				P.node2.atmos_init()
 				P.node2.build_network()
 		if(PIPE_SUPPLY_DOWN)
 			var/obj/machinery/atmospherics/pipe/zpipe/down/supply/P = new(src.loc)
@@ -1184,13 +1185,13 @@ Buildable meters
 				P.name = pipename
 			var/turf/T = P.loc
 			P.level = !T.is_plating() ? 2 : 1
-			P.initialize()
+			P.atmos_init()
 			P.build_network()
 			if (P.node1)
-				P.node1.initialize()
+				P.node1.atmos_init()
 				P.node1.build_network()
 			if (P.node2)
-				P.node2.initialize()
+				P.node2.atmos_init()
 				P.node2.build_network()
 		if(PIPE_SCRUBBERS_UP)
 			var/obj/machinery/atmospherics/pipe/zpipe/up/scrubbers/P = new(src.loc)
@@ -1200,13 +1201,13 @@ Buildable meters
 				P.name = pipename
 			var/turf/T = P.loc
 			P.level = !T.is_plating() ? 2 : 1
-			P.initialize()
+			P.atmos_init()
 			P.build_network()
 			if (P.node1)
-				P.node1.initialize()
+				P.node1.atmos_init()
 				P.node1.build_network()
 			if (P.node2)
-				P.node2.initialize()
+				P.node2.atmos_init()
 				P.node2.build_network()
 		if(PIPE_SCRUBBERS_DOWN)
 			var/obj/machinery/atmospherics/pipe/zpipe/down/scrubbers/P = new(src.loc)
@@ -1216,26 +1217,26 @@ Buildable meters
 				P.name = pipename
 			var/turf/T = P.loc
 			P.level = !T.is_plating() ? 2 : 1
-			P.initialize()
+			P.atmos_init()
 			P.build_network()
 			if (P.node1)
-				P.node1.initialize()
+				P.node1.atmos_init()
 				P.node1.build_network()
 			if (P.node2)
-				P.node2.initialize()
+				P.node2.atmos_init()
 				P.node2.build_network()
 ///// Z-Level stuff
 		if(PIPE_OMNI_MIXER)
 			var/obj/machinery/atmospherics/omni/mixer/P = new(loc)
 			var/turf/T = P.loc
 			P.level = !T.is_plating() ? 2 : 1
-			P.initialize()
+			P.atmos_init()
 			P.build_network()
 		if(PIPE_OMNI_FILTER)
 			var/obj/machinery/atmospherics/omni/atmos_filter/P = new(loc)
 			var/turf/T = P.loc
 			P.level = !T.is_plating() ? 2 : 1
-			P.initialize()
+			P.atmos_init()
 			P.build_network()
 		if(PIPE_PASSIVE_VENT)
 			var/obj/machinery/atmospherics/pipe/vent/P = new(loc)
@@ -1243,10 +1244,10 @@ Buildable meters
 			P.initialize_directions = pipe_dir
 			var/turf/T = P.loc
 			P.level = !T.is_plating() ? 2 : 1
-			P.initialize()
+			P.atmos_init()
 			P.build_network()
 			if (P.node1)
-				P.node1.initialize()
+				P.node1.atmos_init()
 				P.node1.build_network()
 
 	playsound(src, W.usesound, 50, 1)

--- a/code/game/objects/items/weapons/circuitboards/machinery/unary_atmos.dm
+++ b/code/game/objects/items/weapons/circuitboards/machinery/unary_atmos.dm
@@ -7,10 +7,10 @@
 
 /obj/item/weapon/circuitboard/unary_atmos/construct(var/obj/machinery/atmospherics/unary/U)
 	//TODO: Move this stuff into the relevant constructor when pipe/construction.dm is cleaned up.
-	U.initialize()
+	U.atmos_init()
 	U.build_network()
 	if (U.node)
-		U.node.initialize()
+		U.node.atmos_init()
 		U.node.build_network()
 
 /obj/item/weapon/circuitboard/unary_atmos/heater

--- a/code/modules/maps/tg/map_template.dm
+++ b/code/modules/maps/tg/map_template.dm
@@ -82,7 +82,7 @@ var/list/global/map_templates = list()
 
 	admin_notice("<span class='danger'>Initializing atmos pipenets and machinery in submap.</span>", R_DEBUG)
 	for(var/obj/machinery/atmospherics/machine in atmos_machines)
-		machine.initialize()
+		machine.atmos_init()
 		i++
 
 	for(var/obj/machinery/atmospherics/machine in atmos_machines)


### PR DESCRIPTION
We want all machines, air, pipe networks etc to initialize quickly and smoothly both at system startup, but especially during dynamic map loading.   To best support the /tg maploader we want atoms to initialize properly.  Atmospherics machinery (both pipes and components) are among the oldest machines needing to be initialized after creation, and have a proc named initialize() with a different purpose than the way the rest of SS13 uses initialize().  We should follow /tg and Bay's example of renaming this proc.

#### Rename /obj/machinery/atmospherics initialize() to atmos_init()
* These days `initialize()` is used to handle general object initialization that is moved outside of New().  The node connection discovery of atmos machinery needs to happen after all that, and so needs to be in a separate proc.
* Make sure to actually call atmos_init during system startup.

#### Add preloader.load() to /atom/New()
* This was present in the Polaris maploader used prior to porting to TG's maploader.   It is used by TG and Baystation, but not by us.
* The effect of not having it is that any custom var overrides in a .dmm file will be applies *after* invoking New(), instead of before.  This caused bad side effects for some types (i.e. atmos machinery).
* Therefore we put the lines back in.

#### Revert calling target.init_dir() before connecting to neighbors
* This change was added in https://github.com/PolarisSS13/Polaris/pull/3775 to counteract `dir` not being set prior to New() for dynamically loaded maps.  However the true root cause of that problem was /atom/New() not calling _preloader.load().  Undoing the change now that /atom/New() is fixed.
* The addition of the init_dir() proc itself however, is useful, because there ARE other times some atmos machinery will want to re-initialize its dir, specifically whenever it is rotated.
* init_dir() must be called in the constructor of all atmospherics machines capable of connecting to another.   Since it has to happen for ALL machines, lets move that call to /obj/machinery/atmospherics/New()

Also did some to_chat() replacement for the sake of code consistency

