### PR TITLE
Two organ bugfixes

### DIFF
--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -83,10 +83,9 @@ var/list/organ_cache = list()
 			blood_DNA[dna.unique_enzymes] = dna.b_type
 
 /obj/item/organ/proc/die()
-	if(robotic >= ORGAN_ROBOT)
-		return
+	if(robotic < ORGAN_ROBOT)
+		status |= ORGAN_DEAD
 	damage = max_damage
-	status |= ORGAN_DEAD
 	processing_objects -= src
 	if(owner && vital)
 		owner.death()
@@ -107,6 +106,11 @@ var/list/organ_cache = list()
 		return
 	if(preserved)
 		return
+
+	//check if we've hit max_damage
+	if(damage >= max_damage)
+		die()
+
 	//Process infections
 	if(robotic >= ORGAN_ROBOT || (owner && owner.species && (owner.species.flags & IS_PLANT || (owner.species.flags & NO_INFECT))))
 		germ_level = 0
@@ -131,10 +135,6 @@ var/list/organ_cache = list()
 		handle_antibiotics()
 		handle_rejection()
 		handle_germ_effects()
-
-	//check if we've hit max_damage
-	if(damage >= max_damage)
-		die()
 
 /obj/item/organ/examine(mob/user)
 	..(user)

--- a/code/modules/surgery/organs_internal.dm
+++ b/code/modules/surgery/organs_internal.dm
@@ -73,7 +73,7 @@
 		return
 	var/is_organ_damaged = 0
 	for(var/obj/item/organ/I in affected.internal_organs)
-		if(I.damage > 0)
+		if(I && (I.damage > 0 || I.status == ORGAN_DEAD))
 			is_organ_damaged = 1
 			break
 	return ..() && is_organ_damaged
@@ -91,7 +91,7 @@
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 
 	for(var/obj/item/organ/I in affected.internal_organs)
-		if(I && I.damage > 0)
+		if(I && (I.damage > 0 || I.status == ORGAN_DEAD))
 			if(!(I.robotic >= ORGAN_ROBOT))
 				user.visible_message("[user] starts treating damage to [target]'s [I.name] with [tool_name].", \
 				"You start treating damage to [target]'s [I.name] with [tool_name]." )
@@ -111,17 +111,16 @@
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 
 	for(var/obj/item/organ/internal/I in affected.internal_organs)
-		if(I && I.damage > 0)
+		if(I && (I.damage > 0 || I.status == ORGAN_DEAD))
 			if(!(I.robotic >= ORGAN_ROBOT))
 				user.visible_message("<span class='notice'>[user] treats damage to [target]'s [I.name] with [tool_name].</span>", \
 				"<span class='notice'>You treat damage to [target]'s [I.name] with [tool_name].</span>" )
 				I.damage = 0
+				I.status = 0
 				if(I.organ_tag == O_EYES)
 					target.sdisabilities &= ~BLIND
 				if(I.organ_tag == O_LUNGS)
 					target.SetLosebreath(0)
-				if (I.status == ORGAN_DEAD)
-					I.status = 0
 
 /datum/surgery_step/internal/fix_organ/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	if (!hasorgans(target))

--- a/code/modules/surgery/organs_internal.dm
+++ b/code/modules/surgery/organs_internal.dm
@@ -120,6 +120,8 @@
 					target.sdisabilities &= ~BLIND
 				if(I.organ_tag == O_LUNGS)
 					target.SetLosebreath(0)
+				if (I.status == ORGAN_DEAD)
+					I.status = 0
 
 /datum/surgery_step/internal/fix_organ/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	if (!hasorgans(target))


### PR DESCRIPTION
First, allows FBPs with synthetic brains (posis and drones) to actually die from massive brain damage. Before, although the damage would still affect them, robotic vital organs taking 60+ damage would never actually kill the owner.

Second, stops the zombie organs bug from popping up in normal play. You were able to repair all the damage on an organ, but not the ORGAN_DEAD status, leading to "dead" organs that still functioned (and that you could never die from them taking damage). Now, repairing the damage surgically will remove that.