### PR TITLE
Fix bug in death ripley visuals

### DIFF
--- a/code/game/mecha/working/ripley.dm
+++ b/code/game/mecha/working/ripley.dm
@@ -34,6 +34,7 @@
 	desc = "OH SHIT IT'S THE DEATHSQUAD WE'RE ALL GONNA DIE"
 	name = "DEATH-RIPLEY"
 	icon_state = "deathripley"
+	initial_icon = "deathripley"
 	step_in = 2
 	opacity=0
 	lights_power = 60


### PR DESCRIPTION
Death ripleys were being reset to normal ripley visuals when a pilot enters, caused by using the inherited `initial_icon` value from the normal ripleys.