### PR TITLE
Removes translators from the loadout

### DIFF
--- a/code/game/objects/items/devices/translator.dm
+++ b/code/game/objects/items/devices/translator.dm
@@ -4,7 +4,7 @@
 	desc = "This handy device appears to translate the languages it hears into onscreen text for a user."
 	icon = 'icons/obj/device.dmi'
 	icon_state = "translator"
-	w_class = ITEMSIZE_SMALL
+	w_class = ITEMSIZE_NORMAL
 	origin_tech = list(TECH_DATA = 3, TECH_ENGINEERING = 3)
 	var/mult_icons = 1	//Changes sprite when it translates
 	var/visual = 1		//If you need to see to get the message

--- a/code/modules/client/preference_setup/loadout/loadout_ears.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_ears.dm
@@ -8,8 +8,3 @@
 /datum/gear/ears/headphones
 	display_name = "headphones"
 	path = /obj/item/clothing/ears/earmuffs/headphones
-
-/datum/gear/ears/translator
-	display_name = "universal translator, ear"
-	path = /obj/item/device/universal_translator/ear
-	cost = 8

--- a/code/modules/client/preference_setup/loadout/loadout_utility.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_utility.dm
@@ -120,11 +120,6 @@
 	slot = "implant"
 	exploitable = 1
 
-/datum/gear/utility/translator
-	display_name = "universal translator"
-	path = /obj/item/device/universal_translator
-	cost = 8
-
 /datum/gear/utility/pen
 	display_name = "Fountain Pen"
 	path = /obj/item/weapon/pen/fountain

--- a/code/modules/research/designs.dm
+++ b/code/modules/research/designs.dm
@@ -1790,9 +1790,17 @@ CIRCUITS BELOW
 	name = "handheld translator"
 	id = "translator"
 	req_tech = list(TECH_DATA = 3, TECH_ENGINEERING = 3)
-	materials = list(DEFAULT_WALL_MATERIAL = 2000, "glass" = 2000)
+	materials = list(DEFAULT_WALL_MATERIAL = 3000, "glass" = 3000)
 	build_path = /obj/item/device/universal_translator
-	sort_string = "HABBA"
+	sort_string = "HABQA"
+
+/datum/design/item/ear_translator
+	name = "earpiece translator"
+	id = "ear_translator"
+	req_tech = list(TECH_DATA = 5, TECH_ENGINEERING = 5)	//It's been hella miniaturized.
+	materials = list(DEFAULT_WALL_MATERIAL = 2000, "glass" = 2000, "gold" = 1000)
+	build_path = /obj/item/device/universal_translator/ear
+	sort_string = "HABQB"
 
 /* Uncomment if someone makes these buildable
 /datum/design/circuit/general_alert

--- a/html/changelogs/Anewbe - Translators.yml
+++ b/html/changelogs/Anewbe - Translators.yml
@@ -1,0 +1,37 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Anewbe
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscdel: "Removed universal translators from the loadout."
+  - rscadd: "RnD can print earpiece translators."


### PR DESCRIPTION
Heavily inspired by https://github.com/VOREStation/VOREStation/pull/2972

https://forum.ss13polaris.com/viewtopic.php?f=14&t=489

- Removes the Translators from the loadout. Go talk to RnD, or apply for the language.
- Makes the handheld translator bigger, so it doesn't fit in pockets. You're supposed to be looking at the screen to see it translated.
- Adds the Ear Translator to the RnD console. It's more expensive than the normal one, because it doesn't take up a hand.