### PR TITLE
Power monitoring consoles find all station-related sensors

### DIFF
--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -566,7 +566,6 @@
 
 	//Projectiles with bonus SA damage
 	if(!Proj.nodamage)
-		var/true_damage = Proj.damage
 		if(!Proj.SA_vulnerability || Proj.SA_vulnerability == intelligence_level)
 			Proj.damage += Proj.SA_bonus_damage
 

--- a/code/modules/nano/modules/power_monitor.dm
+++ b/code/modules/nano/modules/power_monitor.dm
@@ -43,8 +43,12 @@
 /datum/nano_module/power_monitor/proc/refresh_sensors()
 	grid_sensors = list()
 	var/turf/T = get_turf(nano_host())
+	var/list/levels = list()
+	if(T)
+		levels += using_map.get_map_levels(T.z, FALSE)
+		world << "levels"
 	for(var/obj/machinery/power/sensor/S in machines)
-		if((T && S.loc.z == T.z) || (S.long_range)) // Consoles have range on their Z-Level. Sensors with long_range var will work between Z levels.
+		if(T && (S.loc.z == T.z) || (S.loc.z in levels) || (S.long_range)) // Consoles have range on their Z-Level. Sensors with long_range var will work between Z levels.
 			if(S.name_tag == "#UNKN#") // Default name. Shouldn't happen!
 				warning("Powernet sensor with unset ID Tag! [S.x]X [S.y]Y [S.z]Z")
 			else


### PR DESCRIPTION
- Tested with the bridge console, it shows every subgrid and the outposts.
- ~~Also deletes a var that gets defined in simple_animal.dm, but is no longer used.~~

Fixes #4842