### PR TITLE
[PORT] Revamp logging for consistency

### DIFF
--- a/code/_helpers/logging.dm
+++ b/code/_helpers/logging.dm
@@ -140,7 +140,7 @@
 
 //more or less a logging utility
 //Always return "Something/(Something)", even if it's an error message.
-/proc/key_name(var/whom, var/include_link = null, var/highlight_special_characters = 1)
+/proc/key_name(var/whom, var/include_link = FALSE, var/include_name = TRUE, var/highlight_special_characters = TRUE)
 	var/mob/M
 	var/client/C
 	var/key
@@ -186,17 +186,18 @@
 	else
 		. += "INVALID"
 
-	var/name = "INVALID"
-	if(M)
-		if(M.real_name)
-			name = M.real_name
-		else if(M.name)
-			name = M.name
+	if(include_name)
+		var/name = "INVALID"
+		if(M)
+			if(M.real_name)
+				name = M.real_name
+			else if(M.name)
+				name = M.name
 
-		if(include_link && is_special_character(M) && highlight_special_characters)
-			name = "<font color='#FFA500'>[name]</font>" //Orange
-	
-	. += "/([name])"
+			if(include_link && is_special_character(M) && highlight_special_characters)
+				name = "<font color='#FFA500'>[name]</font>" //Orange
+		
+		. += "/([name])"
 
 	return .
 

--- a/code/_helpers/logging.dm
+++ b/code/_helpers/logging.dm
@@ -27,7 +27,7 @@
 
 /proc/log_debug(text)
 	if (config.log_debug)
-		diary << "\[[time_stamp()]]DEBUG: [text][log_end]"
+		debug_log << "\[[time_stamp()]]DEBUG: [text][log_end]"
 
 	for(var/client/C in admins)
 		if(C.is_preference_enabled(/datum/client_preference/debug/show_debug_logs))
@@ -111,6 +111,10 @@
 	world.log << text //this comes before the config check because it can't possibly runtime
 	if(config.log_world_output)
 		diary << "\[[time_stamp()]]DD_OUTPUT: [text][log_end]"
+
+/proc/log_error(text)
+	world.log << text
+	error_log << "\[[time_stamp()]]RUNTIME: [text][log_end]"
 
 /proc/log_misc(text)
 	diary << "\[[time_stamp()]]MISC: [text][log_end]"

--- a/code/_helpers/logging.dm
+++ b/code/_helpers/logging.dm
@@ -41,41 +41,71 @@
 	if (config.log_vote)
 		diary << "\[[time_stamp()]]VOTE: [text][log_end]"
 
-/proc/log_access(text)
+/proc/log_access_in(client/new_client)
 	if (config.log_access)
-		diary << "\[[time_stamp()]]ACCESS: [text][log_end]"
+		var/message = "[key_name(new_client)] - IP:[new_client.address] - CID:[new_client.computer_id] - BYOND v[new_client.byond_version]"			
+		diary << "\[[time_stamp()]]ACCESS IN: [message][log_end]"
 
-/proc/log_say(text)
+/proc/log_access_out(mob/last_mob)
+	if (config.log_access)
+		var/message = "[key_name(last_mob)] - IP:[last_mob.lastKnownIP] - CID:Logged Out - BYOND Logged Out"
+		diary << "\[[time_stamp()]]ACCESS OUT: [message][log_end]"
+
+/proc/log_say(text, mob/speaker)
 	if (config.log_say)
-		diary << "\[[time_stamp()]]SAY: [text][log_end]"
+		diary << "\[[time_stamp()]]SAY: [speaker.simple_info_line()]: [html_decode(text)][log_end]"
 
-/proc/log_ooc(text)
+/proc/log_ooc(text, client/user)
 	if (config.log_ooc)
-		diary << "\[[time_stamp()]]OOC: [text][log_end]"
+		diary << "\[[time_stamp()]]OOC: [user.simple_info_line()]: [html_decode(text)][log_end]"
 
-/proc/log_whisper(text)
+/proc/log_aooc(text, client/user)
+	if (config.log_ooc)
+		diary << "\[[time_stamp()]]AOOC: [user.simple_info_line()]: [html_decode(text)][log_end]"
+
+/proc/log_looc(text, client/user)
+	if (config.log_ooc)
+		diary << "\[[time_stamp()]]LOOC: [user.simple_info_line()]: [html_decode(text)][log_end]"
+
+/proc/log_whisper(text, mob/speaker)
 	if (config.log_whisper)
-		diary << "\[[time_stamp()]]WHISPER: [text][log_end]"
+		diary << "\[[time_stamp()]]WHISPER: [speaker.simple_info_line()]: [html_decode(text)][log_end]"
 
-/proc/log_emote(text)
+/proc/log_emote(text, mob/speaker)
 	if (config.log_emote)
-		diary << "\[[time_stamp()]]EMOTE: [text][log_end]"
+		diary << "\[[time_stamp()]]EMOTE: [speaker.simple_info_line()]: [html_decode(text)][log_end]"
 
-/proc/log_attack(text)
+/proc/log_attack(attacker, defender, message)
 	if (config.log_attack)
-		diary << "\[[time_stamp()]]ATTACK: [text][log_end]" //Seperate attack logs? Why?  FOR THE GLORY OF SATAN!
+		diary << "\[[time_stamp()]]ATTACK: [attacker] against [defender]: [message][log_end]"
 
-/proc/log_adminsay(text)
+/proc/log_adminsay(text, mob/speaker)
 	if (config.log_adminchat)
-		diary << "\[[time_stamp()]]ADMINSAY: [text][log_end]"
+		diary << "\[[time_stamp()]]ADMINSAY: [speaker.simple_info_line()]: [html_decode(text)][log_end]"
+
+/proc/log_modsay(text, mob/speaker)
+	if (config.log_adminchat)
+		diary << "\[[time_stamp()]]MODSAY: [speaker.simple_info_line()]: [html_decode(text)][log_end]"
+
+/proc/log_eventsay(text, mob/speaker)
+	if (config.log_adminchat)
+		diary << "\[[time_stamp()]]EVENTSAY: [speaker.simple_info_line()]: [html_decode(text)][log_end]"
+
+/proc/log_ghostsay(text, mob/speaker)
+	if (config.log_say)
+		diary << "\[[time_stamp()]]DEADCHAT: [speaker.simple_info_line()]: [html_decode(text)][log_end]"
+
+/proc/log_ghostemote(text, mob/speaker)
+	if (config.log_emote)
+		diary << "\[[time_stamp()]]DEADEMOTE: [speaker.simple_info_line()]: [html_decode(text)][log_end]"
 
 /proc/log_adminwarn(text)
 	if (config.log_adminwarn)
-		diary << "\[[time_stamp()]]ADMINWARN: [text][log_end]"
+		diary << "\[[time_stamp()]]ADMINWARN: [html_decode(text)][log_end]"
 
-/proc/log_pda(text)
+/proc/log_pda(text, mob/speaker)
 	if (config.log_pda)
-		diary << "\[[time_stamp()]]PDA: [text][log_end]"
+		diary << "\[[time_stamp()]]PDA: [speaker.simple_info_line()]: [html_decode(text)][log_end]"
 
 /proc/log_to_dd(text)
 	world.log << text //this comes before the config check because it can't possibly runtime
@@ -105,12 +135,14 @@
 	return english_list(comps, nothing_text="0", and_text="|", comma_text="|")
 
 //more or less a logging utility
-/proc/key_name(var/whom, var/include_link = null, var/include_name = 1, var/highlight_special_characters = 1)
+//Always return "Something/(Something)", even if it's an error message.
+/proc/key_name(var/whom, var/include_link = null, var/highlight_special_characters = 1)
 	var/mob/M
 	var/client/C
 	var/key
 
-	if(!whom)	return "*null*"
+	if(!whom)
+		return "INVALID/INVALID"
 	if(istype(whom, /client))
 		C = whom
 		M = C.mob
@@ -127,9 +159,11 @@
 			C = D.current.client
 	else if(istype(whom, /datum))
 		var/datum/D = whom
-		return "*invalid:[D.type]*"
+		return "INVALID/([D.type])"
+	else if(istext(whom))
+		return "AUTOMATED/[whom]" //Just give them the text back
 	else
-		return "*invalid*"
+		return "INVALID/INVALID"
 
 	. = ""
 
@@ -137,7 +171,7 @@
 		if(include_link && C)
 			. += "<a href='?priv_msg=\ref[C]'>"
 
-		if(C && C.holder && C.holder.fakekey && !include_name)
+		if(C && C.holder && C.holder.fakekey)
 			. += "Administrator"
 		else
 			. += key
@@ -146,21 +180,19 @@
 			if(C)	. += "</a>"
 			else	. += " (DC)"
 	else
-		. += "*no key*"
+		. += "INVALID"
 
-	if(include_name && M)
-		var/name
-
+	var/name = "INVALID"
+	if(M)
 		if(M.real_name)
 			name = M.real_name
 		else if(M.name)
 			name = M.name
 
-
 		if(include_link && is_special_character(M) && highlight_special_characters)
-			. += "/(<font color='#FFA500'>[name]</font>)" //Orange
-		else
-			. += "/([name])"
+			name = "<font color='#FFA500'>[name]</font>" //Orange
+	
+	. += "/([name])"
 
 	return .
 
@@ -187,3 +219,9 @@
 	if(!istype(d))
 		return
 	return d.log_info_line()
+
+/mob/proc/simple_info_line()
+	return "[key_name(src)] ([x],[y],[z])"
+
+/client/proc/simple_info_line()
+	return "[key_name(src)] ([mob.x],[mob.y],[mob.z])"

--- a/code/_helpers/mobs.dm
+++ b/code/_helpers/mobs.dm
@@ -145,13 +145,23 @@ Proc for attack log creation, because really why not
 6 is additional information, anything that needs to be added
 */
 
-/proc/add_logs(mob/user, mob/target, what_done, var/admin=1, var/object=null, var/addition=null)
-	if(user && ismob(user))
-		user.attack_log += text("\[[time_stamp()]\] <font color='red'>Has [what_done] [target ? "[target.name][(ismob(target) && target.ckey) ? "([target.ckey])" : ""]" : "NON-EXISTANT SUBJECT"][object ? " with [object]" : " "][addition]</font>")
-	if(target && ismob(target))
-		target.attack_log += text("\[[time_stamp()]\] <font color='orange'>Has been [what_done] by [user ? "[user.name][(ismob(user) && user.ckey) ? "([user.ckey])" : ""]" : "NON-EXISTANT SUBJECT"][object ? " with [object]" : " "][addition]</font>")
-	if(admin)
-		log_attack("<font color='red'>[user ? "[user.name][(ismob(user) && user.ckey) ? "([user.ckey])" : ""]" : "NON-EXISTANT SUBJECT"] [what_done] [target ? "[target.name][(ismob(target) && target.ckey)? "([target.ckey])" : ""]" : "NON-EXISTANT SUBJECT"][object ? " with [object]" : " "][addition]</font>")
+/proc/add_attack_logs(mob/user, mob/target, what_done, var/admin_notify = TRUE)
+	if(islist(target)) //Multi-victim adding
+		var/list/targets = target
+		for(var/mob/M in targets)
+			add_attack_logs(user,M,what_done,admin_notify)
+		return
+
+	var/user_str = key_name(user)
+	var/target_str = key_name(target)
+
+	if(ismob(user))
+		user.attack_log += text("\[[time_stamp()]\] <font color='red'>Attacked [target_str]: [what_done]</font>")
+	if(ismob(target))
+		target.attack_log += text("\[[time_stamp()]\] <font color='orange'>Attacked by [user_str]: [what_done]</font>")
+	log_attack(user_str,target_str,what_done)
+	if(admin_notify)
+		msg_admin_attack("[key_name_admin(user)] vs [target_str]: [what_done]")
 
 //checks whether this item is a module of the robot it is located in.
 /proc/is_robot_module(var/obj/item/thing)

--- a/code/_helpers/time.dm
+++ b/code/_helpers/time.dm
@@ -58,8 +58,11 @@ var/next_station_date_change = 1 DAY
 		station_date = num2text((text2num(time2text(timeofday, "YYYY"))+544)) + "-" + time2text(timeofday, "MM-DD")
 	return station_date
 
+//ISO 8601
 /proc/time_stamp()
-	return time2text(station_time_in_ticks, "hh:mm:ss")
+	var/date_portion = time2text(world.timeofday, "YYYY-MM-DD")
+	var/time_portion = time2text(world.timeofday, "hh:mm:ss")
+	return "[date_portion]T[time_portion]"
 
 /* Returns 1 if it is the selected month and day */
 proc/isDay(var/month, var/day)

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -84,9 +84,7 @@ avoid code duplication. This includes items that may sometimes act as a standard
 	M.lastattacker = user
 
 	if(!no_attack_log)
-		user.attack_log += "\[[time_stamp()]\]<font color='red'> Attacked [M.name] ([M.ckey]) with [name] (INTENT: [uppertext(user.a_intent)]) (DAMTYE: [uppertext(damtype)])</font>"
-		M.attack_log += "\[[time_stamp()]\]<font color='orange'> Attacked by [user.name] ([user.ckey]) with [name] (INTENT: [uppertext(user.a_intent)]) (DAMTYE: [uppertext(damtype)])</font>"
-		msg_admin_attack("[key_name(user)] attacked [key_name(M)] with [name] (INTENT: [uppertext(user.a_intent)]) (DAMTYE: [uppertext(damtype)])" )
+		add_attack_logs(user,M,"attacked with [name] (INTENT: [uppertext(user.a_intent)]) (DAMTYE: [uppertext(damtype)])")
 	/////////////////////////
 
 	user.setClickCooldown(user.get_attack_speed(src))

--- a/code/controllers/subsystems/atoms.dm
+++ b/code/controllers/subsystems/atoms.dm
@@ -135,9 +135,7 @@ SUBSYSTEM_DEF(atoms)
 /datum/controller/subsystem/atoms/Shutdown()
 	var/initlog = InitLog()
 	if(initlog)
-		//text2file(initlog, "[GLOB.log_directory]/initialize.log")
-		var/date_string = time2text(world.realtime, "YYYY/MM-Month/DD-Day")
-		text2file(initlog, "data/logs/[date_string]-initialize.log")
+		text2file(initlog, "[log_path]-initialize.log")
 
 #undef BAD_INIT_QDEL_BEFORE
 #undef BAD_INIT_DIDNT_INIT

--- a/code/controllers/subsystems/garbage.dm
+++ b/code/controllers/subsystems/garbage.dm
@@ -81,8 +81,7 @@ SUBSYSTEM_DEF(garbage)
 			dellog += "\tIgnored force: [I.no_respect_force] times"
 		if (I.no_hint)
 			dellog += "\tNo hint: [I.no_hint] times"
-	var/date_string = time2text(world.realtime, "YYYY/MM-Month/DD-Day")
-	text2file(dellog.Join(), "data/logs/[date_string]-qdel.log")
+	text2file(dellog.Join(), "[log_path]-qdel.log")
 
 /datum/controller/subsystem/garbage/fire()
 	//the fact that this resets its processing each fire (rather then resume where it left off) is intentional.

--- a/code/controllers/subsystems/overlays.dm
+++ b/code/controllers/subsystems/overlays.dm
@@ -31,9 +31,7 @@ var/global/image/appearance_bro = new() // Temporarily super-global because of B
 
 
 /datum/controller/subsystem/overlays/Shutdown()
-	//text2file(render_stats(stats), "[GLOB.log_directory]/overlay.log")
-	var/date_string = time2text(world.realtime, "YYYY/MM-Month/DD-Day")
-	text2file(render_stats(stats), "data/logs/[date_string]-overlay.log")
+	text2file(render_stats(stats), "[log_path]-overlay.log")
 
 /datum/controller/subsystem/overlays/Recover()
 	overlay_icon_state_caches = SSoverlays.overlay_icon_state_caches

--- a/code/defines/procs/announce.dm
+++ b/code/defines/procs/announce.dm
@@ -111,7 +111,7 @@ datum/announcement/priority/command/Sound(var/message_sound)
 
 datum/announcement/proc/Log(message as text, message_title as text)
 	if(log)
-		log_say("[key_name(usr)] has made \a [announcement_type]: [message_title] - [message] - [announcer]")
+		log_game("[key_name(usr)] has made \a [announcement_type]: [message_title] - [message] - [announcer]")
 		message_admins("[key_name_admin(usr)] has made \a [announcement_type].", 1)
 
 /proc/GetNameAndAssignmentFromId(var/obj/item/weapon/card/id/I)

--- a/code/game/gamemodes/changeling/powers/absorb.dm
+++ b/code/game/gamemodes/changeling/powers/absorb.dm
@@ -53,9 +53,7 @@
 				src << "<span class='notice'>We stab [T] with the proboscis.</span>"
 				src.visible_message("<span class='danger'>[src] stabs [T] with the proboscis!</span>")
 				T << "<span class='danger'>You feel a sharp stabbing pain!</span>"
-				T.attack_log += text("\[[time_stamp()]\] <font color='red'>Was absorbed by [key_name(src)]</font>")
-				src.attack_log += text("\[[time_stamp()]\] <font color='orange'> Absorbed [key_name(T)]</font>")
-				msg_admin_attack("[key_name(T)] was absorbed by [key_name(src)]")
+				add_attack_logs(src,T,"Absorbed (changeling)")
 				var/obj/item/organ/external/affecting = T.get_organ(src.zone_sel.selecting)
 				if(affecting.take_damage(39,0,1,0,"large organic needle"))
 					T:UpdateDamageIcon()

--- a/code/game/gamemodes/changeling/powers/bioelectrogenesis.dm
+++ b/code/game/gamemodes/changeling/powers/bioelectrogenesis.dm
@@ -47,7 +47,7 @@
 				var/agony = 80 * siemens //Does more than if hit with an electric hand, since grabbing is slower.
 				G.affecting.stun_effect_act(0, agony, BP_TORSO, src)
 
-				msg_admin_attack("[key_name(src)] shocked [key_name(G.affecting)] with the [src].")
+				add_attack_logs(src,G.affecting,"Changeling shocked")
 
 				if(siemens)
 					visible_message("<span class='warning'>Arcs of electricity strike [G.affecting]!</span>",
@@ -149,7 +149,7 @@
 		C.electrocute_act(electrocute_amount * siemens,src,1.0,BP_TORSO)
 		C.stun_effect_act(0, agony_amount * siemens, BP_TORSO, src)
 
-		msg_admin_attack("[key_name(user)] shocked [key_name(C)] with the [src].")
+		add_attack_logs(user,C,"Shocked with [src]")
 
 		if(siemens)
 			visible_message("<span class='warning'>Arcs of electricity strike [C]!</span>",

--- a/code/game/gamemodes/changeling/powers/blind_sting.dm
+++ b/code/game/gamemodes/changeling/powers/blind_sting.dm
@@ -15,9 +15,7 @@
 	var/mob/living/carbon/T = changeling_sting(20,/mob/proc/changeling_blind_sting)
 	if(!T)
 		return 0
-	T.attack_log += text("\[[time_stamp()]\] <font color='red'>Was blind stung by [key_name(src)]</font>")
-	src.attack_log += text("\[[time_stamp()]\] <font color='orange'> Used blind sting on [key_name(T)]</font>")
-	msg_admin_attack("[key_name(T)] was blind stung by [key_name(src)]")
+	add_attack_logs(src,T,"Blind sting (changeling)")
 	T << "<span class='danger'>Your eyes burn horrificly!</span>"
 	T.disabilities |= NEARSIGHTED
 	var/duration = 300

--- a/code/game/gamemodes/changeling/powers/cryo_sting.dm
+++ b/code/game/gamemodes/changeling/powers/cryo_sting.dm
@@ -16,9 +16,7 @@
 	var/mob/living/carbon/T = changeling_sting(20,/mob/proc/changeling_cryo_sting)
 	if(!T)
 		return 0
-	T.attack_log += text("\[[time_stamp()]\] <font color='red'>Was cryo stung by [key_name(src)]</font>")
-	src.attack_log += text("\[[time_stamp()]\] <font color='orange'> Used cryo sting on [key_name(T)]</font>")
-	msg_admin_attack("[key_name(T)] was cryo stung by [key_name(src)]")
+	add_attack_logs(src,T,"Cryo sting (changeling)")
 	var/inject_amount = 10
 	if(src.mind.changeling.recursive_enhancement)
 		inject_amount = inject_amount * 1.5

--- a/code/game/gamemodes/changeling/powers/deaf_sting.dm
+++ b/code/game/gamemodes/changeling/powers/deaf_sting.dm
@@ -15,9 +15,7 @@
 
 	var/mob/living/carbon/T = changeling_sting(5,/mob/proc/changeling_deaf_sting)
 	if(!T)	return 0
-	T.attack_log += text("\[[time_stamp()]\] <font color='red'>Was deaf stung by [key_name(src)]</font>")
-	src.attack_log += text("\[[time_stamp()]\] <font color='orange'> Used deaf sting on [key_name(T)]</font>")
-	msg_admin_attack("[key_name(T)] was deaf stung by [key_name(src)]")
+	add_attack_logs(src,T,"Deaf sting (changeling)")
 	var/duration = 300
 	if(src.mind.changeling.recursive_enhancement)
 		duration = duration + 100

--- a/code/game/gamemodes/changeling/powers/death_sting.dm
+++ b/code/game/gamemodes/changeling/powers/death_sting.dm
@@ -13,9 +13,7 @@
 	var/mob/living/carbon/T = changeling_sting(40,/mob/proc/changeling_DEATHsting)
 	if(!T)
 		return 0
-	T.attack_log += text("\[[time_stamp()]\] <font color='red'>Was death stung by [key_name(src)]</font>")
-	src.attack_log += text("\[[time_stamp()]\] <font color='orange'> Used death sting on [key_name(T)]</font>")
-	msg_admin_attack("[key_name(T)] was death stung by [key_name(src)]")
+	add_attack_logs(src,T,"Death sting (changeling)")
 	T << "<span class='danger'>You feel a small prick and your chest becomes tight.</span>"
 	T.silent = 10
 	T.Paralyse(10)

--- a/code/game/gamemodes/changeling/powers/delayed_toxin_sting.dm
+++ b/code/game/gamemodes/changeling/powers/delayed_toxin_sting.dm
@@ -28,10 +28,7 @@
 	var/mob/living/carbon/T = changeling_sting(20,/mob/proc/changeling_delayed_toxic_sting)
 	if(!T)
 		return 0
-	T.attack_log += text("\[[time_stamp()]\] <font color='red'>Was delayed toxic stung by [key_name(src)]</font>")
-	src.attack_log += text("\[[time_stamp()]\] <font color='orange'> Used delayed toxic sting on [key_name(T)]</font>")
-	msg_admin_attack("[key_name(T)] was delayed toxic stung by [key_name(src)]")
-
+	add_attack_logs(src,T,"Delayed toxic sting (chagneling)")
 	var/type_to_give = /datum/modifier/delayed_toxin_sting
 	if(src.mind.changeling.recursive_enhancement)
 		type_to_give = /datum/modifier/delayed_toxin_sting/strong

--- a/code/game/gamemodes/changeling/powers/enfeebling_string.dm
+++ b/code/game/gamemodes/changeling/powers/enfeebling_string.dm
@@ -35,9 +35,7 @@
 	if(ishuman(T))
 		var/mob/living/carbon/human/H = T
 
-		T.attack_log += text("\[[time_stamp()]\] <font color='red'>Was enfeebling stung by [key_name(src)]</font>")
-		src.attack_log += text("\[[time_stamp()]\] <font color='orange'> Used enfeebling sting on [key_name(T)]</font>")
-		msg_admin_attack("[key_name(T)] was enfeebling stung by [key_name(src)]")
+		add_attack_logs(src,T,"Enfeebling sting (changeling)")
 
 		var/type_to_give = /datum/modifier/enfeeble
 		if(src.mind.changeling.recursive_enhancement)

--- a/code/game/gamemodes/changeling/powers/extract_dna_sting.dm
+++ b/code/game/gamemodes/changeling/powers/extract_dna_sting.dm
@@ -35,9 +35,7 @@
 		src << "<span class='warning'>This creature's DNA is ruined beyond useability!</span>"
 		return 0
 
-	T.attack_log += text("\[[time_stamp()]\] <font color='red'>Had DNA extracted via sting by [key_name(src)]</font>")
-	src.attack_log += text("\[[time_stamp()]\] <font color='orange'> Used DNA extraction sting on [key_name(T)]</font>")
-	msg_admin_attack("[key_name(T)] was DNA extraction stung by [key_name(src)]")
+	add_attack_logs(src,T,"DNA extraction sting (changeling)")
 
 	var/datum/absorbed_dna/newDNA = new(T.real_name, T.dna, T.species.name, T.languages)
 	absorbDNA(newDNA)

--- a/code/game/gamemodes/changeling/powers/lsd_sting.dm
+++ b/code/game/gamemodes/changeling/powers/lsd_sting.dm
@@ -13,9 +13,7 @@
 
 	var/mob/living/carbon/T = changeling_sting(15,/mob/proc/changeling_lsdsting)
 	if(!T)	return 0
-	T.attack_log += text("\[[time_stamp()]\] <font color='red'>Was hallucination stung by [key_name(src)]</font>")
-	src.attack_log += text("\[[time_stamp()]\] <font color='orange'> Used hallucination sting on [key_name(T)]</font>")
-	msg_admin_attack("[key_name(T)] was hallucination stung by [key_name(src)]")
+	add_attack_logs(src,T,"Hallucination sting (changeling)")
 	spawn(rand(300,600))
 		if(T)	T.hallucination += 400
 	feedback_add_details("changeling_powers","HS")

--- a/code/game/gamemodes/changeling/powers/para_sting.dm
+++ b/code/game/gamemodes/changeling/powers/para_sting.dm
@@ -12,9 +12,7 @@
 	var/mob/living/carbon/T = changeling_sting(30,/mob/proc/changeling_paralysis_sting)
 	if(!T)
 		return 0
-	T.attack_log += text("\[[time_stamp()]\] <font color='red'>Was paralysis stung by [key_name(src)]</font>")
-	src.attack_log += text("\[[time_stamp()]\] <font color='orange'> Used paralysis sting on [key_name(T)]</font>")
-	msg_admin_attack("[key_name(T)] was paralysis stung by [key_name(src)]")
+	add_attack_logs(src,T,"Paralysis sting (changeling)")
 	T << "<span class='danger'>Your muscles begin to painfully tighten.</span>"
 	T.Weaken(20)
 	feedback_add_details("changeling_powers","PS")

--- a/code/game/gamemodes/changeling/powers/shriek.dm
+++ b/code/game/gamemodes/changeling/powers/shriek.dm
@@ -51,12 +51,8 @@
 		range = range * 2
 		to_chat(src, "<span class='notice'>We are extra loud.</span>")
 
-	src.attack_log += text("\[[time_stamp()]\] <font color='red'>Used Resonant Shriek.</font>")
-	message_admins("[key_name(src)] used Resonant Shriek ([src.x],[src.y],[src.z]) (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[src.x];Y=[src.y];Z=[src.z]'>JMP</a>).")
-	log_game("[key_name(src)] used Resonant Shriek.")
-
 	visible_message("<span class='notice'>[src] appears to shout.</span>")
-
+	var/list/affected = list()
 	for(var/mob/living/M in range(range, src))
 		if(iscarbon(M))
 			if(!M.mind || !M.mind.changeling)
@@ -67,7 +63,7 @@
 				M.adjustEarDamage(0,30)
 				M.Confuse(20)
 				M << sound('sound/effects/screech.ogg')
-				M.attack_log += text("\[[time_stamp()]\] <font color='orange'>Was affected by [key_name(src)]'s Resonant Shriek.</font>")
+				affected += M
 			else
 				if(M != src)
 					M << "<span class='notice'>You hear a familiar screech from nearby.  It has no effect on you.</span>"
@@ -77,7 +73,7 @@
 			M << sound('sound/weapons/flash.ogg')
 			M << "<span class='notice'>Auditory input overloaded.  Reinitializing...</span>"
 			M.Weaken(rand(5,10))
-			M.attack_log += text("\[[time_stamp()]\] <font color='orange'>Was affected by [key_name(src)]'s Resonant Shriek.</font>")
+			affected += M
 
 	for(var/obj/machinery/light/L in range(range, src))
 		L.on = 1
@@ -85,6 +81,7 @@
 
 	changeling.last_shriek = world.time
 
+	add_attack_logs(src,affected,"Used resonant shriek")
 	feedback_add_details("changeling_powers","RS")
 	return 1
 
@@ -133,9 +130,7 @@
 
 	visible_message("<span class='notice'>[src] appears to shout.</span>")
 
-	src.attack_log += text("\[[time_stamp()]\] <font color='red'>Used Dissonant Shriek.</font>")
-	message_admins("[key_name(src)] used Dissonant Shriek ([src.x],[src.y],[src.z]) (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[src.x];Y=[src.y];Z=[src.z]'>JMP</a>).")
-	log_game("[key_name(src)] used Dissonant Shriek.")
+	add_attack_logs(src,null,"Use dissonant shriek")
 
 	for(var/obj/machinery/light/L in range(5, src))
 		L.on = 1

--- a/code/game/gamemodes/changeling/powers/silence_sting.dm
+++ b/code/game/gamemodes/changeling/powers/silence_sting.dm
@@ -15,9 +15,7 @@
 
 	var/mob/living/carbon/T = changeling_sting(10,/mob/proc/changeling_silence_sting)
 	if(!T)	return 0
-	T.attack_log += text("\[[time_stamp()]\] <font color='red'>Was silence stung by [key_name(src)]</font>")
-	src.attack_log += text("\[[time_stamp()]\] <font color='orange'> Used silence sting on [key_name(T)]</font>")
-	msg_admin_attack("[key_name(T)] was silence stung by [key_name(src)]")
+	add_attack_logs(src,T,"Silence sting (changeling)")
 	var/duration = 30
 	if(src.mind.changeling.recursive_enhancement)
 		duration = duration + 10

--- a/code/game/gamemodes/changeling/powers/transform_sting.dm
+++ b/code/game/gamemodes/changeling/powers/transform_sting.dm
@@ -36,9 +36,7 @@
 	if((HUSK in T.mutations) || (!ishuman(T) && !issmall(T)))
 		src << "<span class='warning'>Our sting appears ineffective against its DNA.</span>"
 		return 0
-	T.attack_log += text("\[[time_stamp()]\] <font color='red'>Was transform stung by [key_name(src)]</font>")
-	src.attack_log += text("\[[time_stamp()]\] <font color='orange'> Used transform sting on [key_name(T)]</font>")
-	msg_admin_attack("[key_name(T)] was transform stung by [key_name(src)]")
+	add_attack_logs(src,T,"Transformation sting (changeling)")
 	T.visible_message("<span class='warning'>[T] transforms!</span>")
 	T.dna = chosen_dna.Clone()
 	T.real_name = chosen_dna.real_name

--- a/code/game/gamemodes/changeling/powers/unfat_sting.dm
+++ b/code/game/gamemodes/changeling/powers/unfat_sting.dm
@@ -11,9 +11,7 @@
 
 	var/mob/living/carbon/T = changeling_sting(5,/mob/proc/changeling_unfat_sting)
 	if(!T)	return 0
-	T.attack_log += text("\[[time_stamp()]\] <font color='red'>Was unfat stung by [key_name(src)]</font>")
-	src.attack_log += text("\[[time_stamp()]\] <font color='orange'> Used unfat sting on [key_name(T)]</font>")
-	msg_admin_attack("[key_name(T)] was unfat stung by [key_name(src)]")
+	add_attack_logs(src,T,"Unfat sting (changeling)")
 	T << "<span class='danger'>you feel a small prick as stomach churns violently and you become to feel skinnier.</span>"
 	T.overeatduration = 0
 	T.nutrition -= 100

--- a/code/game/gamemodes/cult/ritual.dm
+++ b/code/game/gamemodes/cult/ritual.dm
@@ -292,10 +292,7 @@ var/global/list/rnwords = list("ire","ego","nahlizet","certum","veri","jatkaa","
 			words[cultwords[V]] = V
 
 	attack(mob/living/M as mob, mob/living/user as mob)
-
-		M.attack_log += text("\[[time_stamp()]\] <font color='orange'>Has had the [name] used on them by [user.name] ([user.ckey])</font>")
-		user.attack_log += text("\[[time_stamp()]\] <font color='red'>Used [name] on [M.name] ([M.ckey])</font>")
-		msg_admin_attack("[user.name] ([user.ckey]) used [name] on [M.name] ([M.ckey]) (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[user.x];Y=[user.y];Z=[user.z]'>JMP</a>)")
+		add_attack_logs(user,M,"Hit with [name]")
 
 		if(istype(M,/mob/observer/dead))
 			var/mob/observer/dead/D = M

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -139,7 +139,7 @@ var/list/sacrificed = list()
 				target.take_overall_damage(0, rand(5, 20)) // You dirty resister cannot handle the damage to your mind. Easily. - even cultists who accept right away should experience some effects
 				// Resist messages go!
 				if(initial_message) //don't do this stuff right away, only if they resist or hesitate.
-					admin_attack_log(attacker, target, "Used a convert rune", "Was subjected to a convert rune", "used a convert rune on")
+					add_attack_logs(attacker,target,"Convert rune")
 					switch(target.getFireLoss())
 						if(0 to 25)
 							target << "<span class='cult'>Your blood boils as you force yourself to resist the corruption invading every corner of your mind.</span>"
@@ -247,7 +247,7 @@ var/list/sacrificed = list()
 				if(R.word1==cultwords["travel"] && R.word2==cultwords["blood"] && R.word3==cultwords["self"])
 					for(var/mob/living/carbon/D in R.loc)
 						if(D.stat!=2)
-							admin_attack_log(usr, D, "Used a blood drain rune.", "Was victim of a blood drain rune.", "used a blood drain rune on")
+							add_attack_logs(usr,D,"Blood drain rune")
 							var/bdrain = rand(1,25)
 							D << "<span class='warning'>You feel weakened.</span>"
 							D.take_overall_damage(bdrain, 0)
@@ -933,7 +933,7 @@ var/list/sacrificed = list()
 				if(affected.len)
 					usr.say("Sti[pick("'","`")] kaliedir!")
 					usr << "<span class='warning'>The world becomes quiet as the deafening rune dissipates into fine dust.</span>"
-					admin_attacker_log_many_victims(usr, affected, "Used a deafen rune.", "Was victim of a deafen rune.", "used a deafen rune on")
+					add_attack_logs(usr,affected,"Deafen rune")
 					qdel(src)
 				else
 					return fizzle()
@@ -952,7 +952,7 @@ var/list/sacrificed = list()
 				if(affected.len)
 					usr.whisper("Sti[pick("'","`")] kaliedir!")
 					usr << "<span class='warning'>Your talisman turns into gray dust, deafening everyone around.</span>"
-					admin_attacker_log_many_victims(usr, affected, "Used a deafen rune.", "Was victim of a deafen rune.", "used a deafen rune on")
+					add_attack_logs(usr, affected, "Deafen rune")
 					for (var/mob/V in orange(1,src))
 						if(!(iscultist(V)))
 							V.show_message("<span class='warning'>Dust flows from [usr]'s hands for a moment, and the world suddenly becomes quiet..</span>", 3)
@@ -978,7 +978,7 @@ var/list/sacrificed = list()
 				if(affected.len)
 					usr.say("Sti[pick("'","`")] kaliesin!")
 					usr << "<span class='warning'>The rune flashes, blinding those who not follow the Nar-Sie, and dissipates into fine dust.</span>"
-					admin_attacker_log_many_victims(usr, affected, "Used a blindness rune.", "Was victim of a blindness rune.", "used a blindness rune on")
+					add_attack_logs(usr, affected, "Blindness rune")
 					qdel(src)
 				else
 					return fizzle()
@@ -998,7 +998,7 @@ var/list/sacrificed = list()
 				if(affected.len)
 					usr.whisper("Sti[pick("'","`")] kaliesin!")
 					usr << "<span class='warning'>Your talisman turns into gray dust, blinding those who not follow the Nar-Sie.</span>"
-					admin_attacker_log_many_victims(usr, affected, "Used a blindness rune.", "Was victim of a blindness rune.", "used a blindness rune on")
+					add_attack_logs(usr, affected, "Blindness rune")
 			return
 
 
@@ -1035,8 +1035,7 @@ var/list/sacrificed = list()
 					if(iscultist(C) && !C.stat)
 						C.say("Dedo ol[pick("'","`")]btoh!")
 						C.take_overall_damage(15, 0)
-				admin_attacker_log_many_victims(usr, victims, "Used a blood boil rune.", "Was the victim of a blood boil rune.", "used a blood boil rune on")
-				log_and_message_admins_many(cultists - usr, "assisted activating a blood boil rune.")
+				add_attack_logs(usr, victims, "Blood boil rune")
 				qdel(src)
 			else
 				return fizzle()
@@ -1084,13 +1083,13 @@ var/list/sacrificed = list()
 						C.Weaken(1)
 						C.Stun(1)
 						C.show_message("<span class='danger'>The rune explodes in a bright flash.</span>", 3)
-						admin_attack_log(usr, C, "Used a stun rune.", "Was victim of a stun rune.", "used a stun rune on")
+						add_attack_logs(usr,C,"Stun rune")
 
 					else if(issilicon(L))
 						var/mob/living/silicon/S = L
 						S.Weaken(5)
 						S.show_message("<span class='danger'>BZZZT... The rune has exploded in a bright flash.</span>", 3)
-						admin_attack_log(usr, S, "Used a stun rune.", "Was victim of a stun rune.", "used a stun rune on")
+						add_attack_logs(usr,S,"Stun rune")
 				qdel(src)
 			else                        ///When invoked as talisman, stun and mute the target mob.
 				usr.say("Dream sign ''Evil sealing talisman'[pick("'","`")]!")
@@ -1104,7 +1103,7 @@ var/list/sacrificed = list()
 
 					if(issilicon(T))
 						T.Weaken(15)
-						admin_attack_log(usr, T, "Used a stun rune.", "Was victim of a stun rune.", "used a stun rune on")
+						add_attack_logs(usr,T,"Stun rune")
 					else if(iscarbon(T))
 						var/mob/living/carbon/C = T
 						C.flash_eyes()
@@ -1112,7 +1111,7 @@ var/list/sacrificed = list()
 							C.silent += 15
 						C.Weaken(25)
 						C.Stun(25)
-						admin_attack_log(usr, C, "Used a stun rune.", "Was victim of a stun rune.", "used a stun rune on")
+						add_attack_logs(usr,C,"Stun rune")
 				return
 
 /////////////////////////////////////////TWENTY-FIFTH RUNE

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -187,7 +187,7 @@
 					return
 				CentCom_announce(input, usr)
 				usr << "<font color='blue'>Message transmitted.</font>"
-				log_say("[key_name(usr)] has made an IA [using_map.boss_short] announcement: [input]")
+				log_game("[key_name(usr)] has made an IA [using_map.boss_short] announcement: [input]")
 				centcomm_message_cooldown = 1
 				spawn(300)//10 minute cooldown
 					centcomm_message_cooldown = 0
@@ -204,7 +204,7 @@
 					return
 				Syndicate_announce(input, usr)
 				usr << "<font color='blue'>Message transmitted.</font>"
-				log_say("[key_name(usr)] has made an illegal announcement: [input]")
+				log_game("[key_name(usr)] has made an illegal announcement: [input]")
 				centcomm_message_cooldown = 1
 				spawn(300)//10 minute cooldown
 					centcomm_message_cooldown = 0

--- a/code/game/machinery/computer3/computers/communications.dm
+++ b/code/game/machinery/computer3/computers/communications.dm
@@ -197,7 +197,7 @@
 					return
 				CentCom_announce(input, usr)
 				usr << "Message transmitted."
-				log_say("[key_name(usr)] has made a [using_map.boss_short] announcement: [input]")
+				log_game("[key_name(usr)] has made a [using_map.boss_short] announcement: [input]")
 				centcomm_message_cooldown = 1
 				spawn(600)//10 minute cooldown
 					centcomm_message_cooldown = 0
@@ -214,7 +214,7 @@
 					return
 				Syndicate_announce(input, usr)
 				usr << "Message transmitted."
-				log_say("[key_name(usr)] has made an illegal announcement: [input]")
+				log_game("[key_name(usr)] has made an illegal announcement: [input]")
 				centcomm_message_cooldown = 1
 				spawn(600)//10 minute cooldown
 					centcomm_message_cooldown = 0

--- a/code/game/machinery/computer3/computers/prisoner.dm
+++ b/code/game/machinery/computer3/computers/prisoner.dm
@@ -95,7 +95,7 @@
 			var/obj/item/weapon/implant/I = locate(href_list["warn"])
 			if( istype(I) && I.imp_in)
 				var/mob/living/carbon/R = I.imp_in
-				log_say("PrisonComputer3 message: [key_name(usr)]->[key_name(R)] : [warning]")
+				log_game("PrisonComputer3 message: [key_name(usr)]->[key_name(R)] : [warning]")
 				R << "<span class='notice'>You hear a voice in your head saying: '[warning]'</span>"
 
 		interact()

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -565,7 +565,7 @@ About the new airlock wires panel:
 	else if(duration)	//electrify door for the given duration seconds
 		if(usr)
 			shockedby += text("\[[time_stamp()]\] - [usr](ckey:[usr.ckey])")
-			usr.attack_log += text("\[[time_stamp()]\] <font color='red'>Electrified the [name] at [x] [y] [z]</font>")
+			add_attack_logs(usr,name,"Electrified a door")
 		else
 			shockedby += text("\[[time_stamp()]\] - EMP)")
 		message = "The door is now electrified [duration == -1 ? "permanently" : "for [duration] second\s"]."

--- a/code/game/machinery/kitchen/cooking_machines/fryer.dm
+++ b/code/game/machinery/kitchen/cooking_machines/fryer.dm
@@ -58,9 +58,7 @@
 		victim << "<span class='danger'>Searing hot oil scorches your [E ? E.name : "flesh"]!</span>"
 
 	if(victim.client)
-		user.attack_log += text("\[[time_stamp()]\] <font color='red'>Has [cook_type] \the [victim] ([victim.ckey]) in \a [src]</font>")
-		victim.attack_log += text("\[[time_stamp()]\] <font color='orange'>Has been [cook_type] in \a [src] by [user.name] ([user.ckey])</font>")
-		msg_admin_attack("[user] ([user.ckey]) [cook_type] \the [victim] ([victim.ckey]) in \a [src]. (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[user.x];Y=[user.y];Z=[user.z]'>JMP</a>)")
+		add_attack_logs(user,victim,"[cook_type] in [src]")
 
 	icon_state = off_icon
 	cooking = 0

--- a/code/game/machinery/kitchen/gibber.dm
+++ b/code/game/machinery/kitchen/gibber.dm
@@ -211,9 +211,7 @@
 			if(src.occupant.reagents)
 				src.occupant.reagents.trans_to_obj(new_meat, round(occupant.reagents.total_volume/slab_count,1))
 
-	src.occupant.attack_log += "\[[time_stamp()]\] Was gibbed by <b>[user]/[user.ckey]</b>" //One shall not simply gib a mob unnoticed!
-	user.attack_log += "\[[time_stamp()]\] Gibbed <b>[src.occupant]/[src.occupant.ckey]</b>"
-	msg_admin_attack("[user.name] ([user.ckey]) gibbed [src.occupant] ([src.occupant.ckey]) (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[user.x];Y=[user.y];Z=[user.z]'>JMP</a>)")
+	add_attack_logs(user,occupant,"Used [src] to gib")
 
 	src.occupant.ghostize()
 

--- a/code/game/objects/effects/mines.dm
+++ b/code/game/objects/effects/mines.dm
@@ -208,7 +208,7 @@
 
 /obj/item/weapon/mine/attack_self(mob/user as mob)	// You do not want to move or throw a land mine while priming it... Explosives + Sudden Movement = Bad Times
 	add_fingerprint(user)
-	msg_admin_attack("[user.name] ([user.ckey]) primed \a [src] (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[user.x];Y=[user.y];Z=[user.z]'>JMP</a>)")
+	msg_admin_attack("[key_name_admin(user)] primed \a [src]")
 	user.visible_message("[user] starts priming \the [src.name].", "You start priming \the [src.name]. Hold still!")
 	if(do_after(user, 10 SECONDS))
 		playsound(loc, 'sound/weapons/armbomb.ogg', 75, 1, -3)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -480,9 +480,7 @@ var/list/global/slot_flags_enumeration = list(
 			visible_message("<font color='red'><B>[U] attempts to stab [M] in the eyes, but misses!</B></font>")
 			return
 
-	user.attack_log += "\[[time_stamp()]\]<font color='red'> Attacked [M.name] ([M.ckey]) with [src.name] (INTENT: [uppertext(user.a_intent)])</font>"
-	M.attack_log += "\[[time_stamp()]\]<font color='orange'> Attacked by [user.name] ([user.ckey]) with [src.name] (INTENT: [uppertext(user.a_intent)])</font>"
-	msg_admin_attack("[user.name] ([user.ckey]) attacked [M.name] ([M.ckey]) with [src.name] (INTENT: [uppertext(user.a_intent)]) (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[user.x];Y=[user.y];Z=[user.z]'>JMP</a>)") //BS12 EDIT ALG
+	add_attack_logs(user,M,"Attack eyes with [name]")
 
 	user.setClickCooldown(user.get_attack_speed())
 	user.do_attack_animation(M)

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -1169,7 +1169,7 @@ var/global/list/obj/item/device/pda/PDAs = list()
 	var/reception_message = "\icon[src] <b>Message from [sender] ([sender_job]), </b>\"[message]\" ([reply ? "<a href='byond://?src=\ref[src];choice=Message;notap=[istype(loc, /mob/living/silicon)];skiprefresh=1;target=\ref[sending_unit]'>Reply</a>" : "Unable to Reply"])"
 	new_info(message_silent, ttone, reception_message)
 
-	log_pda("[usr] (PDA: [sending_unit]) sent \"[message]\" to [name]")
+	log_pda("(PDA: [sending_unit]) sent \"[message]\" to [name]", usr)
 	new_message = 1
 	update_icon()
 
@@ -1181,7 +1181,7 @@ var/global/list/obj/item/device/pda/PDAs = list()
 	var/reception_message = "\icon[src] <b>Message from [sender] ([sender_job]), </b>\"[message]\" (<a href='byond://?src=\ref[src];choice=Message;notap=1;skiprefresh=1;target=\ref[sending_unit]'>Reply</a>) [track]"
 	new_info(message_silent, newstone, reception_message)
 
-	log_pda("[usr] (PDA: [sending_unit]) sent \"[message]\" to [name]")
+	log_pda("(PDA: [sending_unit]) sent \"[message]\" to [name]",usr)
 	new_message = 1
 
 /obj/item/device/pda/verb/verb_reset_pda()

--- a/code/game/objects/items/devices/aicard.dm
+++ b/code/game/objects/items/devices/aicard.dm
@@ -61,7 +61,7 @@
 	if (href_list["wipe"])
 		var/confirm = alert("Are you sure you want to disable this core's power? This cannot be undone once started.", "Confirm Shutdown", "Yes", "No")
 		if(confirm == "Yes" && (CanUseTopic(user, state) == STATUS_INTERACTIVE))
-			admin_attack_log(user, carded_ai, "Purged using \the [src.name]", "Was purged with \the [src.name]", "used \the [src.name] to purge")
+			add_attack_logs(user,carded_ai,"Purged from AI Card")
 			flush = 1
 			carded_ai.suiciding = 1
 			carded_ai << "Your power has been disabled!"
@@ -110,7 +110,7 @@
 			new /obj/structure/AIcore/deactivated(get_turf(ai))
 
 		ai.carded = 1
-		admin_attack_log(user, ai, "Extracted with [src.name]", "Was extracted with [src.name]", "used the [src.name] to extract")
+		add_attack_logs(user,ai,"Extracted into AI Card")
 		src.name = "[initial(name)] - [ai.name]"
 
 		ai.loc = src

--- a/code/game/objects/items/devices/communicator/UI.dm
+++ b/code/game/objects/items/devices/communicator/UI.dm
@@ -189,7 +189,7 @@
 		if(text)
 			exonet.send_message(their_address, "text", text)
 			im_list += list(list("address" = exonet.address, "to_address" = their_address, "im" = text))
-			log_pda("[usr] (COMM: [src]) sent \"[text]\" to [exonet.get_atom_from_address(their_address)]")
+			log_pda("(COMM: [src]) sent \"[text]\" to [exonet.get_atom_from_address(their_address)]", usr)
 			for(var/mob/M in player_list)
 				if(M.stat == DEAD && M.is_preference_enabled(/datum/client_preference/ghost_ears))
 					if(istype(M, /mob/new_player) || M.forbid_seeing_deadchat)

--- a/code/game/objects/items/devices/communicator/messaging.dm
+++ b/code/game/objects/items/devices/communicator/messaging.dm
@@ -136,7 +136,7 @@
 
 			to_chat(src, "<span class='notice'>You have sent '[text_message]' to [chosen_communicator].</span>")
 			exonet_messages.Add("<b>To [chosen_communicator]:</b><br>[text_message]")
-			log_pda("[usr] (COMM: [src]) sent \"[text_message]\" to [chosen_communicator]")
+			log_pda("(DCOMM: [src]) sent \"[text_message]\" to [chosen_communicator]", src)
 			for(var/mob/M in player_list)
 				if(M.stat == DEAD && M.is_preference_enabled(/datum/client_preference/ghost_ears))
 					if(istype(M, /mob/new_player) || M.forbid_seeing_deadchat)

--- a/code/game/objects/items/devices/defib.dm
+++ b/code/game/objects/items/devices/defib.dm
@@ -475,7 +475,7 @@
 	if(burn_damage > 15 && H.can_feel_pain())
 		H.emote("scream")
 
-	admin_attack_log(user, H, "Electrocuted using \a [src]", "Was electrocuted with \a [src]", "used \a [src] to electrocute")
+	add_attack_logs(user,H,"Shocked using [name]")
 
 /obj/item/weapon/shockpaddles/proc/make_alive(mob/living/carbon/human/M) //This revives the mob
 	var/deadtime = world.time - M.timeofdeath

--- a/code/game/objects/items/devices/flash.dm
+++ b/code/game/objects/items/devices/flash.dm
@@ -59,9 +59,7 @@
 /obj/item/device/flash/attack(mob/living/M, mob/living/user, var/target_zone)
 	if(!user || !M)	return	//sanity
 
-	M.attack_log += text("\[[time_stamp()]\] <font color='orange'>Has been flashed (attempt) with [src.name]  by [user.name] ([user.ckey])</font>")
-	user.attack_log += text("\[[time_stamp()]\] <font color='red'>Used the [src.name] to flash [M.name] ([M.ckey])</font>")
-	msg_admin_attack("[user.name] ([user.ckey]) Used the [src.name] to flash [M.name] ([M.ckey]) (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[user.x];Y=[user.y];Z=[user.z]'>JMP</a>)")
+	add_attack_logs(user,M,"Flashed (attempt) with [src]")
 
 	user.setClickCooldown(user.get_attack_speed(src))
 	user.do_attack_animation(M)

--- a/code/game/objects/items/devices/traitordevices.dm
+++ b/code/game/objects/items/devices/traitordevices.dm
@@ -35,9 +35,9 @@ effective or pretty fucking useless.
 		user << "<span class='warning'>The mind batterer has been burnt out!</span>"
 		return
 
-	user.attack_log += text("\[[time_stamp()]\] <font color='red'>Used [src] to knock down people in the area.</font>")
-
+	var/list/affected = list()
 	for(var/mob/living/carbon/human/M in orange(10, user))
+		affected += M
 		spawn()
 			if(prob(50))
 
@@ -48,6 +48,8 @@ effective or pretty fucking useless.
 
 			else
 				M << "<span class='danger'>You feel a sudden, electric jolt travel through your head.</span>"
+
+	add_attack_logs(user,affected,"Used a [name]")
 
 	playsound(src.loc, 'sound/misc/interference.ogg', 50, 1)
 	user << "<span class='notice'>You trigger [src].</span>"

--- a/code/game/objects/items/weapons/cigs_lighters.dm
+++ b/code/game/objects/items/weapons/cigs_lighters.dm
@@ -562,7 +562,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 
 	if(lit == 1)
 		M.IgniteMob()
-		msg_admin_attack("[user.name] ([user.ckey]) attacked [M.name] ([M.ckey]) with [src.name] and lit them on fire (INTENT: [uppertext(user.a_intent)]) (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[user.x];Y=[user.y];Z=[user.z]'>JMP</a>)")
+		add_attack_logs(user,M,"Lit on fire with [src]")
 
 	if(istype(M.wear_mask, /obj/item/clothing/mask/smokable/cigarette) && user.zone_sel.selecting == O_MOUTH && lit)
 		var/obj/item/clothing/mask/smokable/cigarette/cig = M.wear_mask

--- a/code/game/objects/items/weapons/dna_injector.dm
+++ b/code/game/objects/items/weapons/dna_injector.dm
@@ -130,10 +130,7 @@
 	if((buf.types & DNA2_BUF_SE) && (block ? (GetState() && block == MONKEYBLOCK) : GetState(MONKEYBLOCK)))
 		injected_with_monkey = " <span class='danger'>(MONKEY)</span>"
 
-	M.attack_log += text("\[[time_stamp()]\] <font color='orange'>Has been injected with [name] by [user.name] ([user.ckey])</font>")
-	user.attack_log += text("\[[time_stamp()]\] <font color='red'>Used the [name] to inject [M.name] ([M.ckey])</font>")
-	log_attack("[user.name] ([user.ckey]) used the [name] to inject [M.name] ([M.ckey])")
-	message_admins("[key_name_admin(user)] injected [key_name_admin(M)] with \the [src][injected_with_monkey]")
+	add_attack_logs(user,M,"[injected_with_monkey] used the [name] on")
 
 	// Apply the DNA shit.
 	inject(M, user)

--- a/code/game/objects/items/weapons/explosives.dm
+++ b/code/game/objects/items/weapons/explosives.dm
@@ -55,11 +55,8 @@
 		loc = null
 
 		if (ismob(target))
-			add_logs(user, target, "planted [name] on")
+			add_attack_logs(user, target, "planted [name] on with [timer] second fuse")
 			user.visible_message("<span class='danger'>[user.name] finished planting an explosive on [target.name]!</span>")
-			message_admins("[key_name(user, user.client)](<A HREF='?_src_=holder;adminmoreinfo=\ref[user]'>?</A>) planted [src.name] on [key_name(target)](<A HREF='?_src_=holder;adminmoreinfo=\ref[target]'>?</A>) with [timer] second fuse",0,1)
-			log_game("[key_name(user)] planted [src.name] on [key_name(target)] with [timer] second fuse")
-
 		else
 			message_admins("[key_name(user, user.client)](<A HREF='?_src_=holder;adminmoreinfo=\ref[user]'>?</A>) planted [src.name] on [target.name] at ([target.x],[target.y],[target.z] - <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[target.x];Y=[target.y];Z=[target.z]'>JMP</a>) with [timer] second fuse",0,1)
 			log_game("[key_name(user)] planted [src.name] on [target.name] at ([target.x],[target.y],[target.z]) with [timer] second fuse")

--- a/code/game/objects/items/weapons/gift_wrappaper.dm
+++ b/code/game/objects/items/weapons/gift_wrappaper.dm
@@ -179,10 +179,7 @@
 
 			H.loc = present
 
-			H.attack_log += text("\[[time_stamp()]\] <font color='orange'>Has been wrapped with [src.name]  by [user.name] ([user.ckey])</font>")
-			user.attack_log += text("\[[time_stamp()]\] <font color='red'>Used the [src.name] to wrap [H.name] ([H.ckey])</font>")
-			msg_admin_attack("[key_name(user)] used [src] to wrap [key_name(H)]")
-
+			add_attack_logs(user,H,"Wrapped with [src]")
 		else
 			user << "<span class='warning'>You need more paper.</span>"
 	else

--- a/code/game/objects/items/weapons/grenades/chem_grenade.dm
+++ b/code/game/objects/items/weapons/grenades/chem_grenade.dm
@@ -43,7 +43,7 @@
 		if(stage > 1 && !active && clown_check(user))
 			user << "<span class='warning'>You prime \the [name]!</span>"
 
-			msg_admin_attack("[user.name] ([user.ckey]) primed \a [src]. (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[user.x];Y=[user.y];Z=[user.z]'>JMP</a>)")
+			msg_admin_attack("[key_name_admin(user)] primed \a [src]")
 
 			activate()
 			add_fingerprint(user)
@@ -136,7 +136,7 @@
 			icon_state = initial(icon_state) + "_active"
 
 			if(user)
-				msg_admin_attack("[user.name] ([user.ckey]) primed \a [src] (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[user.x];Y=[user.y];Z=[user.z]'>JMP</a>)")
+				msg_admin_attack("[key_name_admin(user)] primed \a [src.name]")
 
 		return
 

--- a/code/game/objects/items/weapons/grenades/grenade.dm
+++ b/code/game/objects/items/weapons/grenades/grenade.dm
@@ -72,7 +72,7 @@
 		return
 
 	if(user)
-		msg_admin_attack("[user.name] ([user.ckey]) primed \a [src] (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[user.x];Y=[user.y];Z=[user.z]'>JMP</a>)")
+		msg_admin_attack("[key_name_admin(user)] primed \a [src.name]")
 
 	icon_state = initial(icon_state) + "_active"
 	active = 1

--- a/code/game/objects/items/weapons/handcuffs.dm
+++ b/code/game/objects/items/weapons/handcuffs.dm
@@ -82,9 +82,7 @@
 	if(!can_place(target, user)) //victim may have resisted out of the grab in the meantime
 		return 0
 
-	H.attack_log += text("\[[time_stamp()]\] <font color='orange'>Has been handcuffed (attempt) by [user.name] ([user.ckey])</font>")
-	user.attack_log += text("\[[time_stamp()]\] <font color='red'>Attempted to handcuff [H.name] ([H.ckey])</font>")
-	msg_admin_attack("[key_name(user)] attempted to handcuff [key_name(H)]")
+	add_attack_logs(user,H,"Handcuffed (attempt)")
 	feedback_add_details("handcuffs","H")
 
 	user.setClickCooldown(user.get_attack_speed(src))
@@ -129,8 +127,7 @@ var/last_chew = 0
 	
 	var/s = "<span class='warning'>[H.name] chews on [T.his] [O.name]!</span>"
 	H.visible_message(s, "<span class='warning'>You chew on your [O.name]!</span>")
-	H.attack_log += text("\[[time_stamp()]\] <font color='red'>[s] ([H.ckey])</font>")
-	log_attack("[s] ([H.ckey])")
+	add_attack_logs(H,H,"chewed own [O.name]")
 
 	if(O.take_damage(3,0,1,1,"teeth marks"))
 		H:UpdateDamageIcon()
@@ -302,9 +299,7 @@ var/last_chew = 0
 	if(!can_place(target, user)) //victim may have resisted out of the grab in the meantime
 		return 0
 
-	H.attack_log += text("\[[time_stamp()]\] <font color='orange'>Has been legcuffed (attempt) by [user.name] ([user.ckey])</font>")
-	user.attack_log += text("\[[time_stamp()]\] <font color='red'>Attempted to legcuff [H.name] ([H.ckey])</font>")
-	msg_admin_attack("[key_name(user)] attempted to legcuff [key_name(H)]")
+	add_attack_logs(user,H,"Legcuffed (attempt)")
 	feedback_add_details("legcuffs","H")
 
 	user.setClickCooldown(user.get_attack_speed(src))

--- a/code/game/objects/items/weapons/implants/implanter.dm
+++ b/code/game/objects/items/weapons/implants/implanter.dm
@@ -54,7 +54,7 @@
 				if(user && M && (get_turf(M) == T1) && src && src.imp)
 					M.visible_message("<span class='warning'>[M] has been implanted by [user].</span>")
 
-					admin_attack_log(user, M, "Implanted using \the [src.name] ([src.imp.name])", "Implanted with \the [src.name] ([src.imp.name])", "used an implanter, [src.name] ([src.imp.name]), on")
+					add_attack_logs(user,M,"Implanted with [imp.name] using [name]")
 
 					if(src.imp.implanted(M))
 						src.imp.loc = M

--- a/code/game/objects/items/weapons/trays.dm
+++ b/code/game/objects/items/weapons/trays.dm
@@ -52,9 +52,7 @@
 			if (istype(location, /turf/simulated))
 				location.add_blood(H)     ///Plik plik, the sound of blood
 
-		M.attack_log += text("\[[time_stamp()]\] <font color='orange'>Has been attacked with [src.name] by [user.name] ([user.ckey])</font>")
-		user.attack_log += text("\[[time_stamp()]\] <font color='red'>Used the [src.name] to attack [M.name] ([M.ckey])</font>")
-		msg_admin_attack("[user.name] ([user.ckey]) used the [src.name] to attack [M.name] ([M.ckey]) (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[user.x];Y=[user.y];Z=[user.z]'>JMP</a>)")
+		add_attack_logs(user,M,"Hit with [src]")
 
 		if(prob(15))
 			M.Weaken(3)

--- a/code/game/objects/items/weapons/weaponry.dm
+++ b/code/game/objects/items/weapons/weaponry.dm
@@ -17,10 +17,7 @@
 
 /obj/item/weapon/nullrod/attack(mob/M as mob, mob/living/user as mob) //Paste from old-code to decult with a null rod.
 
-	M.attack_log += text("\[[time_stamp()]\] <font color='orange'>Has been attacked with [src.name] by [user.name] ([user.ckey])</font>")
-	user.attack_log += text("\[[time_stamp()]\] <font color='red'>Used the [src.name] to attack [M.name] ([M.ckey])</font>")
-
-	msg_admin_attack("[user.name] ([user.ckey]) attacked [M.name] ([M.ckey]) with [src.name] (INTENT: [uppertext(user.a_intent)]) (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[user.x];Y=[user.y];Z=[user.z]'>JMP</a>)")
+	add_attack_logs(user,M,"Hit with [src] (nullrod)")
 
 	user.setClickCooldown(user.get_attack_speed(src))
 	user.do_attack_animation(M)

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -306,10 +306,6 @@
 					if (C.can_feel_pain())
 						C.emote("scream")
 
-			//Logging for this causes runtimes resulting in the cremator locking up. Commenting it out until that's figured out.
-			//M.attack_log += "\[[time_stamp()]\] Has been cremated by <b>[user]/[user.ckey]</b>" //No point in this when the mob's about to be deleted
-			//user.attack_log +="\[[time_stamp()]\] Cremated <b>[M]/[M.ckey]</b>"
-			//log_attack("\[[time_stamp()]\] <b>[user]/[user.ckey]</b> cremated <b>[M]/[M.ckey]</b>")
 			M.death(1)
 			M.ghostize()
 			qdel(M)

--- a/code/game/objects/structures/stool_bed_chair_nest/wheelchair.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/wheelchair.dm
@@ -176,9 +176,7 @@
 		if(pulling)
 			occupant.visible_message("<span class='danger'>[pulling] has thrusted \the [name] into \the [A], throwing \the [occupant] out of it!</span>")
 
-			pulling.attack_log += "\[[time_stamp()]\]<font color='red'> Crashed [occupant.name]'s ([occupant.ckey]) [name] into \a [A]</font>"
-			occupant.attack_log += "\[[time_stamp()]\]<font color='orange'> Thrusted into \a [A] by [pulling.name] ([pulling.ckey]) with \the [name]</font>"
-			msg_admin_attack("[pulling.name] ([pulling.ckey]) has thrusted [occupant.name]'s ([occupant.ckey]) [name] into \a [A] (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[pulling.x];Y=[pulling.y];Z=[pulling.z]'>JMP</a>)")
+			add_attack_logs(pulling,occupant,"Crashed their [name] into [A]")
 		else
 			occupant.visible_message("<span class='danger'>[occupant] crashed into \the [A]!</span>")
 

--- a/code/game/verbs/ooc.dm
+++ b/code/game/verbs/ooc.dm
@@ -35,7 +35,7 @@
 			message_admins("[key_name_admin(src)] has attempted to advertise in OOC: [msg]")
 			return
 
-	log_ooc("[mob.name]/[key] : [msg]")
+	log_ooc(msg, src)
 
 	if(msg)
 		handle_spam_prevention(MUTE_OOC)
@@ -108,7 +108,7 @@
 			message_admins("[key_name_admin(src)] has attempted to advertise in OOC: [msg]")
 			return
 
-	log_ooc("(LOCAL) [mob.name]/[key] : [msg]")
+	log_looc(msg,src)
 
 	if(msg)
 		handle_spam_prevention(MUTE_OOC)

--- a/code/global.dm
+++ b/code/global.dm
@@ -21,7 +21,10 @@ var/global/list/global_map = null
 
 // Noises made when hit while typing.
 var/list/hit_appends	= list("-OOF", "-ACK", "-UGH", "-HRNK", "-HURGH", "-GLORF")
+var/log_path			= "data/logs/" //See world.dm for the full calculated path
 var/diary				= null
+var/error_log			= null
+var/debug_log			= null
 var/href_logfile		= null
 // var/station_name		= "Northern Star"
 // var/const/station_orig	= "Northern Star" //station_name can't be const due to event prefix/suffix

--- a/code/modules/admin/IsBanned.dm
+++ b/code/modules/admin/IsBanned.dm
@@ -6,13 +6,13 @@ world/IsBanned(key,address,computer_id)
 
 	//Guest Checking
 	if(!config.guests_allowed && IsGuestKey(key))
-		log_access("Failed Login: [key] - Guests not allowed")
+		log_adminwarn("Failed Login: [key] - Guests not allowed")
 		message_admins("<font color='blue'>Failed Login: [key] - Guests not allowed</font>")
 		return list("reason"="guest", "desc"="\nReason: Guests not allowed. Please sign in with a byond account.")
 
 	//check if the IP address is a known TOR node
 	if(config && config.ToRban && ToRban_isbanned(address))
-		log_access("Failed Login: [src] - Banned: ToR")
+		log_adminwarn("Failed Login: [src] - Banned: ToR")
 		message_admins("<font color='blue'>Failed Login: [src] - Banned: ToR</font>")
 		//ban their computer_id and ckey for posterity
 		AddBan(ckey(key), computer_id, "Use of ToR", "Automated Ban", 0, 0)
@@ -24,7 +24,7 @@ world/IsBanned(key,address,computer_id)
 		//Ban Checking
 		. = CheckBan( ckey(key), computer_id, address )
 		if(.)
-			log_access("Failed Login: [key] [computer_id] [address] - Banned [.["reason"]]")
+			log_adminwarn("Failed Login: [key] [computer_id] [address] - Banned [.["reason"]]")
 			message_admins("<font color='blue'>Failed Login: [key] id:[computer_id] ip:[address] - Banned [.["reason"]]</font>")
 			return .
 

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -12,7 +12,6 @@ var/global/floorIsLava = 0
 			C << msg
 
 /proc/msg_admin_attack(var/text) //Toggleable Attack Messages
-	log_attack(text)
 	var/rendered = "<span class=\"log_message\"><span class=\"prefix\">ATTACK:</span> <span class=\"message\">[text]</span></span>"
 	for(var/client/C in admins)
 		if((R_ADMIN|R_MOD) & C.holder.rights)

--- a/code/modules/admin/admin_attack_log.dm
+++ b/code/modules/admin/admin_attack_log.dm
@@ -16,7 +16,7 @@ proc/log_and_message_admins_many(var/list/mob/users, var/message)
 
 	log_admin("[english_list(user_keys)] [message]")
 	message_admins("[english_list(user_keys)] [message]")
-
+/* Old procs
 proc/admin_attack_log(var/mob/attacker, var/mob/victim, var/attacker_message, var/victim_message, var/admin_message)
 	if(victim)
 		victim.attack_log += text("\[[time_stamp()]\] <font color='orange'>[key_name(attacker)] - [victim_message]</font>")
@@ -42,3 +42,4 @@ proc/admin_inject_log(mob/attacker, mob/victim, obj/item/weapon, reagents, amoun
 	                 "used \the [weapon] to [violent]inject - [reagents] - [amount_transferred]u transferred",
 	                 "was [violent]injected with \the [weapon] - [reagents] - [amount_transferred]u transferred",
 	                 "used \the [weapon] to [violent]inject [reagents] ([amount_transferred]u transferred) into")
+*/

--- a/code/modules/admin/verbs/adminsay.dm
+++ b/code/modules/admin/verbs/adminsay.dm
@@ -9,7 +9,7 @@
 	if(!msg)
 		return
 
-	log_admin("ADMIN: [key_name(src)] : [msg]")
+	log_adminsay(msg,src)
 
 	if(check_rights(R_ADMIN,0))
 		for(var/client/C in admins)
@@ -27,7 +27,7 @@
 		return
 
 	msg = sanitize(msg)
-	log_admin("MOD: [key_name(src)] : [msg]")
+	log_modsay(msg,src)
 
 	if (!msg)
 		return
@@ -50,7 +50,7 @@
 		return
 
 	msg = sanitize(msg)
-	log_admin("EVENT: [key_name(src)] : [msg]")
+	log_eventsay(msg,src)
 
 	if (!msg)
 		return

--- a/code/modules/admin/verbs/antag-ooc.dm
+++ b/code/modules/admin/verbs/antag-ooc.dm
@@ -39,4 +39,4 @@
 			if((M.mind && M.mind.special_role && A && A.can_use_aooc) || isobserver(M)) // Antags must have their type be allowed to AOOC to see AOOC.  This prevents, say, ERT from seeing AOOC.
 				to_chat(M, "<span class='ooc'><span class='aooc'>[create_text_tag("aooc", "Antag-OOC:", M.client)] <EM>[player_display]:</EM> <span class='message'>[msg]</span></span></span>")
 
-	log_ooc("(ANTAG) [key] : [msg]")
+	log_aooc(msg,src)

--- a/code/modules/admin/verbs/getlogs.dm
+++ b/code/modules/admin/verbs/getlogs.dm
@@ -85,7 +85,7 @@
 	set name = "Show Server Log"
 	set desc = "Shows today's server log."
 
-	var/path = "data/logs/[time2text(world.realtime,"YYYY/MM-Month/DD-Day")].log"
+	var/path = "[log_path].log"
 	if( fexists(path) )
 		src << run( file(path) )
 	else
@@ -99,7 +99,10 @@
 	set category = "Admin"
 	set name = "Show Server Attack Log"
 	set desc = "Shows today's server attack log."
+	
+	to_chat(usr,"This verb doesn't actually do anything.")
 
+	/*
 	var/path = "data/logs/[time2text(world.realtime,"YYYY/MM-Month/DD-Day")] Attack.log"
 	if( fexists(path) )
 		src << run( file(path) )
@@ -109,3 +112,5 @@
 	usr << run( file(path) )
 	feedback_add_details("admin_verb","SSAL") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 	return
+	*/
+	

--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -252,7 +252,7 @@
 	//Panic bunker code
 	if (isnum(player_age) && player_age == 0) //first connection
 		if (config.panic_bunker && !holder && !deadmin_holder)
-			log_access("Failed Login: [key] - New account attempting to connect during panic bunker")
+			log_adminwarn("Failed Login: [key] - New account attempting to connect during panic bunker")
 			message_admins("<span class='adminnotice'>Failed Login: [key] - New account attempting to connect during panic bunker</span>")
 			to_chat(src, "Sorry but the server is currently not accepting connections from never before seen players.")
 			qdel(src)

--- a/code/modules/clothing/rings/rings.dm
+++ b/code/modules/clothing/rings/rings.dm
@@ -37,9 +37,9 @@
 		if(reagents.total_volume)
 			to_chat(H, "<span class='danger'>You feel a prick as you slip on \the [src].</span>")
 			if(H.reagents)
-				var/contained_reagents = reagents.get_reagents()
+				var/contained = reagents.get_reagents()
 				var/trans = reagents.trans_to_mob(H, 15, CHEM_BLOOD)
-				admin_inject_log(usr, H, src, contained_reagents, trans)
+				add_attack_logs(usr, H, "Injected with [name] containing [contained] transferred [trans] units")
 	return
 
 //Sleepy Ring

--- a/code/modules/error_handler/error_handler.dm
+++ b/code/modules/error_handler/error_handler.dm
@@ -8,7 +8,7 @@ var/total_runtimes_skipped = 0
 #ifdef DEBUG
 /world/Error(var/exception/e, var/datum/e_src)
 	if(!istype(e)) // Something threw an unusual exception
-		log_to_dd("\[[time_stamp()]] Uncaught exception: [e]")
+		log_error("\[[time_stamp()]] Uncaught exception: [e]")
 		return ..()
 	if(!error_last_seen) // A runtime is occurring too early in start-up initialization
 		return ..()
@@ -39,7 +39,7 @@ var/total_runtimes_skipped = 0
 			var/skipcount = abs(error_cooldown[erroruid]) - 1
 			error_cooldown[erroruid] = 0
 			if(skipcount > 0)
-				log_to_dd("\[[time_stamp()]] Skipped [skipcount] runtimes in [e.file],[e.line].")
+				log_error("\[[time_stamp()]] Skipped [skipcount] runtimes in [e.file],[e.line].")
 				error_cache.logError(e, skipCount = skipcount)
 	error_last_seen[erroruid] = world.time
 	error_cooldown[erroruid] = cooldown
@@ -95,9 +95,9 @@ var/total_runtimes_skipped = 0
 		desclines += "  (This error will now be silenced for [ERROR_SILENCE_TIME / 600] minutes)"
 
 	// Now to actually output the error info...
-	log_to_dd("\[[time_stamp()]] Runtime in [e.file],[e.line]: [e]")
+	log_error("\[[time_stamp()]] Runtime in [e.file],[e.line]: [e]")
 	for(var/line in desclines)
-		log_to_dd(line)
+		log_error(line)
 	if(error_cache)
 		error_cache.logError(e, desclines, e_src = e_src)
 

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -747,7 +747,7 @@ mob/observer/dead/MayRespawn(var/feedback = 0)
 			return 0
 		var/msg = sanitize(input(src, "Message:", "Spectral Whisper") as text|null)
 		if(msg)
-			log_say("SpectralWhisper: [key_name(usr)]->[M.key] : [msg]")
+			log_say("(SPECWHISP to [key_name(M)]): [msg]", src)
 			M << "<span class='warning'> You hear a strange, unidentifiable voice in your head... <font color='purple'>[msg]</font></span>"
 			src << "<span class='warning'> You said: '[msg]' to [M].</span>"
 		else

--- a/code/modules/mob/dead/observer/say.dm
+++ b/code/modules/mob/dead/observer/say.dm
@@ -4,7 +4,7 @@
 	if (!message)
 		return
 
-	log_say("Ghost/[src.key] : [message]")
+	log_ghostsay(message, src)
 
 	if (src.client)
 		if(message)
@@ -25,7 +25,7 @@
 	if(act != "me")
 		return
 
-	log_emote("Ghost/[src.key] : [message]")
+	log_ghostemote(message, src)
 
 	if(src.client)
 		if(message)

--- a/code/modules/mob/emote.dm
+++ b/code/modules/mob/emote.dm
@@ -15,14 +15,13 @@
 	else
 		input = message
 	if(input)
+		log_emote(message,src) //Log before we add junk
 		message = "<B>[src]</B> [input]"
 	else
 		return
 
 
 	if (message)
-		log_emote("[name]/[key] : [message]")
-
 		message = say_emphasis(message)
 
  // Hearing gasp and such every five seconds is not good emotes were not global for a reason.
@@ -71,7 +70,7 @@
 	input = say_emphasis(input)
 
 	if(input)
-		log_emote("Ghost/[src.key] : [input]")
+		log_ghostemote(input, src)
 		if(!invisibility) //If the ghost is made visible by admins or cult. And to see if the ghost has toggled its own visibility, as well. -Mech
 			visible_message("<span class='deadsay'><B>[src]</B> [input]</span>")
 		else

--- a/code/modules/mob/language/language.dm
+++ b/code/modules/mob/language/language.dm
@@ -99,7 +99,7 @@
 	return (copytext(message, length(message)) == "!") ? 2 : 1
 
 /datum/language/proc/broadcast(var/mob/living/speaker,var/message,var/speaker_mask)
-	log_say("[key_name(speaker)] : ([name]) [message]")
+	log_say("(HIVE) [message]", src)
 
 	if(!speaker_mask) speaker_mask = speaker.name
 	message = format_message(message, get_spoken_verb(message))

--- a/code/modules/mob/living/carbon/alien/emote.dm
+++ b/code/modules/mob/living/carbon/alien/emote.dm
@@ -119,7 +119,7 @@
 		else
 			src << text("Invalid Emote: []", act)
 	if ((message && src.stat == 0))
-		log_emote("[name]/[key] : [message]")
+		log_emote(message, src)
 		if (m_type & 1)
 			for(var/mob/O in viewers(src, null))
 				O.show_message(message, m_type)

--- a/code/modules/mob/living/carbon/brain/emote.dm
+++ b/code/modules/mob/living/carbon/brain/emote.dm
@@ -63,7 +63,7 @@
 			src << "<font color='blue'>Unusable emote '[act]'. Say *help for a list.</font>"
 
 	if (message)
-		log_emote("[name]/[key] : [message]")
+		log_emote(message, src)
 
 		for(var/mob/M in dead_mob_list)
 			if (!M.client || istype(M, /mob/new_player))

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -101,9 +101,8 @@
 	G.last_action = world.time
 	flick(G.hud.icon_state, G.hud)
 
-	user.attack_log += "\[[time_stamp()]\]<font color='red'> Knifed [name] ([ckey]) with [W.name] (INTENT: [uppertext(user.a_intent)]) (DAMTYE: [uppertext(W.damtype)])</font>"
-	src.attack_log += "\[[time_stamp()]\]<font color='orange'> Got knifed by [user.name] ([user.ckey]) with [W.name] (INTENT: [uppertext(user.a_intent)]) (DAMTYE: [uppertext(W.damtype)])</font>"
-	msg_admin_attack("[key_name(user)] knifed [key_name(src)] with [W.name] (INTENT: [uppertext(user.a_intent)]) (DAMTYE: [uppertext(W.damtype)])" )
+	add_attack_logs(user,src,"Knifed (throat slit)")
+
 	return 1
 
 /mob/living/carbon/proc/shank_attack(obj/item/W, obj/item/weapon/grab/G, mob/user, hit_zone)
@@ -119,9 +118,7 @@
 	if(W.hitsound)
 		playsound(loc, W.hitsound, 50, 1, -1)
 
-	user.attack_log += "\[[time_stamp()]\]<font color='red'> Shanked [name] ([ckey]) with [W.name] (INTENT: [uppertext(user.a_intent)]) (DAMTYE: [uppertext(W.damtype)])</font>"
-	src.attack_log += "\[[time_stamp()]\]<font color='orange'> Got shanked by [user.name] ([user.ckey]) with [W.name] (INTENT: [uppertext(user.a_intent)]) (DAMTYE: [uppertext(W.damtype)])</font>"
-	msg_admin_attack("[key_name(user)] shanked [key_name(src)] with [W.name] (INTENT: [uppertext(user.a_intent)]) (DAMTYE: [uppertext(W.damtype)])" )
+	add_attack_logs(user,src,"Knifed (shanked)")
 
 	return 1
 

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -728,9 +728,7 @@
 			src << "<font color='blue'>Unusable emote '[act]'. Say *help for a list.</font>"
 
 	if (message)
-		log_emote("[name]/[key] : [message]")
 		custom_emote(m_type,message)
-
 
 /mob/living/carbon/human/verb/pose()
 	set name = "Set Pose"

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -877,7 +877,7 @@
 	else
 		target.show_message("<font color='blue'> You hear a voice that seems to echo around the room: [say]</font>")
 	usr.show_message("<font color='blue'> You project your mind into [target.real_name]: [say]</font>")
-	log_say("[key_name(usr)] sent a telepathic message to [key_name(target)]: [say]")
+	log_say("(TPATH to [key_name(target)]) [say]",src)
 	for(var/mob/observer/dead/G in world)
 		G.show_message("<i>Telepathic message from <b>[src]</b> to <b>[target]</b>: [say]</i>")
 

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -235,9 +235,8 @@
 				H.visible_message("<span class='danger'>[attack_message]</span>")
 
 			playsound(loc, ((miss_type) ? (miss_type == 1 ? attack.miss_sound : 'sound/weapons/thudswoosh.ogg') : attack.attack_sound), 25, 1, -1)
-			H.attack_log += text("\[[time_stamp()]\] <font color='red'>[miss_type ? (miss_type == 1 ? "Missed" : "Blocked") : "[pick(attack.attack_verb)]"] [src.name] ([src.ckey])</font>")
-			src.attack_log += text("\[[time_stamp()]\] <font color='orange'>[miss_type ? (miss_type == 1 ? "Was missed by" : "Has blocked") : "Has Been [pick(attack.attack_verb)]"] by [H.name] ([H.ckey])</font>")
-			msg_admin_attack("[key_name(H)] [miss_type ? (miss_type == 1 ? "has missed" : "was blocked by") : "has [pick(attack.attack_verb)]"] [key_name(src)]")
+			
+			add_attack_logs(H,src,"Melee attacked with fists (miss/block)")
 
 			if(miss_type)
 				return 0
@@ -268,10 +267,8 @@
 			apply_damage(real_damage, hit_dam_type, hit_zone, armour, soaked, sharp=attack.sharp, edge=attack.edge)
 
 		if(I_DISARM)
-			M.attack_log += text("\[[time_stamp()]\] <font color='red'>Disarmed [src.name] ([src.ckey])</font>")
-			src.attack_log += text("\[[time_stamp()]\] <font color='orange'>Has been disarmed by [M.name] ([M.ckey])</font>")
+			add_attack_logs(H,src,"Disarmed")
 
-			msg_admin_attack("[key_name(M)] disarmed [src.name] ([src.ckey])")
 			M.do_attack_animation(src)
 
 			if(w_uniform)
@@ -333,8 +330,7 @@
 	if(!damage)
 		return
 
-	user.attack_log += text("\[[time_stamp()]\] <font color='red'>attacked [src.name] ([src.ckey])</font>")
-	src.attack_log += text("\[[time_stamp()]\] <font color='orange'>was attacked by [user.name] ([user.ckey])</font>")
+	add_attack_logs(user,src,"Melee attacked with fists (miss/block)",admin_notify = FALSE) //No admin notice since this is usually fighting simple animals
 	src.visible_message("<span class='danger'>[user] has [attack_message] [src]!</span>")
 	user.do_attack_animation(src)
 

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -65,7 +65,7 @@ emp_act
 				c_hand = r_hand
 
 			if(c_hand && (stun_amount || agony_amount > 10))
-				msg_admin_attack("[src.name] ([src.ckey]) was disarmed by a stun effect")
+				msg_admin_attack("[key_name(src)] was disarmed by a stun effect")
 
 				drop_from_inventory(c_hand)
 				if (affected.robotic >= ORGAN_ROBOT)
@@ -403,13 +403,7 @@ emp_act
 		src.visible_message("<font color='red'>[src] has been hit in the [hit_area] by [O].</font>")
 
 		if(ismob(O.thrower))
-			var/mob/M = O.thrower
-			var/client/assailant = M.client
-			if(assailant)
-				src.attack_log += text("\[[time_stamp()]\] <font color='orange'>Has been hit with a [O], thrown by [M.name] ([assailant.ckey])</font>")
-				M.attack_log += text("\[[time_stamp()]\] <font color='red'>Hit [src.name] ([src.ckey]) with a thrown [O]</font>")
-				if(!istype(src,/mob/living/simple_animal/mouse))
-					msg_admin_attack("[src.name] ([src.ckey]) was hit by a [O], thrown by [M.name] ([assailant.ckey]) (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[src.x];Y=[src.y];Z=[src.z]'>JMP</a>)")
+			add_attack_logs(O.thrower,src,"Hit with thrown [O.name]")
 
 		//If the armor absorbs all of the damage, skip the rest of the calculations
 		var/soaked = get_armor_soak(affecting, "melee", O.armor_penetration)

--- a/code/modules/mob/living/carbon/human/human_powers.dm
+++ b/code/modules/mob/living/carbon/human/human_powers.dm
@@ -74,7 +74,7 @@
 		src << "Not even a [src.species.name] can speak to the dead."
 		return
 
-	log_say("[key_name(src)] communed to [key_name(M)]: [text]")
+	log_say("(COMMUNE to [key_name(M)]) [text]",src)
 
 	M << "<font color='blue'>Like lead slabs crashing into the ocean, alien thoughts drop into your mind: [text]</font>"
 	if(istype(M,/mob/living/carbon/human))
@@ -104,7 +104,7 @@
 
 	var/msg = sanitize(input("Message:", "Psychic Whisper") as text|null)
 	if(msg)
-		log_say("PsychicWhisper: [key_name(src)]->[M.key] : [msg]")
+		log_say("(PWHISPER to [key_name(M)]) [msg]", src)
 		M << "<font color='green'>You hear a strange, alien voice in your head... <i>[msg]</i></font>"
 		src << "<font color='green'>You said: \"[msg]\" to [M]</font>"
 	return

--- a/code/modules/mob/living/carbon/human/stripping.dm
+++ b/code/modules/mob/living/carbon/human/stripping.dm
@@ -48,8 +48,7 @@
 
 			if(istype(A, /obj/item/clothing/accessory/badge) || istype(A, /obj/item/clothing/accessory/medal))
 				user.visible_message("<span class='danger'>\The [user] tears off \the [A] from [src]'s [suit.name]!</span>")
-			attack_log += "\[[time_stamp()]\] <font color='orange'>Has had \the [A] removed by [user.name] ([user.ckey])</font>"
-			user.attack_log += "\[[time_stamp()]\] <font color='red'>Attempted to remove [name]'s ([ckey]) [A.name]</font>"
+			add_attack_logs(user,src,"Stripped [A.name] off [suit.name]")
 			A.on_removed(user)
 			suit.accessories -= A
 			update_inv_w_uniform()
@@ -81,7 +80,7 @@
 		return
 
 	if(stripping)
-		admin_attack_log(user, src, "Attempted to remove \a [target_slot]", "Target of an attempt to remove \a [target_slot].", "attempted to remove \a [target_slot] from")
+		add_attack_logs(user,src,"Removed equipment from slot [target_slot]")
 		unEquip(target_slot)
 	else if(user.unEquip(held))
 		equip_to_slot_if_possible(held, text2num(slot_to_strip), 0, 1, 1)
@@ -108,8 +107,7 @@
 	if (suit.has_sensor >= 2)
 		user << "<span class='warning'>\The [src]'s suit sensor controls are locked.</span>"
 		return
-	attack_log += text("\[[time_stamp()]\] <font color='orange'>Has had their sensors toggled by [user.name] ([user.ckey])</font>")
-	user.attack_log += text("\[[time_stamp()]\] <font color='red'>Attempted to toggle [name]'s ([ckey]) sensors</font>")
+	add_attack_logs(user,src,"Adjusted suit sensor level")
 	suit.set_sensors(user)
 
 // Remove all splints.

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1136,15 +1136,9 @@ default behaviour is:
 			//limit throw range by relative mob size
 			throw_range = round(M.throw_range * min(src.mob_size/M.mob_size, 1))
 
-			var/turf/start_T = get_turf(loc) //Get the start and target tile for the descriptors
 			var/turf/end_T = get_turf(target)
-			if(start_T && end_T)
-				var/start_T_descriptor = "<font color='#6b5d00'>tile at [start_T.x], [start_T.y], [start_T.z] in area [get_area(start_T)]</font>"
-				var/end_T_descriptor = "<font color='#6b4400'>tile at [end_T.x], [end_T.y], [end_T.z] in area [get_area(end_T)]</font>"
-
-				M.attack_log += text("\[[time_stamp()]\] <font color='orange'>Has been thrown by [usr.name] ([usr.ckey]) from [start_T_descriptor] with the target [end_T_descriptor]</font>")
-				usr.attack_log += text("\[[time_stamp()]\] <font color='red'>Has thrown [M.name] ([M.ckey]) from [start_T_descriptor] with the target [end_T_descriptor]</font>")
-				msg_admin_attack("[usr.name] ([usr.ckey]) has thrown [M.name] ([M.ckey]) from [start_T_descriptor] with the target [end_T_descriptor] (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[usr.x];Y=[usr.y];Z=[usr.z]'>JMP</a>)")
+			if(end_T)
+				add_attack_logs(src,M,"Thrown via grab to [end_T.x],[end_T.y],[end_T.z]")
 
 	src.drop_from_inventory(item)
 	if(!item || !isturf(item.loc))

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -271,10 +271,7 @@
 			var/mob/M = O.thrower
 			var/client/assailant = M.client
 			if(assailant)
-				src.attack_log += text("\[[time_stamp()]\] <font color='orange'>Has been hit with a [O], thrown by [M.name] ([assailant.ckey])</font>")
-				M.attack_log += text("\[[time_stamp()]\] <font color='red'>Hit [src.name] ([src.ckey]) with a thrown [O]</font>")
-				if(!istype(src,/mob/living/simple_animal/mouse))
-					msg_admin_attack("[src.name] ([src.ckey]) was hit by a [O], thrown by [M.name] ([assailant.ckey]) (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[src.x];Y=[src.y];Z=[src.z]'>JMP</a>)")
+				add_attack_logs(M,src,"Hit by thrown [O.name]")
 
 		// Begin BS12 momentum-transfer code.
 		var/mass = 1.5
@@ -337,8 +334,7 @@
 		return
 
 	adjustBruteLoss(damage)
-	user.attack_log += text("\[[time_stamp()]\] <font color='red'>attacked [src.name] ([src.ckey])</font>")
-	src.attack_log += text("\[[time_stamp()]\] <font color='orange'>was attacked by [user.name] ([user.ckey])</font>")
+	add_attack_logs(user,src,"Generic attack (probably animal)", admin_notify = FALSE) //Usually due to simple_animal attacks
 	src.visible_message("<span class='danger'>[user] has [attack_message] [src]!</span>")
 	user.do_attack_animation(src)
 	spawn(1) updatehealth()

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -270,7 +270,7 @@ proc/get_radio_key_from_channel(var/channel)
 				src.custom_emote(1, "[pick(speaking.signlang_verb)].")
 
 		if (speaking.flags & SIGNLANG)
-			log_say("[name]/[key] : SIGN: [message]")
+			log_say("(SIGN) [message]", src)
 			return say_signlang(message, pick(speaking.signlang_verb), speaking)
 
 	//These will contain the main receivers of the message
@@ -345,7 +345,10 @@ proc/get_radio_key_from_channel(var/channel)
 					O.hear_talk(src, message, verb, speaking)
 
 	//Log the message to file
-	log_say("[name]/[key][whispering ? " (W)" : ""]: [message]")
+	if(whispering)
+		log_whisper(message,src)
+	else
+		log_say(message, src)
 	return 1
 
 /mob/living/proc/say_signlang(var/message, var/verb="gestures", var/datum/language/language)

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -390,7 +390,7 @@ var/list/ai_verbs_default = list(
 		return
 	CentCom_announce(input, usr)
 	usr << "<span class='notice'>Message transmitted.</span>"
-	log_say("[key_name(usr)] has made an IA [using_map.boss_short] announcement: [input]")
+	log_game("[key_name(usr)] has made an IA [using_map.boss_short] announcement: [input]")
 	emergency_message_cooldown = 1
 	spawn(300)
 		emergency_message_cooldown = 0

--- a/code/modules/mob/living/silicon/say.dm
+++ b/code/modules/mob/living/silicon/say.dm
@@ -2,7 +2,7 @@
 	return ..((sanitize ? sanitize(message) : message), whispering = whispering)
 
 /mob/living/silicon/handle_message_mode(message_mode, message, verb, speaking, used_radios, alt_name)
-	log_say("[key_name(src)] : [message]")
+	log_say(message, src)
 
 /mob/living/silicon/robot/handle_message_mode(message_mode, message, verb, speaking, used_radios, alt_name)
 	..()
@@ -64,7 +64,7 @@
 //For holopads only. Usable by AI.
 /mob/living/silicon/ai/proc/holopad_talk(var/message, verb, datum/language/speaking)
 
-	log_say("[key_name(src)] : [message]")
+	log_say("(HPAD) [message]",src)
 
 	message = trim(message)
 
@@ -112,8 +112,6 @@
 
 /mob/living/silicon/ai/proc/holopad_emote(var/message) //This is called when the AI uses the 'me' verb while using a holopad.
 
-	log_emote("[key_name(src)] : [message]")
-
 	message = trim(message)
 
 	if (!message)
@@ -140,6 +138,8 @@
 			spawn(0)
 				if(O)
 					O.see_emote(src, message)
+
+		log_emote("(HPAD) [message]", src)
 
 	else //This shouldn't occur, but better safe then sorry.
 		src << "No holopad connected."

--- a/code/modules/mob/living/simple_animal/borer/borer_captive.dm
+++ b/code/modules/mob/living/simple_animal/borer/borer_captive.dm
@@ -15,7 +15,7 @@
 		message = sanitize(message)
 		if (!message)
 			return
-		log_say("[key_name(src)] : [message]")
+		log_say(message,src)
 		if (stat == 2)
 			return say_dead(message)
 

--- a/code/modules/mob/living/simple_animal/constructs/soulstone.dm
+++ b/code/modules/mob/living/simple_animal/constructs/soulstone.dm
@@ -27,10 +27,7 @@
 		user << "<span class='warning'>This being is corrupted by an alien intelligence and cannot be soul trapped.</span>"
 		return..()
 
-	M.attack_log += text("\[[time_stamp()]\] <font color='orange'>Has had their soul captured with [src.name] by [user.name] ([user.ckey])</font>")
-	user.attack_log += text("\[[time_stamp()]\] <font color='red'>Used the [src.name] to capture the soul of [M.name] ([M.ckey])</font>")
-	msg_admin_attack("[user.name] ([user.ckey]) used the [src.name] to capture the soul of [M.name] ([M.ckey]) (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[user.x];Y=[user.y];Z=[user.z]'>JMP</a>)")
-
+	add_attack_logs(user,M,"Soulstone'd with [src.name]")
 	transfer_soul("VICTIM", M, user)
 	return
 

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -1248,8 +1248,7 @@
 		var/mob/living/L = target_mob
 
 		if(prob(melee_miss_chance))
-			src.attack_log += text("\[[time_stamp()]\] <font color='red'>attacked [L.name] ([L.ckey])</font>")
-			L.attack_log += text("\[[time_stamp()]\] <font color='orange'>was attacked by [src.name] ([src.ckey])</font>")
+			add_attack_logs(src,L,"Animal-attacked (miss)", admin_notify = FALSE)
 			visible_message("<span class='danger'>[src] misses [L]!</span>")
 			do_attack_animation(src)
 			return L

--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -3,7 +3,7 @@
 	//Multikey checks and logging
 	lastKnownIP	= client.address
 	computer_id	= client.computer_id
-	log_access("Login: [key_name(src)] from [lastKnownIP ? lastKnownIP : "localhost"]-[computer_id] || BYOND v[client.byond_version]")
+	log_access_in(client)
 	if(config.log_access)
 		for(var/mob/M in player_list)
 			if(M == src)	continue
@@ -18,10 +18,10 @@
 				if(matches)
 					if(M.client)
 						message_admins("<font color='red'><B>Notice: </B></font><font color='blue'><A href='?src=\ref[usr];priv_msg=\ref[src]'>[key_name_admin(src)]</A> has the same [matches] as <A href='?src=\ref[usr];priv_msg=\ref[M]'>[key_name_admin(M)]</A>.</font>", 1)
-						log_access("Notice: [key_name(src)] has the same [matches] as [key_name(M)].")
+						log_adminwarn("Notice: [key_name(src)] has the same [matches] as [key_name(M)].")
 					else
 						message_admins("<font color='red'><B>Notice: </B></font><font color='blue'><A href='?src=\ref[usr];priv_msg=\ref[src]'>[key_name_admin(src)]</A> has the same [matches] as [key_name_admin(M)] (no longer logged in). </font>", 1)
-						log_access("Notice: [key_name(src)] has the same [matches] as [key_name(M)] (no longer logged in).")
+						log_adminwarn("Notice: [key_name(src)] has the same [matches] as [key_name(M)] (no longer logged in).")
 
 /mob/Login()
 

--- a/code/modules/mob/logout.dm
+++ b/code/modules/mob/logout.dm
@@ -1,7 +1,7 @@
 /mob/Logout()
 	nanomanager.user_logout(src) // this is used to clean up (remove) this user's Nano UIs
 	player_list -= src
-	log_access("Logout: [key_name(src)]")
+	log_access_out(src)
 	if(admin_datums[src.ckey])
 		if (ticker && ticker.current_state == GAME_STATE_PLAYING) //Only report this stuff if we are currently playing.
 			var/admins_number = admins.len

--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -265,9 +265,7 @@
 		state = GRAB_NECK
 		icon_state = "grabbed+1"
 		assailant.set_dir(get_dir(assailant, affecting))
-		affecting.attack_log += "\[[time_stamp()]\] <font color='orange'>Has had their neck grabbed by [assailant.name] ([assailant.ckey])</font>"
-		assailant.attack_log += "\[[time_stamp()]\] <font color='red'>Grabbed the neck of [affecting.name] ([affecting.ckey])</font>"
-		msg_admin_attack("[key_name(assailant)] grabbed the neck of [key_name(affecting)]")
+		add_attack_logs(assailant,affecting,"Neck grabbed")
 		hud.icon_state = "kill"
 		hud.name = "kill"
 		affecting.Stun(10) //10 ticks of ensured grab
@@ -277,10 +275,7 @@
 
 		state = GRAB_KILL
 		assailant.visible_message("<span class='danger'>[assailant] has tightened [TU.his] grip on [affecting]'s neck!</span>")
-		affecting.attack_log += "\[[time_stamp()]\] <font color='orange'>Has been strangled (kill intent) by [assailant.name] ([assailant.ckey])</font>"
-		assailant.attack_log += "\[[time_stamp()]\] <font color='red'>Strangled (kill intent) [affecting.name] ([affecting.ckey])</font>"
-		msg_admin_attack("[key_name(assailant)] strangled (kill intent) [key_name(affecting)]")
-
+		add_attack_logs(assailant,affecting,"Strangled")
 		affecting.setClickCooldown(10)
 		affecting.AdjustLosebreath(1)
 		affecting.set_dir(WEST)

--- a/code/modules/mob/mob_grab_specials.dm
+++ b/code/modules/mob/mob_grab_specials.dm
@@ -82,9 +82,7 @@
 		attacker << "<span class='danger'>You cannot locate any eyes on [target]!</span>"
 		return
 
-	attacker.attack_log += text("\[[time_stamp()]\] <font color='red'>Attacked [target.name]'s eyes using grab ([target.ckey])</font>")
-	target.attack_log += text("\[[time_stamp()]\] <font color='orange'>Had eyes attacked by [attacker.name]'s grab ([attacker.ckey])</font>")
-	msg_admin_attack("[key_name(attacker)] attacked [key_name(target)]'s eyes using a grab action.")
+	add_attack_logs(attacker,target,"Eye gouge using grab")
 
 	attack.handle_eye_attack(attacker, target)
 
@@ -111,9 +109,7 @@
 		target.visible_message("<span class='danger'>[target] [target.species.get_knockout_message(target)]</span>")
 
 	playsound(attacker.loc, "swing_hit", 25, 1, -1)
-	attacker.attack_log += text("\[[time_stamp()]\] <font color='red'>Headbutted [target.name] ([target.ckey])</font>")
-	target.attack_log += text("\[[time_stamp()]\] <font color='orange'>Headbutted by [attacker.name] ([attacker.ckey])</font>")
-	msg_admin_attack("[key_name(attacker)] has headbutted [key_name(target)]")
+	add_attack_logs(attacker,target,"Headbutted using grab")
 
 	attacker.drop_from_inventory(src)
 	src.loc = null

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -345,6 +345,7 @@
 	var/mob/living/character = create_character(T)	//creates the human and transfers vars and mind
 	character = job_master.EquipRank(character, rank, 1)					//equips the human
 	UpdateFactionList(character)
+	log_game("JOINED [key_name(character)] as \"[rank]\"")
 
 	// AIs don't need a spawnpoint, they must spawn at an empty core
 	if(character.mind.assigned_role == "AI")

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -327,9 +327,7 @@ var/list/organ_cache = list()
 
 	if(owner && vital)
 		if(user)
-			user.attack_log += "\[[time_stamp()]\]<font color='red'> removed a vital organ ([src]) from [owner.name] ([owner.ckey]) (INTENT: [uppertext(user.a_intent)])</font>"
-			owner.attack_log += "\[[time_stamp()]\]<font color='orange'> had a vital organ ([src]) removed by [user.name] ([user.ckey]) (INTENT: [uppertext(user.a_intent)])</font>"
-			msg_admin_attack("[user.name] ([user.ckey]) removed a vital organ ([src]) from [owner.name] ([owner.ckey]) (INTENT: [uppertext(user.a_intent)]) (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[user.x];Y=[user.y];Z=[user.z]'>JMP</a>)")
+			add_attack_logs(user,owner,"Removed vital organ [src.name]")
 		owner.death()
 		owner.can_defib = 0
 

--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -62,17 +62,6 @@
 	icon_state = "pen"
 	colour = "white"
 
-
-/obj/item/weapon/pen/attack(mob/M as mob, mob/user as mob)
-	if(!ismob(M))
-		return
-	user << "<span class='warning'>You stab [M] with the pen.</span>"
-//	M << "<font color='red'>You feel a tiny prick!</font>" //That's a whole lot of meta!
-	M.attack_log += text("\[[time_stamp()]\] <font color='orange'>Has been stabbed with [name]  by [user.name] ([user.ckey])</font>")
-	user.attack_log += text("\[[time_stamp()]\] <font color='red'>Used the [name] to stab [M.name] ([M.ckey])</font>")
-	msg_admin_attack("[user.name] ([user.ckey]) Used the [name] to stab [M.name] ([M.ckey]) (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[user.x];Y=[user.y];Z=[user.z]'>JMP</a>)")
-	return
-
 /*
  * Reagent pens
  */
@@ -95,9 +84,9 @@
 	if(M.can_inject(user,1))
 		if(reagents.total_volume)
 			if(M.reagents)
-				var/contained_reagents = reagents.get_reagents()
+				var/contained = reagents.get_reagents()
 				var/trans = reagents.trans_to_mob(M, 30, CHEM_BLOOD)
-				admin_inject_log(user, M, src, contained_reagents, trans)
+				add_attack_logs(user,M,"Injected with [src.name] containing [contained], trasferred [trans] units")
 
 /*
  * Sleepy Pens

--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -48,7 +48,7 @@
 
 /obj/machinery/power/emitter/Destroy()
 	message_admins("Emitter deleted at ([x],[y],[z] - <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'>JMP</a>)",0,1)
-	log_game("Emitter deleted at ([x],[y],[z])")
+	log_game("EMITTER([x],[y],[z]) Destroyed/deleted.")
 	investigate_log("<font color='red'>deleted</font> at ([x],[y],[z])","singulo")
 	..()
 
@@ -72,7 +72,7 @@
 				src.active = 0
 				user << "You turn off [src]."
 				message_admins("Emitter turned off by [key_name(user, user.client)](<A HREF='?_src_=holder;adminmoreinfo=\ref[user]'>?</A>) in ([x],[y],[z] - <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'>JMP</a>)",0,1)
-				log_game("Emitter turned off by [user.ckey]([user]) in ([x],[y],[z])")
+				log_game("EMITTER([x],[y],[z]) OFF by [key_name(user)]")
 				investigate_log("turned <font color='red'>off</font> by [user.key]","singulo")
 			else
 				src.active = 1
@@ -80,7 +80,7 @@
 				src.shot_number = 0
 				src.fire_delay = get_initial_fire_delay()
 				message_admins("Emitter turned on by [key_name(user, user.client)](<A HREF='?_src_=holder;adminmoreinfo=\ref[user]'>?</A>) in ([x],[y],[z] - <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'>JMP</a>)",0,1)
-				log_game("Emitter turned on by [user.ckey]([user]) in ([x],[y],[z])")
+				log_game("EMITTER([x],[y],[z]) ON by [key_name(user)]")
 				investigate_log("turned <font color='green'>on</font> by [user.key]","singulo")
 			update_icon()
 		else
@@ -112,11 +112,13 @@
 			if(!powered)
 				powered = 1
 				update_icon()
+				log_game("EMITTER([x],[y],[z]) Regained power and is ON.")
 				investigate_log("regained power and turned <font color='green'>on</font>","singulo")
 		else
 			if(powered)
 				powered = 0
 				update_icon()
+				log_game("EMITTER([x],[y],[z]) Lost power and was ON.")
 				investigate_log("lost power and turned <font color='red'>off</font>","singulo")
 			return
 

--- a/code/modules/power/singularity/field_generator.dm
+++ b/code/modules/power/singularity/field_generator.dm
@@ -90,6 +90,7 @@ field_generator power level display
 					"You turn on the [src.name].", \
 					"You hear heavy droning")
 				turn_on()
+				log_game("FIELDGEN([x],[y],[z]) Activated by [key_name(user)]")
 				investigate_log("<font color='green'>activated</font> by [user.key].","singulo")
 
 				src.add_fingerprint(user)
@@ -213,6 +214,7 @@ field_generator power level display
 		for(var/mob/M in viewers(src))
 			M.show_message("<font color='red'>\The [src] shuts down!</font>")
 		turn_off()
+		log_game("FIELDGEN([x],[y],[z]) Lost power and was ON.")
 		investigate_log("ran out of power and <font color='red'>deactivated</font>","singulo")
 		src.power = 0
 		return 0
@@ -338,4 +340,5 @@ field_generator power level display
 					temp = 0
 					message_admins("A singulo exists and a containment field has failed.",1)
 					investigate_log("has <font color='red'>failed</font> whilst a singulo exists.","singulo")
+					log_game("FIELDGEN([x],[y],[z]) Containment failed while singulo/tesla exists.")
 			O.last_warning = world.time

--- a/code/modules/power/singularity/particle_accelerator/particle_accelerator.dm
+++ b/code/modules/power/singularity/particle_accelerator/particle_accelerator.dm
@@ -139,6 +139,7 @@ So, hopefully this is helpful if any more icons are to be added/changed/wonderin
 	..()
 	if(master && master.active)
 		master.toggle_power()
+		log_game("PACCEL([x],[y],[z]) Was moved while active and turned off.")
 		investigate_log("was moved whilst active; it <font color='red'>powered down</font>.","singulo")
 
 /obj/structure/particle_accelerator/ex_act(severity)

--- a/code/modules/power/singularity/particle_accelerator/particle_control.dm
+++ b/code/modules/power/singularity/particle_accelerator/particle_control.dm
@@ -119,7 +119,7 @@
 			strength = strength_upper_limit
 		else
 			message_admins("PA Control Computer increased to [strength] by [key_name(usr, usr.client)](<A HREF='?_src_=holder;adminmoreinfo=\ref[usr]'>?</A>) in ([x],[y],[z] - <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'>JMP</a>)",0,1)
-			log_game("PA Control Computer increased to [strength] by [usr.ckey]([usr]) in ([x],[y],[z])")
+			log_game("PACCEL([x],[y],[z]) [key_name(usr)] increased to [strength]")
 			investigate_log("increased to <font color='red'>[strength]</font> by [usr.key]","singulo")
 		strength_change()
 
@@ -130,7 +130,7 @@
 			strength = 0
 		else
 			message_admins("PA Control Computer decreased to [strength] by [key_name(usr, usr.client)](<A HREF='?_src_=holder;adminmoreinfo=\ref[usr]'>?</A>) in ([x],[y],[z] - <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'>JMP</a>)",0,1)
-			log_game("PA Control Computer decreased to [strength] by [usr.ckey]([usr]) in ([x],[y],[z])")
+			log_game("PACCEL([x],[y],[z]) [key_name(usr)] decreased to [strength]")
 			investigate_log("decreased to <font color='green'>[strength]</font> by [usr.key]","singulo")
 		strength_change()
 
@@ -147,6 +147,7 @@
 	if(src.active)
 		//a part is missing!
 		if( length(connected_parts) < 6 )
+			log_game("PACCEL([x],[y],[z]) Failed due to missing parts.")
 			investigate_log("lost a connected part; It <font color='red'>powered down</font>.","singulo")
 			toggle_power()
 			return
@@ -209,7 +210,7 @@
 	active = !active
 	investigate_log("turned [active?"<font color='red'>ON</font>":"<font color='green'>OFF</font>"] by [usr ? usr.key : "outside forces"]","singulo")
 	message_admins("PA Control Computer turned [active ?"ON":"OFF"] by [key_name(usr, usr.client)](<A HREF='?_src_=holder;adminmoreinfo=\ref[usr]'>?</A>) in ([x],[y],[z] - <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'>JMP</a>)",0,1)
-	log_game("PA Control Computer turned [active ?"ON":"OFF"] by [usr.ckey]([usr]) in ([x],[y],[z])")
+	log_game("PACCEL([x],[y],[z]) [key_name(usr)] turned [active?"ON":"OFF"].")
 	if(active)
 		update_use_power(2)
 		for(var/obj/structure/particle_accelerator/part in connected_parts)

--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -148,6 +148,7 @@
 		if(output_used < 0.0001)			// either from no charge or set to 0
 			outputting(0)
 			investigate_log("lost power and turned <font color='red'>off</font>","singulo")
+			log_game("SMES([x],[y],[z]) Power depleted.")
 	else if(output_attempt && output_level > 0)
 		outputting = 1
 	else
@@ -374,7 +375,7 @@
 		output_level = max(0, min(output_level_max, output_level))	// clamp to range
 
 	investigate_log("input/output; <font color='[input_level>output_level?"green":"red"][input_level]/[output_level]</font> | Output-mode: [output_attempt?"<font color='green'>on</font>":"<font color='red'>off</font>"] | Input-mode: [input_attempt?"<font color='green'>auto</font>":"<font color='red'>off</font>"] by [usr.key]","singulo")
-
+	log_game("SMES([x],[y],[z]) [key_name(usr)] changed settings: I:[input_level]([input_attempt]), O:[output_level]([output_attempt])")
 	return 1
 
 

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -94,7 +94,7 @@
 
 /obj/machinery/power/supermatter/proc/explode()
 	message_admins("Supermatter exploded at ([x],[y],[z] - <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'>JMP</a>)",0,1)
-	log_game("Supermatter exploded at ([x],[y],[z])")
+	log_game("SUPERMATTER([x],[y],[z]) Exploded. Power:[power], Oxygen:[oxygen], Damage:[damage], Integrity:[get_integrity()]")
 	anchored = 1
 	grav_pulling = 1
 	exploded = 1
@@ -146,10 +146,12 @@
 		alert_msg = null
 	if(alert_msg)
 		global_announcer.autosay(alert_msg, "Supermatter Monitor", "Engineering")
+		log_game("SUPERMATTER([x],[y],[z]) Emergency engineering announcement. Power:[power], Oxygen:[oxygen], Damage:[damage], Integrity:[get_integrity()]")
 		//Public alerts
 		if((damage > emergency_point) && !public_alert)
 			global_announcer.autosay("WARNING: SUPERMATTER CRYSTAL DELAMINATION IMMINENT!", "Supermatter Monitor")
 			public_alert = 1
+			log_game("SUPERMATTER([x],[y],[z]) Emergency PUBLIC announcement. Power:[power], Oxygen:[oxygen], Damage:[damage], Integrity:[get_integrity()]")
 		else if(safe_warned && public_alert)
 			global_announcer.autosay(alert_msg, "Supermatter Monitor")
 			public_alert = 0
@@ -277,12 +279,17 @@
 		return 0	// This stops people from being able to really power up the supermatter
 				// Then bring it inside to explode instantly upon landing on a valid turf.
 
-
+	var/added_energy
+	var/added_damage
 	var/proj_damage = Proj.get_structure_damage()
 	if(istype(Proj, /obj/item/projectile/beam))
-		power += proj_damage * config_bullet_energy	* CHARGING_FACTOR / POWER_FACTOR
+		added_energy = proj_damage * config_bullet_energy	* CHARGING_FACTOR / POWER_FACTOR
+		power += added_energy
 	else
-		damage += proj_damage * config_bullet_energy
+		added_damage = proj_damage * config_bullet_energy
+		damage += added_damage
+	if(added_energy || added_damage)
+		log_game("SUPERMATTER([x],[y],[z]) Hit by \"[Proj.name]\". +[added_energy] Energy, +[added_damage] Damage.")
 	return 0
 
 /obj/machinery/power/supermatter/attack_robot(mob/user as mob)

--- a/code/modules/power/tesla/energy_ball.dm
+++ b/code/modules/power/tesla/energy_ball.dm
@@ -93,6 +93,7 @@
 
 /obj/singularity/energy_ball/proc/handle_energy()
 	if (energy <= 0)
+		log_game("TESLA([x],[y],[z]) Collapsed entirely.")
 		investigate_log("collapsed.", I_SINGULO)
 		qdel(src)
 		return TRUE
@@ -287,6 +288,8 @@
 	else if(closest_mob)
 		var/shock_damage = Clamp(round(power/400), 10, 90) + rand(-5, 5)
 		closest_mob.electrocute_act(shock_damage, source, 1, ran_zone())
+		log_game("TESLA([source.x],[source.y],[source.z]) Shocked [key_name(closest_mob)] for [shock_damage]dmg.")
+		message_admins("Tesla zapped [key_name_admin(closest_mob)]!")
 		if(issilicon(closest_mob))
 			var/mob/living/silicon/S = closest_mob
 			if(stun_mobs)

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -379,10 +379,13 @@
 		if(one_handed_penalty >= 20)
 			to_chat(user, "<span class='warning'>You struggle to keep \the [src] pointed at the correct position with just one hand!</span>")
 
-	if(reflex)
-		admin_attack_log(user, target, attacker_message = "fired [src] by reflex.", victim_message = "triggered a reflex shot from [src].", admin_message = "shot [target], who triggered gunfire ([src]) by reflex)")
+	var/target_for_log
+	if(ismob(target))
+		target_for_log = target
 	else
-		admin_attack_log(usr, attacker_message="Fired [src]", admin_message="fired a gun ([src]) (MODE: [src.mode_name]) [reflex ? "by reflex" : "manually"].")
+		target_for_log = "[target.name]"
+
+	add_attack_logs(user,target_for_log,"Fired gun [src.name] ([reflex ? "REFLEX" : "MANUAL"])")
 
 	//update timing
 	user.setClickCooldown(DEFAULT_QUICK_COOLDOWN)
@@ -453,10 +456,14 @@
 		if(!(target && target.loc))
 			target = targloc
 			//pointblank = 0
+	
+	var/target_for_log
+	if(ismob(target))
+		target_for_log = target
+	else
+		target_for_log = "[target.name]"
 
-	log_and_message_admins("Fired [src].")
-
-	//admin_attack_log(usr, attacker_message="Fired [src]", admin_message="fired a gun ([src]) (MODE: [src.mode_name]) [reflex ? "by reflex" : "manually"].")
+	add_attack_logs("Unmanned",target_for_log,"Fired [src.name]")
 
 	//update timing
 	next_fire_time = world.time + fire_delay

--- a/code/modules/projectiles/guns/launcher/syringe_gun.dm
+++ b/code/modules/projectiles/guns/launcher/syringe_gun.dm
@@ -52,9 +52,9 @@
 			var/mob/living/L = hit_atom
 			//unfortuately we don't know where the dart will actually hit, since that's done by the parent.
 			if(L.can_inject() && syringe.reagents)
-				var/reagent_log = syringe.reagents.get_reagents()
-				syringe.reagents.trans_to_mob(L, 15, CHEM_BLOOD)
-				admin_inject_log(thrower, L, src, reagent_log, 15, violent=1)
+				var/contained = syringe.reagents.get_reagents()
+				var/trans = syringe.reagents.trans_to_mob(L, 15, CHEM_BLOOD)
+				add_attack_logs(thrower,L,"Shot with [src.name] containing [contained], trasferred [trans] units")
 
 		syringe.break_syringe(iscarbon(hit_atom)? hit_atom : null)
 		syringe.update_icon()

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -200,17 +200,8 @@
 
 	//admin logs
 	if(!no_attack_log)
-		if(istype(firer, /mob))
-
-			var/attacker_message = "shot with \a [src.type]"
-			var/victim_message = "shot with \a [src.type]"
-			var/admin_message = "shot (\a [src.type])"
-
-			admin_attack_log(firer, target_mob, attacker_message, victim_message, admin_message)
-		else
-			if(target_mob) // Sometimes the target_mob gets gibbed or something.
-				target_mob.attack_log += "\[[time_stamp()]\] <b>UNKNOWN SUBJECT (No longer exists)</b> shot <b>[target_mob]/[target_mob.ckey]</b> with <b>\a [src]</b>"
-				msg_admin_attack("UNKNOWN shot [target_mob] ([target_mob.ckey]) with \a [src] (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[target_mob.x];Y=[target_mob.y];Z=[target_mob.z]'>JMP</a>)")
+		if(istype(firer, /mob) && istype(target_mob))
+			add_attack_logs(firer,target_mob,"Shot with \a [src.type] projectile")
 
 	//sometimes bullet_act() will want the projectile to continue flying
 	if (result == PROJECTILE_CONTINUE)

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -62,10 +62,7 @@
 		return 1
 
 	var/contained = reagentlist()
-	target.attack_log += text("\[[time_stamp()]\] <font color='orange'>Has been splashed with [name] by [user.name] ([user.ckey]). Reagents: [contained]</font>")
-	user.attack_log += text("\[[time_stamp()]\] <font color='red'>Used the [name] to splash [target.name] ([target.key]). Reagents: [contained]</font>")
-	msg_admin_attack("[user.name] ([user.ckey]) splashed [target.name] ([target.key]) with [name]. Reagents: [contained] (INTENT: [uppertext(user.a_intent)]) (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[user.x];Y=[user.y];Z=[user.z]'>JMP</a>)")
-
+	add_attack_logs(user,target,"Splashed with [src.name] containing [contained]")
 	user.visible_message("<span class='danger'>[target] has been splashed with something by [user]!</span>", "<span class = 'notice'>You splash the solution onto [target].</span>")
 	reagents.splash(target, reagents.total_volume)
 	return 1
@@ -126,10 +123,7 @@
 		other_feed_message_finish(user, target)
 
 		var/contained = reagentlist()
-		target.attack_log += text("\[[time_stamp()]\] <font color='orange'>Has been fed [name] by [user.name] ([user.ckey]). Reagents: [contained]</font>")
-		user.attack_log += text("\[[time_stamp()]\] <font color='red'>Fed [name] by [target.name] ([target.ckey]). Reagents: [contained]</font>")
-		msg_admin_attack("[key_name(user)] fed [key_name(target)] with [name]. Reagents: [contained] (INTENT: [uppertext(user.a_intent)]) (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[user.x];Y=[user.y];Z=[user.z]'>JMP</a>)")
-
+		add_attack_logs(user,target,"Fed from [src.name] containing [contained]")
 		reagents.trans_to_mob(target, amount_per_transfer_from_this, CHEM_INGEST)
 		feed_sound(user)
 		return 1

--- a/code/modules/reagents/reagent_containers/borghydro.dm
+++ b/code/modules/reagents/reagent_containers/borghydro.dm
@@ -88,7 +88,7 @@
 			var/t = min(amount_per_transfer_from_this, reagent_volumes[reagent_ids[mode]])
 			M.reagents.add_reagent(reagent_ids[mode], t)
 			reagent_volumes[reagent_ids[mode]] -= t
-			admin_inject_log(user, M, src, reagent_ids[mode], t)
+			add_attack_logs(user, M, "Borg injected with [reagent_ids[mode]]")
 			user << "<span class='notice'>[t] units injected. [reagent_volumes[reagent_ids[mode]]] units remaining.</span>"
 	return
 

--- a/code/modules/reagents/reagent_containers/dropper.dm
+++ b/code/modules/reagents/reagent_containers/dropper.dm
@@ -62,12 +62,8 @@
 					user.visible_message("<span class='warning'>[user] tries to squirt something into [target]'s eyes, but fails!</span>", "<span class='notice'>You transfer [trans] units of the solution.</span>")
 					return
 
-			var/mob/living/M = target
 			var/contained = reagentlist()
-			M.attack_log += text("\[[time_stamp()]\] <font color='orange'>Has been squirted with [name] by [user.name] ([user.ckey]). Reagents: [contained]</font>")
-			user.attack_log += text("\[[time_stamp()]\] <font color='red'>Used the [name] to squirt [M.name] ([M.key]). Reagents: [contained]</font>")
-			msg_admin_attack("[user.name] ([user.ckey]) squirted [M.name] ([M.key]) with [name]. Reagents: [contained] (INTENT: [uppertext(user.a_intent)]) (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[user.x];Y=[user.y];Z=[user.z]'>JMP</a>)")
-
+			add_attack_logs(user,target,"Used [src.name] containing [contained]")
 
 			trans += reagents.trans_to_mob(target, min(amount_per_transfer_from_this, reagents.total_volume)/2, CHEM_INGEST) //Half injected, half ingested
 			trans += reagents.trans_to_mob(target, min(amount_per_transfer_from_this, reagents.total_volume), CHEM_BLOOD) //I guess it gets into the bloodstream through the eyes or something

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -105,9 +105,8 @@
 				user.setClickCooldown(user.get_attack_speed(src))
 				if(!do_mob(user, M)) return
 
-				M.attack_log += text("\[[time_stamp()]\] <font color='orange'>Has been fed [src.name] by [user.name] ([user.ckey]) Reagents: [reagentlist(src)]</font>")
-				user.attack_log += text("\[[time_stamp()]\] <font color='red'>Fed [src.name] by [M.name] ([M.ckey]) Reagents: [reagentlist(src)]</font>")
-				msg_admin_attack("[key_name(user)] fed [key_name(M)] with [src.name] Reagents: [reagentlist(src)] (INTENT: [uppertext(user.a_intent)])")
+				//Do we really care about this
+				add_attack_logs(user,M,"Fed with [src.name] containing [reagentlist(src)]", admin_notify = FALSE)
 
 				user.visible_message("<span class='danger'>[user] feeds [M] [src].</span>")
 

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -59,7 +59,7 @@
 	if(M.reagents)
 		var/contained = reagentlist()
 		var/trans = reagents.trans_to_mob(M, amount_per_transfer_from_this, CHEM_BLOOD)
-		admin_inject_log(user, M, src, contained, trans)
+		add_attack_logs(user,M,"Injected with [src.name] containing [contained], trasferred [trans] units")
 		to_chat(user, "<span class='notice'>[trans] units injected. [reagents.total_volume] units remaining in \the [src].</span>")
 
 	return

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -59,9 +59,7 @@
 		user.visible_message("<span class='warning'>[user] forces [M] to swallow \the [src].</span>")
 
 		var/contained = reagentlist()
-		M.attack_log += text("\[[time_stamp()]\] <font color='orange'>Has been fed [name] by [key_name(user)] Reagents: [contained]</font>")
-		user.attack_log += text("\[[time_stamp()]\] <font color='red'>Fed [name] to [key_name(M)] Reagents: [contained]</font>")
-		msg_admin_attack("[key_name_admin(user)] fed [key_name_admin(M)] with [name] Reagents: [contained] (INTENT: [uppertext(user.a_intent)]) (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[user.x];Y=[user.y];Z=[user.z]'>JMP</a>)")
+		add_attack_logs(user,M,"Fed a pill containing [contained]")
 
 		if(reagents && reagents.total_volume)
 			reagents.trans_to_mob(M, reagents.total_volume, CHEM_INGEST)
@@ -80,8 +78,7 @@
 			return
 		to_chat(user, "<span class='notice'>You dissolve \the [src] in [target].</span>")
 
-		user.attack_log += text("\[[time_stamp()]\] <font color='red'>Spiked \a [target] with a pill. Reagents: [reagentlist()]</font>")
-		msg_admin_attack("[user.name] ([user.ckey]) spiked \a [target] with a pill. Reagents: [reagentlist()] (INTENT: [uppertext(user.a_intent)]) (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[user.x];Y=[user.y];Z=[user.z]'>JMP</a>)")
+		add_attack_logs(user,null,"Spiked [target.name] with a pill containing [reagentlist()]")
 
 		reagents.trans_to(target, reagents.total_volume)
 		for(var/mob/O in viewers(2, user))

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -216,7 +216,7 @@
 			if(trans)
 				to_chat(user, "<span class='notice'>You inject [trans] units of the solution. The syringe now contains [src.reagents.total_volume] units.</span>")
 				if(ismob(target))
-					admin_inject_log(user, target, src, contained, trans)
+					add_attack_logs(user,target,"Injected with [src.name] containing [contained], trasferred [trans] units")
 			else
 				to_chat(user, "<span class='notice'>The syringe is empty.</span>")
 			if (reagents.total_volume <= 0 && mode == SYRINGE_INJECT)
@@ -275,9 +275,7 @@
 			user.remove_from_mob(src)
 			qdel(src)
 
-			user.attack_log += "\[[time_stamp()]\]<font color='red'> Attacked [target.name] ([target.ckey]) with \the [src] (INTENT: HARM).</font>"
-			target.attack_log += "\[[time_stamp()]\]<font color='orange'> Attacked by [user.name] ([user.ckey]) with [src.name] (INTENT: HARM).</font>"
-			msg_admin_attack("[key_name_admin(user)] attacked [key_name_admin(target)] with [src.name] (INTENT: HARM) (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[user.x];Y=[user.y];Z=[user.z]'>JMP</a>)")
+			add_attack_logs(user,target,"Syringe harmclick")
 
 			return
 
@@ -293,10 +291,10 @@
 
 
 	var/syringestab_amount_transferred = rand(0, (reagents.total_volume - 5)) //nerfed by popular demand
-	var/contained_reagents = reagents.get_reagents()
+	var/contained = reagents.get_reagents()
 	var/trans = reagents.trans_to_mob(target, syringestab_amount_transferred, CHEM_BLOOD)
 	if(isnull(trans)) trans = 0
-	admin_inject_log(user, target, src, contained_reagents, trans, violent=1)
+	add_attack_logs(user,target,"Stabbed with [src.name] containing [contained], trasferred [trans] units")
 	break_syringe(target, user)
 
 /obj/item/weapon/reagent_containers/syringe/proc/break_syringe(mob/living/carbon/target, mob/living/carbon/user)

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -130,9 +130,8 @@
 				for (var/mob/C in viewers(src))
 					C.show_message("<font color='red'>[GM.name] has been placed in the [src] by [user].</font>", 3)
 				qdel(G)
-				usr.attack_log += text("\[[time_stamp()]\] <font color='red'>Has placed [GM.name] ([GM.ckey]) in disposals.</font>")
-				GM.attack_log += text("\[[time_stamp()]\] <font color='orange'>Has been placed in disposals by [usr.name] ([usr.ckey])</font>")
-				msg_admin_attack("[usr] ([usr.ckey]) placed [GM] ([GM.ckey]) in a disposals unit. (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[usr.x];Y=[usr.y];Z=[usr.z]'>JMP</a>)")
+				
+				add_attack_logs(user,GM,"Disposals dunked")
 		return
 
 	if(isrobot(user))
@@ -185,9 +184,7 @@
 		msg = "[user.name] stuffs [target.name] into the [src]!"
 		user << "You stuff [target.name] into the [src]!"
 
-		user.attack_log += text("\[[time_stamp()]\] <font color='red'>Has placed [target.name] ([target.ckey]) in disposals.</font>")
-		target.attack_log += text("\[[time_stamp()]\] <font color='orange'>Has been placed in disposals by [user.name] ([user.ckey])</font>")
-		msg_admin_attack("[user] ([user.ckey]) placed [target] ([target.ckey]) in a disposals unit. (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[user.x];Y=[user.y];Z=[user.z]'>JMP</a>)")
+		add_attack_logs(user,target,"Disposals dunked")
 	else
 		return
 	if (target.client)

--- a/code/modules/vehicles/cargo_train.dm
+++ b/code/modules/vehicles/cargo_train.dm
@@ -164,8 +164,8 @@
 		var/mob/living/carbon/human/D = load
 		D << "<font color='red'><B>You ran over [H]!</B></font>"
 		visible_message("<B><font color='red'>\The [src] ran over [H]!</B></font>")
+		add_attack_logs(D,H,"Ran over with [src.name]")
 		attack_log += text("\[[time_stamp()]\] <font color='red'>ran over [H.name] ([H.ckey]), driven by [D.name] ([D.ckey])</font>")
-		msg_admin_attack("[D.name] ([D.ckey]) ran over [H.name] ([H.ckey]). (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[src.x];Y=[src.y];Z=[src.z]'>JMP</a>)")
 	else
 		attack_log += text("\[[time_stamp()]\] <font color='red'>ran over [H.name] ([H.ckey])</font>")
 

--- a/code/modules/vehicles/train.dm
+++ b/code/modules/vehicles/train.dm
@@ -56,7 +56,7 @@
 			if(istype(load, /mob/living/carbon/human))
 				var/mob/living/D = load
 				D << "<font color='red'>You hit [M]!</font>"
-				msg_admin_attack("[D.name] ([D.ckey]) hit [M.name] ([M.ckey]) with [src]. (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[src.x];Y=[src.y];Z=[src.z]'>JMP</a>)")
+				add_attack_logs(D,M,"Ran over with [src.name]")
 
 
 //-------------------------------------------

--- a/code/modules/xenoarcheaology/tools/ano_device_battery.dm
+++ b/code/modules/xenoarcheaology/tools/ano_device_battery.dm
@@ -209,6 +209,4 @@
 	M.lastattacker = user
 
 	if(inserted_battery.battery_effect)
-		user.attack_log += "\[[time_stamp()]\]<font color='red'> Tapped [M.name] ([M.ckey]) with [name] (EFFECT: [inserted_battery.battery_effect.name])</font>"
-		M.attack_log += "\[[time_stamp()]\]<font color='orange'> Tapped by [user.name] ([user.ckey]) with [name] (EFFECT: [inserted_battery.battery_effect.name])</font>"
-		msg_admin_attack("[key_name(user)] tapped [key_name(M)] with [name] (EFFECT: [inserted_battery.battery_effect.name])" )
+		add_attack_logs(user,M,"Anobattery tap ([inserted_battery.battery_effect.name])")

--- a/code/world.dm
+++ b/code/world.dm
@@ -144,7 +144,7 @@ var/world_topic_spam_protect_ip = "0.0.0.0"
 var/world_topic_spam_protect_time = world.timeofday
 
 /world/Topic(T, addr, master, key)
-	diary << "TOPIC: \"[T]\", from:[addr], master:[master], key:[key][log_end]"
+	debug_log << "TOPIC: \"[T]\", from:[addr], master:[master], key:[key][log_end]"
 
 	if (T == "ping")
 		var/x = 1

--- a/code/world.dm
+++ b/code/world.dm
@@ -42,10 +42,12 @@ var/global/datum/global_init/init = new ()
 /world/New()
 	world.log << "Map Loading Complete"
 	//logs
-	var/date_string = time2text(world.realtime, "YYYY/MM-Month/DD-Day")
-	href_logfile = file("data/logs/[date_string] hrefs.htm")
-	diary = file("data/logs/[date_string].log")
-	diary << "[log_end]\n[log_end]\nStarting up. [time2text(world.timeofday, "hh:mm.ss")][log_end]\n---------------------[log_end]"
+	log_path += time2text(world.realtime, "YYYY/MM-Month/DD-Day/round-hh-mm-ss")
+	diary = file("[log_path].log")
+	href_logfile = file("[log_path]-hrefs.htm")
+	error_log = file("[log_path]-error.log")
+	debug_log = file("[log_path]-debug.log")
+	debug_log << "[log_end]\n[log_end]\nStarting up. [time_stamp()][log_end]\n---------------------[log_end]"
 	changelog_hash = md5('html/changelog.html')					//used for telling if the changelog has changed recently
 
 	if(byond_version < RECOMMENDED_VERSION)


### PR DESCRIPTION
Ports VOREStation/VOREStation#3204  and the subsequent PRs that enhanced it:
VOREStation/VOREStation#3211 - Puts topic logging into debug log to get it out of the way.
VOREStation/VOREStation#3219 - Makes logging about engine stuff consistent too.
VOREStation/VOREStation#3223 - Fixes issue from final production testing.

### summary
Previously, logging would occur using shift time on everything, even runtimes. Why this was the case, I have no idea. I don't understand why it would do that. Now we log with ISO 8601 timestamps at the start of every line, and we log in a consistent manner easily parsable by 3rd party log inspection tools.

When you want to log attack stuff, use `add_attack_logs(attacker,defender,"What happened",admin_notify = TRUE)`

Everything else is things like `log_say(message,speaker)`

### Developer Notes
With this change, logging out put is improved in a few ways
- Each round now has a separate new logfile instead of appending to previous round on the same day!
- Some logging is logged into separate files, like runtimes and init and qdel stuff.
- Logging format is far more standardized.  This allows you to use tools like splunk to parse logs and actually read them.
- Using attack logs is far cleaner.  No longer must you use 5 lines of code every time you want to do attack logging.