### PR TITLE
Explorer webbing

### DIFF
--- a/maps/southern_cross/structures/closets/misc.dm
+++ b/maps/southern_cross/structures/closets/misc.dm
@@ -47,6 +47,8 @@
 	new	/obj/item/clothing/mask/gas/explorer(src)
 	new /obj/item/clothing/shoes/boots/winter/explorer(src)
 	new /obj/item/clothing/gloves/black(src)
+	new /obj/item/clothing/accessory/storage/brown_vest(src)
+	new /obj/item/clothing/accessory/storage/brown_drop_pouches(src)
 	new /obj/item/device/radio/headset/explorer(src)
 	new /obj/item/device/flashlight(src)
 	new /obj/item/device/gps/explorer(src)


### PR DESCRIPTION
Adds a brown webbing vest and a set of brown drop pouches to the explorer lockers. This doesn't allow them to take webbing in the loadout, because I get the sinking feeling something would go wrong if I tried to make that happen.