### PR TITLE
Lets poi gps units display gps_tag instead of hardcoded string

### DIFF
--- a/code/game/objects/items/devices/gps.dm
+++ b/code/game/objects/items/devices/gps.dm
@@ -111,7 +111,7 @@ var/list/GPS_list = list()
 			direction = "CENTER"
 
 		if(istype(T, /obj/item/device/gps/internal/poi))
-			signals += "	Unidentified Signal: [area_name] [local ? "Dist: [round(distance, 10)]m [direction])" : "in \the [Z_name]"]"
+			signals += "	[G.gps_tag]: [area_name] [local ? "Dist: [round(distance, 10)]m [direction])" : "in \the [Z_name]"]"
 		else
 			signals += "     [G.gps_tag]: [area_name] [local ? "Dist: [round(distance, 10)]m [direction])" : "in \the [Z_name]"]"
 
@@ -200,7 +200,7 @@ var/list/GPS_list = list()
 	desc = "A homing signal from NanoTrasen's outpost."
 
 /obj/item/device/gps/internal/poi
-	gps_tag = "Mysterious Signal"
+	gps_tag = "Unidentified Signal"
 	desc = "A signal that seems forboding."
 
 /obj/item/device/gps/syndie
@@ -257,7 +257,7 @@ var/list/GPS_list = list()
 			direction = "CENTER"
 			degrees = "N/A"
 
-		signals += "     [G.gps_tag]: [area_name] ([coord]) [local ? "Dist: [distance]m Dir: [degrees]° ([direction])":""]"
+		signals += "     [G.gps_tag]: [area_name] ([coord]) [local ? "Dist: [distance]m Dir: [degrees]Â° ([direction])":""]"
 
 	if(signals.len)
 		dat += "Detected signals;"


### PR DESCRIPTION
Because devstaff are all donks and anewbe merged the first one as I was making this commit, because this came up in discussion.

When mapping, signals should not have specific names, and ideally there'd be several that share a name. Having 15 pois with "Unidentified Signal" is a lot more explorative than having "Sif free radio, crashed ufo, blackshuttledown, doomp, rockybase, shaqden"

Also I don't know where those other changed lines are coming from.