### PR TITLE
Small fixes and ports discovered during merge.

### DIFF
--- a/code/__defines/_planes+layers.dm
+++ b/code/__defines/_planes+layers.dm
@@ -40,10 +40,6 @@ What is the naming convention for planes or layers?
 
 */
 
-#define PLANE_ADMIN1			-92 //Purely for shenanigans
-#define PLANE_ADMIN2			-91 //And adminbuse
-#define PLANE_ADMIN3			-90 //And generating salt
-
 #define SPACE_PLANE     		-82	// Reserved for use in space/parallax
 #define PARALLAX_PLANE  		-80	// Reserved for use in space/parallax
 
@@ -105,7 +101,8 @@ What is the naming convention for planes or layers?
 
 	#define HUD_LAYER				20	// Above lighting, but below obfuscation. For in-game HUD effects (whereas SCREEN_LAYER is for abstract/OOC things like inventory slots)
 	#define SCREEN_LAYER			22	// Mob HUD/effects layer
-	
+
+#define PLANE_ADMIN1			3 //Purely for shenanigans (below lighting)
 #define PLANE_PLANETLIGHTING	4 //Lighting on planets
 #define PLANE_LIGHTING			5 //Where the lighting (and darkness) lives
 #define PLANE_LIGHTING_ABOVE	6 //For glowy eyes etc. that shouldn't be affected by darkness
@@ -127,6 +124,8 @@ What is the naming convention for planes or layers?
 
 #define PLANE_MESONS			30 //Stuff seen with mesons, like open ceilings. This is 30 for downstreams.
 
+#define PLANE_ADMIN2			33 //Purely for shenanigans (above lighting)
+
 //Fullscreen overlays under inventory
 #define PLANE_FULLSCREEN		90 //Blindness, mesons, druggy, etc
 	#define OBFUSCATION_LAYER	5 //Where images covering the view for eyes are put
@@ -142,6 +141,8 @@ What is the naming convention for planes or layers?
 	#define LAYER_HUD_ITEM		3 //Things sitting on HUD items (largely irrelevant because PLANE_PLAYER_HUD_ITEMS)
 	#define LAYER_HUD_ABOVE		4 //Things that reside above items (highlights)
 #define PLANE_PLAYER_HUD_ITEMS	96 //Separate layer with which to apply colorblindness
+
+#define PLANE_ADMIN3			99 //Purely for shenanigans (above HUD)
 
 
 //////////////////////////

--- a/code/modules/client/preference_setup/occupation/occupation.dm
+++ b/code/modules/client/preference_setup/occupation/occupation.dm
@@ -94,7 +94,7 @@
 		if(job.minimum_character_age && user.client && (user.client.prefs.age < job.minimum_character_age))
 			. += "<del>[rank]</del></td><td> \[MINIMUM CHARACTER AGE: [job.minimum_character_age]]</td></tr>"
 			continue
-		if((pref.job_civilian_low & ASSISTANT) && job.flag != ASSISTANT)
+		if((pref.job_civilian_low & ASSISTANT) && job.type != /datum/job/assistant)
 			. += "<font color=grey>[rank]</font></td><td></td></tr>"
 			continue
 		if((rank in command_positions) || (rank == "AI"))//Bold head jobs
@@ -106,7 +106,7 @@
 
 		. += "<a href='?src=\ref[src];set_job=[rank]'>"
 
-		if(job.flag == ASSISTANT)//Assistant is special
+		if(job.type == /datum/job/assistant)//Assistant is special
 			if(pref.job_civilian_low & ASSISTANT)
 				. += " <font color=55cc55>\[Yes]</font>"
 			else
@@ -180,7 +180,7 @@
 	if(!job)
 		return 0
 
-	if(job.flag == ASSISTANT)
+	if(job.type == /datum/job/assistant)
 		if(pref.job_civilian_low & job.flag)
 			pref.job_civilian_low &= ~job.flag
 		else

--- a/code/modules/mob/emote.dm
+++ b/code/modules/mob/emote.dm
@@ -29,7 +29,7 @@
 
 		var/turf/T = get_turf(src)
 		if(!T) return
-		var/list/in_range = get_mobs_and_objs_in_view_fast(T,range,2)
+		var/list/in_range = get_mobs_and_objs_in_view_fast(T,range,2,remote_ghosts = client ? TRUE : FALSE)
 		var/list/m_viewers = in_range["mobs"]
 		var/list/o_viewers = in_range["objs"]
 

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -756,6 +756,9 @@ var/global/list/damage_icon_parts = list() //see UpdateDamageIcon()
 
 //update whether handcuffs appears on our hud.
 /mob/living/carbon/proc/update_hud_handcuffed()
+	if(QDESTROYING(src))
+		return
+
 	if(hud_used && hud_used.l_hand_hud_object && hud_used.r_hand_hud_object)
 		hud_used.l_hand_hud_object.update_icon()
 		hud_used.r_hand_hud_object.update_icon()

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -292,7 +292,7 @@ proc/get_radio_key_from_channel(var/channel)
 			sound_vol *= 0.5
 
 		//Obtain the mobs and objects in the message range
-		var/list/results = get_mobs_and_objs_in_view_fast(T, world.view)
+		var/list/results = get_mobs_and_objs_in_view_fast(T, world.view, remote_ghosts = client ? TRUE : FALSE)
 		listening = results["mobs"]
 		listening_obj = results["objs"]
 	else

--- a/code/modules/mob/living/simple_animal/animals/cat.dm
+++ b/code/modules/mob/living/simple_animal/animals/cat.dm
@@ -156,6 +156,7 @@
 /mob/living/simple_animal/cat/fluff/Runtime
 	name = "Runtime"
 	desc = "Her fur has the look and feel of velvet, and her tail quivers occasionally."
+	tt_desc = "Felis medicalis"
 	gender = FEMALE
 	icon_state = "cat"
 	item_state = "cat"

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -16,7 +16,7 @@
 	icon = 'icons/obj/lighting.dmi'
 	icon_state = "tube-construct-stage1"
 	anchored = 1
-	plane = MOB_LAYER
+	plane = MOB_PLANE
 	layer = ABOVE_MOB_LAYER
 	var/stage = 1
 	var/fixture_type = "tube"
@@ -133,8 +133,6 @@
 	icon = 'icons/obj/lighting.dmi'
 	icon_state = "bulb-construct-stage1"
 	anchored = 1
-	plane = MOB_LAYER
-	layer = ABOVE_MOB_LAYER
 	stage = 1
 	fixture_type = "bulb"
 	sheets_refunded = 1
@@ -145,6 +143,8 @@
 	icon = 'icons/obj/lighting.dmi'
 	icon_state = "flamp-construct-stage1"
 	anchored = 0
+	plane = OBJ_PLANE
+	layer = OBJ_LAYER
 	stage = 1
 	fixture_type = "flamp"
 	sheets_refunded = 2
@@ -157,7 +157,7 @@
 	icon_state = "tube1"
 	desc = "A lighting fixture."
 	anchored = 1
-	plane = MOB_LAYER
+	plane = MOB_PLANE
 	layer = ABOVE_MOB_LAYER
 	use_power = 2
 	idle_power_usage = 2
@@ -194,6 +194,7 @@
 	fitting = "bulb"
 	brightness_range = 5
 	brightness_power = 2
+	plane = OBJ_PLANE
 	layer = OBJ_LAYER
 	brightness_color = "#FFF4E5"
 	desc = "A floor lamp."


### PR DESCRIPTION
A series of small couple-line fixes from vorestation or discovered during syncing polaris to vorestation.
- Port of VOREStation/VOREStation#2905: Replace messy string compare with nice type compare for assistant job.
- Port of VOREStation/VOREStation#2957: Move admin planes to more useful places for better shenanigans.
- Port of VOREStation/VOREStation#3120: Only spam ghosts with chat messages from things with real clients.   That way ghosts don't get spammed by simple animals.
- Fix small forgotten lines of text accidentally left out of VS syncs.
- Fix typo'd plane in lighting.dm and remove redundant definitions.