### PR TITLE
Grant remote profile access to R_DEBUG holders

### DIFF
--- a/code/modules/admin/admin_ranks.dm
+++ b/code/modules/admin/admin_ranks.dm
@@ -6,6 +6,10 @@ var/list/admin_ranks = list()								//list of all ranks with associated rights
 
 	var/previous_rights = 0
 
+	//Clear profile access
+	for(var/A in world.GetConfig("admin"))
+		world.SetConfig("APP/admin", A, null)
+
 	//load text from file
 	var/list/Lines = file2list("config/admin_ranks.txt")
 

--- a/code/modules/admin/holder2.dm
+++ b/code/modules/admin/holder2.dm
@@ -23,6 +23,8 @@ var/list/admin_datums = list()
 	rank = initial_rank
 	rights = initial_rights
 	admin_datums[ckey] = src
+	if(rights & R_DEBUG) //grant profile access
+		world.SetConfig("APP/admin", ckey, "role=admin")
 
 /datum/admins/proc/associate(client/C)
 	if(istype(C))


### PR DESCRIPTION
This lets developers access profiling data and sleeping proc data!
Inspired by tgstation/tgstation#19880