### PR TITLE
Makes electrochromatic glass buildable and programmable in game.

### DIFF
--- a/html/changelogs/Leshana-polarized-windows.yml
+++ b/html/changelogs/Leshana-polarized-windows.yml
@@ -1,0 +1,4 @@
+author: Leshana
+delete-after: True
+changes: 
+  - rscadd: "Makes electrochromatic glass buildable and programmable in game.  Use cable and multitool."


### PR DESCRIPTION
- Reinforced glass windows can be upgraded to electrochromatic by hitting them with a cable coil.  The window must not be unpried from its frame to upgrade it (but it can remain anchored).
- Windows can be linked with a tint button by using a multitool on the button to buffer it, then using it on the window to set the ID.  The window must be completely unanchored to edit its id.
- Window tint buttons can have thier ID set *once* with a multtool.
- Inspired by Baystation12/Baystation12#20508
- Also adds a "full tile" polarized window type for use by mappers.