### PR TITLE
Fixes borg synth sheet naming when depleted to 1

### DIFF
--- a/code/modules/materials/material_synth.dm
+++ b/code/modules/materials/material_synth.dm
@@ -12,6 +12,9 @@
 		desc = "A device that synthesises [material.display_name]."
 		matter = null
 
+/obj/item/stack/material/cyborg/update_strings()
+	return
+
 /obj/item/stack/material/cyborg/plastic
 	icon_state = "sheet-plastic"
 	default_type = "plastic"


### PR DESCRIPTION
-The thing changing the sheet stack names to singular/plural no longer breaks the naming for borg sheet synthesisers.