### PR TITLE
Adds TG-style floor tile swapping

### DIFF
--- a/code/game/turfs/simulated/floor_attackby.dm
+++ b/code/game/turfs/simulated/floor_attackby.dm
@@ -4,39 +4,14 @@
 		return 0
 
 	if(flooring)
-		if(istype(C, /obj/item/weapon/crowbar))
-			if(broken || burnt)
-				to_chat(user, "<span class='notice'>You remove the broken [flooring.descriptor].</span>")
-				make_plating()
-			else if(flooring.flags & TURF_IS_FRAGILE)
-				to_chat(user, "<span class='danger'>You forcefully pry off the [flooring.descriptor], destroying them in the process.</span>")
-				make_plating()
-			else if(flooring.flags & TURF_REMOVE_CROWBAR)
-				to_chat(user, "<span class='notice'>You lever off the [flooring.descriptor].</span>")
-				make_plating(1)
-			else
-				return
-			playsound(src, C.usesound, 80, 1)
-			return
-		else if(istype(C, /obj/item/weapon/screwdriver) && (flooring.flags & TURF_REMOVE_SCREWDRIVER))
-			if(broken || burnt)
-				return
-			to_chat(user, "<span class='notice'>You unscrew and remove the [flooring.descriptor].</span>")
-			make_plating(1)
-			playsound(src, C.usesound, 80, 1)
-			return
-		else if(istype(C, /obj/item/weapon/wrench) && (flooring.flags & TURF_REMOVE_WRENCH))
-			to_chat(user, "<span class='notice'>You unwrench and remove the [flooring.descriptor].</span>")
-			make_plating(1)
-			playsound(src, C.usesound, 80, 1)
-			return
-		else if(istype(C, /obj/item/weapon/shovel) && (flooring.flags & TURF_REMOVE_SHOVEL))
-			to_chat(user, "<span class='notice'>You shovel off the [flooring.descriptor].</span>")
-			make_plating(1)
-			playsound(src, 'sound/items/Deconstruct.ogg', 80, 1)
+		if(istype(C, /obj/item/weapon))
+			try_deconstruct_tile(C, user)
 			return
 		else if(istype(C, /obj/item/stack/cable_coil))
 			to_chat(user, "<span class='warning'>You must remove the [flooring.descriptor] first.</span>")
+			return
+		else if(istype(C, /obj/item/stack/tile))
+			try_replace_tile(C, user)
 			return
 	else
 
@@ -88,3 +63,47 @@
 						broken = null
 					else
 						to_chat(user, "<span class='warning'>You need more welding fuel to complete this task.</span>")
+
+/turf/simulated/floor/proc/try_deconstruct_tile(obj/item/weapon/W as obj, mob/user as mob)
+	if(istype(W, /obj/item/weapon/crowbar))
+		if(broken || burnt)
+			to_chat(user, "<span class='notice'>You remove the broken [flooring.descriptor].</span>")
+			make_plating()
+		else if(flooring.flags & TURF_IS_FRAGILE)
+			to_chat(user, "<span class='danger'>You forcefully pry off the [flooring.descriptor], destroying them in the process.</span>")
+			make_plating()
+		else if(flooring.flags & TURF_REMOVE_CROWBAR)
+			to_chat(user, "<span class='notice'>You lever off the [flooring.descriptor].</span>")
+			make_plating(1)
+		else
+			return 0
+		playsound(src, W.usesound, 80, 1)
+		return 1
+	else if(istype(W, /obj/item/weapon/screwdriver) && (flooring.flags & TURF_REMOVE_SCREWDRIVER))
+		if(broken || burnt)
+			return 0
+		to_chat(user, "<span class='notice'>You unscrew and remove the [flooring.descriptor].</span>")
+		make_plating(1)
+		playsound(src, W.usesound, 80, 1)
+		return 1
+	else if(istype(W, /obj/item/weapon/wrench) && (flooring.flags & TURF_REMOVE_WRENCH))
+		to_chat(user, "<span class='notice'>You unwrench and remove the [flooring.descriptor].</span>")
+		make_plating(1)
+		playsound(src, W.usesound, 80, 1)
+		return 1
+	else if(istype(W, /obj/item/weapon/shovel) && (flooring.flags & TURF_REMOVE_SHOVEL))
+		to_chat(user, "<span class='notice'>You shovel off the [flooring.descriptor].</span>")
+		make_plating(1)
+		playsound(src, 'sound/items/Deconstruct.ogg', 80, 1)
+		return 1
+	return 0
+
+/turf/simulated/floor/proc/try_replace_tile(obj/item/stack/tile/T as obj, mob/user as mob)
+	if(T.type == flooring.build_type)
+		return
+	var/obj/item/weapon/W = user.is_holding_item_of_type(/obj/item/weapon)
+	if(!try_deconstruct_tile(W, user))
+		return
+	if(flooring)
+		return
+	attackby(T, user)

--- a/code/modules/mob/living/silicon/robot/inventory.dm
+++ b/code/modules/mob/living/silicon/robot/inventory.dm
@@ -256,3 +256,9 @@
 /mob/living/silicon/robot/put_in_hands(var/obj/item/W) // No hands.
 	W.loc = get_turf(src)
 	return 1
+
+/mob/living/silicon/robot/is_holding_item_of_type(typepath)
+	for(var/obj/item/I in list(module_state_1, module_state_2, module_state_3))
+		if(istype(I, typepath))
+			return I
+	return FALSE

--- a/html/changelogs/Nerezza - Tilematic.yml
+++ b/html/changelogs/Nerezza - Tilematic.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Nerezza
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Added /tg/-style floor tile swapping. Equip crowbar/screwdriver in offhand and click the floor tiles you want to directly swap with a stack of new floor tiles (like teal carpet)."


### PR DESCRIPTION
Hold the tool for pulling a floor tile in your offhand and use a stack of floor tiles (ie, carpet) on the target floor to (almost) immediately swap the tiles.

This respects the different tools and their effects so replacing wooden tiles should be done with a screwdriver, not a crowbar.

Also adds is_holding_item_of_type() to cyborgs/drons.