### PR TITLE
Multiple loadout slots

### DIFF
--- a/code/_macros.dm
+++ b/code/_macros.dm
@@ -59,6 +59,8 @@
 #define to_world_log(message) world.log << message
 // TODO - Baystation has this log to crazy places. For now lets just world.log, but maybe look into it later.
 #define log_world(message) world.log << message
+#define to_file(file_entry, source_var) file_entry << source_var
+#define from_file(file_entry, target_var) file_entry >> target_var
 
 
 #define CanInteract(user, state) (CanUseTopic(user, state) == STATUS_INTERACTIVE)

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -81,6 +81,7 @@ var/list/gamemode_cache = list()
 	var/cult_ghostwriter_req_cultists = 10 //...so long as this many cultists are active.
 
 	var/character_slots = 10				// The number of available character slots
+	var/loadout_slots = 3					// The number of loadout slots per character
 
 	var/max_maint_drones = 5				//This many drones can spawn,
 	var/allow_drone_spawn = 1				//assuming the admin allow them to.
@@ -648,6 +649,9 @@ var/list/gamemode_cache = list()
 
 				if("character_slots")
 					config.character_slots = text2num(value)
+
+				if("loadout_slots")
+					config.loadout_slots = text2num(value)
 
 				if("allow_drone_spawn")
 					config.allow_drone_spawn = text2num(value)

--- a/code/modules/client/preference_setup/loadout/loadout.dm
+++ b/code/modules/client/preference_setup/loadout/loadout.dm
@@ -47,10 +47,18 @@ var/list/gear_datums = list()
 	var/current_tab = "General"
 
 /datum/category_item/player_setup_item/loadout/load_character(var/savefile/S)
-	S["gear"] >> pref.gear
+	from_file(S["gear_list"], pref.gear_list)
+	from_file(S["gear_slot"], pref.gear_slot)
+	if(pref.gear_list!=null && pref.gear_slot!=null)
+		pref.gear = pref.gear_list["[pref.gear_slot]"]
+	else
+		from_file(S["gear"], pref.gear)
+		pref.gear_slot = 1
 
 /datum/category_item/player_setup_item/loadout/save_character(var/savefile/S)
-	S["gear"] << pref.gear
+	pref.gear_list["[pref.gear_slot]"] = pref.gear
+	to_file(S["gear_list"], pref.gear_list)
+	to_file(S["gear_slot"], pref.gear_slot)
 
 /datum/category_item/player_setup_item/loadout/proc/valid_gear_choices(var/max_cost)
 	. = list()
@@ -68,6 +76,8 @@ var/list/gear_datums = list()
 	var/mob/preference_mob = preference_mob()
 	if(!islist(pref.gear))
 		pref.gear = list()
+	if(!islist(pref.gear_list))
+		pref.gear_list = list()
 
 	for(var/gear_name in pref.gear)
 		if(!(gear_name in gear_datums))
@@ -102,7 +112,7 @@ var/list/gear_datums = list()
 		fcolor = "#E67300"
 
 	. += "<table align = 'center' width = 100%>"
-	. += "<tr><td colspan=3><center><b><font color = '[fcolor]'>[total_cost]/[MAX_GEAR_COST]</font> loadout points spent.</b> \[<a href='?src=\ref[src];clear_loadout=1'>Clear Loadout</a>\]</center></td></tr>"
+	. += "<tr><td colspan=3><center><a href='?src=\ref[src];prev_slot=1'>\<\<</a><b><font color = '[fcolor]'>\[[pref.gear_slot]\]</font> </b><a href='?src=\ref[src];next_slot=1'>\>\></a><b><font color = '[fcolor]'>[total_cost]/[MAX_GEAR_COST]</font> loadout points spent.</b> \[<a href='?src=\ref[src];clear_loadout=1'>Clear Loadout</a>\]</center></td></tr>"
 
 	. += "<tr><td colspan=3><center><b>"
 	var/firstcat = 1
@@ -186,6 +196,29 @@ var/list/gear_datums = list()
 		if(!metadata || !CanUseTopic(user))
 			return TOPIC_NOACTION
 		set_tweak_metadata(gear, tweak, metadata)
+		return TOPIC_REFRESH_UPDATE_PREVIEW
+	if(href_list["next_slot"] || href_list["prev_slot"])
+		//Set the current slot in the gear list to the currently selected gear
+		pref.gear_list["[pref.gear_slot]"] = pref.gear
+		//If we're moving up a slot..
+		if(href_list["next_slot"])
+			//change the current slot number
+			pref.gear_slot = pref.gear_slot+1
+			if(pref.gear_slot>config.loadout_slots)
+				pref.gear_slot = 1
+		//If we're moving down a slot..
+		else if(href_list["prev_slot"])
+			//change current slot one down
+			pref.gear_slot = pref.gear_slot-1
+			if(pref.gear_slot<1)
+				pref.gear_slot = config.loadout_slots
+		// Set the currently selected gear to whatever's in the new slot
+		if(pref.gear_list["[pref.gear_slot]"])
+			pref.gear = pref.gear_list["[pref.gear_slot]"]
+		else
+			pref.gear = list()
+			pref.gear_list["[pref.gear_slot]"] = list()
+		// Refresh?
 		return TOPIC_REFRESH_UPDATE_PREVIEW
 	else if(href_list["select_category"])
 		current_tab = href_list["select_category"]

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -50,7 +50,9 @@ datum/preferences
 	var/species_preview                 //Used for the species selection window.
 	var/list/alternate_languages = list() //Secondary language(s)
 	var/list/language_prefixes = list() //Kanguage prefix keys
-	var/list/gear						//Custom/fluff item loadout.
+	var/list/gear						//Left in for Legacy reasons, will no longer save.
+	var/list/gear_list = list()			//Custom/fluff item loadouts.
+	var/gear_slot = 1					//The current gear save slot
 	var/list/traits						//Traits which modifier characters for better or worse (mostly worse).
 	var/synth_color	= 0					//Lets normally uncolorable synth parts be colorable.
 	var/r_synth							//Used with synth_color to color synth parts that normaly can't be colored.
@@ -131,6 +133,8 @@ datum/preferences
 	b_type = RANDOM_BLOOD_TYPE
 
 	gear = list()
+	gear_list = list()
+	gear_slot = 1
 
 	if(istype(C))
 		client = C

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -306,6 +306,9 @@ REQ_CULT_GHOSTWRITER 6
 ## Sets the number of available character slots
 CHARACTER_SLOTS 10
 
+## Sets the number of loadout slots per character
+LOADOUT_SLOTS 3
+
 ## Uncomment to use overmap system for zlevel travel
 #USE_OVERMAP
 

--- a/html/changelogs/PrismaticGynoid-toomanyloadouts.yml
+++ b/html/changelogs/PrismaticGynoid-toomanyloadouts.yml
@@ -1,0 +1,4 @@
+author: ZeroBits
+delete-after: True
+changes: 
+  - rscadd: "Added the ability to have multiple loadouts per character."


### PR DESCRIPTION
Ported from Bay. Each character can have 3 (number can be overridden by config) loadout slots. This way, you can have different outfits for different situations without needing to have a separate character slot or edit your loadout every time.

Tested here, works as intended. The current loadout is set as slot 1, so you don't need to worry about remaking it. This also ports the to_file and from_file macros to make it work, I'm assuming they could later be used elsewhere as well.

[Here's what it looks like.](https://i.gyazo.com/27a6020e386fd9c3752b0d8578e00a36.mp4)