### PR TITLE
Makes promethean transparency toggleable

### DIFF
--- a/code/modules/mob/living/carbon/human/species/species_shapeshift.dm
+++ b/code/modules/mob/living/carbon/human/species/species_shapeshift.dm
@@ -163,6 +163,22 @@ var/list/wrapped_species_by_ref = list()
 	visible_message("<span class='notice'>\The [src] shifts and contorts, taking the form of \a [new_species]!</span>")
 	regenerate_icons()
 
+/mob/living/carbon/human/proc/promethean_select_opaqueness()
+
+	set name = "Toggle Transparency"
+	set category = "Abilities"
+
+	if(stat || world.time < last_special)
+		return
+
+	last_special = world.time + 50
+
+	for(var/limb in src.organs)
+		var/obj/item/organ/external/L = limb
+		L.transparent = !L.transparent
+	visible_message("<span class='notice'>\The [src]'s interal composition seems to change.</span>")
+	update_icons_body()
+
 /mob/living/carbon/human/proc/shapeshifter_select_colour()
 
 	set name = "Select Body Colour"

--- a/code/modules/mob/living/carbon/human/species/station/prometheans.dm
+++ b/code/modules/mob/living/carbon/human/species/station/prometheans.dm
@@ -85,7 +85,8 @@ var/datum/species/shapeshifter/promethean/prometheans
 		/mob/living/carbon/human/proc/shapeshifter_select_hair,
 		/mob/living/carbon/human/proc/shapeshifter_select_hair_colors,
 		/mob/living/carbon/human/proc/shapeshifter_select_gender,
-		/mob/living/carbon/human/proc/regenerate
+		/mob/living/carbon/human/proc/regenerate,
+		/mob/living/carbon/human/proc/promethean_select_opaqueness
 		)
 
 	valid_transform_species = list("Human", "Vatborn", "Unathi", "Tajara", "Skrell", "Diona", "Teshari", "Monkey")

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -508,7 +508,7 @@ var/global/list/damage_icon_parts = list()
 
 			face_standing.Blend(hair_s, ICON_OVERLAY)
 
-	if(head_organ.nonsolid)
+	if(head_organ.transparent)
 		face_standing += rgb(,,,120)
 
 	overlays_standing[HAIR_LAYER]	= image(face_standing)

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -379,6 +379,8 @@ var/global/list/damage_icon_parts = list()
 				icon_key += "3"
 			else
 				icon_key += "1"
+			if(part.transparent)
+				icon_key += "_t"
 
 	icon_key = "[icon_key][husk ? 1 : 0][fat ? 1 : 0][hulk ? 1 : 0][skeleton ? 1 : 0]"
 

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -26,7 +26,8 @@
 	var/last_dam = -1                  // used in healing/processing calculations.
 
 	// Appearance vars.
-	var/nonsolid                       // Snowflake warning, reee. Used for slime limbs.
+	var/nonsolid                       // Used for slime limbs.
+	var/transparent                    // Makes limbs see-through.
 	var/icon_name = null               // Icon state base.
 	var/body_part = null               // Part flag
 	var/icon_position = 0              // Used in mob overlay layering calculations.

--- a/code/modules/organs/organ_icon.dm
+++ b/code/modules/organs/organ_icon.dm
@@ -106,7 +106,7 @@ var/global/list/limb_icon_cache = list()
 	if(owner && owner.gender == MALE)
 		gender = "m"
 
-	icon_cache_key = "[icon_name]_[species ? species.name : "Human"]"
+	icon_cache_key = "[icon_name]_[species ? species.get_bodytype() : "Human"]"
 
 	if(force_icon)
 		mob_icon = new /icon(force_icon, "[icon_name][gendered_icon ? "_[gender]" : ""]")
@@ -181,7 +181,7 @@ var/global/list/limb_icon_cache = list()
 	else
 		if(s_col && s_col.len >= 3)
 			applying.Blend(rgb(s_col[1], s_col[2], s_col[3]), s_col_blend)
-			icon_cache_key += "_color_[s_col[1]]_[s_col[2]]_[s_col[3]]_[s_col_blend]"
+			icon_cache_key += "_color_[s_col[1]]_[s_col[2]]_[s_col[3]]_[s_col_blend]_[transparent]"
 
 	// Translucency.
 	if(transparent) applying += rgb(,,,180) // SO INTUITIVE TY BYOND

--- a/code/modules/organs/organ_icon.dm
+++ b/code/modules/organs/organ_icon.dm
@@ -160,7 +160,7 @@ var/global/list/limb_icon_cache = list()
 
 /obj/item/organ/external/proc/apply_colouration(var/icon/applying)
 
-	if(nonsolid)
+	if(transparent)
 		applying.MapColors("#4D4D4D","#969696","#1C1C1C", "#000000")
 		if(species && species.get_bodytype(owner) != "Human")
 			applying.SetIntensity(1.5) // Unathi, Taj and Skrell have -very- dark base icons.
@@ -184,7 +184,7 @@ var/global/list/limb_icon_cache = list()
 			icon_cache_key += "_color_[s_col[1]]_[s_col[2]]_[s_col[3]]_[s_col_blend]"
 
 	// Translucency.
-	if(nonsolid) applying += rgb(,,,180) // SO INTUITIVE TY BYOND
+	if(transparent) applying += rgb(,,,180) // SO INTUITIVE TY BYOND
 
 	return applying
 

--- a/code/modules/organs/subtypes/slime.dm
+++ b/code/modules/organs/subtypes/slime.dm
@@ -1,46 +1,57 @@
 /obj/item/organ/external/chest/unbreakable/slime
 	nonsolid = 1
+	transparent = 1
 	max_damage = 50
 	encased = 0
 
 /obj/item/organ/external/groin/unbreakable/slime
 	nonsolid = 1
+	transparent = 1
 	max_damage = 30
 
 /obj/item/organ/external/arm/unbreakable/slime
 	nonsolid = 1
+	transparent = 1
 	max_damage = 5
 
 /obj/item/organ/external/arm/right/unbreakable/slime
 	nonsolid = 1
+	transparent = 1
 	max_damage = 5
 
 /obj/item/organ/external/leg/unbreakable/slime
 	nonsolid = 1
+	transparent = 1
 	max_damage = 5
 
 /obj/item/organ/external/leg/right/unbreakable/slime
 	nonsolid = 1
+	transparent = 1
 	max_damage = 5
 
 /obj/item/organ/external/foot/unbreakable/slime
 	nonsolid = 1
+	transparent = 1
 	max_damage = 5
 
 /obj/item/organ/external/foot/right/unbreakable/slime
 	nonsolid = 1
+	transparent = 1
 	max_damage = 5
 
 /obj/item/organ/external/hand/unbreakable/slime
 	nonsolid = 1
+	transparent = 1
 	max_damage = 5
 
 /obj/item/organ/external/hand/right/unbreakable/slime
 	nonsolid = 1
+	transparent = 1
 	max_damage = 5
 
 /obj/item/organ/external/head/unbreakable/slime	//They don't need this anymore.
 	nonsolid = 1
+	transparent = 1
 	cannot_gib = 0
 	vital = 0
 	max_damage = 5


### PR DESCRIPTION
Have you ever played a promethean and thought "Man, I wish I could be opaque instead of transparent?" because your promethean has dense slime or something like that?

Well, this adds a toggle. There are some oddities, however. 

- Adds a toggle to turn transparency on or off for prometheans.


Photos & information:

- Transparent promethean, 0 0 0 color https://i.imgur.com/uLY3dn1.png
- Transparent promethean, 0 0 0 color 
