### PR TITLE
Allows Prometheans to be cloned from their Core.

### DIFF
--- a/code/game/dna/dna_modifier.dm
+++ b/code/game/dna/dna_modifier.dm
@@ -53,7 +53,6 @@
 	var/mob/living/carbon/occupant = null
 	var/obj/item/weapon/reagent_containers/glass/beaker = null
 	var/opened = 0
-	var/allowed_braintype = /obj/item/organ/internal/brain/slime //Incase an admin wishes to varchange this to allow another type of brain, or subtypes are needed.
 
 /obj/machinery/dna_scannernew/New()
 	..()
@@ -135,17 +134,22 @@
 		item.loc = src
 		user.visible_message("\The [user] adds \a [item] to \the [src]!", "You add \a [item] to \the [src]!")
 		return
-	else if(istype(item, allowed_braintype))
+
+	else if(istype(item, /obj/item/organ/internal/brain))
 		if (src.occupant)
 			user << "<span class='warning'>The scanner is already occupied!</span>"
 			return
 		var/obj/item/organ/internal/brain/brain = item
-		user.drop_item()
-		brain.loc = src
-		put_in(brain.brainmob)
-		src.add_fingerprint(user)
-		user.visible_message("\The [user] adds \a [item] to \the [src]!", "You add \a [item] to \the [src]!")
-		return
+		if(brain.clone_source)
+			user.drop_item()
+			brain.loc = src
+			put_in(brain.brainmob)
+			src.add_fingerprint(user)
+			user.visible_message("\The [user] adds \a [item] to \the [src]!", "You add \a [item] to \the [src]!")
+			return
+		else
+			to_chat(user,"\The [brain] is not acceptable for genetic sampling!")
+
 	else if (!istype(item, /obj/item/weapon/grab))
 		return
 	var/obj/item/weapon/grab/G = item

--- a/code/game/dna/dna_modifier.dm
+++ b/code/game/dna/dna_modifier.dm
@@ -126,7 +126,7 @@
 /obj/machinery/dna_scannernew/attackby(var/obj/item/weapon/item as obj, var/mob/user as mob)
 	if(istype(item, /obj/item/weapon/reagent_containers/glass))
 		if(beaker)
-			user << "<span class='warning'>A beaker is already loaded into the machine.</span>"
+			to_chat(user, "<span class='warning'>A beaker is already loaded into the machine.</span>")
 			return
 
 		beaker = item
@@ -137,7 +137,7 @@
 
 	else if(istype(item, /obj/item/organ/internal/brain))
 		if (src.occupant)
-			user << "<span class='warning'>The scanner is already occupied!</span>"
+			to_chat(user, "<span class='warning'>The scanner is already occupied!</span>")
 			return
 		var/obj/item/organ/internal/brain/brain = item
 		if(brain.clone_source)
@@ -156,10 +156,10 @@
 	if (!ismob(G.affecting))
 		return
 	if (src.occupant)
-		user << "<span class='warning'>The scanner is already occupied!</span>"
+		to_chat(user, "<span class='warning'>The scanner is already occupied!</span>")
 		return
 	if (G.affecting.abiotic())
-		user << "<span class='warning'>The subject cannot have abiotic items on.</span>"
+		to_chat(user, "<span class='warning'>The subject cannot have abiotic items on.</span>")
 		return
 	put_in(G.affecting)
 	src.add_fingerprint(user)

--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -153,7 +153,7 @@
 	modifier_lower_bound = round(modifier_lower_bound * clone_sickness_length, 1)
 	modifier_upper_bound = round(modifier_upper_bound * clone_sickness_length, 1)
 
-	H.add_modifier(/datum/modifier/cloning_sickness, rand(modifier_lower_bound, modifier_upper_bound))
+	H.add_modifier(H.species.cloning_modifier, rand(modifier_lower_bound, modifier_upper_bound))
 
 	// Modifier that doesn't do anything.
 	H.add_modifier(/datum/modifier/cloned)
@@ -342,7 +342,10 @@
 		occupant.client.perspective = MOB_PERSPECTIVE
 	occupant.loc = src.loc
 	eject_wait = 0 //If it's still set somehow.
-	domutcheck(occupant) //Waiting until they're out before possible transforming.
+	if(ishuman(occupant)) //Need to be safe.
+		var/mob/living/carbon/human/patient = occupant
+		if(!(patient.species.flags & NO_SCAN)) //If, for some reason, someone makes a genetically-unalterable clone, let's not make them permanently disabled.
+			domutcheck(occupant) //Waiting until they're out before possible transforming.
 	occupant = null
 
 	biomass -= CLONE_BIOMASS

--- a/code/game/machinery/computer/cloning.dm
+++ b/code/game/machinery/computer/cloning.dm
@@ -289,10 +289,13 @@
 	add_fingerprint(usr)
 
 /obj/machinery/computer/cloning/proc/scan_mob(mob/living/carbon/human/subject as mob)
-	if ((isnull(subject)) || (!(ishuman(subject))) || (!subject.dna))
+	var/brain_skip = 0
+	if (istype(subject, /mob/living/carbon/brain)) //Brain scans.
+		brain_skip = 1
+	if ((isnull(subject)) || (!(ishuman(subject)) && !brain_skip) || (!subject.dna))
 		scantemp = "Error: Unable to locate valid genetic data."
 		return
-	if (!subject.has_brain())
+	if (!subject.has_brain() && !brain_skip)
 		if(istype(subject, /mob/living/carbon/human))
 			var/mob/living/carbon/human/H = subject
 			if(H.should_have_organ("brain"))
@@ -313,7 +316,7 @@
 	if (NOCLONE in subject.mutations)
 		scantemp = "Error: Mental interface failure."
 		return
-	if (subject.species && subject.species.flags & NO_SCAN)
+	if (subject.species && subject.species.flags & NO_SCAN && !brain_skip)
 		scantemp = "Error: Mental interface failure."
 		return
 	for(var/modifier_type in subject.modifiers)	//Can't be cloned, even if they had a previous scan
@@ -333,7 +336,10 @@
 	R.name = R.dna.real_name
 	R.types = DNA2_BUF_UI|DNA2_BUF_UE|DNA2_BUF_SE
 	R.languages = subject.languages
-	R.flavor = subject.flavor_texts.Copy()
+	if(!brain_skip) //Brains don't have flavor text.
+		R.flavor = subject.flavor_texts.Copy()
+	else
+		R.flavor = list()
 	for(var/datum/modifier/mod in subject.modifiers)
 		if(mod.flags & MODIFIER_GENETIC)
 			R.genetic_modifiers.Add(mod.type)

--- a/code/modules/mob/_modifiers/cloning.dm
+++ b/code/modules/mob/_modifiers/cloning.dm
@@ -39,7 +39,25 @@
 
 // Prevents borging (specifically the MMI part), actual effect is on the MMI.
 /datum/modifier/no_borg
-	name = "Cyboernetic Incompatability"
+	name = "Cybernetic Incompatability"
 	desc = "For whatever reason, your brain is incompatable with direct cybernetic interfaces, such as the MMI."
 
 	flags = MODIFIER_GENETIC
+
+//////////////////////////////////////
+//Species-Specific Cloning Modifiers//
+/////////////////////////////////////
+
+/datum/modifier/cloning_sickness/promethean
+	name = "reformation sickness"
+	desc = "Your core feels damaged, as you were reformed with the improper machinery."
+
+	on_created_text = "<span class='warning'><font size='3'>Your core aches.</font></span>"
+	on_expired_text = "<span class='notice'><font size='3'>You feel your core's strength returning to normal.</font></span>"
+
+	incoming_damage_percent = 1 //Level the incoming damage from the parent modifier. They already take 200% burn.
+	incoming_brute_damage_percent = 1.5 //150% incoming brute damage. Decreases the effectiveness of their 0.75 modifier.
+	incoming_hal_damage_percent = 1.25 //125% incoming halloss.
+
+	outgoing_melee_damage_percent = 0.5 //50% less outgoing melee damage.
+	attack_speed_percent = 1.2 //20% slower attack speed.

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -90,6 +90,7 @@
 	var/death_sound
 	var/death_message = "seizes up and falls limp, their eyes dead and lifeless..."
 	var/knockout_message = "has been knocked unconscious!"
+	var/cloning_modifier = /datum/modifier/cloning_sickness
 
 	// Environment tolerance/life processes vars.
 	var/reagent_tag                                   //Used for metabolizing reagents.

--- a/code/modules/mob/living/carbon/human/species/station/prometheans.dm
+++ b/code/modules/mob/living/carbon/human/species/station/prometheans.dm
@@ -44,6 +44,8 @@ var/datum/species/shapeshifter/promethean/prometheans
 	burn_mod =		2
 	oxy_mod =		0
 
+	cloning_modifier = /datum/modifier/cloning_sickness/promethean
+
 	cold_level_1 = 280 //Default 260 - Lower is better
 	cold_level_2 = 220 //Default 200
 	cold_level_3 = 130 //Default 120

--- a/code/modules/organs/internal/brain.dm
+++ b/code/modules/organs/internal/brain.dm
@@ -13,6 +13,7 @@
 	throw_range = 5
 	origin_tech = list(TECH_BIO = 3)
 	attack_verb = list("attacked", "slapped", "whacked")
+	var/clone_source = FALSE
 	var/mob/living/carbon/brain/brainmob = null
 
 /obj/item/organ/internal/brain/robotize()
@@ -133,6 +134,7 @@
 	icon = 'icons/mob/slimes.dmi'
 	icon_state = "green slime extract"
 	parent_organ = BP_TORSO
+	clone_source = TRUE
 
 /obj/item/orgam/internal/brain/slime/is_open_container()
 	return 1

--- a/code/modules/organs/internal/brain.dm
+++ b/code/modules/organs/internal/brain.dm
@@ -134,6 +134,9 @@
 	icon_state = "green slime extract"
 	parent_organ = BP_TORSO
 
+/obj/item/orgam/internal/brain/slime/is_open_container()
+	return 1
+
 /obj/item/organ/internal/brain/golem
 	name = "chem"
 	desc = "A tightly furled roll of paper, covered with indecipherable runes."

--- a/html/changelogs/Mechoid-PrometheanCloning.yml
+++ b/html/changelogs/Mechoid-PrometheanCloning.yml
@@ -1,0 +1,11 @@
+
+author: Mechoid
+
+delete-after: True
+
+changes: 
+  - rscadd: "Brains can be set to be a source of genetic information."
+  - rscadd: "Promethean cores can be inserted into a cloning scanner to be cloned. This gives them a worse modifier upon completion."
+  - rscadd: "Promethean cores can now have chemicals added or removed from them. Base for future slime cloner."
+  - rscadd: "Species-based cloning sicknesses possible."
+  - spellcheck: "Cyboernetic - > Cybernetic"


### PR DESCRIPTION
Brains can be set to be a source of genetic information for cloning scanners. Currently only enabled on Promethean cores.

Promethean cores are now 'open containers', to allow addition / removal of chemicals, currently has no purpose, but will in Take 2.

Allows species to have a special cloning modifier, only Prometheans currently have one.

Fixes a spelling mistake in the cloning modifiers file.