### PR TITLE
Fix Destructive Analyzer and Circuit Imprinter deconstruction runtimes.

### DIFF
--- a/code/modules/research/circuitprinter.dm
+++ b/code/modules/research/circuitprinter.dm
@@ -93,7 +93,7 @@ using metal and glass, it uses glass and reagents (usually sulphuric acid).
 		if(materials[f] >= SHEET_MATERIAL_AMOUNT)
 			var/path = getMaterialType(f)
 			if(path)
-				var/obj/item/stack/S = new f(loc)
+				var/obj/item/stack/S = new path(loc)
 				S.amount = round(materials[f] / SHEET_MATERIAL_AMOUNT)
 	..()
 

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -258,7 +258,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 									qdel(S)
 									linked_destroy.icon_state = "d_analyzer"
 							else
-								if(!(I in linked_destroy.component_parts))
+								if(I != linked_destroy.circuit && !(I in linked_destroy.component_parts))
 									qdel(I)
 									linked_destroy.icon_state = "d_analyzer"
 


### PR DESCRIPTION
Fix Destructive Analyzer and Circuit Imprinter deconstruction runtimes.

### Use the right variable when ejecting stacks.
- Fixes PolarisSS13/Polaris#3404 - Runtime in destructive analyzer deconstruction or part replacer.
- Fixes VOREStation/VOREStation#1883 - Same issue
### Destructive Analyzer shouldn't delete its own circuit board when analyzing.
- Fixes PolarisSS13/Polaris#3518 - Runtime in circuit imprinter deconstruction. 