### PR TITLE
Makes Projectiles Sometimes Pass Through Door Assemblies

### DIFF
--- a/code/game/objects/structures/door_assembly.dm
+++ b/code/game/objects/structures/door_assembly.dm
@@ -320,3 +320,10 @@
 		if(2)
 			name = "near finished "
 	name += "[glass == 1 ? "window " : ""][istext(glass) ? "[glass] airlock" : base_name] assembly ([created_name])"
+
+// Airlock frames are indestructable, so bullets hitting them would always be stopped.
+// To fix this, airlock assemblies will sometimes let bullets pass through, since generally the sprite shows them partially open.
+/obj/structure/door_assembly/bullet_act(var/obj/item/projectile/P)
+	if(prob(40)) // Chance for the frame to let the bullet keep going.
+		return PROJECTILE_CONTINUE
+	return ..()


### PR DESCRIPTION
What it says on the tin. Bullets and beams will pass 40% of the time, so hiding behind one of these isn't guaranteed to protect you, but its still better than nothing.