### PR TITLE
Move these defines into proper files

### DIFF
--- a/code/game/objects/effects/step_triggers.dm
+++ b/code/game/objects/effects/step_triggers.dm
@@ -146,9 +146,6 @@ var/global/list/tele_landmarks = list() // Terrible, but the alternative is loop
 /obj/effect/step_trigger/teleporter/planetary_fall
 	var/datum/planet/planet = null
 
-/obj/effect/step_trigger/teleporter/planetary_fall/sif/initialize()
-	planet = planet_sif
-
 /obj/effect/step_trigger/teleporter/planetary_fall/Trigger(var/atom/movable/A)
 	if(planet)
 		if(!planet.planet_floors.len)

--- a/code/modules/shuttles/shuttle.dm
+++ b/code/modules/shuttles/shuttle.dm
@@ -254,3 +254,7 @@
 			sound_to_play = 'sound/effects/shuttles/hyperspace_end.ogg'
 	for(var/obj/machinery/door/E in A)	//dumb, I know, but playing it on the engines doesn't do it justice
 		playsound(E, sound_to_play, 50, FALSE)
+
+/datum/shuttle/proc/message_passengers(area/A, var/message)
+	for(var/mob/M in A)
+		M.show_message(message, 2)

--- a/code/modules/shuttles/shuttle_arrivals.dm
+++ b/code/modules/shuttles/shuttle_arrivals.dm
@@ -57,10 +57,6 @@
 
 	..() // Do everything else
 
-/datum/shuttle/proc/message_passengers(area/A, var/message)
-	for(var/mob/M in A)
-		M.show_message(message, 2)
-
 /*
 /datum/shuttle/ferry/arrivals/current_dock_target()
 	if(location) // If we're off station.

--- a/maps/southern_cross/turfs/outdoors.dm
+++ b/maps/southern_cross/turfs/outdoors.dm
@@ -159,3 +159,7 @@
 	oxygen = 0
 	nitrogen = 0
 	temperature = TCMB
+
+// Step trigger to fall down to planet Sif
+/obj/effect/step_trigger/teleporter/planetary_fall/sif/initialize()
+	planet = planet_sif


### PR DESCRIPTION
Sif defines should be in souther_cross places, and this message_passengers proc is used by other shuttles, not just arrivals, so should be higher.