### PR TITLE
No longer emphasizes basic words.

### DIFF
--- a/code/modules/mob/hear_say.dm
+++ b/code/modules/mob/hear_say.dm
@@ -87,7 +87,9 @@
 
 // Checks if the mob's own name is included inside message.  Handles both first and last names.
 /mob/proc/check_mentioned(var/message)
+	var/not_included = list("a", "the", "of", "in", "for", "through", "throughout", "therefore", "here", "there", "then", "now", "I", "you", "they", "he", "she", "by")
 	var/list/valid_names = splittext(real_name, " ") // Should output list("John", "Doe") as an example.
+	valid_names -= not_included
 	var/list/nicknames = splittext(nickname, " ")
 	valid_names += nicknames
 	valid_names += special_mentions()


### PR DESCRIPTION
Names that contain words such as "the, of, by, there" no longer get emphasized when just those words are spoken.
![image](https://user-images.githubusercontent.com/31356648/35174544-cf86eebe-fd3d-11e7-910f-038544100426.png)
