### PR TITLE
Lowercases the Giant Crab name

### DIFF
--- a/code/modules/mob/living/simple_animal/animals/crab.dm
+++ b/code/modules/mob/living/simple_animal/animals/crab.dm
@@ -49,7 +49,7 @@
 
 //Sif Crabs
 /mob/living/simple_animal/giant_crab
-	name = "Giant Crab"
+	name = "giant crab"
 	desc = "A large, hard-shelled crustacean. This one is mostly grey."
 	icon_state = "sif_crab"
 	icon_living = "sif_crab"


### PR DESCRIPTION
They should have a `the` in front, so the name should be lowercase.