### PR TITLE
Tweaks Shield Generators

### DIFF
--- a/code/modules/shieldgen/shield_gen.dm
+++ b/code/modules/shieldgen/shield_gen.dm
@@ -20,27 +20,26 @@
 	var/target_field_strength = 10
 	var/max_field_strength = 10
 	var/time_since_fail = 100
-	var/energy_conversion_rate = 0.0002	//how many renwicks per watt?  Higher numbers equals more effiency.
+	var/energy_conversion_rate = 0.0006	//how many renwicks per watt?  Higher numbers equals more effiency.
 	var/z_range = 0 // How far 'up and or down' to extend the shield to, in z-levels.  Only works on MultiZ supported z-levels.
 	use_power = 0	//doesn't use APC power
 
 /obj/machinery/shield_gen/advanced
 	name = "advanced bubble shield generator"
 	desc = "A machine that generates a field of energy optimized for blocking meteorites when activated.  This version comes with a more efficent shield matrix."
-	energy_conversion_rate = 0.0004
+	energy_conversion_rate = 0.0012
 
-/obj/machinery/shield_gen/New()
-	spawn(1 SECOND)
-		if(anchored)
-			for(var/obj/machinery/shield_capacitor/cap in range(1, src))
-				if(!cap.anchored)
-					continue
-				if(cap.owned_gen)
-					continue
-				if(get_dir(cap, src) == cap.dir)
-					capacitors |= cap
-					cap.owned_gen = src
-	..()
+/obj/machinery/shield_gen/initialize()
+	if(anchored)
+		for(var/obj/machinery/shield_capacitor/cap in range(1, src))
+			if(!cap.anchored)
+				continue
+			if(cap.owned_gen)
+				continue
+			if(get_dir(cap, src) == cap.dir)
+				capacitors |= cap
+				cap.owned_gen = src
+	return ..()
 
 /obj/machinery/shield_gen/Destroy()
 	qdel_null_list(field)

--- a/code/modules/shieldgen/shield_gen_external.dm
+++ b/code/modules/shieldgen/shield_gen_external.dm
@@ -11,7 +11,7 @@
 /obj/machinery/shield_gen/external/advanced
 	name = "advanced hull shield generator"
 	desc = "A machine that generates a field of energy optimized for blocking meteorites when activated.  This version comes with a more efficent shield matrix."
-	energy_conversion_rate = 0.0004
+	energy_conversion_rate = 0.0012
 
 //Search for space turfs within range that are adjacent to a simulated turf.
 /obj/machinery/shield_gen/external/get_shielded_turfs_on_z_level(var/turf/gen_turf)


### PR DESCRIPTION
Adjusts numbers on shield generators, so that they can protect the station with roughly similar amounts of power they would need on the old map, before multiZ.
Cleans up a bit of initialization code for shield gens.

Specifically, the base number for the conversion rate was tripled ``(0.002 -> 0.006)``, due to having three z-levels to shield, and the 'advanced' subtypes were changed to be double the default rate, as they were before.
```
Current Levels
(0.002)
1 RW Normal - 477.2 kW
2 RW Normal - 954.3 kW
3 RW Normal - 1.4 MW

(0.004)
1 RW Upgrade - 238.6 kW
2 RW Upgrade - 477.1 kW
3 RW Upgrade - 715.7 kW

---
Potential Future Levels
(0.006)
1 RW Normal - 159.1 kW
2 RW Normal - 318.1 kW
3 RW Normal - 477.1 kW
5 RW Normal - 792.2 kW

(0.012)
5 RW Upgrade - 397.6 kW
10 RW Upgrade - 795.2 kW
```