### PR TITLE
Munitions/Security Supplypack touchy

### DIFF
--- a/code/datums/supplypacks/contraband.dm
+++ b/code/datums/supplypacks/contraband.dm
@@ -43,8 +43,8 @@
 	containername = "Moghes imports crate"
 	contraband = 1
 
-/datum/supply_packs/security/bolt_rifles_militia
- 	name = "Surplus militia rifles"
+/datum/supply_packs/munitions/bolt_rifles_militia
+ 	name = "Weapon - Surplus militia rifles"
  	contains = list(
  			/obj/item/weapon/gun/projectile/shotgun/pump/rifle = 3,
  			/obj/item/ammo_magazine/clip/c762 = 6
@@ -52,7 +52,7 @@
  	cost = 50
  	contraband = 1
  	containertype = /obj/structure/closet/crate/secure/weapon
- 	containername = "Weapons crate"
+ 	containername = "Ballistic weapons crate"
 
 /datum/supply_packs/randomised/misc/telecrate //you get something awesome, a couple of decent things, and a few weak/filler things
 	name = "ERR_NULL_ENTRY" //null crate! also dream maker is hell,

--- a/code/datums/supplypacks/misc.dm
+++ b/code/datums/supplypacks/misc.dm
@@ -73,7 +73,7 @@
 
 /datum/supply_packs/misc/holoplant
 	name = "Holoplant Pot"
-	contains = list()
+	contains = list(/obj/machinery/holoplant/shipped)
 	cost = 15
-	containertype = /obj/machinery/holoplant/shipped
-	containername = "holoplant"
+	containertype = /obj/structure/closet/crate
+	containername = "Holoplant crate"

--- a/code/datums/supplypacks/munitions.dm
+++ b/code/datums/supplypacks/munitions.dm
@@ -10,21 +10,30 @@
 	group = "Munitions"
 
 /datum/supply_packs/munitions/weapons
-	name = "Weapons crate"
+	name = "Weapons - Security basic equipment"
 	contains = list(
+			/obj/item/device/flash = 2,
+			/obj/item/weapon/reagent_containers/spray/pepper = 2,
 			/obj/item/weapon/melee/baton/loaded = 2,
-			/obj/item/weapon/gun/energy/gun = 2,
 			/obj/item/weapon/gun/energy/taser = 2,
 			/obj/item/weapon/gun/projectile/colt/detective = 2,
 			/obj/item/weapon/storage/box/flashbangs = 2
 			)
 	cost = 40
+	containertype = /obj/structure/closet/crate/secure/gear
+	containername = "Security equipment crate"
+	access = access_security
+
+/datum/supply_packs/munitions/egunpistol
+	name = "Weapons - Energy sidearms"
+	contains = list(/obj/item/weapon/gun/energy/gun = 2)
+	cost = 40
 	containertype = /obj/structure/closet/crate/secure/weapon
-	containername = "Weapons crate"
+	containername = "Energy sidearms crate"
 	access = access_security
 
 /datum/supply_packs/munitions/flareguns
-	name = "Flare guns crate"
+	name = "Weapons - Flare guns"
 	contains = list(
 			/obj/item/weapon/gun/projectile/sec/flash,
 			/obj/item/ammo_magazine/m45/flash,
@@ -32,100 +41,96 @@
 			/obj/item/weapon/storage/box/flashshells
 			)
 	cost = 25
-	containertype = /obj/structure/closet/crate/secure/weapon
+	containertype = /obj/structure/closet/crate/secure/gear
 	containername = "Flare gun crate"
 	access = access_security
 
 /datum/supply_packs/munitions/eweapons
-	name = "Experimental weapons crate"
+	name = "Weapons - Experimental weapons crate"
 	contains = list(
 			/obj/item/weapon/gun/energy/xray = 2,
 			/obj/item/weapon/shield/energy = 2)
 	cost = 100
-	containertype = /obj/structure/closet/crate/secure/weapon
+	containertype = /obj/structure/closet/crate/secure/science
 	containername = "Experimental weapons crate"
 	access = access_armory
 
 /datum/supply_packs/munitions/energyweapons
-	name = "Laser carbine crate"
+	name = "Weapons - Laser rifle crate"
 	contains = list(/obj/item/weapon/gun/energy/laser = 3)
 	cost = 50
-	containertype = /obj/structure/closet/crate/secure
-	containername = "energy weapons crate"
+	containertype = /obj/structure/closet/crate/secure/weapon
+	containername = "Energy weapons crate"
 	access = access_armory
 
 /datum/supply_packs/munitions/shotgun
-	name = "Shotgun crate"
+	name = "Weapons - Shotgun crate"
 	contains = list(
 			/obj/item/weapon/storage/box/shotgunammo,
 			/obj/item/weapon/storage/box/shotgunshells,
 			/obj/item/weapon/gun/projectile/shotgun/pump/combat = 2
 			)
 	cost = 50
-	containertype = /obj/structure/closet/crate/secure
+	containertype = /obj/structure/closet/crate/secure/weapon
 	containername = "Shotgun crate"
 	access = access_armory
 
 /datum/supply_packs/munitions/erifle
-	name = "Energy marksman crate"
+	name = "Weapons - Energy marksman"
 	contains = list(/obj/item/weapon/gun/energy/sniperrifle = 2)
 	cost = 100
-	containertype = /obj/structure/closet/crate/secure
+	containertype = /obj/structure/closet/crate/secure/weapon
 	containername = "Energy marksman crate"
 	access = access_armory
 
 /datum/supply_packs/munitions/burstlaser
-	name = "Burst laser crate"
+	name = "Weapons - Burst laser"
 	contains = list(/obj/item/weapon/gun/energy/gun/burst = 2)
 	cost = 50
-	containertype = /obj/structure/closet/crate/secure
+	containertype = /obj/structure/closet/crate/secure/weapon
 	containername = "Burst laser crate"
 	access = access_armory
 
 /datum/supply_packs/munitions/ionweapons
-	name = "Electromagnetic weapons crate"
+	name = "Weapons - Electromagnetic Rifles"
 	contains = list(
 			/obj/item/weapon/gun/energy/ionrifle = 2,
 			/obj/item/weapon/storage/box/empslite
 			)
 	cost = 50
-	containertype = /obj/structure/closet/crate/secure
-	containername = "electromagnetic weapons crate"
+	containertype = /obj/structure/closet/crate/secure/weapon
+	containername = "Electromagnetic weapons crate"
 	access = access_armory
 
 /datum/supply_packs/munitions/ionpistols
-	name = "Electromagnetic pistols crate"
+	name = "Weapons - Electromagnetic pistols"
 	contains = list(
 			/obj/item/weapon/gun/energy/ionrifle/pistol = 2,
 			/obj/item/weapon/storage/box/empslite
 			)
 	cost = 30
-	containertype = /obj/structure/closet/crate/secure
-	containername = "electromagnetic weapons crate"
+	containertype = /obj/structure/closet/crate/secure/weapon
+	containername = "Electromagnetic weapons crate"
 	access = access_armory
 
-/datum/supply_packs/randomised/munitions/automatic
-	name = "Automatic weapon crate"
-	num_contained = 2
-	contains = list(
-			/obj/item/weapon/gun/projectile/automatic/wt550,
-			/obj/item/weapon/gun/projectile/automatic/z8
-			)
-	cost = 100
-	containertype = /obj/structure/closet/crate/secure
-	containername = "Automatic weapon crate"
-	access = access_armory
-
-/datum/supply_packs/munitions/energy_guns
-	name = "Energy gun crate"
-	contains = list(/obj/item/weapon/gun/energy/gun = 2)
+/datum/supply_packs/munitions/bsmg
+	name = "Weapons - Ballistic SMGs"
+	contains = list(/obj/item/weapon/gun/projectile/automatic/wt550 = 2)
 	cost = 50
-	containertype = /obj/structure/closet/crate/secure
-	containername = "Energy gun crate"
+	containertype = /obj/structure/closet/crate/secure/weapon
+	containername = "Ballistic weapon crate"
+	access = access_armory
+
+/datum/supply_packs/munitions/brifle
+	name = "Weapons - Ballistic Rifles"
+	contains = list(/obj/item/weapon/gun/projectile/automatic/z8 = 2)
+	cost = 80
+	containertype = /obj/structure/closet/crate/secure/weapon
+	containername = "Ballistic weapon crate"
 	access = access_armory
 
 /datum/supply_packs/munitions/bolt_rifles_competitive
- 	name = "Competitive shooting crate"
+ 	name = "Weapons - Competitive shooting rifles"
  	contains = list(
  			/obj/item/device/assembly/timer,
  			/obj/item/weapon/gun/projectile/shotgun/pump/rifle/practice = 2,
@@ -136,37 +141,56 @@
  			)
  	cost = 40
  	containertype = /obj/structure/closet/crate/secure/weapon
- 	containername = "Weapons crate"
+ 	containername = "Ballistic weapons crate"
  	access = access_security
 
 /datum/supply_packs/munitions/shotgunammo
-	name = "Shotgun ammunition crate"
+	name = "Ammunition - Shotgun shells"
 	contains = list(
 			/obj/item/weapon/storage/box/shotgunammo = 2,
 			/obj/item/weapon/storage/box/shotgunshells = 2
 			)
 	cost = 25
 	containertype = /obj/structure/closet/crate/secure
-	containername = "ballistic ammunition crate"
-	access = access_armory
-
-/datum/supply_packs/randomised/munitions/autoammo
-	name = "Automatic weapon ammunition crate"
-	num_contained = 6
-	contains = list(
-			/obj/item/ammo_magazine/m9mmt,
-			/obj/item/ammo_magazine/m9mmt/rubber,
-			/obj/item/ammo_magazine/m545saw
-			)
-	cost = 25
-	containertype = /obj/structure/closet/crate/secure
-	containername = "Automatic weapon ammunition crate"
+	containername = "Ballistic ammunition crate"
 	access = access_armory
 
 /datum/supply_packs/munitions/beanbagammo
-	name = "Beanbag shells"
+	name = "Ammunition - Beanbag shells"
 	contains = list(/obj/item/weapon/storage/box/beanbags = 3)
 	cost = 25
 	containertype = /obj/structure/closet/crate
-	containername = "Beanbag shells"
+	containername = "Ballistic ammunition crate"
 	access = null
+
+/datum/supply_packs/munitions/bsmgammo
+	name = "Ammunition - 9mm top mounted lethal"
+	contains = list(/obj/item/ammo_magazine/m9mmt = 6)
+	cost = 25
+	containertype = /obj/structure/closet/crate/secure
+	containername = "Ballistic ammunition crate"
+	access = access_armory
+
+/datum/supply_packs/munitions/bsmgammorubber
+	name = "Ammunition - 9mm top mounted rubber"
+	contains = list(/obj/item/ammo_magazine/m9mmt/rubber = 6)
+	cost = 25
+	containertype = /obj/structure/closet/crate/secure
+	containername = "Ballistic ammunition crate"
+	access = access_security
+
+/datum/supply_packs/munitions/brifleammo
+	name = "Ammunition - 7.62mm lethal"
+	contains = list(/obj/item/ammo_magazine/m762 = 6)
+	cost = 25
+	containertype = /obj/structure/closet/crate/secure
+	containername = "Ballistic ammunition crate"
+	access = access_armory
+
+/datum/supply_packs/munitions/pcellammo
+	name = "Ammunition - Power cell"
+	contains = list(/obj/item/weapon/cell/device/weapon = 3)
+	cost = 50
+	containertype = /obj/structure/closet/crate/secure
+	containername = "Energy ammunition crate"
+	access = access_security

--- a/code/datums/supplypacks/security.dm
+++ b/code/datums/supplypacks/security.dm
@@ -13,6 +13,7 @@
 	access = access_security
 
 /datum/supply_packs/randomised/security/armor
+	name = "Armor - Security armor"
 	num_contained = 5
 	contains = list(
 			/obj/item/clothing/suit/storage/vest,
@@ -27,14 +28,12 @@
 			/obj/item/clothing/suit/storage/vest/heavy/hos,
 			/obj/item/clothing/suit/storage/vest/heavy/pcrc
 			)
-
-	name = "Armor crate"
 	cost = 40
-	containertype = /obj/structure/closet/crate/secure
+	containertype = /obj/structure/closet/crate/secure/gear
 	containername = "Armor crate"
 
 /datum/supply_packs/security/riot_gear
-	name = "Riot gear crate"
+	name = "Gear - Riot"
 	contains = list(
 			/obj/item/weapon/melee/baton = 3,
 			/obj/item/weapon/shield/riot = 3,
@@ -44,12 +43,12 @@
 			/obj/item/weapon/storage/box/handcuffs
 			)
 	cost = 40
-	containertype = /obj/structure/closet/crate/secure
-	containername = "riot gear crate"
+	containertype = /obj/structure/closet/crate/secure/gear
+	containername = "Riot gear crate"
 	access = access_armory
 
 /datum/supply_packs/security/riot_armor
-	name = "Riot armor set crate"
+	name = "Armor - Riot"
 	contains = list(
 			/obj/item/clothing/head/helmet/riot,
 			/obj/item/clothing/suit/armor/riot,
@@ -57,12 +56,12 @@
 			/obj/item/clothing/shoes/leg_guard/riot
 			)
 	cost = 30
-	containertype = /obj/structure/closet/crate/secure
-	containername = "riot armor set crate"
+	containertype = /obj/structure/closet/crate/secure/gear
+	containername = "Riot armor crate"
 	access = access_armory
 
 /datum/supply_packs/security/ablative_armor
-	name = "Ablative armor set crate"
+	name = "Armor - Ablative"
 	contains = list(
 			/obj/item/clothing/head/helmet/laserproof,
 			/obj/item/clothing/suit/armor/laserproof,
@@ -70,12 +69,12 @@
 			/obj/item/clothing/shoes/leg_guard/laserproof
 			)
 	cost = 40
-	containertype = /obj/structure/closet/crate/secure
-	containername = "ablative armor set crate"
+	containertype = /obj/structure/closet/crate/secure/gear
+	containername = "Ablative armor crate"
 	access = access_armory
 
 /datum/supply_packs/security/bullet_resistant_armor
-	name = "Bullet resistant armor set crate"
+	name = "Armor - Ballistic"
 	contains = list(
 			/obj/item/clothing/head/helmet/bulletproof,
 			/obj/item/clothing/suit/armor/bulletproof,
@@ -83,12 +82,12 @@
 			/obj/item/clothing/shoes/leg_guard/bulletproof
 			)
 	cost = 40
-	containertype = /obj/structure/closet/crate/secure
-	containername = "bullet resistant armor set crate"
+	containertype = /obj/structure/closet/crate/secure/gear
+	containername = "Ballistic armor crate"
 	access = access_armory
 
 /datum/supply_packs/security/combat_armor
-	name = "Combat armor set crate"
+	name = "Armor - Combat"
 	contains = list(
 			/obj/item/clothing/head/helmet/combat,
 			/obj/item/clothing/suit/armor/combat,
@@ -96,14 +95,14 @@
 			/obj/item/clothing/shoes/leg_guard/combat
 			)
 	cost = 40
-	containertype = /obj/structure/closet/crate/secure
-	containername = "combat armor set crate"
+	containertype = /obj/structure/closet/crate/secure/gear
+	containername = "Combat armor crate"
 	access = access_armory
 
 /datum/supply_packs/security/tactical
-	name = "Tactical suits"
-	containertype = /obj/structure/closet/crate/secure
-	containername = "Tactical Suit Locker"
+	name = "Armor - Tactical"
+	containertype = /obj/structure/closet/crate/secure/gear
+	containername = "Tactical armor crate"
 	cost = 40
 	access = access_armory
 	contains = list(
@@ -126,23 +125,23 @@
 			)
 
 /datum/supply_packs/security/securitybarriers
-	name = "Security barrier crate"
+	name = "Misc - Security Barriers"
 	contains = list(/obj/machinery/deployable/barrier = 4)
 	cost = 20
-	containertype = /obj/structure/closet/crate/secure/gear
+	containertype = /obj/structure/largecrate
 	containername = "Security barrier crate"
 	access = null
 
 /datum/supply_packs/security/securityshieldgen
-	name = "Wall shield Generators"
+	name = "Misc - Wall shield generators"
 	contains = list(/obj/machinery/shieldwallgen = 4)
 	cost = 20
 	containertype = /obj/structure/closet/crate/secure
-	containername = "wall shield generators crate"
+	containername = "Wall shield generators crate"
 	access = access_teleporter
 
 /datum/supply_packs/randomised/security/holster
-	name = "Holster crate"
+	name = "Gear - Holsters"
 	num_contained = 4
 	contains = list(
 			/obj/item/clothing/accessory/holster,
@@ -151,11 +150,11 @@
 			/obj/item/clothing/accessory/holster/hip
 			)
 	cost = 15
-	containertype = "/obj/structure/closet/crate/secure"
+	containertype = /obj/structure/closet/crate
 	containername = "Holster crate"
 
 /datum/supply_packs/security/extragear
-	name = "Security surplus equipment"
+	name = "Gear - Security surplus equipment"
 	contains = list(
 			/obj/item/weapon/storage/belt/security = 3,
 			/obj/item/clothing/glasses/sunglasses/sechud = 3,
@@ -163,12 +162,11 @@
 			/obj/item/clothing/suit/storage/hooded/wintercoat/security = 3
 			)
 	cost = 10
-	containertype = "/obj/structure/closet/crate/secure"
+	containertype = /obj/structure/closet/crate
 	containername = "Security surplus equipment"
-	access = null
 
 /datum/supply_packs/security/detectivegear
-	name = "Forensic investigation equipment"
+	name = "Forensic - Investigation equipment"
 	contains = list(
 			/obj/item/weapon/storage/box/evidence = 2,
 			/obj/item/clothing/suit/storage/vest/detective,
@@ -190,12 +188,12 @@
 			/obj/item/weapon/storage/briefcase/crimekit
 			)
 	cost = 20
-	containertype = "/obj/structure/closet/crate/secure"
+	containertype = /obj/structure/closet/crate/secure
 	containername = "Forensic equipment"
 	access = access_forensics_lockers
 
 /datum/supply_packs/security/detectiveclothes
-	name = "Investigation apparel"
+	name = "Forensic - Investigation apparel"
 	contains = list(
 			/obj/item/clothing/under/det/black = 2,
 			/obj/item/clothing/under/det/grey = 2,
@@ -212,12 +210,12 @@
 			/obj/item/clothing/gloves/black = 2
 			)
 	cost = 10
-	containertype = "/obj/structure/closet/crate/secure"
+	containertype = /obj/structure/closet/crate/secure
 	containername = "Investigation clothing"
 	access = access_forensics_lockers
 
 /datum/supply_packs/security/officergear
-	name = "Officer equipment"
+	name = "Gear - Officer equipment"
 	contains = list(
 			/obj/item/clothing/suit/storage/vest/officer,
 			/obj/item/clothing/head/helmet,
@@ -242,12 +240,12 @@
 			/obj/item/device/flashlight/maglight
 			)
 	cost = 20
-	containertype = "/obj/structure/closet/crate/secure"
+	containertype = /obj/structure/closet/crate/secure
 	containername = "Officer equipment"
 	access = access_brig
 
 /datum/supply_packs/security/wardengear
-	name = "Warden equipment"
+	name = "Gear - Warden equipment"
 	contains = list(
 			/obj/item/clothing/suit/storage/vest/warden,
 			/obj/item/clothing/under/rank/warden,
@@ -270,12 +268,12 @@
 			/obj/item/device/flashlight/maglight
 			)
 	cost = 20
-	containertype = "/obj/structure/closet/crate/secure"
+	containertype = /obj/structure/closet/crate/secure
 	containername = "Warden equipment"
 	access = access_armory
 
 /datum/supply_packs/security/headofsecgear
-	name = "Head of security equipment"
+	name = "Gear - Head of security equipment"
 	contains = list(
 			/obj/item/clothing/head/helmet/HoS,
 			/obj/item/clothing/suit/storage/vest/hos,
@@ -296,12 +294,12 @@
 			/obj/item/device/flashlight/maglight
 			)
 	cost = 50
-	containertype = "/obj/structure/closet/crate/secure"
+	containertype = /obj/structure/closet/crate/secure
 	containername = "Head of security equipment"
 	access = access_hos
 
 /datum/supply_packs/security/securityclothing
-	name = "Security uniform crate"
+	name = "Misc - Security uniform red"
 	contains = list(
 			/obj/item/weapon/storage/backpack/satchel/sec = 2,
 			/obj/item/weapon/storage/backpack/security = 2,
@@ -315,11 +313,11 @@
 			/obj/item/weapon/storage/box/holobadge
 			)
 	cost = 10
-	containertype = "/obj/structure/closet/crate/secure"
+	containertype = /obj/structure/closet/crate/secure
 	containername = "Security uniform crate"
 
 /datum/supply_packs/security/navybluesecurityclothing
-	name = "Navy blue security uniform crate"
+	name = "Misc - Security uniform navy blue"
 	contains = list(
 			/obj/item/weapon/storage/backpack/satchel/sec = 2,
 			/obj/item/weapon/storage/backpack/security = 2,
@@ -336,11 +334,11 @@
 			/obj/item/weapon/storage/box/holobadge
 			)
 	cost = 10
-	containertype = "/obj/structure/closet/crate/secure"
+	containertype = /obj/structure/closet/crate/secure
 	containername = "Navy blue security uniform crate"
 
 /datum/supply_packs/security/corporatesecurityclothing
-	name = "Corporate security uniform crate"
+	name = "Misc - Security uniform corporate"
 	contains = list(
 			/obj/item/weapon/storage/backpack/satchel/sec = 2,
 			/obj/item/weapon/storage/backpack/security = 2,
@@ -356,11 +354,11 @@
 			/obj/item/weapon/storage/box/holobadge
 			)
 	cost = 10
-	containertype = "/obj/structure/closet/crate/secure"
+	containertype = /obj/structure/closet/crate/secure
 	containername = "Corporate security uniform crate"
 
 /datum/supply_packs/security/biosuit
-	name = "Security biohazard gear"
+	name = "Gear - Security biohazard gear"
 	contains = list(
 			/obj/item/clothing/head/bio_hood/security = 3,
 			/obj/item/clothing/under/rank/security = 3,
@@ -371,6 +369,7 @@
 			/obj/item/clothing/gloves/sterile/latex,
 			/obj/item/weapon/storage/box/gloves
 			)
-	cost = 50
-	containertype = "/obj/structure/closet/crate/secure"
+	cost = 25
+	containertype = /obj/structure/closet/crate/secure
 	containername = "Security biohazard gear"
+	access = access_security

--- a/html/changelogs/Woodrat - Supplypack Adjustments.yml
+++ b/html/changelogs/Woodrat - Supplypack Adjustments.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Woodrat
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Added in a weapons crate for explorers that has bolt action rifles."
+  - rscadd: "Weapon powercells can be ordered from cargo (security access crate)."
+  - tweak: "Automatic weapons crate split into two crates now. One for SMGs one for the rifle. Minor adjustments to other munitions and security supply packs as well."
+  - rscadd: "The automatic weapons ammo crate has also been split."
+  - tweak: "Names of the crates for the munitions and security catogory supply packs have been adjusted slightly. In certain places contents also adjusted."
+  - bugfix: "Holoplant now comes in a crate." 

--- a/maps/southern_cross/datums/supplypacks/munitions.dm
+++ b/maps/southern_cross/datums/supplypacks/munitions.dm
@@ -1,0 +1,16 @@
+/*
+*	Here is where any supply packs
+*	related to sc weapons live.
+*/
+
+/datum/supply_packs/munitions/bolt_rifles_explorer
+ 	name = "Weapons - Surplus explorer rifles"
+ 	contains = list(
+ 			/obj/item/weapon/gun/projectile/shotgun/pump/rifle = 4,
+ 			/obj/item/ammo_magazine/clip/c762 = 4,
+ 			/obj/item/ammo_magazine/clip/c762/hunter = 8
+ 			)
+ 	cost = 50
+ 	containertype = /obj/structure/closet/crate/secure/weapon
+ 	containername = "Explorer weapons crate"
+ 	access = access_explorer

--- a/maps/southern_cross/southern_cross.dm
+++ b/maps/southern_cross/southern_cross.dm
@@ -20,6 +20,7 @@
 	#include "loadout/loadout_suit.dm"
 	#include "loadout/loadout_uniform.dm"
 
+	#include "datums/supplypacks/munitions.dm"
 	#include "items/encryptionkey_sc.dm"
 	#include "items/headset_sc.dm"
 	#include "items/clothing/sc_suit.dm"


### PR DESCRIPTION
- Added, weapons crate for explorers that has bolt action rifles, weapon powercell crate (security access only).
- Touchy of all the munition and security supply pack names so it's easier to tell what crate contains weapons, armor, and or gear.
- Slight adjustment of certain security and weapon crates. Moving some guns out of some crates, splitting some crates up (automatic weapons crate is two crates now) and changing the type of crate stuff comes in.
- Holoplant fix, now properly comes in a crate instead of being shipped without a protective box.