### PR TITLE
Removes the VeyMed license from Cargo

### DIFF
--- a/code/datums/supplypacks/robotics.dm
+++ b/code/datums/supplypacks/robotics.dm
@@ -116,14 +116,6 @@
 	containername = "Robolimb blueprints (Bishop)"
 	access = access_robotics
 
-/datum/supply_packs/robotics/robolimbs/veymed
-	name = "Vey-Med robolimb blueprints"
-	contains = list(/obj/item/weapon/disk/limb/veymed)
-	cost = 70
-	containertype = /obj/structure/closet/crate/secure/science
-	containername = "Robolimb blueprints (Vey-Med)"
-	access = access_robotics
-
 /datum/supply_packs/robotics/mecha_ripley
 	name = "Circuit Crate (\"Ripley\" APLU)"
 	contains = list(


### PR DESCRIPTION
Accurately representing the cost of this brand is not currently possible. Pending a rewrite of the actual character setup robolimb spawning, this will have to do.