### PR TITLE
Flooring fixes

### DIFF
--- a/code/game/objects/items/stacks/tiles/fifty_spawner_tiles.dm
+++ b/code/game/objects/items/stacks/tiles/fifty_spawner_tiles.dm
@@ -10,7 +10,7 @@
 
 /obj/fiftyspawner/wood/sif
 	name = "stack of alien wood"
-	type_to_spawn = /obj/item/stack/tile/sifwood
+	type_to_spawn = /obj/item/stack/tile/wood/sif
 
 /obj/fiftyspawner/carpet
 	name = "stack of carpet"

--- a/code/game/objects/items/stacks/tiles/tile_types.dm
+++ b/code/game/objects/items/stacks/tiles/tile_types.dm
@@ -37,9 +37,6 @@
 	flags = 0
 	origin_tech = list(TECH_BIO = 1)
 	no_variants = FALSE
-
-/obj/item/stack/tile/grass/fifty
-	amount = 50
 /*
  * Wood
  */
@@ -55,23 +52,11 @@
 	flags = 0
 	no_variants = FALSE
 
-/obj/item/stack/tile/sifwood
+/obj/item/stack/tile/wood/sif
 	name = "alien wood tile"
 	singular_name = "alien wood tile"
 	desc = "An easy to fit wooden floor tile. It's blue!"
 	icon_state = "tile-sifwood"
-	force = 1.0
-	throwforce = 1.0
-	throw_speed = 5
-	throw_range = 20
-	flags = 0
-	no_variants = FALSE
-
-/obj/item/stack/tile/wood/fifty
-	amount = 50
-
-/obj/item/stack/tile/sifwood/fifty
-	amount = 50
 
 /obj/item/stack/tile/wood/cyborg
 	name = "wood floor tile synthesizer"

--- a/code/game/turfs/flooring/flooring.dm
+++ b/code/game/turfs/flooring/flooring.dm
@@ -1,5 +1,10 @@
 var/list/flooring_types
 
+/proc/populate_flooring_types()
+	flooring_types = list()
+	for (var/flooring_path in typesof(/decl/flooring))
+		flooring_types["[flooring_path]"] = new flooring_path
+
 /proc/get_flooring_data(var/flooring_path)
 	if(!flooring_types)
 		flooring_types = list()
@@ -270,7 +275,7 @@ var/list/flooring_types
 
 /decl/flooring/wood
 	name = "wooden floor"
-	desc = "Polished redwood planks."
+	desc = "Polished wooden planks."
 	icon = 'icons/turf/flooring/wood.dmi'
 	icon_base = "wood"
 	has_damage_range = 6
@@ -285,22 +290,12 @@ var/list/flooring_types
 		'sound/effects/footstep/wood4.ogg',
 		'sound/effects/footstep/wood5.ogg'))
 
-/decl/flooring/sifwood
+/decl/flooring/wood/sif
 	name = "alien wooden floor"
 	desc = "Polished alien wood planks."
 	icon = 'icons/turf/flooring/wood.dmi'
 	icon_base = "sifwood"
-	has_damage_range = 6
-	damage_temperature = T0C+200
-	descriptor = "planks"
-	build_type = /obj/item/stack/tile/sifwood
-	flags = TURF_CAN_BREAK | TURF_IS_FRAGILE | TURF_REMOVE_SCREWDRIVER
-	footstep_sounds = list("human" = list(
-		'sound/effects/footstep/wood1.ogg',
-		'sound/effects/footstep/wood2.ogg',
-		'sound/effects/footstep/wood3.ogg',
-		'sound/effects/footstep/wood4.ogg',
-		'sound/effects/footstep/wood5.ogg'))
+	build_type = /obj/item/stack/tile/wood/sif
 
 /decl/flooring/reinforced
 	name = "reinforced floor"

--- a/code/game/turfs/flooring/flooring_premade.dm
+++ b/code/game/turfs/flooring/flooring_premade.dm
@@ -68,11 +68,11 @@
 	icon_state = "wood"
 	initial_flooring = /decl/flooring/wood
 
-/turf/simulated/floor/sifwood
+/turf/simulated/floor/wood/sif
 	name = "alien wooden floor"
 	icon = 'icons/turf/flooring/wood.dmi'
 	icon_state = "sifwood"
-	initial_flooring = /decl/flooring/sifwood
+	initial_flooring = /decl/flooring/wood/sif
 
 /turf/simulated/floor/grass
 	name = "grass patch"

--- a/code/modules/materials/material_recipes.dm
+++ b/code/modules/materials/material_recipes.dm
@@ -186,6 +186,6 @@
 
 /material/wood/sif/generate_recipes()
 	..()
-	recipes += new/datum/stack_recipe("alien wood floor tile", /obj/item/stack/tile/sifwood, 1, 4, 20)
+	recipes += new/datum/stack_recipe("alien wood floor tile", /obj/item/stack/tile/wood/sif, 1, 4, 20)
 	recipes -= new/datum/stack_recipe("wood floor tile", /obj/item/stack/tile/wood, 1, 4, 20)
 	recipes -= new/datum/stack_recipe("wooden chair", /obj/structure/bed/chair/wood, 3, time = 10, one_per_turf = 1, on_floor = 1)

--- a/code/world.dm
+++ b/code/world.dm
@@ -111,6 +111,9 @@ var/global/datum/global_init/init = new ()
 	// Create frame types.
 	populate_frame_types()
 
+	// Create floor types.
+	populate_flooring_types()
+
 	// Create robolimbs for chargen.
 	populate_robolimb_list()
 
@@ -121,7 +124,7 @@ var/global/datum/global_init/init = new ()
 	processScheduler.setup()
 	Master.Initialize(10, FALSE)
 
-	spawn(1)		
+	spawn(1)
 		master_controller.setup()
 #if UNIT_TEST
 		initialize_unit_tests()

--- a/html/changelogs/Nerezza - Floor-fixes.yml
+++ b/html/changelogs/Nerezza - Floor-fixes.yml
@@ -1,0 +1,37 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Nerezza
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Fixes not being able to install the different carpet colors. Finally."
+  - bugfix: "Removes certain unusable duplicate stacks of tiles from the code."


### PR DESCRIPTION
Firstly it fixes a long-standing bugs with constructable flooring not actually populating on server startup, but instead through a proc that's only called on existing floor tiles. Fixes #4947

Second it changes sif wood tiles into a child of wood tiles now that the reason for carpet colors not working is known & fixed.

Credit to `@jade` on Discord for pointing me in the right direction for the first fix.

Edit: Oh and third it removes three 'fifty' stacks that were incorrectly defined (and duplicates), which would create tile stacks that were non-functional.