### PR TITLE
zShadow qdel fix

### DIFF
--- a/code/modules/multiz/zshadow.dm
+++ b/code/modules/multiz/zshadow.dm
@@ -20,14 +20,16 @@
 	if(!istype(L))
 		qdel(src)
 		return
-	..() // I'm cautious about this, but its the right thing to do.
 	owner = L
 	sync_icon(L)
 
+/mob/zshadow/Destroy()
+	owner = null
+	..() //But we don't return because the hint is wrong
+	return QDEL_HINT_QUEUE
+
 /mob/Destroy()
-	if(shadow)
-		qdel(shadow)
-		shadow = null
+	qdel_null(shadow)
 	. = ..()
 
 /mob/zshadow/examine(mob/user, distance, infix, suffix)


### PR DESCRIPTION
The default QDEL hint for mob is DELETE_ME_RIGHT_NOW_PLS because mobs are a scary and mysterious thing and we don't want them sticking around, just in case it somehow destroys the universe.

But, zshadows are not real mobs, we can get qdel-queued instead. Should result in a pretty large performance improvement where multiz shadows are often created and deleted. Also removes ..() in zshadow New, because it's unnecessary and all the functions of zshadow work without it (also it adds the zshadow to lists and stuff).