### PR TITLE
Makes tape appliable to hazard shutters just like airlocks

### DIFF
--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -218,6 +218,8 @@
 
 /obj/machinery/door/firedoor/attackby(obj/item/weapon/C as obj, mob/user as mob)
 	add_fingerprint(user)
+	if(istype(C, /obj/item/taperoll))
+		return //Don't open the door if we're putting tape on it to tell people 'don't open the door'.
 	if(operating)
 		return//Already doing something.
 	if(istype(C, /obj/item/weapon/weldingtool) && !repairing)

--- a/code/game/objects/items/weapons/policetape.dm
+++ b/code/game/objects/items/weapons/policetape.dm
@@ -17,9 +17,9 @@
 		var/turf/T = get_turf(src)
 		if(!T)
 			return
-		var/obj/machinery/door/airlock/airlock = locate(/obj/machinery/door/airlock) in T
-		if(airlock)
-			afterattack(airlock, null, TRUE)
+		var/obj/machinery/door/door = locate(/obj/machinery/door) in T
+		if((door == /obj/machinery/door/airlock) || (door == /obj/machinery/door/firedoor))
+			afterattack(door, null, TRUE)
 		return INITIALIZE_HINT_QDEL
 
 
@@ -250,7 +250,7 @@ var/list/tape_roll_applications = list()
 	if(!proximity)
 		return
 
-	if (istype(A, /obj/machinery/door/airlock))
+	if (istype(A, /obj/machinery/door))
 		var/turf/T = get_turf(A)
 		if(locate(/obj/item/tape, A.loc))
 			user << "There's already tape over that door!"

--- a/html/changelogs/Nerezza - Shutter-tape.yml
+++ b/html/changelogs/Nerezza - Shutter-tape.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Nerezza
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Using tape (police/medical/engineering) on a hazard shutter now tapes the hazard shutter instead of trying to open the hazard shutter."


### PR DESCRIPTION
Clicking hazard shutters with tape will now tape them up like airlocks instead of trying to open them.