### PR TITLE
Adds Map Template Groups

### DIFF
--- a/code/game/turfs/flooring/flooring_premade.dm
+++ b/code/game/turfs/flooring/flooring_premade.dm
@@ -68,11 +68,25 @@
 	icon_state = "wood"
 	initial_flooring = /decl/flooring/wood
 
+/turf/simulated/floor/wood/broken
+	icon_state = "wood_broken0" // This gets changed when spawned.
+
+/turf/simulated/floor/wood/broken/initialize()
+	break_tile()
+	return ..()
+
 /turf/simulated/floor/wood/sif
 	name = "alien wooden floor"
 	icon = 'icons/turf/flooring/wood.dmi'
 	icon_state = "sifwood"
 	initial_flooring = /decl/flooring/wood/sif
+
+/turf/simulated/floor/wood/sif/broken
+	icon_state = "sifwood_broken0" // This gets changed when spawned.
+
+/turf/simulated/floor/wood/sif/broken/initialize()
+	break_tile()
+	return ..()
 
 /turf/simulated/floor/grass
 	name = "grass patch"

--- a/maps/submaps/surface_submaps/wilderness/DJOutpost2.dmm
+++ b/maps/submaps/surface_submaps/wilderness/DJOutpost2.dmm
@@ -1,0 +1,56 @@
+"a" = (/turf/template_noop,/area/template_noop)
+"b" = (/turf/simulated/wall/wood,/area/submap/DJOutpost1)
+"c" = (/obj/structure/grille/broken,/obj/item/weapon/material/shard,/obj/item/weapon/material/shard{tag = "icon-shardmedium"; icon_state = "shardmedium"},/obj/item/stack/rods,/turf/simulated/floor,/area/submap/DJOutpost1)
+"d" = (/obj/structure/grille/broken,/obj/item/weapon/material/shard,/turf/simulated/floor,/area/submap/DJOutpost1)
+"e" = (/turf/simulated/floor/wood/broken,/area/submap/DJOutpost1)
+"f" = (/obj/structure/loot_pile/maint/technical,/turf/simulated/floor/wood/broken,/area/submap/DJOutpost1)
+"g" = (/obj/structure/sign/goldenplaque{desc = "An award given to Sif Free Radio for media excellency. It looks fake."; name = "Best Radio Station 2558"; pixel_y = 30},/turf/simulated/floor/wood/broken,/area/submap/DJOutpost1)
+"h" = (/obj/structure/cable/yellow{d1 = 2; d2 = 4; icon_state = "2-4"},/obj/structure/loot_pile/maint/technical,/turf/simulated/floor/wood/broken,/area/submap/DJOutpost1)
+"i" = (/obj/structure/loot_pile/surface/bones,/turf/simulated/floor/wood/broken,/area/submap/DJOutpost1)
+"k" = (/obj/structure/girder,/turf/simulated/floor,/area/submap/DJOutpost1)
+"l" = (/obj/structure/bed/chair/office/dark{dir = 1},/obj/structure/cable/yellow{d1 = 1; d2 = 2; icon_state = "1-2"},/turf/simulated/floor/wood/broken,/area/submap/DJOutpost1)
+"m" = (/obj/structure/table/steel_reinforced,/obj/item/device/radio/phone,/turf/simulated/floor/outdoors/dirt,/area/submap/DJOutpost1)
+"n" = (/obj/item/stack/rods,/turf/template_noop,/area/template_noop)
+"o" = (/turf/simulated/floor/outdoors/dirt,/area/submap/DJOutpost1)
+"p" = (/obj/structure/loot_pile/surface/bones,/turf/simulated/floor/outdoors/dirt,/area/submap/DJOutpost1)
+"q" = (/obj/structure/table/steel_reinforced,/obj/item/device/radio,/obj/structure/cable/yellow,/turf/simulated/floor/wood/broken,/area/submap/DJOutpost1)
+"r" = (/turf/simulated/floor/outdoors/rocks,/area/submap/DJOutpost1)
+"s" = (/obj/effect/overlay/snow/floor,/turf/simulated/floor{outdoors = 1},/area/submap/DJOutpost1)
+"u" = (/obj/effect/decal/cleanable/ash,/turf/simulated/floor/outdoors/dirt,/area/submap/DJOutpost1)
+"w" = (/obj/structure/grille/broken,/obj/item/weapon/material/shard{tag = "icon-shardmedium"; icon_state = "shardmedium"},/turf/simulated/floor,/area/submap/DJOutpost1)
+"x" = (/obj/structure/girder,/turf/simulated/floor/outdoors/rocks,/area/submap/DJOutpost1)
+"y" = (/obj/structure/table/steel_reinforced,/obj/item/device/radio/intercom/syndicate{desc = "Talk through this."; name = "station intercom (General)"},/turf/simulated/floor/outdoors/dirt,/area/submap/DJOutpost1)
+"A" = (/obj/item/stack/rods,/turf/simulated/floor/outdoors/dirt,/area/submap/DJOutpost1)
+"B" = (/obj/structure/door_assembly/door_assembly_ext,/turf/simulated/floor/outdoors/rocks,/area/submap/DJOutpost1)
+"C" = (/obj/structure/grille/broken,/obj/item/weapon/material/shard{icon_state = "medium"},/obj/structure/cable/yellow{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor,/area/submap/DJOutpost1)
+"D" = (/obj/item/weapon/material/shard{tag = "icon-shardmedium"; icon_state = "shardmedium"},/turf/template_noop,/area/template_noop)
+"F" = (/obj/item/device/transfer_valve,/turf/simulated/floor/outdoors/rocks,/area/submap/DJOutpost1)
+"G" = (/obj/structure/grille/broken,/obj/item/weapon/material/shard{icon_state = "medium"},/turf/simulated/floor,/area/submap/DJOutpost1)
+"H" = (/obj/item/weapon/material/shard{icon_state = "medium"},/turf/template_noop,/area/template_noop)
+"I" = (/obj/machinery/door/airlock/external,/turf/simulated/floor/wood/broken,/area/submap/DJOutpost1)
+"J" = (/obj/item/weapon/material/shard,/turf/template_noop,/area/template_noop)
+"K" = (/obj/structure/sink{dir = 4; icon_state = "sink"; pixel_x = 15; tag = "icon-sink (EAST)"},/turf/simulated/floor/wood/broken,/area/submap/DJOutpost1)
+"L" = (/obj/item/weapon/storage/toolbox/mechanical,/turf/simulated/floor/outdoors/rocks,/area/submap/DJOutpost1)
+"M" = (/obj/structure/grille/broken,/obj/item/weapon/material/shard{icon_state = "medium"},/obj/item/stack/rods,/turf/simulated/floor,/area/submap/DJOutpost1)
+"N" = (/obj/structure/grille/broken,/obj/item/stack/rods,/turf/simulated/floor,/area/submap/DJOutpost1)
+"O" = (/obj/structure/lattice,/turf/simulated/floor/outdoors/dirt,/area/submap/DJOutpost1)
+"P" = (/obj/effect/decal/cleanable/ash,/turf/simulated/floor/wood/broken,/area/submap/DJOutpost1)
+"S" = (/obj/structure/girder,/turf/simulated/floor/outdoors/dirt,/area/submap/DJOutpost1)
+
+(1,1,1) = {"
+aaaaaaaaaaaaaaaaaa
+aaabcbbbbbdbaaaaaa
+aabbeekffefbbaaaaa
+abbePOSoOeegbbaaaa
+nweeOooroOiPhCsoaa
+DbeporxrrooOlSruoa
+abeOrrrrrLmyqxrroa
+abbkxrrFrrxbbkrAoa
+abPorrrrrroOfbouaa
+abeOorrrropeeboaaa
+ndeOokxBxkOPfMHaaa
+abbeOkOoOkeKbbaaaa
+aabbObePebfbbaaaaa
+aaabNbbIbbGbaaaaaa
+aaaaJaaaaaaaaaaaaa
+"}

--- a/maps/submaps/surface_submaps/wilderness/wilderness.dm
+++ b/maps/submaps/surface_submaps/wilderness/wilderness.dm
@@ -17,6 +17,7 @@
 #include "Lab1.dmm"
 #include "Rocky4.dmm"
 #include "DJOutpost1.dmm"
+#include "DJOutpost2.dmm"
 #include "Rockybase.dmm"
 #include "MHR.dmm"
 #include "GovPatrol.dmm"
@@ -132,6 +133,14 @@
 	name = "DJOutpost1"
 	desc = "Home of Sif Free Radio, the best - and only - radio station for miles around."
 	mappath = 'maps/submaps/surface_submaps/wilderness/DJOutpost1.dmm'
+	template_group = "Sif Free Radio"
+	cost = 5
+
+/datum/map_template/surface/wilderness/deep/DJOutpost2
+	name = "DJOutpost2"
+	desc = "The cratered remains of Sif Free Radio, the best - and only - radio station for miles around."
+	mappath = 'maps/submaps/surface_submaps/wilderness/DJOutpost2.dmm'
+	template_group = "Sif Free Radio"
 	cost = 5
 
 /datum/map_template/surface/wilderness/deep/Boombase

--- a/maps/submaps/surface_submaps/wilderness/wilderness_areas.dm
+++ b/maps/submaps/surface_submaps/wilderness/wilderness_areas.dm
@@ -54,6 +54,9 @@
 /area/submap/DJOutpost1
 	name = "DJOutpost1"
 
+/area/submap/DJOutpost2
+	name = "DJOutpost2"
+
 /area/submap/MHR
 	name = "Manhack Rock"
 


### PR DESCRIPTION
Adds ability to have many different 'versions' of a PoI, yet only having one show up per round.
An example on how to do this is provided with Radio Free Sif (aka DJOutpost).
Just make sure all the different versions have the same 'template_group' value.

Includes DJOutpost2.dmm as a demo.
![Map preview](https://puu.sh/zSwb6/8887e4422f.png)
(The door assembly resembles the red external one when the map is actually loaded)