### PR TITLE
Slimes should no longer /list you.

### DIFF
--- a/code/game/gamemodes/technomancer/assistance/golem.dm
+++ b/code/game/gamemodes/technomancer/assistance/golem.dm
@@ -30,7 +30,7 @@
 	melee_damage_lower = 30 // It has a built in esword.
 	melee_damage_upper = 30
 	attack_sound = 'sound/weapons/blade1.ogg'
-	attacktext = "slashed"
+	attacktext = list("slashed")
 	friendly = "hugs"
 	resistance = 0
 	melee_miss_chance = 0

--- a/code/modules/blob2/mobs/spore.dm
+++ b/code/modules/blob2/mobs/spore.dm
@@ -12,7 +12,7 @@
 	melee_damage_lower = 2
 	melee_damage_upper = 4
 	layer = MOB_LAYER + 0.2 // Over the blob.
-	attacktext = "slams into"
+	attacktext = list("slams into")
 	attack_sound = 'sound/effects/slime_squish.ogg'
 	emote_see = list("sways", "inflates briefly")
 	var/mob/living/carbon/human/infested = null // The human this thing is totally not making into a zombie.
@@ -97,7 +97,7 @@
 	melee_damage_lower += 8  // 10 total.
 	melee_damage_upper += 11 // 15 total.
 	emote_see = list("shambles around", "twitches", "stares")
-	attacktext = "claws"
+	attacktext = list("claws")
 
 	H.forceMove(src)
 	infested = H

--- a/code/modules/mob/living/simple_animal/animals/sif_wildlife/diyaab.dm
+++ b/code/modules/mob/living/simple_animal/animals/sif_wildlife/diyaab.dm
@@ -18,7 +18,7 @@
 	melee_damage_lower = 1
 	melee_damage_upper = 8
 
-	attacktext = "gouged"
+	attacktext = list("gouged")
 	cold_damage_per_tick = 0
 
 	speak_chance = 5

--- a/code/modules/mob/living/simple_animal/animals/sif_wildlife/savik.dm
+++ b/code/modules/mob/living/simple_animal/animals/sif_wildlife/savik.dm
@@ -17,7 +17,7 @@
 	melee_damage_lower = 15
 	melee_damage_upper = 25
 
-	attacktext = "mauled"
+	attacktext = list("mauled")
 	cold_damage_per_tick = 0
 
 	speak_chance = 5

--- a/code/modules/mob/living/simple_animal/animals/sif_wildlife/shantak.dm
+++ b/code/modules/mob/living/simple_animal/animals/sif_wildlife/shantak.dm
@@ -17,7 +17,7 @@
 	melee_damage_lower = 3
 	melee_damage_upper = 12
 
-	attacktext = "gouged"
+	attacktext = list("gouged")
 	cold_damage_per_tick = 0
 
 	speak_chance = 5

--- a/code/modules/mob/living/simple_animal/slime/combat.dm
+++ b/code/modules/mob/living/simple_animal/slime/combat.dm
@@ -180,7 +180,7 @@
 				var/damage_to_do = rand(melee_damage_lower, melee_damage_upper)
 				var/armor_modifier = abs((L.getarmor(null, "bio") / 100) - 1)
 
-				L.attack_generic(src, damage_to_do, attacktext)
+				L.attack_generic(src, damage_to_do, pick(attacktext))
 				playsound(src, 'sound/weapons/bite.ogg', 75, 1)
 
 				// Give the slime some nutrition, if applicable.
@@ -199,7 +199,7 @@
 
 	if(istype(L,/obj/mecha))
 		var/obj/mecha/M = L
-		M.attack_generic(src, rand(melee_damage_lower, melee_damage_upper), attacktext)
+		M.attack_generic(src, rand(melee_damage_lower, melee_damage_upper), pick(attacktext))
 
 /mob/living/simple_animal/slime/proc/post_attack(var/mob/living/L, var/intent = I_HURT)
 	if(intent != I_HELP)

--- a/code/modules/xenobio2/mob/slime/slime.dm
+++ b/code/modules/xenobio2/mob/slime/slime.dm
@@ -22,7 +22,7 @@ Slime definitions, Life and New live here.
 	var/shiny = 0
 	move_to_delay = 17 //Slimes shouldn't be able to go faster than humans.
 	default_chems = list("slimejelly" = 5)
-	attacktext = "absorbed some of"
+	attacktext = list("absorbed some of")
 	response_help = "pats"
 	response_disarm = "tries to stop"
 	response_harm = "hits"

--- a/code/modules/xenobio2/mob/xeno.dm
+++ b/code/modules/xenobio2/mob/xeno.dm
@@ -12,7 +12,7 @@ Also includes Life and New
 	desc = "Something's broken, yell at someone."
 	melee_damage_lower = 0
 	melee_damage_upper = 0
-	attacktext = "hit"
+	attacktext = list("hit")
 	attack_sound = null
 	friendly = "touches"
 	environment_smash = 0


### PR DESCRIPTION
Should fix #4872 

I probably didn't need to change all of these files, but future-proofing is good.

I'm pretty sure the issue is fixed in slime/combat.dm, where it was passing attacktext instead of pick(attacktext). It seemed to be fixed in testing.