### PR TITLE
VOREStation Ports Catchup

### DIFF
--- a/code/__defines/mobs.dm
+++ b/code/__defines/mobs.dm
@@ -10,7 +10,7 @@
 #define CANPUSH     0x8
 #define LEAPING     0x10
 #define HIDING		0x20
-#define PASSEMOTES  0x32    // Mob has a cortical borer or holders inside of it that need to see emotes.
+#define PASSEMOTES  0x40    // Mob has a cortical borer or holders inside of it that need to see emotes.
 #define GODMODE     0x1000
 #define FAKEDEATH   0x2000  // Replaces stuff like changeling.changeling_fakedeath.
 #define DISFIGURED  0x4000  // Set but never checked. Remove this sometime and replace occurences with the appropriate organ code

--- a/code/_helpers/logging.dm
+++ b/code/_helpers/logging.dm
@@ -25,6 +25,11 @@
 	if (config.log_admin)
 		diary << "\[[time_stamp()]]ADMIN: [text][log_end]"
 
+/proc/log_adminpm(text, client/source, client/dest)
+	admin_log.Add(text)
+	if (config.log_admin)
+		diary << "\[[time_stamp()]]ADMINPM: [key_name(source)]->[key_name(dest)]: [html_decode(text)][log_end]"
+
 /proc/log_debug(text)
 	if (config.log_debug)
 		debug_log << "\[[time_stamp()]]DEBUG: [text][log_end]"

--- a/code/game/gamemodes/changeling/powers/revive.dm
+++ b/code/game/gamemodes/changeling/powers/revive.dm
@@ -33,7 +33,7 @@
 		H.restore_all_organs(ignore_prosthetic_prefs=1) //Covers things like fractures and other things not covered by the above.
 		H.restore_blood()
 		H.mutations.Remove(HUSK)
-		H.status_flags -= DISFIGURED
+		H.status_flags &= ~DISFIGURED
 		H.update_icons_body()
 		for(var/limb in H.organs_by_name)
 			var/obj/item/organ/external/current_limb = H.organs_by_name[limb]

--- a/code/game/objects/items/devices/communicator/UI.dm
+++ b/code/game/objects/items/devices/communicator/UI.dm
@@ -134,11 +134,7 @@
 	if(href_list["rename"])
 		var/new_name = sanitizeSafe(input(usr,"Please enter your name.","Communicator",usr.name) )
 		if(new_name)
-			owner = new_name
-			name = "[owner]'s [initial(name)]"
-			if(camera)
-				camera.name = name
-				camera.c_tag = name
+			register_device(new_name)
 
 	if(href_list["toggle_visibility"])
 		switch(network_visibility)

--- a/code/game/objects/items/devices/communicator/communicator.dm
+++ b/code/game/objects/items/devices/communicator/communicator.dm
@@ -75,12 +75,12 @@ var/global/list/obj/item/device/communicator/all_communicators = list()
 	//This is a pretty terrible way of doing this.
 	spawn(5 SECONDS) //Wait for our mob to finish spawning.
 		if(ismob(loc))
-			register_device(loc)
+			register_device(loc.name)
 			initialize_exonet(loc)
 		else if(istype(loc, /obj/item/weapon/storage))
 			var/obj/item/weapon/storage/S = loc
 			if(ismob(S.loc))
-				register_device(S.loc)
+				register_device(S.loc.name)
 				initialize_exonet(S.loc)
 
 // Proc: examine()
@@ -268,12 +268,12 @@ var/global/list/obj/item/device/communicator/all_communicators = list()
 // Proc: register_device()
 // Parameters: 1 (user - the person to use their name for)
 // Description: Updates the owner's name and the device's name.
-/obj/item/device/communicator/proc/register_device(mob/user)
-	if(!user)
+/obj/item/device/communicator/proc/register_device(new_name)
+	if(!new_name)
 		return
-	owner = user.name
+	owner = new_name
 
-	name = "[owner]'s [initial(name)]"
+	name = "[new_name]'s [initial(name)]"
 	if(camera)
 		camera.name = name
 		camera.c_tag = name

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -6,7 +6,7 @@ var/global/floorIsLava = 0
 ////////////////////////////////
 /proc/message_admins(var/msg)
 	msg = "<span class=\"log_message\"><span class=\"prefix\">ADMIN LOG:</span> <span class=\"message\">[msg]</span></span>"
-	log_adminwarn(msg)
+	//log_adminwarn(msg) //log_and_message_admins is for this
 	for(var/client/C in admins)
 		if((R_ADMIN|R_MOD) & C.holder.rights)
 			C << msg

--- a/code/modules/admin/verbs/adminpm.dm
+++ b/code/modules/admin/verbs/adminpm.dm
@@ -104,7 +104,7 @@
 	if(C.is_preference_enabled(/datum/client_preference/holder/play_adminhelp_ping))
 		C << 'sound/effects/adminhelp.ogg'
 
-	log_admin("PM: [key_name(src)]->[key_name(C)]: [msg]")
+	log_adminpm(msg,src,C)
 	send2adminirc("Reply: [key_name(src)]->[key_name(C)]: [html_decode(msg)]")
 
 	//we don't use message_admins here because the sender/receiver might get it too

--- a/code/modules/client/preference_setup/general/03_body.dm
+++ b/code/modules/client/preference_setup/general/03_body.dm
@@ -741,7 +741,15 @@ var/global/list/valid_bloodtypes = list("A+", "A-", "B+", "B-", "AB+", "AB-", "O
 	dat += "<b>Language:</b> [current_species.species_language]<br/>"
 	dat += "<small>"
 	if(current_species.spawn_flags & SPECIES_CAN_JOIN)
-		dat += "</br><b>Often present on human stations.</b>"
+		switch(current_species.rarity_value)
+			if(1 to 2)
+				dat += "</br><b>Often present on human stations.</b>"
+			if(3 to 4)
+				dat += "</br><b>Rarely present on human stations.</b>"
+			if(5)
+				dat += "</br><b>Unheard of on human stations.</b>"
+			else
+				dat += "</br><b>May be present on human stations.</b>"
 	if(current_species.spawn_flags & SPECIES_IS_WHITELISTED)
 		dat += "</br><b>Whitelist restricted.</b>"
 	if(!current_species.has_organ[O_HEART])

--- a/code/modules/client/preference_setup/occupation/occupation.dm
+++ b/code/modules/client/preference_setup/occupation/occupation.dm
@@ -94,7 +94,7 @@
 		if(job.minimum_character_age && user.client && (user.client.prefs.age < job.minimum_character_age))
 			. += "<del>[rank]</del></td><td> \[MINIMUM CHARACTER AGE: [job.minimum_character_age]]</td></tr>"
 			continue
-		if((pref.job_civilian_low & ASSISTANT) && (rank != "Assistant"))
+		if((pref.job_civilian_low & ASSISTANT) && job.flag != ASSISTANT)
 			. += "<font color=grey>[rank]</font></td><td></td></tr>"
 			continue
 		if((rank in command_positions) || (rank == "AI"))//Bold head jobs
@@ -106,7 +106,7 @@
 
 		. += "<a href='?src=\ref[src];set_job=[rank]'>"
 
-		if(rank == "Assistant")//Assistant is special
+		if(job.flag == ASSISTANT)//Assistant is special
 			if(pref.job_civilian_low & ASSISTANT)
 				. += " <font color=55cc55>\[Yes]</font>"
 			else
@@ -180,7 +180,7 @@
 	if(!job)
 		return 0
 
-	if(role == "Assistant")
+	if(job.flag == ASSISTANT)
 		if(pref.job_civilian_low & job.flag)
 			pref.job_civilian_low &= ~job.flag
 		else

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -57,7 +57,7 @@
 	if (!..())
 		return 0
 
-	if(species_restricted && istype(M,/mob/living/carbon/human))
+	if(LAZYLEN(species_restricted) && istype(M,/mob/living/carbon/human))
 		var/exclusive = null
 		var/wearable = null
 		var/mob/living/carbon/human/H = M

--- a/code/modules/mob/animations.dm
+++ b/code/modules/mob/animations.dm
@@ -167,7 +167,17 @@ note dizziness decrements automatically in the mob's Life() proc.
 
 /mob/living/do_attack_animation(atom/A)
 	..()
-	is_floating = 0 // If we were without gravity, the bouncing animation got stopped, so we make sure we restart the bouncing after the next movement.
+	//Check for clients with pref enabled
+	var/list/viewing = list()
+	for(var/m in viewers(A))
+		var/mob/M = m
+		var/client/C = M.client
+		if(C && C.is_preference_enabled(/datum/client_preference/attack_icons))
+			viewing += M.client
+
+	//Animals attacking each other in the distance, probably. Forgeddaboutit.
+	if(!viewing.len)
+		return FALSE
 
 	// What icon do we use for the attack?
 	var/obj/used_item
@@ -179,6 +189,9 @@ note dizziness decrements automatically in the mob's Life() proc.
 	//Couldn't find an item, do they have a sprite specified (like animal claw stuff?)
 	if(!used_item && !(attack_icon && attack_icon_state))
 		return FALSE //Didn't find an item, not doing animation.
+
+	// If we were without gravity, the bouncing animation got stopped, so we make sure we restart the bouncing after the next movement.
+	is_floating = 0
 
 	var/image/I
 
@@ -192,13 +205,7 @@ note dizziness decrements automatically in the mob's Life() proc.
 		I = image(attack_icon, A, attack_icon_state, A.layer + 1)
 		I.dir = dir
 
-	//Check for clients with pref enabled
-	var/list/viewing = list()
-	for(var/m in viewers(A))
-		var/mob/M = m
-		var/client/C = M.client
-		if(C && C.is_preference_enabled(/datum/client_preference/attack_icons))
-			viewing += M.client
+	// Show the overlay to the clients
 	flick_overlay(I, viewing, 5, TRUE) // 5 ticks/half a second
 
 	// Set the direction of the icon animation.

--- a/code/modules/mob/freelook/chunk.dm
+++ b/code/modules/mob/freelook/chunk.dm
@@ -100,6 +100,7 @@
 	for(var/turf in visRemoved)
 		var/turf/t = turf
 		if(obscuredTurfs[t])
+			LAZYINITLIST(t.obfuscations)
 			if(!t.obfuscations[obfuscation.type])
 				var/image/ob_image = image(obfuscation.icon, t, obfuscation.icon_state, OBFUSCATION_LAYER)
 				ob_image.plane = PLANE_FULLSCREEN
@@ -141,6 +142,7 @@
 
 	for(var/turf in obscuredTurfs)
 		var/turf/t = turf
+		LAZYINITLIST(t.obfuscations)
 		if(!t.obfuscations[obfuscation.type])
 			var/image/ob_image = image(obfuscation.icon, t, obfuscation.icon_state, OBFUSCATION_LAYER)
 			ob_image.plane = PLANE_FULLSCREEN

--- a/code/modules/mob/freelook/update_triggers.dm
+++ b/code/modules/mob/freelook/update_triggers.dm
@@ -8,7 +8,7 @@
 			VN.updateVisibility(A, opacity_check)
 
 /turf
-	var/list/image/obfuscations = new()
+	var/list/image/obfuscations
 
 /turf/drain_power()
 	return -1

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -94,6 +94,8 @@
 				stat("Chemical Storage", mind.changeling.chem_charges)
 				stat("Genetic Damage Time", mind.changeling.geneticdamage)
 				stat("Re-Adaptations", "[mind.changeling.readapts]/[mind.changeling.max_readapts]")
+	if(species)
+		species.Stat(src)
 
 /mob/living/carbon/human/ex_act(severity)
 	if(!blinded)

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -1161,7 +1161,7 @@
 
 	else
 		sight &= ~(SEE_TURFS|SEE_MOBS|SEE_OBJS)
-		see_invisible = see_in_dark>2 ? SEE_INVISIBLE_LEVEL_ONE : SEE_INVISIBLE_LIVING
+		see_invisible = see_in_dark>2 ? SEE_INVISIBLE_LEVEL_ONE : see_invisible_default
 
 		if(XRAY in mutations)
 			sight |= SEE_TURFS|SEE_MOBS|SEE_OBJS
@@ -1173,7 +1173,7 @@
 			if(R && R.word1 == cultwords["see"] && R.word2 == cultwords["hell"] && R.word3 == cultwords["join"])
 				see_invisible = SEE_INVISIBLE_CULT
 			else
-				see_invisible = SEE_INVISIBLE_LIVING
+				see_invisible = see_invisible_default
 				seer = 0
 
 		if(!seedarkness)
@@ -1184,7 +1184,7 @@
 		else
 			sight = species.get_vision_flags(src)
 			see_in_dark = species.darksight
-			see_invisible = see_in_dark>2 ? SEE_INVISIBLE_LEVEL_ONE : SEE_INVISIBLE_LIVING
+			see_invisible = see_in_dark>2 ? SEE_INVISIBLE_LEVEL_ONE : see_invisible_default
 
 		var/tmp/glasses_processed = 0
 		var/obj/item/weapon/rig/rig = back
@@ -1205,7 +1205,7 @@
 		if(!glasses_processed && (species.get_vision_flags(src) > 0))
 			sight |= species.get_vision_flags(src)
 		if(!seer && !glasses_processed && seedarkness)
-			see_invisible = SEE_INVISIBLE_LIVING
+			see_invisible = see_invisible_default
 
 		if(healths)
 			if (chem_effects[CE_PAINKILLER] > 100)
@@ -1385,7 +1385,7 @@
 		if(G.see_invisible >= 0)
 			see_invisible = G.see_invisible
 		else if(!druggy && !seer)
-			see_invisible = SEE_INVISIBLE_LIVING
+			see_invisible = see_invisible_default
 
 /mob/living/carbon/human/handle_random_events()
 	if(inStasisNow())

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -422,3 +422,7 @@
 // Used to override normal fall behaviour. Use only when the species does fall down a level.
 /datum/species/proc/fall_impact_special(var/mob/living/carbon/human/H, var/atom/A)
 	return FALSE
+
+// Allow species to display interesting information in the human stat panels
+/datum/species/proc/Stat(var/mob/living/carbon/human/H)
+	return

--- a/code/modules/mob/living/carbon/metroid/life.dm
+++ b/code/modules/mob/living/carbon/metroid/life.dm
@@ -100,7 +100,7 @@
 		src.lying = 1
 		src.blinded = 1
 	else
-		if (src.paralysis || src.stunned || src.weakened || (status_flags && FAKEDEATH)) //Stunned etc.
+		if (src.paralysis || src.stunned || src.weakened || (status_flags & FAKEDEATH)) //Stunned etc.
 			if (src.stunned > 0)
 				src.stat = 0
 			if (src.weakened > 0)

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -55,5 +55,7 @@
 	var/glow_intensity = null
 	var/glow_color = "#FFFFFF"			// The color they're glowing!
 
+	var/see_invisible_default = SEE_INVISIBLE_LIVING
+
 	var/list/hud_list		//Holder for health hud, status hud, wanted hud, etc (not like inventory slots)
 	var/has_huds = FALSE	//Whether or not we should bother initializing the above list

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -359,7 +359,8 @@ proc/get_radio_key_from_channel(var/channel)
 			var/list/clients_from_image = images_to_clients[I]
 			for(var/client in clients_from_image)
 				var/client/C = client
-				C.images -= I
+				if(C) //Could have disconnected after message sent, before removing bubble.
+					C.images -= I
 			qdel(I)
 
 	//Log the message to file

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -258,7 +258,7 @@ var/list/ai_verbs_default = list(
 		aiPDA.name = pickedName + " (" + aiPDA.ownjob + ")"
 
 	if(aiCommunicator)
-		aiCommunicator.register_device(src)
+		aiCommunicator.register_device(src.name)
 
 /*
 	The AI Power supply is a dummy object used for powering the AI since only machinery should be using power.

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -210,7 +210,7 @@
 /mob/living/silicon/robot/proc/setup_communicator()
 	if (!communicator)
 		communicator = new/obj/item/device/communicator/integrated(src)
-	communicator.register_device(src, "[modtype] [braintype]")
+	communicator.register_device(src.name, "[modtype] [braintype]")
 
 //If there's an MMI in the robot, have it ejected when the mob goes away. --NEO
 //Improved /N

--- a/code/modules/multiz/zshadow.dm
+++ b/code/modules/multiz/zshadow.dm
@@ -56,6 +56,7 @@
 	overlays = M.overlays
 	transform = M.transform
 	dir = M.dir
+	invisibility = M.invisibility
 	if(shadow)
 		shadow.sync_icon(src)
 


### PR DESCRIPTION
Catches up on minor fixes and refactors done on VOREStation over the past month.  These are all minor, no real feature changes or major bugs.

## Bugfixes
Quick bugfixes for assistant ->visitor/intern VOREStation/VOREStation#2902
Improve two image GC cleanups VOREStation/VOREStation#3096
Zshadows should be as invisible as their origin VOREStation/VOREStation#3105
say() safety check on client VOREStation/VOREStation#3111
Reduce double admin logs VOREStation/VOREStation#3226
"0x32" is not a valid single-bit flag VOREStation/VOREStation#3265

## Minor Refactors
Make turf obfuscation lists lazy VOREStation/VOREStation#3057
Allow alteration of mob default see_invisible VOREStation/VOREStation#3106
Communicator Refactor VOREStation/VOREStation#3242
Allow species-specific statpanels VOREStation/VOREStation#3246 
Lazylen species restricted list VOREStation/VOREStation#3309

## The one Tweak
UI Tweak involving species rarity VOREStation/VOREStation#3248

