### PR TITLE
Adds generic can_telecomm() proc, applies to Communicators

### DIFF
--- a/code/game/machinery/telecomms/telecomunications.dm
+++ b/code/game/machinery/telecomms/telecomunications.dm
@@ -314,7 +314,25 @@ var/global/list/obj/machinery/telecomms/telecomms_list = list()
 	circuitboard = "/obj/item/weapon/circuitboard/telecomms/hub"
 	long_range_link = 1
 	netspeed = 40
+	var/list/telecomms_map
 
+/obj/machinery/telecomms/hub/initialize()
+	. = ..()
+	LAZYINITLIST(telecomms_map)
+
+/obj/machinery/telecomms/hub/process()
+	. = ..()
+	telecomms_map.Cut()
+
+	if(!on)
+		return
+
+	for(var/M in links)
+		if(istype(M,/obj/machinery/telecomms/receiver) || istype(M,/obj/machinery/telecomms/relay))
+			var/obj/machinery/telecomms/R = M
+			if(!R.on)
+				continue
+			telecomms_map |= R.listening_level
 
 /obj/machinery/telecomms/hub/receive_information(datum/signal/signal, obj/machinery/telecomms/machine_from)
 	if(is_freq_listening(signal))
@@ -633,9 +651,40 @@ var/global/list/obj/machinery/telecomms/telecomms_list = list()
 	var/garbage_collector = 1 // if set to 0, will not be garbage collected
 	var/input_type = "Speech File"
 
+//Generic telecomm connectivity test proc
+/proc/can_telecomm(var/atom/A, var/atom/B, var/ad_hoc = FALSE)
+	if(!A || !B)
+		log_debug("can_telecomm(): Undefined endpoints!")
+		return FALSE
 
+	//Can't in this case, obviously!
+	if(is_jammed(A) || is_jammed(B))
+		return FALSE
 
+	//Items don't have a Z when inside an object or mob
+	var/turf/src_turf = get_turf(A)
+	var/turf/dst_turf = get_turf(B)
 
+	//Nullspace, probably.
+	if(!src_turf || !dst_turf)
+		return FALSE
 
+	var/src_z = src_turf.z
+	var/dst_z = dst_turf.z
 
+	//Mysterious!
+	if(!src_z || !dst_z)
+		return FALSE
 
+	//We can do the simple check first, if you have ad_hoc radios.
+	if(ad_hoc && src_z == dst_z)
+		return TRUE
+
+	//Let's look at hubs and see what we got.
+	var/can_comm = FALSE
+	for(var/obj/machinery/telecomms/hub/H in telecomms_list)
+		if((src_z in H.telecomms_map) && (dst_z in H.telecomms_map))
+			can_comm = TRUE
+			break
+
+	return can_comm

--- a/code/game/objects/items/devices/communicator/communicator.dm
+++ b/code/game/objects/items/devices/communicator/communicator.dm
@@ -173,8 +173,8 @@ var/global/list/obj/item/device/communicator/all_communicators = list()
 // Parameters: None
 // Description: Simple check to see if the exonet node is active.
 /obj/item/device/communicator/proc/get_connection_to_tcomms()
-	if(node && node.on && node.allow_external_communicators && !is_jammed(src))
-		return 1
+	if(node && node.on && node.allow_external_communicators)
+		return can_telecomm(src,node)
 	return 0
 
 // Proc: process()


### PR DESCRIPTION
Adds a generic proc to determine if two atoms should be able to speak to each other over the telecomms network. It's a simple implementation.

It's applied on Communicators now, so you can't use a communicator where you don't have telecomms (sorta defeats the purpose of having telecomms if you can use a thing to make voice calls to/from anywhere).

I intend to apply it to cameras in some way or another (the AI can see borgs *anywhere*, 100% of the time, regardless of z-level, in any area, period. It's a little silly).