### PR TITLE
Fix paddle runtime

### DIFF
--- a/code/game/objects/items/devices/defib.dm
+++ b/code/game/objects/items/devices/defib.dm
@@ -44,7 +44,7 @@
 
 	if(paddles && paddles.loc == src) //in case paddles got destroyed somehow.
 		new_overlays += "[initial(icon_state)]-paddles"
-	if(bcell)
+	if(bcell && paddles)
 		if(bcell.check_charge(paddles.chargecost))
 			if(paddles.combat)
 				new_overlays += "[initial(icon_state)]-combat"


### PR DESCRIPTION
Allows defibs to die properly.

```
[18:22:40] Runtime in defib.dm,48: Cannot read null.chargecost
   Caught by process: obj
   proc name: update icon (/obj/item/device/defib_kit/update_icon)
   src: (the open space) (167,120,2) (/turf/simulated/open)
   src.loc: (the open space) (167,120,2) (/turf/simulated/open)
   src.loc: the open space (164,119,2) (/turf/simulated/open)
   call stack:
   the defibrillator (/obj/item/device/defib_kit/loaded): update icon()
   the defibrillator paddles (/obj/item/weapon/shockpaddles/linked): Destroy(0)
   qdel(the defibrillator paddles (/obj/item/weapon/shockpaddles/linked), 0)
   the defibrillator (/obj/item/device/defib_kit/loaded): Destroy(0)
   the defibrillator (/obj/item/device/defib_kit/loaded): Destroy(0)
   the defibrillator (/obj/item/device/defib_kit/loaded): Destroy(0)
   the defibrillator (/obj/item/device/defib_kit/loaded): Destroy(0)
   the defibrillator (/obj/item/device/defib_kit/loaded): Destroy(0)
   the defibrillator (/obj/item/device/defib_kit/loaded): Destroy(0)
   the defibrillator (/obj/item/device/defib_kit/loaded): Destroy(0)
   qdel(the defibrillator (/obj/item/device/defib_kit/loaded), 0)
   the defibrillator (/obj/item/device/defib_kit/loaded): ex act(1)
   the defibrillator (/obj/item/device/defib_kit/loaded): singularity act(the gravitational singularity (/obj/singularity), 7)
   the gravitational singularity (/obj/singularity): consume(the defibrillator (/obj/item/device/defib_kit/loaded))
   the gravitational singularity (/obj/singularity): eat()
   the gravitational singularity (/obj/singularity): process()
   obj (/datum/controller/process/obj): doWork()
   obj (/datum/controller/process/obj): process()
   /datum/controller/processSched... (/datum/controller/processScheduler): runProcess(obj (/datum/controller/process/obj))
```
```[
18:22:42] Runtime in garbage.dm,332: /obj/item/device/defib_kit/loaded destroy proc was called multiple times, likely due to a qdel loop in the Destroy logic
   Caught by process: obj
   proc name: qdel (/proc/qdel)
   src: (the open space) (167,120,2) (/turf/simulated/open)
   src.loc: (the open space) (167,120,2) (/turf/simulated/open)
   call stack:
   qdel(the defibrillator (/obj/item/device/defib_kit/loaded), 0)
   the defibrillator (/obj/item/device/defib_kit/loaded): ex act(1)
   the defibrillator (/obj/item/device/defib_kit/loaded): singularity act(the gravitational singularity (/obj/singularity), 7)
   the gravitational singularity (/obj/singularity): consume(the defibrillator (/obj/item/device/defib_kit/loaded))
   the gravitational singularity (/obj/singularity): eat()
   the gravitational singularity (/obj/singularity): process()
   obj (/datum/controller/process/obj): doWork()
   obj (/datum/controller/process/obj): process()
   /datum/controller/processSched... (/datum/controller/processScheduler): runProcess(obj (/datum/controller/process/obj))```