### PR TITLE
Hyposprays and autoinjectors have a delay when used on a target that is not in help intent

### DIFF
--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -31,7 +31,7 @@
 
 /obj/item/weapon/reagent_containers/hypospray/attack(mob/living/M as mob, mob/user as mob)
 	if(!reagents.total_volume)
-		user << "<span class='warning'>[src] is empty.</span>"
+		to_chat(user, "<span class='warning'>[src] is empty.</span>")
 		return
 	if (!istype(M))
 		return
@@ -40,21 +40,29 @@
 	if(istype(H))
 		var/obj/item/organ/external/affected = H.get_organ(user.zone_sel.selecting)
 		if(!affected)
-			user << "<span class='danger'>\The [H] is missing that limb!</span>"
+			to_chat(user, "<span class='danger'>\The [H] is missing that limb!</span>")
 			return
 		else if(affected.robotic >= ORGAN_ROBOT)
-			user << "<span class='danger'>You cannot inject a robotic limb.</span>"
+			to_chat(user, "<span class='danger'>You cannot inject a robotic limb.</span>")
 			return
 
+		if(!H.stat)
+			if(H != user)
+				if(H.a_intent != I_HELP)
+					to_chat(user, "<span class='notice'>[H] is resisting your attempt to inject them with \the [src].</span>")
+					to_chat(H, "<span class='danger'> [user] is trying to inject you with \the [src]!</span>")
+					if(!do_after(user, 30))
+						return
+
 	user.setClickCooldown(DEFAULT_QUICK_COOLDOWN)
-	user << "<span class='notice'>You inject [M] with [src].</span>"
-	M << "<span class='notice'>You feel a tiny prick!</span>"
+	to_chat(user, "<span class='notice'>You inject [M] with \the [src].</span>")
+	to_chat(M, "<span class='notice'>You feel a tiny prick!</span>")
 
 	if(M.reagents)
 		var/contained = reagentlist()
 		var/trans = reagents.trans_to_mob(M, amount_per_transfer_from_this, CHEM_BLOOD)
 		admin_inject_log(user, M, src, contained, trans)
-		user << "<span class='notice'>[trans] units injected. [reagents.total_volume] units remaining in \the [src].</span>"
+		to_chat(user, "<span class='notice'>[trans] units injected. [reagents.total_volume] units remaining in \the [src].</span>")
 
 	if(!reusable && !used)
 		used = !used
@@ -110,7 +118,7 @@
 			user << "<span class='notice'>\The [src] already has a vial.</span>"
 	else
 		..()
-		
+
 /obj/item/weapon/reagent_containers/hypospray/autoinjector
 	name = "autoinjector"
 	desc = "A rapid and safe way to administer small amounts of drugs by untrained or trained personnel."

--- a/html/changelogs/Anewbe - Hyposprays.yml
+++ b/html/changelogs/Anewbe - Hyposprays.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Anewbe
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Hyposprays and autoinjectors now have a delay on use when the target is conscious and not in Help Intent."


### PR DESCRIPTION
As discussed in the Staff Meeting.
- Using a hypospray or autoinjector on someone who is not in help intent will warn them, and take roughly 3 seconds.