### PR TITLE
Should be able to attach accessories by clicking the target item again

### DIFF
--- a/code/modules/clothing/clothing_accessories.dm
+++ b/code/modules/clothing/clothing_accessories.dm
@@ -1,11 +1,9 @@
 /obj/item/clothing/proc/can_attach_accessory(obj/item/clothing/accessory/A)
-	var/obj/item/clothing/accessory/attach = A
-	if(src.valid_accessory_slots && (attach.slot in src.valid_accessory_slots))
-		if(accessories.len && restricted_accessory_slots && (attach.slot in restricted_accessory_slots))
+	if(src.valid_accessory_slots && (A.slot in src.valid_accessory_slots))
+		if(accessories.len && restricted_accessory_slots && (A.slot in restricted_accessory_slots))
 			for(var/obj/item/clothing/accessory/AC in accessories)
-				if (AC.slot == attach.slot)
+				if (AC.slot == A.slot)
 					return FALSE
-			return TRUE
 		return TRUE
 	else
 		return FALSE

--- a/code/modules/clothing/clothing_accessories.dm
+++ b/code/modules/clothing/clothing_accessories.dm
@@ -1,21 +1,20 @@
 /obj/item/clothing/proc/can_attach_accessory(obj/item/clothing/accessory/A)
-	if(valid_accessory_slots && istype(A) && (A.slot in valid_accessory_slots))
-		if(accessories.len && restricted_accessory_slots && (A.slot in restricted_accessory_slots))
+	var/obj/item/clothing/accessory/attach = A
+	if(src.valid_accessory_slots && (attach.slot in src.valid_accessory_slots))
+		if(accessories.len && restricted_accessory_slots && (attach.slot in restricted_accessory_slots))
 			for(var/obj/item/clothing/accessory/AC in accessories)
-				if (AC.slot == A.slot)
-					return 0
-		return 1
-	return 0
-
-	if(accessories.len && restricted_accessory_slots && (A.slot in restricted_accessory_slots))
-		for(var/obj/item/clothing/accessory/AC in accessories)
-			if (AC.slot == A.slot)
-				return 0
-	return 1
+				if (AC.slot == attach.slot)
+					return FALSE
+			return TRUE
+		return TRUE
+	else
+		return FALSE
 
 /obj/item/clothing/attackby(var/obj/item/I, var/mob/user)
 	if(istype(I, /obj/item/clothing/accessory))
-		attempt_attach_accessory(I, user)
+		var/obj/item/clothing/accessory/A = I
+		if(attempt_attach_accessory(user, A))
+			return
 
 	if(accessories.len)
 		for(var/obj/item/clothing/accessory/A in accessories)
@@ -80,6 +79,7 @@
 	else
 		to_chat(user, "<span class='warning'>You cannot attach more accessories of this type to [src].</span>")
 		return FALSE
+
 
 /obj/item/clothing/proc/attach_accessory(mob/user, obj/item/clothing/accessory/A)
 	accessories += A

--- a/code/modules/clothing/clothing_accessories.dm
+++ b/code/modules/clothing/clothing_accessories.dm
@@ -13,7 +13,7 @@
 /obj/item/clothing/attackby(var/obj/item/I, var/mob/user)
 	if(istype(I, /obj/item/clothing/accessory))
 		var/obj/item/clothing/accessory/A = I
-		if(attempt_attach_accessory(user, A))
+		if(attempt_attach_accessory(A, user))
 			return
 
 	if(accessories.len)
@@ -66,18 +66,21 @@
  *  user is the user doing the attaching. Can be null, such as when attaching
  *  items on spawn
  */
-/obj/item/clothing/proc/attempt_attach_accessory(mob/user, obj/item/clothing/accessory/A)
+/obj/item/clothing/proc/attempt_attach_accessory(obj/item/clothing/accessory/A, mob/user)
 	if(!valid_accessory_slots || !valid_accessory_slots.len)
-		to_chat(user, "<span class='warning'>You cannot attach accessories of any kind to \the [src].</span>")
+		if(user)
+			to_chat(user, "<span class='warning'>You cannot attach accessories of any kind to \the [src].</span>")
 		return FALSE
 
 	var/obj/item/clothing/accessory/acc = A
 	if(can_attach_accessory(acc))
-		user.drop_item()
+		if(user)
+			user.drop_item()
 		attach_accessory(user, acc)
 		return TRUE
 	else
-		to_chat(user, "<span class='warning'>You cannot attach more accessories of this type to [src].</span>")
+		if(user)
+			to_chat(user, "<span class='warning'>You cannot attach more accessories of this type to [src].</span>")
 		return FALSE
 
 

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -319,7 +319,7 @@ This saves us from having to call add_fingerprint() any time something is put in
 			for(var/obj/item/clothing/C in worn_clothing)
 				if(istype(W, /obj/item/clothing/accessory))
 					var/obj/item/clothing/accessory/A = W
-					if(C.attempt_attach_accessory(usr, A))
+					if(C.attempt_attach_accessory(A))
 						return
 		else
 			src << "<font color='red'>You are trying to equip this item to an unsupported inventory slot. How the heck did you manage that? Stop it...</font>"

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -319,7 +319,7 @@ This saves us from having to call add_fingerprint() any time something is put in
 			for(var/obj/item/clothing/C in worn_clothing)
 				if(istype(W, /obj/item/clothing/accessory))
 					var/obj/item/clothing/accessory/A = W
-					if(C.attempt_attach_accessory(A))
+					if(C.attempt_attach_accessory(A, src))
 						return
 		else
 			src << "<font color='red'>You are trying to equip this item to an unsupported inventory slot. How the heck did you manage that? Stop it...</font>"


### PR DESCRIPTION
- Current workaround is to hit tab to switch to hotkeys and just press E.
- Removal of functionality was unintentional.
- This was tested. Hopefully better than the last one.