### PR TITLE
Cache dips new mannequins for fresh observers

### DIFF
--- a/code/modules/mob/living/carbon/human/human_species.dm
+++ b/code/modules/mob/living/carbon/human/human_species.dm
@@ -9,6 +9,7 @@
 	living_mob_list -= src
 	dead_mob_list -= src
 	delete_inventory()
+	update_icons_body()
 
 /mob/living/carbon/human/skrell/New(var/new_loc)
 	h_style = "Skrell Short Tentacles"


### PR DESCRIPTION
Found another slightly different crash bugson by simply observing without having done any icon generation relevant things prior. (such as opening char setup for refreshed previews etc.) Immediately crashed myself first, and then literally everyone else I passed by.
Found out recently updated observer join copies the ghost appearance directly from a new mannequin deleted right afterwards, and there was no room for body icon caching inbetween or something that way. The mannequin mob preparations only had the icon updates for worn gear before deletion.