### PR TITLE
Fixed teshari sprites for back-slot air tank items.

### DIFF
--- a/code/game/objects/items/weapons/tanks/tanks.dm
+++ b/code/game/objects/items/weapons/tanks/tanks.dm
@@ -7,6 +7,9 @@ var/list/global/tank_gauge_cache = list()
 /obj/item/weapon/tank
 	name = "tank"
 	icon = 'icons/obj/tank.dmi'
+	sprite_sheets = list(
+		"Teshari" = 'icons/mob/species/seromi/back.dmi'
+		)
 
 	var/gauge_icon = "indicator_tank"
 	var/last_gauge_pressure


### PR DESCRIPTION
Sprites existed but code was missing. Applies to all worn subitems under item/weapon/tank.

I forgot to get a before pic where they were huge and floating about 3 pixels off thir backs, but here's an after:
https://gyazo.com/432be6c33627863d0348eb13ed9a0a63