### PR TITLE
Ethylredox removes alcohol

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -461,11 +461,11 @@
 	if(M.ingested)
 		for(var/datum/reagent/R in M.ingested.reagent_list)
 			if(istype(R, /datum/reagent/ethanol))
-				R.dose = max(R.dose - removed * 5, 0)
+				R.remove_self(removed * 5)
 	if(M.bloodstr)
 		for(var/datum/reagent/R in M.bloodstr.reagent_list)
 			if(istype(R, /datum/reagent/ethanol))
-				R.dose = max(R.dose - removed * 15, 0) 
+				R.remove_self(removed * 15)
 
 /datum/reagent/hyronalin
 	name = "Hyronalin"

--- a/html/changelogs/Atermonera - ethyl_fix.yml
+++ b/html/changelogs/Atermonera - ethyl_fix.yml
@@ -1,0 +1,5 @@
+author: Atermonera
+
+delete-after: True
+changes:
+  - tweak: "Ethylredoxrazine actively removes alcohol from the stomach and bloodstream"


### PR DESCRIPTION
Fixes #4752 
Ethyl does NOT react with alcohol because then as soon as you ingest or inject it, it'll instantly react with whatever alcohol is in that reagent container and you may need more to handle anything in the other container.

Tested, it had a noticeable impact on the rate alcoholic beverages were removed at, sorta hard to give a hard rate without looking at how it's metabolized, but it's notably faster.