### PR TITLE
Fixes lack of Travis multiz testing

### DIFF
--- a/code/unit_tests/map_tests.dm
+++ b/code/unit_tests/map_tests.dm
@@ -39,8 +39,10 @@
 	exempt_from_atmos += using_map.unit_test_exempt_from_atmos.Copy()
 	exempt_from_apc += using_map.unit_test_exempt_from_apc.Copy()
 
+	var/list/zs_to_test = using_map.unit_test_z_levels || list(1) //Either you set it, or you just get z1
+
 	for(var/area/A in world)
-		if(A.z == 1 && !(A.type in exempt_areas))
+		if((A.z in zs_to_test) && !(A.type in exempt_areas))
 			area_test_count++
 			var/area_good = 1
 			var/bad_msg = "--------------- [A.name]([A.type])"

--- a/maps/~map_system/maps.dm
+++ b/maps/~map_system/maps.dm
@@ -78,6 +78,7 @@ var/list/all_maps = list()
 	var/list/unit_test_exempt_areas = list()
 	var/list/unit_test_exempt_from_atmos = list()
 	var/list/unit_test_exempt_from_apc = list()
+	var/list/unit_test_z_levels //To test more than Z1, set your z-levels to test here.
 
 /datum/map/New()
 	..()


### PR DESCRIPTION
Travis is hardcoded to only test z1 for APC/vent/scrubber issues and things like that. This allows it to be specified in the map_datum. You should probably make a PR to specify these for your map so you can start checking map PRs for any issues.