### PR TITLE
Fixes Rainbow Slime Cores Having Infinite Uses 

### DIFF
--- a/code/modules/xenobio/items/extracts.dm
+++ b/code/modules/xenobio/items/extracts.dm
@@ -970,6 +970,7 @@
 
 	if(S)
 		new S(get_turf(holder.my_atom))
+	..()
 
 /datum/chemical_reaction/slime/rainbow_unity
 	name = "Slime Unity"


### PR DESCRIPTION
As much as I hate to see it go, it is a bug, after all.