### PR TITLE
Adds planetside gun permits

### DIFF
--- a/code/modules/clothing/under/accessories/permits.dm
+++ b/code/modules/clothing/under/accessories/permits.dm
@@ -34,6 +34,10 @@
 	name = "bar shotgun permit"
 	desc = "A card indicating that the owner is allowed to carry a shotgun in the bar."
 
+/obj/item/clothing/accessory/permit/gun/planetside
+	name = "planetside gun permit"
+	desc = "A card indicating that the owner is allowed to carry a firearm while on the surface."
+
 /obj/item/clothing/accessory/permit/drone
 	name = "drone identification card"
 	desc = "A card issued by the EIO, indicating that the owner is a Drone Intelligence. Drones are mandated to carry this card within SolGov space, by law."

--- a/html/changelogs/Anewbe - Planetside Permits.yml
+++ b/html/changelogs/Anewbe - Planetside Permits.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Anewbe
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Added a Planetside Gun Permit item, specifying permission to possess a firearm on the planet's surface. Explorers should spawn with these by default, and a further two can be found in their gun locker."

--- a/maps/southern_cross/job/outfits.dm
+++ b/maps/southern_cross/job/outfits.dm
@@ -17,6 +17,12 @@ Keep outfits simple. Spawn with basic uniforms and minimal gear. Gear instead go
 	id_type = /obj/item/weapon/card/id/civilian/explorer
 	id_pda_assignment = "Explorer"
 	flags = OUTFIT_HAS_BACKPACK|OUTFIT_COMPREHENSIVE_SURVIVAL
+	backpack_contents = list(/obj/item/clothing/accessory/permit/gun/planetside = 1)
+
+/decl/hierarchy/outfit/job/explorer2/post_equip(mob/living/carbon/human/H)
+	..()
+	for(var/obj/item/clothing/accessory/permit/gun/planetside/permit in H.back.contents)
+		permit.set_name(H.real_name)
 
 /decl/hierarchy/outfit/job/explorer2/technician
 	name = OUTFIT_JOB_NAME("Explorer Technician")

--- a/maps/southern_cross/structures/closets/misc.dm
+++ b/maps/southern_cross/structures/closets/misc.dm
@@ -37,6 +37,8 @@
 	// One spare cell per gun
 	new /obj/item/weapon/cell/device/weapon(src)
 	new /obj/item/weapon/cell/device/weapon(src)
+	// One spare gun permit per locker
+	new /obj/item/clothing/accessory/permit/gun/planetside(src)
 
 //Explorer Lockers
 


### PR DESCRIPTION
- Added a planetside gun permit item. Anyone with a registered permit can have a gun on the planet's surface.
- Explorers spawn with a planetside gun permit. One also spawns in each explorer gun cabinet.