### PR TITLE
Make Singulo Stable Again

### DIFF
--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -512,12 +512,25 @@
 		return
 
 	for(var/obj/machinery/power/emitter/E in world)
-		if(E.anchored)
-			E.active = 1
+		if(istype(get_area(E), /area/space))
+			E.anchored = TRUE
+			E.state = 2
+			E.connect_to_network()
+			E.active = TRUE
 
 	for(var/obj/machinery/field_generator/F in world)
-		if(F.anchored)
+		if(istype(get_area(F), /area/space))
 			F.Varedit_start = 1
+
+	for(var/obj/structure/particle_accelerator/PA in world)
+		PA.anchored = TRUE
+		PA.construction_state = 3
+		PA.update_icon()
+	for(var/obj/machinery/particle_accelerator/PA in world)
+		PA.anchored = TRUE
+		PA.construction_state = 3
+		PA.update_icon()
+
 	spawn(30)
 		for(var/obj/machinery/the_singularitygen/G in world)
 			if(G.anchored)
@@ -548,10 +561,6 @@
 
 			if(!Rad.active)
 				Rad.toggle_power()
-
-	for(var/obj/machinery/power/smes/SMES in world)
-		if(SMES.anchored)
-			SMES.input_attempt = 1
 
 /client/proc/setup_supermatter_engine()
 	set category = "Debug"

--- a/code/modules/power/singularity/act.dm
+++ b/code/modules/power/singularity/act.dm
@@ -95,6 +95,9 @@
 /obj/item/projectile/beam/emitter/singularity_pull()
 	return
 
+/obj/effect/projectile/emitter/singularity_pull()
+	return
+
 /obj/item/weapon/storage/backpack/holding/singularity_act(S, current_size)
 	var/dist = max((current_size - 2), 1)
 	explosion(src.loc,(dist),(dist*2),(dist*4))
@@ -126,6 +129,9 @@
 				dismantle_wall()
 
 /turf/space/singularity_act()
+	return
+
+/turf/simulated/open/singularity_act()
 	return
 
 /*******************

--- a/code/modules/power/singularity/particle_accelerator/particle.dm
+++ b/code/modules/power/singularity/particle_accelerator/particle.dm
@@ -71,7 +71,8 @@
 	qdel(src)
 	return
 
-
+/obj/effect/accelerated_particle/singularity_act()
+	return
 
 /obj/effect/accelerated_particle/proc/toxmob(var/mob/living/M)
 	var/radiation = (energy*2)

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -267,21 +267,15 @@
 	return 1
 
 /obj/singularity/proc/eat()
-	for(var/atom/X in orange(grav_pull, src))
-		if(X.type == /atom/movable/lighting_overlay) //since there's one on every turf
+	for(var/T in orange(grav_pull, src))
+		var/atom/X = T
+		if(!X.simulated)
 			continue
 		var/dist = get_dist(X, src)
-		var/obj/singularity/S = src
-		if(!istype(src))
-			return
 		if(dist > consume_range)
-			X.singularity_pull(S, current_size)
-		else if(dist <= consume_range)
+			X.singularity_pull(src, current_size)
+		else
 			consume(X)
-
-	//for (var/turf/T in trange(grav_pull, src)) //TODO: Create a similar trange for orange to prevent snowflake of self check.
-	//	consume(T)
-
 	return
 
 /obj/singularity/proc/consume(const/atom/A)

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -47,7 +47,7 @@
 
 /obj/singularity/Destroy()
 	processing_objects -= src
-	..()
+	return ..()
 
 /obj/singularity/attack_hand(mob/user as mob)
 	consume(user)
@@ -169,7 +169,7 @@
 				pixel_y = -64
 				grav_pull = 8
 				consume_range = 2
-				dissipate_delay = 10
+				dissipate_delay = 4
 				dissipate_track = 0
 				dissipate_strength = 20
 				overlays = 0
@@ -268,6 +268,8 @@
 
 /obj/singularity/proc/eat()
 	for(var/atom/X in orange(grav_pull, src))
+		if(X.type == /atom/movable/lighting_overlay) //since there's one on every turf
+			continue
 		var/dist = get_dist(X, src)
 		var/obj/singularity/S = src
 		if(!istype(src))

--- a/html/changelogs/Leshana-singulo.yml
+++ b/html/changelogs/Leshana-singulo.yml
@@ -1,0 +1,5 @@
+author: Leshana
+delete-after: True
+changes: 
+  - tweak: "Fix singularity energy balance so it is stable under normal operation."
+  - bugfix: "Fix emitter beams and PA effects from being grav pulled or consumed."


### PR DESCRIPTION
* Prevents emitter beam effects from being pulled by singulo.  Now watch them hit the field gens instead of veering off course.
* Prevent singulo from consuming the PA particle effects.  It already gets fed by impact, don't try to eat them.
* Improve the Setup Singularity debug verb to do more better setup (including PA)
* Fix the energy dissipation values so that singularity does not just keep on growing even when setup properly.