### PR TITLE
Changes mine code, adds random mine spawners

### DIFF
--- a/code/game/objects/effects/mines.dm
+++ b/code/game/objects/effects/mines.dm
@@ -1,6 +1,6 @@
 /obj/effect/mine
-	name = "mine"
-	desc = "A small explosive mine with 'HE' and a grenade symbol on the side."
+	name = "land mine"	//The name and description are deliberately NOT modified, so you can't game the landmines you find.
+	desc = "A small explosive landmine."
 	density = 0
 	anchored = 1
 	icon = 'icons/obj/weapons.dmi'
@@ -21,6 +21,7 @@
 	s.set_up(3, 1, src)
 	s.start()
 	explosion(loc, 0, 2, 3, 4) //land mines are dangerous, folks.
+	visible_message("\The [src.name] detonates!")
 	qdel(s)
 	qdel(src)
 
@@ -38,10 +39,12 @@
 
 /obj/effect/mine/Bumped(mob/M as mob|obj)
 
-	if(triggered) return
+	if(triggered)
+		return
 
 	if(istype(M, /mob/living/))
-		explode(M)
+		if(!M.hovering)
+			explode(M)
 
 /obj/effect/mine/attackby(obj/item/W as obj, mob/living/user as mob)
 	if(isscrewdriver(W))
@@ -62,8 +65,6 @@
 	wires.Interact(user)
 
 /obj/effect/mine/dnascramble
-	name = "radiation mine"
-	desc = "A small explosive mine with a radiation symbol on the side."
 	mineitemtype = /obj/item/weapon/mine/dnascramble
 
 /obj/effect/mine/dnascramble/explode(var/mob/living/M)
@@ -71,31 +72,31 @@
 	triggered = 1
 	s.set_up(3, 1, src)
 	s.start()
-	M.radiation += 50
-	randmutb(M)
-	domutcheck(M,null)
+	if(M)
+		M.radiation += 50
+		randmutb(M)
+		domutcheck(M,null)
+	visible_message("\The [src.name] flashes violently before disintigrating!")
 	spawn(0)
 		qdel(s)
 		qdel(src)
 
 /obj/effect/mine/stun
-	name = "stun mine"
-	desc = "A small explosive mine with a lightning bolt symbol on the side."
 	mineitemtype = /obj/item/weapon/mine/stun
 
 /obj/effect/mine/stun/explode(var/mob/living/M)
 	triggered = 1
-	M.Stun(30)
 	var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread()
 	s.set_up(3, 1, src)
 	s.start()
+	if(M)
+		M.Stun(30)
+	visible_message("\The [src.name] flashes violently before disintigrating!")
 	spawn(0)
 		qdel(s)
 		qdel(src)
 
 /obj/effect/mine/n2o
-	name = "nitrous oxide mine"
-	desc = "A small explosive mine with three Z's on the side."
 	mineitemtype = /obj/item/weapon/mine/n2o
 
 /obj/effect/mine/n2o/explode(var/mob/living/M)
@@ -103,12 +104,11 @@
 	for (var/turf/simulated/floor/target in range(1,src))
 		if(!target.blocks_air)
 			target.assume_gas("sleeping_agent", 30)
+	visible_message("\The [src.name] detonates!")
 	spawn(0)
 		qdel(src)
 
 /obj/effect/mine/phoron
-	name = "incendiary mine"
-	desc = "A small explosive mine with a fire symbol on the side."
 	mineitemtype = /obj/item/weapon/mine/phoron
 
 /obj/effect/mine/phoron/explode(var/mob/living/M)
@@ -117,12 +117,11 @@
 		if(!target.blocks_air)
 			target.assume_gas("phoron", 30)
 			target.hotspot_expose(1000, CELL_VOLUME)
+	visible_message("\The [src.name] detonates!")
 	spawn(0)
 		qdel(src)
 
 /obj/effect/mine/kick
-	name = "kick mine"
-	desc = "Concentrated war crimes. Handle with care."
 	mineitemtype = /obj/item/weapon/mine/kick
 
 /obj/effect/mine/kick/explode(var/mob/living/M)
@@ -130,14 +129,13 @@
 	triggered = 1
 	s.set_up(3, 1, src)
 	s.start()
-	qdel(M.client)
+	if(M)
+		qdel(M.client)
 	spawn(0)
 		qdel(s)
 		qdel(src)
 
 /obj/effect/mine/frag
-	name = "fragmentation mine"
-	desc = "A small explosive mine with 'FRAG' and a grenade symbol on the side."
 	mineitemtype = /obj/item/weapon/mine/frag
 	var/fragment_types = list(/obj/item/projectile/bullet/pellet/fragment)
 	var/num_fragments = 20  //total number of fragments produced by the grenade
@@ -153,13 +151,14 @@
 	if(!O)
 		return
 	src.fragmentate(O, 20, 7, list(/obj/item/projectile/bullet/pellet/fragment)) //only 20 weak fragments because you're stepping directly on it
+	visible_message("\The [src.name] detonates!")
 	spawn(0)
 		qdel(s)
 		qdel(src)
 
-/obj/effect/mine/training
-	name = "training mine"
-	desc = "A mine with its payload removed, for EOD training and demonstrations."
+/obj/effect/mine/training	//Name and Desc commented out so it's possible to trick people with the training mines
+//	name = "training mine"
+//	desc = "A mine with its payload removed, for EOD training and demonstrations."
 	mineitemtype = /obj/item/weapon/mine/training
 
 /obj/effect/mine/training/explode(var/mob/living/M)
@@ -170,56 +169,62 @@
 		qdel(src)
 
 /obj/effect/mine/emp
-	name = "EMP Mine"
-	desc = "A small explosive mine with a lightning bolt symbol on the side."
 	mineitemtype = /obj/item/weapon/mine/emp
 
 /obj/effect/mine/emp/explode(var/mob/living/M)
 	var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread()
 	s.set_up(3, 1, src)
 	s.start()
+	visible_message("\The [src.name] flashes violently before disintigrating!")
 	empulse(loc, 2, 4, 7, 10, 1) // As strong as an EMP grenade
 	spawn(0)
 		qdel(src)
 
+/obj/effect/mine/incendiary
+	mineitemtype = /obj/item/weapon/mine/incendiary
+
+/obj/effect/mine/incendiary/explode(var/mob/living/M)
+	triggered = 1
+	var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread()
+	s.set_up(3, 1, src)
+	s.start()
+	if(M)
+		M.adjust_fire_stacks(5)
+		M.fire_act()
+	visible_message("\The [src.name] bursts into flame!")
+	spawn(0)
+		qdel(src)
+
+/////////////////////////////////////////////
+// The held item version of the above mines
+/////////////////////////////////////////////
 /obj/item/weapon/mine
 	name = "mine"
 	desc = "A small explosive mine with 'HE' and a grenade symbol on the side."
 	icon = 'icons/obj/weapons.dmi'
 	icon_state = "uglymine"
-	var/arming = 0
 	var/countdown = 10
-	var/minetype = /obj/effect/mine
+	var/minetype = /obj/effect/mine		//This MUST be an /obj/effect/mine type, or it'll runtime.
 
-/obj/item/weapon/mine/attack_self(mob/user as mob)
-	if(!arming)
-		to_chat(user, "<span class='warning'>You prime \the [name]! [countdown] seconds!</span>")
-		icon_state = initial(icon_state) + "armed"
-		arming = 1
+/obj/item/weapon/mine/attack_self(mob/user as mob)	// You do not want to move or throw a land mine while priming it... Explosives + Sudden Movement = Bad Times
+	add_fingerprint(user)
+	msg_admin_attack("[user.name] ([user.ckey]) primed \a [src] (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[user.x];Y=[user.y];Z=[user.z]'>JMP</a>)")
+	user.visible_message("[user] starts priming \the [src.name].", "You start priming \the [src.name]. Hold still!")
+	if(do_after(user, 10 SECONDS))
 		playsound(loc, 'sound/weapons/armbomb.ogg', 75, 1, -3)
-		add_fingerprint(user)
-		if(iscarbon(user))
-			var/mob/living/carbon/C = user
-			C.throw_mode_on()
-		spawn(countdown*10)
-			if(arming)
-				prime()
-				if(user)
-					msg_admin_attack("[user.name] ([user.ckey]) primed \a [src] (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[user.x];Y=[user.y];Z=[user.z]'>JMP</a>)")
-				return
+		prime(user)
 	else
-		to_chat(user, "You cancel \the [name]'s priming sequence.")
-		arming = 0
-		countdown = initial(countdown)
-		icon_state = initial(icon_state)
-		add_fingerprint(user)
+		visible_message("[user] triggers \the [src.name]!", "You accidentally trigger \the [src.name]!")
+		prime(user, TRUE)
 	return
 
-/obj/item/weapon/mine/proc/prime(mob/user as mob)
+/obj/item/weapon/mine/proc/prime(mob/user as mob, var/explode_now = FALSE)
 	visible_message("\The [src.name] beeps as the priming sequence completes.")
-	var/atom/R = new minetype(get_turf(src))
+	var/obj/effect/mine/R = new minetype(get_turf(src))
 	src.transfer_fingerprints_to(R)
 	R.add_fingerprint(user)
+	if(explode_now)
+		R.explode(user)
 	spawn(0)
 		qdel(src)
 
@@ -262,3 +267,8 @@
 	name = "emp mine"
 	desc = "A small explosive mine with a lightning bolt symbol on the side."
 	minetype = /obj/effect/mine/emp
+
+/obj/item/weapon/mine/incendiary
+	name = "incendiary mine"
+	desc = "A small explosive mine with a fire symbol on the side."
+	minetype = /obj/effect/mine/incendiary

--- a/code/game/objects/effects/mines.dm
+++ b/code/game/objects/effects/mines.dm
@@ -1,6 +1,6 @@
 /obj/effect/mine
-	name = "land mine"	//The name and description are deliberately NOT modified, so you can't game the landmines you find.
-	desc = "A small explosive landmine."
+	name = "land mine"	//The name and description are deliberately NOT modified, so you can't game the mines you find.
+	desc = "A small explosive land mine."
 	density = 0
 	anchored = 1
 	icon = 'icons/obj/weapons.dmi'
@@ -76,7 +76,7 @@
 		M.radiation += 50
 		randmutb(M)
 		domutcheck(M,null)
-	visible_message("\The [src.name] flashes violently before disintigrating!")
+	visible_message("\The [src.name] flashes violently before disintegrating!")
 	spawn(0)
 		qdel(s)
 		qdel(src)
@@ -91,7 +91,7 @@
 	s.start()
 	if(M)
 		M.Stun(30)
-	visible_message("\The [src.name] flashes violently before disintigrating!")
+	visible_message("\The [src.name] flashes violently before disintegrating!")
 	spawn(0)
 		qdel(s)
 		qdel(src)
@@ -175,7 +175,7 @@
 	var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread()
 	s.set_up(3, 1, src)
 	s.start()
-	visible_message("\The [src.name] flashes violently before disintigrating!")
+	visible_message("\The [src.name] flashes violently before disintegrating!")
 	empulse(loc, 2, 4, 7, 10, 1) // As strong as an EMP grenade
 	spawn(0)
 		qdel(src)
@@ -191,7 +191,7 @@
 	if(M)
 		M.adjust_fire_stacks(5)
 		M.fire_act()
-	visible_message("\The [src.name] bursts into flame!")
+	visible_message("\The [src.name] bursts into flames!")
 	spawn(0)
 		qdel(src)
 

--- a/code/game/objects/random/random.dm
+++ b/code/game/objects/random/random.dm
@@ -1126,8 +1126,8 @@ var/list/multi_point_spawns
 		)
 
 /obj/random/landmine
-	name = "Random Landmine"
-	desc = "This is a random landmine."
+	name = "Random Land Mine"
+	desc = "This is a random land mine."
 	icon = 'icons/obj/weapons.dmi'
 	icon_state = "uglymine"
 	spawn_nothing_percentage = 25

--- a/code/game/objects/random/random.dm
+++ b/code/game/objects/random/random.dm
@@ -1124,3 +1124,17 @@ var/list/multi_point_spawns
 				/obj/item/clothing/head/helmet/space/void/mining/alt
 			)
 		)
+
+/obj/random/landmine
+	name = "Random Landmine"
+	desc = "This is a random landmine."
+	icon = 'icons/obj/weapons.dmi'
+	icon_state = "uglymine"
+	spawn_nothing_percentage = 25
+
+/obj/random/landmine/item_to_spawn()
+	return pick(prob(30);/obj/effect/mine,
+				prob(25);/obj/effect/mine/frag,
+				prob(25);/obj/effect/mine/emp,
+				prob(10);/obj/effect/mine/stun,
+				prob(10);/obj/effect/mine/incendiary,)

--- a/code/modules/mob/living/simple_animal/aliens/drone.dm
+++ b/code/modules/mob/living/simple_animal/aliens/drone.dm
@@ -25,6 +25,7 @@
 	projectiletype = /obj/item/projectile/beam/drone
 	projectilesound = 'sound/weapons/laser3.ogg'
 	destroy_surroundings = 0
+	hovering = TRUE
 
 	//Drones aren't affected by atmos.
 	min_oxy = 0

--- a/code/modules/mob/living/simple_animal/animals/carp.dm
+++ b/code/modules/mob/living/simple_animal/animals/carp.dm
@@ -8,6 +8,7 @@
 
 	faction = "carp"
 	intelligence_level = SA_ANIMAL
+	hovering = TRUE
 	maxHealth = 25
 	health = 25
 	speed = 4

--- a/code/modules/mob/living/simple_animal/constructs/constructs.dm
+++ b/code/modules/mob/living/simple_animal/constructs/constructs.dm
@@ -8,6 +8,7 @@
 	response_disarm = "flailed at"
 	response_harm   = "punched"
 	intelligence_level = SA_HUMANOID // Player controlled.
+	hovering = TRUE
 	icon_dead = "shade_dead"
 	speed = -1
 	a_intent = I_HURT

--- a/code/modules/mob/living/simple_animal/humanoids/syndicate.dm
+++ b/code/modules/mob/living/simple_animal/humanoids/syndicate.dm
@@ -167,6 +167,7 @@
 	icon_state = "viscerator_attack"
 	icon_living = "viscerator_attack"
 	intelligence_level = SA_ROBOTIC
+	hovering = TRUE
 
 	faction = "syndicate"
 	maxHealth = 15

--- a/html/changelogs/Anewbe - Mines.yml
+++ b/html/changelogs/Anewbe - Mines.yml
@@ -1,0 +1,40 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Anewbe
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Added a random mine spawner, for use in PoIs. Replaces mines in PoIs with the random spawner."
+  - rscadd: "Mines now give a visible message when they go off."
+  - tweak: "Land mines on the ground can no longer be told apart from one another, to prevent gaming the system."
+  - bugfix: "Hovering mobs (viscerators, drones, Poly, carp) no longer set off land mines."
+  - tweak: "Arming a land mine now takes concentration. If you move, it will boom."

--- a/maps/submaps/surface_submaps/wilderness/CaveS.dmm
+++ b/maps/submaps/surface_submaps/wilderness/CaveS.dmm
@@ -3,35 +3,39 @@
 "c" = (/obj/item/ammo_casing/a45,/turf/template_noop,/area/submap/CaveS)
 "d" = (/turf/simulated/mineral/ignore_mapgen,/area/submap/CaveS)
 "e" = (/obj/item/ammo_casing/a45,/obj/item/weapon/reagent_containers/food/snacks/xenomeat/spidermeat,/turf/template_noop,/area/submap/CaveS)
-"f" = (/turf/simulated/floor/outdoors/dirt,/area/submap/CaveS)
-"g" = (/obj/effect/spider/stickyweb,/turf/simulated/floor/outdoors/dirt,/area/submap/CaveS)
-"h" = (/obj/item/ammo_casing/a45,/obj/item/ammo_casing/a45,/turf/template_noop,/area/submap/CaveS)
-"i" = (/obj/item/weapon/reagent_containers/food/snacks/xenomeat/spidermeat,/turf/template_noop,/area/submap/CaveS)
-"j" = (/obj/item/clothing/accessory/storage/webbing,/obj/item/weapon/material/knife/tacknife/combatknife,/turf/simulated/floor/outdoors/dirt,/area/submap/CaveS)
-"k" = (/mob/living/simple_animal/hostile/giant_spider,/turf/simulated/floor/outdoors/dirt,/area/submap/CaveS)
-"l" = (/obj/effect/decal/cleanable/cobweb,/turf/simulated/floor/outdoors/dirt,/area/submap/CaveS)
-"m" = (/mob/living/simple_animal/hostile/giant_spider/lurker,/turf/simulated/floor/outdoors/dirt,/area/submap/CaveS)
-"n" = (/obj/effect/decal/cleanable/cobweb2,/turf/simulated/floor/outdoors/dirt,/area/submap/CaveS)
-"o" = (/obj/effect/mine,/turf/simulated/floor/outdoors/dirt,/area/submap/CaveS)
-"p" = (/mob/living/simple_animal/hostile/giant_spider/webslinger,/turf/simulated/floor/outdoors/dirt,/area/submap/CaveS)
-"q" = (/obj/effect/decal/cleanable/cobweb2,/mob/living/simple_animal/hostile/giant_spider/lurker,/turf/simulated/floor/outdoors/dirt,/area/submap/CaveS)
-"r" = (/turf/simulated/floor/outdoors/grass/sif/forest,/area/submap/CaveS)
-"s" = (/mob/living/simple_animal/hostile/giant_spider/hunter,/turf/simulated/floor/outdoors/dirt,/area/submap/CaveS)
-"t" = (/obj/structure/flora/tree/sif,/turf/simulated/floor/outdoors/grass/sif/forest,/area/submap/CaveS)
-"u" = (/turf/simulated/floor,/area/submap/CaveS)
-"v" = (/obj/structure/closet/crate,/obj/item/stack/cable_coil,/obj/item/stack/cable_coil,/obj/item/weapon/storage/toolbox,/obj/random/toolbox,/turf/simulated/floor,/area/submap/CaveS)
-"w" = (/obj/structure/loot_pile/maint/technical,/turf/simulated/floor,/area/submap/CaveS)
-"x" = (/obj/structure/table/woodentable,/turf/simulated/floor,/area/submap/CaveS)
-"y" = (/obj/machinery/power/port_gen/pacman,/obj/structure/cable{icon_state = "0-2"; d2 = 2},/turf/simulated/floor,/area/submap/CaveS)
-"z" = (/turf/simulated/wall,/area/submap/CaveS)
-"A" = (/obj/structure/closet/crate,/obj/item/weapon/reagent_containers/hypospray,/obj/item/weapon/reagent_containers/glass/bottle/stoxin,/obj/item/weapon/reagent_containers/glass/bottle/antitoxin,/obj/item/weapon/reagent_containers/pill/antitox,/obj/item/weapon/reagent_containers/pill/antitox,/obj/item/weapon/reagent_containers/pill/antitox,/obj/item/weapon/reagent_containers/pill/paracetamol,/obj/random/firstaid,/turf/simulated/floor,/area/submap/CaveS)
-"B" = (/obj/structure/cable{d1 = 1; d2 = 2; icon_state = "1-2"; pixel_y = 0},/turf/simulated/floor,/area/submap/CaveS)
-"C" = (/obj/structure/closet/crate,/obj/random/contraband,/obj/random/contraband,/obj/random/contraband,/obj/random/energy,/obj/item/weapon/material/star,/obj/item/weapon/material/star,/obj/item/weapon/material/star,/obj/item/weapon/material/star,/obj/item/weapon/material/star,/turf/simulated/floor,/area/submap/CaveS)
-"D" = (/obj/effect/spider/stickyweb,/mob/living/simple_animal/hostile/giant_spider/lurker,/turf/simulated/floor/outdoors/dirt,/area/submap/CaveS)
-"E" = (/obj/structure/cable{d1 = 1; d2 = 4; icon_state = "1-4"},/turf/simulated/floor,/area/submap/CaveS)
-"F" = (/obj/structure/cable{d1 = 4; d2 = 8; icon_state = "4-8"; pixel_x = 0},/turf/simulated/floor,/area/submap/CaveS)
-"G" = (/obj/machinery/computer/communications,/obj/structure/cable{d2 = 8; icon_state = "0-8"},/turf/simulated/floor,/area/submap/CaveS)
-"H" = (/obj/structure/loot_pile/maint/boxfort,/turf/simulated/floor,/area/submap/CaveS)
+"f" = (/obj/random/landmine,/turf/template_noop,/area/submap/CaveS)
+"g" = (/obj/item/ammo_casing/a45,/obj/random/landmine,/turf/template_noop,/area/submap/CaveS)
+"h" = (/obj/random/landmine,/turf/simulated/floor/outdoors/dirt,/area/submap/CaveS)
+"i" = (/obj/effect/spider/stickyweb,/turf/simulated/floor/outdoors/dirt,/area/submap/CaveS)
+"j" = (/obj/item/ammo_casing/a45,/obj/item/ammo_casing/a45,/turf/template_noop,/area/submap/CaveS)
+"k" = (/turf/simulated/floor/outdoors/dirt,/area/submap/CaveS)
+"l" = (/obj/item/weapon/reagent_containers/food/snacks/xenomeat/spidermeat,/turf/template_noop,/area/submap/CaveS)
+"m" = (/obj/item/clothing/accessory/storage/webbing,/obj/item/weapon/material/knife/tacknife/combatknife,/turf/simulated/floor/outdoors/dirt,/area/submap/CaveS)
+"n" = (/mob/living/simple_animal/hostile/giant_spider,/turf/simulated/floor/outdoors/dirt,/area/submap/CaveS)
+"o" = (/obj/effect/decal/cleanable/cobweb,/turf/simulated/floor/outdoors/dirt,/area/submap/CaveS)
+"p" = (/mob/living/simple_animal/hostile/giant_spider/lurker,/turf/simulated/floor/outdoors/dirt,/area/submap/CaveS)
+"q" = (/obj/effect/decal/cleanable/cobweb2,/turf/simulated/floor/outdoors/dirt,/area/submap/CaveS)
+"r" = (/mob/living/simple_animal/hostile/giant_spider/webslinger,/turf/simulated/floor/outdoors/dirt,/area/submap/CaveS)
+"s" = (/obj/effect/decal/cleanable/cobweb2,/mob/living/simple_animal/hostile/giant_spider/lurker,/turf/simulated/floor/outdoors/dirt,/area/submap/CaveS)
+"t" = (/turf/simulated/floor/outdoors/grass/sif/forest,/area/submap/CaveS)
+"u" = (/mob/living/simple_animal/hostile/giant_spider/hunter,/turf/simulated/floor/outdoors/dirt,/area/submap/CaveS)
+"v" = (/obj/structure/flora/tree/sif,/turf/simulated/floor/outdoors/grass/sif/forest,/area/submap/CaveS)
+"w" = (/obj/random/landmine,/turf/simulated/floor/outdoors/grass/sif/forest,/area/submap/CaveS)
+"x" = (/turf/simulated/floor,/area/submap/CaveS)
+"y" = (/obj/structure/closet/crate,/obj/item/stack/cable_coil,/obj/item/stack/cable_coil,/obj/item/weapon/storage/toolbox,/obj/random/toolbox,/turf/simulated/floor,/area/submap/CaveS)
+"z" = (/obj/structure/loot_pile/maint/technical,/turf/simulated/floor,/area/submap/CaveS)
+"A" = (/obj/structure/table/woodentable,/turf/simulated/floor,/area/submap/CaveS)
+"B" = (/obj/random/landmine,/turf/simulated/floor,/area/submap/CaveS)
+"C" = (/obj/machinery/power/port_gen/pacman,/obj/structure/cable{icon_state = "0-2"; d2 = 2},/turf/simulated/floor,/area/submap/CaveS)
+"D" = (/turf/simulated/wall,/area/submap/CaveS)
+"E" = (/obj/structure/closet/crate,/obj/item/weapon/reagent_containers/hypospray,/obj/item/weapon/reagent_containers/glass/bottle/stoxin,/obj/item/weapon/reagent_containers/glass/bottle/antitoxin,/obj/item/weapon/reagent_containers/pill/antitox,/obj/item/weapon/reagent_containers/pill/antitox,/obj/item/weapon/reagent_containers/pill/antitox,/obj/item/weapon/reagent_containers/pill/paracetamol,/obj/random/firstaid,/obj/random/landmine,/turf/simulated/floor,/area/submap/CaveS)
+"F" = (/obj/structure/cable{d1 = 1; d2 = 2; icon_state = "1-2"; pixel_y = 0},/turf/simulated/floor,/area/submap/CaveS)
+"G" = (/obj/structure/closet/crate,/obj/random/contraband,/obj/random/contraband,/obj/random/contraband,/obj/random/energy,/obj/item/weapon/material/star,/obj/item/weapon/material/star,/obj/item/weapon/material/star,/obj/item/weapon/material/star,/obj/item/weapon/material/star,/turf/simulated/floor,/area/submap/CaveS)
+"H" = (/obj/effect/spider/stickyweb,/mob/living/simple_animal/hostile/giant_spider/lurker,/turf/simulated/floor/outdoors/dirt,/area/submap/CaveS)
+"I" = (/obj/structure/cable{d1 = 1; d2 = 4; icon_state = "1-4"},/turf/simulated/floor,/area/submap/CaveS)
+"J" = (/obj/structure/cable{d1 = 4; d2 = 8; icon_state = "4-8"; pixel_x = 0},/turf/simulated/floor,/area/submap/CaveS)
+"K" = (/obj/machinery/computer/communications,/obj/structure/cable{d2 = 8; icon_state = "0-8"},/turf/simulated/floor,/area/submap/CaveS)
+"L" = (/obj/structure/loot_pile/maint/boxfort,/turf/simulated/floor,/area/submap/CaveS)
 
 (1,1,1) = {"
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
@@ -42,34 +46,34 @@ abbbbbbbbbbbbbbbbbbbbbcbbbbbbbbbbbbbbbba
 abbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbba
 abbbbbbbbbbbbbbbcbbbbbbcccdddddbbbbbbbba
 abbbbbbbbbbbbbbbbbbbbbbbeddddddddbbddbba
-abbbbbbbbbbbbbbbbbbbbbbbdddddddddddddbba
-abbbbdddddbbbbcbbbbcbbbfgddddddddddddbba
-abbbbddddddddbbbbbhbbbbffddddddddddddbba
-abbbddddddddddbbbbcbibdgfggdddddddddbbba
-abbbdddddddddddbbbbbbdddgfffdddddddbbbba
-abbbddddddddddddbbbbddddddffgddddddbbbba
-abbdddddjdffgdddbbddddddddffffffddddbbba
-abbdddkffffffdddbbdddddddlffffffkdddbbba
-abbdddgfffffmddbbddddddddfffffffdddddbba
-abbddddfffffdddbdddddddddffddddfnddddbba
-abdddddddffffddddddddddddofddddffdddddba
-abdddddddffffndddddlfkffffddddlfddddddba
-abddddddddffffffffffffffffddddofddddddda
-abdddddddddpfffffffffffffffqddffddddddda
-abdddddrrdddddffdddmdddddgffffffddddddba
-abdddrrrrdddddffddddddddddofffsddddddbba
-abddrtrrrdddddffmdddddddddddddddddddbbba
-abddrrrrrrdddddfffffddddddddmfddddddbbba
-abdddrrrtrgddddfffofffogdddfffffdddbbbba
-abdddrrrrrfffffffdfffffgddffuuvfffddbbba
-abddrrrrrrrffffgdddgffffffffuuuwfdddbbba
-abddrrrrrrffddddddddfofffffuxxuuffddbbba
-abdddrrrrrffmddddddfffgdffuyzzAfffdddbba
-abdddddtrffddddddgffffddffuBzzCffddddbba
-abdddddddrgddddddDffffddffuEFGuuddddbbba
-abbddddddddddddddfffffdddffuuuudddddbbba
-abbdddddddddddddddfgdddddfffuHdddddbbbba
-abbdddddddddddddddddddddddmffddddbbbbbba
+abbbbbbbbbbbbbbbbbbbbbfbdddddddddddddbba
+abbbbdddddbbbbcbbbbgbbbhiddddddddddddbba
+abbbbddddddddbbbbbjbbfbkkddddddddddddbba
+abbbddddddddddbbbbcblbdikiidddddddddbbba
+abbbdddddddddddbbbbbbdddikkkdddddddbbbba
+abbbddddddddddddbbbbddddddhkiddddddbbbba
+abbdddddmdkkidddbbddddddddkkkkkkddddbbba
+abbdddnkkkkkkdddbbdddddddokkkkkkndddbbba
+abbdddikkkkkpddbbddddddddkkkkkkkdddddbba
+abbddddkkkkkdddbdddddddddkkddddkqddddbba
+abdddddddkkkkddddddddddddhkddddkkdddddba
+abdddddddkkkkqdddddoknkkkkddddokddddddba
+abddddddddkkkkkkkkkkkkkkkkddddhkddddddda
+abdddddddddrkkkkkkkkkkkkkkksddkkddddddda
+abdddddttdddddkkdddpdddddikkkkkkddddddba
+abdddttttdddddkkddddddddddkkkkuddddddbba
+abddtvtttdddddkkpdddddddddddddddddddbbba
+abddttwtttdddddkkkkkddddddddpkddddddbbba
+abdddtttvtiddddkkkkkkkhidddkkkkkdddbbbba
+abdddtttwtkkkkkkkdkkkkkiddkkxxykkkddbbba
+abddtttttttkkkkidddikkkhkkkkxxxzkdddbbba
+abddttttttkkddddddddkhkkkkkxAABxkkddbbba
+abdddtttttkkpddddddkkkidkkxCDDEkkkdddbba
+abdddddvtkkddddddikkkkddkkxFDDGkkddddbba
+abdddddddtiddddddHkkkkddkkxIJKBxddddbbba
+abbddddddddddddddkkkkkdddkkxxxxdddddbbba
+abbdddddddddddddddkidddddkkkxLdddddbbbba
+abbdddddddddddddddddddddddpkkddddbbbbbba
 abbbdddddddddddddddddddddddddddbbbbbbbba
 abbbddddbbbbdddddddbbdddddddddbbbbbbbbba
 abbbddbbbbbbbddddbbbbdbbdddddbbbbbbbbbba

--- a/maps/submaps/surface_submaps/wilderness/DoomP.dmm
+++ b/maps/submaps/surface_submaps/wilderness/DoomP.dmm
@@ -5,126 +5,129 @@
 "ae" = (/mob/living/simple_animal/hostile/viscerator{returns_home = 1},/turf/template_noop,/area/submap/DoomP)
 "af" = (/turf/simulated/floor/water,/area/submap/DoomP)
 "ag" = (/obj/structure/flora/tree/sif,/turf/template_noop,/area/submap/DoomP)
-"ah" = (/obj/effect/mine,/turf/simulated/floor/outdoors/grass/sif/forest,/area/submap/DoomP)
+"ah" = (/obj/random/landmine,/turf/simulated/floor/outdoors/grass/sif/forest,/area/submap/DoomP)
 "ai" = (/mob/living/simple_animal/hostile/viscerator{returns_home = 1},/turf/simulated/floor/outdoors/grass/sif/forest,/area/submap/DoomP)
-"aj" = (/obj/effect/decal/cleanable/blood,/turf/simulated/floor/outdoors/grass/sif/forest,/area/submap/DoomP)
+"aj" = (/obj/effect/decal/cleanable/blood,/obj/random/landmine,/turf/simulated/floor/outdoors/grass/sif/forest,/area/submap/DoomP)
 "ak" = (/turf/simulated/floor/water/deep,/area/submap/DoomP)
-"al" = (/obj/effect/decal/remains/mouse,/turf/simulated/floor/outdoors/grass/sif/forest,/area/submap/DoomP)
-"am" = (/obj/effect/decal/remains/deer,/turf/simulated/floor/outdoors/grass/sif/forest,/area/submap/DoomP)
-"an" = (/obj/structure/flora/tree/sif,/turf/simulated/floor/outdoors/grass/sif/forest,/area/submap/DoomP)
-"ao" = (/obj/machinery/light/small,/turf/simulated/floor/outdoors/grass/sif/forest,/area/submap/DoomP)
-"ap" = (/obj/machinery/porta_turret,/turf/simulated/floor/plating,/area/submap/DoomP)
-"aq" = (/turf/simulated/wall/r_wall,/area/submap/DoomP)
-"ar" = (/obj/structure/sign/warning/secure_area,/turf/simulated/wall/r_wall,/area/submap/DoomP)
-"as" = (/obj/effect/floor_decal/industrial/warning,/turf/simulated/floor/plating,/area/submap/DoomP)
-"at" = (/obj/machinery/door/airlock/external,/turf/simulated/floor/plating,/area/submap/DoomP)
-"au" = (/obj/effect/floor_decal/borderfloor{dir = 9},/turf/simulated/floor/tiled,/area/submap/DoomP)
-"av" = (/obj/structure/bed/chair,/obj/effect/floor_decal/borderfloor{dir = 1},/turf/simulated/floor/tiled,/area/submap/DoomP)
-"aw" = (/obj/effect/floor_decal/borderfloor{dir = 1},/turf/simulated/floor/tiled,/area/submap/DoomP)
-"ax" = (/obj/structure/bed/chair,/obj/effect/floor_decal/borderfloor{dir = 1},/mob/living/simple_animal/hostile/syndicate/ranged{desc = "Even less friendly than he looks."; speak = list("Wish I had better equipment...","I knew I should have been a line chef...","Fuckin' helmet keeps fogging up.","Anyone else smell that?")},/turf/simulated/floor/tiled,/area/submap/DoomP)
-"ay" = (/obj/machinery/light/small{dir = 1},/obj/effect/floor_decal/borderfloor{dir = 1},/turf/simulated/floor/tiled,/area/submap/DoomP)
-"az" = (/obj/machinery/vending/cigarette,/obj/effect/floor_decal/borderfloor{dir = 5},/turf/simulated/floor/tiled,/area/submap/DoomP)
-"aA" = (/obj/machinery/light/small{dir = 8},/turf/simulated/floor/tiled,/area/submap/DoomP)
-"aB" = (/obj/machinery/power/smes/buildable/point_of_interest,/obj/structure/cable/green{d2 = 4; icon_state = "0-4"},/turf/simulated/floor/plating,/area/submap/DoomP)
-"aC" = (/obj/machinery/power/smes/buildable/point_of_interest,/obj/structure/cable/green{d2 = 4; icon_state = "0-4"},/obj/structure/cable/green{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor/plating,/area/submap/DoomP)
-"aD" = (/obj/machinery/power/apc{dir = 1; name = "PAPC"; pixel_x = 0; pixel_y = 24},/obj/structure/cable/green{d2 = 8; icon_state = "0-8"},/turf/simulated/floor/tiled/techfloor/grid,/area/submap/DoomP)
-"aE" = (/obj/structure/cable{icon_state = "0-2"; d2 = 2},/obj/machinery/power/port_gen/pacman,/turf/simulated/floor/plating,/area/submap/DoomP)
-"aF" = (/obj/structure/table/standard,/obj/random/toolbox,/turf/simulated/floor/tiled/techfloor/grid,/area/submap/DoomP)
-"aG" = (/obj/structure/table/standard,/obj/item/stack/material/phoron{amount = 25},/turf/simulated/floor/tiled/techfloor/grid,/area/submap/DoomP)
-"aH" = (/obj/structure/closet/secure_closet/engineering_electrical,/turf/simulated/floor/tiled/techfloor/grid,/area/submap/DoomP)
-"aI" = (/obj/structure/lattice,/turf/simulated/floor/outdoors/rocks,/area/submap/DoomP)
-"aJ" = (/obj/structure/bed/chair{dir = 4},/obj/effect/floor_decal/borderfloor{dir = 8},/mob/living/simple_animal/hostile/syndicate/ranged{desc = "Even less friendly than he looks."; speak = list("Wish I had better equipment...","I knew I should have been a line chef...","Fuckin' helmet keeps fogging up.","Anyone else smell that?")},/turf/simulated/floor/tiled,/area/submap/DoomP)
-"aK" = (/obj/structure/table/standard,/turf/simulated/floor/tiled,/area/submap/DoomP)
-"aL" = (/obj/structure/table/standard,/obj/item/pizzabox,/turf/simulated/floor/tiled,/area/submap/DoomP)
-"aM" = (/turf/simulated/floor/tiled,/area/submap/DoomP)
-"aN" = (/obj/machinery/vending/snack,/obj/effect/floor_decal/borderfloor{dir = 4},/turf/simulated/floor/tiled,/area/submap/DoomP)
-"aO" = (/obj/machinery/power/terminal{icon_state = "term"; dir = 1},/obj/structure/cable{icon_state = "0-4"; d2 = 4},/turf/simulated/floor/tiled/techfloor/grid,/area/submap/DoomP)
-"aP" = (/obj/machinery/power/terminal{icon_state = "term"; dir = 1},/obj/structure/cable{icon_state = "0-4"; d2 = 4},/obj/structure/cable{d1 = 4; d2 = 8; icon_state = "4-8"; pixel_x = 0},/turf/simulated/floor/tiled/techfloor/grid,/area/submap/DoomP)
-"aQ" = (/obj/structure/cable{d1 = 4; d2 = 8; icon_state = "4-8"; pixel_x = 0},/turf/simulated/floor/tiled/techfloor/grid,/area/submap/DoomP)
-"aR" = (/obj/structure/cable{d1 = 1; d2 = 8; icon_state = "1-8"},/turf/simulated/floor/tiled/techfloor/grid,/area/submap/DoomP)
-"aS" = (/turf/simulated/floor/tiled/techfloor/grid,/area/submap/DoomP)
-"aT" = (/obj/machinery/light/small,/turf/simulated/floor/tiled/techfloor/grid,/area/submap/DoomP)
-"aU" = (/obj/structure/lattice,/turf/simulated/floor/water,/area/submap/DoomP)
-"aV" = (/obj/machinery/light/small{dir = 8},/obj/effect/floor_decal/borderfloor{dir = 8},/turf/simulated/floor/tiled,/area/submap/DoomP)
-"aW" = (/obj/machinery/vending/cola,/obj/effect/floor_decal/borderfloor/corner{dir = 4},/turf/simulated/floor/tiled,/area/submap/DoomP)
-"aX" = (/obj/machinery/door/airlock/external,/turf/simulated/floor/tiled,/area/submap/DoomP)
-"aY" = (/obj/machinery/door/airlock/engineering,/turf/simulated/floor/tiled/techfloor/grid,/area/submap/DoomP)
-"aZ" = (/obj/structure/sign/electricshock,/turf/simulated/wall/r_wall,/area/submap/DoomP)
-"ba" = (/obj/effect/floor_decal/borderfloor{dir = 10},/turf/simulated/floor/tiled,/area/submap/DoomP)
-"bb" = (/obj/effect/floor_decal/borderfloor,/turf/simulated/floor/tiled,/area/submap/DoomP)
-"bc" = (/obj/machinery/light/small,/obj/effect/floor_decal/borderfloor,/turf/simulated/floor/tiled,/area/submap/DoomP)
-"bd" = (/obj/effect/floor_decal/borderfloor/corner{dir = 8},/turf/simulated/floor/tiled,/area/submap/DoomP)
-"be" = (/obj/machinery/door/airlock/hatch,/turf/simulated/floor/tiled,/area/submap/DoomP)
-"bf" = (/obj/machinery/light/small{dir = 1},/turf/simulated/floor/tiled,/area/submap/DoomP)
-"bg" = (/obj/machinery/door/airlock/highsecurity,/turf/simulated/floor/tiled/techfloor,/area/submap/DoomP)
-"bh" = (/obj/machinery/door/airlock,/turf/simulated/floor/tiled/white,/area/submap/DoomP)
-"bi" = (/turf/simulated/floor/tiled/techfloor,/area/submap/DoomP)
-"bj" = (/obj/structure/table/standard,/turf/simulated/floor/tiled/techfloor,/area/submap/DoomP)
-"bk" = (/obj/structure/table/standard,/obj/item/weapon/storage/box/syndie_kit/spy,/turf/simulated/floor/tiled/techfloor,/area/submap/DoomP)
-"bl" = (/obj/structure/table/rack,/obj/item/weapon/storage/box/smokes,/turf/simulated/floor/tiled/techfloor,/area/submap/DoomP)
-"bm" = (/obj/structure/table/rack,/obj/item/weapon/storage/box/handcuffs,/turf/simulated/floor/tiled/techfloor,/area/submap/DoomP)
-"bn" = (/obj/structure/table/rack,/obj/item/weapon/cell/device/weapon,/obj/item/weapon/cell/device/weapon,/obj/item/weapon/cell/device/weapon,/obj/item/weapon/cell/device/weapon,/obj/item/weapon/cell/device/weapon,/turf/simulated/floor/tiled/techfloor,/area/submap/DoomP)
-"bo" = (/obj/structure/table/rack,/obj/item/weapon/gun/energy/laser/mounted,/turf/simulated/floor/tiled/techfloor,/area/submap/DoomP)
-"bp" = (/obj/structure/table/rack,/obj/item/weapon/gun/projectile/contender,/obj/item/ammo_magazine/s357,/obj/item/ammo_magazine/s357,/obj/item/ammo_magazine/s357,/turf/simulated/floor/tiled/techfloor,/area/submap/DoomP)
-"bq" = (/obj/structure/bed,/obj/item/weapon/bedsheet,/obj/item/toy/plushie/spider,/obj/effect/floor_decal/corner/lime/full{dir = 8},/turf/simulated/floor/tiled/white,/area/submap/DoomP)
-"br" = (/obj/structure/table/standard,/obj/effect/floor_decal/corner/lime{dir = 5},/turf/simulated/floor/tiled/white,/area/submap/DoomP)
-"bs" = (/obj/structure/bed,/obj/item/weapon/bedsheet,/obj/effect/floor_decal/corner/lime{dir = 5},/turf/simulated/floor/tiled/white,/area/submap/DoomP)
-"bt" = (/obj/structure/table/standard,/obj/item/device/flashlight/lamp,/obj/effect/floor_decal/corner/lime{dir = 5},/turf/simulated/floor/tiled/white,/area/submap/DoomP)
-"bu" = (/obj/structure/table/standard,/obj/structure/bedsheetbin,/obj/effect/floor_decal/corner/lime{dir = 1},/turf/simulated/floor/tiled/white,/area/submap/DoomP)
-"bv" = (/turf/simulated/floor/tiled/white,/area/submap/DoomP)
-"bw" = (/obj/machinery/light/small{dir = 1},/turf/simulated/floor/tiled/white,/area/submap/DoomP)
-"bx" = (/obj/structure/sink{dir = 4; icon_state = "sink"; pixel_x = 11; pixel_y = 0},/obj/machinery/light/small{dir = 1},/turf/simulated/floor/tiled/white,/area/submap/DoomP)
-"by" = (/obj/machinery/light/small,/turf/simulated/floor/tiled/techfloor,/area/submap/DoomP)
-"bz" = (/obj/machinery/light/small{dir = 8},/obj/effect/floor_decal/corner/lime/full,/turf/simulated/floor/tiled/white,/area/submap/DoomP)
-"bA" = (/obj/effect/floor_decal/corner/lime{dir = 10},/turf/simulated/floor/tiled/white,/area/submap/DoomP)
-"bB" = (/obj/machinery/light/small{dir = 4; pixel_y = 0},/obj/effect/floor_decal/corner/lime{dir = 10},/turf/simulated/floor/tiled/white,/area/submap/DoomP)
-"bC" = (/obj/machinery/shower{dir = 1},/obj/structure/curtain/open/shower,/turf/simulated/floor/tiled/white,/area/submap/DoomP)
-"bD" = (/obj/structure/toilet{dir = 1},/turf/simulated/floor/tiled/white,/area/submap/DoomP)
-"bE" = (/obj/structure/grille,/obj/structure/window/reinforced{dir = 1},/obj/structure/window/reinforced,/obj/machinery/door/firedoor/border_only,/obj/structure/window/reinforced{dir = 8},/turf/simulated/floor/plating,/area/submap/DoomP)
-"bF" = (/obj/structure/grille,/obj/structure/window/reinforced{dir = 1},/obj/structure/window/reinforced,/obj/machinery/door/firedoor/border_only,/turf/simulated/floor/plating,/area/submap/DoomP)
-"bG" = (/obj/structure/grille,/obj/structure/window/reinforced{dir = 1},/obj/structure/window/reinforced,/obj/structure/window/reinforced{dir = 4},/obj/machinery/door/firedoor/border_only,/turf/simulated/floor/plating,/area/submap/DoomP)
-"bH" = (/obj/structure/lattice,/turf/simulated/floor/outdoors/grass/sif/forest,/area/submap/DoomP)
+"al" = (/obj/effect/decal/cleanable/blood,/turf/simulated/floor/outdoors/grass/sif/forest,/area/submap/DoomP)
+"am" = (/obj/random/landmine,/turf/simulated/floor/outdoors/rocks,/area/submap/DoomP)
+"an" = (/obj/effect/decal/remains/mouse,/turf/simulated/floor/outdoors/grass/sif/forest,/area/submap/DoomP)
+"ao" = (/obj/effect/decal/remains/deer,/turf/simulated/floor/outdoors/grass/sif/forest,/area/submap/DoomP)
+"ap" = (/obj/effect/decal/remains/mouse,/obj/random/landmine,/turf/simulated/floor/outdoors/grass/sif/forest,/area/submap/DoomP)
+"aq" = (/obj/structure/flora/tree/sif,/turf/simulated/floor/outdoors/grass/sif/forest,/area/submap/DoomP)
+"ar" = (/obj/machinery/light/small,/turf/simulated/floor/outdoors/grass/sif/forest,/area/submap/DoomP)
+"as" = (/obj/machinery/porta_turret,/turf/simulated/floor/plating,/area/submap/DoomP)
+"at" = (/turf/simulated/wall/r_wall,/area/submap/DoomP)
+"au" = (/obj/structure/sign/warning/secure_area,/turf/simulated/wall/r_wall,/area/submap/DoomP)
+"av" = (/obj/effect/floor_decal/industrial/warning,/turf/simulated/floor/plating,/area/submap/DoomP)
+"aw" = (/obj/machinery/door/airlock/external,/turf/simulated/floor/plating,/area/submap/DoomP)
+"ax" = (/obj/effect/floor_decal/borderfloor{dir = 9},/turf/simulated/floor/tiled,/area/submap/DoomP)
+"ay" = (/obj/structure/bed/chair,/obj/effect/floor_decal/borderfloor{dir = 1},/turf/simulated/floor/tiled,/area/submap/DoomP)
+"az" = (/obj/effect/floor_decal/borderfloor{dir = 1},/turf/simulated/floor/tiled,/area/submap/DoomP)
+"aA" = (/obj/structure/bed/chair,/obj/effect/floor_decal/borderfloor{dir = 1},/mob/living/simple_animal/hostile/syndicate/ranged{desc = "Even less friendly than he looks."; speak = list("Wish I had better equipment...","I knew I should have been a line chef...","Fuckin' helmet keeps fogging up.","Anyone else smell that?")},/turf/simulated/floor/tiled,/area/submap/DoomP)
+"aB" = (/obj/machinery/light/small{dir = 1},/obj/effect/floor_decal/borderfloor{dir = 1},/turf/simulated/floor/tiled,/area/submap/DoomP)
+"aC" = (/obj/machinery/vending/cigarette,/obj/effect/floor_decal/borderfloor{dir = 5},/turf/simulated/floor/tiled,/area/submap/DoomP)
+"aD" = (/obj/machinery/light/small{dir = 8},/turf/simulated/floor/tiled,/area/submap/DoomP)
+"aE" = (/obj/machinery/power/smes/buildable/point_of_interest,/obj/structure/cable/green{d2 = 4; icon_state = "0-4"},/turf/simulated/floor/plating,/area/submap/DoomP)
+"aF" = (/obj/machinery/power/smes/buildable/point_of_interest,/obj/structure/cable/green{d2 = 4; icon_state = "0-4"},/obj/structure/cable/green{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor/plating,/area/submap/DoomP)
+"aG" = (/obj/machinery/power/apc{dir = 1; name = "PAPC"; pixel_x = 0; pixel_y = 24},/obj/structure/cable/green{d2 = 8; icon_state = "0-8"},/turf/simulated/floor/tiled/techfloor/grid,/area/submap/DoomP)
+"aH" = (/obj/structure/cable{icon_state = "0-2"; d2 = 2},/obj/machinery/power/port_gen/pacman,/turf/simulated/floor/plating,/area/submap/DoomP)
+"aI" = (/obj/structure/table/standard,/obj/random/toolbox,/turf/simulated/floor/tiled/techfloor/grid,/area/submap/DoomP)
+"aJ" = (/obj/structure/table/standard,/obj/item/stack/material/phoron{amount = 25},/turf/simulated/floor/tiled/techfloor/grid,/area/submap/DoomP)
+"aK" = (/obj/structure/closet/secure_closet/engineering_electrical,/turf/simulated/floor/tiled/techfloor/grid,/area/submap/DoomP)
+"aL" = (/obj/structure/lattice,/turf/simulated/floor/outdoors/rocks,/area/submap/DoomP)
+"aM" = (/obj/structure/bed/chair{dir = 4},/obj/effect/floor_decal/borderfloor{dir = 8},/mob/living/simple_animal/hostile/syndicate/ranged{desc = "Even less friendly than he looks."; speak = list("Wish I had better equipment...","I knew I should have been a line chef...","Fuckin' helmet keeps fogging up.","Anyone else smell that?")},/turf/simulated/floor/tiled,/area/submap/DoomP)
+"aN" = (/obj/structure/table/standard,/turf/simulated/floor/tiled,/area/submap/DoomP)
+"aO" = (/obj/structure/table/standard,/obj/item/pizzabox,/turf/simulated/floor/tiled,/area/submap/DoomP)
+"aP" = (/turf/simulated/floor/tiled,/area/submap/DoomP)
+"aQ" = (/obj/machinery/vending/snack,/obj/effect/floor_decal/borderfloor{dir = 4},/turf/simulated/floor/tiled,/area/submap/DoomP)
+"aR" = (/obj/machinery/power/terminal{icon_state = "term"; dir = 1},/obj/structure/cable{icon_state = "0-4"; d2 = 4},/turf/simulated/floor/tiled/techfloor/grid,/area/submap/DoomP)
+"aS" = (/obj/machinery/power/terminal{icon_state = "term"; dir = 1},/obj/structure/cable{icon_state = "0-4"; d2 = 4},/obj/structure/cable{d1 = 4; d2 = 8; icon_state = "4-8"; pixel_x = 0},/turf/simulated/floor/tiled/techfloor/grid,/area/submap/DoomP)
+"aT" = (/obj/structure/cable{d1 = 4; d2 = 8; icon_state = "4-8"; pixel_x = 0},/turf/simulated/floor/tiled/techfloor/grid,/area/submap/DoomP)
+"aU" = (/obj/structure/cable{d1 = 1; d2 = 8; icon_state = "1-8"},/turf/simulated/floor/tiled/techfloor/grid,/area/submap/DoomP)
+"aV" = (/turf/simulated/floor/tiled/techfloor/grid,/area/submap/DoomP)
+"aW" = (/obj/machinery/light/small,/turf/simulated/floor/tiled/techfloor/grid,/area/submap/DoomP)
+"aX" = (/obj/structure/lattice,/turf/simulated/floor/water,/area/submap/DoomP)
+"aY" = (/obj/machinery/light/small{dir = 8},/obj/effect/floor_decal/borderfloor{dir = 8},/turf/simulated/floor/tiled,/area/submap/DoomP)
+"aZ" = (/obj/machinery/vending/cola,/obj/effect/floor_decal/borderfloor/corner{dir = 4},/turf/simulated/floor/tiled,/area/submap/DoomP)
+"ba" = (/obj/machinery/door/airlock/external,/turf/simulated/floor/tiled,/area/submap/DoomP)
+"bb" = (/obj/machinery/door/airlock/engineering,/turf/simulated/floor/tiled/techfloor/grid,/area/submap/DoomP)
+"bc" = (/obj/structure/sign/electricshock,/turf/simulated/wall/r_wall,/area/submap/DoomP)
+"bd" = (/obj/effect/floor_decal/borderfloor{dir = 10},/turf/simulated/floor/tiled,/area/submap/DoomP)
+"be" = (/obj/effect/floor_decal/borderfloor,/turf/simulated/floor/tiled,/area/submap/DoomP)
+"bf" = (/obj/machinery/light/small,/obj/effect/floor_decal/borderfloor,/turf/simulated/floor/tiled,/area/submap/DoomP)
+"bg" = (/obj/effect/floor_decal/borderfloor/corner{dir = 8},/turf/simulated/floor/tiled,/area/submap/DoomP)
+"bh" = (/obj/machinery/door/airlock/hatch,/turf/simulated/floor/tiled,/area/submap/DoomP)
+"bi" = (/obj/machinery/light/small{dir = 1},/turf/simulated/floor/tiled,/area/submap/DoomP)
+"bj" = (/obj/machinery/door/airlock/highsecurity,/turf/simulated/floor/tiled/techfloor,/area/submap/DoomP)
+"bk" = (/obj/machinery/door/airlock,/turf/simulated/floor/tiled/white,/area/submap/DoomP)
+"bl" = (/turf/simulated/floor/tiled/techfloor,/area/submap/DoomP)
+"bm" = (/obj/structure/table/standard,/turf/simulated/floor/tiled/techfloor,/area/submap/DoomP)
+"bn" = (/obj/structure/table/standard,/obj/item/weapon/storage/box/syndie_kit/spy,/turf/simulated/floor/tiled/techfloor,/area/submap/DoomP)
+"bo" = (/obj/structure/table/rack,/obj/item/weapon/storage/box/smokes,/turf/simulated/floor/tiled/techfloor,/area/submap/DoomP)
+"bp" = (/obj/structure/table/rack,/obj/item/weapon/storage/box/handcuffs,/turf/simulated/floor/tiled/techfloor,/area/submap/DoomP)
+"bq" = (/obj/structure/table/rack,/obj/item/weapon/cell/device/weapon,/obj/item/weapon/cell/device/weapon,/obj/item/weapon/cell/device/weapon,/obj/item/weapon/cell/device/weapon,/obj/item/weapon/cell/device/weapon,/turf/simulated/floor/tiled/techfloor,/area/submap/DoomP)
+"br" = (/obj/structure/table/rack,/obj/item/weapon/gun/energy/laser/mounted,/turf/simulated/floor/tiled/techfloor,/area/submap/DoomP)
+"bs" = (/obj/structure/table/rack,/obj/item/weapon/gun/projectile/contender,/obj/item/ammo_magazine/s357,/obj/item/ammo_magazine/s357,/obj/item/ammo_magazine/s357,/turf/simulated/floor/tiled/techfloor,/area/submap/DoomP)
+"bt" = (/obj/structure/bed,/obj/item/weapon/bedsheet,/obj/item/toy/plushie/spider,/obj/effect/floor_decal/corner/lime/full{dir = 8},/turf/simulated/floor/tiled/white,/area/submap/DoomP)
+"bu" = (/obj/structure/table/standard,/obj/effect/floor_decal/corner/lime{dir = 5},/turf/simulated/floor/tiled/white,/area/submap/DoomP)
+"bv" = (/obj/structure/bed,/obj/item/weapon/bedsheet,/obj/effect/floor_decal/corner/lime{dir = 5},/turf/simulated/floor/tiled/white,/area/submap/DoomP)
+"bw" = (/obj/structure/table/standard,/obj/item/device/flashlight/lamp,/obj/effect/floor_decal/corner/lime{dir = 5},/turf/simulated/floor/tiled/white,/area/submap/DoomP)
+"bx" = (/obj/structure/table/standard,/obj/structure/bedsheetbin,/obj/effect/floor_decal/corner/lime{dir = 1},/turf/simulated/floor/tiled/white,/area/submap/DoomP)
+"by" = (/turf/simulated/floor/tiled/white,/area/submap/DoomP)
+"bz" = (/obj/machinery/light/small{dir = 1},/turf/simulated/floor/tiled/white,/area/submap/DoomP)
+"bA" = (/obj/structure/sink{dir = 4; icon_state = "sink"; pixel_x = 11; pixel_y = 0},/obj/machinery/light/small{dir = 1},/turf/simulated/floor/tiled/white,/area/submap/DoomP)
+"bB" = (/obj/machinery/light/small,/turf/simulated/floor/tiled/techfloor,/area/submap/DoomP)
+"bC" = (/obj/machinery/light/small{dir = 8},/obj/effect/floor_decal/corner/lime/full,/turf/simulated/floor/tiled/white,/area/submap/DoomP)
+"bD" = (/obj/effect/floor_decal/corner/lime{dir = 10},/turf/simulated/floor/tiled/white,/area/submap/DoomP)
+"bE" = (/obj/machinery/light/small{dir = 4; pixel_y = 0},/obj/effect/floor_decal/corner/lime{dir = 10},/turf/simulated/floor/tiled/white,/area/submap/DoomP)
+"bF" = (/obj/machinery/shower{dir = 1},/obj/structure/curtain/open/shower,/turf/simulated/floor/tiled/white,/area/submap/DoomP)
+"bG" = (/obj/structure/toilet{dir = 1},/turf/simulated/floor/tiled/white,/area/submap/DoomP)
+"bH" = (/obj/structure/grille,/obj/structure/window/reinforced{dir = 1},/obj/structure/window/reinforced,/obj/machinery/door/firedoor/border_only,/obj/structure/window/reinforced{dir = 8},/turf/simulated/floor/plating,/area/submap/DoomP)
+"bI" = (/obj/structure/grille,/obj/structure/window/reinforced{dir = 1},/obj/structure/window/reinforced,/obj/machinery/door/firedoor/border_only,/turf/simulated/floor/plating,/area/submap/DoomP)
+"bJ" = (/obj/structure/grille,/obj/structure/window/reinforced{dir = 1},/obj/structure/window/reinforced,/obj/structure/window/reinforced{dir = 4},/obj/machinery/door/firedoor/border_only,/turf/simulated/floor/plating,/area/submap/DoomP)
+"bK" = (/obj/structure/lattice,/turf/simulated/floor/outdoors/grass/sif/forest,/area/submap/DoomP)
 
 (1,1,1) = {"
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 aaabababababababababababababababababababababababababababababababababababacacacacacacacacabababababababadadadabababaeabaa
 aaaeabababababababababababababababababababababababababababababababababacacafafafafafafacacacacababacadadadadadacacacabaa
 aaababacacacacacacacabababababababagababababacacacacacacacacababacacacacafafafafafafafafafafacacacacadadahadacafafacabaa
-aaabacacafafafafafacacacacacacababaeabacacacacafafafafacacacacacafafafafafafafafafafafafafacacadadadadadacacacafafacabaa
+aaabacacafafafafafacacacacacacababaeabacacacacafafafafacacacacacafafafafafafafafafafafafafacacadadahadadacacacafafacabaa
 aaabacafafafafafafafafafafafacacacacacacafafafafafafafafafafafafafafafafafafafafafafafafacacadaiadadajacacafafafafacacaa
-aaabacafafafafafafafafafafafafafafafafafafafafafafafafafafafafafafafafafafafafafafafacacacadadadadadadacafafafafafafacaa
-aaabacafafafafakakakakakakafafafafafafafafafafafafafakakakakakakakafafafafafafafafacacadajadadahadadadacafafafafafafacaa
-aaabacafafafafafakakakakakafafafafafafafafafakakakakakakakakakakakakakakafafafafafacadahadadadadadadacacafafafafafafacaa
-aaabacacafafafafafakakakakafafafafafafafafafakakakakakakakakakakakakakafafafafafacacaladadadamadahacacafafafafafafafacaa
-aaababacafafafafafafakakakakakafafafakakakakakakakakakakakakakakakakakakakakakafafacacadadadadadacacafafafafafafafafacaa
-aaababacafafafafafafakakakakakakakakakakakakakakakakakakakakakakakakakakafafafafafafacadadadaiadacacafafafafafafafacacaa
-aaababacacafafafafafafakakakakakakakakakakakakakakakakakakakakakakakakakafafafafafacacadahadadacacafafafafafafafafacabaa
+aaabacafafafafafafafafafafafafafafafafafafafafafafafafafafafafafafafafafafafafafafafacacacahadadadadadacafafafafafafacaa
+aaabacafafafafakakakakakakafafafafafafafafafafafafafakakakakakakakafafafafafafafafacacadaladadahadadadacafafafafafafacaa
+aaabacafafafafafakakakakakafafafafafafafafafakakakakakakakakakakakakakakafafafafafacadahadadadadadadamacafafafafafafacaa
+aaabacacafafafafafakakakakafafafafafafafafafakakakakakakakakakakakakakafafafafafacacanadadadaoadahacacafafafafafafafacaa
+aaababacafafafafafafakakakakakafafafakakakakakakakakakakakakakakakakakakakakakafafacacadadahadadacacafafafafafafafafacaa
+aaababacafafafafafafakakakakakakakakakakakakakakakakakakakakakakakakakakafafafafafafacadadadaiadacamafafafafafafafacacaa
+aaababacacafafafafafafakakakakakakakakakakakakakakakakakakakakakakakakakafafafafafacamadahadadacacafafafafafafafafacabaa
 aaabababacafafafafafafafakakakakakakakakakakakakafafakakakakakakakakakafafafafafafacacadadadadacafafafafafafafafafacabaa
-aaabababacacafafafafafafafakakakakakakakakakakafafafafakakakakakakakakakafafafafafacacadadalacacafafafafafafafacacacabaa
+aaabababacacafafafafafafafakakakakakakakakakakafafafafakakakakakakakakakafafafafafamacadadapacacafafafafafafafacacacabaa
 aaababababacafafafafafafakakakakakakakakakafafafafafafafafafafafafafafafafafafacacacadadadadacafafafafakafafafacacababaa
-aaababababacacafafafafafafakakakakakakafafafafafafafafafafafafafafafafafafafacacadadadadadacacafafafakakafafafafacababaa
-aaababababacacafafafafafakakakakakafafafafafafafafafafafafafafafafafafafafacacadadadadacacacafafafafakakakafafafacacabaa
-aaababababaeacafafafafakakakakakafafafafafafafafafafafafafafafafafafafafacacadadadacacacafafafafafafakakakafafafafacabaa
-aaababababacacafafakakakakakakakakafafafafafafafafafacacacacacacacafafacacadadacacacafafafafafafafafakakakafafafafacabaa
+aaababababacacafafafafafafakakakakakakafafafafafafafafafafafafafafafafafafafacacadahadahadacacafafafakakafafafafacababaa
+aaababababacacafafafafafakakakakakafafafafafafafafafafafafafafafafafafafafacacahadadadacacacafafafafakakakafafafacacabaa
+aaababababaeacafafafafakakakakakafafafafafafafafafafafafafafafafafafafafacacadadadamacacafafafafafafakakakafafafafacabaa
+aaababababacacafafakakakakakakakakafafafafafafafafafacacacacacacacafafacamadadacacacafafafafafafafafakakakafafafafacabaa
 aaababababacafafafakakakakakakakakakakafafafafafacacacadadadadadacacacacadadacacafafafafafafafakafakakakafafafafafacabaa
-aaabababacacafafafafakakakakakakakafafafafafafacacadadanadadadadadadadadadadacafafafafafafafafakakakakakafafafafafacabaa
-aaabababacafafafafafafakakakakakafafafafafafacacadadadadadadanadadadadadadadacafafafafafafafakakakakakakafafafafacacabaa
+aaabababacacafafafafakakakakakakakafafafafafafacacadadaqadadadadadadadadadadacafafafafafafafafakakakakakafafafafafacabaa
+aaabababacafafafafafafakakakakakafafafafafafacacadadadadadadaqadadadahadadadamafafafafafafafakakakakakakafafafafacacabaa
 aaabababacafafafafafafakakakakakafafafafafacacadadadadadadadadadadadadadadacacafafafafafafafakakakakakakakakafafacacabaa
 aaabababacafafafafafafafakakakakafafafafacacadadadadadadadadadadadadadadadadacacafafafafafafakakakakakakakakafafafacabaa
 aaabababacafafafafafafafakakakafafafafafacadadadadadadadadadadadadadadadadadadacacafafafafafafakakakakakakafafafafacabaa
-aaabababacafafafafafafafakakakakakafafafacadadadadadadadaoadadadadadaoadadadadadacacafafafafafafakakakakafafafafafacabaa
-aaabababacafafafafafafafakakakakakafafafacadadapadadapadaqarasasasaraqadapadadapadacafafafafafafakakakakafafafafafacabaa
-aaabababacafafafafafafafakakakakakakafafacaqaqaqaqaqaqaqaqaqaqataqaqaqaqaqaqaqaqaqaqaqafafafafafakakakakafafafafacacabaa
-aaabababacacafafafafafafakakakakakakafafacaqauavawaxayaxawazaqaAaqaBaCaCaCaDaEaFaGaHaqafafafafafakakakakafafafafacacabaa
-aaabababacacacafafafafakakakakakakakafapaIaqaJaKaLaKaKaKaMaNaqaMaqaOaPaPaPaQaRaSaTaSaqaUapafafafakakakafafafafafafacabaa
-aaabababababacacafafafakakakakakakakafafafaqaVaKaKaKaKaKaMaWaqaXaqaqaqaqaqaqaYaZaqaqaqafafafafafakakakafafafafafafacabaa
-aaababababababacafafafakakakakakakakakafafaqbabbbbbcbbbbbdaMbeaMaMbfaMaMaMaMaMbfaMaMaqafafafafafakakakafafafafafafafacaa
-aaabababagabababacafafakakakakakakakakapaUaqbgaqaqaqaqaqaqaqaqaqaqaqaqaqaqbhaqaqaqaqaqaUapafafafakakakafafafafafafafacaa
-aaababababababacacafafafakakakakakakakakafaqbibjbkblbmbnbobpaqbqbrbsbtbsbubvbhbwbhbxaqafafafafafakakakafafafafafafafacaa
-aaababababababacafafafafakakakakakakakakafaqbibibybibibybibiaqbzbAbAbAbAbAbBaqbCaqbDaqafafafafakakakakakafafafafafafacaa
-aaababababababacafafafafakakakakakakakakakaqaqaqaqaqaqaqaqaqaqaqaqbEbFbFbFbGaqaqaqaqaqafafafafakakakakafafafafafafafacaa
-aaabababababacacafafafakakakakakakakakakakafafafafaIacacadadadadbHadadadadadbHacacafafafafafafakakakakafafafafafafafacaa
-aaabababababacafafafafakakakakakakakakakakakakafafapafacacacacacapadadadadadapacafafafafafafakakakakakafafafafafafacacaa
+aaabababacafafafafafafafakakakakakafafafacadadadadadadadaradadadadadaradadadadadacacafafafafafafakakakakafafafafafacabaa
+aaabababacafafafafafafafakakakakakafafafacadadasadadasadatauavavavauatadasadadasadacafafafafafafakakakakafafafafafacabaa
+aaabababacafafafafafafafakakakakakakafafacatatatatatatatatatatawatatatatatatatatatatatafafafafafakakakakafafafafacacabaa
+aaabababacacafafafafafafakakakakakakafafacataxayazaAaBaAazaCataDataEaFaFaFaGaHaIaJaKatafafafafafakakakakafafafafacacabaa
+aaabababacacacafafafafakakakakakakakafasaLataMaNaOaNaNaNaPaQataPataRaSaSaSaTaUaVaWaVataXasafafafakakakafafafafafafacabaa
+aaabababababacacafafafakakakakakakakafafafataYaNaNaNaNaNaPaZatbaatatatatatatbbbcatatatafafafafafakakakafafafafafafacabaa
+aaababababababacafafafakakakakakakakakafafatbdbebebfbebebgaPbhaPaPbiaPaPaPaPaPbiaPaPatafafafafafakakakafafafafafafafacaa
+aaabababagabababacafafakakakakakakakakasaXatbjatatatatatatatatatatatatatatbkatatatatataXasafafafakakakafafafafafafafacaa
+aaababababababacacafafafakakakakakakakakafatblbmbnbobpbqbrbsatbtbubvbwbvbxbybkbzbkbAatafafafafafakakakafafafafafafafacaa
+aaababababababacafafafafakakakakakakakakafatblblbBblblbBblblatbCbDbDbDbDbDbEatbFatbGatafafafafakakakakakafafafafafafacaa
+aaababababababacafafafafakakakakakakakakakatatatatatatatatatatatatbHbIbIbIbJatatatatatafafafafakakakakafafafafafafafacaa
+aaabababababacacafafafakakakakakakakakakakafafafafaLacacadadadadbKadadadadadbKacacafafafafafafakakakakafafafafafafafacaa
+aaabababababacafafafafakakakakakakakakakakakakafafasafacacacacacasadadadadadasacafafafafafafakakakakakafafafafafafacacaa
 aaababababacacafafafafakakakakakakakakakakakakakafafafafafafafacacadadadadadacacafafafafafakakakakakakafafafafafafacabaa
 aaababababacafafafafafafakakakakakakakakakakakakafafafafafafafafacacacacacacacafafafafafafafakakakakakafafafafafacacabaa
 aaabababacacafafafafafafakakakakakakakakakakakakakafafafafafafafafafafafafafafafafafafafafafafakakakafafafafafafacababaa

--- a/maps/submaps/surface_submaps/wilderness/MCamp1.dmm
+++ b/maps/submaps/surface_submaps/wilderness/MCamp1.dmm
@@ -1,53 +1,60 @@
 "a" = (/turf/template_noop,/area/template_noop)
 "b" = (/turf/template_noop,/area/submap/MilitaryCamp1)
 "c" = (/turf/simulated/floor/outdoors/dirt,/area/submap/MilitaryCamp1)
-"d" = (/obj/effect/mine,/turf/template_noop,/area/submap/MilitaryCamp1)
+"d" = (/obj/random/landmine,/turf/template_noop,/area/submap/MilitaryCamp1)
 "e" = (/obj/structure/flora/bush,/turf/template_noop,/area/submap/MilitaryCamp1)
 "f" = (/obj/effect/decal/cleanable/blood,/turf/template_noop,/area/submap/MilitaryCamp1)
-"g" = (/obj/effect/decal/remains,/turf/simulated/floor/outdoors/dirt,/area/submap/MilitaryCamp1)
-"h" = (/obj/structure/flora/tree/sif,/turf/template_noop,/area/submap/MilitaryCamp1)
-"i" = (/obj/item/stack/rods,/turf/template_noop,/area/submap/MilitaryCamp1)
-"j" = (/obj/effect/mine,/turf/simulated/floor/outdoors/dirt,/area/submap/MilitaryCamp1)
-"k" = (/turf/simulated/wall,/area/submap/MilitaryCamp1)
-"l" = (/turf/simulated/floor,/area/submap/MilitaryCamp1)
-"m" = (/obj/item/weapon/material/shard,/turf/template_noop,/area/submap/MilitaryCamp1)
-"n" = (/mob/living/simple_animal/hostile/viscerator{returns_home = 1},/turf/simulated/floor,/area/submap/MilitaryCamp1)
-"o" = (/obj/structure/girder,/turf/simulated/floor,/area/submap/MilitaryCamp1)
-"p" = (/obj/machinery/computer/communications,/mob/living/simple_animal/hostile/viscerator{returns_home = 1},/mob/living/simple_animal/hostile/viscerator{returns_home = 1},/turf/simulated/floor,/area/submap/MilitaryCamp1)
-"q" = (/obj/structure/table/standard,/mob/living/simple_animal/hostile/viscerator{returns_home = 1},/mob/living/simple_animal/hostile/viscerator{returns_home = 1},/turf/simulated/floor,/area/submap/MilitaryCamp1)
-"r" = (/obj/effect/mine,/turf/simulated/floor,/area/submap/MilitaryCamp1)
-"s" = (/obj/effect/decal/cleanable/dirt,/turf/simulated/floor,/area/submap/MilitaryCamp1)
-"t" = (/obj/machinery/computer/security,/mob/living/simple_animal/hostile/viscerator{returns_home = 1},/mob/living/simple_animal/hostile/viscerator{returns_home = 1},/turf/simulated/floor,/area/submap/MilitaryCamp1)
-"u" = (/mob/living/simple_animal/hostile/viscerator{returns_home = 1},/mob/living/simple_animal/hostile/viscerator{returns_home = 1},/turf/simulated/floor,/area/submap/MilitaryCamp1)
-"v" = (/obj/machinery/door/airlock,/turf/simulated/floor,/area/submap/MilitaryCamp1)
-"w" = (/obj/effect/decal/cleanable/dirt,/mob/living/simple_animal/hostile/viscerator{returns_home = 1},/turf/simulated/floor,/area/submap/MilitaryCamp1)
-"x" = (/mob/living/simple_animal/hostile/viscerator{returns_home = 1},/turf/template_noop,/area/submap/MilitaryCamp1)
-"y" = (/obj/structure/table,/turf/simulated/floor,/area/submap/MilitaryCamp1)
-"z" = (/obj/structure/table/standard,/obj/random/firstaid,/turf/simulated/floor,/area/submap/MilitaryCamp1)
-"A" = (/obj/machinery/door/airlock,/obj/effect/mine,/turf/simulated/floor,/area/submap/MilitaryCamp1)
-"B" = (/obj/structure/flora/tree/dead,/turf/template_noop,/area/submap/MilitaryCamp1)
-"C" = (/obj/structure/table/standard,/obj/item/weapon/gun/projectile/automatic/c20r,/turf/simulated/floor,/area/submap/MilitaryCamp1)
-"D" = (/obj/structure/table/standard,/obj/item/weapon/gun/energy/gun,/turf/simulated/floor,/area/submap/MilitaryCamp1)
+"g" = (/obj/random/landmine,/turf/simulated/floor/outdoors/dirt,/area/submap/MilitaryCamp1)
+"h" = (/obj/effect/decal/remains,/turf/simulated/floor/outdoors/dirt,/area/submap/MilitaryCamp1)
+"i" = (/obj/effect/mine,/turf/template_noop,/area/submap/MilitaryCamp1)
+"j" = (/obj/effect/decal/remains,/obj/random/landmine,/turf/simulated/floor/outdoors/dirt,/area/submap/MilitaryCamp1)
+"k" = (/obj/structure/flora/tree/sif,/turf/template_noop,/area/submap/MilitaryCamp1)
+"l" = (/obj/item/stack/rods,/turf/template_noop,/area/submap/MilitaryCamp1)
+"m" = (/turf/simulated/wall,/area/submap/MilitaryCamp1)
+"n" = (/obj/random/landmine,/turf/simulated/floor,/area/submap/MilitaryCamp1)
+"o" = (/turf/simulated/floor,/area/submap/MilitaryCamp1)
+"p" = (/obj/item/weapon/material/shard,/turf/template_noop,/area/submap/MilitaryCamp1)
+"q" = (/mob/living/simple_animal/hostile/viscerator{returns_home = 1},/turf/simulated/floor,/area/submap/MilitaryCamp1)
+"r" = (/obj/structure/girder,/turf/simulated/floor,/area/submap/MilitaryCamp1)
+"s" = (/obj/machinery/computer/communications,/mob/living/simple_animal/hostile/viscerator{returns_home = 1},/mob/living/simple_animal/hostile/viscerator{returns_home = 1},/turf/simulated/floor,/area/submap/MilitaryCamp1)
+"t" = (/obj/structure/table/standard,/mob/living/simple_animal/hostile/viscerator{returns_home = 1},/mob/living/simple_animal/hostile/viscerator{returns_home = 1},/turf/simulated/floor,/area/submap/MilitaryCamp1)
+"u" = (/obj/effect/mine,/obj/random/landmine,/turf/simulated/floor,/area/submap/MilitaryCamp1)
+"v" = (/obj/effect/decal/cleanable/dirt,/turf/simulated/floor,/area/submap/MilitaryCamp1)
+"w" = (/obj/machinery/computer/security,/mob/living/simple_animal/hostile/viscerator{returns_home = 1},/mob/living/simple_animal/hostile/viscerator{returns_home = 1},/turf/simulated/floor,/area/submap/MilitaryCamp1)
+"x" = (/mob/living/simple_animal/hostile/viscerator{returns_home = 1},/mob/living/simple_animal/hostile/viscerator{returns_home = 1},/turf/simulated/floor,/area/submap/MilitaryCamp1)
+"y" = (/obj/item/weapon/material/shard,/obj/random/landmine,/turf/template_noop,/area/submap/MilitaryCamp1)
+"z" = (/obj/machinery/door/airlock,/turf/simulated/floor,/area/submap/MilitaryCamp1)
+"A" = (/obj/effect/decal/cleanable/dirt,/mob/living/simple_animal/hostile/viscerator{returns_home = 1},/turf/simulated/floor,/area/submap/MilitaryCamp1)
+"B" = (/mob/living/simple_animal/hostile/viscerator{returns_home = 1},/turf/template_noop,/area/submap/MilitaryCamp1)
+"C" = (/obj/structure/table,/turf/simulated/floor,/area/submap/MilitaryCamp1)
+"D" = (/obj/structure/table/standard,/obj/random/firstaid,/turf/simulated/floor,/area/submap/MilitaryCamp1)
+"E" = (/obj/machinery/door/airlock,/obj/effect/mine,/turf/simulated/floor,/area/submap/MilitaryCamp1)
+"F" = (/obj/structure/flora/tree/dead,/turf/template_noop,/area/submap/MilitaryCamp1)
+"G" = (/obj/random/landmine,/turf/template_noop,/area/template_noop)
+"H" = (/obj/effect/decal/cleanable/dirt,/obj/random/landmine,/turf/simulated/floor,/area/submap/MilitaryCamp1)
+"I" = (/obj/structure/table/standard,/obj/item/weapon/gun/projectile/automatic/c20r,/turf/simulated/floor,/area/submap/MilitaryCamp1)
+"J" = (/obj/structure/table/standard,/obj/item/weapon/gun/energy/gun,/turf/simulated/floor,/area/submap/MilitaryCamp1)
+"K" = (/obj/effect/decal/cleanable/blood,/obj/random/landmine,/turf/template_noop,/area/submap/MilitaryCamp1)
 
 (1,1,1) = {"
 aaaaaaaaaaaaaaaaaaaa
 abbcbdbefdbbbbbbbbba
-acgcbbbbbbbfdbcgbbba
-abccbbdbbhibbbccjhba
-abhbbikkllkklkmcbbba
-abbbbkkkllkkkkkbdbda
-abbdkknllokpqnkkbeba
-abbbkknorsktuukkbbba
-abbmkkvkkwkkkvkoxdba
-abbblknllslnwskkbbba
-afdblknllyznsskkbdba
-abbbokvAkkkkvvkobBba
-abbxkknlosssnnkkbbba
-aBbbkkCDkllnnnkkmbfa
-abbebkkkkvlkkkkbdbba
-abdbbbkkkslkkkbccdba
-abcbbbbkkbmkkbjcbbba
-acgcdbbbddbibbcghbba
-abccebdbhfbbdccbbbba
+aghcdbbbbbbfibcjbbba
+abccbbdbbklbbbccgkba
+adkbblmmnommnmpcbbba
+abbbbmmmonmmmmmbdbda
+abbdmmqoormstqmmbeba
+abbbmmqruvmwxxmmbbda
+abbymmzmmAmmmzmrBdba
+abbbomqoovoqAvmmbbba
+afdbomqooCDqvvmmbida
+abbbrmzEmmmmzzmrbFba
+GbbBmmqorvHvqqmmbbba
+aFbbmmIJmooqqqmmpbKa
+abbebmmmmzommmmbibba
+abddbbmmmvommmbcciba
+abcbbdbmmbymmbgcbbba
+acjcdbbbidblbdcjkbba
+abccebdbkfbbdccbbbba
 aaaaaaaaaaaaaaaaaaaa
 "}


### PR DESCRIPTION
- Added a random mine spawner, for use in PoIs. Replaces mines in PoIs with the random spawner.
- Mines now give a visible message when they go off.
- Land mines on the ground can no longer be told apart from one another, to prevent gaming the system.
- Hovering mobs (viscerators, drones, Poly, carp) no longer set off land mines.
- Arming a land mine now takes concentration. If you move, it will boom.

Also adds a few null checks.