### PR TITLE
Port Recharger Fixes

### DIFF
--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -289,7 +289,7 @@
 	set name = "Eject Recharger"
 	set src in oview(1)
 
-	if(usr.incapacitated())
+	if(usr.incapacitated() || !isliving(usr))
 		return
 
 	go_out()
@@ -301,8 +301,9 @@
 	set name = "Enter Recharger"
 	set src in oview(1)
 
-	if(!usr.incapacitated())
+	if(usr.incapacitated() || !isliving(usr))
 		return
+	
 	go_in(usr)
 
 /obj/machinery/recharge_station/ghost_pod_recharger

--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -115,7 +115,7 @@
 			H.adjustBrainLoss(-(rand(1,3)))
 
 		// Also recharge their internal battery.
-		if(!isnull(H.internal_organs_by_name["cell"]) && H.nutrition < 450)
+		if(H.isSynthetic() && H.nutrition < 450)
 			H.nutrition = min(H.nutrition+10, 450)
 			cell.use(7000/450*10)
 
@@ -263,17 +263,6 @@
 			return 1
 	else
 		return
-
-/obj/machinery/recharge_station/proc/hascell(var/mob/M)
-	if(isrobot(M))
-		var/mob/living/silicon/robot/R = M
-		if(R.cell)
-			return 1
-	if(ishuman(M))
-		var/mob/living/carbon/human/H = M
-		if(!isnull(H.internal_organs_by_name["cell"]))
-			return 1
-	return 0
 
 /obj/machinery/recharge_station/proc/go_out()
 	if(!occupant)

--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -254,7 +254,7 @@
 
 	else if(istype(L,  /mob/living/carbon/human))
 		var/mob/living/carbon/human/H = L
-		if(!isnull(H.internal_organs_by_name["cell"]))
+		if(H.isSynthetic())
 			add_fingerprint(H)
 			H.reset_view(src)
 			H.forceMove(src)


### PR DESCRIPTION
Ports some bugfixes to recharge stations to allow all sorts of borgs and robots and such to recharge without ghosts being able to eject them or runtimes.

Port of:
VOREStation/VOREStation#3208, VOREStation/VOREStation#3263, and VOREStation/VOREStation#3289