### PR TITLE
Fixed sheet snatcher spawning stacks with wrong looking icon

### DIFF
--- a/code/game/objects/items/weapons/storage/bags.dm
+++ b/code/game/objects/items/weapons/storage/bags.dm
@@ -275,6 +275,7 @@
 			var/stacksize = min(S.amount,N.max_amount)
 			N.amount = stacksize
 			S.amount -= stacksize
+			N.update_icon()
 		if(!S.amount)
 			qdel(S) // todo: there's probably something missing here
 	orient2hud(usr)


### PR DESCRIPTION
Now they correctly reflect amount of sheets in stack