### PR TITLE
Critters Can Crawl Carrying Client Constructs

### DIFF
--- a/code/_onclick/hud/human.dm
+++ b/code/_onclick/hud/human.dm
@@ -75,7 +75,7 @@
 		ico = new(ui_style, "black")
 		ico.MapColors(0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0, -1,-1,-1,-1)
 		ico.DrawBox(rgb(255,255,255,1),1,ico.Height()/2,ico.Width()/2,ico.Height())
-		using = new /obj/screen( src )
+		using = new /obj/screen()
 		using.name = I_HELP
 		using.icon = ico
 		using.screen_loc = ui_acti
@@ -87,7 +87,7 @@
 		ico = new(ui_style, "black")
 		ico.MapColors(0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0, -1,-1,-1,-1)
 		ico.DrawBox(rgb(255,255,255,1),ico.Width()/2,ico.Height()/2,ico.Width(),ico.Height())
-		using = new /obj/screen( src )
+		using = new /obj/screen()
 		using.name = I_DISARM
 		using.icon = ico
 		using.screen_loc = ui_acti
@@ -99,7 +99,7 @@
 		ico = new(ui_style, "black")
 		ico.MapColors(0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0, -1,-1,-1,-1)
 		ico.DrawBox(rgb(255,255,255,1),ico.Width()/2,1,ico.Width(),ico.Height()/2)
-		using = new /obj/screen( src )
+		using = new /obj/screen()
 		using.name = I_GRAB
 		using.icon = ico
 		using.screen_loc = ui_acti
@@ -111,7 +111,7 @@
 		ico = new(ui_style, "black")
 		ico.MapColors(0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0, -1,-1,-1,-1)
 		ico.DrawBox(rgb(255,255,255,1),1,1,ico.Width()/2,ico.Height()/2)
-		using = new /obj/screen( src )
+		using = new /obj/screen()
 		using.name = I_HURT
 		using.icon = ico
 		using.screen_loc = ui_acti

--- a/code/modules/mob/living/simple_animal/simple_hud.dm
+++ b/code/modules/mob/living/simple_animal/simple_hud.dm
@@ -74,7 +74,7 @@
 	ico = new(ui_style, "black")
 	ico.MapColors(0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0, -1,-1,-1,-1)
 	ico.DrawBox(rgb(255,255,255,1),1,ico.Height()/2,ico.Width()/2,ico.Height())
-	using = new /obj/screen( src )
+	using = new /obj/screen()
 	using.name = I_HELP
 	using.icon = ico
 	using.screen_loc = ui_acti
@@ -86,7 +86,7 @@
 	ico = new(ui_style, "black")
 	ico.MapColors(0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0, -1,-1,-1,-1)
 	ico.DrawBox(rgb(255,255,255,1),ico.Width()/2,ico.Height()/2,ico.Width(),ico.Height())
-	using = new /obj/screen( src )
+	using = new /obj/screen()
 	using.name = I_DISARM
 	using.icon = ico
 	using.screen_loc = ui_acti
@@ -98,7 +98,7 @@
 	ico = new(ui_style, "black")
 	ico.MapColors(0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0, -1,-1,-1,-1)
 	ico.DrawBox(rgb(255,255,255,1),ico.Width()/2,1,ico.Width(),ico.Height()/2)
-	using = new /obj/screen( src )
+	using = new /obj/screen()
 	using.name = I_GRAB
 	using.icon = ico
 	using.screen_loc = ui_acti
@@ -110,7 +110,7 @@
 	ico = new(ui_style, "black")
 	ico.MapColors(0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0, -1,-1,-1,-1)
 	ico.DrawBox(rgb(255,255,255,1),1,1,ico.Width()/2,ico.Height()/2)
-	using = new /obj/screen( src )
+	using = new /obj/screen()
 	using.name = I_HURT
 	using.icon = ico
 	using.screen_loc = ui_acti

--- a/code/modules/ventcrawl/ventcrawl.dm
+++ b/code/modules/ventcrawl/ventcrawl.dm
@@ -10,6 +10,7 @@ var/list/ventcrawl_machinery = list(
 	/obj/item/weapon/holder,
 	/obj/machinery/camera,
 	/mob/living/simple_animal/borer,
+	/obj/screen
 	)
 
 /mob/living/var/list/icon/pipes_shown = list()
@@ -41,18 +42,21 @@ var/list/ventcrawl_machinery = list(
 		return FALSE
 	. = ..()
 
-/mob/living/proc/is_allowed_vent_crawl_item(var/obj/item/carried_item)
+/mob/living/proc/is_allowed_vent_crawl_item(var/obj/carried_item)
+	//Ability master easy test for allowed (cheaper than istype)
 	if(carried_item == ability_master)
 		return 1
 
-	var/list/allowed = list()
-	for(var/type in can_enter_vent_with)
-		var/list/types = typesof(type)
-		allowed += types
+	//Try to find it in our allowed list (istype includes subtypes)
+	var/listed = FALSE
+	for(var/test_type in can_enter_vent_with)
+		if(istype(carried_item,test_type))
+			listed = TRUE
+			break
 
-	if(carried_item.type in allowed)
-		if(get_inventory_slot(carried_item) == 0)
-			return 1
+	//Only allow it if it's "IN" the mob, not equipped on/being held
+	if(listed && !get_inventory_slot(carried_item))
+		return 1
 
 /mob/living/carbon/is_allowed_vent_crawl_item(var/obj/item/carried_item)
 	if(carried_item in internal_organs)


### PR DESCRIPTION
When I copied the hud elements from humans to simple animals, I copied a bug with it, which nobody noticed on humans because they can't ventcrawl.

You shouldn't put the hud elements literally inside the mob, especially considering the huds are deleted/created whenever you logout/login. This results in s_a's played by admins having like 999999 of these objects as they aghost over and over.

That will fix the ventcrawl problem, but ventcrawl was written weird to begin with. This is better than it was, but not as good as /tg/'s typecaches. S o m e d a y.