### PR TITLE
Species var that enables eyes to glow

### DIFF
--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -162,6 +162,7 @@
 	var/obj/effect/decal/cleanable/blood/tracks/move_trail = /obj/effect/decal/cleanable/blood/tracks/footprints // What marks are left when walking
 	var/list/skin_overlays = list()
 	var/has_floating_eyes = 0     // Whether the eyes can be shown above other icons
+	var/has_glowing_eyes = 0      // Whether the eyes are shown above all lighting
 	var/water_movement = 0		  // How much faster or slower the species is in water
 	var/snow_movement = 0		  // How much faster or slower the species is on snow
 


### PR DESCRIPTION
By glow I mean be drawn above the darkness plane, not actually generate and illuminate turfs. Just set the var to 1. Covered up by anything that also covers up your facial hair, so opaque helmets and such. If you wear transparent facemasks or anything, your eyes will be on top of them, piercingly glowy.

![2018-01-24_00-45-30](https://user-images.githubusercontent.com/15028025/35344606-8beb19e8-00fb-11e8-8737-07fa8375842d.gif)

Adjusting eyes are from https://github.com/PolarisSS13/Polaris/pull/4626