### PR TITLE
Switch cables and pipes to use define constants instead of literals for layers.

### DIFF
--- a/code/ATMOSPHERICS/atmospherics.dm
+++ b/code/ATMOSPHERICS/atmospherics.dm
@@ -17,7 +17,7 @@ Pipelines + Other Objects -> Pipe network
 	var/nodealert = 0
 	var/power_rating //the maximum amount of power the machine can use to do work, affects how powerful the machine is, in Watts
 
-	layer = PIPES_LAYER
+	layer = ATMOS_LAYER
 	plane = PLATING_PLANE
 
 	var/pipe_flags = PIPING_DEFAULT_LAYER_ONLY // Allow other layers by exception basis.
@@ -202,12 +202,12 @@ Pipelines + Other Objects -> Pipe network
 		if(PIPING_LAYER_SCRUBBER)
 			icon_state = "[icon_state]-scrubbers"
 			connect_types = CONNECT_TYPE_SCRUBBER
-			layer = 2.38
+			layer = PIPES_SCRUBBER_LAYER
 			icon_connect_type = "-scrubbers"
 		if(PIPING_LAYER_SUPPLY)
 			icon_state = "[icon_state]-supply"
 			connect_types = CONNECT_TYPE_SUPPLY
-			layer = 2.39
+			layer = PIPES_SUPPLY_LAYER
 			icon_connect_type = "-supply"
 	if(pipe_flags & PIPING_ALL_LAYER)
 		connect_types = CONNECT_TYPE_REGULAR|CONNECT_TYPE_SUPPLY|CONNECT_TYPE_SCRUBBER

--- a/code/ATMOSPHERICS/pipes/cap.dm
+++ b/code/ATMOSPHERICS/pipes/cap.dm
@@ -79,7 +79,7 @@
 	icon_state = "cap-scrubbers"
 	connect_types = CONNECT_TYPE_SCRUBBER
 	piping_layer = PIPING_LAYER_SCRUBBER
-	layer = 2.38
+	layer = PIPES_SCRUBBER_LAYER
 	icon_connect_type = "-scrubbers"
 	color = PIPE_COLOR_RED
 
@@ -89,7 +89,7 @@
 	icon_state = "cap-supply"
 	connect_types = CONNECT_TYPE_SUPPLY
 	piping_layer = PIPING_LAYER_SUPPLY
-	layer = 2.39
+	layer = PIPES_SUPPLY_LAYER
 	icon_connect_type = "-supply"
 	color = PIPE_COLOR_BLUE
 
@@ -104,7 +104,7 @@
 	icon_state = "cap-f-scrubbers"
 	connect_types = CONNECT_TYPE_SCRUBBER
 	piping_layer = PIPING_LAYER_SCRUBBER
-	layer = 2.38
+	layer = PIPES_SCRUBBER_LAYER
 	icon_connect_type = "-scrubbers"
 	color = PIPE_COLOR_RED
 
@@ -114,6 +114,6 @@
 	icon_state = "cap-f-supply"
 	connect_types = CONNECT_TYPE_SUPPLY
 	piping_layer = PIPING_LAYER_SUPPLY
-	layer = 2.39
+	layer = PIPES_SUPPLY_LAYER
 	icon_connect_type = "-supply"
 	color = PIPE_COLOR_BLUE

--- a/code/ATMOSPHERICS/pipes/he_pipes.dm
+++ b/code/ATMOSPHERICS/pipes/he_pipes.dm
@@ -12,7 +12,7 @@
 	construction_type = /obj/item/pipe/binary/bendable
 	pipe_state = "he"
 
-	layer = 2.41
+	layer = PIPES_HE_LAYER
 	var/initialize_directions_he
 	var/surface = 2	//surface area in m^2
 	var/icon_temperature = T20C //stop small changes in temperature causing an icon refresh

--- a/code/ATMOSPHERICS/pipes/manifold.dm
+++ b/code/ATMOSPHERICS/pipes/manifold.dm
@@ -18,7 +18,6 @@
 	var/obj/machinery/atmospherics/node3
 
 	level = 1
-	layer = 2.4 //under wires with their 2.44
 
 /obj/machinery/atmospherics/pipe/manifold/New()
 	..()
@@ -166,7 +165,7 @@
 	icon_state = "map-scrubbers"
 	connect_types = CONNECT_TYPE_SCRUBBER
 	piping_layer = PIPING_LAYER_SCRUBBER
-	layer = 2.38
+	layer = PIPES_SCRUBBER_LAYER
 	icon_connect_type = "-scrubbers"
 	color = PIPE_COLOR_RED
 
@@ -176,7 +175,7 @@
 	icon_state = "map-supply"
 	connect_types = CONNECT_TYPE_SUPPLY
 	piping_layer = PIPING_LAYER_SUPPLY
-	layer = 2.39
+	layer = PIPES_SUPPLY_LAYER
 	icon_connect_type = "-supply"
 	color = PIPE_COLOR_BLUE
 
@@ -212,7 +211,7 @@
 	icon_state = "map-scrubbers"
 	connect_types = CONNECT_TYPE_SCRUBBER
 	piping_layer = PIPING_LAYER_SCRUBBER
-	layer = 2.38
+	layer = PIPES_SCRUBBER_LAYER
 	icon_connect_type = "-scrubbers"
 	color = PIPE_COLOR_RED
 
@@ -222,7 +221,7 @@
 	icon_state = "map-supply"
 	connect_types = CONNECT_TYPE_SUPPLY
 	piping_layer = PIPING_LAYER_SUPPLY
-	layer = 2.39
+	layer = PIPES_SUPPLY_LAYER
 	icon_connect_type = "-supply"
 	color = PIPE_COLOR_BLUE
 

--- a/code/ATMOSPHERICS/pipes/manifold4w.dm
+++ b/code/ATMOSPHERICS/pipes/manifold4w.dm
@@ -19,7 +19,6 @@
 	var/obj/machinery/atmospherics/node4
 
 	level = 1
-	layer = 2.4 //under wires with their 2.44
 
 /obj/machinery/atmospherics/pipe/manifold4w/New()
 	..()
@@ -168,7 +167,7 @@
 	icon_state = "map_4way-scrubbers"
 	connect_types = CONNECT_TYPE_SCRUBBER
 	piping_layer = PIPING_LAYER_SCRUBBER
-	layer = 2.38
+	layer = PIPES_SCRUBBER_LAYER
 	icon_connect_type = "-scrubbers"
 	color = PIPE_COLOR_RED
 
@@ -178,7 +177,7 @@
 	icon_state = "map_4way-supply"
 	connect_types = CONNECT_TYPE_SUPPLY
 	piping_layer = PIPING_LAYER_SUPPLY
-	layer = 2.39
+	layer = PIPES_SUPPLY_LAYER
 	icon_connect_type = "-supply"
 	color = PIPE_COLOR_BLUE
 
@@ -214,7 +213,7 @@
 	icon_state = "map_4way-scrubbers"
 	connect_types = CONNECT_TYPE_SCRUBBER
 	piping_layer = PIPING_LAYER_SCRUBBER
-	layer = 2.38
+	layer = PIPES_SCRUBBER_LAYER
 	icon_connect_type = "-scrubbers"
 	color = PIPE_COLOR_RED
 
@@ -224,7 +223,7 @@
 	icon_state = "map_4way-supply"
 	connect_types = CONNECT_TYPE_SUPPLY
 	piping_layer = PIPING_LAYER_SUPPLY
-	layer = 2.39
+	layer = PIPES_SUPPLY_LAYER
 	icon_connect_type = "-supply"
 	color = PIPE_COLOR_BLUE
 

--- a/code/ATMOSPHERICS/pipes/pipe_base.dm
+++ b/code/ATMOSPHERICS/pipes/pipe_base.dm
@@ -7,7 +7,7 @@
 	var/datum/pipeline/parent
 	var/volume = 0
 
-	layer = 2.4 //under wires with their 2.44
+	layer = PIPES_LAYER
 	use_power = 0
 
 	pipe_flags = 0 // Does not have PIPING_DEFAULT_LAYER_ONLY flag.

--- a/code/ATMOSPHERICS/pipes/simple.dm
+++ b/code/ATMOSPHERICS/pipes/simple.dm
@@ -173,7 +173,7 @@
 	icon_state = "intact-scrubbers"
 	connect_types = CONNECT_TYPE_SCRUBBER
 	piping_layer = PIPING_LAYER_SCRUBBER
-	layer = 2.38
+	layer = PIPES_SCRUBBER_LAYER
 	icon_connect_type = "-scrubbers"
 	color = PIPE_COLOR_RED
 
@@ -183,7 +183,7 @@
 	icon_state = "intact-supply"
 	connect_types = CONNECT_TYPE_SUPPLY
 	piping_layer = PIPING_LAYER_SUPPLY
-	layer = 2.39
+	layer = PIPES_SUPPLY_LAYER
 	icon_connect_type = "-supply"
 	color = PIPE_COLOR_BLUE
 
@@ -219,7 +219,7 @@
 	icon_state = "intact-scrubbers"
 	connect_types = CONNECT_TYPE_SCRUBBER
 	piping_layer = PIPING_LAYER_SCRUBBER
-	layer = 2.38
+	layer = PIPES_SCRUBBER_LAYER
 	icon_connect_type = "-scrubbers"
 	color = PIPE_COLOR_RED
 
@@ -229,7 +229,7 @@
 	icon_state = "intact-supply"
 	connect_types = CONNECT_TYPE_SUPPLY
 	piping_layer = PIPING_LAYER_SUPPLY
-	layer = 2.39
+	layer = PIPES_SUPPLY_LAYER
 	icon_connect_type = "-supply"
 	color = PIPE_COLOR_BLUE
 

--- a/code/ATMOSPHERICS/pipes/tank.dm
+++ b/code/ATMOSPHERICS/pipes/tank.dm
@@ -11,6 +11,7 @@
 	volume = 10000 //in liters, 1 meters by 1 meters by 2 meters ~tweaked it a little to simulate a pressure tank without needing to recode them yet
 	var/start_pressure = 25*ONE_ATMOSPHERE
 
+	layer = ATMOS_LAYER
 	level = 1
 	dir = SOUTH
 	initialize_directions = SOUTH

--- a/code/__defines/_planes+layers.dm
+++ b/code/__defines/_planes+layers.dm
@@ -57,8 +57,9 @@ What is the naming convention for planes or layers?
 #define SPACE_PLANE				-43 // Space turfs themselves
 #define PLATING_PLANE			-44 // Plating
 	#define DISPOSAL_LAYER		2.1 // Under objects, even when planeswapped
-	#define WIRES_LAYER			2.2 // Under objects, even when planeswapped
-	#define PIPES_LAYER			2.3	// Under objects, even when planeswapped
+	#define PIPES_LAYER			2.2	// Under objects, even when planeswapped
+	#define WIRES_LAYER			2.3 // Under objects, even when planeswapped
+	#define ATMOS_LAYER			2.4 // Pipe-like atmos machinery that goes on the floor, like filters.
 	#define ABOVE_UTILITY		2.5 // Above stuff like pipes and wires
 #define TURF_PLANE				-45 // Turfs themselves, most flooring
 	#define ABOVE_TURF_LAYER	2.1	// Snow and such

--- a/code/__defines/construction.dm
+++ b/code/__defines/construction.dm
@@ -28,7 +28,7 @@
 #define PIPE_BENDABLE			1 //6 directions: N/S, E/W, N/E, N/W, S/E, S/W
 #define PIPE_TRINARY			2 //4 directions: N/E/S, E/S/W, S/W/N, W/N/E
 #define PIPE_TRIN_M				3 //8 directions: N->S+E, S->N+E, N->S+W, S->N+W, E->W+S, W->E+S, E->W+N, W->E+N
-#define PIPE_DIRECTIONAL				4 //4 directions: N, S, E, W
+#define PIPE_DIRECTIONAL		4 //4 directions: N, S, E, W
 #define PIPE_ONEDIR				5 //1 direction: N/S/E/W
 #define PIPE_UNARY_FLIPPABLE	6 //8 directions: N, S, E, W, N-flipped, S-flipped, E-flipped, W-flipped
 #define PIPE_TRIN_T				7 //8 directions: N->S+E, S->N+E, N->S+W, S->N+W, E->W+S, W->E+S, E->W+N, W->E+N
@@ -44,6 +44,11 @@
 #define PIPING_LAYER_REGULAR	2
 #define PIPING_LAYER_SCRUBBER	3
 #define PIPING_LAYER_DEFAULT	PIPING_LAYER_REGULAR
+
+// We offset the layer values of the different pipe types to ensure they look nice
+#define PIPES_SCRUBBER_LAYER	(PIPES_LAYER - 0.02)
+#define PIPES_SUPPLY_LAYER		(PIPES_LAYER - 0.01)
+#define PIPES_HE_LAYER			(PIPES_LAYER + 0.01)
 
 // Pipe flags
 #define PIPING_ALL_LAYER 1					//intended to connect with all layers, check for all instead of just one.

--- a/code/game/machinery/atmoalter/portable_atmospherics.dm
+++ b/code/game/machinery/atmoalter/portable_atmospherics.dm
@@ -1,6 +1,7 @@
 /obj/machinery/portable_atmospherics
 	name = "atmoalter"
 	use_power = 0
+	layer = OBJ_LAYER // These are mobile, best not be under everything.
 	var/datum/gas_mixture/air_contents = new
 
 	var/obj/machinery/atmospherics/portables_connector/connected_port

--- a/code/modules/multiz/pipes.dm
+++ b/code/modules/multiz/pipes.dm
@@ -201,7 +201,7 @@ obj/machinery/atmospherics/pipe/zpipe/up/scrubbers
 	desc = "A scrubbers pipe segment to connect upwards."
 	connect_types = CONNECT_TYPE_SCRUBBER
 	piping_layer = PIPING_LAYER_SCRUBBER
-	layer = 2.38
+	layer = PIPES_SCRUBBER_LAYER
 	icon_connect_type = "-scrubbers"
 	color = PIPE_COLOR_RED
 
@@ -211,7 +211,7 @@ obj/machinery/atmospherics/pipe/zpipe/up/supply
 	desc = "A supply pipe segment to connect upwards."
 	connect_types = CONNECT_TYPE_SUPPLY
 	piping_layer = PIPING_LAYER_SUPPLY
-	layer = 2.39
+	layer = PIPES_SUPPLY_LAYER
 	icon_connect_type = "-supply"
 	color = PIPE_COLOR_BLUE
 
@@ -221,7 +221,7 @@ obj/machinery/atmospherics/pipe/zpipe/down/scrubbers
 	desc = "A scrubbers pipe segment to connect downwards."
 	connect_types = CONNECT_TYPE_SCRUBBER
 	piping_layer = PIPING_LAYER_SCRUBBER
-	layer = 2.38
+	layer = PIPES_SCRUBBER_LAYER
 	icon_connect_type = "-scrubbers"
 	color = PIPE_COLOR_RED
 
@@ -231,6 +231,6 @@ obj/machinery/atmospherics/pipe/zpipe/down/supply
 	desc = "A supply pipe segment to connect downwards."
 	connect_types = CONNECT_TYPE_SUPPLY
 	piping_layer = PIPING_LAYER_SUPPLY
-	layer = 2.39
+	layer = PIPES_SUPPLY_LAYER
 	icon_connect_type = "-supply"
 	color = PIPE_COLOR_BLUE

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -53,7 +53,8 @@ var/list/possible_cable_coil_colours = list(
 	icon_state = "0-1"
 	var/d1 = 0
 	var/d2 = 1
-	layer = 2.44 //Just below unary stuff, which is at 2.45 and above pipes, which are at 2.4
+	plane = PLATING_PLANE
+	layer = WIRES_LAYER
 	color = COLOR_RED
 	var/obj/machinery/power/breakerbox/breaker_box
 

--- a/code/modules/power/cable_ender.dm
+++ b/code/modules/power/cable_ender.dm
@@ -8,7 +8,8 @@
 	icon = 'icons/obj/power_cond_heavy.dmi'
 	name = "large power cable"
 	desc = "This cable is tough. It cannot be cut with simple hand tools."
-	layer = 2.39 //Just below pipes, which are at 2.4
+	plane = PLATING_PLANE
+	layer = PIPES_LAYER - 0.05 //Just below pipes
 	color = null
 	unacidable = 1
 	var/id = null

--- a/code/modules/power/cable_heavyduty.dm
+++ b/code/modules/power/cable_heavyduty.dm
@@ -7,7 +7,8 @@
 	icon = 'icons/obj/power_cond_heavy.dmi'
 	name = "large power cable"
 	desc = "This cable is tough. It cannot be cut with simple hand tools."
-	layer = 2.39 //Just below pipes, which are at 2.4
+	plane = PLATING_PLANE
+	layer = PIPES_LAYER - 0.05 //Just below pipes
 	color = null
 
 /obj/structure/cable/heavyduty/attackby(obj/item/W, mob/user)

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -663,6 +663,7 @@
 	var/dpdir = 0		// bitmask of pipe directions
 	dir = 0				// dir will contain dominant direction for junction pipes
 	var/health = 10 	// health points 0-10
+	plane = PLATING_PLANE
 	layer = DISPOSAL_LAYER	// slightly lower than wires and other pipes
 	var/base_icon_state	// initial icon state on map
 	var/sortType = ""


### PR DESCRIPTION
Also fix a few things to be on the correct plane.  Basically the under-floor stuff is supposed to be on PLATING_PLANE.
Fixed wires to be on top of pipes like they used to be, otherwise they'd be obscured too often.

![image](https://user-images.githubusercontent.com/14110581/38225368-99bd52e6-36c2-11e8-853d-7464bb857d3d.png)

Portable atmospherics go on object layer so they are above stationary machinery, given that they move around. This also fixes reported issue with canisters going under meters.
![image](https://user-images.githubusercontent.com/14110581/38225741-51c5d592-36c4-11e8-9d1c-5064dbc3c2df.png)

