### PR TITLE
Removes some unnecessary hoops from head icon updates.

### DIFF
--- a/code/modules/organs/organ_icon.dm
+++ b/code/modules/organs/organ_icon.dm
@@ -61,7 +61,8 @@ var/global/list/limb_icon_cache = list()
 		var/datum/sprite_accessory/marking/mark_style = markings[M]["datum"]
 		var/icon/mark_s = new/icon("icon" = mark_style.icon, "icon_state" = "[mark_style.icon_state]-[organ_tag]")
 		mark_s.Blend(markings[M]["color"], ICON_ADD)
-		overlays |= mark_s //So when it's not on your body, it has icons
+		if(severed)
+			overlays |= mark_s //So when it's not on your body, it has icons
 		mob_icon.Blend(mark_s, ICON_OVERLAY) //So when it's on your body, it has icons
 		icon_cache_key += "[M][markings[M]["color"]]"
 
@@ -75,11 +76,13 @@ var/global/list/limb_icon_cache = list()
 			else
 				eyes_icon.Blend(rgb(128,0,0), ICON_ADD)
 			mob_icon.Blend(eyes_icon, ICON_OVERLAY)
-			overlays |= eyes_icon
+			if(severed)
+				overlays |= eyes_icon
 
 	if(owner.lip_style && (species && (species.appearance_flags & HAS_LIPS)))
 		var/icon/lip_icon = new/icon('icons/mob/human_face.dmi', "lips_[owner.lip_style]_s")
-		overlays |= lip_icon
+		if(severed)
+			overlays |= lip_icon
 		mob_icon.Blend(lip_icon, ICON_OVERLAY)
 
 	if(severed) //Properly applied on intact mobs at update_icons_body

--- a/code/modules/organs/organ_icon.dm
+++ b/code/modules/organs/organ_icon.dm
@@ -65,23 +65,24 @@ var/global/list/limb_icon_cache = list()
 		mob_icon.Blend(mark_s, ICON_OVERLAY) //So when it's on your body, it has icons
 		icon_cache_key += "[M][markings[M]["color"]]"
 
+
+	if(owner.should_have_organ(O_EYES))
+		var/obj/item/organ/internal/eyes/eyes = owner.internal_organs_by_name[O_EYES]
+		if(eye_icon)
+			var/icon/eyes_icon = new/icon(eye_icon_location, eye_icon)
+			if(eyes)
+				eyes_icon.Blend(rgb(eyes.eye_colour[1], eyes.eye_colour[2], eyes.eye_colour[3]), ICON_ADD)
+			else
+				eyes_icon.Blend(rgb(128,0,0), ICON_ADD)
+			mob_icon.Blend(eyes_icon, ICON_OVERLAY)
+			overlays |= eyes_icon
+
+	if(owner.lip_style && (species && (species.appearance_flags & HAS_LIPS)))
+		var/icon/lip_icon = new/icon('icons/mob/human_face.dmi', "lips_[owner.lip_style]_s")
+		overlays |= lip_icon
+		mob_icon.Blend(lip_icon, ICON_OVERLAY)
+
 	if(severed) //Properly applied on intact mobs at update_icons_body
-		if(owner.should_have_organ(O_EYES))
-			var/obj/item/organ/internal/eyes/eyes = owner.internal_organs_by_name[O_EYES]
-			if(eye_icon)
-				var/icon/eyes_icon = new/icon(eye_icon_location, eye_icon)
-				if(eyes)
-					eyes_icon.Blend(rgb(eyes.eye_colour[1], eyes.eye_colour[2], eyes.eye_colour[3]), ICON_ADD)
-				else
-					eyes_icon.Blend(rgb(128,0,0), ICON_ADD)
-				mob_icon.Blend(eyes_icon, ICON_OVERLAY)
-				overlays |= eyes_icon
-
-		if(owner.lip_style && (species && (species.appearance_flags & HAS_LIPS)))
-			var/icon/lip_icon = new/icon('icons/mob/human_face.dmi', "lips_[owner.lip_style]_s")
-			overlays |= lip_icon
-			mob_icon.Blend(lip_icon, ICON_OVERLAY)
-
 		if(owner.f_style)
 			var/datum/sprite_accessory/facial_hair_style = facial_hair_styles_list[owner.f_style]
 			if(facial_hair_style && facial_hair_style.species_allowed && (species.get_bodytype(owner) in facial_hair_style.species_allowed))

--- a/code/modules/organs/organ_icon.dm
+++ b/code/modules/organs/organ_icon.dm
@@ -55,21 +55,6 @@ var/global/list/limb_icon_cache = list()
 	overlays.Cut()
 	if(!owner || !owner.species)
 		return
-	if(owner.should_have_organ(O_EYES))
-		var/obj/item/organ/internal/eyes/eyes = owner.internal_organs_by_name[O_EYES]
-		if(eye_icon)
-			var/icon/eyes_icon = new/icon(eye_icon_location, eye_icon)
-			if(eyes)
-				eyes_icon.Blend(rgb(eyes.eye_colour[1], eyes.eye_colour[2], eyes.eye_colour[3]), ICON_ADD)
-			else
-				eyes_icon.Blend(rgb(128,0,0), ICON_ADD)
-			mob_icon.Blend(eyes_icon, ICON_OVERLAY)
-			overlays |= eyes_icon
-
-	if(owner.lip_style && (species && (species.appearance_flags & HAS_LIPS)))
-		var/icon/lip_icon = new/icon('icons/mob/human_face.dmi', "lips_[owner.lip_style]_s")
-		overlays |= lip_icon
-		mob_icon.Blend(lip_icon, ICON_OVERLAY)
 
 	//Head markings.
 	for(var/M in markings)
@@ -80,7 +65,23 @@ var/global/list/limb_icon_cache = list()
 		mob_icon.Blend(mark_s, ICON_OVERLAY) //So when it's on your body, it has icons
 		icon_cache_key += "[M][markings[M]["color"]]"
 
-	if(severed)
+	if(severed) //Properly applied on intact mobs at update_icons_body
+		if(owner.should_have_organ(O_EYES))
+			var/obj/item/organ/internal/eyes/eyes = owner.internal_organs_by_name[O_EYES]
+			if(eye_icon)
+				var/icon/eyes_icon = new/icon(eye_icon_location, eye_icon)
+				if(eyes)
+					eyes_icon.Blend(rgb(eyes.eye_colour[1], eyes.eye_colour[2], eyes.eye_colour[3]), ICON_ADD)
+				else
+					eyes_icon.Blend(rgb(128,0,0), ICON_ADD)
+				mob_icon.Blend(eyes_icon, ICON_OVERLAY)
+				overlays |= eyes_icon
+
+		if(owner.lip_style && (species && (species.appearance_flags & HAS_LIPS)))
+			var/icon/lip_icon = new/icon('icons/mob/human_face.dmi', "lips_[owner.lip_style]_s")
+			overlays |= lip_icon
+			mob_icon.Blend(lip_icon, ICON_OVERLAY)
+
 		if(owner.f_style)
 			var/datum/sprite_accessory/facial_hair_style = facial_hair_styles_list[owner.f_style]
 			if(facial_hair_style && facial_hair_style.species_allowed && (species.get_bodytype(owner) in facial_hair_style.species_allowed))

--- a/code/modules/organs/organ_icon.dm
+++ b/code/modules/organs/organ_icon.dm
@@ -49,7 +49,7 @@ var/global/list/limb_icon_cache = list()
 	var/obj/item/organ/internal/eyes/eyes = owner.internal_organs_by_name[O_EYES]
 	if(eyes) eyes.update_colour()
 
-/obj/item/organ/external/head/get_icon()
+/obj/item/organ/external/head/get_icon(var/severed = FALSE)
 
 	..()
 	overlays.Cut()
@@ -80,23 +80,24 @@ var/global/list/limb_icon_cache = list()
 		mob_icon.Blend(mark_s, ICON_OVERLAY) //So when it's on your body, it has icons
 		icon_cache_key += "[M][markings[M]["color"]]"
 
-	if(owner.f_style)
-		var/datum/sprite_accessory/facial_hair_style = facial_hair_styles_list[owner.f_style]
-		if(facial_hair_style && facial_hair_style.species_allowed && (species.get_bodytype(owner) in facial_hair_style.species_allowed))
-			var/icon/facial_s = new/icon("icon" = facial_hair_style.icon, "icon_state" = "[facial_hair_style.icon_state]_s")
-			if(facial_hair_style.do_colouration)
-				facial_s.Blend(rgb(owner.r_facial, owner.g_facial, owner.b_facial), ICON_ADD)
-			overlays |= facial_s
+	if(severed)
+		if(owner.f_style)
+			var/datum/sprite_accessory/facial_hair_style = facial_hair_styles_list[owner.f_style]
+			if(facial_hair_style && facial_hair_style.species_allowed && (species.get_bodytype(owner) in facial_hair_style.species_allowed))
+				var/icon/facial_s = new/icon("icon" = facial_hair_style.icon, "icon_state" = "[facial_hair_style.icon_state]_s")
+				if(facial_hair_style.do_colouration)
+					facial_s.Blend(rgb(owner.r_facial, owner.g_facial, owner.b_facial), ICON_ADD)
+				overlays |= facial_s
 
-	if(owner.h_style && !(owner.head && (owner.head.flags_inv & BLOCKHEADHAIR)))
-		var/datum/sprite_accessory/hair/hair_style = hair_styles_list[owner.h_style]
-		if(hair_style && (species.get_bodytype(owner) in hair_style.species_allowed))
-			var/icon/hair_s = new/icon("icon" = hair_style.icon, "icon_state" = "[hair_style.icon_state]_s")
-			var/icon/hair_s_add = new/icon("icon" = hair_style.icon_add, "icon_state" = "[hair_style.icon_state]_s")
-			if(hair_style.do_colouration && islist(h_col) && h_col.len >= 3)
-				hair_s.Blend(rgb(h_col[1], h_col[2], h_col[3]), ICON_MULTIPLY)
-				hair_s.Blend(hair_s_add, ICON_ADD)
-			overlays |= hair_s
+		if(owner.h_style && !(owner.head && (owner.head.flags_inv & BLOCKHEADHAIR)))
+			var/datum/sprite_accessory/hair/hair_style = hair_styles_list[owner.h_style]
+			if(hair_style && (species.get_bodytype(owner) in hair_style.species_allowed))
+				var/icon/hair_s = new/icon("icon" = hair_style.icon, "icon_state" = "[hair_style.icon_state]_s")
+				var/icon/hair_s_add = new/icon("icon" = hair_style.icon_add, "icon_state" = "[hair_style.icon_state]_s")
+				if(hair_style.do_colouration && islist(h_col) && h_col.len >= 3)
+					hair_s.Blend(rgb(h_col[1], h_col[2], h_col[3]), ICON_MULTIPLY)
+					hair_s.Blend(hair_s_add, ICON_ADD)
+				overlays |= hair_s
 
 	return mob_icon
 

--- a/code/modules/organs/subtypes/standard.dm
+++ b/code/modules/organs/subtypes/standard.dm
@@ -280,7 +280,7 @@
 		owner.drop_from_inventory(owner.wear_mask)
 		spawn(1)
 			owner.update_hair()
-	get_icon()
+	get_icon(severed = TRUE)
 	..()
 
 /obj/item/organ/external/head/take_damage(brute, burn, sharp, edge, used_weapon = null, list/forbidden_limbs = list())


### PR DESCRIPTION
-Now head organ's get_icon() only applies hair/beard overlays on dismembered heads. Intact heads get to use the proper mob layer system as they should without the heft of needless duping underneath.
-Also apparently happens to fix markings covering up eyes.