### PR TITLE
Succumb changes

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -172,10 +172,10 @@ default behaviour is:
 /mob/living/verb/succumb()
 	set hidden = 1
 	if ((src.health < 0 && src.health > (5-src.getMaxHealth()))) // Health below Zero but above 5-away-from-death, as before, but variable
-		src.adjustOxyLoss(src.health + src.getMaxHealth() * 2) // Deal 2x health in OxyLoss damage, as before but variable.
-		src.health = src.getMaxHealth() - src.getOxyLoss() - src.getToxLoss() - src.getFireLoss() - src.getBruteLoss()
+		src.death()
 		to_chat(src, "<font color='blue'>You have given up life and succumbed to death.</font>")
-
+	else
+		to_chat(src, "<font color='blue'>You are not injured enough to succumb to death!</font>")
 
 /mob/living/proc/updatehealth()
 	if(status_flags & GODMODE)

--- a/html/changelogs/PrismaticGynoid-acceptyourfate.yml
+++ b/html/changelogs/PrismaticGynoid-acceptyourfate.yml
@@ -1,0 +1,4 @@
+author: PrismaticGynoid
+delete-after: True
+changes: 
+  - bugfix: "The succumb verb will now work on species that can't take oxyloss damage."


### PR DESCRIPTION
Succumb now works on sufficiently-injured mobs that are unable to take oxyloss damage, like prometheans, FBPs, and dionaea. You're also now given a notification if you try to succumb when you're not injured enough for it.