### PR TITLE
Make Travis run a build matrix, add new test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,14 @@ language: c
 sudo: false
 
 env:
-  BYOND_MAJOR="511"
-  BYOND_MINOR="1381"
-  MACRO_COUNT=4
+  global:
+    - BYOND_MAJOR="511"
+    - BYOND_MINOR="1381"
+    - MACRO_COUNT=4
+  matrix:
+    - TEST_DEFINE="MAP_TEST" TEST_FILE="code/_map_tests.dm" RUN="0"
+    - TEST_DEFINE="AWAY_MISSION_TEST" TEST_FILE="code/_away_mission_tests.dm" RUN="0"
+    - TEST_DEFINE="UNIT_TEST" TEST_FILE="code/_unit_tests.dm" RUN="1"
 
 cache:
   directories:
@@ -36,14 +41,10 @@ script:
   - (num=`grep -E '\\\\(red|blue|green|black|b|i[^mc])' **/*.dm | wc -l`; echo "$num escapes (expecting ${MACRO_COUNT} or less)"; [ $num -le ${MACRO_COUNT} ])
   - source $HOME/BYOND-${BYOND_MAJOR}.${BYOND_MINOR}/byond/bin/byondsetup
   - python tools/TagMatcher/tag-matcher.py ../..
-  #First compile is to ensure maps are valid.
-  - echo "#define MAP_TEST 1" > code/_map_tests.dm
+  # Run our test
   - cp config/example/* config/
+  - echo "#define ${TEST_DEFINE} 1" > ${TEST_FILE}
   - DreamMaker polaris.dme
-  - echo "#define MAP_TEST 0" > code/_map_tests.dm
-  #Second compile is for the unit tests. Compiling a second time to exclude the validated maps is actually faster than waiting for startup with them compiled.
-  - echo "#define UNIT_TEST 1" > code/_unit_tests.dm
-  - DreamMaker polaris.dme
-  - DreamDaemon polaris.dmb -invisible -trusted -core 2>&1 | tee log.txt
-  - grep "All Unit Tests Passed" log.txt
+  - if [ $RUN -eq 1 ]; then DreamDaemon polaris.dmb -invisible -trusted -core 2>&1 | tee log.txt; fi
+  - if [ $RUN -eq 1 ]; then grep "All Unit Tests Passed" log.txt; fi
 

--- a/code/__defines/_compile_options.dm
+++ b/code/__defines/_compile_options.dm
@@ -6,3 +6,9 @@
 								1 to use the default behaviour (preload compiled in recourses, not player uploaded ones);
 								2 for preloading absolutely everything;
 								*/
+
+// If we are doing the map test build, do not include the main maps, only the submaps.
+#if MAP_TEST
+	#define USING_MAP_DATUM /datum/map
+	#define MAP_OVERRIDE 1
+#endif

--- a/code/_away_mission_tests.dm
+++ b/code/_away_mission_tests.dm
@@ -1,0 +1,10 @@
+/*
+ *
+ *   This file is used by Travis to indicate that additional maps need to be compiled to look for errors such as missing paths.
+ *   Do not add anything but the AWAY_MISSION_TEST definition here as it will be overwritten by Travis when running tests.
+ *
+ *
+ *   Should you wish to edit set AWAY_MISSION_TEST to 1 like so:
+ *   #define AWAY_MISSION_TEST 1
+ */
+#define AWAY_MISSION_TEST 0


### PR DESCRIPTION
This adds a new type of testing, for away missions, which may or may not need to be compiled at the same time as your main map (may share dependencies) but which shouldn't be RUN, similar to submap testing, because perhaps all hell will break loose if you RUN all the away missions at once.

This also makes Travis use a build matrix to run three builds at the same time to cut down on how long it takes, especially with three tests going on. Click the Travis details on this PR to see what I mean.