### PR TITLE
Fix Wall Frames - Several Ways

### DIFF
--- a/code/_helpers/unsorted.dm
+++ b/code/_helpers/unsorted.dm
@@ -1223,20 +1223,21 @@ proc/is_hot(obj/item/W as obj)
 
 /*
 Checks if that loc and dir has a item on the wall
+TODO - Fix this ancient list of wall items. Preferably make it dynamically populated. ~Leshana
 */
 var/list/WALLITEMS = list(
-	"/obj/machinery/power/apc", "/obj/machinery/alarm", "/obj/item/device/radio/intercom",
-	"/obj/structure/extinguisher_cabinet", "/obj/structure/reagent_dispensers/peppertank",
-	"/obj/machinery/status_display", "/obj/machinery/requests_console", "/obj/machinery/light_switch", "/obj/effect/sign",
-	"/obj/machinery/newscaster", "/obj/machinery/firealarm", "/obj/structure/noticeboard", "/obj/machinery/door_control",
-	"/obj/machinery/computer/security/telescreen", "/obj/machinery/embedded_controller/radio/simple_vent_controller",
-	"/obj/item/weapon/storage/secure/safe", "/obj/machinery/door_timer", "/obj/machinery/flasher", "/obj/machinery/keycard_auth",
-	"/obj/structure/mirror", "/obj/structure/closet/fireaxecabinet", "/obj/machinery/computer/security/telescreen/entertainment"
+	/obj/machinery/power/apc, /obj/machinery/alarm, /obj/item/device/radio/intercom, /obj/structure/frame,
+	/obj/structure/extinguisher_cabinet, /obj/structure/reagent_dispensers/peppertank,
+	/obj/machinery/status_display, /obj/machinery/requests_console, /obj/machinery/light_switch, /obj/structure/sign,
+	/obj/machinery/newscaster, /obj/machinery/firealarm, /obj/structure/noticeboard, /obj/machinery/button/remote,
+	/obj/machinery/computer/security/telescreen, /obj/machinery/embedded_controller/radio,
+	/obj/item/weapon/storage/secure/safe, /obj/machinery/door_timer, /obj/machinery/flasher, /obj/machinery/keycard_auth,
+	/obj/structure/mirror, /obj/structure/closet/fireaxecabinet, /obj/machinery/computer/security/telescreen/entertainment
 	)
 /proc/gotwallitem(loc, dir)
 	for(var/obj/O in loc)
 		for(var/item in WALLITEMS)
-			if(istype(O, text2path(item)))
+			if(istype(O, item))
 				//Direction works sometimes
 				if(O.dir == dir)
 					return 1
@@ -1260,7 +1261,7 @@ var/list/WALLITEMS = list(
 	//Some stuff is placed directly on the wallturf (signs)
 	for(var/obj/O in get_step(loc, dir))
 		for(var/item in WALLITEMS)
-			if(istype(O, text2path(item)))
+			if(istype(O, item))
 				if(O.pixel_x == 0 && O.pixel_y == 0)
 					return 1
 	return 0

--- a/code/game/machinery/frame.dm
+++ b/code/game/machinery/frame.dm
@@ -12,11 +12,6 @@
 		else
 			construction_frame_floor += type
 
-	var/datum/frame/frame_types/cancel/cancel = new /datum/frame/frame_types/cancel
-	construction_frame_wall += cancel
-	construction_frame_floor += cancel
-
-
 //////////////////////////////
 // Frame Type Datum - Describes the frame structures that can be created from a frame item.
 //////////////////////////////
@@ -179,9 +174,6 @@
 	frame_style = FRAME_STYLE_WALL
 	x_offset = 24
 	y_offset = 24
-
-/datum/frame/frame_types/cancel //used to get out of input dialogue
-	name = "Cancel"
 
 //////////////////////////////
 // Frame Object (Structure)

--- a/code/game/machinery/wall_frames.dm
+++ b/code/game/machinery/wall_frames.dm
@@ -54,17 +54,6 @@
 
 /obj/item/frame/proc/try_build(turf/on_wall, mob/user as mob)
 	update_type_list()
-	var/datum/frame/frame_types/frame_type
-	if(!build_machine_type)
-		var/datum/frame/frame_types/response = input(user, "What kind of frame would you like to make?", "Frame type request", null) in frame_types_wall
-		if(!response || response.name == "Cancel")
-			return
-		frame_type = response
-
-		build_machine_type = /obj/structure/frame
-
-		if(frame_type.frame_size != 5)
-			new /obj/item/stack/material/steel(user.loc, (5 - frame_type.frame_size))
 
 	if(get_dist(on_wall, user)>1)
 		return
@@ -91,6 +80,18 @@
 	if(gotwallitem(loc, ndir))
 		to_chat(user, "<span class='danger'>There's already an item on this wall!</span>")
 		return
+
+	var/datum/frame/frame_types/frame_type
+	if(!build_machine_type)
+		var/datum/frame/frame_types/response = input(user, "What kind of frame would you like to make?", "Frame type request", null) in frame_types_wall
+		if(!response || response.name == "Cancel")
+			return
+		frame_type = response
+
+		build_machine_type = /obj/structure/frame
+
+		if(frame_type.frame_size != 5)
+			new /obj/item/stack/material/steel(user.loc, (5 - frame_type.frame_size))
 
 	var/obj/machinery/M = new build_machine_type(loc, ndir, 1, frame_type)
 	M.fingerprints = fingerprints

--- a/code/game/machinery/wall_frames.dm
+++ b/code/game/machinery/wall_frames.dm
@@ -29,8 +29,8 @@
 	update_type_list()
 	var/datum/frame/frame_types/frame_type
 	if(!build_machine_type)
-		var/datum/frame/frame_types/response = input(user, "What kind of frame would you like to make?", "Frame type request", null) in frame_types_floor
-		if(!response || response.name == "Cancel")
+		var/datum/frame/frame_types/response = input(user, "What kind of frame would you like to make?", "Frame type request", null) as null|anything in frame_types_floor
+		if(!response)
 			return
 		frame_type = response
 
@@ -83,8 +83,8 @@
 
 	var/datum/frame/frame_types/frame_type
 	if(!build_machine_type)
-		var/datum/frame/frame_types/response = input(user, "What kind of frame would you like to make?", "Frame type request", null) in frame_types_wall
-		if(!response || response.name == "Cancel")
+		var/datum/frame/frame_types/response = input(user, "What kind of frame would you like to make?", "Frame type request", null) as null|anything in frame_types_wall
+		if(!response)
 			return
 		frame_type = response
 

--- a/code/game/objects/items/apc_frame.dm
+++ b/code/game/objects/items/apc_frame.dm
@@ -13,31 +13,31 @@
 		new /obj/item/stack/material/steel( get_turf(src.loc), 2 )
 		qdel(src)
 
-/obj/item/frame/apc/try_build(turf/on_wall)
-	if (get_dist(on_wall,usr)>1)
+/obj/item/frame/apc/try_build(turf/on_wall, mob/user as mob)
+	if (get_dist(on_wall, user)>1)
 		return
-	var/ndir = get_dir(usr,on_wall)
+	var/ndir = get_dir(user, on_wall)
 	if (!(ndir in cardinal))
 		return
-	var/turf/loc = get_turf(usr)
+	var/turf/loc = get_turf(user)
 	var/area/A = loc.loc
 	if (!istype(loc, /turf/simulated/floor))
-		usr << "<span class='warning'>APC cannot be placed on this spot.</span>"
+		to_chat(user, "<span class='warning'>APC cannot be placed on this spot.</span>")
 		return
 	if (A.requires_power == 0 || istype(A, /area/space))
-		usr << "<span class='warning'>APC cannot be placed in this area.</span>"
+		to_chat(user, "<span class='warning'>APC cannot be placed in this area.</span>")
 		return
 	if (A.get_apc())
-		usr << "<span class='warning'>This area already has an APC.</span>"
+		to_chat(user, "<span class='warning'>This area already has an APC.</span>")
 		return //only one APC per area
 	for(var/obj/machinery/power/terminal/T in loc)
 		if (T.master)
-			usr << "<span class='warning'>There is another network terminal here.</span>"
+			to_chat(user, "<span class='warning'>There is another network terminal here.</span>")
 			return
 		else
 			var/obj/item/stack/cable_coil/C = new /obj/item/stack/cable_coil(loc)
 			C.amount = 10
-			usr << "You cut the cables and disassemble the unused power terminal."
+			to_chat(user, "You cut the cables and disassemble the unused power terminal.")
 			qdel(T)
 	new /obj/machinery/power/apc(loc, ndir, 1)
 	qdel(src)

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -311,7 +311,7 @@
 				qdel(src)
 	else if(istype(W,/obj/item/frame) && anchored)
 		var/obj/item/frame/F = W
-		F.try_build(src)
+		F.try_build(src, user)
 	else
 		user.setClickCooldown(user.get_attack_speed(W))
 		if(W.damtype == BRUTE || W.damtype == BURN)

--- a/code/game/turfs/simulated/wall_attacks.dm
+++ b/code/game/turfs/simulated/wall_attacks.dm
@@ -362,7 +362,7 @@
 
 	if(istype(W,/obj/item/frame))
 		var/obj/item/frame/F = W
-		F.try_build(src)
+		F.try_build(src, user)
 		return
 
 	else if(!istype(W,/obj/item/weapon/rcd) && !istype(W, /obj/item/weapon/reagent_containers))


### PR DESCRIPTION
**Fix building frames on walls and windows.**
`try_build()` has long accepted `user` parameter, but nothing that called try_build actually passed it! Upgraded try_build on APC to use the user parameter, and switched to use to_chat while I was there.

**Fix wall frames dropping steel and bugging on failure to place.**
Previously, if you tried to place a frame on a wall and it failed (due to something already being there etc) you would no longer be asked what type to use next time you try, and it will runtime.
Fixes this by performing the safety checks *before* asking you want you want to build.  Since the checks don't depend on what type you want to build anyway its fine.

**Fix allowing frames on walls with machine-under-construction on it already.**
Add `/object/structure/frame` to the list of objects that count as wall items. Also convert from strings to actual type paths ... and fix the paths that haven't existed for four years.  Properly speaking it should be a dynamically generated list at some point.

**Switch frame construction menu to have a cancel button.**
Instead of having a whole frame type dedicated to giving a "Cancel" option... lets just tell BYOND to add a cancel button to the menu.
![cancel option](https://user-images.githubusercontent.com/14110581/38652033-2d349014-3dd2-11e8-8147-93cb13912d9a.png)
Port of VOREStation/VOREStation#3445
