### PR TITLE
Allow constructing breaker boxes in game

### DIFF
--- a/code/game/objects/items/weapons/circuitboards/machinery/power.dm
+++ b/code/game/objects/items/weapons/circuitboards/machinery/power.dm
@@ -29,3 +29,13 @@
 	board_type = new /datum/frame/frame_types/machine
 	origin_tech = list(TECH_POWER = 4, TECH_ENGINEERING = 3)
 	req_components = list(/obj/item/weapon/stock_parts/capacitor = 3, /obj/item/stack/cable_coil = 10)
+
+/obj/item/weapon/circuitboard/breakerbox
+	name = T_BOARD("breaker box")
+	build_path = /obj/machinery/power/breakerbox
+	board_type = new /datum/frame/frame_types/machine
+	origin_tech = list(TECH_POWER = 3, TECH_ENGINEERING = 3)
+	req_components = list(
+		/obj/item/weapon/stock_parts/spring = 1,
+		/obj/item/weapon/stock_parts/manipulator = 1,
+		/obj/item/stack/cable_coil = 10)

--- a/code/modules/power/breaker_box.dm
+++ b/code/modules/power/breaker_box.dm
@@ -13,6 +13,7 @@
 	var/icon_state_off = "bbox_off"
 	density = 1
 	anchored = 1
+	circuit = /obj/item/weapon/circuitboard/breakerbox
 	var/on = 0
 	var/busy = 0
 	var/directions = list(1,2,4,8,5,6,9,10)
@@ -20,15 +21,22 @@
 	var/update_locked = 0
 
 /obj/machinery/power/breakerbox/Destroy()
+	for(var/obj/structure/cable/C in src.loc)
+		qdel(C)
 	. = ..()
 	for(var/datum/nano_module/rcon/R in world)
 		R.FindDevices()
 
+/obj/machinery/power/breakerbox/initialize()
+	. = ..()
+	default_apply_parts()
+
 /obj/machinery/power/breakerbox/activated
 	icon_state = "bbox_on"
 
-	// Enabled on server startup. Used in substations to keep them in bypass mode.
+// Enabled on server startup. Used in substations to keep them in bypass mode.
 /obj/machinery/power/breakerbox/activated/initialize()
+	. = ..()
 	set_state(1)
 
 /obj/machinery/power/breakerbox/examine(mob/user)
@@ -87,10 +95,15 @@
 		if(newtag)
 			RCon_tag = newtag
 			user << "<span class='notice'>You changed the RCON tag to: [newtag]</span>"
-
-
-
-
+	if(on)
+		to_chat(user, "<font color='red'>Disable the breaker before performing maintenance.</font>")
+		return
+	if(default_deconstruction_screwdriver(user, W))
+		return
+	if(default_deconstruction_crowbar(user, W))
+		return
+	if(default_part_replacement(user, W))
+		return
 
 /obj/machinery/power/breakerbox/proc/set_state(var/state)
 	on = state

--- a/code/modules/research/designs.dm
+++ b/code/modules/research/designs.dm
@@ -1229,6 +1229,14 @@ CIRCUITS BELOW
 	build_path = /obj/item/weapon/circuitboard/grid_checker
 	sort_string = "JBABC"
 
+/datum/design/circuit/breakerbox
+	name = "breaker box"
+	desc = "Allows for the construction of circuit boards used to build a breaker box."
+	id = "breakerbox"
+	req_tech = list(TECH_POWER = 3, TECH_ENGINEERING = 3)
+	build_path = /obj/item/weapon/circuitboard/breakerbox
+	sort_string = "JBABD"
+
 /datum/design/circuit/gas_heater
 	name = "gas heating system"
 	id = "gasheater"

--- a/html/changelogs/Leshana-breakerbox.yml
+++ b/html/changelogs/Leshana-breakerbox.yml
@@ -1,0 +1,4 @@
+author: Leshana
+delete-after: True
+changes: 
+  - rscadd: "Breaker boxes can be constructed in game."


### PR DESCRIPTION
You can make SMES, but not breaker boxes! Lets add a circuit for it so we can make new substations in game if we want. Adds circuit and R&D design for it.
I chose a manipulator and spring for components because its a circuit breaker so it needs to KACHUNK contacts into place with a spring.
Also fixes breakerbox's Destroy() to actually clean up its wires which have a pointer to it.