### PR TITLE
Fixes RUST bugs and invisible gas blocker

### DIFF
--- a/code/modules/power/fusion/core/core_field.dm
+++ b/code/modules/power/fusion/core/core_field.dm
@@ -186,8 +186,8 @@
 		if(percent_unstable < 0)
 			percent_unstable = 0
 		else
-			if(percent_unstable > 100)
-				percent_unstable = 100
+			if(percent_unstable > 1)
+				percent_unstable = 1
 			if(percent_unstable > 0)
 				percent_unstable = max(0, percent_unstable-rand(0.01,0.03))
 

--- a/code/modules/power/fusion/fusion_particle_catcher.dm
+++ b/code/modules/power/fusion/fusion_particle_catcher.dm
@@ -38,4 +38,8 @@
 	return 0
 
 /obj/effect/fusion_particle_catcher/CanPass(var/atom/movable/mover, var/turf/target, var/height=0, var/air_group=0)
-	return ismob(mover)
+	if(istype(mover, /obj/item/projectile/beam))
+		return 0
+	if(istype(mover, /obj/effect/accelerated_particle))
+		return 0
+	return 1


### PR DESCRIPTION
The cross of invisible particle accelerator/gyrotron targets where the
field goes was set as impassible to everything but mobs. Including
air. Now it's impassible to beams and particles only.

One place was capping the 0-1 percent_instability float to 100 instead
of 1, easy fix.