### PR TITLE
Generic aura animation proc, works on any icon

### DIFF
--- a/code/_helpers/icons.dm
+++ b/code/_helpers/icons.dm
@@ -888,3 +888,77 @@ proc/sort_atoms_by_layer(var/list/atoms)
 	img.plane = plane //Thanks Byond.
 	img.appearance_flags = APPEARANCE_UI|KEEP_APART
 	return img
+
+/**
+* Animate a 'halo' around an object.
+*
+* This proc is not exactly cheap. You'd be well advised to set up many-loops rather than call this super-often. getCompoundIcon is
+* mostly to blame for this. If Byond ever implements a way to get something's icon more 'gently' than this, do that instead.
+*
+* @param A This is the atom to put the halo on
+* @param simple_icons If set to TRUE, will just perform a very basic icon and icon_state steal. DO USE when possible.
+* @param color This is the color for the halo
+* @param anim_duration This decides how fast (or slow) the animation plays
+* @param offset Mysterious variable that determines size of the halo's gap from icon
+* @param loops How many times the animation loops
+* @param grow_to Relative to the size of the icon, how big the halo grows while fading (don't use negatives for inward halos, use < 1)
+* @param pixel_scale If you'd like the halo to use pixel scale or the default 'fuzzy' scale
+*/
+/proc/animate_aura(var/atom/A, var/simple_icons, var/color = "#00FF22", var/anim_duration = 5, var/offset = 1, var/loops = 1, var/grow_to = 2, var/pixel_scale = FALSE)
+	ASSERT(A)
+
+	//Take a guess at this, if they didn't set it
+	if(isnull(simple_icons))
+		if(ismob(A))
+			simple_icons = FALSE
+		else
+			simple_icons = TRUE
+
+	//Get their icon
+	var/icon/hole
+
+	if(simple_icons)
+		hole = icon(A.icon, A.icon_state)
+	else
+		hole = getCompoundIcon(A)
+
+	hole.MapColors(0,0,0, 0,0,0, 0,0,0, 1,1,1) //White.
+
+	//Make a bigger version
+	var/icon/grower = new(hole)
+	var/orig_width = grower.Width()
+	var/orig_height = grower.Height()
+	var/end_width = orig_width+(offset*2)
+	var/end_height = orig_height+(offset*2)
+	var/half_diff_width = (end_width-orig_width)*0.5
+	var/half_diff_height = (end_height-orig_height)*0.5
+
+	//Make icon black
+	grower.SwapColor("#FFFFFF","#000000") //Black.
+
+	//Scale both icons big so we don't have to deal with low-pixel garbage issues
+	grower.Scale(orig_width*10,orig_height*10)
+	hole.Scale(orig_width*9,orig_height*9)
+
+	//Blend the hole in
+	grower.Blend(hole,ICON_OVERLAY, x = ((orig_width*10-orig_width*9)*0.5)+1, y = ((orig_height*10-orig_height*9)*0.5)+1)
+
+	//Swap white to zero alpha
+	grower.SwapColor("#FFFFFF","#00000000")
+
+	//Color it
+	grower.SwapColor("#000000",color)
+
+	//Scale it to final height
+	grower.Scale(end_width,end_height)
+
+	//Flick it onto them
+	var/image/img = image(grower,A)
+	if(pixel_scale)
+		img.appearance_flags |= PIXEL_SCALE
+	img.pixel_x = half_diff_width*-1
+	img.pixel_y = half_diff_height*-1
+	flick_overlay_view(img, A, anim_duration*loops, TRUE)
+
+	//Animate it growing
+	animate(img, alpha = 0, transform = matrix()*grow_to, time = anim_duration, loop = loops)


### PR DESCRIPTION
Generic proc that allows you to animate an aura around something. Useful to get rid of all those hardcoded 'the teleport animation is the outline of a bald human facing south' things.

![2018-02-24_02-40-13](https://user-images.githubusercontent.com/15028025/36633493-c27ba320-1964-11e8-9e28-0e96707cf1cd.gif)

I know your server doesn't have resizey things but it's still a good demo.