### PR TITLE
[PORT] Cleans up Humanoid Hiding

### DIFF
--- a/code/__defines/mobs.dm
+++ b/code/__defines/mobs.dm
@@ -9,6 +9,7 @@
 #define CANPARALYSE 0x4
 #define CANPUSH     0x8
 #define LEAPING     0x10
+#define HIDING		0x20
 #define PASSEMOTES  0x32    // Mob has a cortical borer or holders inside of it that need to see emotes.
 #define GODMODE     0x1000
 #define FAKEDEATH   0x2000  // Replaces stuff like changeling.changeling_fakedeath.

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -17,7 +17,6 @@
 	var/last_spit = 0 					//Timestamp.
 
 	var/can_defib = 1					//Horrible damage (like beheadings) will prevent defibbing organics.
-	var/hiding = 0						// If the mob is hiding or not. Makes them appear under tables and the like.
 	var/active_regen = FALSE //Used for the regenerate proc in human_powers.dm
 	var/active_regen_delay = 300
 
@@ -42,7 +41,7 @@
 	nutrition = rand(200,400)
 
 	human_mob_list |= src
-	
+
 	..()
 
 	hide_underwear.Cut()
@@ -1029,7 +1028,7 @@
 	else
 		bloody_hands = 0
 		germ_level = 0
-	
+
 	//Sometimes do shoes if asked (or feet if no shoes)
 	if(washshoes && shoes)
 		shoes.clean_blood()
@@ -1039,7 +1038,7 @@
 		LAZYCLEARLIST(feet_blood_DNA)
 		feet_blood_DNA = null
 		feet_blood_color = null
-	
+
 	update_bloodied()
 
 /mob/living/carbon/human/get_visible_implants(var/class = 0)
@@ -1558,8 +1557,8 @@
 		equip_to_appropriate_slot(permit) // If for some reason it can't find room, it'll still be on the floor.
 
 /mob/living/carbon/human/proc/update_icon_special() //For things such as teshari hiding and whatnot.
-	if(hiding) // Hiding? Carry on.
+	if(status_flags & HIDING) // Hiding? Carry on.
 		if(stat == DEAD || paralysis || weakened || stunned) //stunned/knocked down by something that isn't the rest verb? Note: This was tried with INCAPACITATION_STUNNED, but that refused to work.
-			hiding = FALSE //No hiding for you. Mob layer should be updated naturally, but it actually doesn't.
+			status_flags &= ~HIDING //No hiding for you. Mob layer should be updated naturally, but it actually isn't.
 		else
 			layer = HIDING_LAYER

--- a/code/modules/mob/living/carbon/human/human_powers.dm
+++ b/code/modules/mob/living/carbon/human/human_powers.dm
@@ -282,17 +282,17 @@
 
 /mob/living/carbon/human/proc/hide_humanoid()
 	set name = "Hide"
-	set desc = "Allows to hide beneath tables or certain items. Toggled on or off."
+	set desc = "Allows you to hide beneath tables or certain items. Toggled on or off."
 	set category = "Abilities"
 
-	if(stat == DEAD || paralysis || weakened || stunned) // No hiding if you're stunned!
+	if(stat == DEAD || paralysis || weakened || stunned || restrained()) // No hiding if you're stunned!
 		return
 
-	if (!hiding)
-		layer = 2.45 //Just above cables with their 2.44
-		hiding = 1
-		to_chat(src, "<font color='blue'>You are now hiding.</font>")
-	else
+	if(status_flags & HIDING)
 		layer = MOB_LAYER
-		hiding = 0
 		to_chat(src, "<font color='blue'>You have stopped hiding.</font>")
+	else
+		layer = HIDING_LAYER //Just above cables with their 2.44
+		to_chat(src, "<font color='blue'>You are now hiding.</font>")
+
+	status_flags ^= HIDING

--- a/code/modules/mob/living/living_powers.dm
+++ b/code/modules/mob/living/living_powers.dm
@@ -6,9 +6,9 @@
 	if(stat == DEAD || paralysis || weakened || stunned || restrained())
 		return
 
-	if(layer != HIDING_LAYER)
-		layer = HIDING_LAYER //Just above cables with their 2.44
-		src << text("<font color='blue'>You are now hiding.</font>")
-	else
+	if(layer == HIDING_LAYER)
 		layer = MOB_LAYER
 		src << text("<font color='blue'>You have stopped hiding.</font>")
+	else
+		layer = HIDING_LAYER //Just above cables with their 2.44
+		src << text("<font color='blue'>You are now hiding.</font>")

--- a/code/modules/mob/living/living_powers.dm
+++ b/code/modules/mob/living/living_powers.dm
@@ -6,8 +6,8 @@
 	if(stat == DEAD || paralysis || weakened || stunned || restrained())
 		return
 
-	if (layer != 2.45)
-		layer = 2.45 //Just above cables with their 2.44
+	if(layer != HIDING_LAYER)
+		layer = HIDING_LAYER //Just above cables with their 2.44
 		src << text("<font color='blue'>You are now hiding.</font>")
 	else
 		layer = MOB_LAYER


### PR DESCRIPTION
Ports the humanoid hiding cleanup from https://github.com/VOREStation/VOREStation/pull/3234
- Refactors humanoid hiding to use `status_flags` and a define rather than a snowflake variable.
- Swaps a magic number for a define.
- Amends the humanoid hiding eligibility check.