### PR TITLE
Adds emergency bolt overrides to airlock code

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -39,11 +39,6 @@
 	var/bolt_up_sound = 'sound/machines/boltsup.ogg'
 	var/bolt_down_sound = 'sound/machines/boltsdown.ogg'
 
-/obj/machinery/door/airlock/New()
-	.=..()
-	if(emergency_override)
-		desc += " This one is equipped with an emergency bolt override under its panel."
-
 /obj/machinery/door/airlock/attack_generic(var/mob/user, var/damage)
 	if(stat & (BROKEN|NOPOWER))
 		if(damage >= 10)
@@ -1198,6 +1193,8 @@ About the new airlock wires panel:
 			if(A.closeOtherId == src.closeOtherId && A != src)
 				src.closeOther = A
 				break
+	if(emergency_override)
+		desc += " This one is equipped with an emergency bolt override under its panel."
 	. = ..()
 
 /obj/machinery/door/airlock/Destroy()

--- a/code/modules/examine/descriptions/engineering.dm
+++ b/code/modules/examine/descriptions/engineering.dm
@@ -62,6 +62,8 @@
 		results += "[desc_panel_image("screwdriver")]to close the wire panel."
 		results += "[desc_panel_image("wirecutters")]to cut an internal wire while hacking."
 		results += "[desc_panel_image("multitool")]to pulse an internal wire while hacking."
+		if(emergency_override)
+			results += "[desc_panel_image("wrench")]to crank the emergency bolt override."
 	else
 		results += "[desc_panel_image("screwdriver")]to open the wire panel, enabling the ability to hack."
 

--- a/html/changelogs/Nerezza - emergency-override.yml
+++ b/html/changelogs/Nerezza - emergency-override.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Nerezza
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "External airlocks now have an emergency override under their panel, so their bolts can be forcefully locked/unlocked with a wrench when the airlock is unpowered."


### PR DESCRIPTION
Airlocks now have an emergency_override var that gives the option to manually alter the bolt state when the airlock's unpowered by cranking the override with a wrench for 8 seconds (for the default wrench).

By default only external airlocks have this enabled so that people don't have to break a window to bypass inaccessible external airlocks anymore. However, map makers can set the variable to 1 on other airlocks to provide the same function (good for Virology airlocks and probably some Science airlocks).

All airlocks that start with emergency_override set to 1 will have their description altered in ~~New()~~ initialize() to indicate the presence of an emergency override. If the panel is open, detailed examine will inform the user that a wrench can crank the emergency override.

This does not add a way to add/remove an emergency override to/from doors in-round aside from var edits, to prevent people from adding a crank to the vault and cranking it open.

Fully tested. The examines work, the cranking works if area power is disabled and if door power is disabled, and editing a normal airlock in the map editor to have an emergency override 100% works as intended.