### PR TITLE
Tweak map-loading in some ways

### DIFF
--- a/code/modules/admin/verbs/map_template_loadverb.dm
+++ b/code/modules/admin/verbs/map_template_loadverb.dm
@@ -41,7 +41,12 @@
 	if(!map)
 		return
 	template = map_templates[map]
-
+	
+	if(template.width > world.maxx || template.height > world.maxy)		
+		if(alert(usr,"This template is larger than the existing z-levels. It will EXPAND ALL Z-LEVELS to match the size of the template. This may cause chaos. Are you sure you want to do this?","DANGER!!!","Cancel","Yes") == "Cancel")
+			to_chat(usr,"Template placement aborted.")
+			return
+	
 	if(alert(usr,"Confirm map load.", "Template Confirm","No","Yes") == "Yes")
 		if(template.load_new_z())
 			message_admins("<span class='adminnotice'>[key_name_admin(usr)] has placed a map template ([template.name]) on Z level [world.maxz].</span>")

--- a/code/modules/maps/tg/map_template.dm
+++ b/code/modules/maps/tg/map_template.dm
@@ -103,18 +103,23 @@ var/list/global/map_templates = list()
 
 	admin_notice("<span class='danger'>Submap initializations finished.</span>", R_DEBUG)
 
-/datum/map_template/proc/load_new_z()
-	var/x = round(world.maxx/2)
-	var/y = round(world.maxy/2)
+/datum/map_template/proc/load_new_z(var/centered = FALSE, var/dont_init = FALSE)
+	var/x = 1
+	var/y = 1
 
-	var/list/bounds = maploader.load_map(file(mappath), x, y)
+	if(centered)
+		x = round((world.maxx - width)/2)
+		y = round((world.maxy - height)/2)
+
+	var/list/bounds = maploader.load_map(file(mappath), x, y, no_changeturf = TRUE)
 	if(!bounds)
 		return FALSE
 
 //	repopulate_sorted_areas()
 
 	//initialize things that are normally initialized after map load
-	initTemplateBounds(bounds)
+	if(!dont_init)
+		initTemplateBounds(bounds)
 	log_game("Z-level [name] loaded at at [x],[y],[world.maxz]")
 	return TRUE
 

--- a/maps/~map_system/maps.dm
+++ b/maps/~map_system/maps.dm
@@ -38,6 +38,12 @@ var/list/all_maps = list()
 	//This list contains the z-level numbers which can be accessed via space travel and the percentile chances to get there.
 	var/list/accessible_z_levels = list()
 
+	//List of additional z-levels to load above the existing .dmm file z-levels using the maploader. Must be map template >>> NAMES <<<.
+	var/list/lateload_z_levels = list()
+
+	//Similar to above, but only pick ONE to load, useful for random away missions and whatnot
+	var/list/lateload_single_pick = list()
+
 	var/list/allowed_jobs = list() //Job datums to use.
 	                               //Works a lot better so if we get to a point where three-ish maps are used
 	                               //We don't have to C&P ones that are only common between two of them


### PR DESCRIPTION
Fixes loading of map templates, now loads it acutally in the center instead of to the upper-left of center.
Warns you if you try to load a submap which is larger than the current world size.