### PR TITLE
Don't require hostile SAs for special purposes

### DIFF
--- a/code/modules/mob/living/simple_animal/animals/cat.dm
+++ b/code/modules/mob/living/simple_animal/animals/cat.dm
@@ -9,7 +9,6 @@
 	icon_dead = "cat2_dead"
 	icon_rest = "cat2_rest"
 
-	hostile = 1 //To mice, anyway.
 	investigates = 1
 	specific_targets = 1 //Only targets with Found()
 	run_at_them = 0 //DOMESTICATED

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -459,7 +459,7 @@
 					stop_automated_movement = 0
 
 			//Search for targets while idle
-			if(hostile)
+			if(hostile || specific_targets)
 				FindTarget()
 		if(STANCE_FOLLOW)
 			annoyed = 15
@@ -467,7 +467,7 @@
 			if(follow_until_time && world.time > follow_until_time)
 				LoseFollow()
 				return
-			if(hostile)
+			if(hostile || specific_targets)
 				FindTarget()
 		if(STANCE_ATTACK)
 			annoyed = 50


### PR DESCRIPTION
Using the pre-existing specific_targets variable, you don't need to make your things hostile anymore. I dunno why I didn't originally do this instead of setting Runtime to be 'quietly hostile'