### PR TITLE
Makes More Machines Movable

### DIFF
--- a/code/game/machinery/biogenerator.dm
+++ b/code/game/machinery/biogenerator.dm
@@ -46,6 +46,8 @@
 		return
 	if(default_part_replacement(user, O))
 		return
+	if(default_unfasten_wrench(user, O, 40))
+		return
 	if(istype(O, /obj/item/weapon/reagent_containers/glass))
 		if(beaker)
 			user << "<span class='notice'>]The [src] is already loaded.</span>"

--- a/code/game/machinery/bioprinter.dm
+++ b/code/game/machinery/bioprinter.dm
@@ -44,6 +44,8 @@
 		return
 	if(default_part_replacement(user, O))
 		return
+	if(default_unfasten_wrench(user, O, 20))
+		return
 	return ..()
 
 /obj/machinery/organ_printer/update_icon()

--- a/code/game/machinery/computer3/lapvend.dm
+++ b/code/game/machinery/computer3/lapvend.dm
@@ -29,6 +29,9 @@
 /obj/machinery/lapvend/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	var/obj/item/weapon/card/id/I = W.GetID()
 
+	if(default_unfasten_wrench(user, W, 20))
+		return
+
 	if(vendmode == 1 && I)
 		scan_id(I, W)
 		vendmode = 0

--- a/code/game/machinery/kitchen/cooking_machines/_cooker.dm
+++ b/code/game/machinery/kitchen/cooking_machines/_cooker.dm
@@ -50,6 +50,9 @@
 		user << "<span class='warning'>\The [src] is running!</span>"
 		return
 
+	if(default_unfasten_wrench(user, I, 20))
+		return
+
 	// We are trying to cook a grabbed mob.
 	var/obj/item/weapon/grab/G = I
 	if(istype(G))

--- a/code/game/machinery/kitchen/gibber.dm
+++ b/code/game/machinery/kitchen/gibber.dm
@@ -92,6 +92,9 @@
 /obj/machinery/gibber/attackby(var/obj/item/W, var/mob/user)
 	var/obj/item/weapon/grab/G = W
 
+	if(default_unfasten_wrench(user, W, 40))
+		return
+
 	if(!istype(G))
 		return ..()
 

--- a/code/game/machinery/kitchen/microwave.dm
+++ b/code/game/machinery/kitchen/microwave.dm
@@ -95,6 +95,8 @@
 		return
 	else if(default_deconstruction_crowbar(user, O))
 		return
+	else if(default_unfasten_wrench(user, O, 10))
+		return
 
 	else if(src.dirty==100) // The microwave is all dirty so can't be used!
 		if(istype(O, /obj/item/weapon/reagent_containers/spray/cleaner) || istype(O, /obj/item/weapon/soap)) // If they're trying to clean it then let them

--- a/code/game/machinery/kitchen/smartfridge.dm
+++ b/code/game/machinery/kitchen/smartfridge.dm
@@ -22,6 +22,7 @@
 	var/locked = 0
 	var/scan_id = 1
 	var/is_secure = 0
+	var/wrenchable = 0
 	var/datum/wires/smartfridge/wires = null
 
 /obj/machinery/smartfridge/secure
@@ -128,6 +129,7 @@
 /obj/machinery/smartfridge/drying_rack
 	name = "\improper Drying Rack"
 	desc = "A machine for drying plants."
+	wrenchable = 1
 	icon_state = "drying_rack"
 	icon_on = "drying_rack_on"
 	icon_off = "drying_rack"
@@ -215,6 +217,9 @@
 		if(panel_open)
 			overlays += image(icon, icon_panel)
 		nanomanager.update_uis(src)
+		return
+
+	if(wrenchable && default_unfasten_wrench(user, O, 20))
 		return
 
 	if(istype(O, /obj/item/device/multitool)||istype(O, /obj/item/weapon/wirecutters))

--- a/code/game/machinery/seed_extractor.dm
+++ b/code/game/machinery/seed_extractor.dm
@@ -40,4 +40,7 @@ obj/machinery/seed_extractor/attackby(var/obj/item/O as obj, var/mob/user as mob
 			user << "<span class='notice'>You extract some seeds from the grass tile.</span>"
 			new /obj/item/seeds/grassseed(loc)
 
+	else if(default_unfasten_wrench(user, O, 20))
+		return
+
 	return

--- a/code/game/machinery/washing_machine.dm
+++ b/code/game/machinery/washing_machine.dm
@@ -88,6 +88,8 @@
 			return
 		if(default_deconstruction_crowbar(user, W))
 			return
+		if(default_unfasten_wrench(user, W, 40))
+			return
 	/*if(istype(W,/obj/item/weapon/screwdriver))
 		panel = !panel
 		user << "<span class='notice'>You [panel ? "open" : "close"] the [src]'s maintenance panel</span>"*/

--- a/code/modules/reagents/Chemistry-Machinery.dm
+++ b/code/modules/reagents/Chemistry-Machinery.dm
@@ -68,6 +68,10 @@
 		user.drop_item()
 		B.loc = src
 		user << "You add \the [loaded_pill_bottle] into the dispenser slot!"
+
+	else if(default_unfasten_wrench(user, B, 20))
+		return
+
 	return
 
 /obj/machinery/chem_master/attack_hand(mob/user as mob)

--- a/code/modules/virus2/analyser.dm
+++ b/code/modules/virus2/analyser.dm
@@ -11,7 +11,10 @@
 	var/obj/item/weapon/virusdish/dish = null
 
 /obj/machinery/disease2/diseaseanalyser/attackby(var/obj/O as obj, var/mob/user as mob)
-	if(!istype(O,/obj/item/weapon/virusdish)) return
+	if(default_unfasten_wrench(user, O, 20))
+		return
+
+	else if(!istype(O,/obj/item/weapon/virusdish)) return
 
 	if(dish)
 		user << "\The [src] is already loaded."

--- a/code/modules/virus2/centrifuge.dm
+++ b/code/modules/virus2/centrifuge.dm
@@ -13,6 +13,9 @@
 	if(istype(O, /obj/item/weapon/screwdriver))
 		return ..(O,user)
 
+	if(default_unfasten_wrench(user, O, 20))
+		return
+
 	if(istype(O,/obj/item/weapon/reagent_containers/glass/beaker/vial))
 		if(sample)
 			user << "\The [src] is already loaded."

--- a/code/modules/virus2/diseasesplicer.dm
+++ b/code/modules/virus2/diseasesplicer.dm
@@ -15,6 +15,9 @@
 	if(istype(I, /obj/item/weapon/screwdriver))
 		return ..(I,user)
 
+	if(default_unfasten_wrench(user, I, 20))
+		return
+
 	if(istype(I,/obj/item/weapon/virusdish))
 		var/mob/living/carbon/c = user
 		if (dish)

--- a/code/modules/virus2/dishincubator.dm
+++ b/code/modules/virus2/dishincubator.dm
@@ -15,6 +15,9 @@
 	var/toxins = 0
 
 /obj/machinery/disease2/incubator/attackby(var/obj/O as obj, var/mob/user as mob)
+	if(default_unfasten_wrench(user, O, 20))
+		return
+
 	if(istype(O, /obj/item/weapon/reagent_containers/glass) || istype(O,/obj/item/weapon/reagent_containers/syringe))
 
 		if(beaker)

--- a/code/modules/virus2/isolator.dm
+++ b/code/modules/virus2/isolator.dm
@@ -28,7 +28,10 @@
 		icon_state = "isolator"
 
 /obj/machinery/disease2/isolator/attackby(var/obj/O as obj, var/mob/user)
-	if(!istype(O,/obj/item/weapon/reagent_containers/syringe)) return
+	if(default_unfasten_wrench(user, O, 20))
+		return
+
+	else if(!istype(O,/obj/item/weapon/reagent_containers/syringe)) return
 	var/obj/item/weapon/reagent_containers/syringe/S = O
 
 	if(sample)

--- a/html/changelogs/PrismaticGynoid-movethosemachines.yml
+++ b/html/changelogs/PrismaticGynoid-movethosemachines.yml
@@ -1,0 +1,4 @@
+author: PrismaticGynoid
+delete-after: True
+changes: 
+  - rscadd: "A lot more machines can now be moved with a wrench, mostly kitchen, hydroponics, and virology machines."


### PR DESCRIPTION
Adds in the ability to wrench/unwrench a number of machines that previously could not be. Now you're able to move:

- Laptop venders!
- Seed extractors!
- Biogenerators!
- Drying racks!
- Microwaves!
- Cooking machines!
- Gibbers!
- Chemmasters/Condimasters!
- Bioprinters!
- Virology machines!
- Washing machines!

Tested with no apparent problems.