### PR TITLE
Removes sleep from fusion fuel injection

### DIFF
--- a/code/modules/power/fusion/fuel_assembly/fuel_injector.dm
+++ b/code/modules/power/fusion/fuel_assembly/fuel_injector.dm
@@ -122,7 +122,6 @@ var/list/fuel_injectors = list()
 				var/obj/effect/accelerated_particle/A = new/obj/effect/accelerated_particle(get_turf(src), dir)
 				A.particle_type = reagent
 				A.additional_particles = numparticles - 1
-				A.move(1)
 				if(cur_assembly)
 					cur_assembly.rod_quantities[reagent] -= amount
 					amount_left += cur_assembly.rod_quantities[reagent]


### PR DESCRIPTION
Particles already start moving when created, this is unneeded and holds up the whole machinery subsystem.