### PR TITLE
Makes slightly smaller objects capable of bashing open busted APCs

### DIFF
--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -674,7 +674,7 @@
 				istype(W, /obj/item/weapon/wirecutters) || istype(W, /obj/item/device/assembly/signaler)))
 				return src.attack_hand(user)
 			//Placeholder until someone can do take_damage() for APCs or something.
-			to_chat(user,"<span class='notice'>The [src.name] looks too sturdy to bash open with the [W.name].</span>")
+			to_chat(user,"<span class='notice'>The [src.name] looks too sturdy to bash open with \the [W.name].</span>")
 
 // attack with hand - remove cell (if cover open) or interact with the APC
 

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -656,7 +656,7 @@
 		if ((stat & BROKEN) \
 				&& !opened \
 				&& W.force >= 5 \
-				&& W.w_class >= ITEMSIZE_NORMAL )
+				&& W.w_class >= ITEMSIZE_SMALL )
 			user.visible_message("<span class='danger'>The [src.name] has been hit with the [W.name] by [user.name]!</span>", \
 				"<span class='danger'>You hit the [src.name] with your [W.name]!</span>", \
 				"You hear a bang!")
@@ -674,7 +674,7 @@
 				istype(W, /obj/item/weapon/wirecutters) || istype(W, /obj/item/device/assembly/signaler)))
 				return src.attack_hand(user)
 			//Placeholder until someone can do take_damage() for APCs or something.
-			to_chat(user,"<span class='notice'>The [src.name] looks too sturdy to bash open.</span>")
+			to_chat(user,"<span class='notice'>The [src.name] looks too sturdy to bash open with the [W.name].</span>")
 
 // attack with hand - remove cell (if cover open) or interact with the APC
 

--- a/html/changelogs/Nerezza - APC-Tweak.yml
+++ b/html/changelogs/Nerezza - APC-Tweak.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Nerezza
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Broken APCs can be bashed open with slightly smaller objects now. This means wrenches are acceptable, no need to hunt down a fire extinguisher."


### PR DESCRIPTION
Currently broken APCs have to be busted open by a weapon with a force of 5+ and a weight class of Normal or higher. Basically, fire extinguishers.

This PR changes the weight class (not the force) requirement to Small or higher, so that tools like wrenches can bust open broken APCs.

This is partly to alleviate the tediousness of replacing broken APCs, and partly because what's acceptable for bashing open a broken APC can be difficult to discern and allowing a wider variety of 'weapons' for the task is likely to make it easier on fresher engineers. As a bonus the failure line now suggests that the chosen weapon is the issue, though as it is now that isn't always the case.

Full disclosure: This hasn't been tested, but the nature of the changed code allows me to guaruntee it's bug-free o3od