### PR TITLE
Sundry Runtime Fixes - March

### DIFF
--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -46,7 +46,7 @@
 		return TRUE
 
 /atom/movable/Destroy()
-	unbuckle_mob()
+	unbuckle_all_mobs()
 	return ..()
 
 

--- a/code/game/objects/items/weapons/tools.dm
+++ b/code/game/objects/items/weapons/tools.dm
@@ -236,7 +236,7 @@
 	..()
 
 /obj/item/weapon/wirecutters/attack(mob/living/carbon/C as mob, mob/user as mob)
-	if(user.a_intent == I_HELP && (C.handcuffed) && (istype(C.handcuffed, /obj/item/weapon/handcuffs/cable)))
+	if(istype(C) && user.a_intent == I_HELP && (C.handcuffed) && (istype(C.handcuffed, /obj/item/weapon/handcuffs/cable)))
 		usr.visible_message("\The [usr] cuts \the [C]'s restraints with \the [src]!",\
 		"You cut \the [C]'s restraints with \the [src]!",\
 		"You hear cable being cut.")

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -13,6 +13,8 @@
 /mob/living/Destroy()
 	dsoverlay.loc = null //I'll take my coat with me
 	dsoverlay = null
+	if(buckled)
+		buckled.unbuckle_mob(src, TRUE)
 	return ..()
 
 //mob verbs are faster than object verbs. See mob/verb/examine.

--- a/code/modules/mob/living/silicon/robot/robot_items.dm
+++ b/code/modules/mob/living/silicon/robot/robot_items.dm
@@ -24,7 +24,7 @@
 	if(response == "Analyze")
 		if(loaded_item)
 			var/confirm = alert(user, "This will destroy the item inside forever.  Are you sure?","Confirm Analyze","Yes","No")
-			if(confirm == "Yes") //This is pretty copypasta-y
+			if(confirm == "Yes" && !QDELETED(loaded_item)) //This is pretty copypasta-y
 				user << "You activate the analyzer's microlaser, analyzing \the [loaded_item] and breaking it down."
 				flick("portable_analyzer_scan", src)
 				playsound(src.loc, 'sound/items/Welder2.ogg', 50, 1)

--- a/code/modules/multiz/zshadow.dm
+++ b/code/modules/multiz/zshadow.dm
@@ -33,6 +33,10 @@
 	. = ..()
 
 /mob/zshadow/examine(mob/user, distance, infix, suffix)
+	if(!owner)
+	 	// The only time we should have a null owner is if we are in nullspace. Help figure out why we were examined.
+		crash_with("[src] ([type]) @ [log_info_line()] was examined by [user] @ [global.log_info_line(user)]")
+		return
 	return owner.examine(user, distance, infix, suffix)
 
 // Relay some stuff they hear

--- a/code/modules/paperwork/paper_bundle.dm
+++ b/code/modules/paperwork/paper_bundle.dm
@@ -164,7 +164,7 @@
 			usr.put_in_hands(W)
 			pages.Remove(pages[page])
 
-			usr << "<span class='notice'>You remove the [W.name] from the bundle.</span>"
+			to_chat(usr, "<span class='notice'>You remove the [W.name] from the bundle.</span>")
 
 			if(pages.len <= 1)
 				var/obj/item/weapon/paper/P = src[1]
@@ -178,11 +178,11 @@
 				page = pages.len
 
 			update_icon()
-	else
-		usr << "<span class='notice'>You need to hold it in hands!</span>"
-	if (src.loc && istype(src.loc, /mob) ||istype(src.loc.loc, /mob))
+
 		src.attack_self(usr)
 		updateUsrDialog()
+	else
+		to_chat(usr, "<span class='notice'>You need to hold it in hands!</span>")
 
 /obj/item/weapon/paper_bundle/verb/rename()
 	set name = "Rename bundle"


### PR DESCRIPTION
- Fix Runtime in buckling.dm,165: Cannot execute null.forceMove(). 
- Fixes Runtime in tools.dm,239: undefined variable var/handcuffed
- Add logging to help track down the root cause cause of runtime in examining zshadow mobs.

