### PR TITLE
Makes containment fields and tesla bolts bypass gloves

### DIFF
--- a/code/modules/power/singularity/containment_field.dm
+++ b/code/modules/power/singularity/containment_field.dm
@@ -53,7 +53,7 @@
 	if(isliving(user))
 		hasShocked = 1
 		var/shock_damage = min(rand(30,40),rand(30,40))
-		user.electrocute_act(shock_damage, src)
+		user.electrocute_act(shock_damage, src, 1, BP_TORSO)
 
 		var/atom/target = get_edge_target_turf(user, get_dir(src, get_step_away(user, src)))
 		user.throw_at(target, 200, 4)
@@ -61,7 +61,6 @@
 		sleep(20)
 
 		hasShocked = 0
-	return
 
 /obj/machinery/containment_field/proc/set_master(var/master1,var/master2)
 	if(!master1 || !master2)

--- a/code/modules/power/tesla/energy_ball.dm
+++ b/code/modules/power/tesla/energy_ball.dm
@@ -285,7 +285,7 @@
 
 	else if(closest_mob)
 		var/shock_damage = Clamp(round(power/400), 10, 90) + rand(-5, 5)
-		closest_mob.electrocute_act(shock_damage, source, 1/*, tesla_shock = 1, stun = stun_mobs*/)
+		closest_mob.electrocute_act(shock_damage, source, 1, ran_zone())
 		if(issilicon(closest_mob))
 			var/mob/living/silicon/S = closest_mob
 			if(stun_mobs)


### PR DESCRIPTION
Wearing a pair of rubber gloves on your hands will no longer save you from giant bolts of lightning or running facefirst into a deathfield. The containment field hits the torso, and the telsa bolts select a random body part.