### PR TITLE
Clean up diona-specific stuff in life.dm, move to its own section.

### DIFF
--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -850,28 +850,6 @@
 	if(status_flags & GODMODE)
 		return 0	//godmode
 
-	var/obj/item/organ/internal/diona/node/light_organ = locate() in internal_organs
-
-	if(!isSynthetic())
-		if(light_organ && !light_organ.is_broken())
-			var/light_amount = 0 //how much light there is in the place, affects receiving nutrition and healing
-			if(isturf(loc)) //else, there's considered to be no light
-				var/turf/T = loc
-				light_amount = T.get_lumcount() * 10
-			nutrition += light_amount
-			traumatic_shock -= light_amount
-
-			if(species.flags & IS_PLANT)
-				if(nutrition > 450)
-					nutrition = 450
-
-				if(light_amount >= 3) //if there's enough light, heal
-					adjustBruteLoss(-(round(light_amount/2)))
-					adjustFireLoss(-(round(light_amount/2)))
-					adjustToxLoss(-(light_amount))
-					adjustOxyLoss(-(light_amount))
-					//TODO: heal wounds, heal broken limbs.
-
 	if(species.light_dam)
 		var/light_amount = 0
 		if(isturf(loc))
@@ -898,14 +876,6 @@
 	else
 		if(overeatduration > 1)
 			overeatduration -= 2 //doubled the unfat rate
-
-	if(!isSynthetic() && (species.flags & IS_PLANT) && (!light_organ || light_organ.is_broken()))
-		if(nutrition < 200)
-			take_overall_damage(2,0)
-
-			//traumatic_shock is updated every tick, incrementing that is pointless - shock_stage is the counter.
-			//Not that it matters much for diona, who have NO_PAIN.
-			shock_stage++
 
 	// TODO: stomach and bloodstream organ.
 	if(!isSynthetic())

--- a/code/modules/mob/living/carbon/human/species/station/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station.dm
@@ -405,3 +405,33 @@
 			qdel(D)
 
 	H.visible_message("<span class='danger'>\The [H] splits apart with a wet slithering noise!</span>")
+
+/datum/species/diona/handle_environment_special(var/mob/living/carbon/human/H)
+	if(H.inStasisNow())
+		return
+
+	var/obj/item/organ/internal/diona/node/light_organ = locate() in H.internal_organs
+
+	if(light_organ && !light_organ.is_broken())
+		var/light_amount = 0 //how much light there is in the place, affects receiving nutrition and healing
+		if(isturf(H.loc)) //else, there's considered to be no light
+			var/turf/T = H.loc
+			light_amount = T.get_lumcount() * 10
+		H.nutrition += light_amount
+		H.shock_stage -= light_amount
+
+		if(H.nutrition > 450)
+			H.nutrition = 450
+		if(light_amount >= 3) //if there's enough light, heal
+			H.adjustBruteLoss(-(round(light_amount/2)))
+			H.adjustFireLoss(-(round(light_amount/2)))
+			H.adjustToxLoss(-(light_amount))
+			H.adjustOxyLoss(-(light_amount))
+			//TODO: heal wounds, heal broken limbs.
+
+	else if(H.nutrition < 200)
+		H.take_overall_damage(2,0)
+
+		//traumatic_shock is updated every tick, incrementing that is pointless - shock_stage is the counter.
+		//Not that it matters much for diona, who have NO_PAIN.
+		H.shock_stage++


### PR DESCRIPTION
Removes diona light organ checks and is_plant related checks that exist only for diona from life.dm and puts them into handle_environment_special instead.

Reasons:

1. Seems silly to have every /human mob check for a plant specific organ every life tick, never mind all the other checks like repeatedly checking issynthetic.

2. handle_chemicals_in_body isn't the right place for environmental checks.

3. I'm hoping to write a plant species downstream (think tg podpeople) and use the IS_PLANT tag for things like somatoray reactions, but _not_ have their tanky regen hardwired right into their life() ticks. You guys probably don't care about that part so much but it's a general maintainability thing.