### PR TITLE
Clean up some recent update_icons() changes

### DIFF
--- a/code/__defines/_planes+layers.dm
+++ b/code/__defines/_planes+layers.dm
@@ -60,6 +60,7 @@ What is the naming convention for planes or layers?
 	//#define TURF_LAYER		2 //For easy recordkeeping; this is a byond define
 	#define DECALS_LAYER		2.01
 	#define OVERTURF_LAYER		2.1
+	#define HIDING_LAYER		2.45 //Layer at which mobs hide to be under things like tables
 	#define DOOR_OPEN_LAYER		2.7 //Under all objects if opened. 2.7 due to tables being at 2.6
 	//#define OBJ_LAYER			3 //For easy recordkeeping; this is a byond define
 	#define DOOR_CLOSED_LAYER	3.1 //Above most items if closed

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1546,11 +1546,14 @@
 		permit.set_name(real_name)
 		equip_to_appropriate_slot(permit) // If for some reason it can't find room, it'll still be on the floor.
 
-/mob/living/carbon/human/proc/update_icon_special() //For things such as teshari hiding and whatnot.
+/mob/living/carbon/human/proc/update_icon_special(var/mutable_appearance/ma, var/update_icons = TRUE) //For things such as teshari hiding and whatnot.
 	if(hiding) // Hiding? Carry on.
 		if(stat == DEAD || paralysis || weakened || stunned) //stunned/knocked down by something that isn't the rest verb? Note: This was tried with INCAPACITATION_STUNNED, but that refused to work.
-			hiding = 0 //No hiding for you. Mob layer should be updated naturally, but it actually doesn't.
+			hiding = FALSE //No hiding for you. Mob layer should be updated naturally, but it actually doesn't.
 		else
-			layer = 2.45
-	else //Replace this else with other variables if added in the future. Alternatively, could make other things effect this hiding variable.
-		return
+			ma.layer = HIDING_LAYER
+
+	//Can put special species icon update proc calls here, if any are ever invented.
+
+	if(update_icons)
+		update_icons()

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -159,6 +159,8 @@ Please contact me on #coderbus IRC. ~Carn x
 
 	//0: We start with their existing appearance (this contains their verbs, important to keep those!)
 	var/mutable_appearance/ma_compiled = new(src)
+	ma_compiled.plane = plane //Required because of an override on mutable_appearance/New() that sets it to FLOAT_PLANE...for some reason.
+	ma_compiled.layer = layer
 
 	//1: HUDs because these are hidden behind a backplane. See update_icons_huds()
 	ma_compiled.overlays = list_huds //The first one can set instead of add
@@ -170,16 +172,13 @@ Please contact me on #coderbus IRC. ~Carn x
 	ma_compiled.overlays += list_layers
 
 	//4: Apply transforms based on situation
-	update_transform(ma_compiled, FALSE)
+	update_transform(ma_compiled)
 
-	//4.5 Set layer to PLANE_WORLD to make sure its not magically FLOAT_PLANE due to byond madness
-	ma_compiled.plane = PLANE_WORLD
+	//5: Do any species specific layering updates, such as when hiding.
+	update_icon_special(ma_compiled, FALSE)
 
-	//5: Set appearance once
+	//6: Set appearance once
 	appearance = ma_compiled
-
-	//6: Do any species specific layering updates, such as when hiding.
-	update_icon_special()
 
 /mob/living/carbon/human/update_transform(var/mutable_appearance/passed_ma)
 	if(QDESTROYING(src))
@@ -190,6 +189,8 @@ Please contact me on #coderbus IRC. ~Carn x
 		ma = passed_ma
 	else
 		ma = new(src)
+		ma.plane = plane //Required because of an override on mutable_appearance/New() that sets it to FLOAT_PLANE...for some reason.
+		ma.layer = layer
 
 	// First, get the correct size.
 	var/desired_scale = icon_scale
@@ -214,9 +215,9 @@ Please contact me on #coderbus IRC. ~Carn x
 		M.Translate(0, 16*(desired_scale-1))
 		ma.transform = M
 		ma.layer = MOB_LAYER // Fix for a byond bug where turf entry order no longer matters
-	update_icon_special() //Adjust their layer, like when they are hiding.
 
 	if(!passed_ma)
+		update_icon_special(ma)
 		appearance = ma
 
 //Update the layers from the defines above
@@ -251,10 +252,9 @@ Please contact me on #coderbus IRC. ~Carn x
 		list_huds = hud_list.Copy()
 		list_huds += backplane // Required to mask HUDs in context menus: http://www.byond.com/forum/?post=2336679
 
-//TYPING INDICATOR CODE.
+	//Typing indicator code
 	if(client && !stat) //They have a client & aren't dead/KO'd? Continue on!
 		if(typing_indicator && hud_typing) //They already have the indicator and are still typing
-			overlays += typing_indicator //This might not be needed? It works, so I'm leaving it.
 			list_huds += typing_indicator
 			typing_indicator.invisibility = invisibility
 
@@ -262,13 +262,11 @@ Please contact me on #coderbus IRC. ~Carn x
 			typing_indicator = new
 			typing_indicator.icon = 'icons/mob/talk.dmi'
 			typing_indicator.icon_state = "[speech_bubble_appearance()]_typing"
-			overlays += typing_indicator
 			list_huds += typing_indicator
 
 		else if(typing_indicator && !hud_typing) //Did they stop typing?
-			overlays -= typing_indicator
-			typing = 0
-			hud_typing = 0
+			typing = FALSE
+			hud_typing = FALSE
 
 	if(update_icons)
 		update_icons()

--- a/code/modules/mob/typing_indicator.dm
+++ b/code/modules/mob/typing_indicator.dm
@@ -26,15 +26,18 @@
 
 	if(!ishuman(src)) //If they're a mob, use the old code.
 		set_typing_indicator(1)
-	if(is_preference_enabled(/datum/client_preference/show_typing_indicator))
+	else if(is_preference_enabled(/datum/client_preference/show_typing_indicator))
 		hud_typing = 1
 		update_icons_huds()
+
 	var/message = input("","say (text)") as text
-	if(is_preference_enabled(/datum/client_preference/show_typing_indicator))
-		hud_typing = 0
-		update_icons_huds()
+
 	if(!ishuman(src)) //If they're a mob, use the old code.
 		set_typing_indicator(0)
+	else if(is_preference_enabled(/datum/client_preference/show_typing_indicator))
+		hud_typing = 0
+		update_icons_huds()
+
 	if(message)
 		say_verb(message)
 
@@ -44,14 +47,17 @@
 
 	if(!ishuman(src)) //If they're a mob, use the old code.
 		set_typing_indicator(1)
-	if(is_preference_enabled(/datum/client_preference/show_typing_indicator))
+	else if(is_preference_enabled(/datum/client_preference/show_typing_indicator))
 		hud_typing = 1
 		update_icons_huds()
+
 	var/message = input("","me (text)") as text
+
 	if(is_preference_enabled(/datum/client_preference/show_typing_indicator))
 		hud_typing = 0
 		update_icons_huds()
-	if(!ishuman(src)) //If they're a mob, use the old code.
+	else if(!ishuman(src)) //If they're a mob, use the old code.
 		set_typing_indicator(0)
+
 	if(message)
 		me_verb(message)


### PR DESCRIPTION
Just cleans this up a bit, avoids modifying overlays. That's why we're using mutable_appearances to begin with. To make this fast.