### PR TITLE
Adds new languages

### DIFF
--- a/code/__defines/species_languages.dm
+++ b/code/__defines/species_languages.dm
@@ -45,6 +45,9 @@
 #define LANGUAGE_OCCULT "Occult"
 #define LANGUAGE_CHANGELING "Changeling"
 #define LANGUAGE_VOX "Vox-Pidgin"
+#define LANGUAGE_TERMINUS "Terminus"
+#define LANGUAGE_SKRELLIANFAR "High Skrellian"
+#define LANGUAGE_MINBUS "Minbus"
 
 // Language flags.
 #define WHITELISTED  1   // Language is available if the speaker is whitelisted.

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -211,8 +211,10 @@
 	R.add_language(LANGUAGE_UNATHI, 1)
 	R.add_language(LANGUAGE_SIIK, 1)
 	R.add_language(LANGUAGE_SKRELLIAN, 1)
+	R.add_language(LANGUAGE_SKRELLIANFAR, 0)
 	R.add_language(LANGUAGE_GUTTER, 1)
 	R.add_language(LANGUAGE_SCHECHI, 1)
 	R.add_language(LANGUAGE_ROOTLOCAL, 1)
+	R.add_language(LANGUAGE_TERMINUS, 1)
 
 	return 1

--- a/code/modules/mob/language/generic.dm
+++ b/code/modules/mob/language/generic.dm
@@ -42,7 +42,7 @@
 // Galactic common languages (systemwide accepted standards).
 /datum/language/trader
 	name = LANGUAGE_TRADEBAND
-	desc = "Maintained by the various trading cartels in major systems, this elegant, structured language is used for bartering and bargaining."
+	desc = "Spoken by the humans of the upper-class Sagittarius Heights, Tradeband was designed to be pleasing both to humans and to their Skrellian trading partners."
 	speech_verb = "enunciates"
 	colour = "say_quote"
 	key = "2"
@@ -53,10 +53,21 @@
 "nt","ti","us","it","en","at","tu","te","ri","es","et","ra","ta","an","ni","li","on","or","se",
 "am","ae","ia","di","ue","em","ar","ui","st","si","de","ci","iu","ne","pe","co","os","ur","ru")
 
+/datum/language/terminus
+	name = LANGUAGE_TERMINUS
+	desc = "A soft language spoken by the people of the sparsely populated, socially-concious Precursors' Crypt region."
+	speech_verb = "mentions"
+	exclaim_verb = "insinuates"
+	colour = "terminus"
+	key = "4"
+	syllables = list ("die", "en", "skei", "van", "son", "der", "aar", "ch", "op", "ruk", "aa", "be", "ne", "het",
+ 	"ek", "ras", "ver", "zan", "das", "waa", "geb", "vol", "lu", "min", "breh", "rus", "stv", "ee", "goe", "sk",
+ 	"la", "ver", "we", "ge", "luk", "an", "ar", "at", "es", "et", "bel", "du", "jaa", "ch", "kk", "gh", "ll", "uu", "wat")
+
 // Criminal language.
 /datum/language/gutter
 	name = LANGUAGE_GUTTER
-	desc = "There is no true language named Gutter. 'Gutter' is a catchall term for a collection of unofficial SolCom dialects that has somehow managed to spread across the stars."
+	desc = "Gutterspeak originated as a Thieves' Cant of sorts during the early colonization era. The language eventually spread from the cartels and triads to the disenfranchised people of the Bowl."
 	speech_verb = "growls"
 	colour = "rough"
 	key = "3"

--- a/code/modules/mob/language/generic.dm
+++ b/code/modules/mob/language/generic.dm
@@ -60,6 +60,7 @@
 	exclaim_verb = "insinuates"
 	colour = "terminus"
 	key = "4"
+	flags = WHITELISTED
 	syllables = list ("die", "en", "skei", "van", "son", "der", "aar", "ch", "op", "ruk", "aa", "be", "ne", "het",
  	"ek", "ras", "ver", "zan", "das", "waa", "geb", "vol", "lu", "min", "breh", "rus", "stv", "ee", "goe", "sk",
  	"la", "ver", "we", "ge", "luk", "an", "ar", "at", "es", "et", "bel", "du", "jaa", "ch", "kk", "gh", "ll", "uu", "wat")

--- a/code/modules/mob/language/outsider.dm
+++ b/code/modules/mob/language/outsider.dm
@@ -92,7 +92,7 @@
 	speech_verb = "hisses"
 	ask_verb = "hisses"
 	exclaim_verb = "hisses"
-	key = "4"
+	key = "u"
 	flags = RESTRICTED
 	syllables = list("sss","sSs","SSS")
 
@@ -115,3 +115,17 @@
 		return 1
 
 	return 0
+
+//for your antag purposes. machine-translatable, if you don't want that use Cult or one of the animal langs
+/datum/language/minbus
+	name = LANGUAGE_MINBUS
+	desc = "The Powers That Be have seen it fit to grace you with a special language that sounds like Russian for some reason."
+	speech_verb = "says"
+	ask_verb = "asks"
+	exclaim_verb = "shouts"
+	colour = "deadsay"
+	key = "r"
+	flags = RESTRICTED | WHITELISTED
+	syllables = list("rus","zem","ave","groz","ski","ska","ven","konst","pol","lin","svy",
+	"danya","da","mied","zan","das","krem","myka","cyka","blyat","to","st","no","na","ni",
+	"ko","ne","en","po","ra","li","on","byl","cto","eni","ost","ol","ego","ver","stv","pro")

--- a/code/modules/mob/language/station.dm
+++ b/code/modules/mob/language/station.dm
@@ -85,6 +85,20 @@
 	flags = WHITELISTED
 	syllables = list("qr","qrr","xuq","qil","quum","xuqm","vol","xrim","zaoo","qu-uu","qix","qoo","zix")
 
+/datum/language/skrellfar
+	name = LANGUAGE_SKRELLIANFAR
+	desc = "The most common language among the Skrellian Far Kingdoms. Has an even higher than usual concentration of inaudible phonemes."
+	speech_verb = "warbles"
+	ask_verb = "warbles"
+	exclaim_verb = "sings"
+	whisper_verb = "hums"
+	colour = "skrellfar"
+	key = "p"
+	space_chance = 30
+	flags = WHITELISTED
+	syllables = list("qr","qrr","xuq","qil","quum","xuqm","vol","xrim","zaoo","qu-uu","qix","qoo","zix", "...", "oo", "q", "nq", "x", "xq", "ll", "...", "...", "...") //should sound like there's holes in it
+
+
 /datum/language/human
 	name = LANGUAGE_SOL_COMMON
 	desc = "A bastardized hybrid of many languages, including Chinese, English, French, and more; it is the common language of the Sol system."
@@ -114,7 +128,7 @@
 
 /datum/language/machine
 	name = LANGUAGE_EAL
-	desc = "An efficient language of encoded tones developed by synthetics and cyborgs."
+	desc = "An efficient language of encoded tones developed by positronics."
 	speech_verb = "whistles"
 	ask_verb = "chirps"
 	exclaim_verb = "whistles loudly"

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -151,12 +151,14 @@ var/list/ai_verbs_default = list(
 	add_language(LANGUAGE_UNATHI, 1)
 	add_language(LANGUAGE_SIIK, 1)
 	add_language(LANGUAGE_SKRELLIAN, 1)
+	add_language(LANGUAGE_SKRELLIANFAR, 0)
 	add_language(LANGUAGE_TRADEBAND, 1)
 	add_language(LANGUAGE_GUTTER, 1)
 	add_language(LANGUAGE_EAL, 1)
 	add_language(LANGUAGE_SCHECHI, 1)
 	add_language(LANGUAGE_SIGN, 1)
 	add_language(LANGUAGE_ROOTLOCAL, 1)
+	add_language(LANGUAGE_TERMINUS, 1)
 
 	if(!safety)//Only used by AIize() to successfully spawn an AI.
 		if (!B)//If there is no player/brain inside.

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -98,6 +98,7 @@
 	add_language(LANGUAGE_TRADEBAND, 1)
 	add_language(LANGUAGE_GUTTER, 1)
 	add_language(LANGUAGE_EAL, 1)
+	add_language(LANGUAGE_TERMINUS, 1)
 	add_language(LANGUAGE_SIGN, 0)
 
 	verbs += /mob/living/silicon/pai/proc/choose_chassis

--- a/code/modules/mob/living/silicon/robot/robot_modules/station.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules/station.dm
@@ -23,7 +23,7 @@ var/global/list/robot_modules = list(
 	var/hide_on_manifest = 0
 	var/channels = list()
 	var/networks = list()
-	var/languages = list(LANGUAGE_SOL_COMMON = 1, LANGUAGE_TRADEBAND = 1, LANGUAGE_UNATHI = 0, LANGUAGE_SIIK = 0, LANGUAGE_SKRELLIAN = 0, LANGUAGE_GUTTER = 0, LANGUAGE_SCHECHI = 0, LANGUAGE_SIGN = 0)
+	var/languages = list(LANGUAGE_SOL_COMMON = 1, LANGUAGE_TRADEBAND = 1, LANGUAGE_UNATHI = 0, LANGUAGE_SIIK = 0, LANGUAGE_SKRELLIAN = 0, LANGUAGE_GUTTER = 0, LANGUAGE_SCHECHI = 0, LANGUAGE_SIGN = 0, LANGUAGE_TERMINUS = 1)
 	var/sprites = list()
 	var/can_be_pushed = 1
 	var/no_slip = 0
@@ -574,11 +574,13 @@ var/global/list/robot_modules = list(
 					LANGUAGE_UNATHI		= 1,
 					LANGUAGE_SIIK		= 1,
 					LANGUAGE_SKRELLIAN	= 1,
+					LANGUAGE_SKRELLIANFAR = 0,
 					LANGUAGE_ROOTLOCAL	= 0,
 					LANGUAGE_TRADEBAND	= 1,
 					LANGUAGE_GUTTER		= 1,
 					LANGUAGE_SCHECHI	= 1,
 					LANGUAGE_EAL		= 1,
+					LANGUAGE_TERMINUS	= 1,
 					LANGUAGE_SIGN		= 0
 					)
 

--- a/code/modules/mob/living/silicon/robot/robot_modules/syndicate.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules/syndicate.dm
@@ -9,11 +9,13 @@
 					LANGUAGE_UNATHI = 0,
 					LANGUAGE_SIIK	= 0,
 					LANGUAGE_SKRELLIAN = 0,
+					LANGUAGE_SKRELLIANFAR = 0,
 					LANGUAGE_ROOTLOCAL = 0,
 					LANGUAGE_GUTTER = 1,
 					LANGUAGE_SCHECHI = 0,
 					LANGUAGE_EAL	 = 1,
-					LANGUAGE_SIGN	 = 0
+					LANGUAGE_SIGN	 = 0,
+					LANGUAGE_TERMINUS = 1
 					)
 	sprites = list(
 					"Cerberus" = "syndie_bloodhound",

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -89,6 +89,7 @@
 	add_language(LANGUAGE_EAL, 1)
 	add_language(LANGUAGE_SCHECHI, 1)
 	add_language(LANGUAGE_SIGN, 1)
+	add_language(LANGUAGE_TERMINUS, 1)
 
 	// Lorefolks say it may be so.
 	if(O.client && O.client.prefs)

--- a/code/stylesheet.dm
+++ b/code/stylesheet.dm
@@ -92,13 +92,14 @@ h1.alert, h2.alert		{color: #000000;}
 .tajaran				{color: #803B56;}
 .tajaran_signlang		{color: #941C1C;}
 .skrell					{color: #00B0B3;}
+.skrellfar				{color: #70FCFF;}
 .soghun					{color: #228B22;}
 .solcom					{color: #22228B;}
 .changeling				{color: #800080;}
 .vox					{color: #AA00AA;}
 .rough					{font-family: "Trebuchet MS", cursive, sans-serif;}
 .say_quote				{font-family: Georgia, Verdana, sans-serif;}
-
+.terminus				{font-family: "Times New Roman", Times, serif, sans-serif}
 .interface				{color: #330033;}
 
 BIG IMG.icon 			{width: 32px; height: 32px;}


### PR DESCRIPTION
- Adds Terminus, a fairly uncommon human-only language invented by Diet Racist xenoarchs
- Adds High Skrellian, a Skrell language spoken by the Wise and True Skrell on the other side of Loop 2-- and you can go to those wonderful Far Kingdoms too, comrade, if only you work hard for the glory of the City-State! Whitelisted and probably won't be open to applications until we have at least some Far Kingdoms lore.
- Adds Minbus, an adminbus language that sounds like Russian.
- Also the local xenochat is now ,u instead of ,4 because saycode is voodoo magic.

Terminus syllables from Bay12's Space. Minbus syllables from Bay12's Terran.