### PR TITLE
Add an adhoc radio fallback mechanism

### DIFF
--- a/code/game/machinery/telecomms/broadcaster.dm
+++ b/code/game/machinery/telecomms/broadcaster.dm
@@ -250,7 +250,7 @@ var/message_delay = 0 // To make sure restarting the recentmessages list is kept
 
 		for (var/obj/item/device/radio/R in connection.devices["[RADIO_CHAT]"])
 
-			if(istype(R, /obj/item/device/radio/headset))
+			if(istype(R, /obj/item/device/radio/headset) && !R.adhoc_fallback)
 				continue
 
 			if(R.receive_range(display_freq, level) > -1)


### PR DESCRIPTION
Allows subspace radios (eg headsets) to have `adhoc_fallback` enabled on them, which allows them to turn into shortwaves until they reestablish telecomms. I'm doing this for exp/sar/pilot headsets on our server, you can too if you want. What else are those giant antennas for? Up to you. This doesn't change anything for you unless you `adhoc_fallback = TRUE` on some headsets, but you can use it if you want!