### PR TITLE
Fixes fullbright mode hiding lighting overlays.

### DIFF
--- a/code/modules/mob/mob_planes.dm
+++ b/code/modules/mob/mob_planes.dm
@@ -135,6 +135,7 @@
 //Lighting is weird and has matrix shenanigans. Think of this as turning on/off darkness.
 /obj/screen/plane_master/fullbright
 	plane = PLANE_LIGHTING
+	layer = LAYER_HUD_BASE+1 // This MUST be above the lighting plane_master
 	color = null //To break lighting when visible (this is sorta backwards)
 	alpha = 0 //Starts full opaque
 	invisibility = 101


### PR DESCRIPTION
Fullbright plane master being above lighting plane master is important, shouldn't be removed.
Fixes #5122
Addresses part of #5116