### PR TITLE
Syndicate Dufflebag Tweak

### DIFF
--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -138,18 +138,18 @@
 
 /obj/item/weapon/storage/backpack/dufflebag/syndie
 	name = "black dufflebag"
-	desc = "A large dufflebag for holding extra tactical supplies."
+	desc = "A large dufflebag for holding extra tactical supplies. This one appears to be made out of lighter material than usual."
 	icon_state = "duffle_syndie"
 	slowdown = 0
 
 /obj/item/weapon/storage/backpack/dufflebag/syndie/med
 	name = "medical dufflebag"
-	desc = "A large dufflebag for holding extra tactical medical supplies."
+	desc = "A large dufflebag for holding extra tactical medical supplies. This one appears to be made out of lighter material than usual."
 	icon_state = "duffle_syndiemed"
 
 /obj/item/weapon/storage/backpack/dufflebag/syndie/ammo
 	name = "ammunition dufflebag"
-	desc = "A large dufflebag for holding extra weapons ammunition and supplies."
+	desc = "A large dufflebag for holding extra weapons ammunition and supplies. This one appears to be made out of lighter material than usual."
 	icon_state = "duffle_syndieammo"
 
 /obj/item/weapon/storage/backpack/dufflebag/captain


### PR DESCRIPTION
- Makes syndicate dufflebags hint that they don't slow you down.

Mainly doing this for clarity, as the only way you'd know otherwise is to:
1. Use the dufflebag and notice the difference
2. Read the code