### PR TITLE
Fix for Camera Networks

### DIFF
--- a/code/__defines/machinery.dm
+++ b/code/__defines/machinery.dm
@@ -53,7 +53,7 @@ var/global/defer_powernet_rebuild = 0      // True if net rebuild will be called
 #define NETWORK_PRISON "Prison"
 #define NETWORK_SECURITY "Security"
 #define NETWORK_INTERROGATION "Interrogation"
-#define NETWORK_TELECOM "Tcomsat"
+#define NETWORK_TELECOM "Tcomms"
 #define NETWORK_THUNDER "Thunderdome"
 #define NETWORK_COMMUNICATORS "Communicators"
 

--- a/maps/southern_cross/southern_cross_defines.dm
+++ b/maps/southern_cross/southern_cross_defines.dm
@@ -39,7 +39,27 @@
 	emergency_shuttle_called_message = "An emergency evacuation shuttle has been called. It will arrive at docks one and two in approximately %ETA%"
 	emergency_shuttle_recall_message = "The emergency shuttle has been recalled."
 
-	station_networks = list()
+	// Networks that will show up as options in the camera monitor program
+	station_networks = list(
+							NETWORK_CARGO,
+							NETWORK_CIVILIAN,
+							NETWORK_COMMAND,
+							NETWORK_ENGINE,
+							NETWORK_ENGINEERING,
+							NETWORK_ENGINEERING_OUTPOST,
+							NETWORK_FIRST_DECK,
+							NETWORK_SECOND_DECK,
+							NETWORK_THIRD_DECK,
+							NETWORK_MAIN_OUTPOST,
+							NETWORK_MEDICAL,
+							NETWORK_MINE,
+							NETWORK_RESEARCH,
+							NETWORK_RESEARCH_OUTPOST,
+							NETWORK_ROBOTS,
+							NETWORK_PRISON,
+							NETWORK_SECURITY,
+							NETWORK_TELECOM
+							)
 
 	allowed_spawns = list("Arrivals Shuttle","Gateway", "Cryogenic Storage", "Cyborg Storage")
 	unit_test_exempt_areas = list(/area/ninja_dojo, /area/ninja_dojo/firstdeck, /area/ninja_dojo/arrivals_dock)

--- a/maps/southern_cross/southern_cross_presets.dm
+++ b/maps/southern_cross/southern_cross_presets.dm
@@ -4,24 +4,6 @@ var/const/NETWORK_FIRST_DECK   = "First Deck"
 var/const/NETWORK_SUPPLY       = "Supply"
 var/const/NETWORK_MAIN_OUTPOST = "Main Outpost"
 
-/datum/map/southern_cross
-	// Networks that will show up as options in the camera monitor program
-	station_networks = list(
-		NETWORK_ENGINE,
-		NETWORK_THIRD_DECK,
-		NETWORK_SECOND_DECK,
-		NETWORK_FIRST_DECK,
-		NETWORK_ROBOTS,
-		NETWORK_SUPPLY,
-		NETWORK_COMMAND,
-		NETWORK_ENGINEERING,
-		NETWORK_MEDICAL,
-		NETWORK_MAIN_OUTPOST,
-		NETWORK_RESEARCH,
-		NETWORK_SECURITY,
-		NETWORK_THUNDER,
-	)
-
 //
 // Cameras
 //


### PR DESCRIPTION
- Proper Camera Networks should be on the Camera console now
- Miner name change for Tcomm Network
- Removal of the unneeded Network list