### PR TITLE
Removes some alt-titles with insufficiently clear roles

### DIFF
--- a/code/game/jobs/job/captain.dm
+++ b/code/game/jobs/job/captain.dm
@@ -87,4 +87,3 @@ var/datum/announcement/minor/captain_announcement = new(do_newscast = 1)
 	minimal_access = list(access_heads, access_keycard_auth)
 
 	outfit_type = /decl/hierarchy/outfit/job/secretary
-	alt_titles = list("Command Liaison", "Bridge Secretary")

--- a/code/game/jobs/job/civilian.dm
+++ b/code/game/jobs/job/civilian.dm
@@ -49,7 +49,7 @@
 	minimal_access = list(access_hydroponics)
 
 	outfit_type = /decl/hierarchy/outfit/job/service/gardener
-	alt_titles = list("Hydroponicist", "Gardener")
+	alt_titles = list("Gardener")
 
 //Cargo
 /datum/job/qm
@@ -105,7 +105,7 @@
 	minimal_access = list(access_mining, access_mining_station, access_mailsorting)
 
 	outfit_type = /decl/hierarchy/outfit/job/cargo/mining
-	alt_titles = list("Drill Technician","Prospector")
+	alt_titles = list("Drill Technician")
 
 //Service
 /datum/job/janitor
@@ -123,7 +123,7 @@
 	minimal_access = list(access_janitor, access_maint_tunnels)
 
 	outfit_type = /decl/hierarchy/outfit/job/service/janitor
-	alt_titles = list("Custodian", "Sanitation Technician")
+	alt_titles = list("Custodian")
 
 //More or less assistants
 /datum/job/librarian
@@ -141,7 +141,7 @@
 	minimal_access = list(access_library)
 
 	outfit_type = /decl/hierarchy/outfit/job/librarian
-	alt_titles = list("Journalist", "Professor", "Historian", "Writer")
+	alt_titles = list("Journalist", "Writer")
 
 //var/global/lawyer = 0//Checks for another lawyer //This changed clothes on 2nd lawyer, both IA get the same dreds.
 /datum/job/lawyer

--- a/html/changelogs/Anewbe - Alt Titles 1.yml
+++ b/html/changelogs/Anewbe - Alt Titles 1.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Anewbe
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscdel: "Removes Command Liaison, Bridge Secretary, Hydroponicist, Prospector, Sanitation Technician, Professor, and Historian alt-titles. "


### PR DESCRIPTION
As part of an ongoing effort to write better guides for our jobs and alt-titles, we are clearing out alt-titles that don't have clear differences from their default roles, are rarely used, are inaccurate to the current station, or imply things that should not be implied. This is the first of a few PRs that will whittle down the alt-titles list into something that is clear and concise in what is expected of the role.