### PR TITLE
Suit modkits can now be used for all hooded things.

### DIFF
--- a/code/game/objects/items/paintkit.dm
+++ b/code/game/objects/items/paintkit.dm
@@ -66,7 +66,7 @@
 	var/new_light_overlay
 
 /obj/item/device/kit/suit/can_customize(var/obj/item/I)
-	return istype(I, /obj/item/clothing/head/helmet/space/void) || istype(I, /obj/item/clothing/suit/space/void) || istype(I, /obj/item/clothing/suit/storage/hooded/explorer)
+	return istype(I, /obj/item/clothing/head/helmet/space/void) || istype(I, /obj/item/clothing/suit/space/void) || istype(I, /obj/item/clothing/suit/storage/hooded)
 
 /obj/item/device/kit/suit/set_info(var/kit_name, var/kit_desc, var/kit_icon, var/kit_icon_file = CUSTOM_ITEM_OBJ, var/kit_icon_override_file = CUSTOM_ITEM_MOB, var/additional_data)
 	..()


### PR DESCRIPTION
On the tin.

Suit modkits no longer hard-check for explorer suits.