### PR TITLE
Fix IDs so they do not instantiate every job datum on New

### DIFF
--- a/code/game/gamemodes/changeling/powers/fabricate_clothing.dm
+++ b/code/game/gamemodes/changeling/powers/fabricate_clothing.dm
@@ -277,6 +277,9 @@ var/global/list/changeling_fabricated_clothing = list(
 /obj/item/weapon/card/id/syndicate/changeling/New(mob/user as mob)
 	..()
 	registered_user = user
+
+/obj/item/weapon/card/id/syndicate/changeling/initialize()
+	. = ..()
 	access = null
 
 /obj/item/weapon/card/id/syndicate/changeling/verb/shred()

--- a/code/game/machinery/computer/guestpass.dm
+++ b/code/game/machinery/computer/guestpass.dm
@@ -54,8 +54,8 @@
 			expired = 1
 	return ..()
 
-/obj/item/weapon/card/id/guest/New()
-	..()
+/obj/item/weapon/card/id/guest/initialize()
+	. = ..() 
 	processing_objects.Add(src)
 	update_icon()
 

--- a/code/game/objects/items/weapons/id cards/station_ids.dm
+++ b/code/game/objects/items/weapons/id cards/station_ids.dm
@@ -112,15 +112,11 @@
 	usr << "The fingerprint hash on the card is [fingerprint_hash]."
 	return
 
-/obj/item/weapon/card/id/New()
-	..()
-	var/datum/job/jobdatum
-	for(var/jobtype in typesof(/datum/job))
-		var/datum/job/J = new jobtype
-		if(J.title == rank)
-			jobdatum = J
-			access = jobdatum.get_access()
-			return
+/obj/item/weapon/card/id/initialize()
+	. = ..()
+	var/datum/job/J = job_master.GetJob(rank)
+	if(J)
+		access = J.get_access()
 
 /obj/item/weapon/card/id/silver
 	name = "identification card"
@@ -163,8 +159,8 @@
 	item_state = "tdgreen"
 	assignment = "Synthetic"
 
-/obj/item/weapon/card/id/synthetic/New()
-	..()
+/obj/item/weapon/card/id/synthetic/initialize()
+	. = ..()
 	access = get_all_station_access() + access_synth
 
 /obj/item/weapon/card/id/centcom
@@ -174,12 +170,12 @@
 	registered_name = "Central Command"
 	assignment = "General"
 
-/obj/item/weapon/card/id/centcom/New()
+/obj/item/weapon/card/id/centcom/initialize()
+	. = ..()
 	access = get_all_centcom_access()
-	..()
 
-/obj/item/weapon/card/id/centcom/station/New()
-	..()
+/obj/item/weapon/card/id/centcom/station/initialize()
+	. = ..()
 	access |= get_all_station_access()
 
 /obj/item/weapon/card/id/centcom/ERT
@@ -187,8 +183,8 @@
 	assignment = "Emergency Response Team"
 	icon_state = "centcom"
 
-/obj/item/weapon/card/id/centcom/ERT/New()
-	..()
+/obj/item/weapon/card/id/centcom/ERT/initialize()
+	. = ..()
 	access |= get_all_station_access()
 
 // Department-flavor IDs

--- a/code/game/objects/items/weapons/id cards/syndicate_ids.dm
+++ b/code/game/objects/items/weapons/id cards/syndicate_ids.dm
@@ -6,12 +6,12 @@
 	var/electronic_warfare = 1
 	var/mob/registered_user = null
 
-/obj/item/weapon/card/id/syndicate/New(mob/user as mob)
-	..()
+/obj/item/weapon/card/id/syndicate/initialize()
+	. = ..()
 	access = syndicate_access.Copy()
 
-/obj/item/weapon/card/id/syndicate/station_access/New()
-	..() // Same as the normal Syndicate id, only already has all station access
+/obj/item/weapon/card/id/syndicate/station_access/initialize()
+	. = ..() // Same as the normal Syndicate id, only already has all station access
 	access |= get_all_station_access()
 
 /obj/item/weapon/card/id/syndicate/Destroy()


### PR DESCRIPTION
Every ID was instantiatating and deleting a copy of *every* job datum in its New().  Thats silly.  Switch to initialize so job_master is available.