### PR TITLE
Fix 3 server errors

### DIFF
--- a/code/modules/lighting/lighting_overlay.dm
+++ b/code/modules/lighting/lighting_overlay.dm
@@ -53,10 +53,11 @@
 
 	// See LIGHTING_CORNER_DIAGONAL in lighting_corner.dm for why these values are what they are.
 	// No I seriously cannot think of a more efficient method, fuck off Comic.
-	var/datum/lighting_corner/cr = T.corners[3] || dummy_lighting_corner
-	var/datum/lighting_corner/cg = T.corners[2] || dummy_lighting_corner
-	var/datum/lighting_corner/cb = T.corners[4] || dummy_lighting_corner
-	var/datum/lighting_corner/ca = T.corners[1] || dummy_lighting_corner
+
+	var/datum/lighting_corner/cr = LAZYACCESS(T.corners,3) || dummy_lighting_corner
+	var/datum/lighting_corner/cg = LAZYACCESS(T.corners,2) || dummy_lighting_corner
+	var/datum/lighting_corner/cb = LAZYACCESS(T.corners,4) || dummy_lighting_corner
+	var/datum/lighting_corner/ca = LAZYACCESS(T.corners,1) || dummy_lighting_corner
 
 	var/max = max(cr.cache_mx, cg.cache_mx, cb.cache_mx, ca.cache_mx)
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -57,11 +57,11 @@
 	for(var/organ in organs)
 		qdel(organ)
 
-	list_layers.Cut()
+	LAZYCLEARLIST(list_layers)
 	list_layers = null //Be free!
-	list_body.Cut()
+	LAZYCLEARLIST(list_body)
 	list_body = null
-	list_huds.Cut()
+	LAZYCLEARLIST(list_huds)
 	list_huds = null
 
 	return ..()

--- a/code/modules/mob/mob_planes.dm
+++ b/code/modules/mob/mob_planes.dm
@@ -40,7 +40,7 @@
 		my_mob.plane_holder = null
 		my_mob = null
 	plane_masters.Cut() //Goodbye my children, be free
-	..() //We will get qdel'd, as there will not be references to us, then our planelets will disappear on their own.
+	return ..()
 
 /datum/plane_holder/proc/set_vis(var/which = null, var/state = FALSE)
 	ASSERT(which)


### PR DESCRIPTION
Was tailing the server logs and noticed these runtimes, so decided to fix them to clean things up.

* The lighting corners on turfs would try to update when there was no lighting corner list on that turf. Unsure how that list would be null, but let's use /tg/'s 'lazy' safe way of accessing this list.
* We'll use /tg/'s lazy list clearing for Destroy on humans too, to clean up these lists.
* And also in Destroy, in plane_holder this time, just return parent, no more trusting that we'll be GC'd, just go with the flow.