### PR TITLE
Allow greater customisation of wiki links

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -102,6 +102,7 @@ var/list/gamemode_cache = list()
 	var/server
 	var/banappeals
 	var/wikiurl
+	var/wikisearchurl
 	var/forumurl
 	var/githuburl
 	var/rulesurl
@@ -427,6 +428,9 @@ var/list/gamemode_cache = list()
 
 				if ("wikiurl")
 					config.wikiurl = value
+
+				if ("wikisearchurl")
+					config.wikisearchurl = value
 
 				if ("forumurl")
 					config.forumurl = value

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -217,6 +217,11 @@ GUEST_BAN
 ## Wiki address
 # WIKIURL http://example.com
 
+## Wiki search path
+## Set this to whatever path your wiki uses to search for articles
+## Use %s to mark where the search query should be inserted
+# WIKISEARCHURL http://example.com/index.php?title=Special%3ASearch&search=%s
+
 ## GitHub address
 # GITHUBURL https://github.com/example-user/example-repository
 ## Ban appeals URL - usually for a forum or wherever people should go to contact your admins.

--- a/html/changelogs/Leshana-wikisearch.yml
+++ b/html/changelogs/Leshana-wikisearch.yml
@@ -1,0 +1,4 @@
+author: Leshana
+delete-after: True
+changes:
+  - rscadd: "Wiki search URL is now configurable in config.txt"

--- a/interface/interface.dm
+++ b/interface/interface.dm
@@ -5,8 +5,11 @@
 	set category = "OOC"
 	if(config.wikiurl)
 		if(query)
-			var/output = config.wikiurl + "/index.php?title=Special%3ASearch&profile=default&search=" + query
-			src << link(output)
+			if(config.wikisearchurl)
+				var/output = replacetext(config.wikisearchurl, "%s", url_encode(query))	
+				src << link(output)
+			else
+				src << "<span class='warning'> The wiki search URL is not set in the server configuration.</span>"
 		else
 			src << link(config.wikiurl)
 	else


### PR DESCRIPTION
## Ported VOREStation/VOREStation#461
Allows customizing the exact syntax of the search URL & query params for whatever wiki software you're using.

> Because different servers have different wiki setups, it's just not right to have the search URL hardcoded in. MediaWiki has its own search URL, other wikis have their own. I've added in a new config option to allow server owners to designate the URL to be used for searching.

**After merging this, you will need to add the `WIKISEARCHURL` to your config.txt**
If your current config is working...  then you just need to copy the value for `WIKIURL` and add `/index.php?title=Special%3ASearch&profile=default&search=%s` to the end of it.

This should prevent the need for things like #4553 if you switch wikis again.  And yes this is porting a 2 year old PR that was forgotten.