### PR TITLE
Stop doors from sleeping during machine controller process() execution

### DIFF
--- a/code/game/machinery/doors/airlock_control.dm
+++ b/code/game/machinery/doors/airlock_control.dm
@@ -21,8 +21,7 @@ obj/machinery/door/airlock/receive_signal(datum/signal/signal)
 	if(id_tag != signal.data["tag"] || !signal.data["command"]) return
 
 	cur_command = signal.data["command"]
-	spawn()
-		execute_current_command()
+	execute_current_command()
 
 obj/machinery/door/airlock/proc/execute_current_command()
 	if(operating)
@@ -31,9 +30,10 @@ obj/machinery/door/airlock/proc/execute_current_command()
 	if (!cur_command)
 		return
 
-	do_command(cur_command)
-	if (command_completed(cur_command))
-		cur_command = null
+	spawn()
+		do_command(cur_command)
+		if (command_completed(cur_command))
+			cur_command = null
 
 obj/machinery/door/airlock/proc/do_command(var/command)
 	switch(command)

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -79,7 +79,8 @@
 	if(close_door_at && world.time >= close_door_at)
 		if(autoclose)
 			close_door_at = next_close_time()
-			close()
+			spawn(0)
+				close()
 		else
 			close_door_at = 0
 


### PR DESCRIPTION
Port of VOREStation/VOREStation#2691 to fix  sluggish machines subsystem.

* Sleeping during process() is BAD BAD BAD!
* Since close() sleeps, we make sure to spawn() before calling it.