### PR TITLE
Adds a 'Save PNG' verb for wiki use, etc

### DIFF
--- a/code/_helpers/icons.dm
+++ b/code/_helpers/icons.dm
@@ -817,6 +817,11 @@ proc // Creates a single icon from a given /atom or /image.  Only the first argu
 	qdel(west)
 	return full
 
+/proc/downloadImage(atom/A, dir)
+	var/icon/this_icon = getFlatIcon(A,defdir=dir||A.dir,always_use_defdir=1)
+
+	usr << ftp(this_icon,"[A.name].png")
+
 /mob/proc/AddCamoOverlay(atom/A)//A is the atom which we are using as the overlay.
 	var/icon/opacity_icon = new(A.icon, A.icon_state)//Don't really care for overlays/underlays.
 	//Now we need to culculate overlays+underlays and add them together to form an image for a mask.

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -378,10 +378,15 @@
 		qdel(adminmob)
 	feedback_add_details("admin_verb","ADC") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
+/client/proc/take_picture(var/atom/A in world)
+	set name = "Save PNG"
+	set category = "Debug"
+	set desc = "Opens a dialog to save a PNG of any object in the game."
 
+	if(!check_rights(R_DEBUG))
+		return
 
-
-
+	downloadImage(A)
 
 /client/proc/cmd_admin_areatest()
 	set category = "Mapping"

--- a/code/modules/admin/verbs/mapping.dm
+++ b/code/modules/admin/verbs/mapping.dm
@@ -160,8 +160,9 @@ var/list/debug_verbs = list (
         ,/client/proc/testZAScolors
         ,/client/proc/testZAScolors_remove
         ,/datum/admins/proc/setup_supermatter
-		,/client/proc/atmos_toggle_debug
-		,/client/proc/spawn_tanktransferbomb
+        ,/client/proc/atmos_toggle_debug
+        ,/client/proc/spawn_tanktransferbomb
+        ,/client/proc/take_picture
 	)
 
 


### PR DESCRIPTION
If you use Debug>Debug Verbs, it will add a 'Save PNG' verb to the rightclick menu of every atom, where you can save a PNG of that atom to your computer. Useful for making pictures for the wiki or things of that nature.