### PR TITLE
Fixes vis_enabled becoming unobtainable if something happens to apply plane_holder to mob before client

### DIFF
--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -50,6 +50,7 @@
 
 	if(!plane_holder) //Lazy
 		plane_holder = new(src) //Not a location, it takes it and saves it.
+	if(!vis_enabled)
 		vis_enabled = list()
 	client.screen += plane_holder.plane_masters
 	recalculate_vis()


### PR DESCRIPTION
Yeah a feature somewhere down there relied on the mob getting its plane_holder before client (and thus making the only vis_enabled init right here, that required the lack of plane_holder on login, completely unobtainable) and I was vaguely told to fix this here instead of fixing the forementioned downstream feature.