### PR TITLE
Makes teshari hide work once more.

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -2,20 +2,21 @@
 	name = "unknown"
 	real_name = "unknown"
 	voice_name = "unknown"
-	icon = 'icons/effects/effects.dmi' //We have an ultra-complex update icons that overlays everything, don't load some stupid random male human
+	icon = 'icons/effects/effects.dmi'	//We have an ultra-complex update icons that overlays everything, don't load some stupid random male human
 	icon_state = "nothing"
 
 	var/list/hud_list[TOTAL_HUDS]
-	var/embedded_flag	  //To check if we've need to roll for damage on movement while an item is imbedded in us.
+	var/embedded_flag					//To check if we've need to roll for damage on movement while an item is imbedded in us.
 	var/obj/item/weapon/rig/wearing_rig // This is very not good, but it's much much better than calling get_rig() every update_canmove() call.
-	var/last_push_time	//For human_attackhand.dm, keeps track of the last use of disarm
+	var/last_push_time					//For human_attackhand.dm, keeps track of the last use of disarm
 
-	var/spitting = 0 //Spitting and spitting related things. Any human based ranged attacks, be it innate or added abilities.
-	var/spit_projectile = null //Projectile type.
-	var/spit_name = null //String
-	var/last_spit = 0 //Timestamp.
+	var/spitting = 0 					//Spitting and spitting related things. Any human based ranged attacks, be it innate or added abilities.
+	var/spit_projectile = null			//Projectile type.
+	var/spit_name = null 				//String
+	var/last_spit = 0 					//Timestamp.
 
-	var/can_defib = 1	//Horrible damage (like beheadings) will prevent defibbing organics.
+	var/can_defib = 1					//Horrible damage (like beheadings) will prevent defibbing organics.
+	var/hiding = 0						// If the mob is hiding or not. Makes them appear under tables and the like.
 
 /mob/living/carbon/human/New(var/new_loc, var/new_species = null)
 
@@ -1077,7 +1078,7 @@
 	var/self = 0
 
 	if(usr.stat || usr.restrained() || !isliving(usr)) return
-	
+
 	var/datum/gender/TU = gender_datums[usr.get_visible_gender()]
 	var/datum/gender/T = gender_datums[get_visible_gender()]
 
@@ -1536,3 +1537,12 @@
 		var/obj/item/clothing/accessory/permit/drone/permit = new(T)
 		permit.set_name(real_name)
 		equip_to_appropriate_slot(permit) // If for some reason it can't find room, it'll still be on the floor.
+
+/mob/living/carbon/human/proc/update_icon_special() //For things such as teshari hiding and whatnot.
+	if(hiding) // Hiding? Carry on.
+		if(incapacitated(INCAPACITATION_STUNNED)) //stunned/knocked down by something that isn't the rest verb?
+			hiding = 0 //No hiding for you. Mob layer should be updated naturally.
+		else
+			layer = 2.45
+	else //Replace this else with other variables if added in the future. Alternatively, could make other things effect this hiding variable.
+		return

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1540,8 +1540,8 @@
 
 /mob/living/carbon/human/proc/update_icon_special() //For things such as teshari hiding and whatnot.
 	if(hiding) // Hiding? Carry on.
-		if(incapacitated(INCAPACITATION_STUNNED)) //stunned/knocked down by something that isn't the rest verb?
-			hiding = 0 //No hiding for you. Mob layer should be updated naturally.
+		if(stat == DEAD || paralysis || weakened || stunned) //stunned/knocked down by something that isn't the rest verb? Note: This was tried with INCAPACITATION_STUNNED, but that refused to work.
+			hiding = 0 //No hiding for you. Mob layer should be updated naturally, but it actually doesn't.
 		else
 			layer = 2.45
 	else //Replace this else with other variables if added in the future. Alternatively, could make other things effect this hiding variable.

--- a/code/modules/mob/living/carbon/human/human_powers.dm
+++ b/code/modules/mob/living/carbon/human/human_powers.dm
@@ -271,7 +271,7 @@
 	set desc = "Allows to hide beneath tables or certain items. Toggled on or off."
 	set category = "Abilities"
 
-	if(incapacitated(INCAPACITATION_STUNNED)) // No hiding if you're stunned!
+	if(stat == DEAD || paralysis || weakened || stunned) // No hiding if you're stunned!
 		return
 
 	if (!hiding)

--- a/code/modules/mob/living/carbon/human/human_powers.dm
+++ b/code/modules/mob/living/carbon/human/human_powers.dm
@@ -277,8 +277,8 @@
 	if (!hiding)
 		layer = 2.45 //Just above cables with their 2.44
 		hiding = 1
-		src << text("<font color='blue'>You are now hiding.</font>")
+		to_chat(src, "<font color='blue'>You are now hiding.</font>")
 	else
 		layer = MOB_LAYER
 		hiding = 0
-		src << text("<font color='blue'>You have stopped hiding.</font>")
+		to_chat(src, "<font color='blue'>You have stopped hiding.</font>")

--- a/code/modules/mob/living/carbon/human/human_powers.dm
+++ b/code/modules/mob/living/carbon/human/human_powers.dm
@@ -265,3 +265,20 @@
 			organ_data["descriptor"] = O.name
 			to_chat(src, "<span class='notice'>You feel a slithering sensation as your [O.name] reform.</span>")
 	update_icons_all()
+
+/mob/living/carbon/human/proc/hide_humanoid()
+	set name = "Hide"
+	set desc = "Allows to hide beneath tables or certain items. Toggled on or off."
+	set category = "Abilities"
+
+	if(incapacitated(INCAPACITATION_STUNNED)) // No hiding if you're stunned!
+		return
+
+	if (!hiding)
+		layer = 2.45 //Just above cables with their 2.44
+		hiding = 1
+		src << text("<font color='blue'>You are now hiding.</font>")
+	else
+		layer = MOB_LAYER
+		hiding = 0
+		src << text("<font color='blue'>You have stopped hiding.</font>")

--- a/code/modules/mob/living/carbon/human/species/station/seromi.dm
+++ b/code/modules/mob/living/carbon/human/species/station/seromi.dm
@@ -114,7 +114,7 @@
 
 	inherent_verbs = list(
 		/mob/living/carbon/human/proc/sonar_ping,
-		/mob/living/proc/hide
+		/mob/living/carbon/human/proc/hide_humanoid
 		)
 
 /datum/species/teshari/equip_survival_gear(var/mob/living/carbon/human/H)

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -178,6 +178,9 @@ Please contact me on #coderbus IRC. ~Carn x
 	//5: Set appearance once
 	appearance = ma_compiled
 
+	//6: Do any species specific layering updates, such as when hiding.
+	update_icon_special()
+
 /mob/living/carbon/human/update_transform(var/mutable_appearance/passed_ma)
 	if(QDESTROYING(src))
 		return
@@ -211,6 +214,7 @@ Please contact me on #coderbus IRC. ~Carn x
 		M.Translate(0, 16*(desired_scale-1))
 		ma.transform = M
 		ma.layer = MOB_LAYER // Fix for a byond bug where turf entry order no longer matters
+	update_icon_special() //Adjust their layer, like when they are hiding.
 
 	if(!passed_ma)
 		appearance = ma


### PR DESCRIPTION
- Makes the human.dm variable comments all line up nice and neatly. https://i.imgur.com/Mm5xHLW.png

- Makes a new proc called on update_icon and update_icons, update_icon_special

- update_icon_special checks to see if the creature is hiding. If so, it sets their layer to the "hide" layer (Taken from the old hide proc. Layer is 2.45). Left open to make more edits for further expansion, such as clothing possibly making you able to hide, or maybe another variable that makes you able to show yourself above all layers no matter what. Of course, this is out of the scope of the current PR, but would be possible in the future by using this.

- Adds a humanoid hide proc. Pretty much the same as old proc, but sets a hiding variable to 1
