### PR TITLE
Fix several Destoy()s

### DIFF
--- a/code/controllers/subsystems/garbage.dm
+++ b/code/controllers/subsystems/garbage.dm
@@ -169,7 +169,12 @@ SUBSYSTEM_DEF(garbage)
 				#endif
 				var/type = D.type
 				var/datum/qdel_item/I = items[type]
-				testing("GC: -- \ref[D] | [type] was unable to be GC'd --")
+				var/extrainfo = "--"
+				if(istype(D,/image))
+					var/image/img = D
+					var/icon/ico = img.icon
+					extrainfo = "L:[img.loc] -- I:[ico] -- IS:[img.icon_state] --"
+				testing("GC: -- \ref[D] | [type] was unable to be GC'd [extrainfo]")
 				I.failures++
 			if (GC_QUEUE_HARDDELETE)
 				HardDelete(D)

--- a/code/datums/EPv2.dm
+++ b/code/datums/EPv2.dm
@@ -40,6 +40,10 @@ var/global/list/all_exonet_connections = list()
 	src.holder = holder
 	..()
 
+/datum/exonet_protocol/Destroy()
+	remove_address()
+	holder = null
+	return ..()
 
 // Proc: make_address()
 // Parameters: 1 (string - used to make into a hash that will be part of the new address)

--- a/code/datums/mixed.dm
+++ b/code/datums/mixed.dm
@@ -23,6 +23,18 @@
 	size = 5.0
 	var/list/fields = list(  )
 
+// Mostly used for data_core records, but unfortuantely used some other places too.  But mostly here, so lets make a good effort.
+// TODO - Some machines/computers might be holding references to us.  Lets look into that, but at least for now lets make sure that the manifest is cleaned up.
+/datum/data/record/Destroy(var/force)
+	if(data_core.locked.Find(src))
+		if(!force)
+			crash_with("Someone tried to qdel a record that was in data_core.locked [log_info_line(src)]")
+			return QDEL_HINT_LETMELIVE
+		data_core.locked -= src
+	data_core.medical -= src
+	data_core.general -= src
+	data_core.security -= src
+	. = ..()
 
 /datum/data/text
 	name = "text"

--- a/code/datums/progressbar.dm
+++ b/code/datums/progressbar.dm
@@ -22,8 +22,10 @@
 /datum/progressbar/Destroy()
 	if (client)
 		client.images -= bar
-	qdel(bar)
-	. = ..()
+	qdel_null(bar)
+	user = null
+	client = null
+	return ..()
 
 /datum/progressbar/proc/update(progress)
 	//world << "Update [progress] - [goal] - [(progress / goal)] - [((progress / goal) * 100)] - [round(((progress / goal) * 100), 5)]"

--- a/code/game/objects/items/devices/communicator/communicator.dm
+++ b/code/game/objects/items/devices/communicator/communicator.dm
@@ -287,17 +287,20 @@ var/global/list/obj/item/device/communicator/all_communicators = list()
 		to_chat(voice, "<span class='danger'>\icon[src] Connection timed out with remote host.</span>")
 		qdel(voice)
 	close_connection(reason = "Connection timed out")
+
+	//Clean up all references we might have to others
 	communicating.Cut()
 	voice_requests.Cut()
 	voice_invites.Cut()
+	node = null
+
+	//Clean up references that might point at us
 	all_communicators -= src
 	processing_objects -= src
 	listening_objects.Remove(src)
-	qdel(camera)
-	camera = null
-	if(exonet)
-		exonet.remove_address()
-		exonet = null
+	qdel_null(camera)
+	qdel_null(exonet)
+
 	return ..()
 
 // Proc: update_icon()

--- a/code/game/objects/items/weapons/implants/implant.dm
+++ b/code/game/objects/items/weapons/implants/implant.dm
@@ -52,7 +52,9 @@
 /obj/item/weapon/implant/Destroy()
 	if(part)
 		part.implants.Remove(src)
+	listening_objects.Remove(src)
 	part = null
+	imp_in = null
 	return ..()
 
 /obj/item/weapon/implant/attackby(obj/item/I, mob/user)
@@ -82,7 +84,6 @@
 
 /obj/item/weapon/implant/tracking/implanted(var/mob/source)
 	processing_objects.Add(src)
-	listening_objects |= src
 	return 1
 
 /obj/item/weapon/implant/tracking/Destroy()

--- a/code/modules/mob/mob_planes.dm
+++ b/code/modules/mob/mob_planes.dm
@@ -94,6 +94,9 @@
 	var/invis_toggle = FALSE
 	var/list/sub_planes
 
+/obj/screen/plane_master/New()
+	..(null) //Never be in anything ever.
+
 /obj/screen/plane_master/proc/set_desired_alpha(var/new_alpha)
 	if(new_alpha != alpha && new_alpha > 0 && new_alpha <= 255)
 		desired_alpha = new_alpha

--- a/code/modules/nano/modules/nano_module.dm
+++ b/code/modules/nano/modules/nano_module.dm
@@ -5,6 +5,10 @@
 /datum/nano_module/New(var/host)
 	src.host = host
 
+/datum/nano_module/Destroy()
+	host = null
+	return ..()
+
 /datum/nano_module/nano_host()
 	return host ? host : src
 


### PR DESCRIPTION
Several objects were not able to be GC'd, and this fixes them:
* Communicators
* Progress bars on do_after
* Implants (do we really need them to all listen though?)
* Anything with a nano_module pointed at it

Also contains a change to log icon and iconstate of images that are unable to GC, in the hopes of being able to find where they are, or what they're from. They're annoying to troubleshoot.

`mixed.dm`'s diff appears to be a line ending change. I guess it had the wrong endings before.