### PR TITLE
Trees take damage from bullets/lasers

### DIFF
--- a/code/game/objects/structures/flora/trees.dm
+++ b/code/game/objects/structures/flora/trees.dm
@@ -47,13 +47,19 @@
 	animate(transform=null, pixel_x=init_px, time=6, easing=ELASTIC_EASING)
 
 // Used when the tree gets hurt.
-/obj/structure/flora/tree/proc/adjust_health(var/amount)
+/obj/structure/flora/tree/proc/adjust_health(var/amount, var/is_ranged = FALSE)
 	if(is_stump)
 		return
+
+	// Bullets and lasers ruin some of the wood
+	if(is_ranged && product_amount > 0)
+		var/wood = initial(product_amount)
+		product_amount -= round(wood * (abs(amount)/max_health))
 
 	health = between(0, health + amount, max_health)
 	if(health <= 0)
 		die()
+		return
 
 // Called when the tree loses all health, for whatever reason.
 /obj/structure/flora/tree/proc/die()
@@ -81,6 +87,9 @@
 /obj/structure/flora/tree/ex_act(var/severity)
 	adjust_health(-(max_health / severity))
 
+/obj/structure/flora/tree/bullet_act(var/obj/item/projectile/Proj)
+	if(Proj.get_structure_damage())
+		adjust_health(-Proj.get_structure_damage(), TRUE)
 
 /obj/structure/flora/tree/get_description_interaction()
 	var/list/results = list()


### PR DESCRIPTION
- Trees now have a bullet_act()
- Shooting a tree eats away at some of the wood it has, based on damage. Shooting a tree all the way to death yields no wood.