### PR TITLE
3 Fixes

### DIFF
--- a/code/_helpers/game.dm
+++ b/code/_helpers/game.dm
@@ -264,7 +264,7 @@
 // then adds additional mobs or objects if they are in range 'smartly',
 // based on their presence in lists of players or registered objects
 // Type: 1-audio, 2-visual, 0-neither
-/proc/get_mobs_and_objs_in_view_fast(var/turf/T, var/range, var/type = 1)
+/proc/get_mobs_and_objs_in_view_fast(var/turf/T, var/range, var/type = 1, var/remote_ghosts = TRUE)
 	var/list/mobs = list()
 	var/list/objs = list()
 
@@ -274,10 +274,10 @@
 	for(var/thing in hear)
 		if(istype(thing,/obj))
 			objs += thing
-			hearturfs += get_turf(thing)
+			hearturfs |= get_turf(thing)
 		else if(istype(thing,/mob))
 			mobs += thing
-			hearturfs += get_turf(thing)
+			hearturfs |= get_turf(thing)
 
 	//A list of every mob with a client
 	for(var/mob in player_list)
@@ -289,7 +289,7 @@
 			continue
 
 		var/mob/M = mob
-		if(M && M.stat == DEAD && !M.forbid_seeing_deadchat)
+		if(M && M.stat == DEAD && remote_ghosts && !M.forbid_seeing_deadchat)
 			switch(type)
 				if(1) //Audio messages use ghost_ears
 					if(M.is_preference_enabled(/datum/client_preference/ghost_ears))

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -394,20 +394,20 @@
 // blind_message (optional) is what blind people will hear e.g. "You hear something!"
 /atom/proc/visible_message(var/message, var/blind_message)
 
-	var/list/see = get_mobs_or_objects_in_view(world.view,src) | viewers(get_turf(src), null)
+	var/list/see = get_mobs_and_objs_in_view_fast(get_turf(src),world.view,remote_ghosts = FALSE)
 
-	for(var/I in see)
-		if(isobj(I))
-			//spawn(0)
-			//if(I) //It's possible that it could be deleted in the meantime.
-			var/obj/O = I
-			O.show_message(message, 1, blind_message, 2)
-		else if(ismob(I))
-			var/mob/M = I
-			if(M.see_invisible >= invisibility && MOB_CAN_SEE_PLANE(M, plane)) // Cannot view the invisible
-				M.show_message(message, 1, blind_message, 2)
-			else if (blind_message)
-				M.show_message(blind_message, 2)
+	var/list/seeing_mobs = see["mobs"]
+	var/list/seeing_objs = see["objs"]
+
+	for(var/obj in seeing_objs)
+		var/obj/O = obj
+		O.show_message(message, 1, blind_message, 2)
+	for(var/mob in seeing_mobs)
+		var/mob/M = mob
+		if(M.see_invisible >= invisibility && MOB_CAN_SEE_PLANE(M, plane))
+			M.show_message(message, 1, blind_message, 2)
+		else if(blind_message)
+			M.show_message(blind_message, 2)
 
 // Show a message to all mobs and objects in earshot of this atom
 // Use for objects performing audible actions
@@ -416,20 +416,20 @@
 // hearing_distance (optional) is the range, how many tiles away the message can be heard.
 /atom/proc/audible_message(var/message, var/deaf_message, var/hearing_distance)
 
-	var/range = world.view
-	if(hearing_distance)
-		range = hearing_distance
-	var/list/hear = get_mobs_or_objects_in_view(range,src)
+	var/range = hearing_distance || world.view
+	var/list/hear = get_mobs_and_objs_in_view_fast(get_turf(src),range,remote_ghosts = FALSE)
 
-	for(var/I in hear)
-		if(isobj(I))
-			spawn(0)
-				if(I) //It's possible that it could be deleted in the meantime.
-					var/obj/O = I
-					O.show_message(message, 2, deaf_message, 1)
-		else if(ismob(I))
-			var/mob/M = I
-			M.show_message(message, 2, deaf_message, 1)
+	var/list/hearing_mobs = hear["mobs"]
+	var/list/hearing_objs = hear["objs"]
+
+	for(var/obj in hearing_objs)
+		var/obj/O = obj
+		O.show_message(message, 2, deaf_message, 1)
+
+	for(var/mob in hearing_mobs)
+		var/mob/M = mob
+		var/msg = message
+		M.show_message(msg, 2, deaf_message, 1)
 
 /atom/movable/proc/dropInto(var/atom/destination)
 	while(istype(destination))

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -102,7 +102,7 @@
 		if (ishuman(body))
 			var/mob/living/carbon/human/H = body
 			icon = H.icon
-			H.list_huds.Cut()
+			LAZYCLEARLIST(H.list_huds)
 			H.update_icons()
 			overlays = H.overlays
 		else

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -79,24 +79,24 @@
 // message is the message output to anyone who can see e.g. "[src] does something!"
 // self_message (optional) is what the src mob sees  e.g. "You do something!"
 // blind_message (optional) is what blind people will hear e.g. "You hear something!"
-
 /mob/visible_message(var/message, var/self_message, var/blind_message)
-	var/list/see = get_mobs_or_objects_in_view(world.view,src) | viewers(world.view,src)
 
-	for(var/I in see)
-		if(isobj(I))
-			//spawn(0)
-			//if(I) //It's possible that it could be deleted in the meantime.
-			var/obj/O = I
-			O.show_message( message, 1, blind_message, 2)
-		else if(ismob(I))
-			var/mob/M = I
-			if(self_message && M==src)
-				M.show_message( self_message, 1, blind_message, 2)
-			else if(M.see_invisible >= invisibility && MOB_CAN_SEE_PLANE(M, plane)) // Cannot view the invisible
-				M.show_message( message, 1, blind_message, 2)
-			else if (blind_message)
-				M.show_message(blind_message, 2)
+	var/list/see = get_mobs_and_objs_in_view_fast(get_turf(src),world.view,remote_ghosts = FALSE)
+
+	var/list/seeing_mobs = see["mobs"]
+	var/list/seeing_objs = see["objs"]
+
+	for(var/obj in seeing_objs)
+		var/obj/O = obj
+		O.show_message(message, 1, blind_message, 2)
+	for(var/mob in seeing_mobs)
+		var/mob/M = mob
+		if(self_message && M == src)
+			M.show_message( self_message, 1, blind_message, 2)
+		else if(M.see_invisible >= invisibility && MOB_CAN_SEE_PLANE(M, plane))
+			M.show_message(message, 1, blind_message, 2)
+		else if(blind_message)
+			M.show_message(blind_message, 2)
 
 // Returns an amount of power drawn from the object (-1 if it's not viable).
 // If drain_check is set it will not actually drain power, just return a value.
@@ -113,24 +113,22 @@
 // hearing_distance (optional) is the range, how many tiles away the message can be heard.
 /mob/audible_message(var/message, var/deaf_message, var/hearing_distance, var/self_message)
 
-	var/range = world.view
-	if(hearing_distance)
-		range = hearing_distance
-	var/list/hear = get_mobs_or_objects_in_view(range,src)
+	var/range = hearing_distance || world.view
+	var/list/hear = get_mobs_and_objs_in_view_fast(get_turf(src),range,remote_ghosts = FALSE)
 
-	for(var/I in hear)
-		if(isobj(I))
-			spawn(0)
-				if(I) //It's possible that it could be deleted in the meantime.
-					var/obj/O = I
-					O.show_message( message, 2, deaf_message, 1)
-		else if(ismob(I))
-			var/mob/M = I
-			var/msg = message
-			if(self_message && M==src)
-				msg = self_message
-			M.show_message( msg, 2, deaf_message, 1)
+	var/list/hearing_mobs = hear["mobs"]
+	var/list/hearing_objs = hear["objs"]
 
+	for(var/obj in hearing_objs)
+		var/obj/O = obj
+		O.show_message(message, 2, deaf_message, 1)
+
+	for(var/mob in hearing_mobs)
+		var/mob/M = mob
+		var/msg = message
+		if(self_message && M==src)
+			msg = self_message
+		M.show_message(msg, 2, deaf_message, 1)
 
 /mob/proc/findname(msg)
 	for(var/mob/M in mob_list)

--- a/code/modules/mob/mob_planes.dm
+++ b/code/modules/mob/mob_planes.dm
@@ -37,7 +37,7 @@
 
 /datum/plane_holder/Destroy()
 	my_mob = null
-	plane_masters.Cut() //Goodbye my children, be free
+	qdel_null_list(plane_masters) //Goodbye my children, be free
 	return ..()
 
 /datum/plane_holder/proc/set_vis(var/which = null, var/state = FALSE)


### PR DESCRIPTION
* Lazily cut this list list on ghosts like we do in destroy on humans, otherwise sometimes ghosts fail to ghost
* Replace visible_message and audible_message with faster code used in places like say()
* qdel() everything in this list rather than just getting rid of them in case someone writes one that uses Destroy() (we did on ours, you might on yours)