### PR TITLE
Ingested reagents act half as quickly, rather than half as well

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -1,8 +1,8 @@
 /mob/living/carbon/New()
 	//setup reagent holders
-	bloodstr = new/datum/reagents/metabolism(1000, src, CHEM_BLOOD)
-	ingested = new/datum/reagents/metabolism(1000, src, CHEM_INGEST)
-	touching = new/datum/reagents/metabolism(1000, src, CHEM_TOUCH)
+	bloodstr = new/datum/reagents/metabolism/bloodstream(500, src)
+	ingested = new/datum/reagents/metabolism/ingested(500, src)
+	touching = new/datum/reagents/metabolism/touch(500, src)
 	reagents = bloodstr
 	if (!default_language && species_language)
 		default_language = all_languages[species_language]

--- a/code/modules/mob/living/carbon/carbon_defines.dm
+++ b/code/modules/mob/living/carbon/carbon_defines.dm
@@ -17,9 +17,9 @@
 	//Active emote/pose
 	var/pose = null
 	var/list/chem_effects = list()
-	var/datum/reagents/metabolism/bloodstr = null
-	var/datum/reagents/metabolism/ingested = null
-	var/datum/reagents/metabolism/touching = null
+	var/datum/reagents/metabolism/bloodstream/bloodstr = null
+	var/datum/reagents/metabolism/ingested/ingested = null
+	var/datum/reagents/metabolism/touch/touching = null
 
 	var/pulse = PULSE_NORM	//current pulse level
 

--- a/code/modules/reagents/Chemistry-Metabolism.dm
+++ b/code/modules/reagents/Chemistry-Metabolism.dm
@@ -1,21 +1,34 @@
 /datum/reagents/metabolism
 	var/metabolism_class //CHEM_TOUCH, CHEM_INGEST, or CHEM_BLOOD
+	var/metabolism_speed = 1	// Multiplicative, 1 is full speed, 0.5 is half, etc.
 	var/mob/living/carbon/parent
 
-/datum/reagents/metabolism/New(var/max = 100, mob/living/carbon/parent_mob, var/met_class)
+/datum/reagents/metabolism/New(var/max = 100, mob/living/carbon/parent_mob, var/met_class = null)
 	..(max, parent_mob)
-	
-	metabolism_class = met_class
+
+	if(met_class)
+		metabolism_class = met_class
 	if(istype(parent_mob))
 		parent = parent_mob
 
 /datum/reagents/metabolism/proc/metabolize()
-	
+
 	var/metabolism_type = 0 //non-human mobs
 	if(ishuman(parent))
 		var/mob/living/carbon/human/H = parent
 		metabolism_type = H.species.reagent_tag
-	
+
 	for(var/datum/reagent/current in reagent_list)
-		current.on_mob_life(parent, metabolism_type, metabolism_class)
+		current.on_mob_life(parent, metabolism_type, src)
 	update_total()
+
+// "Specialized" metabolism datums
+/datum/reagents/metabolism/bloodstream
+	metabolism_class = CHEM_BLOOD
+
+/datum/reagents/metabolism/ingested
+	metabolism_class = CHEM_INGEST
+	metabolism_speed = 0.5
+
+/datum/reagents/metabolism/touch
+	metabolism_class = CHEM_TOUCH

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -57,12 +57,17 @@
 /datum/reagent/proc/touch_turf(var/turf/T, var/amount) // Cleaner cleaning, lube lubbing, etc, all go here
 	return
 
-/datum/reagent/proc/on_mob_life(var/mob/living/carbon/M, var/alien, var/location) // Currently, on_mob_life is called on carbons. Any interaction with non-carbon mobs (lube) will need to be done in touch_mob.
+/datum/reagent/proc/on_mob_life(var/mob/living/carbon/M, var/alien, var/datum/reagents/metabolism/location) // Currently, on_mob_life is called on carbons. Any interaction with non-carbon mobs (lube) will need to be done in touch_mob.
 	if(!istype(M))
 		return
 	if(!affects_dead && M.stat == DEAD)
 		return
+	if(!istype(location))
+		return
+
+	var/datum/reagents/metabolism/active_metab = location
 	var/removed = metabolism
+
 	if(!mrate_static == TRUE)
 		// Modifiers
 		for(var/datum/modifier/mod in M.modifiers)
@@ -70,23 +75,25 @@
 				removed *= mod.metabolism_percent
 		// Species
 		removed *= M.species.metabolic_rate
+		// Metabolism
+		removed *= active_metab.metabolism_speed
 
-	if(ingest_met && (location == CHEM_INGEST))
+	if(ingest_met && (active_metab.metabolism_class == CHEM_INGEST))
 		removed = ingest_met
-	if(touch_met && (location == CHEM_TOUCH))
+	if(touch_met && (active_metab.metabolism_class == CHEM_TOUCH))
 		removed = touch_met
 	removed = min(removed, volume)
 	max_dose = max(volume, max_dose)
 	dose = min(dose + removed, max_dose)
 	if(removed >= (metabolism * 0.1) || removed >= 0.1) // If there's too little chemical, don't affect the mob, just remove it
-		switch(location)
+		switch(active_metab.metabolism_class)
 			if(CHEM_BLOOD)
 				affect_blood(M, alien, removed)
 			if(CHEM_INGEST)
 				affect_ingest(M, alien, removed)
 			if(CHEM_TOUCH)
 				affect_touch(M, alien, removed)
-	if(overdose && (volume > overdose) && (location != CHEM_TOUCH))
+	if(overdose && (volume > overdose) && (active_metab.metabolism_class != CHEM_TOUCH))
 		overdose(M, alien, removed)
 	remove_self(removed)
 	return
@@ -95,7 +102,7 @@
 	return
 
 /datum/reagent/proc/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed)
-	affect_blood(M, alien, removed * 0.5)
+	M.bloodstr.add_reagent(id, removed)
 	return
 
 /datum/reagent/proc/affect_touch(var/mob/living/carbon/M, var/alien, var/removed)

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Dispenser.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Dispenser.dm
@@ -64,6 +64,9 @@
 	taste_description = "pure alcohol"
 	reagent_state = LIQUID
 	color = "#404030"
+
+	ingest_met = REM
+
 	var/nutriment_factor = 0
 	var/strength = 10 // This is, essentially, units between stages - the lower, the stronger. Less fine tuning, more clarity.
 	var/toxicity = 1

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
@@ -7,6 +7,7 @@
 	taste_mult = 4
 	reagent_state = SOLID
 	metabolism = REM * 4
+	ingest_met = REM * 4
 	var/nutriment_factor = 30 // Per unit
 	var/injectable = 0
 	color = "#664330"
@@ -252,6 +253,7 @@
 	reagent_state = SOLID
 	color = "#FFFFFF"
 	overdose = REAGENTS_OVERDOSE
+	ingest_met = REM
 
 /datum/reagent/blackpepper
 	name = "Black Pepper"
@@ -259,6 +261,7 @@
 	description = "A powder ground from peppercorns. *AAAACHOOO*"
 	taste_description = "pepper"
 	reagent_state = SOLID
+	ingest_met = REM
 	color = "#000000"
 
 /datum/reagent/enzyme
@@ -278,6 +281,7 @@
 	taste_description = "mint"
 	taste_mult = 1.5
 	reagent_state = LIQUID
+	ingest_met = REM
 	color = "#B31008"
 
 /datum/reagent/frostoil/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
@@ -305,6 +309,7 @@
 	taste_description = "hot peppers"
 	taste_mult = 1.5
 	reagent_state = LIQUID
+	ingest_met = REM
 	color = "#B31008"
 
 /datum/reagent/capsaicin/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
@@ -338,6 +343,7 @@
 	taste_mult = 10
 	reagent_state = LIQUID
 	touch_met = 50 // Get rid of it quickly
+	ingest_met = REM
 	color = "#B31008"
 
 /datum/reagent/condensedcapsaicin/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
@@ -421,6 +427,7 @@
 	name = "Drink"
 	id = "drink"
 	description = "Uh, some kind of drink."
+	ingest_met = REM
 	reagent_state = LIQUID
 	color = "#E78108"
 	var/nutrition = 0 // Per unit

--- a/html/changelogs/Anewbe - Pills.yml
+++ b/html/changelogs/Anewbe - Pills.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Anewbe
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Pills and ingested reagents actually process at half speed, rather than just ignoring half of the reagents."


### PR DESCRIPTION
- Pills will actually have the full effect of their contents, but over time. I'm pretty sure that was the intention of the default affect_ingest proc.   **EDIT:** This is now done by directly adding the processed amount of the processed reagent to the mob's bloodstream. It seems clunky, but the other way had its own issues, an example being that it allowed you to ignore the OD limits on drugs.
- Food and booze should still process at the speeds they do now.
- Reagent cap on the human metabolism reagent holders dropped to 500. You still really shouldn't hit this cap, a human mob has 560 units of blood.
