### PR TITLE
Miscellaneous Small Fixes II

### DIFF
--- a/code/ATMOSPHERICS/components/omni_devices/mixer.dm
+++ b/code/ATMOSPHERICS/components/omni_devices/mixer.dm
@@ -52,7 +52,7 @@
 /obj/machinery/atmospherics/omni/mixer/Destroy()
 	inputs.Cut()
 	output = null
-	..()
+	. = ..()
 
 /obj/machinery/atmospherics/omni/mixer/sort_ports()
 	for(var/datum/omni_port/P in ports)

--- a/code/ATMOSPHERICS/components/omni_devices/omni_base.dm
+++ b/code/ATMOSPHERICS/components/omni_devices/omni_base.dm
@@ -244,7 +244,7 @@
 			P.node.disconnect(src)
 			qdel(P.network)
 			P.node = null
-
+	ports = null
 	. = ..()
 
 /obj/machinery/atmospherics/omni/atmos_init()

--- a/code/ATMOSPHERICS/components/unary/vent_pump.dm
+++ b/code/ATMOSPHERICS/components/unary/vent_pump.dm
@@ -106,8 +106,6 @@
 /obj/machinery/atmospherics/unary/vent_pump/update_icon(var/safety = 0)
 	if(!check_icon_cache())
 		return
-	if (!node)
-		use_power = 0
 
 	overlays.Cut()
 
@@ -122,10 +120,10 @@
 
 	if(welded)
 		vent_icon += "weld"
-	else if(!powered())
+	else if(!use_power || !node || (stat & (NOPOWER|BROKEN)))
 		vent_icon += "off"
 	else
-		vent_icon += "[use_power ? "[pump_direction ? "out" : "in"]" : "off"]"
+		vent_icon += "[pump_direction ? "out" : "in"]"
 
 	overlays += icon_manager.get_atmos_icon("device", , , vent_icon)
 

--- a/code/controllers/subsystems/garbage.dm
+++ b/code/controllers/subsystems/garbage.dm
@@ -169,7 +169,7 @@ SUBSYSTEM_DEF(garbage)
 				#endif
 				var/type = D.type
 				var/datum/qdel_item/I = items[type]
-				testing("GC: -- \ref[src] | [type] was unable to be GC'd --")
+				testing("GC: -- \ref[D] | [type] was unable to be GC'd --")
 				I.failures++
 			if (GC_QUEUE_HARDDELETE)
 				HardDelete(D)

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -251,7 +251,7 @@
 	t = replacetext(t, "\[u\]", "<U>")
 	t = replacetext(t, "\[/u\]", "</U>")
 	t = replacetext(t, "\[time\]", "[stationtime2text()]")
-	t = replacetext(t, "\[date\]", "[station_date]")
+	t = replacetext(t, "\[date\]", "[stationdate2text()]")
 	t = replacetext(t, "\[large\]", "<font size=\"4\">")
 	t = replacetext(t, "\[/large\]", "</font>")
 	if(findtext(t, "\[sign\]"))

--- a/code/modules/power/sensors/powernet_sensor.dm
+++ b/code/modules/power/sensors/powernet_sensor.dm
@@ -32,6 +32,13 @@
 /obj/machinery/power/sensor/proc/auto_set_name()
 	name = "[name_tag] - Powernet Sensor"
 
+/obj/machinery/power/sensor/Destroy()
+	. = ..()
+	// TODO - Switch power_monitor to register deletion events instead of this.
+	for(var/obj/machinery/computer/power_monitor/PM in world)
+		if(PM.power_monitor)
+			PM.power_monitor.refresh_sensors()
+
 // Proc: check_grid_warning()
 // Parameters: None
 // Description: Checks connected powernet for warnings. If warning is found returns 1


### PR DESCRIPTION
* Fixes VOREStation/VOREStation#2820 - Vent pumps shutting down after some map template loads  (And fixes dumb code in vent_pumps's update_icons proc.
* Fixes /obj/machinery/atmospherics/omni mixer and filter's being GC-able
* Fixes /obj/machinery/power/sensor being GC-able
* Fixes VOREStation/VOREStation#2654 - Writing [date] on paper works again.
* Fixes bug in garbage.dm - Debug printout of "was unable to be GC'd" printed ref of SSgarbage instead of the instance that failed to GC.