### PR TITLE
Allow pulling objects through step teleports

### DIFF
--- a/code/game/objects/effects/step_triggers.dm
+++ b/code/game/objects/effects/step_triggers.dm
@@ -96,7 +96,18 @@
 	Trigger(var/atom/movable/A)
 		if(teleport_x && teleport_y && teleport_z)
 			var/turf/T = locate(teleport_x, teleport_y, teleport_z)
-			A.forceMove(T)
+			if(isliving(A))
+				var/mob/living/L = A
+				if(L.pulling)
+					var/atom/movable/P = L.pulling
+					L.stop_pulling()
+					P.forceMove(T)
+					L.forceMove(T)
+					L.start_pulling(P)
+				else
+					A.forceMove(T)
+			else
+				A.forceMove(T)
 
 /* Random teleporter, teleports atoms to locations ranging from teleport_x - teleport_x_offset, etc */
 


### PR DESCRIPTION
Like on the Southern Cross map edges between wilderness, mining, and such. So you don't have to walk around it and push it through, then start pulling again every time.

You lose a little immershuns because it ends up on the same turf as you but, yanno, whatchagonnado.