### PR TITLE
Fixes Switch Shoe Layer to re-layer shoes in real time

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -542,9 +542,7 @@
 	overlays.Cut()
 	if(holding)
 		overlays += image(icon, "[icon_state]_knife")
-	if(ismob(usr))
-		var/mob/M = usr
-		M.update_inv_shoes()
+	update_clothing_icon()
 	return ..()
 
 /obj/item/clothing/shoes/proc/handle_movement(var/turf/walking, var/running)

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -542,7 +542,9 @@
 	overlays.Cut()
 	if(holding)
 		overlays += image(icon, "[icon_state]_knife")
-	update_clothing_icon()
+	if(ismob(usr))
+		var/mob/M = usr
+		M.update_inv_shoes()
 	return ..()
 
 /obj/item/clothing/shoes/proc/handle_movement(var/turf/walking, var/running)

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -909,7 +909,7 @@ var/global/list/damage_icon_parts = list()
 		else
 			overlays_standing[SHOES_LAYER] = null
 			overlays_standing[SHOES_LAYER_ALT] = null
-	if(update_icons)   update_icons()
+	if(update_icons)   update_icons_layers()
 
 /mob/living/carbon/human/update_inv_s_store(var/update_icons=1)
 	if(QDESTROYING(src))


### PR DESCRIPTION
Switch Shoe Layer wouldn't visually do anything to clothing layers until you altered your clothing via another method, such as Switch Belt Layer.

~~This fixes the two bugs that caused this.~~ Actually the clothing.dm change wasn't necessary...

update_inv_shoes() called update_icons() at the end when it should call update_icons_layers() to process the layer swap instead.

This PR has been tested locally and works as intended. Since update_icons_layers() calls update_icons() when it ends, there's ~~a 99.9% chance of~~ no bugs introduced too o3od

Edit: Also looking through the blame it seems like this bug was introduced by https://github.com/PolarisSS13/Polaris/pull/4545 as a small oversight. Unsurprising considering that's a hooooooog PR.