### PR TITLE
Fix for borgs accidentally getting into useless grab/disarm intents

### DIFF
--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -566,7 +566,6 @@
 
 	//Projectiles with bonus SA damage
 	if(!Proj.nodamage)
-		var/true_damage = Proj.damage
 		if(!Proj.SA_vulnerability || Proj.SA_vulnerability == intelligence_level)
 			Proj.damage += Proj.SA_bonus_damage
 

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -328,7 +328,7 @@ var/list/intents = list(I_HELP,I_DISARM,I_GRAB,I_HURT)
 	set name = "a-intent"
 	set hidden = 1
 
-	if(isliving(src))
+	if(isliving(src) && !isrobot(src))
 		switch(input)
 			if(I_HELP,I_DISARM,I_GRAB,I_HURT)
 				a_intent = input


### PR DESCRIPTION
Previous PR accidentally allowed them to enter these intents. They don't do anything, but make the intent icon disappear because they don't have the correct states to display.

Fixes #4851 