### PR TITLE
Fixed pAI communicator buttons.

### DIFF
--- a/code/modules/nano/interaction/default.dm
+++ b/code/modules/nano/interaction/default.dm
@@ -17,7 +17,7 @@
 	return STATUS_UPDATE									// Ghosts can view updates
 
 /mob/living/silicon/pai/default_can_use_topic(var/src_object)
-	if((src_object == src || src_object == radio) && !stat)
+	if((src_object == src || src_object == radio || src_object == communicator) && !stat)
 		return STATUS_INTERACTIVE
 	else
 		return ..()


### PR DESCRIPTION
While pAI could open their communicator, they were unable to interact
with any of the buttons in its UI. This adds the UI of their own
built-in communicator to the other two UIs they were already explicitly
allowed to access (those of their own radio and their own interface).