### PR TITLE
Add shuttle door/environment sensors

### DIFF
--- a/code/modules/shuttles/shuttles_web.dm
+++ b/code/modules/shuttles/shuttles_web.dm
@@ -128,6 +128,31 @@
 	icon_state = "flightcomp_center"
 	icon_keyboard = "flight_center_key"
 	icon_screen = "flight_center"
+	var/list/my_doors //Should be list("id_tag" = "Pretty Door Name", ...)
+	var/list/my_sensors //Should be list("id_tag" = "Pretty Sensor Name", ...)
+
+/obj/machinery/computer/shuttle_control/web/initialize()
+	. = ..()
+	var/area/my_area = get_area(src)
+	if(my_doors)
+		var/list/find_doors = my_doors
+		my_doors = list()
+		for(var/obj/machinery/door/airlock/A in my_area)
+			if(A.id_tag in find_doors)
+				my_doors[find_doors[A.id_tag]] = A
+				find_doors -= A.id_tag
+		for(var/lost in find_doors)
+			log_debug("[my_area] shuttle computer couldn't find [lost] door!")
+
+	if(my_sensors)
+		var/list/find_sensors = my_sensors
+		my_sensors = list()
+		for(var/obj/machinery/shuttle_sensor/S in my_area)
+			if(S.id_tag in find_sensors)
+				my_sensors[find_sensors[S.id_tag]] = S
+				find_sensors -= S.id_tag
+		for(var/lost in find_sensors)
+			log_debug("[my_area] shuttle computer couldn't find [lost] sensor!")
 
 // Fairly copypasta-y.
 /obj/machinery/computer/shuttle_control/web/attack_hand(mob/user)
@@ -244,6 +269,21 @@
 	if(total_time) // Need to check or we might divide by zero.
 		percent_finished = (elapsed_time / total_time) * 100
 
+
+	var/list/doors = list()
+	if(my_doors)
+		for(var/doorname in my_doors)
+			var/obj/machinery/door/airlock/A = my_doors[doorname]
+			if(A)
+				doors[doorname] = list("bolted" = A.locked, "open" = !A.density)
+
+	var/list/sensors = list()
+	if(my_sensors)
+		for(var/sensorname in my_sensors)
+			var/obj/machinery/shuttle_sensor/S = my_sensors[sensorname]
+			if(S)
+				sensors[sensorname] = S.air_list()
+
 	data = list(
 		"shuttle_location" = shuttle_location,
 		"future_location" = future_location,
@@ -261,13 +301,15 @@
 		"cloaked" = shuttle.cloaked ? 1 : 0,
 		"can_autopilot" = shuttle.can_autopilot ? 1 : 0,
 		"autopilot" = shuttle.autopilot ? 1 : 0,
-		"can_rename" = shuttle.can_rename ? 1 : 0
+		"can_rename" = shuttle.can_rename ? 1 : 0,
+		"doors" = doors,
+		"sensors" = sensors
 	)
 
 	ui = nanomanager.try_update_ui(user, src, ui_key, ui, data, force_open)
 
 	if(!ui)
-		ui = new(user, src, ui_key, "flight.tmpl", "[shuttle.visible_name] Flight Computer", 470, 500)
+		ui = new(user, src, ui_key, "flight.tmpl", "[shuttle.visible_name] Flight Computer", 500, 500)
 		ui.set_initial_data(data)
 		ui.open()
 		ui.set_auto_update(1)
@@ -411,3 +453,45 @@
 	processing_objects -= src
 
 	qdel(src)
+
+//A sensor for detecting air outside shuttles! Handy, that.
+/obj/machinery/shuttle_sensor
+	name = "environment sensor"
+	icon = 'icons/obj/airlock_machines.dmi'
+	icon_state = "airlock_sensor_standby"
+	var/id_tag
+
+/obj/machinery/shuttle_sensor/process()
+	return PROCESS_KILL //nty
+
+/obj/machinery/shuttle_sensor/proc/air_list()
+	. = list("reading" = FALSE)
+	var/turf/T = get_step(src,dir)
+
+	if(isnull(T))
+		return
+
+	var/list/aircontents
+	var/datum/gas_mixture/environment = T.return_air()
+	var/pressure = environment.return_pressure()
+	var/total_moles = environment.total_moles
+
+	if(total_moles)
+		var/o2_level = environment.gas["oxygen"]/total_moles
+		var/n2_level = environment.gas["nitrogen"]/total_moles
+		var/co2_level = environment.gas["carbon_dioxide"]/total_moles
+		var/phoron_level = environment.gas["phoron"]/total_moles
+		var/unknown_level =  1-(o2_level+n2_level+co2_level+phoron_level)
+		aircontents = list(\
+			"pressure" = "[round(pressure,0.1)]",\
+			"nitrogen" = "[round(n2_level*100,0.1)]",\
+			"oxygen" = "[round(o2_level*100,0.1)]",\
+			"carbon_dioxide" = "[round(co2_level*100,0.1)]",\
+			"phoron" = "[round(phoron_level*100,0.01)]",\
+			"other" = "[round(unknown_level, 0.01)]",\
+			"temp" = "[round(environment.temperature-T0C,0.1)]",\
+			"reading" = TRUE\
+			)
+
+	if(aircontents)
+		return aircontents

--- a/nano/templates/flight.tmpl
+++ b/nano/templates/flight.tmpl
@@ -116,7 +116,6 @@
 
 {{if data.is_moving == 0}}
 	<h3>Available Destinations</h3>
-
 	<HR>
 	<div class="itemContent" style="width: 100%;"></div><BR>
 		{{for data.routes}}
@@ -127,9 +126,7 @@
 				<div class="itemContent">
 					<div style="float: left; width: 100%;">
 						{{:helper.link(value.travel_time, 'clock', {"traverse" : value.index})}}
-					
-					</div> 
-
+					</div>
 				</div>
 			</div>
 		{{/for}}
@@ -150,3 +147,95 @@
 		</div>
 	</div>
 {{/if}}
+
+{{if data.doors}}
+	<h3>Hatch Status</h3>
+	<HR>
+	<div class="item">
+		{{props data.doors}}
+			<div class="item">
+				<div class="itemLabel">{{:key}}</div>
+				<div class="itemContent">
+					{{if value.open}}
+						<span class="bad">OPN</span>
+					{{else}}
+						<span class="good">CLS</span>
+					{{/if}}
+					 - 
+					{{if value.bolted}}
+						<span class="good">BLT</span>
+					{{else}}
+						<span class="bad">UBLT</span>
+					{{/if}}
+				</div>
+			</div>
+		{{/props}}
+	</div>
+{{/if}}
+
+{{if data.sensors}}
+	<h3>Air Readout</h3>
+	<hr>
+	{{props data.sensors}}
+		<div class="item" style="position: relative; overflow: hidden;">
+			<div class="itemLabel" style="padding-right: 2px; height: 100%; position:absolute;">
+				<span style="position: relative;display: inline-block; top: 50%;left: 50%;transform: translate(-50%, -50%);">{{:key}}</span>
+			</div>
+			<div class="itemContentMedium statusDisplay floatRight" style="overflow: hidden;">
+				{{if value.reading == 1}}
+					<div class="itemLabelWide">
+						Pressure:
+					</div>
+					<div class = "itemContentSmall">
+						{{:helper.string('<span class="{0}">{1} kPa</span>', value.pressure < 80 || value.pressure > 120 ? 'bad' : value.pressure < 95 || value.pressure > 110 ? 'average' : 'good' , value.pressure)}}
+					</div>
+					<div class="itemLabelWide">
+						Temperature:
+					</div>
+					<div class = "itemContentSmall">
+						{{:helper.string('<span class="{0}">{1} &deg;C</span>', value.temp < 5 || value.temp > 35 ? 'bad' : value.temp < 15 || value.temp > 25 ? 'average' : 'good' , value.temp)}}
+					</div>
+					<br>
+					<div class="itemLabelWide">
+						Oxygen:
+					</div>
+					<div class = "itemContentSmall">
+						{{:helper.string('<span class="{0}">{1}%</span>', value.oxygen < 17 ? 'bad' : value.oxygen < 19 ? 'average' : 'good' , value.oxygen)}}
+					</div>
+					<div class="itemLabelWide">
+						Nitrogen:
+					</div>
+					<div class = "itemContentSmall">
+						{{:helper.string('<span class="{0}">{1}%</span>', value.nitrogen > 82 ? 'bad' : value.nitrogen > 80 ? 'average' : 'good' , value.nitrogen)}}
+					</div>
+					<div class="itemLabelWide">
+						Carbon&nbsp;Dioxide:
+					</div>
+					<div class = "itemContentSmall">
+						{{:helper.string('<span class="{0}">{1}%</span>', value.carbon_dioxide > 5 ? 'bad' : 'good' , value.carbon_dioxide)}}
+					</div>
+					<div class="itemLabelWide">
+						Phoron:
+					</div>
+					<div class = "itemContentSmall">
+						{{:helper.string('<span class="{0}">{1}%</span>', value.phoron  > 0 ? 'bad' : 'good' , value.phoron)}}
+
+					</div>
+					{{if value.other > 0}}
+						<div class="itemLabelWide">
+							Unknown:
+						</div>
+						<div class = "itemContentSmall">
+							<span class="bad">{{:value.other}}%</span>
+						</div>
+					{{/if}}
+				{{else}}
+					<div class="itemContent" style="width: 100%;">
+						<span class="average"><b>Unable to get air reading</b></span>
+					</div>
+				{{/if}}
+			</div>
+		</div>
+	{{/props}}
+{{/if}}
+


### PR DESCRIPTION
You would have to map them in to use them.

The console needs two lists mapped in (or made on a subtype):
`my_doors` is a list of `id_tag = Pretty Name` doors
`my_sensors` is a list of `id_tag = Pretty Name` sensors (`/obj/machinery/shuttle_sensor`)

Shuttle sensors are a new type of environment sensor meant specifically to address the issue of "no sensors in the game let me get air on an ADJACENT turf", so environment sensors **report on the environment 1 step in the dir they are facing**, so dir 2 shuttle sensor gets air on the turf to the south. This allows them to sit on the shuttle walls and not outside the shuttle and get left behind.

![2018-02-03_19-17-13](https://user-images.githubusercontent.com/15028025/35773610-7cede114-0925-11e8-8e88-2cc92183b117.png)

![image](https://user-images.githubusercontent.com/15028025/35773621-bda755be-0925-11e8-8782-0f5ac5f82bd5.png)
