### PR TITLE
Sundry Bugfixes - Feburary

### DIFF
--- a/code/game/objects/items/weapons/RCD.dm
+++ b/code/game/objects/items/weapons/RCD.dm
@@ -103,7 +103,7 @@
 		build_delay = 50
 		build_type = "airlock"
 		build_other = /obj/machinery/door/airlock
-	else if(!deconstruct && (istype(T,/turf/space) || istype(T,get_base_turf_by_area(T))))
+	else if(!deconstruct && isturf(T) && (istype(T,/turf/space) || istype(T,get_base_turf_by_area(T))))
 		build_cost =  1
 		build_type =  "floor"
 		build_turf =  /turf/simulated/floor/airless

--- a/code/game/objects/items/weapons/candle.dm
+++ b/code/game/objects/items/weapons/candle.dm
@@ -8,7 +8,7 @@
 	var/wax = 2000
 
 /obj/item/weapon/flame/candle/New()
-	wax = rand(800, 1000) // Enough for 27-33 minutes. 30 minutes on average.
+	wax -= rand(800, 1000) // Enough for 27-33 minutes. 30 minutes on average.
 	..()
 
 /obj/item/weapon/flame/candle/update_icon()
@@ -26,7 +26,7 @@
 	if(istype(W, /obj/item/weapon/weldingtool))
 		var/obj/item/weapon/weldingtool/WT = W
 		if(WT.isOn()) //Badasses dont get blinded by lighting their candle with a welding tool
-			light("<span class='notice'>\The [user] casually lights the [name] with [W].</span>")
+			light("<span class='notice'>\The [user] casually lights the [src] with [W].</span>")
 	else if(istype(W, /obj/item/weapon/flame/lighter))
 		var/obj/item/weapon/flame/lighter/L = W
 		if(L.lit)
@@ -41,15 +41,12 @@
 			light()
 
 
-/obj/item/weapon/flame/candle/proc/light(var/flavor_text = "<span class='notice'>\The [usr] lights the [name].</span>")
-	if(!src.lit)
-		src.lit = 1
-		//src.damtype = "fire"
-		for(var/mob/O in viewers(usr, null))
-			O.show_message(flavor_text, 1)
+/obj/item/weapon/flame/candle/proc/light(var/flavor_text = "<span class='notice'>\The [usr] lights the [src].</span>")
+	if(!lit)
+		lit = TRUE
+		visible_message(flavor_text)
 		set_light(CANDLE_LUM)
 		processing_objects.Add(src)
-
 
 /obj/item/weapon/flame/candle/process()
 	if(!lit)
@@ -88,23 +85,13 @@
 /obj/item/weapon/flame/candle/everburn
 	wax = 99999
 
-/obj/item/weapon/flame/candle/everburn/New()
-	if(!src.lit)
-		src.lit = 1
-		//src.damtype = "fire"
-		for(var/mob/O in viewers(usr, null))
-			O.show_message("<span class='notice'>\The [name] mysteriously lights itself!.</span>", 1)
-		set_light(CANDLE_LUM)
-		processing_objects.Add(src)
+/obj/item/weapon/flame/candle/everburn/initialize()
+	. = ..()
+	light("<span class='notice'>\The [src] mysteriously lights itself!.</span>")
 
 /obj/item/weapon/flame/candle/candelabra/everburn
 	wax = 99999
 
-/obj/item/weapon/flame/candle/candelabra/everburn/New()
-	if(!src.lit)
-		src.lit = 1
-		//src.damtype = "fire"
-		for(var/mob/O in viewers(usr, null))
-			O.show_message("<span class='notice'>\The [name] mysteriously lights itself!.</span>", 1)
-		set_light(CANDLE_LUM)
-		processing_objects.Add(src)
+/obj/item/weapon/flame/candle/candelabra/everburn/initialize()
+	. = ..()
+	light("<span class='notice'>\The [src] mysteriously lights itself!.</span>")

--- a/code/game/objects/items/weapons/storage/fancy.dm
+++ b/code/game/objects/items/weapons/storage/fancy.dm
@@ -307,6 +307,7 @@
 /obj/item/weapon/storage/fancy/heartbox
 	icon_state = "heartbox"
 	name = "box of chocolates"
+	icon_type = "chocolates"
 	var/startswith = 6
 	max_storage_space = ITEMSIZE_COST_SMALL * 6
 	can_hold = list(


### PR DESCRIPTION
- Fixes VOREStation/VOREStation#3075 - Boxes of Chocolates say they contain donuts.
- Fix runtime when clicking RCD on almost anything. - get_base_turf_by_area() is only for turfs!
- Stop candles from messaging the universe when they light. 