### PR TITLE
Makes drills report faults over supply channel

### DIFF
--- a/code/modules/mining/drilling/drill.dm
+++ b/code/modules/mining/drilling/drill.dm
@@ -61,7 +61,7 @@
 	if(!active) return
 
 	if(!anchored || !use_cell_power())
-		system_error("system configuration or charge error")
+		system_error("System configuration or charge error.")
 		return
 
 	if(need_update_field)
@@ -99,7 +99,7 @@
 		for(var/metal in ore_types)
 
 			if(contents.len >= capacity)
-				system_error("insufficient storage space")
+				system_error("Insufficient storage space.")
 				active = 0
 				need_player_check = 1
 				update_icon()
@@ -135,7 +135,7 @@
 		active = 0
 		need_player_check = 1
 		update_icon()
-		system_error("resources depleted")
+		system_error("Resources depleted.")
 
 /obj/machinery/mining/drill/attack_ai(var/mob/user as mob)
 	return src.attack_hand(user)

--- a/code/modules/mining/drilling/drill.dm
+++ b/code/modules/mining/drilling/drill.dm
@@ -146,7 +146,7 @@
 			var/newtag = text2num(sanitizeSafe(input(user, "Enter new ID number or leave empty to cancel.", "Assign ID number") as text, 4))
 			if(newtag)
 				name = "[initial(name)] #[newtag]"
-				user << "<span class='notice'>You changed the drill ID to: [newtag]</span>"
+				to_chat(user, "<span class='notice'>You changed the drill ID to: [newtag]</span>")
 			return
 		if(default_deconstruction_screwdriver(user, O))
 			return


### PR DESCRIPTION
Drills now have an inbuilt radio that reports over the supply channel when they have an error, so miners are alerted to go and fix them. Previously it was a visible message only, so the miners would have to be physically present at the moment they fail to get the error message.

In order that miners know which drill just failed, they can use a multitool to give it a 3-digit ID number which will be appended onto the name.

Covers a missing line where the "resources depleted" error message wasn't being called in circumstances where it _found_ minerals when it was started, but they were subsequently depleted.

Fixes a runtime in the while loop in process() - the resource_field list was having items removed before pick() was called on it, which threw an error when the last item on the list was removed.