### PR TITLE
Remove the admin ghostview verb

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -59,7 +59,6 @@ var/list/admin_verbs_admin = list(
 	/client/proc/check_antagonists,
 	/client/proc/admin_memo,			//admin memo system. show/delete/write. +SERVER needed to delete admin memos of others,
 	/client/proc/dsay,					//talk in deadchat using our ckey/fakekey,
-	/client/proc/ghost_view,			//let us see ghosts WHENEVERRRR
 //	/client/proc/toggle_hear_deadcast,	//toggles whether we hear deadchat,
 	/client/proc/investigate_show,		//various admintools for investigation. Such as a singulo grief-log,
 	/client/proc/secrets,
@@ -213,7 +212,6 @@ var/list/admin_verbs_debug = list(
 	/client/proc/jumptomob,
 	/client/proc/jumptocoord,
 	/client/proc/dsay,
-	/client/proc/ghost_view,
 	/client/proc/toggle_debug_logs,
 	/client/proc/admin_ghost,			//allows us to ghost/reenter body at will,
 	/datum/admins/proc/view_runtimes,
@@ -326,7 +324,6 @@ var/list/admin_verbs_mod = list(
 	/datum/admins/proc/show_player_info,
 	/client/proc/player_panel_new,
 	/client/proc/dsay,
-	/client/proc/ghost_view,
 	/datum/admins/proc/show_skills,
 	/datum/admins/proc/show_player_panel,
 	/client/proc/check_antagonists,
@@ -351,7 +348,6 @@ var/list/admin_verbs_event_manager = list(
 	/client/proc/admin_ghost,
 	/datum/admins/proc/show_player_info,
 	/client/proc/dsay,
-	/client/proc/ghost_view,
 	/client/proc/cmd_admin_subtle_message,
 	/client/proc/debug_variables,
 	/client/proc/check_antagonists,
@@ -490,26 +486,6 @@ var/list/admin_verbs_event_manager = list(
 			if(!body.key)
 				body.key = "@[key]"	//Haaaaaaaack. But the people have spoken. If it breaks; blame adminbus
 		feedback_add_details("admin_verb","O") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
-
-/client/proc/ghost_view()
-	set category = "Admin"
-	set name = "Ghost View"
-	set desc = "Toggles ability to see ghosts, even while in a mob."
-	if(!holder) return
-	if(!mob.plane_holder) return
-
-	var/choice = alert(src,"Do you want to see ghosts, or not?","Ghost viewing","Show 'em!","Cancel","Hide 'em!")
-	if(choice == "Cancel")
-		return
-
-	if(choice == "Show 'em!" && mob.plane_holder)
-		mob.plane_holder.set_vis(VIS_GHOSTS,TRUE)
-		usr.see_invisible = SEE_INVISIBLE_CULT
-		to_chat(src,"<span class='notice'>Ghosts are now visible (while in this mob).</span>")
-	else if(mob.plane_holder)
-		mob.plane_holder.set_vis(VIS_GHOSTS,FALSE)
-		usr.see_invisible = initial(mob.see_invisible)
-		to_chat(src,"<span class='notice'>Ghosts are now hidden (while in this mob).</span>")
 
 /client/proc/invisimin()
 	set name = "Invisimin"
@@ -1046,7 +1022,7 @@ var/list/admin_verbs_event_manager = list(
 	set category = "Fun"
 	set name = "Man Up"
 	set desc = "Tells mob to man up and deal with it."
-	
+
 	if(alert("Are you sure you want to tell them to man up?","Confirmation","Deal with it","No")=="No") return
 
 	T << "<span class='notice'><b><font size=3>Man up and deal with it.</font></b></span>"
@@ -1059,7 +1035,7 @@ var/list/admin_verbs_event_manager = list(
 	set category = "Fun"
 	set name = "Man Up Global"
 	set desc = "Tells everyone to man up and deal with it."
-	
+
 	if(alert("Are you sure you want to tell the whole server up?","Confirmation","Deal with it","No")=="No") return
 
 	for (var/mob/T as mob in mob_list)


### PR DESCRIPTION
Since we went back to ghosts having invisibility, and see_invisible is reset every life() on humans (for annoying reasons), and this verb is very similar in name to the show/hide ghost view verb for ghosts, it's annoying.

To be revisited in the future when we can make a verb like this actually work.