### PR TITLE
Fixes Typing Indicator

### DIFF
--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -253,19 +253,19 @@ Please contact me on #coderbus IRC. ~Carn x
 
 //TYPING INDICATOR CODE.
 	if(client && !stat) //They have a client & aren't dead? Continue on!
-		if(typing_indicator && (hud_typing || chatbar_typing)) //They already have the indicator and are still typing
+		if(typing_indicator && hud_typing) //They already have the indicator and are still typing
 			overlays += typing_indicator //This might not be needed? It works, so I'm leaving it.
 			list_huds += typing_indicator
 			typing_indicator.invisibility = invisibility
 
-		else if(!typing_indicator && (hud_typing || chatbar_typing) && is_preference_enabled(/datum/client_preference/show_typing_indicator)) //Are they in their body, NOT dead, have hud_typing, do NOT have a typing indicator. and have it enabled?
+		else if(!typing_indicator && hud_typing && is_preference_enabled(/datum/client_preference/show_typing_indicator)) //Are they in their body, NOT dead, have hud_typing, do NOT have a typing indicator. and have it enabled?
 			typing_indicator = new
 			typing_indicator.icon = 'icons/mob/talk.dmi'
 			typing_indicator.icon_state = "[speech_bubble_appearance()]_typing"
 			overlays += typing_indicator
 			list_huds += typing_indicator
 
-		else if(typing_indicator && !hud_typing && !chatbar_typing) //Did they stop typing?
+		else if(typing_indicator && !hud_typing) //Did they stop typing?
 			overlays -= typing_indicator
 			typing = 0
 			hud_typing = 0

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -251,6 +251,25 @@ Please contact me on #coderbus IRC. ~Carn x
 		list_huds = hud_list.Copy()
 		list_huds += backplane // Required to mask HUDs in context menus: http://www.byond.com/forum/?post=2336679
 
+//TYPING INDICATOR CODE.
+	if(client && !stat) //They have a client & aren't dead? Continue on!
+		if(typing_indicator && (hud_typing || chatbar_typing)) //They already have the indicator and are still typing
+			overlays += typing_indicator //This might not be needed? It works, so I'm leaving it.
+			list_huds += typing_indicator
+			typing_indicator.invisibility = invisibility
+
+		else if(!typing_indicator && (hud_typing || chatbar_typing) && is_preference_enabled(/datum/client_preference/show_typing_indicator)) //Are they in their body, NOT dead, have hud_typing, do NOT have a typing indicator. and have it enabled?
+			typing_indicator = new
+			typing_indicator.icon = 'icons/mob/talk.dmi'
+			typing_indicator.icon_state = "[speech_bubble_appearance()]_typing"
+			overlays += typing_indicator
+			list_huds += typing_indicator
+
+		else if(typing_indicator && !hud_typing && !chatbar_typing) //Did they stop typing?
+			overlays -= typing_indicator
+			typing = 0
+			hud_typing = 0
+
 	if(update_icons)
 		update_icons()
 

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -252,13 +252,13 @@ Please contact me on #coderbus IRC. ~Carn x
 		list_huds += backplane // Required to mask HUDs in context menus: http://www.byond.com/forum/?post=2336679
 
 //TYPING INDICATOR CODE.
-	if(client && !stat) //They have a client & aren't dead? Continue on!
+	if(client && !stat) //They have a client & aren't dead/KO'd? Continue on!
 		if(typing_indicator && hud_typing) //They already have the indicator and are still typing
 			overlays += typing_indicator //This might not be needed? It works, so I'm leaving it.
 			list_huds += typing_indicator
 			typing_indicator.invisibility = invisibility
 
-		else if(!typing_indicator && hud_typing && is_preference_enabled(/datum/client_preference/show_typing_indicator)) //Are they in their body, NOT dead, have hud_typing, do NOT have a typing indicator. and have it enabled?
+		else if(!typing_indicator && hud_typing) //Are they in their body, NOT dead, have hud_typing, do NOT have a typing indicator. and have it enabled?
 			typing_indicator = new
 			typing_indicator.icon = 'icons/mob/talk.dmi'
 			typing_indicator.icon_state = "[speech_bubble_appearance()]_typing"

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -144,7 +144,6 @@
 /mob/proc/Life()
 //	if(organStructure)
 //		organStructure.ProcessOrgans()
-	//handle_typing_indicator() //You said the typing indicator would be fine. The test determined that was a lie.
 	return
 
 #define UNBUCKLED 0

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -220,8 +220,5 @@
 	var/get_rig_stats = 0 //Moved from computer.dm
 
 	var/hud_typing = 0 //Typing indicator stuff.
-	var/typing
-	var/last_typed
-	var/last_typed_time
+	var/typing //Simple mobs use this variable.
 	var/obj/effect/decal/typing_indicator
-	var/chatbar_typing

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -218,3 +218,10 @@
 	var/seedarkness = 1	//Determines mob's ability to see shadows. 1 = Normal vision, 0 = darkvision
 
 	var/get_rig_stats = 0 //Moved from computer.dm
+
+	var/hud_typing = 0 //Typing indicator stuff.
+	var/typing
+	var/last_typed
+	var/last_typed_time
+	var/obj/effect/decal/typing_indicator
+	var/chatbar_typing

--- a/code/modules/mob/typing_indicator.dm
+++ b/code/modules/mob/typing_indicator.dm
@@ -1,5 +1,3 @@
-#define TYPING_INDICATOR_LIFETIME 5 * 10	//grace period after which typing indicator disappears regardless of text in chatbar. 5 seconds.
-
 /mob/proc/set_typing_indicator(var/state) //Leaving this here for mobs.
 
 	if(!typing_indicator)
@@ -53,36 +51,3 @@
 		set_typing_indicator(0)
 	if(message)
 		me_verb(message)
-
-//This segment is unused. Being updated to actually be usable. WIP!!!
-/mob/proc/handle_typing_indicator() //This was disabled three years ago. I'm going to get the typing indicator fixed and THEN work on fixing this, too. ~Jas
-	if(!client || stat) //No client or dead/KO'd? No typing indicator.
-		return
-
-	if(!hud_typing && is_preference_enabled(/datum/client_preference/show_typing_indicator)) //Are they using the popout window? If so, don't time it out.
-		var/temp = winget(client, "input", "text")
-
-		if (temp != last_typed)
-			last_typed = temp
-			last_typed_time = world.time
-
-		if (world.time > last_typed_time + TYPING_INDICATOR_LIFETIME)
-			if(!ishuman(src))
-				set_typing_indicator(0)
-			chatbar_typing = 0
-			return
-
-		if(length(temp) > 5 && findtext(temp, "Say \"", 1, 7))
-			if(!ishuman(src))
-				set_typing_indicator(1)
-			chatbar_typing = 1
-
-		else if(length(temp) > 3 && findtext(temp, "Me ", 1, 5))
-			if(!ishuman(src))
-				set_typing_indicator(1)
-			chatbar_typing = 1
-
-		else
-			if(!ishuman(src))
-				set_typing_indicator(0)
-			chatbar_typing = 0

--- a/code/modules/mob/typing_indicator.dm
+++ b/code/modules/mob/typing_indicator.dm
@@ -1,13 +1,6 @@
-#define TYPING_INDICATOR_LIFETIME 30 * 10	//grace period after which typing indicator disappears regardless of text in chatbar
+#define TYPING_INDICATOR_LIFETIME 5 * 10	//grace period after which typing indicator disappears regardless of text in chatbar. 5 seconds.
 
-mob/var/hud_typing = 0 //set when typing in an input window instead of chatline
-mob/var/typing
-mob/var/last_typed
-mob/var/last_typed_time
-
-mob/var/obj/effect/decal/typing_indicator
-
-/mob/proc/set_typing_indicator(var/state)
+/mob/proc/set_typing_indicator(var/state) //Leaving this here for mobs.
 
 	if(!typing_indicator)
 		typing_indicator = new
@@ -33,11 +26,15 @@ mob/var/obj/effect/decal/typing_indicator
 	set name = ".Say"
 	set hidden = 1
 
-	set_typing_indicator(1)
+	if(!ishuman(src)) //If they're a mob, use the old code.
+		set_typing_indicator(1)
 	hud_typing = 1
+	update_icons_huds()
 	var/message = input("","say (text)") as text
 	hud_typing = 0
-	set_typing_indicator(0)
+	update_icons_huds()
+	if(!ishuman(src)) //If they're a mob, use the old code.
+		set_typing_indicator(0)
 	if(message)
 		say_verb(message)
 
@@ -45,16 +42,24 @@ mob/var/obj/effect/decal/typing_indicator
 	set name = ".Me"
 	set hidden = 1
 
-	set_typing_indicator(1)
+	if(!ishuman(src)) //If they're a mob, use the old code.
+		set_typing_indicator(1)
 	hud_typing = 1
+	update_icons_huds()
 	var/message = input("","me (text)") as text
 	hud_typing = 0
-	set_typing_indicator(0)
+	update_icons_huds()
+	if(!ishuman(src)) //If they're a mob, use the old code.
+		set_typing_indicator(0)
 	if(message)
 		me_verb(message)
 
-/mob/proc/handle_typing_indicator()
-	if(is_preference_enabled(/datum/client_preference/show_typing_indicator) && !hud_typing)
+//This segment is unused. Being updated to actually be usable. WIP!!!
+/mob/proc/handle_typing_indicator() //This was disabled three years ago. I'm going to get the typing indicator fixed and THEN work on fixing this, too. ~Jas
+	if(!client || stat) //No client or dead/KO'd? No typing indicator.
+		return
+
+	if(!hud_typing && is_preference_enabled(/datum/client_preference/show_typing_indicator)) //Are they using the popout window? If so, don't time it out.
 		var/temp = winget(client, "input", "text")
 
 		if (temp != last_typed)
@@ -62,12 +67,22 @@ mob/var/obj/effect/decal/typing_indicator
 			last_typed_time = world.time
 
 		if (world.time > last_typed_time + TYPING_INDICATOR_LIFETIME)
-			set_typing_indicator(0)
+			if(!ishuman(src))
+				set_typing_indicator(0)
+			chatbar_typing = 0
 			return
+
 		if(length(temp) > 5 && findtext(temp, "Say \"", 1, 7))
-			set_typing_indicator(1)
+			if(!ishuman(src))
+				set_typing_indicator(1)
+			chatbar_typing = 1
+
 		else if(length(temp) > 3 && findtext(temp, "Me ", 1, 5))
-			set_typing_indicator(1)
+			if(!ishuman(src))
+				set_typing_indicator(1)
+			chatbar_typing = 1
 
 		else
-			set_typing_indicator(0)
+			if(!ishuman(src))
+				set_typing_indicator(0)
+			chatbar_typing = 0

--- a/code/modules/mob/typing_indicator.dm
+++ b/code/modules/mob/typing_indicator.dm
@@ -26,11 +26,13 @@
 
 	if(!ishuman(src)) //If they're a mob, use the old code.
 		set_typing_indicator(1)
-	hud_typing = 1
-	update_icons_huds()
+	if(is_preference_enabled(/datum/client_preference/show_typing_indicator))
+		hud_typing = 1
+		update_icons_huds()
 	var/message = input("","say (text)") as text
-	hud_typing = 0
-	update_icons_huds()
+	if(is_preference_enabled(/datum/client_preference/show_typing_indicator))
+		hud_typing = 0
+		update_icons_huds()
 	if(!ishuman(src)) //If they're a mob, use the old code.
 		set_typing_indicator(0)
 	if(message)
@@ -42,11 +44,13 @@
 
 	if(!ishuman(src)) //If they're a mob, use the old code.
 		set_typing_indicator(1)
-	hud_typing = 1
-	update_icons_huds()
+	if(is_preference_enabled(/datum/client_preference/show_typing_indicator))
+		hud_typing = 1
+		update_icons_huds()
 	var/message = input("","me (text)") as text
-	hud_typing = 0
-	update_icons_huds()
+	if(is_preference_enabled(/datum/client_preference/show_typing_indicator))
+		hud_typing = 0
+		update_icons_huds()
 	if(!ishuman(src)) //If they're a mob, use the old code.
 		set_typing_indicator(0)
 	if(message)


### PR DESCRIPTION
- Fixes typing indicator
- Makes typing indicator able to be shown while down
- Removes unused, 3 yr old code that had no chance in hell of actually functioning. I tried multiple times to get it to work.

Tested & everything is working.

Code in action:
Using text indicator while standing up: https://i.imgur.com/hE9PItG.gifv
Using text indicator while laying down: https://i.imgur.com/gAerAMS.gifv

Using text indicator while standing up w/ it disabled: https://i.imgur.com/UF5Zv9p.png