### PR TITLE
Fix health analyzer names

### DIFF
--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -266,15 +266,15 @@ REAGENT SCANNER
 		if(0)
 			to_chat(usr, "The scanner will now perform a basic analysis.")
 
-/obj/item/device/healthanalyzer/advanced //reports bone fractures, IB, quantity of beneficial reagents in stomach; also regular health analyzer stuff
-	name = "advanced health analyzer"
+/obj/item/device/healthanalyzer/improved //reports bone fractures, IB, quantity of beneficial reagents in stomach; also regular health analyzer stuff
+	name = "improved health analyzer"
 	desc = "A miracle of medical technology, this handheld scanner can produce an accurate and specific report of a patient's biosigns."
 	advscan = 1
 	origin_tech = list(TECH_MAGNET = 5, TECH_BIO = 6)
 	icon_state = "health1"
 
-/obj/item/device/healthanalyzer/enhanced //reports all of the above, as well as radiation severity and minor brain damage
-	name = "enhanced health analyzer"
+/obj/item/device/healthanalyzer/advanced //reports all of the above, as well as radiation severity and minor brain damage
+	name = "advanced health analyzer"
 	desc = "An even more advanced handheld health scanner, complete with a full biosign monitor and on-board radiation and neurological analysis suites."
 	advscan = 2
 	origin_tech = list(TECH_MAGNET = 6, TECH_BIO = 7)

--- a/code/game/objects/items/weapons/storage/firstaid.dm
+++ b/code/game/objects/items/weapons/storage/firstaid.dm
@@ -132,7 +132,7 @@
 		/obj/item/weapon/surgical/FixOVein,
 		/obj/item/stack/medical/advanced/bruise_pack,
 		/obj/item/stack/nanopaste,
-		/obj/item/device/healthanalyzer/enhanced
+		/obj/item/device/healthanalyzer/advanced
 		)
 
 	starts_with = list(
@@ -146,7 +146,7 @@
 		/obj/item/weapon/surgical/bonegel,
 		/obj/item/weapon/surgical/FixOVein,
 		/obj/item/stack/medical/advanced/bruise_pack,
-		/obj/item/device/healthanalyzer/enhanced
+		/obj/item/device/healthanalyzer/advanced
 		)
 
 /obj/item/weapon/storage/firstaid/clotting

--- a/code/modules/research/designs.dm
+++ b/code/modules/research/designs.dm
@@ -491,8 +491,8 @@ other types of metals and chemistry for reagents).
 	build_path = /obj/item/roller/adv
 	sort_string = "MBBAF"
 
-/datum/design/item/medical/enhanced_analyzer
-	name = "enhanced health analyzer"
+/datum/design/item/medical/advanced_analyzer
+	name = "advanced health analyzer"
 	desc = "A prototype version of the regular health analyzer, able to distinguish the location of more serious injuries as well as accurately determine radiation levels."
 	id = "advanced_analyzer"
 	req_tech = list(TECH_MAGNET = 5, TECH_BIO = 6)

--- a/code/modules/research/designs.dm
+++ b/code/modules/research/designs.dm
@@ -491,13 +491,13 @@ other types of metals and chemistry for reagents).
 	build_path = /obj/item/roller/adv
 	sort_string = "MBBAF"
 
-/datum/design/item/medical/advanced_analyzer
-	name = "advanced health analyzer"
+/datum/design/item/medical/improved_analyzer
+	name = "improved health analyzer"
 	desc = "A prototype version of the regular health analyzer, able to distinguish the location of more serious injuries as well as accurately determine radiation levels."
-	id = "advanced_analyzer"
+	id = "improved_analyzer"
 	req_tech = list(TECH_MAGNET = 5, TECH_BIO = 6)
 	materials = list(DEFAULT_WALL_MATERIAL = 2000, "glass" = 1000, "silver" = 1000, "gold" = 1500)
-	build_path = /obj/item/device/healthanalyzer/advanced
+	build_path = /obj/item/device/healthanalyzer/improved
 	sort_string = "MBBAG"
 
 /datum/design/item/implant

--- a/maps/submaps/surface_submaps/mountains/CrashedMedShuttle1.dmm
+++ b/maps/submaps/surface_submaps/mountains/CrashedMedShuttle1.dmm
@@ -106,7 +106,7 @@
 "cb" = (/obj/machinery/iv_drip,/obj/item/weapon/reagent_containers/blood/OMinus,/turf/simulated/shuttle/floor/white,/area/submap/CrashedMedShuttle)
 "cc" = (/obj/structure/table/standard,/obj/item/weapon/storage/box/masks,/obj/item/weapon/storage/box/gloves,/obj/random/medical,/obj/random/medical,/obj/random/medical,/turf/simulated/shuttle/floor/white,/area/submap/CrashedMedShuttle)
 "cd" = (/obj/effect/spider/stickyweb,/obj/structure/door_assembly/door_assembly_ext,/turf/simulated/shuttle/plating,/area/submap/CrashedMedShuttle)
-"ce" = (/obj/structure/table/standard,/obj/item/device/healthanalyzer/enhanced,/obj/random/firstaid,/turf/simulated/shuttle/floor/white,/area/submap/CrashedMedShuttle)
+"ce" = (/obj/structure/table/standard,/obj/item/device/healthanalyzer/advanced,/obj/random/firstaid,/turf/simulated/shuttle/floor/white,/area/submap/CrashedMedShuttle)
 "cf" = (/obj/structure/table/standard,/obj/item/weapon/storage/backpack/medic,/obj/random/medical/lite,/turf/simulated/shuttle/floor/white,/area/submap/CrashedMedShuttle)
 "cg" = (/obj/structure/table/standard,/obj/effect/spider/stickyweb,/obj/random/medical,/turf/simulated/shuttle/floor/white,/area/submap/CrashedMedShuttle)
 "ch" = (/obj/structure/girder,/turf/simulated/shuttle/plating,/area/submap/CrashedMedShuttle)


### PR DESCRIPTION
The one that comes out is called advanced. And there IS an enhanced one (level 3) that this is not.

Now also renames them: [nothing] -> Improved -> Advanced -> Phasic

That seems like a linear progression to me.