### PR TITLE
Fixes #4669.

### DIFF
--- a/code/_helpers/unsorted.dm
+++ b/code/_helpers/unsorted.dm
@@ -821,7 +821,9 @@ proc/GaussRandRound(var/sigma,var/roundto)
 					for(var/mob/M in T)
 						if(istype(M, /mob/observer/eye)) continue // If we need to check for more mobs, I'll add a variable
 						M.loc = X
-						M.check_shadow() // Need to check their Z-shadow, which is normally done in forceMove().
+						if(istype(M, /mob/living)
+							var/mob/living/LM = M
+							LM.check_shadow() // Need to check their Z-shadow, which is normally done in forceMove().
 
 					if(shuttlework)
 						var/turf/simulated/shuttle/SS = T

--- a/code/_helpers/unsorted.dm
+++ b/code/_helpers/unsorted.dm
@@ -817,11 +817,11 @@ proc/GaussRandRound(var/sigma,var/roundto)
 					for(var/obj/O in T)
 						O.loc = X
 
-					//Move the mobs unless it's an AI eye or other eye type. Need to check their Z-shadow.
+					//Move the mobs unless it's an AI eye or other eye type.
 					for(var/mob/M in T)
 						if(istype(M, /mob/observer/eye)) continue // If we need to check for more mobs, I'll add a variable
 						M.loc = X
-						M.check_shadow()
+						M.check_shadow() // Need to check their Z-shadow, which is normally done in forceMove().
 
 					if(shuttlework)
 						var/turf/simulated/shuttle/SS = T

--- a/code/_helpers/unsorted.dm
+++ b/code/_helpers/unsorted.dm
@@ -821,7 +821,7 @@ proc/GaussRandRound(var/sigma,var/roundto)
 					for(var/mob/M in T)
 						if(istype(M, /mob/observer/eye)) continue // If we need to check for more mobs, I'll add a variable
 						M.loc = X
-						if(istype(M, /mob/living)
+						if(istype(M, /mob/living))
 							var/mob/living/LM = M
 							LM.check_shadow() // Need to check their Z-shadow, which is normally done in forceMove().
 

--- a/code/_helpers/unsorted.dm
+++ b/code/_helpers/unsorted.dm
@@ -817,10 +817,11 @@ proc/GaussRandRound(var/sigma,var/roundto)
 					for(var/obj/O in T)
 						O.loc = X
 
-					//Move the mobs unless it's an AI eye or other eye type.
+					//Move the mobs unless it's an AI eye or other eye type. Need to check their Z-shadow.
 					for(var/mob/M in T)
 						if(istype(M, /mob/observer/eye)) continue // If we need to check for more mobs, I'll add a variable
 						M.loc = X
+						M.check_shadow()
 
 					if(shuttlework)
 						var/turf/simulated/shuttle/SS = T


### PR DESCRIPTION
Now calls check_shadow() on mobs when they get moved in `area.move_contents_to()`. This should fix #4669 for both elevators and shuttles.