### PR TITLE
Turret controls can reference their control area by path

### DIFF
--- a/code/game/machinery/turret_control.dm
+++ b/code/game/machinery/turret_control.dm
@@ -48,6 +48,8 @@
 /obj/machinery/turretid/initialize()
 	if(!control_area)
 		control_area = get_area(src)
+	else if(ispath(control_area))
+		control_area = locate(control_area)
 	else if(istext(control_area))
 		for(var/area/A in world)
 			if(A.name && A.name==control_area)


### PR DESCRIPTION
This is, I think, obviously more robust.  Mapping typos will be found at compile time.
Port of VOREStation/VOREStation#2981