### PR TITLE
Nanoui now supports use of multiple templates

### DIFF
--- a/code/modules/nano/nanoui.dm
+++ b/code/modules/nano/nanoui.dm
@@ -519,3 +519,8 @@ nanoui is used to open and update nano browser uis
   */
 /datum/nanoui/proc/update(var/force_open = 0)
 	src_object.ui_interact(user, ui_key, src, force_open, master_ui, state)
+
+/datum/nanoui/proc/append_template(var/key, var/filename)
+	add_template(key, filename)
+	open()
+	update(1)

--- a/nano/js/nano_state.js
+++ b/nano/js/nano_state.js
@@ -7,8 +7,7 @@ function NanoStateClass() {
 		return;
 	}
 	
-    this.key = this.key.toLowerCase();
-	
+	this.key = this.key.toLowerCase();
 	NanoStateManager.addState(this);*/
 }
 
@@ -18,108 +17,99 @@ NanoStateClass.prototype.contentRendered = false;
 NanoStateClass.prototype.mapInitialised = false;
 
 NanoStateClass.prototype.isCurrent = function () {
-    return NanoStateManager.getCurrentState() == this;
+	return NanoStateManager.getCurrentState() == this;
 };
 
 NanoStateClass.prototype.onAdd = function (previousState) {
-    // Do not add code here, add it to the 'default' state (nano_state_defaut.js) or create a new state and override this function
-
-    NanoBaseCallbacks.addCallbacks();
-    NanoBaseHelpers.addHelpers();
+	// Do not add code here, add it to the 'default' state (nano_state_defaut.js) or create a new state and override this function
+	NanoBaseCallbacks.addCallbacks();
+	NanoBaseHelpers.addHelpers();
 };
 
 NanoStateClass.prototype.onRemove = function (nextState) {
-    // Do not add code here, add it to the 'default' state (nano_state_defaut.js) or create a new state and override this function
-
-    NanoBaseCallbacks.removeCallbacks();
-    NanoBaseHelpers.removeHelpers();
+	// Do not add code here, add it to the 'default' state (nano_state_defaut.js) or create a new state and override this function
+	NanoBaseCallbacks.removeCallbacks();
+	NanoBaseHelpers.removeHelpers();
 };
 
 NanoStateClass.prototype.onBeforeUpdate = function (data) {
-    // Do not add code here, add it to the 'default' state (nano_state_defaut.js) or create a new state and override this function
-
-    data = NanoStateManager.executeBeforeUpdateCallbacks(data);
-
-    return data; // Return data to continue, return false to prevent onUpdate and onAfterUpdate
+	// Do not add code here, add it to the 'default' state (nano_state_defaut.js) or create a new state and override this function
+	data = NanoStateManager.executeBeforeUpdateCallbacks(data);
+	return data; // Return data to continue, return false to prevent onUpdate and onAfterUpdate
 };
 
 NanoStateClass.prototype.onUpdate = function (data) {
-    // Do not add code here, add it to the 'default' state (nano_state_defaut.js) or create a new state and override this function
-
-    try
-    {
-        if (!this.layoutRendered || (data['config'].hasOwnProperty('autoUpdateLayout') && data['config']['autoUpdateLayout']))
-        {
-            $("#uiLayout").html(NanoTemplate.parse('layout', data)); // render the 'mail' template to the #mainTemplate div
-            this.layoutRendered = true;
-        }
-        if (!this.contentRendered || (data['config'].hasOwnProperty('autoUpdateContent') && data['config']['autoUpdateContent']))
-        {
-			var content = "";// = "<div>" + JSON.stringify(NanoTemplate.getKeys()) + "</div>";
+	// Do not add code here, add it to the 'default' state (nano_state_defaut.js) or create a new state and override this function
+	try
+	{
+		if (!this.layoutRendered || (data['config'].hasOwnProperty('autoUpdateLayout') && data['config']['autoUpdateLayout']))
+		{
+			$("#uiLayout").html(NanoTemplate.parse('layout', data)); // render the 'mail' template to the #mainTemplate div
+			this.layoutRendered = true;
+		}
+		if (!this.contentRendered || (data['config'].hasOwnProperty('autoUpdateContent') && data['config']['autoUpdateContent']))
+		{
+			var content = "";
 			var keys = NanoTemplate.getKeys();
 			for (i = 0; i < keys.length; i++) {
 				if(keys[i] == "layout"){ continue; }
 				content += NanoTemplate.parse(keys[i], data);
 			}
-            $("#uiContent").html(content); // render the 'mail' template to the #mainTemplate div
-            this.contentRendered = true;
-        }
-        if (NanoTemplate.templateExists('mapContent'))
-        {
-            if (!this.mapInitialised)
-            {
-                // Add drag functionality to the map ui
-                $('#uiMap').draggable();
+			$("#uiContent").html(content); // render the 'mail' template to the #mainTemplate div
+			this.contentRendered = true;
+		}
+		if (NanoTemplate.templateExists('mapContent'))
+		{
+			if (!this.mapInitialised)
+			{
+				// Add drag functionality to the map ui
+				$('#uiMap').draggable();
+				$('#uiMapTooltip')
+				.off('click')
+				.on('click', function (event) {
+					event.preventDefault();
+					$(this).fadeOut(400);
+				});
+				this.mapInitialised = true;
+			}
 
-                $('#uiMapTooltip')
-                    .off('click')
-                    .on('click', function (event) {
-                        event.preventDefault();
-                        $(this).fadeOut(400);
-                    });
+			$("#uiMapContent").html(NanoTemplate.parse('mapContent', data)); // render the 'mapContent' template to the #uiMapContent div
 
-                this.mapInitialised = true;
-            }
-
-            $("#uiMapContent").html(NanoTemplate.parse('mapContent', data)); // render the 'mapContent' template to the #uiMapContent div
-
-            if (data['config'].hasOwnProperty('showMap') && data['config']['showMap'])
-            {
-                $('#uiContent').addClass('hidden');
-                $('#uiMapWrapper').removeClass('hidden');
-            }
-            else
-            {
-                $('#uiMapWrapper').addClass('hidden');
-                $('#uiContent').removeClass('hidden');
-            }
-        }
-        if (NanoTemplate.templateExists('mapHeader'))
-        {
-            $("#uiMapHeader").html(NanoTemplate.parse('mapHeader', data)); // render the 'mapHeader' template to the #uiMapHeader div
-        }
-        if (NanoTemplate.templateExists('mapFooter'))
-        {
-            $("#uiMapFooter").html(NanoTemplate.parse('mapFooter', data)); // render the 'mapFooter' template to the #uiMapFooter div
-        }
-    }
-    catch(error)
-    {
-        alert('ERROR: An error occurred while rendering the UI: ' + error.message);
-        return;
-    }
+			if (data['config'].hasOwnProperty('showMap') && data['config']['showMap'])
+			{
+				$('#uiContent').addClass('hidden');
+				$('#uiMapWrapper').removeClass('hidden');
+			}
+			else
+			{
+				$('#uiMapWrapper').addClass('hidden');
+				$('#uiContent').removeClass('hidden');
+			}
+		}
+		if (NanoTemplate.templateExists('mapHeader'))
+		{
+			$("#uiMapHeader").html(NanoTemplate.parse('mapHeader', data)); // render the 'mapHeader' template to the #uiMapHeader div
+		}
+		if (NanoTemplate.templateExists('mapFooter'))
+		{
+			$("#uiMapFooter").html(NanoTemplate.parse('mapFooter', data)); // render the 'mapFooter' template to the #uiMapFooter div
+		}
+	}
+	catch(error)
+	{
+		alert('ERROR: An error occurred while rendering the UI: ' + error.message);
+        	return;
+	}
 };
 
 NanoStateClass.prototype.onAfterUpdate = function (data) {
-    // Do not add code here, add it to the 'default' state (nano_state_defaut.js) or create a new state and override this function
-
-    NanoStateManager.executeAfterUpdateCallbacks(data);
+	// Do not add code here, add it to the 'default' state (nano_state_defaut.js) or create a new state and override this function
+	NanoStateManager.executeAfterUpdateCallbacks(data);
 };
 
 NanoStateClass.prototype.alertText = function (text) {
-    // Do not add code here, add it to the 'default' state (nano_state_defaut.js) or create a new state and override this function
-
-    alert(text);
+	// Do not add code here, add it to the 'default' state (nano_state_defaut.js) or create a new state and override this function
+	alert(text);
 };
 
 

--- a/nano/js/nano_state.js
+++ b/nano/js/nano_state.js
@@ -55,7 +55,13 @@ NanoStateClass.prototype.onUpdate = function (data) {
         }
         if (!this.contentRendered || (data['config'].hasOwnProperty('autoUpdateContent') && data['config']['autoUpdateContent']))
         {
-            $("#uiContent").html(NanoTemplate.parse('main', data)); // render the 'mail' template to the #mainTemplate div
+			var content = "";// = "<div>" + JSON.stringify(NanoTemplate.getKeys()) + "</div>";
+			var keys = NanoTemplate.getKeys();
+			for (i = 0; i < keys.length; i++) {
+				if(keys[i] == "layout"){ continue; }
+				content += NanoTemplate.parse(keys[i], data);
+			}
+            $("#uiContent").html(content); // render the 'mail' template to the #mainTemplate div
             this.contentRendered = true;
         }
         if (NanoTemplate.templateExists('mapContent'))

--- a/nano/js/nano_template.js
+++ b/nano/js/nano_template.js
@@ -91,6 +91,13 @@ var NanoTemplate = function () {
         templateExists: function (key) {
             return _templates.hasOwnProperty(key);
         },
+		getKeys: function () {
+			var _keys = [];
+			for(var key in _templates) {
+				_keys.push(key);
+			}
+			return _keys;
+		},
         parse: function (templateKey, data) {
             if (!_compiledTemplates.hasOwnProperty(templateKey) || !_compiledTemplates[templateKey]) {
                 if (!_templates.hasOwnProperty(templateKey)) {

--- a/nano/js/nano_template.js
+++ b/nano/js/nano_template.js
@@ -1,15 +1,15 @@
 
 var NanoTemplate = function () {
 
-    var _templateData = {};
+	var _templateData = {};
 
-    var _templates = {};
-    var _compiledTemplates = {};
+	var _templates = {};
+	var _compiledTemplates = {};
 	
 	var _helpers = {};
 
-    var init = function () {
-        // We store templateData in the body tag, it's as good a place as any
+	var init = function () {
+	// We store templateData in the body tag, it's as good a place as any
 		_templateData = $('body').data('templateData');
 
 		if (_templateData == null)
@@ -18,79 +18,79 @@ var NanoTemplate = function () {
 		}
 
 		loadNextTemplate();
-    };
+	};
 
-    var loadNextTemplate = function () {
-        // we count the number of templates for this ui so that we know when they've all been rendered
-        var templateCount = Object.size(_templateData);
+	var loadNextTemplate = function () {
+		// we count the number of templates for this ui so that we know when they've all been rendered
+		var templateCount = Object.size(_templateData);
 
-        if (!templateCount)
-        {
-            $(document).trigger('templatesLoaded');
-            return;
-        }
+		if (!templateCount)
+		{
+			$(document).trigger('templatesLoaded');
+			return;
+		}
 
-        // load markup for each template and register it
-        for (var key in _templateData)
-        {
-            if (!_templateData.hasOwnProperty(key))
-            {
-                continue;
-            }
+		// load markup for each template and register it
+		for (var key in _templateData)
+		{
+			if (!_templateData.hasOwnProperty(key))
+			{
+				continue;
+			}
 
-            $.when($.ajax({
-                    url: _templateData[key],
-                    cache: false,
-                    dataType: 'text'
-                }))
-                .done(function(templateMarkup) {
+			$.when($.ajax({
+				url: _templateData[key],
+				cache: false,
+				dataType: 'text'
+			}))
+			.done(function(templateMarkup) {
 
-                    templateMarkup += '<div class="clearBoth"></div>';
+				templateMarkup += '<div class="clearBoth"></div>';
 
-                    try
-                    {
-                        NanoTemplate.addTemplate(key, templateMarkup);
-                    }
-                    catch(error)
-                    {
-                        alert('ERROR: An error occurred while loading the UI: ' + error.message);
-                        return;
-                    }
+				try
+				{
+					NanoTemplate.addTemplate(key, templateMarkup);
+				}
+				catch(error)
+				{
+					alert('ERROR: An error occurred while loading the UI: ' + error.message);
+					return;
+				}
 
-                    delete _templateData[key];
+				delete _templateData[key];
 
-                    loadNextTemplate();
-                })
-                .fail(function () {
-                    alert('ERROR: Loading template ' + key + '(' + _templateData[key] + ') failed!');
-                });
+				loadNextTemplate();
+			})
+			.fail(function () {
+				alert('ERROR: Loading template ' + key + '(' + _templateData[key] + ') failed!');
+			});
 
-            return;
-        }
-    }
+			return;
+		}
+	}
 
-    var compileTemplates = function () {
+	var compileTemplates = function () {
 
-        for (var key in _templates) {
-            try {
-                _compiledTemplates[key] = doT.template(_templates[key], null, _templates)
-            }
-            catch (error) {
-                alert(error.message);
-            }
-        }
-    };
+		for (var key in _templates) {
+			try {
+				_compiledTemplates[key] = doT.template(_templates[key], null, _templates)
+			}
+			catch (error) {
+				alert(error.message);
+			}
+		}
+	};
 
-    return {
-        init: function () {
-            init();
-        },
-        addTemplate: function (key, templateString) {
-            _templates[key] = templateString;
-        },
-        templateExists: function (key) {
-            return _templates.hasOwnProperty(key);
-        },
+	return {
+		init: function () {
+			init();
+		},
+		addTemplate: function (key, templateString) {
+			_templates[key] = templateString;
+		},
+		templateExists: function (key) {
+			return _templates.hasOwnProperty(key);
+		},
 		getKeys: function () {
 			var _keys = [];
 			for(var key in _templates) {
@@ -98,21 +98,21 @@ var NanoTemplate = function () {
 			}
 			return _keys;
 		},
-        parse: function (templateKey, data) {
-            if (!_compiledTemplates.hasOwnProperty(templateKey) || !_compiledTemplates[templateKey]) {
-                if (!_templates.hasOwnProperty(templateKey)) {
-                    alert('ERROR: Template "' + templateKey + '" does not exist in _compiledTemplates!');
-                    return '<h2>Template error (does not exist)</h2>';
-                }
-                compileTemplates();
-            }
-            if (typeof _compiledTemplates[templateKey] != 'function') {
-                alert(_compiledTemplates[templateKey]);
-                alert('ERROR: Template "' + templateKey + '" failed to compile!');
-                return '<h2>Template error (failed to compile)</h2>';
-            }
-            return _compiledTemplates[templateKey].call(this, data['data'], data['config'], _helpers);
-        },
+		parse: function (templateKey, data) {
+			if (!_compiledTemplates.hasOwnProperty(templateKey) || !_compiledTemplates[templateKey]) {
+				if (!_templates.hasOwnProperty(templateKey)) {
+					alert('ERROR: Template "' + templateKey + '" does not exist in _compiledTemplates!');
+					return '<h2>Templateerror (does not exist)</h2>';
+				}
+				compileTemplates();
+			}
+			if (typeof _compiledTemplates[templateKey] != 'function') {
+				alert(_compiledTemplates[templateKey]);
+				alert('ERROR: Template "' + templateKey + '" failed to compile!');
+				return '<h2>Template error (failed to compile)</h2>';
+			}
+			return _compiledTemplates[templateKey].call(this, data['data'], data['config'], _helpers);
+		},
 		addHelper: function (helperName, helperFunction) {
 			if (!jQuery.isFunction(helperFunction)) {
 				alert('NanoTemplate.addHelper failed to add ' + helperName + ' as it is not a function.');
@@ -136,7 +136,7 @@ var NanoTemplate = function () {
 				delete _helpers[helperName];
 			}	
 		}
-    }
+	}
 }();
  
 


### PR DESCRIPTION
This shouldn't change any existing NanoUI, but in the future I'll likely be refactoring that stuff so everything uses the same template for the same function. Looking at you, PAI records templates that happen to be almost exactly what I'm looking for for records display.
The order in which templates are added matters: those added first will be displayed first. I didn't test changing a template that was initially put above a different one, but I suspect that it will not re-order them.
There isn't currently a way to remove templates.
You no longer have to use the key "main", any will do so long as you're consistent.

This was tested and developed using code I'm working on for communicators, that stuff isn't included here. The first status bar at the top is taken from one file, the rest of the main template is on another, which is exchanged when it becomes `test text` with a link home. The External Device menu will be utilized for cartridge functions, which I'm mostly doing this for.
It was also tested on PDAs, which retain their old function, to ensure it doesn't break anything.

`Add_template()` on its own doesn't do much, because it explicitly states that the ui has to be opened afterwards.
`Append_template()` will add the template or change an existing key to a new template, re-open the ui, and update it with the data. The third step is important, otherwise it won't finish updating until it auto-updates, if at all.

[Testing with multiple templates](https://puu.sh/zONWN/a88a240a02.mp4)
[Testing with a single template](https://puu.sh/zOP54/6c2bd9a2fc.mp4)