### PR TITLE
Removes the Explorer hood lights

### DIFF
--- a/code/modules/clothing/suits/miscellaneous.dm
+++ b/code/modules/clothing/suits/miscellaneous.dm
@@ -798,9 +798,6 @@ obj/item/clothing/suit/storage/toggle/peacoat
 	name = "explorer hood"
 	desc = "An armoured hood for exploring harsh environments."
 	icon_state = "explorer"
-	brightness_on = 3
-	light_overlay = "hood_light"
-	action_button_name = "Toggle Head-light"
 	body_parts_covered = HEAD
 	cold_protection = HEAD
 	flags = THICKMATERIAL


### PR DESCRIPTION
These were added on a whim. Now that we've seen them in action, we'd prefer they not be a thing. Explorers have immediate access to flashlights, as is.