### PR TITLE
Cleans up PDA Manifest template

### DIFF
--- a/code/defines/obj.dm
+++ b/code/defines/obj.dm
@@ -65,15 +65,16 @@ var/global/list/PDA_Manifest = list()
 /datum/datacore/proc/get_manifest_list()
 	if(PDA_Manifest.len)
 		return
-	var/heads[0]
-	var/sec[0]
-	var/eng[0]
-	var/med[0]
-	var/sci[0]
-	var/car[0]
-	var/civ[0]
-	var/bot[0]
-	var/misc[0]
+	var/list/heads = list()
+	var/list/sec = list()
+	var/list/eng = list()
+	var/list/med = list()
+	var/list/sci = list()
+	var/list/car = list()
+	var/list/pla = list() // Planetside crew: Explorers, Pilots, S&S
+	var/list/civ = list()
+	var/list/bot = list()
+	var/list/misc = list()
 	for(var/datum/data/record/t in data_core.general)
 		var/name = sanitize(t.fields["name"])
 		var/rank = sanitize(t.fields["rank"])
@@ -113,6 +114,10 @@ var/global/list/PDA_Manifest = list()
 			if(depthead && sci.len != 1)
 				sci.Swap(1,sci.len)
 
+		if(real_rank in planet_positions)
+			pla[++pla.len] = list("name" = name, "rank" = rank, "active" = isactive)
+			department = 1
+
 		if(real_rank in cargo_positions)
 			car[++car.len] = list("name" = name, "rank" = rank, "active" = isactive)
 			department = 1
@@ -133,16 +138,17 @@ var/global/list/PDA_Manifest = list()
 			misc[++misc.len] = list("name" = name, "rank" = rank, "active" = isactive)
 
 
-	PDA_Manifest = list(\
-		"heads" = heads,\
-		"sec" = sec,\
-		"eng" = eng,\
-		"med" = med,\
-		"sci" = sci,\
-		"car" = car,\
-		"civ" = civ,\
-		"bot" = bot,\
-		"misc" = misc\
+	PDA_Manifest = list(
+		list("cat" = "Command", "elems" = heads),
+		list("cat" = "Security", "elems" = sec),
+		list("cat" = "Engineering", "elems" = eng),
+		list("cat" = "Medical", "elems" = med),
+		list("cat" = "Science", "elems" = sci),
+		list("cat" = "Cargo", "elems" = car),
+		list("cat" = "Planetside", "elems" = pla),
+		list("cat" = "Civilian", "elems" = civ),
+		list("cat" = "Silicon", "elems" = bot),
+		list("cat" = "Miscellaneous", "elems" = misc)
 		)
 	return
 

--- a/code/game/jobs/jobs.dm
+++ b/code/game/jobs/jobs.dm
@@ -113,6 +113,13 @@ var/list/security_positions = list(
 )
 
 
+var/list/planet_positions = list(
+	"Explorer",
+	"Pilot",
+	"Search and Rescue"
+)
+
+
 var/list/nonhuman_positions = list(
 	"AI",
 	"Cyborg",

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -642,10 +642,6 @@ var/global/list/obj/item/device/pda/PDAs = list()
 
 		data["feed"] = feed
 
-//	var/PDA_Manifest_Array[0]
-//	for(var/cat in PDA_Manifest)
-//		PDA_Manifest_Array[++PDA_Manifest_Array.len] = cat
-
 	data["manifest"] = PDA_Manifest
 
 	nanoUI = data

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -642,6 +642,10 @@ var/global/list/obj/item/device/pda/PDAs = list()
 
 		data["feed"] = feed
 
+//	var/PDA_Manifest_Array[0]
+//	for(var/cat in PDA_Manifest)
+//		PDA_Manifest_Array[++PDA_Manifest_Array.len] = cat
+
 	data["manifest"] = PDA_Manifest
 
 	nanoUI = data

--- a/nano/css/shared.css
+++ b/nano/css/shared.css
@@ -600,49 +600,55 @@ table.pmon td, table.pmon th {
 
 /* Table Stuffs for manifest*/
 
-th.command {
+th.Command {
     background: #3333FF;
     font-weight: bold;
     color: #ffffff;
 }
 
-th.sec {
+th.Security {
     background: #8e0000;
     font-weight: bold;
     color: #ffffff;
 }
 
-th.med {
+th.Medical {
     background: #006600;
     font-weight: bold;
     color: #ffffff;
 }
 
-th.eng {
+th.Engineering {
     background: #b27300;
     font-weight: bold;
     color: #ffffff;
 }
 
-th.sci {
+th.Science {
     background: #a65ba6;
     font-weight: bold;
     color: #ffffff;
 }
 
-th.car {
+th.Cargo {
     background: #bb9040;
     font-weight: bold;
     color: #ffffff;
 }
 
-th.civ {
+th.Planetside{
+	background: #555555;
+	font-weight: bold;
+	color: #ffffff;
+}
+
+th.Civilian {
     background: #a32800;
     font-weight: bold;
     color: #ffffff;
 }
 
-th.misc {
+th.Miscellaneous {
     background: #666666;
     font-weight: bold;
     color: #ffffff;

--- a/nano/templates/pda.tmpl
+++ b/nano/templates/pda.tmpl
@@ -296,7 +296,7 @@ Used In File(s): \code\game\objects\items\devices\PDA\PDA.dm
 
 	{{else data.mode== 41}} <!-- Manifest uses cached data so we only use nanowriter when shit changes.-->
 		<div class="item">
-            <center><table class="pmon"><tbody>
+			<center><table class="pmon"><tbody>
 				{{for data.manifest}}
 					<tr><th colspan="3" class={{:value.cat}}>{{:value.cat}}</th></tr>
 					{{for value.elems :itemValue:itemIndex}}

--- a/nano/templates/pda.tmpl
+++ b/nano/templates/pda.tmpl
@@ -298,14 +298,16 @@ Used In File(s): \code\game\objects\items\devices\PDA\PDA.dm
 		<div class="item">
 			<center><table class="pmon"><tbody>
 				{{for data.manifest}}
-					<tr><th colspan="3" class={{:value.cat}}>{{:value.cat}}</th></tr>
-					{{for value.elems :itemValue:itemIndex}}
-						<tr>
-							<td><span class="average">{{:itemValue.name}}</span></td>
-							<td><span class="average">{{:itemValue.rank}}</span></td>
-							<td><span class="average">{{:itemValue.active}}</span></td>
-						</tr>
-					{{/for}}
+					{{if value.elems.length}}
+						<tr><th colspan="3" class={{:value.cat}}>{{:value.cat}}</th></tr>
+						{{for value.elems :itemValue:itemIndex}}
+							<tr>
+								<td><span class="average">{{:itemValue.name}}</span></td>
+								<td><span class="average">{{:itemValue.rank}}</span></td>
+								<td><span class="average">{{:itemValue.active}}</span></td>
+							</tr>
+						{{/for}}
+					{{/if}}
 				{{/for}}
 				 
 

--- a/nano/templates/pda.tmpl
+++ b/nano/templates/pda.tmpl
@@ -295,84 +295,20 @@ Used In File(s): \code\game\objects\items\devices\PDA\PDA.dm
 
 
 	{{else data.mode== 41}} <!-- Manifest uses cached data so we only use nanowriter when shit changes.-->
-	    <div class="item">
+		<div class="item">
             <center><table class="pmon"><tbody>
-                {{if data.manifest.heads.length}}
-                    <tr><th colspan="3" class="command">Command</th></tr>
-                    {{for data.manifest["heads"]}}
-                        {{if value.rank == "Captain"}}
-                            <tr><td><span class="good">{{:value.name}}</span></td><td><span class="good">{{:value.rank}}</span></td><td><span class="good">{{:value.active}}</span></td></tr>
-                        {{else}}
-                            <tr><td><span class="average">{{:value.name}}</span></td><td><span class="average">{{:value.rank}}</span></td><td><span class="average">{{:value.active}}</span></td></tr>
-                        {{/if}}
-                    {{/for}}
-                {{/if}}
-                {{if data.manifest.sec.length}}
-                    <tr><th colspan="3" class="sec">Security</th></tr>
-                    {{for data.manifest["sec"]}}
-                        {{if value.rank == "Head of Security"}}
-                            <tr><td><span class="good">{{:value.name}}</span></td><td><span class="good">{{:value.rank}}</span></td><td><span class="good">{{:value.active}}</span></td></tr>
-                        {{else}}
-                            <tr><td><span class="average">{{:value.name}}</span></td><td><span class="average">{{:value.rank}}</span></td><td><span class="average">{{:value.active}}</span></td></tr>
-                        {{/if}}
-                    {{/for}}
-                {{/if}}
-                {{if data.manifest.eng.length}}
-                    <tr><th colspan="3" class="eng">Engineering</th></tr>
-                    {{for data.manifest["eng"]}}
-                        {{if value.rank == "Chief Engineer"}}
-                            <tr><td><span class="good">{{:value.name}}</span></td><td><span class="good">{{:value.rank}}</span></td><td><span class="good">{{:value.active}}</span></td></tr>
-                        {{else}}
-                            <tr><td><span class="average">{{:value.name}}</span></td><td><span class="average">{{:value.rank}}</span></td><td><span class="average">{{:value.active}}</span></td></tr>
-                        {{/if}}
-                    {{/for}}
-                {{/if}}
-                {{if data.manifest.med.length}}
-                    <tr><th colspan="3" class="med">Medical</th></tr>
-                    {{for data.manifest["med"]}}
-                        {{if value.rank == "Chief Medical Officer"}}
-                            <tr><td><span class="good">{{:value.name}}</span></td><td><span class="good">{{:value.rank}}</span></td><td><span class="good">{{:value.active}}</span></td></tr>
-                        {{else}}
-                            <tr><td><span class="average">{{:value.name}}</span></td><td><span class="average">{{:value.rank}}</span></td><td><span class="average">{{:value.active}}</span></td></tr>
-                        {{/if}}
-                    {{/for}}
-                {{/if}}
-                {{if data.manifest.sci.length}}
-                    <tr><th colspan="3" class="sci">Science</th></tr>
-                    {{for data.manifest["sci"]}}
-                        {{if value.rank == "Research Director"}}
-                            <tr><td><span class="good">{{:value.name}}</span></td><td><span class="good">{{:value.rank}}</span></td><td><span class="good">{{:value.active}}</span></td></tr>
-                        {{else}}
-                            <tr><td><span class="average">{{:value.name}}</span></td><td><span class="average">{{:value.rank}}</span></td><td><span class="average">{{:value.active}}</span></td></tr>
-                        {{/if}}
-                    {{/for}}
-                {{/if}}
-				{{if data.manifest.car.length}}
-                    <tr><th colspan="3" class="car">Cargo</th></tr>
-                    {{for data.manifest["car"]}}
-                        {{if value.rank == "Quartermaster"}}
-                            <tr><td><span class="good">{{:value.name}}</span></td><td><span class="good">{{:value.rank}}</span></td><td><span class="good">{{:value.active}}</span></td></tr>
-                        {{else}}
-                            <tr><td><span class="average">{{:value.name}}</span></td><td><span class="average">{{:value.rank}}</span></td><td><span class="average">{{:value.active}}</span></td></tr>
-                        {{/if}}
-                    {{/for}}
-                {{/if}}
-                {{if data.manifest.civ.length}}
-                    <tr><th colspan="3" class="civ">Civilian</th></tr>
-                    {{for data.manifest["civ"]}}
-                        {{if value.rank == "Head of Personnel"}}
-                            <tr><td><span class="good">{{:value.name}}</span></td><td><span class="good">{{:value.rank}}</span></td><td><span class="good">{{:value.active}}</span></td></tr>
-                        {{else}}
-                            <tr><td><span class="average">{{:value.name}}</span></td><td><span class="average">{{:value.rank}}</span></td><td><span class="average">{{:value.active}}</span></td></tr>
-                        {{/if}}
-                    {{/for}}
-                {{/if}}
-                {{if data.manifest.misc.length}}
-                    <tr><th colspan="3" class="misc">Misc</th></tr>
-                    {{for data.manifest["misc"]}}
-                        <tr><td><span class="average">{{:value.name}}</span></td><td><span class="average">{{:value.rank}}</span></td><td><span class="average">{{:value.active}}</span></td></tr>
-                    {{/for}}
-                {{/if}}
+				{{for data.manifest}}
+					<tr><th colspan="3" class={{:value.cat}}>{{:value.cat}}</th></tr>
+					{{for value.elems :itemValue:itemIndex}}
+						<tr>
+							<td><span class="average">{{:itemValue.name}}</span></td>
+							<td><span class="average">{{:itemValue.rank}}</span></td>
+							<td><span class="average">{{:itemValue.active}}</span></td>
+						</tr>
+					{{/for}}
+				{{/for}}
+				 
+
             </tbody></table></center>
         </div>
 


### PR DESCRIPTION
Also adds silicon section for stationbounds, and moves explorers, SAR, and pilots to a new 'planetside' section. Ordering and stuff is easy to fix, but I want this so when I add a manifest to communicators I can use this clean, concise code instead of that old wall
![Tested](https://puu.sh/z1SUA/863ab34811.png)

If desired, I can very easily hide empty sections of the manifest.
Fixes #4536 