### PR TITLE
Makes coffee milkshakes STOP KILLING PEOPLE 

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
@@ -450,8 +450,8 @@
 	if(adj_temp < 0 && M.bodytemperature > 310)
 		M.bodytemperature = min(310, M.bodytemperature - (adj_temp * TEMPERATURE_DAMAGE_COEFFICIENT))
 
-/datum/reagent/drink/overdose(var/mob/living/carbon/M, var/alien) //Added this is a failsafe, as coffee milkshakes were FUCKING KILLING PEOPLE
-	M.make_jittery(5)
+/datum/reagent/drink/overdose(var/mob/living/carbon/M, var/alien) //Add special interactions here in the future if desired.
+	..()
 
 // Juices
 
@@ -1047,10 +1047,13 @@
 	adj_dizzy = -5
 	adj_drowsy = -3
 	adj_sleepy = -2
-	overdose = 45
+	
 
 	glass_name = "Coffee Milkshake"
 	glass_desc = "An energizing coffee milkshake, perfect for hot days at work.."
+
+/datum/reagent/drink/milkshake/coffeeshake/overdose(var/mob/living/carbon/M, var/alien)
+	M.make_jittery(5) 
 
 /datum/reagent/drink/rewriter
 	name = "Rewriter"

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
@@ -450,6 +450,9 @@
 	if(adj_temp < 0 && M.bodytemperature > 310)
 		M.bodytemperature = min(310, M.bodytemperature - (adj_temp * TEMPERATURE_DAMAGE_COEFFICIENT))
 
+/datum/reagent/drink/overdose(var/mob/living/carbon/M, var/alien) //Added this is a failsafe, as coffee milkshakes were FUCKING KILLING PEOPLE
+	M.make_jittery(5)
+
 // Juices
 
 /datum/reagent/drink/juice/banana


### PR DESCRIPTION
You see, coffeemilkshake had an overdose proc of 45.

However, it wasn't a child of coffee. This is due to milkshakes having special effects on Unathi and stuff like that.

This meant that having > 45u of coffeemilkshake would OD you. Sure! It'll just make you jittery then, right?

Nope. It _**FUCKING KILLS YOU**_ because it defaults to the /reagent OD since /drink doesn't have a OD set.

- This PR makes it future toxic drinks can have an OD and call back to the reagent OD instead via having the overdose proc for /drinks calls ..(). This can also be edited in the future.

- Gave coffeemilkshake a specific OD proc.