### PR TITLE
Shuttle connector for lateloaded maps

### DIFF
--- a/code/modules/shuttles/shuttles_web.dm
+++ b/code/modules/shuttles/shuttles_web.dm
@@ -379,3 +379,35 @@
 	icon_state = "right"
 	density = TRUE
 	anchored = TRUE
+
+//An object for creating a shuttle destination to dynamically loaded maps
+/obj/shuttle_connector
+	name = "shuttle connector"
+	var/shuttle_name					//Text name of the shuttle to connect to
+	var/start_time = 60 SECONDS			//After round start (needs to be some time, to let other destinations set up)
+	var/list/destinations				//Make sure this STARTS with a destination that builds a route to one that always exists as an anchor.
+
+/obj/shuttle_connector/initialize()
+	. = ..()
+
+	processing_objects += src
+
+/obj/shuttle_connector/process()
+	if(world.time < start_time)
+		return
+
+	if(destinations && shuttle_name)
+		var/datum/shuttle/web_shuttle/ES = shuttle_controller.shuttles[shuttle_name]
+		var/datum/shuttle_web_master/WM = ES.web_master
+
+		for(var/new_dest in destinations)
+			var/datum/shuttle_destination/D = new new_dest(WM)
+			WM.destinations += D
+
+			for(var/type_to_link in D.routes_to_make)
+				var/travel_delay = D.routes_to_make[type_to_link]
+				D.link_destinations(WM.get_destination_by_type(type_to_link), D.preferred_interim_area, travel_delay)
+
+	processing_objects -= src
+
+	qdel(src)

--- a/code/modules/shuttles/web_datums.dm
+++ b/code/modules/shuttles/web_datums.dm
@@ -54,6 +54,7 @@
 	var/datum/shuttle_web_master/master = null // The datum that does the coordination with the actual shuttle datum.
 	var/list/routes = list()			// Routes that are connected to this destination.
 	var/preferred_interim_area = null	// When building a new route, use this interim area.
+	var/skip_me = FALSE					// We will not autocreate this one. Some map must be doing it.
 
 	var/dock_target = null				// The tag_id that the shuttle will use to try to dock to the destination, if able.
 
@@ -194,8 +195,10 @@
 	// First, instantiate all the destination subtypes relevant to this datum.
 	var/list/destination_types = typesof(destination_class) - destination_class
 	for(var/new_type in destination_types)
-		var/datum/shuttle_destination/D = new new_type(src)
-		destinations += D
+		var/datum/shuttle_destination/D = new_type
+		if(initial(D.skip_me))
+			continue
+		destinations += new new_type(src)
 
 	// Now start the process of connecting all of them.
 	for(var/datum/shuttle_destination/D in destinations)


### PR DESCRIPTION
Place a configured subtype of this object into any submap or z-level and it will connect the map to the web shuttle network. There is a better way to do this (rather than the cheap process() garbage) but it needs a shuttle subsystem (or ssatoms?) first.