### PR TITLE
Meteor events have fewer waves with less dangerous meteors

### DIFF
--- a/code/modules/events/meteors.dm
+++ b/code/modules/events/meteors.dm
@@ -6,7 +6,7 @@
 	var/start_side
 
 /datum/event/meteor_wave/setup()
-	waves = severity * rand(1,3)
+	waves = 2 + rand(1, severity)		//EVENT_LEVEL_MAJOR is 3-5 waves
 	start_side = pick(cardinal)
 	endWhen = worst_case_end()
 
@@ -37,10 +37,10 @@
 			command_announcement.Announce("The colony has cleared the meteor shower", "Meteor Alert")
 
 /datum/event/meteor_wave/proc/get_meteors()
-	switch(severity)
-		if(EVENT_LEVEL_MAJOR)
+	if(EVENT_LEVEL_MAJOR)
+		if(prob(10))
 			return meteors_catastrophic
-		if(EVENT_LEVEL_MODERATE)
-			return meteors_threatening
 		else
-			return meteors_normal
+			return meteors_threatening
+	else
+		return meteors_normal

--- a/html/changelogs/Anewbe - Meteors.yml
+++ b/html/changelogs/Anewbe - Meteors.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Anewbe
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Meteor events should be a lot less brutal."


### PR DESCRIPTION
- Meteor events now have a more stable number of waves. Moderate events are now between 3 and 4 waves (from 2, 4, or 6) and major events are now between 3 and 5 waves (from 3, 6, or 9) .
- Meteor events in general throw weaker rocks.