### PR TITLE
Fixes two minor PDA cart issues.

### DIFF
--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -1247,20 +1247,17 @@ var/global/list/obj/item/device/pda/PDAs = list()
 	if(issilicon(usr))
 		return
 
-	if (can_use(usr) && !isnull(cartridge))
-		var/turf/T = get_turf(src)
-		cartridge.loc = T
-		if (ismob(loc))
+	if(can_use(usr) && !isnull(cartridge))
+		cartridge.forceMove(get_turf(src))
+		if(ismob(loc))
 			var/mob/M = loc
 			M.put_in_hands(cartridge)
-		else
-			cartridge.loc = get_turf(src)
 		mode = 0
 		scanmode = 0
 		if (cartridge.radio)
 			cartridge.radio.hostpda = null
-		cartridge = null
 		to_chat(usr, "<span class='notice'>You remove \the [cartridge] from the [name].</span>")
+		cartridge = null
 	else
 		to_chat(usr, "<span class='notice'>You cannot do this while restrained.</span>")
 

--- a/code/game/objects/items/devices/PDA/cart.dm
+++ b/code/game/objects/items/devices/PDA/cart.dm
@@ -265,8 +265,6 @@ var/list/civilian_cartridges = list(
 			if(loc)
 				var/obj/item/PDA = loc
 				var/mob/user = PDA.fingerprintslast
-				if(istype(PDA.loc,/mob/living))
-					name = PDA.loc
 				log_admin("STATUS: [user] set status screen with [PDA]. Message: [data1] [data2]")
 				message_admins("STATUS: [user] set status screen with [PDA]. Message: [data1] [data2]")
 


### PR DESCRIPTION
Using the status display message mode doesn't delete the name of the cartridge.
Removing cartridges shows their name correctly.