### PR TITLE
Re-establishes existing foundations for human icon construction

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1168,7 +1168,7 @@
 	if(!(gender in species.genders))
 		gender = species.genders[1]
 
-	icon_state = lowertext(species.name)
+	//icon_state = lowertext(species.name) //Necessary?
 
 	species.create_organs(src)
 


### PR DESCRIPTION
This line had no real use at all that I could find. It may even have contributed to various issues.
Before this line was added, all basic humanoid species have had their appearances constructed onto an _actually existing_ blank 32x32 icon_state named and called for as "nothing" inside the effects.dmi.
There are no untitled blanks either inside the effects.dmi file, so the funky deviant species specific icon_states would never have had any proper fallback either.

No negative effects whatsoever detected in testing runs. Maybe slight framerate increase, but that was likely unrelated/placebo lmao