### PR TITLE
removes redundant override in human emp_act()

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -197,12 +197,6 @@ emp_act
 		if(.) return
 	return 0
 
-/mob/living/carbon/human/emp_act(severity)
-	for(var/obj/O in src)
-		if(!O)	continue
-		O.emp_act(severity)
-	..()
-
 /mob/living/carbon/human/proc/get_accuracy_penalty(mob/living/user)
 	// Certain statuses make it harder to score a hit.  These are the same as gun accuracy, however melee doesn't use multiples of 15.
 	var/accuracy_penalty = 0


### PR DESCRIPTION
Removed:
```
/mob/living/carbon/human/emp_act(severity)
    for(var/obj/O in src)
        if(!O)    continue
        O.emp_act(severity)
    ..()
```

Because it calls the parent, which is:
```
/mob/living/emp_act(severity)
    var/list/L = src.get_contents()
    for(var/obj/O in L)
        O.emp_act(severity)
    ..()
```

Fixes bizarre behaviour where calling emp_act() on a human mob would cause it to run emp_act() on all its contents twice.

May affect balance for FBPs if people have been coding around this bug. If this is the case, tweak the numbers in /obj/item/organ/emp_act().