### PR TITLE
Simple mobs respect armor pen, sharp, and edge

### DIFF
--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -327,7 +327,7 @@
 /mob/living/carbon/human/proc/afterattack(atom/target as mob|obj|turf|area, mob/living/user as mob|obj, inrange, params)
 	return
 
-/mob/living/carbon/human/attack_generic(var/mob/user, var/damage, var/attack_message)
+/mob/living/carbon/human/attack_generic(var/mob/user, var/damage, var/attack_message, var/armor_type = "melee", var/armor_pen = 0, var/a_sharp = 0, var/a_edge = 0)
 
 	if(!damage)
 		return
@@ -339,9 +339,9 @@
 
 	var/dam_zone = pick(organs_by_name)
 	var/obj/item/organ/external/affecting = get_organ(ran_zone(dam_zone))
-	var/armor_block = run_armor_check(affecting, "melee")
-	var/armor_soak = get_armor_soak(affecting, "melee")
-	apply_damage(damage, BRUTE, affecting, armor_block, armor_soak)
+	var/armor_block = run_armor_check(affecting, armor_type, armor_pen)
+	var/armor_soak = get_armor_soak(affecting, armor_type, armor_pen)
+	apply_damage(damage, BRUTE, affecting, armor_block, armor_soak, sharp = a_sharp, edge = a_edge)
 	updatehealth()
 	return 1
 

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -119,6 +119,10 @@
 	var/melee_miss_chance = 15		// percent chance to miss a melee attack.
 	var/melee_attack_minDelay = 5		// How long between attacks at least
 	var/melee_attack_maxDelay = 10		// How long between attacks at most
+	var/attack_armor_type = "melee"		// What armor does this check?
+	var/attack_armor_pen = 0			// How much armor pen this attack has.
+	var/attack_sharp = 0				// Is the attack sharp?
+	var/attack_edge = 0					// Does the attack have an edge?
 
 	//Special attacks
 	var/spattack_prob = 0			// Chance of the mob doing a special attack (0 for never)
@@ -1275,7 +1279,7 @@
 		if(H.check_shields(damage = damage_to_do, damage_source = src, attacker = src, def_zone = null, attack_text = "the attack"))
 			return FALSE
 
-	if(A.attack_generic(src, damage_to_do, pick(attacktext)) && attack_sound)
+	if(A.attack_generic(src, damage_to_do, pick(attacktext), attack_armor_type, attack_armor_pen, attack_sharp, attack_edge) && attack_sound)
 		playsound(src, attack_sound, 75, 1)
 
 	return TRUE


### PR DESCRIPTION
- Mobs are no longer forced to always check melee armor. I have **_PLANS_** ™️.
- Simple mobs can now use armor penetration on their melee attacks. I have **_MORE PLANS_** ™️.
- Simple mobs can now be given sharp and edge. I have **_YET MORE PLANS_** ™️.


Long story short, this lets us make more dangerous melee mobs.