### PR TITLE
Moves var/get_rig_stats to the correct file.

### DIFF
--- a/code/modules/clothing/spacesuits/rig/modules/computer.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/computer.dm
@@ -46,9 +46,6 @@
 	var/obj/item/ai_card  // Reference to the MMI, posibrain, intellicard or pAI card previously holding the AI.
 	var/obj/item/ai_verbs/verb_holder
 
-/mob
-	var/get_rig_stats = 0
-
 /obj/item/rig_module/ai_container/process()
 	if(integrated_ai)
 		var/obj/item/weapon/rig/rig = get_rig()

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -221,3 +221,4 @@
 	var/hovering = FALSE	// Is the mob floating or flying in some way? If so, don't fall normally.	//Not implemented yet, idea is to let them ignore terrain slowdown and falling down floors
 	var/softfall = FALSE	// Is the mob able to lessen their impact upon falling?
 	var/parachuting = FALSE	// Is the mob able to jump out of planes and survive? Don't check this directly outside of CanParachute().
+	var/get_rig_stats = 0 //Moved from computer.dm


### PR DESCRIPTION
- Having a random /mob variable defined in some other file unlike all the other /mob variables doesn't look too nice.