### PR TITLE
Adjusts probably-temporary attack values for simple mobs

### DIFF
--- a/code/modules/mob/living/simple_animal/aliens/alien.dm
+++ b/code/modules/mob/living/simple_animal/aliens/alien.dm
@@ -24,6 +24,8 @@
 	harm_intent_damage = 5
 	melee_damage_lower = 25
 	melee_damage_upper = 25
+	attack_sharp = 1
+	attack_edge = 1
 
 	attacktext = list("slashed")
 	attack_sound = 'sound/weapons/bladeslice.ogg'

--- a/code/modules/mob/living/simple_animal/aliens/creature.dm
+++ b/code/modules/mob/living/simple_animal/aliens/creature.dm
@@ -13,8 +13,12 @@
 	speed = 8
 
 	harm_intent_damage = 8
-	melee_damage_lower = 5
-	melee_damage_upper = 5
+
+	melee_damage_lower = 8
+	melee_damage_upper = 15
+	attack_armor_pen = 5	//It's a horror from beyond, I ain't gotta explain 5 AP
+	attack_sharp = 1
+	attack_edge = 1
 
 	attacktext = list("chomped")
 	attack_sound = 'sound/weapons/bite.ogg'
@@ -48,7 +52,7 @@
 	health = 160
 
 	harm_intent_damage = 5
-	melee_damage_lower = 8
+	melee_damage_lower = 13
 	melee_damage_upper = 25
 
 /mob/living/simple_animal/hostile/creature/strong/cult

--- a/code/modules/mob/living/simple_animal/aliens/faithless.dm
+++ b/code/modules/mob/living/simple_animal/aliens/faithless.dm
@@ -17,8 +17,10 @@
 	response_harm = "hits"
 
 	harm_intent_damage = 10
-	melee_damage_lower = 5
-	melee_damage_upper = 5
+
+	melee_damage_lower = 10
+	melee_damage_upper = 18
+	attack_armor_pen = 5	//It's a horror from beyond, I ain't gotta explain 5 AP
 
 	attacktext = list("gripped")
 	attack_sound = 'sound/hallucinations/growl1.ogg'
@@ -67,8 +69,8 @@
 	health = 100
 
 	harm_intent_damage = 5
-	melee_damage_lower = 7
-	melee_damage_upper = 20
+	melee_damage_lower = 13
+	melee_damage_upper = 28
 
 
 /mob/living/simple_animal/hostile/faithless/strong/cult

--- a/code/modules/mob/living/simple_animal/aliens/hivebot.dm
+++ b/code/modules/mob/living/simple_animal/aliens/hivebot.dm
@@ -62,8 +62,8 @@
 	desc = "A robot. It looks fragile and weak"
 	maxHealth = 1 LASERS_TO_KILL
 	health = 1 LASERS_TO_KILL
-	melee_damage_lower = 3
-	melee_damage_upper = 3
+	melee_damage_lower = 8
+	melee_damage_upper = 8
 
 // This one has a semi-weak ranged attack.
 /mob/living/simple_animal/hostile/hivebot/range

--- a/code/modules/mob/living/simple_animal/aliens/shade.dm
+++ b/code/modules/mob/living/simple_animal/aliens/shade.dm
@@ -20,6 +20,7 @@
 
 	melee_damage_lower = 5
 	melee_damage_upper = 15
+	attack_armor_pen = 100	//It's a ghost/horror from beyond, I ain't gotta explain 100 AP
 	attacktext = list("drained the life from")
 
 	minbodytemp = 0

--- a/code/modules/mob/living/simple_animal/animals/bat.dm
+++ b/code/modules/mob/living/simple_animal/animals/bat.dm
@@ -20,8 +20,11 @@
 	response_harm = "hits the"
 
 	harm_intent_damage = 10
-	melee_damage_lower = 3
-	melee_damage_upper = 3
+
+	melee_damage_lower = 5
+	melee_damage_upper = 5
+	attack_sharp = 1
+
 	environment_smash = 1
 
 	attacktext = list("bites")

--- a/code/modules/mob/living/simple_animal/animals/bear.dm
+++ b/code/modules/mob/living/simple_animal/animals/bear.dm
@@ -23,6 +23,8 @@
 
 	melee_damage_lower = 20
 	melee_damage_upper = 30
+	attack_sharp = 1
+	attack_edge = 1
 
 	//Space bears aren't affected by atmos.
 	min_oxy = 0

--- a/code/modules/mob/living/simple_animal/animals/crab.dm
+++ b/code/modules/mob/living/simple_animal/animals/crab.dm
@@ -67,8 +67,11 @@
 
 	minbodytemp = 175
 
-	melee_damage_lower = 15
+	melee_damage_lower = 22
 	melee_damage_upper = 35
+	attack_armor_pen = 35
+	attack_sharp = 1
+	attack_edge = 1
 
 	meat_type = /obj/item/weapon/reagent_containers/food/snacks/meat
 	response_help  = "pets"

--- a/code/modules/mob/living/simple_animal/animals/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/animals/giant_spider.dm
@@ -28,8 +28,11 @@
 	response_disarm = "gently pushes aside"
 	response_harm   = "punches"
 
-	melee_damage_lower = 15
-	melee_damage_upper = 20
+	melee_damage_lower = 18
+	melee_damage_upper = 30
+	attack_sharp = 1
+	attack_edge = 1
+
 	heat_damage_per_tick = 20
 	cold_damage_per_tick = 20
 
@@ -69,8 +72,8 @@ Nurse Family
 	maxHealth = 40
 	health = 40
 
-	melee_damage_lower = 5
-	melee_damage_upper = 10
+	melee_damage_lower = 8
+	melee_damage_upper = 15
 	poison_per_bite = 7
 	poison_type = "stoxin"
 
@@ -88,10 +91,11 @@ Nurse Family
 	maxHealth = 320
 	health = 320
 
-	melee_damage_lower = 15
-	melee_damage_upper = 25
-	poison_per_bite = 10
+	melee_damage_lower = 20
+	melee_damage_upper = 30
+	attack_armor_pen = 25
 
+	poison_per_bite = 10
 	egg_inject_chance = 10
 
 	pixel_x = -16
@@ -115,8 +119,8 @@ Nurse Family
 	cooperative = 1
 	shoot_range = 5
 
-	melee_damage_lower = 5
-	melee_damage_upper = 10
+	melee_damage_lower = 8
+	melee_damage_upper = 15
 	poison_per_bite = 2
 	poison_type = "psilocybin"
 
@@ -148,8 +152,8 @@ Nurse Family
 	maxHealth = 100
 	health = 100
 
-	melee_damage_lower = 5
-	melee_damage_upper = 20
+	melee_damage_lower = 8
+	melee_damage_upper = 25
 
 	poison_per_bite = 3
 	poison_type = "chloralhydrate"
@@ -208,9 +212,6 @@ Hunter Family
 	health = 120
 	move_to_delay = 4
 
-	melee_damage_lower = 10
-	melee_damage_upper = 20
-
 	poison_per_bite = 5
 
 /mob/living/simple_animal/hostile/giant_spider/lurker
@@ -224,7 +225,7 @@ Hunter Family
 	health = 100
 	move_to_delay = 4
 
-	melee_damage_lower = 5
+	melee_damage_lower = 8
 	melee_damage_upper = 20
 
 
@@ -275,8 +276,8 @@ Guard Family
 	maxHealth = 210
 	health = 210
 
-	melee_damage_lower = 5
-	melee_damage_upper = 10
+	melee_damage_lower = 8
+	melee_damage_upper = 15
 
 	poison_chance = 20
 	poison_per_bite = 5
@@ -295,8 +296,8 @@ Guard Family
 	maxHealth = 175
 	health = 175
 
-	melee_damage_lower = 5
-	melee_damage_upper = 15
+	melee_damage_lower = 10
+	melee_damage_upper = 25
 
 	poison_chance = 30
 	poison_per_bite = 1
@@ -312,8 +313,8 @@ Guard Family
 	health = 210
 	taser_kill = 0 //It -is- the taser.
 
-	melee_damage_lower = 5
-	melee_damage_upper = 10
+	melee_damage_lower = 10
+	melee_damage_upper = 25
 
 	ranged = 1
 	projectilesound = 'sound/weapons/taser2.ogg'
@@ -335,8 +336,9 @@ Guard Family
 	health = 225
 	taser_kill = 0 //You will need more than a peashooter to kill the juggernaut.
 
-	melee_damage_lower = 10
-	melee_damage_upper = 20
+	melee_damage_lower = 25
+	melee_damage_upper = 40
+	attack_armor_pen = 15
 
 	poison_chance = 30
 	poison_per_bite = 0.5
@@ -365,9 +367,6 @@ Guard Family
 
 	maxHealth = 175
 	health = 175
-
-	melee_damage_lower = 15
-	melee_damage_upper = 20
 
 	poison_per_bite = 5
 	poison_type = "cryotoxin"

--- a/code/modules/mob/living/simple_animal/animals/sif_wildlife/diyaab.dm
+++ b/code/modules/mob/living/simple_animal/animals/sif_wildlife/diyaab.dm
@@ -15,8 +15,9 @@
 	speed = 1
 	move_to_delay = 1
 
-	melee_damage_lower = 1
-	melee_damage_upper = 8
+	melee_damage_lower = 4
+	melee_damage_upper = 12
+	attack_sharp = 1		//Bleeds, but it shouldn't rip off a limb?
 
 	attacktext = list("gouged")
 	cold_damage_per_tick = 0

--- a/code/modules/mob/living/simple_animal/animals/sif_wildlife/savik.dm
+++ b/code/modules/mob/living/simple_animal/animals/sif_wildlife/savik.dm
@@ -15,7 +15,10 @@
 	move_to_delay = 2
 
 	melee_damage_lower = 15
-	melee_damage_upper = 25
+	melee_damage_upper = 35
+	attack_armor_pen = 15
+	attack_sharp = 1
+	attack_edge = 1
 
 	attacktext = list("mauled")
 	cold_damage_per_tick = 0

--- a/code/modules/mob/living/simple_animal/animals/sif_wildlife/shantak.dm
+++ b/code/modules/mob/living/simple_animal/animals/sif_wildlife/shantak.dm
@@ -14,8 +14,11 @@
 	speed = 1
 	move_to_delay = 1
 
-	melee_damage_lower = 3
-	melee_damage_upper = 12
+	melee_damage_lower = 12
+	melee_damage_upper = 28
+	attack_armor_pen = 5
+	attack_sharp = 1
+	attack_edge = 1
 
 	attacktext = list("gouged")
 	cold_damage_per_tick = 0

--- a/code/modules/mob/living/simple_animal/humanoids/pirate.dm
+++ b/code/modules/mob/living/simple_animal/humanoids/pirate.dm
@@ -28,6 +28,10 @@
 	harm_intent_damage = 5
 	melee_damage_lower = 30
 	melee_damage_upper = 30
+	attack_armor_pen = 50
+	attack_sharp = 1
+	attack_edge = 1
+
 	attacktext = list("slashed")
 	attack_sound = 'sound/weapons/bladeslice.ogg'
 

--- a/code/modules/mob/living/simple_animal/humanoids/syndicate.dm
+++ b/code/modules/mob/living/simple_animal/humanoids/syndicate.dm
@@ -73,8 +73,11 @@
 	icon_state = "syndicatemelee"
 	icon_living = "syndicatemelee"
 
-	melee_damage_lower = 20
-	melee_damage_upper = 25
+	melee_damage_lower = 30
+	melee_damage_upper = 30
+	attack_armor_pen = 50
+	attack_sharp = 1
+	attack_edge = 1
 	attacktext = list("slashed")
 
 	status_flags = 0
@@ -177,6 +180,8 @@
 
 	melee_damage_lower = 15
 	melee_damage_upper = 15
+	attack_sharp = 1
+	attack_edge = 1
 	attack_sound = 'sound/weapons/bladeslice.ogg'
 	attacktext = list("cut")
 


### PR DESCRIPTION
Pending simple animal AI rewrite that will hopefully make simple mobs more dangerous, makes simple animals more dangerous.

- Increases attack damage values nearly across the board.
- Assigns attack_sharp and attack_edge where it seemed sensible.
- Gives a sparse few mobs attack_armor_pen.

Notes:
- Bats have sharp but not edge. That's intentional.
- Don't fuck with crabs, as usual.
- The giant_spider default attack might seem unusually high. Most spiders overwrite these values as-is, but the giant_spider itself is in game as the "Guard", if memory serves. Anyway, spiders hurt.
- Queen Spiders, Phoron Spiders, Saviks, and all Xenomorphs have AP.
- The mostly unused melee pirate and melee merc mobs now have damage, pen, and flags appropriate to an esword.