### PR TITLE
Updates misc atmospherics machinery init and destroy

### DIFF
--- a/code/game/machinery/atmoalter/area_atmos_computer.dm
+++ b/code/game/machinery/atmoalter/area_atmos_computer.dm
@@ -14,11 +14,9 @@
 	//Simple variable to prevent me from doing attack_hand in both this and the child computer
 	var/zone = "This computer is working on a wireless range, the range is currently limited to 25 meters."
 
-	New()
-		..()
-		//So the scrubbers have time to spawn
-		spawn(10)
-			scanscrubbers()
+	initialize()
+		. = ..()
+		scanscrubbers()
 
 	attack_ai(var/mob/user as mob)
 		return src.attack_hand(user)

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -30,16 +30,9 @@
 	var/turf/T = src.loc
 	T.contents += contents
 	if(beaker)
-		beaker.loc = get_step(src.loc, SOUTH) //Beaker is carefully ejected from the wreckage of the cryotube
-	..()
-
-/obj/machinery/atmospherics/unary/cryo_cell/initialize()
-	if(node) return
-	var/node_connect = dir
-	for(var/obj/machinery/atmospherics/target in get_step(src,node_connect))
-		if(target.initialize_directions & get_dir(target,src))
-			node = target
-			break
+		beaker.forceMove(get_step(loc, SOUTH)) //Beaker is carefully ejected from the wreckage of the cryotube
+		beaker = null
+	. = ..()
 
 /obj/machinery/atmospherics/unary/cryo_cell/process()
 	..()

--- a/code/modules/multiz/pipes.dm
+++ b/code/modules/multiz/pipes.dm
@@ -26,8 +26,11 @@ obj/machinery/atmospherics/pipe/zpipe
 
 		level = 1
 
-obj/machinery/atmospherics/pipe/zpipe/New()
+/obj/machinery/atmospherics/pipe/zpipe/New()
 	..()
+	init_dir()
+
+/obj/machinery/atmospherics/pipe/zpipe/init_dir()
 	switch(dir)
 		if(SOUTH)
 			initialize_directions = SOUTH
@@ -91,7 +94,7 @@ obj/machinery/atmospherics/pipe/zpipe/Destroy()
 		node1.disconnect(src)
 	if(node2)
 		node2.disconnect(src)
-	..()
+	. = ..()
 
 obj/machinery/atmospherics/pipe/zpipe/pipeline_expansion()
 	return list(node1, node2)
@@ -122,7 +125,7 @@ obj/machinery/atmospherics/pipe/zpipe/up
 		name = "upwards pipe"
 		desc = "A pipe segment to connect upwards."
 
-obj/machinery/atmospherics/pipe/zpipe/up/initialize()
+obj/machinery/atmospherics/pipe/zpipe/up/atmos_init()
 	normalize_dir()
 	var/node1_dir
 
@@ -160,7 +163,7 @@ obj/machinery/atmospherics/pipe/zpipe/down
 		name = "downwards pipe"
 		desc = "A pipe segment to connect downwards."
 
-obj/machinery/atmospherics/pipe/zpipe/down/initialize()
+obj/machinery/atmospherics/pipe/zpipe/down/atmos_init()
 	normalize_dir()
 	var/node1_dir
 


### PR DESCRIPTION
Fixes Destroy() proc on zpipes and cryo cells gets rid of a `loc = X`
Updates remaining atmos machinery to use atmos_init
Fixes area atmos computer to use initialize() instead of spawn-in-New