### PR TITLE
Adds hidden alarms, for air alarms, fire alarms, and APCs

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -52,7 +52,11 @@
 	if (danger_level == 0)
 		atmosphere_alarm.clearAlarm(src, alarm_source)
 	else
-		atmosphere_alarm.triggerAlarm(src, alarm_source, severity = danger_level)
+		var/obj/machinery/alarm/atmosalarm = alarm_source //maybe other things can trigger these, who knows
+		if(istype(atmosalarm))
+			atmosphere_alarm.triggerAlarm(src, alarm_source, severity = danger_level, hidden = atmosalarm.hidden)
+		else
+			atmosphere_alarm.triggerAlarm(src, alarm_source, severity = danger_level)
 
 	//Check all the alarms before lowering atmosalm. Raising is perfectly fine.
 	for (var/obj/machinery/alarm/AA in src)

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -54,7 +54,7 @@
 	else
 		var/obj/machinery/alarm/atmosalarm = alarm_source //maybe other things can trigger these, who knows
 		if(istype(atmosalarm))
-			atmosphere_alarm.triggerAlarm(src, alarm_source, severity = danger_level, hidden = atmosalarm.hidden)
+			atmosphere_alarm.triggerAlarm(src, alarm_source, severity = danger_level, hidden = atmosalarm.alarms_hidden)
 		else
 			atmosphere_alarm.triggerAlarm(src, alarm_source, severity = danger_level)
 

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -81,12 +81,17 @@
 
 	var/report_danger_level = 1
 
+	var/hidden = FALSE
+
 /obj/machinery/alarm/nobreach
 	breach_detection = 0
 
 /obj/machinery/alarm/monitor
 	report_danger_level = 0
 	breach_detection = 0
+
+/obj/machinery/alarm/hidden
+	hidden = TRUE
 
 /obj/machinery/alarm/server/New()
 	..()
@@ -812,6 +817,10 @@ FIRE ALARM
 	panel_open = 0
 	var/seclevel
 	circuit = /obj/item/weapon/circuitboard/firealarm
+	var/hidden = FALSE
+
+/obj/machinery/firealarm/hidden
+	hidden = TRUE
 
 /obj/machinery/firealarm/update_icon()
 	overlays.Cut()
@@ -980,7 +989,7 @@ FIRE ALARM
 		return
 	var/area/area = get_area(src)
 	for(var/obj/machinery/firealarm/FA in area)
-		fire_alarm.triggerAlarm(loc, FA, duration)
+		fire_alarm.triggerAlarm(loc, FA, duration, hidden = hidden)
 	update_icon()
 	//playsound(src.loc, 'sound/ambience/signal.ogg', 75, 0)
 	return

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -81,7 +81,7 @@
 
 	var/report_danger_level = 1
 
-	var/hidden = FALSE
+	var/alarms_hidden = FALSE //If the alarms from this machine are visible on consoles
 
 /obj/machinery/alarm/nobreach
 	breach_detection = 0
@@ -90,8 +90,8 @@
 	report_danger_level = 0
 	breach_detection = 0
 
-/obj/machinery/alarm/hidden
-	hidden = TRUE
+/obj/machinery/alarm/alarms_hidden
+	alarms_hidden = TRUE
 
 /obj/machinery/alarm/server/New()
 	..()
@@ -817,10 +817,10 @@ FIRE ALARM
 	panel_open = 0
 	var/seclevel
 	circuit = /obj/item/weapon/circuitboard/firealarm
-	var/hidden = FALSE
+	var/alarms_hidden = FALSE //If the alarms from this machine are visible on consoles
 
-/obj/machinery/firealarm/hidden
-	hidden = TRUE
+/obj/machinery/firealarm/alarms_hidden
+	alarms_hidden = TRUE
 
 /obj/machinery/firealarm/update_icon()
 	overlays.Cut()
@@ -989,7 +989,7 @@ FIRE ALARM
 		return
 	var/area/area = get_area(src)
 	for(var/obj/machinery/firealarm/FA in area)
-		fire_alarm.triggerAlarm(loc, FA, duration, hidden = hidden)
+		fire_alarm.triggerAlarm(loc, FA, duration, hidden = alarms_hidden)
 	update_icon()
 	//playsound(src.loc, 'sound/ambience/signal.ogg', 75, 0)
 	return

--- a/code/modules/alarm/alarm.dm
+++ b/code/modules/alarm/alarm.dm
@@ -23,12 +23,13 @@
 	var/area/last_name				//The last acquired name, used should origin be lost
 	var/area/last_camera_area		//The last area in which cameras where fetched, used to see if the camera list should be updated.
 	var/end_time					//Used to set when this alarm should clear, in case the origin is lost.
+	var/hidden = FALSE				//If this alarm can be seen from consoles or other things.
 
-/datum/alarm/New(var/atom/origin, var/atom/source, var/duration, var/severity)
+/datum/alarm/New(var/atom/origin, var/atom/source, var/duration, var/severity, var/hidden)
 	src.origin = origin
 
 	cameras()	// Sets up both cameras and last alarm area.
-	set_source_data(source, duration, severity)
+	set_source_data(source, duration, severity, hidden)
 
 /datum/alarm/proc/process()
 	// Has origin gone missing?
@@ -43,17 +44,19 @@
 			AS.duration = 0
 			AS.end_time = world.time + ALARM_RESET_DELAY
 
-/datum/alarm/proc/set_source_data(var/atom/source, var/duration, var/severity)
+/datum/alarm/proc/set_source_data(var/atom/source, var/duration, var/severity, var/hidden)
 	var/datum/alarm_source/AS = sources_assoc[source]
 	if(!AS)
 		AS = new/datum/alarm_source(source)
 		sources += AS
 		sources_assoc[source] = AS
+		src.hidden = hidden
 	// Currently only non-0 durations can be altered (normal alarms VS EMP blasts)
 	if(AS.duration)
 		duration = SecondsToTicks(duration)
 		AS.duration = duration
 	AS.severity = severity
+	src.hidden = min(src.hidden, hidden)
 
 /datum/alarm/proc/clear(var/source)
 	var/datum/alarm_source/AS = sources_assoc[source]

--- a/code/modules/alarm/atmosphere_alarm.dm
+++ b/code/modules/alarm/atmosphere_alarm.dm
@@ -1,19 +1,16 @@
 /datum/alarm_handler/atmosphere
 	category = "Atmosphere Alarms"
 
-/datum/alarm_handler/atmosphere/triggerAlarm(var/atom/origin, var/atom/source, var/duration = 0, var/severity = 1)
-	..()
-
 /datum/alarm_handler/atmosphere/major_alarms()
 	var/list/major_alarms = new()
-	for(var/datum/alarm/A in alarms)
+	for(var/datum/alarm/A in visible_alarms())
 		if(A.max_severity() > 1)
 			major_alarms.Add(A)
 	return major_alarms
 
 /datum/alarm_handler/atmosphere/minor_alarms()
 	var/list/minor_alarms = new()
-	for(var/datum/alarm/A in alarms)
+	for(var/datum/alarm/A in visible_alarms())
 		if(A.max_severity() == 1)
 			minor_alarms.Add(A)
 	return minor_alarms

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -322,6 +322,8 @@
 /mob/living/silicon/proc/receive_alarm(var/datum/alarm_handler/alarm_handler, var/datum/alarm/alarm, was_raised)
 	if(!next_alarm_notice)
 		next_alarm_notice = world.time + SecondsToTicks(10)
+	if(alarm.hidden)
+		return
 
 	var/list/alarms = queued_alarms[alarm_handler]
 	if(was_raised)

--- a/code/modules/nano/modules/alarm_monitor.dm
+++ b/code/modules/nano/modules/alarm_monitor.dm
@@ -26,7 +26,7 @@
 /datum/nano_module/alarm_monitor/proc/all_alarms()
 	var/list/all_alarms = new()
 	for(var/datum/alarm_handler/AH in alarm_handlers)
-		all_alarms += AH.alarms
+		all_alarms += AH.visible_alarms()
 
 	return all_alarms
 

--- a/code/modules/nano/modules/atmos_control.dm
+++ b/code/modules/nano/modules/atmos_control.dm
@@ -36,7 +36,7 @@
 
 	// TODO: Move these to a cache, similar to cameras
 	for(var/obj/machinery/alarm/alarm in (monitored_alarms.len ? monitored_alarms : machines))
-		if(!monitored_alarms.len && alarm.hidden)
+		if(!monitored_alarms.len && alarm.alarms_hidden)
 			continue
 		alarms[++alarms.len] = list(
 			"name" = sanitize(alarm.name),

--- a/code/modules/nano/modules/atmos_control.dm
+++ b/code/modules/nano/modules/atmos_control.dm
@@ -36,6 +36,8 @@
 
 	// TODO: Move these to a cache, similar to cameras
 	for(var/obj/machinery/alarm/alarm in (monitored_alarms.len ? monitored_alarms : machines))
+		if(!monitored_alarms.len && alarm.hidden)
+			continue
 		alarms[++alarms.len] = list(
 			"name" = sanitize(alarm.name),
 			"ref"= "\ref[alarm]",

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -56,8 +56,8 @@
 /obj/machinery/power/apc/hyper
 	cell_type = /obj/item/weapon/cell/hyper
 
-/obj/machinery/power/apc/hidden
-	hidden = TRUE
+/obj/machinery/power/apc/alarms_hidden
+	alarms_hidden = TRUE
 
 /obj/machinery/power/apc
 	name = "area power controller"
@@ -115,7 +115,7 @@
 	var/global/list/status_overlays_equipment
 	var/global/list/status_overlays_lighting
 	var/global/list/status_overlays_environ
-	var/hidden = FALSE //If power alarms from this APC are visible on consoles
+	var/alarms_hidden = FALSE //If power alarms from this APC are visible on consoles
 
 /obj/machinery/power/apc/updateDialog()
 	if (stat & (BROKEN|MAINT))
@@ -229,7 +229,7 @@
 	area.apc = src
 
 	if(istype(area, /area/submap))
-		hidden = TRUE
+		alarms_hidden = TRUE
 
 	update_icon()
 
@@ -1116,7 +1116,7 @@
 		equipment = autoset(equipment, 0)
 		lighting = autoset(lighting, 0)
 		environ = autoset(environ, 0)
-		power_alarm.triggerAlarm(loc, src, hidden=hidden)
+		power_alarm.triggerAlarm(loc, src, hidden=alarms_hidden)
 		autoflag = 0
 
 	// update icon & area power if anything changed
@@ -1146,21 +1146,21 @@
 			equipment = autoset(equipment, 2)
 			lighting = autoset(lighting, 1)
 			environ = autoset(environ, 1)
-			power_alarm.triggerAlarm(loc, src, hidden=hidden)
+			power_alarm.triggerAlarm(loc, src, hidden=alarms_hidden)
 			autoflag = 2
 	else if(cell.percent() <= 15)        // <15%, turn off lighting & equipment
 		if((autoflag > 1 && longtermpower < 0) || (autoflag > 1 && longtermpower >= 0))
 			equipment = autoset(equipment, 2)
 			lighting = autoset(lighting, 2)
 			environ = autoset(environ, 1)
-			power_alarm.triggerAlarm(loc, src, hidden=hidden)
+			power_alarm.triggerAlarm(loc, src, hidden=alarms_hidden)
 			autoflag = 1
 	else                                   // zero charge, turn all off
 		if(autoflag != 0)
 			equipment = autoset(equipment, 0)
 			lighting = autoset(lighting, 0)
 			environ = autoset(environ, 0)
-			power_alarm.triggerAlarm(loc, src, hidden=hidden)
+			power_alarm.triggerAlarm(loc, src, hidden=alarms_hidden)
 			autoflag = 0
 
 // val 0=off, 1=off(auto) 2=on 3=on(auto)

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -57,7 +57,7 @@
 	cell_type = /obj/item/weapon/cell/hyper
 
 /obj/machinery/power/apc/hidden
-	hidden = 1
+	hidden = TRUE
 
 /obj/machinery/power/apc
 	name = "area power controller"
@@ -115,7 +115,7 @@
 	var/global/list/status_overlays_equipment
 	var/global/list/status_overlays_lighting
 	var/global/list/status_overlays_environ
-	var/hidden = 0 //If power alarms from this APC are visible on consoles
+	var/hidden = FALSE //If power alarms from this APC are visible on consoles
 
 /obj/machinery/power/apc/updateDialog()
 	if (stat & (BROKEN|MAINT))

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -56,6 +56,9 @@
 /obj/machinery/power/apc/hyper
 	cell_type = /obj/item/weapon/cell/hyper
 
+/obj/machinery/power/apc/hidden
+	hidden = 1
+
 /obj/machinery/power/apc
 	name = "area power controller"
 	desc = "A control terminal for the area electrical systems."
@@ -107,12 +110,12 @@
 	var/failure_timer = 0
 	var/force_update = 0
 	var/updating_icon = 0
-	var/secret = FALSE // If true, it won't show up on the alert computer.
 	var/global/list/status_overlays_lock
 	var/global/list/status_overlays_charging
 	var/global/list/status_overlays_equipment
 	var/global/list/status_overlays_lighting
 	var/global/list/status_overlays_environ
+	var/hidden = 0 //If power alarms from this APC are visible on consoles
 
 /obj/machinery/power/apc/updateDialog()
 	if (stat & (BROKEN|MAINT))
@@ -226,7 +229,7 @@
 	area.apc = src
 
 	if(istype(area, /area/submap))
-		secret = TRUE
+		hidden = TRUE
 
 	update_icon()
 
@@ -1113,8 +1116,7 @@
 		equipment = autoset(equipment, 0)
 		lighting = autoset(lighting, 0)
 		environ = autoset(environ, 0)
-		if(!secret)
-			power_alarm.triggerAlarm(loc, src)
+		power_alarm.triggerAlarm(loc, src, hidden=hidden)
 		autoflag = 0
 
 	// update icon & area power if anything changed
@@ -1144,24 +1146,21 @@
 			equipment = autoset(equipment, 2)
 			lighting = autoset(lighting, 1)
 			environ = autoset(environ, 1)
-			if(!secret)
-				power_alarm.triggerAlarm(loc, src)
+			power_alarm.triggerAlarm(loc, src, hidden=hidden)
 			autoflag = 2
 	else if(cell.percent() <= 15)        // <15%, turn off lighting & equipment
 		if((autoflag > 1 && longtermpower < 0) || (autoflag > 1 && longtermpower >= 0))
 			equipment = autoset(equipment, 2)
 			lighting = autoset(lighting, 2)
 			environ = autoset(environ, 1)
-			if(!secret)
-				power_alarm.triggerAlarm(loc, src)
+			power_alarm.triggerAlarm(loc, src, hidden=hidden)
 			autoflag = 1
 	else                                   // zero charge, turn all off
 		if(autoflag != 0)
 			equipment = autoset(equipment, 0)
 			lighting = autoset(lighting, 0)
 			environ = autoset(environ, 0)
-			if(!secret)
-				power_alarm.triggerAlarm(loc, src)
+			power_alarm.triggerAlarm(loc, src, hidden=hidden)
 			autoflag = 0
 
 // val 0=off, 1=off(auto) 2=on 3=on(auto)


### PR DESCRIPTION
Accidentally copied part of #4766, but in a different way.
The alarms all still trigger, air/fire alarms still shut firedoors in the area, but they aren't displayed on consoles or to the silicons.

Ideally keep an area to either only unhidden or hidden alarm types, things can get sort of weird when mixed.