### PR TITLE
Fixes Runtime with Deleting Humans

### DIFF
--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -150,6 +150,9 @@ Please contact me on #coderbus IRC. ~Carn x
 //UPDATES OVERLAYS FROM OVERLAYS_LYING/OVERLAYS_STANDING
 //I'll work on removing that stuff by rewriting some of the cloaking stuff at a later date.
 /mob/living/carbon/human/update_icons()
+	if(QDESTROYING(src))
+		return
+
 	lying_prev = lying	//so we don't update overlays for lying/standing unless our stance changes again
 	update_hud()		//TODO: remove the need for this
 
@@ -161,7 +164,7 @@ Please contact me on #coderbus IRC. ~Carn x
 
 	//2: The body itself, all the organs and whatnot
 	ma_compiled.overlays += list_body
-	
+
 	//3: The 'layers' list (overlays_standing), from the defines above
 	ma_compiled.overlays += list_layers
 
@@ -175,6 +178,9 @@ Please contact me on #coderbus IRC. ~Carn x
 	appearance = ma_compiled
 
 /mob/living/carbon/human/update_transform(var/mutable_appearance/passed_ma)
+	if(QDESTROYING(src))
+		return
+
 	var/mutable_appearance/ma
 	if(passed_ma)
 		ma = passed_ma
@@ -210,6 +216,9 @@ Please contact me on #coderbus IRC. ~Carn x
 
 //Update the layers from the defines above
 /mob/living/carbon/human/update_icons_layers(var/update_icons = 1)
+	if(QDESTROYING(src))
+		return
+
 	list_layers.Cut()
 
 	for(var/entry in overlays_standing)
@@ -228,6 +237,9 @@ Please contact me on #coderbus IRC. ~Carn x
 //HUD Icons (ingame huds, not the user interface)
 //Update things like med/sec hud icons
 /mob/living/carbon/human/update_icons_huds(var/update_icons = 1)
+	if(QDESTROYING(src))
+		return
+
 	list_huds.Cut()
 
 	if(has_huds)
@@ -239,6 +251,9 @@ Please contact me on #coderbus IRC. ~Carn x
 
 //A full, crunchy reprocess of all three cached lists
 /mob/living/carbon/human/update_icons_all(var/update_icons = 1)
+	if(QDESTROYING(src))
+		return
+
 	update_icons_huds(FALSE)
 	update_icons_body(FALSE)
 	update_icons_layers(FALSE)
@@ -250,6 +265,9 @@ var/global/list/damage_icon_parts = list()
 //DAMAGE OVERLAYS
 //constructs damage icon for each organ from mask * damage field and saves it in our overlays_ lists
 /mob/living/carbon/human/UpdateDamageIcon(var/update_icons=1)
+	if(QDESTROYING(src))
+		return
+
 	// first check whether something actually changed about damage appearance
 	var/damage_appearance = ""
 
@@ -294,6 +312,8 @@ var/global/list/damage_icon_parts = list()
 
 //BASE MOB SPRITE
 /mob/living/carbon/human/update_icons_body(var/update_icons=1)
+	if(QDESTROYING(src))
+		return
 
 	var/husk_color_mod = rgb(96,88,80)
 	var/hulk_color_mod = rgb(48,224,40)
@@ -422,11 +442,17 @@ var/global/list/damage_icon_parts = list()
 	update_tail_showing(0)
 
 /mob/living/carbon/human/proc/update_skin(var/update_icons=1)
+	if(QDESTROYING(src))
+		return
+
 	overlays_standing[SKIN_LAYER] = species.update_skin(src)
 	if(update_icons)   update_icons_layers()
 
 //UNDERWEAR OVERLAY
 /mob/living/carbon/human/proc/update_underwear(var/update_icons=1)
+	if(QDESTROYING(src))
+		return
+
 	overlays_standing[UNDERWEAR_LAYER] = null
 
 	if(species.appearance_flags & HAS_UNDERWEAR)
@@ -441,6 +467,9 @@ var/global/list/damage_icon_parts = list()
 
 //HAIR OVERLAY
 /mob/living/carbon/human/proc/update_hair(var/update_icons=1)
+	if(QDESTROYING(src))
+		return
+
 	//Reset our hair
 	overlays_standing[HAIR_LAYER]	= null
 
@@ -485,6 +514,9 @@ var/global/list/damage_icon_parts = list()
 	if(update_icons)   update_icons_layers()
 
 /mob/living/carbon/human/update_mutations(var/update_icons=1)
+	if(QDESTROYING(src))
+		return
+
 	var/fat
 	if(FAT in mutations)
 		fat = "fat"
@@ -569,6 +601,9 @@ var/global/list/damage_icon_parts = list()
 //vvvvvv UPDATE_INV PROCS vvvvvv
 
 /mob/living/carbon/human/update_inv_w_uniform(var/update_icons=1)
+	if(QDESTROYING(src))
+		return
+
 	if( (w_uniform && istype(w_uniform, /obj/item/clothing/under)) && !(wear_suit && istype(wear_suit, /obj/item/clothing/suit/space) && wear_suit.flags_inv & HIDEJUMPSUIT && !istype(wear_suit, /obj/item/clothing/suit/space/rig) ))
 		w_uniform.screen_loc = ui_iclothing
 
@@ -628,6 +663,9 @@ var/global/list/damage_icon_parts = list()
 		update_icons_layers()
 
 /mob/living/carbon/human/update_inv_wear_id(var/update_icons=1)
+	if(QDESTROYING(src))
+		return
+
 	if(wear_id)
 		wear_id.screen_loc = ui_id	//TODO
 		if(w_uniform && w_uniform:displays_id)
@@ -650,6 +688,9 @@ var/global/list/damage_icon_parts = list()
 	if(update_icons)   update_icons_layers()
 
 /mob/living/carbon/human/update_inv_gloves(var/update_icons=1)
+	if(QDESTROYING(src))
+		return
+
 	if(gloves)
 		var/t_state = gloves.item_state
 		if(!t_state)	t_state = gloves.icon_state
@@ -688,6 +729,9 @@ var/global/list/damage_icon_parts = list()
 
 
 /mob/living/carbon/human/update_inv_glasses(var/update_icons=1)
+	if(QDESTROYING(src))
+		return
+
 	if(glasses)
 		var/image/standing
 		if(glasses.icon_override)
@@ -712,6 +756,9 @@ var/global/list/damage_icon_parts = list()
 	if(update_icons)   update_icons_layers()
 
 /mob/living/carbon/human/update_inv_ears(var/update_icons=1)
+	if(QDESTROYING(src))
+		return
+
 	overlays_standing[EARS_LAYER] = null
 	if( (head && (head.flags_inv & (BLOCKHAIR | BLOCKHEADHAIR))) || (wear_mask && (wear_mask.flags_inv & (BLOCKHAIR | BLOCKHEADHAIR))))
 		if(update_icons)   update_icons_layers()
@@ -772,6 +819,9 @@ var/global/list/damage_icon_parts = list()
 	if(update_icons)   update_icons_layers()
 
 /mob/living/carbon/human/update_inv_shoes(var/update_icons=1)
+	if(QDESTROYING(src))
+		return
+
 	if(shoes && !((wear_suit && wear_suit.flags_inv & HIDESHOES) || (w_uniform && w_uniform.flags_inv & HIDESHOES)))
 
 		var/image/standing
@@ -819,6 +869,9 @@ var/global/list/damage_icon_parts = list()
 	if(update_icons)   update_icons()
 
 /mob/living/carbon/human/update_inv_s_store(var/update_icons=1)
+	if(QDESTROYING(src))
+		return
+
 	if(s_store)
 		var/t_state = s_store.item_state
 		if(!t_state)	t_state = s_store.icon_state
@@ -830,6 +883,9 @@ var/global/list/damage_icon_parts = list()
 
 
 /mob/living/carbon/human/update_inv_head(var/update_icons=1)
+	if(QDESTROYING(src))
+		return
+
 	if(head)
 		head.screen_loc = ui_head		//TODO
 
@@ -889,6 +945,9 @@ var/global/list/damage_icon_parts = list()
 	if(update_icons)   update_icons_layers()
 
 /mob/living/carbon/human/update_inv_belt(var/update_icons=1)
+	if(QDESTROYING(src))
+		return
+
 	if(belt)
 		belt.screen_loc = ui_belt	//TODO
 		var/t_state = belt.item_state
@@ -934,6 +993,8 @@ var/global/list/damage_icon_parts = list()
 
 
 /mob/living/carbon/human/update_inv_wear_suit(var/update_icons=1)
+	if(QDESTROYING(src))
+		return
 
 	if( wear_suit && istype(wear_suit, /obj/item/) )
 		wear_suit.screen_loc = ui_oclothing
@@ -992,12 +1053,18 @@ var/global/list/damage_icon_parts = list()
 	if(update_icons)   update_icons_layers()
 
 /mob/living/carbon/human/update_inv_pockets(var/update_icons=1)
+	if(QDESTROYING(src))
+		return
+
 	if(l_store)			l_store.screen_loc = ui_storage1	//TODO
 	if(r_store)			r_store.screen_loc = ui_storage2	//TODO
 	if(update_icons)	update_icons_layers()
 
 
 /mob/living/carbon/human/update_inv_wear_mask(var/update_icons=1)
+	if(QDESTROYING(src))
+		return
+
 	if( wear_mask && ( istype(wear_mask, /obj/item/clothing/mask) || istype(wear_mask, /obj/item/clothing/accessory) || istype(wear_mask, /obj/item/weapon/grenade) ) && !(head && head.flags_inv & HIDEMASK))
 		wear_mask.screen_loc = ui_mask	//TODO
 
@@ -1029,6 +1096,9 @@ var/global/list/damage_icon_parts = list()
 
 
 /mob/living/carbon/human/update_inv_back(var/update_icons=1)
+	if(QDESTROYING(src))
+		return
+
 	if(back)
 		back.screen_loc = ui_back	//TODO
 
@@ -1077,6 +1147,9 @@ var/global/list/damage_icon_parts = list()
 		update_icons_layers()
 
 /mob/living/carbon/human/update_hud()	//TODO: do away with this if possible
+	if(QDESTROYING(src))
+		return
+
 	if(client)
 		client.screen |= contents
 		if(hud_used)
@@ -1089,6 +1162,9 @@ var/global/list/damage_icon_parts = list()
 		hud_used.r_hand_hud_object.update_icon()
 
 /mob/living/carbon/human/update_inv_handcuffed(var/update_icons=1)
+	if(QDESTROYING(src))
+		return
+
 	if(handcuffed)
 		drop_r_hand()
 		drop_l_hand()
@@ -1110,6 +1186,9 @@ var/global/list/damage_icon_parts = list()
 	if(update_icons)   update_icons_layers()
 
 /mob/living/carbon/human/update_inv_legcuffed(var/update_icons=1)
+	if(QDESTROYING(src))
+		return
+
 	if(legcuffed)
 
 		var/image/standing
@@ -1132,6 +1211,9 @@ var/global/list/damage_icon_parts = list()
 
 
 /mob/living/carbon/human/update_inv_r_hand(var/update_icons=1)
+	if(QDESTROYING(src))
+		return
+
 	if(r_hand)
 		r_hand.screen_loc = ui_rhand	//TODO
 
@@ -1168,6 +1250,9 @@ var/global/list/damage_icon_parts = list()
 
 
 /mob/living/carbon/human/update_inv_l_hand(var/update_icons=1)
+	if(QDESTROYING(src))
+		return
+
 	if(l_hand)
 		l_hand.screen_loc = ui_lhand	//TODO
 
@@ -1203,6 +1288,9 @@ var/global/list/damage_icon_parts = list()
 	if(update_icons) update_icons_layers()
 
 /mob/living/carbon/human/proc/update_tail_showing(var/update_icons=1)
+	if(QDESTROYING(src))
+		return
+
 	overlays_standing[TAIL_LAYER] = null
 
 	var/species_tail = species.get_tail(src)
@@ -1246,6 +1334,9 @@ var/global/list/damage_icon_parts = list()
 //Not really once, since BYOND can't do that.
 //Update this if the ability to flick() images or make looping animation start at the first frame is ever added.
 /mob/living/carbon/human/proc/animate_tail_once(var/update_icons=1)
+	if(QDESTROYING(src))
+		return
+
 	var/t_state = "[species.get_tail(src)]_once"
 
 	var/image/tail_overlay = overlays_standing[TAIL_LAYER]
@@ -1263,18 +1354,27 @@ var/global/list/damage_icon_parts = list()
 		update_icons_layers()
 
 /mob/living/carbon/human/proc/animate_tail_start(var/update_icons=1)
+	if(QDESTROYING(src))
+		return
+
 	set_tail_state("[species.get_tail(src)]_slow[rand(0,9)]")
 
 	if(update_icons)
 		update_icons_layers()
 
 /mob/living/carbon/human/proc/animate_tail_fast(var/update_icons=1)
+	if(QDESTROYING(src))
+		return
+
 	set_tail_state("[species.get_tail(src)]_loop[rand(0,9)]")
 
 	if(update_icons)
 		update_icons_layers()
 
 /mob/living/carbon/human/proc/animate_tail_reset(var/update_icons=1)
+	if(QDESTROYING(src))
+		return
+
 	if(stat != DEAD)
 		set_tail_state("[species.get_tail(src)]_idle[rand(0,9)]")
 	else
@@ -1284,6 +1384,9 @@ var/global/list/damage_icon_parts = list()
 		update_icons_layers()
 
 /mob/living/carbon/human/proc/animate_tail_stop(var/update_icons=1)
+	if(QDESTROYING(src))
+		return
+
 	set_tail_state("[species.get_tail(src)]_static")
 
 	if(update_icons)
@@ -1293,6 +1396,9 @@ var/global/list/damage_icon_parts = list()
 //Adds a collar overlay above the helmet layer if the suit has one
 //	Suit needs an identically named sprite in icons/mob/collar.dmi
 /mob/living/carbon/human/proc/update_collar(var/update_icons=1)
+	if(QDESTROYING(src))
+		return
+
 	var/icon/C = new('icons/mob/collar.dmi')
 	var/image/standing = null
 
@@ -1305,6 +1411,9 @@ var/global/list/damage_icon_parts = list()
 	if(update_icons)   update_icons_layers()
 
 /mob/living/carbon/human/update_modifier_visuals(var/update_icons=1)
+	if(QDESTROYING(src))
+		return
+
 	overlays_standing[MODIFIER_EFFECTS_LAYER] = null
 	var/image/effects = new()
 	for(var/datum/modifier/M in modifiers)
@@ -1318,6 +1427,9 @@ var/global/list/damage_icon_parts = list()
 		update_icons_layers()
 
 /mob/living/carbon/human/update_fire(var/update_icons=1)
+	if(QDESTROYING(src))
+		return
+
 	overlays_standing[FIRE_LAYER] = null
 	if(on_fire)
 		overlays_standing[FIRE_LAYER] = image("icon"='icons/mob/OnFire.dmi', "icon_state" = get_fire_icon_state())
@@ -1325,6 +1437,9 @@ var/global/list/damage_icon_parts = list()
 	if(update_icons)   update_icons_layers()
 
 /mob/living/carbon/human/update_water(var/update_icons=1)
+	if(QDESTROYING(src))
+		return
+
 	overlays_standing[WATER_LAYER] = null
 	var/depth = check_submerged()
 	if(depth)
@@ -1336,6 +1451,9 @@ var/global/list/damage_icon_parts = list()
 		update_icons_layers()
 
 /mob/living/carbon/human/proc/update_surgery(var/update_icons=1)
+	if(QDESTROYING(src))
+		return
+
 	overlays_standing[SURGERY_LEVEL] = null
 	var/image/total = new
 	for(var/obj/item/organ/external/E in organs)


### PR DESCRIPTION
Humans who got deleted would also delete their clothes, which would then make the human update their icons to not have the clothes anymore, but the human is still being deleted and a specific list was nulled, making lots of non-cat runtimes appear everywhere.

The solution is to make human icon code stop giving a damn if the human is being deleted, I was told.
This might make cryo a bit less noticeable lag-wise but I'm not too sure.