### PR TITLE
Create client preference for if hotkey mode is enabled by default on login

### DIFF
--- a/code/modules/client/preference_setup/global/setting_datums.dm
+++ b/code/modules/client/preference_setup/global/setting_datums.dm
@@ -104,6 +104,13 @@ var/list/_client_preferences_by_type
 	enabled_description = "Show"
 	disabled_description = "Hide"
 
+/datum/client_preference/hotkeys_default
+	description ="Hotkeys Default"
+	key = "HUD_HOTKEYS"
+	enabled_description = "Enabled"
+	disabled_description = "Disabled"
+	enabled_by_default = FALSE // Backwards compatibility
+
 /datum/client_preference/show_typing_indicator
 	description ="Typing indicator"
 	key = "SHOW_TYPING"

--- a/code/modules/mob/living/silicon/robot/login.dm
+++ b/code/modules/mob/living/silicon/robot/login.dm
@@ -5,7 +5,8 @@
 
 	show_laws(0)
 
-	winset(src, null, "mainwindow.macro=borgmacro hotkey_toggle.is-checked=false input.focus=true input.background-color=#D3B5B5")
+	// Override the DreamSeeker macro with the borg version!
+	client.set_hotkeys_macro("borgmacro", "borghotkeymode")
 
 	// Forces synths to select an icon relevant to their module
 	if(!icon_selected)

--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -56,4 +56,4 @@
 	recalculate_vis()
 
 	//set macro to normal incase it was overriden (like cyborg currently does)
-	winset(src, null, "mainwindow.macro=macro hotkey_toggle.is-checked=false input.focus=true input.background-color=#D3B5B5")
+	client.set_hotkeys_macro("macro", "hotkeymode")

--- a/html/changelogs/Leshana - hotkeys-qol.yml
+++ b/html/changelogs/Leshana - hotkeys-qol.yml
@@ -1,0 +1,5 @@
+author: Leshana
+delete-after: True
+changes: 
+  - rscadd: "Added a client preference setting for wether Hotkeys Mode should be enabled or disabled by default."
+  - bugfix: "CTRL+NUMPAD8 while playing a robot won't runtime anymore."

--- a/interface/interface.dm
+++ b/interface/interface.dm
@@ -188,3 +188,14 @@ Any-Mode: (hotkey doesn't need to be on)
 		src << other
 	if(holder)
 		src << admin
+
+// Set the DreamSeeker input macro to the type appropriate for its mob
+/client/proc/set_hotkeys_macro(macro_name = "macro", hotkey_macro_name = "hotkeymode", hotkeys_enabled = null)
+	// If hotkeys mode was not specified, fall back to choice of default in client preferences.
+	if(isnull(hotkeys_enabled))
+		hotkeys_enabled = is_preference_enabled(/datum/client_preference/hotkeys_default)
+
+	if(hotkeys_enabled)
+		winset(src, null, "mainwindow.macro=[hotkey_macro_name] hotkey_toggle.is-checked=true mapwindow.map.focus=true")
+	else
+		winset(src, null, "mainwindow.macro=[macro_name] hotkey_toggle.is-checked=false input.focus=true")

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -991,7 +991,7 @@ macro "borgmacro"
 		is-disabled = false
 	elem 
 		name = "CTRL+NUMPAD8"
-		command = "body-head-toggle"
+		command = "body-toggle-head"
 		is-disabled = false
 	elem 
 		name = "F1"


### PR DESCRIPTION
* Adds preference setting for wether hotkeys should default to enabled or disabled.
* Fixes bug for CTRL+NUMPAD8 using old verb name for toggling head.
* Also slightly organized the code that sets the hotkeys macro so its more understandable.