### PR TITLE
Sort jobs into correct departments, cargo color

### DIFF
--- a/code/_helpers/sorts/comparators.dm
+++ b/code/_helpers/sorts/comparators.dm
@@ -28,3 +28,11 @@
 		. = B.failures - A.failures
 	if (!.)
 		. = B.qdels - A.qdels
+
+// Sorts jobs by department, and then by flag within department
+/proc/cmp_job_datums(var/datum/job/a, var/datum/job/b)
+	. = sorttext(b.department, a.department)
+	if (. == 0) //Same department, push up if they're a head
+		. = b.head_position - a.head_position
+	if (. == 0) //Already in head/nothead spot, sort by name
+		. = sorttext(b.title, a.title)

--- a/code/game/jobs/job/captain.dm
+++ b/code/game/jobs/job/captain.dm
@@ -36,7 +36,7 @@ var/datum/announcement/minor/captain_announcement = new(do_newscast = 1)
 /datum/job/hop
 	title = "Head of Personnel"
 	flag = HOP
-	department = "Civilian"
+	department = "Command"
 	head_position = 1
 	department_flag = CIVILIAN
 	faction = "Station"
@@ -71,7 +71,7 @@ var/datum/announcement/minor/captain_announcement = new(do_newscast = 1)
 /datum/job/secretary
 	title = "Command Secretary"
 	flag = BRIDGE
-	department = "Civilian"
+	department = "Command"
 	head_position = 1
 	department_flag = CIVILIAN
 	faction = "Station"

--- a/code/game/jobs/job/civilian.dm
+++ b/code/game/jobs/job/civilian.dm
@@ -56,12 +56,13 @@
 	title = "Quartermaster"
 	flag = QUARTERMASTER
 	department = "Cargo"
+	head_position = 1
 	department_flag = CIVILIAN
 	faction = "Station"
 	total_positions = 1
 	spawn_positions = 1
 	supervisors = "the head of personnel"
-	selection_color = "#515151"
+	selection_color = "#7a4f33"
 	idtype = /obj/item/weapon/card/id/cargo/head
 	economic_modifier = 5
 	access = list(access_maint_tunnels, access_mailsorting, access_cargo, access_cargo_bot, access_qm, access_mining, access_mining_station)
@@ -81,7 +82,7 @@
 	total_positions = 2
 	spawn_positions = 2
 	supervisors = "the quartermaster and the head of personnel"
-	selection_color = "#515151"
+	selection_color = "#9b633e"
 	idtype = /obj/item/weapon/card/id/cargo/cargo_tech
 	access = list(access_maint_tunnels, access_mailsorting, access_cargo, access_cargo_bot, access_mining, access_mining_station)
 	minimal_access = list(access_maint_tunnels, access_cargo, access_cargo_bot, access_mailsorting)
@@ -97,7 +98,7 @@
 	total_positions = 3
 	spawn_positions = 3
 	supervisors = "the quartermaster and the head of personnel"
-	selection_color = "#515151"
+	selection_color = "#9b633e"
 	idtype = /obj/item/weapon/card/id/cargo/mining
 	economic_modifier = 5
 	access = list(access_maint_tunnels, access_mailsorting, access_cargo, access_cargo_bot, access_mining, access_mining_station)

--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -25,6 +25,7 @@ var/global/datum/controller/occupations/job_master
 			if(!job)	continue
 			if(job.faction != faction)	continue
 			occupations += job
+		sortTim(occupations, /proc/cmp_job_datums)
 
 
 		return 1

--- a/code/modules/client/preference_setup/occupation/occupation.dm
+++ b/code/modules/client/preference_setup/occupation/occupation.dm
@@ -54,7 +54,7 @@
 		if(alt_title && !(alt_title in job.alt_titles))
 			pref.player_alt_titles -= job.title
 
-/datum/category_item/player_setup_item/occupation/content(mob/user, limit = 18, list/splitJobs = list("Chief Medical Officer"))
+/datum/category_item/player_setup_item/occupation/content(mob/user, limit = 18, list/splitJobs = list("Chief Engineer"))
 	if(!job_master)
 		return
 


### PR DESCRIPTION
Causes jobs to be sorted by department name, and then within each department, rather than "the order in which they were defined in the files".

Fixes the fact that your Southern Cross jobs show up at the very bottom of the list.

Also adds some color to cargo, because they were the same color as civilian, but are a real department, so they get a sort of muddy dark brownish orange to go with their department.