### PR TITLE
Makes the large size modifiers less extreme

### DIFF
--- a/code/modules/mob/_modifiers/traits.dm
+++ b/code/modules/mob/_modifiers/traits.dm
@@ -64,13 +64,13 @@
 	name = "Larger"
 	desc = "Your body is larger than average."
 
-	icon_scale_percent = 1.2
+	icon_scale_percent = 1.1
 
 /datum/modifier/trait/large
 	name = "Large"
 	desc = "Your body is a bit larger than average."
 
-	icon_scale_percent = 1.1
+	icon_scale_percent = 1.05
 
 /datum/modifier/trait/small
 	name = "Small"


### PR DESCRIPTION
The traits that increase mob size are now down to 5% and 10% larger, from 10% and 20%.

Should make them less blurry.