### PR TITLE
Fixes simplemob icons when killed while resting.

### DIFF
--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -729,6 +729,7 @@
 /mob/living/simple_animal/death(gibbed, deathmessage = "dies!")
 	density = 0 //We don't block even if we did before
 	walk(src, 0) //We stop any background-processing walks
+	resting = 0 //We can rest in peace later.
 
 	if(faction_friends.len)
 		faction_friends -= src


### PR DESCRIPTION
-Makes the death proc stop simplemobs resting before the icon update so the dying mobs will no longer end up stuck with resting icon instead of the dead one.