### PR TITLE
Tweak Tesla Grounding Rods

### DIFF
--- a/code/modules/power/tesla/energy_ball.dm
+++ b/code/modules/power/tesla/energy_ball.dm
@@ -218,7 +218,8 @@
 			continue //no need checking these other things
 
 		else if(istype(A, /obj/machinery/power/grounding_rod))
-			var/dist = get_dist(source, A)-2
+			var/obj/machinery/power/grounding_rod/G = A
+			var/dist = get_dist(source, A) - (G.anchored ? 2 : 0)
 			if(dist <= zap_range && (dist < closest_dist || !closest_grounding_rod))
 				closest_grounding_rod = A
 				closest_atom = A

--- a/html/changelogs/Leshana - tesla-grounding.yml
+++ b/html/changelogs/Leshana - tesla-grounding.yml
@@ -1,0 +1,4 @@
+author: Leshana
+delete-after: True
+changes: 
+  - tweak: "Grounding rods act intuitively, only having an expanded lighting catch area when anchored."


### PR DESCRIPTION
Grounding rods are unique in that they cover a 2x2 tile area in terms of attracting lightning from the Tesla ball.  This is useful for protecting stuff next to them.  However when not anchored, this had the confusing effect of making it impossible to set one up, as even tho it wasn't "grounded" to the station, it would be preferentially targeted before things *between* it and the Tesla!  This fixes things to be what the players would normally expect.
Port of VOREStation/VOREStation#3076