### PR TITLE
GPS coordinates and POI names are obfuscated

### DIFF
--- a/html/changelogs/Atermonera - gps_tweaks.yml
+++ b/html/changelogs/Atermonera - gps_tweaks.yml
@@ -1,0 +1,6 @@
+author: Atermonera
+
+delete-after: True
+changes:
+  - tweak: "GPS units won't report the exact location of other GPS units, just range and approximate direction"
+  - tweak: "POI gps units won't give any information about the POI, merely its location"

--- a/maps/southern_cross/southern_cross_defines.dm
+++ b/maps/southern_cross/southern_cross_defines.dm
@@ -134,19 +134,19 @@
 
 /datum/map_z_level/southern_cross/surface
 	z = Z_LEVEL_SURFACE
-	name = "Planet"
+	name = "Plains"
 	flags = MAP_LEVEL_STATION|MAP_LEVEL_CONTACT|MAP_LEVEL_PLAYER|MAP_LEVEL_SEALED
 	base_turf = /turf/simulated/floor/outdoors/rocks
 
 /datum/map_z_level/southern_cross/surface_mine
 	z = Z_LEVEL_SURFACE_MINE
-	name = "Planet"
+	name = "Mountains"
 	flags = MAP_LEVEL_STATION|MAP_LEVEL_CONTACT|MAP_LEVEL_PLAYER|MAP_LEVEL_SEALED
 	base_turf = /turf/simulated/floor/outdoors/rocks
 
 /datum/map_z_level/southern_cross/surface_wild
 	z = Z_LEVEL_SURFACE_WILD
-	name = "Wild"
+	name = "Wilderness"
 	flags = MAP_LEVEL_PLAYER|MAP_LEVEL_SEALED
 	base_turf = /turf/simulated/floor/outdoors/rocks
 

--- a/maps/submaps/surface_submaps/mountains/crashed_ufo.dmm
+++ b/maps/submaps/surface_submaps/mountains/crashed_ufo.dmm
@@ -37,7 +37,7 @@
 "aK" = (/obj/item/weapon/crowbar/alien,/turf/simulated/shuttle/floor/alienplating,/area/submap/cave/crashed_ufo)
 "aL" = (/obj/item/stack/cable_coil/alien,/turf/simulated/shuttle/floor/alienplating,/area/submap/cave/crashed_ufo)
 "aM" = (/obj/structure/table/alien,/obj/item/prop/alien/junk,/turf/simulated/shuttle/floor/alienplating,/area/submap/cave/crashed_ufo)
-"aN" = (/obj/structure/table/alien,/obj/item/weapon/paper/alien{icon_state = "alienpaper_words"; info = "\[i]This tablet has a large collection of symbols that you've never seen before outside this ship. You have no hope of figuring out what any of the mean...\[/i]"},/obj/item/device/gps/internal/alien_vessel,/turf/simulated/shuttle/floor/alienplating,/area/submap/cave/crashed_ufo)
+"aN" = (/obj/structure/table/alien,/obj/item/weapon/paper/alien{icon_state = "alienpaper_words"; info = "\[i]This tablet has a large collection of symbols that you've never seen before outside this ship. You have no hope of figuring out what any of the mean...\[/i]"},/obj/item/device/gps/internal/poi,/turf/simulated/shuttle/floor/alienplating,/area/submap/cave/crashed_ufo)
 "aO" = (/obj/structure/prop/alien/computer{tag = "icon-console-c (EAST)"; icon_state = "console-c"; dir = 4},/turf/simulated/shuttle/floor/alien,/area/submap/cave/crashed_ufo)
 "aP" = (/obj/structure/table/alien,/obj/item/clothing/accessory/medal/dungeon/alien_ufo,/turf/simulated/shuttle/floor/alienplating,/area/submap/cave/crashed_ufo)
 "aQ" = (/obj/structure/table/alien,/obj/item/weapon/weldingtool/alien,/turf/simulated/shuttle/floor/alienplating,/area/submap/cave/crashed_ufo)

--- a/maps/submaps/surface_submaps/wilderness/DJOutpost1.dmm
+++ b/maps/submaps/surface_submaps/wilderness/DJOutpost1.dmm
@@ -26,20 +26,21 @@
 "z" = (/obj/structure/table/steel_reinforced,/obj/item/device/radio/intercom/syndicate{desc = "Talk through this."; name = "station intercom (General)"},/obj/item/device/multitool,/turf/simulated/floor/wood,/area/submap/DJOutpost1)
 "A" = (/obj/structure/table/steel_reinforced,/obj/item/device/radio,/obj/machinery/power/apc{cell_type = /obj/item/weapon/cell/hyper; dir = 4; environ = 1; equipment = 1; lighting = 1; locked = 0; name = "Sif Free Radio APC"; operating = 0; pixel_x = 24},/obj/structure/cable/yellow,/turf/simulated/floor/wood,/area/submap/DJOutpost1)
 "B" = (/obj/effect/overlay/snow/floor,/obj/machinery/power/port_gen/pacman,/obj/structure/cable/yellow,/turf/simulated/floor{outdoors = 1},/area/submap/DJOutpost1)
-"C" = (/obj/machinery/biogenerator,/turf/simulated/floor/wood,/area/submap/DJOutpost1)
-"D" = (/obj/structure/table/woodentable,/obj/item/weapon/reagent_containers/food/snacks/unajerky,/obj/machinery/light{icon_state = "tube1"; dir = 8},/obj/random_multi/single_item/sfr_headset,/turf/simulated/floor/wood,/area/submap/DJOutpost1)
-"E" = (/obj/machinery/light{dir = 4; icon_state = "tube1"; pixel_x = 0},/obj/machinery/seed_extractor,/turf/simulated/floor/wood,/area/submap/DJOutpost1)
-"F" = (/obj/structure/bed/chair/wood{tag = "icon-wooden_chair (NORTH)"; icon_state = "wooden_chair"; dir = 1},/turf/simulated/floor/wood,/area/submap/DJOutpost1)
-"G" = (/obj/machinery/door/airlock/external,/turf/simulated/floor/wood,/area/submap/DJOutpost1)
-"H" = (/obj/structure/table/woodentable,/obj/item/weapon/material/knife/machete/hatchet,/obj/item/weapon/reagent_containers/glass/bucket,/obj/item/weapon/material/minihoe,/obj/item/device/analyzer/plant_analyzer,/obj/random_multi/single_item/sfr_headset,/turf/simulated/floor/wood,/area/submap/DJOutpost1)
-"I" = (/obj/structure/undies_wardrobe,/turf/simulated/floor/wood,/area/submap/DJOutpost1)
-"J" = (/obj/structure/table/rack,/obj/item/clothing/shoes/boots/winter,/obj/item/clothing/suit/storage/hooded/wintercoat,/obj/random_multi/single_item/sfr_headset,/turf/simulated/floor/wood,/area/submap/DJOutpost1)
-"K" = (/obj/machinery/light/flamp,/turf/simulated/floor/wood,/area/submap/DJOutpost1)
-"L" = (/obj/structure/sink{dir = 4; icon_state = "sink"; pixel_x = 15; tag = "icon-sink (EAST)"},/turf/simulated/floor/wood,/area/submap/DJOutpost1)
-"M" = (/obj/structure/bed/padded,/obj/item/weapon/bedsheet/clown,/turf/simulated/floor/wood,/area/submap/DJOutpost1)
-"N" = (/obj/structure/table/rack,/obj/item/ammo_magazine/clip/c545/hunter,/obj/item/weapon/gun/projectile/shotgun/pump/rifle,/turf/simulated/floor/wood,/area/submap/DJOutpost1)
-"O" = (/obj/structure/table/rack,/obj/item/device/gps/on{gps_tag = "Sif Free Radio"},/obj/item/device/flashlight/lantern,/turf/simulated/floor/wood,/area/submap/DJOutpost1)
-"P" = (/obj/machinery/portable_atmospherics/hydroponics,/turf/simulated/floor/wood,/area/submap/DJOutpost1)
+"C" = (/obj/machinery/door/airlock/glass,/obj/item/device/gps/internal/poi,/turf/simulated/floor/wood,/area/submap/DJOutpost1)
+"D" = (/obj/machinery/biogenerator,/turf/simulated/floor/wood,/area/submap/DJOutpost1)
+"E" = (/obj/structure/table/woodentable,/obj/item/weapon/reagent_containers/food/snacks/unajerky,/obj/machinery/light{icon_state = "tube1"; dir = 8},/obj/random_multi/single_item/sfr_headset,/turf/simulated/floor/wood,/area/submap/DJOutpost1)
+"F" = (/obj/machinery/light{dir = 4; icon_state = "tube1"; pixel_x = 0},/obj/machinery/seed_extractor,/turf/simulated/floor/wood,/area/submap/DJOutpost1)
+"G" = (/obj/structure/bed/chair/wood{tag = "icon-wooden_chair (NORTH)"; icon_state = "wooden_chair"; dir = 1},/turf/simulated/floor/wood,/area/submap/DJOutpost1)
+"H" = (/obj/machinery/door/airlock/external,/turf/simulated/floor/wood,/area/submap/DJOutpost1)
+"I" = (/obj/structure/table/woodentable,/obj/item/weapon/material/knife/machete/hatchet,/obj/item/weapon/reagent_containers/glass/bucket,/obj/item/weapon/material/minihoe,/obj/item/device/analyzer/plant_analyzer,/obj/random_multi/single_item/sfr_headset,/turf/simulated/floor/wood,/area/submap/DJOutpost1)
+"J" = (/obj/structure/undies_wardrobe,/turf/simulated/floor/wood,/area/submap/DJOutpost1)
+"K" = (/obj/structure/table/rack,/obj/item/clothing/shoes/boots/winter,/obj/item/clothing/suit/storage/hooded/wintercoat,/obj/random_multi/single_item/sfr_headset,/turf/simulated/floor/wood,/area/submap/DJOutpost1)
+"L" = (/obj/machinery/light/flamp,/turf/simulated/floor/wood,/area/submap/DJOutpost1)
+"M" = (/obj/structure/sink{dir = 4; icon_state = "sink"; pixel_x = 15; tag = "icon-sink (EAST)"},/turf/simulated/floor/wood,/area/submap/DJOutpost1)
+"N" = (/obj/structure/bed/padded,/obj/item/weapon/bedsheet/clown,/turf/simulated/floor/wood,/area/submap/DJOutpost1)
+"O" = (/obj/structure/table/rack,/obj/item/ammo_magazine/clip/c545/hunter,/obj/item/weapon/gun/projectile/shotgun/pump/rifle,/turf/simulated/floor/wood,/area/submap/DJOutpost1)
+"P" = (/obj/structure/table/rack,/obj/item/device/flashlight/lantern,/obj/item/device/gps{gps_tag = "Sif Free Radio"},/turf/simulated/floor/wood,/area/submap/DJOutpost1)
+"Q" = (/obj/machinery/portable_atmospherics/hydroponics,/turf/simulated/floor/wood,/area/submap/DJOutpost1)
 
 (1,1,1) = {"
 aaaaaaaaaaaaaaaa
@@ -49,12 +50,12 @@ abbehebeeeeibbaa
 adehjekeeelemnoa
 abpeeqbeeelrsbta
 abuvewbeexyzAbBa
-abbbbbbkbbbbbbaa
-abpeeeeeeeeeCbaa
-abDeeeeeeeeeEbaa
-adFeebbGbbeeHdaa
-abbIebJeKbeLbbaa
-aabbMbNeObPbbaaa
-aaabdbbGbbdbaaaa
+abbbbbbCbbbbbbaa
+abpeeeeeeeeeDbaa
+abEeeeeeeeeeFbaa
+adGeebbHbbeeIdaa
+abbJebKeLbeMbbaa
+aabbNbOePbQbbaaa
+aaabdbbHbbdbaaaa
 aaaaaaaaaaaaaaaa
 "}

--- a/maps/~map_system/maps.dm
+++ b/maps/~map_system/maps.dm
@@ -142,6 +142,10 @@ var/list/all_maps = list()
 	else
 		return list()
 
+/datum/map/proc/get_zlevel_name(var/index)
+	var/datum/map_z_level/Z = zlevels["[index]"]
+	return Z.name
+
 // Another way to setup the map datum that can be convenient.  Just declare all your zlevels as subtypes of a common
 // subtype of /datum/map_z_level and set zlevel_datum_type on /datum/map to have the lists auto-initialized.
 


### PR DESCRIPTION
Tested:
![t](https://puu.sh/zkolz/a1262f5485.png)

The Z level of the current location has also been changed to report z level name instead of number.
POIs with mapped handheld GPS units need to be off by default. If you want explorers to be able to find it with a gps, use `/obj/item/device/gps/internal/poi`

`/obj/item/device/gps/syndie` maintains the current function of GPS units, in addition to their other effects, although they'll also list Z names instead of numbers as well.

Adds a helper proc on datum/map to get the name of a Z level from its number.
Changes the names of planetside Z levels to more accurately reflect what region they contain.