### PR TITLE
Changes 'undislocate' to 'relocate'

### DIFF
--- a/code/game/gamemodes/changeling/powers/revive.dm
+++ b/code/game/gamemodes/changeling/powers/revive.dm
@@ -38,7 +38,7 @@
 		for(var/limb in H.organs_by_name)
 			var/obj/item/organ/external/current_limb = H.organs_by_name[limb]
 			if(current_limb)
-				current_limb.relocate()
+				current_limb.reduce()
 				current_limb.open = 0
 
 		BITSET(H.hud_updateflag, HEALTH_HUD)

--- a/code/game/gamemodes/changeling/powers/revive.dm
+++ b/code/game/gamemodes/changeling/powers/revive.dm
@@ -38,7 +38,7 @@
 		for(var/limb in H.organs_by_name)
 			var/obj/item/organ/external/current_limb = H.organs_by_name[limb]
 			if(current_limb)
-				current_limb.undislocate()
+				current_limb.relocate()
 				current_limb.open = 0
 
 		BITSET(H.hud_updateflag, HEALTH_HUD)

--- a/code/game/gamemodes/changeling/powers/revive.dm
+++ b/code/game/gamemodes/changeling/powers/revive.dm
@@ -38,7 +38,7 @@
 		for(var/limb in H.organs_by_name)
 			var/obj/item/organ/external/current_limb = H.organs_by_name[limb]
 			if(current_limb)
-				current_limb.reduce()
+				current_limb.relocate()
 				current_limb.open = 0
 
 		BITSET(H.hud_updateflag, HEALTH_HUD)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1340,9 +1340,9 @@
 	if(..(slipped_on,stun_duration))
 		return 1
 
-/mob/living/carbon/human/proc/relocate()
+/mob/living/carbon/human/proc/reduce()
 	set category = "Object"
-	set name = "Relocate Joint"
+	set name = "Reduce Joint"
 	set desc = "Pop a joint back into place. Extremely painful."
 	set src in view(1)
 
@@ -1368,17 +1368,17 @@
 	var/list/limbs = list()
 	for(var/limb in organs_by_name)
 		var/obj/item/organ/external/current_limb = organs_by_name[limb]
-		if(current_limb && current_limb.dislocated > 0 && !current_limb.is_parent_dislocated()) //if the parent is also dislocated you will have to relocate that first
+		if(current_limb && current_limb.dislocated > 0 && !current_limb.is_parent_dislocated()) //if the parent is also dislocated you will have to reduce that first
 			limbs |= current_limb
-	var/obj/item/organ/external/current_limb = input(usr,"Which joint do you wish to relocate?") as null|anything in limbs
+	var/obj/item/organ/external/current_limb = input(usr,"Which joint do you wish to reduce?") as null|anything in limbs
 
 	if(!current_limb)
 		return
 
 	if(self)
-		src << "<span class='warning'>You brace yourself to relocate your [current_limb.joint]...</span>"
+		src << "<span class='warning'>You brace yourself to reduce your [current_limb.joint]...</span>"
 	else
-		U << "<span class='warning'>You begin to relocate [S]'s [current_limb.joint]...</span>"
+		U << "<span class='warning'>You begin to reduce [S]'s [current_limb.joint]...</span>"
 
 	if(!do_after(U, 30))
 		return
@@ -1390,7 +1390,7 @@
 	else
 		U << "<span class='danger'>You pop [S]'s [current_limb.joint] back in!</span>"
 		S << "<span class='danger'>[U] pops your [current_limb.joint] back in!</span>"
-	current_limb.relocate()
+	current_limb.reduce()
 
 /mob/living/carbon/human/drop_from_inventory(var/obj/item/W, var/atom/Target = null)
 	if(W in organs)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1340,9 +1340,9 @@
 	if(..(slipped_on,stun_duration))
 		return 1
 
-/mob/living/carbon/human/proc/reduce()
+/mob/living/carbon/human/proc/relocate()
 	set category = "Object"
-	set name = "Reduce Joint"
+	set name = "Relocate Joint"
 	set desc = "Pop a joint back into place. Extremely painful."
 	set src in view(1)
 
@@ -1368,17 +1368,17 @@
 	var/list/limbs = list()
 	for(var/limb in organs_by_name)
 		var/obj/item/organ/external/current_limb = organs_by_name[limb]
-		if(current_limb && current_limb.dislocated > 0 && !current_limb.is_parent_dislocated()) //if the parent is also dislocated you will have to reduce that first
+		if(current_limb && current_limb.dislocated > 0 && !current_limb.is_parent_dislocated()) //if the parent is also dislocated you will have to relocate that first
 			limbs |= current_limb
-	var/obj/item/organ/external/current_limb = input(usr,"Which joint do you wish to reduce?") as null|anything in limbs
+	var/obj/item/organ/external/current_limb = input(usr,"Which joint do you wish to relocate?") as null|anything in limbs
 
 	if(!current_limb)
 		return
 
 	if(self)
-		src << "<span class='warning'>You brace yourself to reduce your [current_limb.joint]...</span>"
+		src << "<span class='warning'>You brace yourself to relocate your [current_limb.joint]...</span>"
 	else
-		U << "<span class='warning'>You begin to reduce [S]'s [current_limb.joint]...</span>"
+		U << "<span class='warning'>You begin to relocate [S]'s [current_limb.joint]...</span>"
 
 	if(!do_after(U, 30))
 		return
@@ -1390,7 +1390,7 @@
 	else
 		U << "<span class='danger'>You pop [S]'s [current_limb.joint] back in!</span>"
 		S << "<span class='danger'>[U] pops your [current_limb.joint] back in!</span>"
-	current_limb.reduce()
+	current_limb.relocate()
 
 /mob/living/carbon/human/drop_from_inventory(var/obj/item/W, var/atom/Target = null)
 	if(W in organs)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1340,9 +1340,9 @@
 	if(..(slipped_on,stun_duration))
 		return 1
 
-/mob/living/carbon/human/proc/undislocate()
+/mob/living/carbon/human/proc/relocate()
 	set category = "Object"
-	set name = "Undislocate Joint"
+	set name = "Relocate Joint"
 	set desc = "Pop a joint back into place. Extremely painful."
 	set src in view(1)
 
@@ -1390,7 +1390,7 @@
 	else
 		U << "<span class='danger'>You pop [S]'s [current_limb.joint] back in!</span>"
 		S << "<span class='danger'>[U] pops your [current_limb.joint] back in!</span>"
-	current_limb.undislocate()
+	current_limb.relocate()
 
 /mob/living/carbon/human/drop_from_inventory(var/obj/item/W, var/atom/Target = null)
 	if(W in organs)

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -193,9 +193,9 @@
 
 	dislocated = 1
 	if(owner)
-		owner.verbs |= /mob/living/carbon/human/proc/undislocate
+		owner.verbs |= /mob/living/carbon/human/proc/relocate
 
-/obj/item/organ/external/proc/undislocate()
+/obj/item/organ/external/proc/relocate()
 	if(dislocated == -1)
 		return
 
@@ -207,7 +207,7 @@
 		for(var/obj/item/organ/external/limb in owner.organs)
 			if(limb.dislocated == 1)
 				return
-		owner.verbs -= /mob/living/carbon/human/proc/undislocate
+		owner.verbs -= /mob/living/carbon/human/proc/relocate
 
 /obj/item/organ/external/update_health()
 	damage = min(max_damage, (brute_dam + burn_dam))

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -193,9 +193,9 @@
 
 	dislocated = 1
 	if(owner)
-		owner.verbs |= /mob/living/carbon/human/proc/reduce
+		owner.verbs |= /mob/living/carbon/human/proc/relocate
 
-/obj/item/organ/external/proc/reduce()
+/obj/item/organ/external/proc/relocate()
 	if(dislocated == -1)
 		return
 
@@ -207,7 +207,7 @@
 		for(var/obj/item/organ/external/limb in owner.organs)
 			if(limb.dislocated == 1)
 				return
-		owner.verbs -= /mob/living/carbon/human/proc/reduce
+		owner.verbs -= /mob/living/carbon/human/proc/relocate
 
 /obj/item/organ/external/update_health()
 	damage = min(max_damage, (brute_dam + burn_dam))

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -193,9 +193,9 @@
 
 	dislocated = 1
 	if(owner)
-		owner.verbs |= /mob/living/carbon/human/proc/relocate
+		owner.verbs |= /mob/living/carbon/human/proc/reduce
 
-/obj/item/organ/external/proc/relocate()
+/obj/item/organ/external/proc/reduce()
 	if(dislocated == -1)
 		return
 
@@ -207,7 +207,7 @@
 		for(var/obj/item/organ/external/limb in owner.organs)
 			if(limb.dislocated == 1)
 				return
-		owner.verbs -= /mob/living/carbon/human/proc/relocate
+		owner.verbs -= /mob/living/carbon/human/proc/reduce
 
 /obj/item/organ/external/update_health()
 	damage = min(max_damage, (brute_dam + burn_dam))


### PR DESCRIPTION
Because undislocate sounds clunky and awful, and who in their right minds calls relocating a limb undislocating a limb.
[![A video of relocating a limb.](https://img.youtube.com/vi/FElcYZ3YT8o/0.jpg)](https://www.youtube.com/watch?v=FElcYZ3YT8o)