### PR TITLE
Fixes rare empty gene_mask

### DIFF
--- a/code/modules/hydroponics/seed_controller.dm
+++ b/code/modules/hydroponics/seed_controller.dm
@@ -90,10 +90,10 @@ var/global/datum/controller/plants/plant_controller // Set in New().
 	var/list/plant_traits = ALL_GENES
 	while(plant_traits && plant_traits.len)
 		var/gene_tag = pick(plant_traits)
-		var/gene_mask = "[uppertext(num2hex(rand(0,255)))]"
+		var/gene_mask = "[uppertext(num2hex(rand(0,255), 2))]"
 
 		while(gene_mask in used_masks)
-			gene_mask = "[uppertext(num2hex(rand(0,255)))]"
+			gene_mask = "[uppertext(num2hex(rand(0,255), 2))]"
 
 		var/decl/plantgene/G
 

--- a/code/modules/xenobio2/controller.dm
+++ b/code/modules/xenobio2/controller.dm
@@ -34,10 +34,10 @@ var/global/datum/controller/xenobio/xenobio_controller // Set in New().
 	var/list/xenobio_traits = ALL_XENO_GENES
 	while(xenobio_traits && xenobio_traits.len)
 		var/gene_tag = pick(xenobio_traits)
-		var/gene_mask = "[uppertext(num2hex(rand(0,255)))]"
+		var/gene_mask = "[uppertext(num2hex(rand(0,255), 2))]"
 
 		while(gene_mask in used_masks)
-			gene_mask = "[uppertext(num2hex(rand(0,255)))]"
+			gene_mask = "[uppertext(num2hex(rand(0,255), 2))]"
 
 		used_masks += gene_mask
 		xenobio_traits -= gene_tag


### PR DESCRIPTION
Gene masks (like for plant genes) used unpadded num2hex on a random
number 0-255. This had the (technically ok) result of masks for values
1-15 being a single character but also had the (not ok) result of the
mask for value 0 being the empty string. This only happened to 1/256 of
genes, so was easy to miss.

This change pads all of them to 2 characters so this issue won't happen
and to line things up nice.

Old behavior, with that 1/256 of genes:
![image](https://user-images.githubusercontent.com/34605836/35200517-02531100-fede-11e7-9e4b-88dcd61ef9fd.png)
