### PR TITLE
Makes organ removal/attachment right again

### DIFF
--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -1189,6 +1189,8 @@ Note that amputating the affected organ does in fact remove the infection from t
 	victim.organs -= src
 	victim.organs_by_name[organ_tag] = null // Remove from owner's vars.
 
+	status |= ORGAN_CUT_AWAY //Checked during surgeries to reattach it
+
 	//Robotic limbs explode if sabotaged.
 	if(is_robotic && sabotaged)
 		victim.visible_message(

--- a/code/modules/surgery/limb_reattach.dm
+++ b/code/modules/surgery/limb_reattach.dm
@@ -84,7 +84,7 @@
 
 /datum/surgery_step/limb/connect/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/E = target.get_organ(target_zone)
-	return E && !E.is_stump() && (E.status & ORGAN_DESTROYED)
+	return E && !E.is_stump() && (E.status & ORGAN_CUT_AWAY)
 
 /datum/surgery_step/limb/connect/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/E = target.get_organ(target_zone)
@@ -95,11 +95,8 @@
 	var/obj/item/organ/external/E = target.get_organ(target_zone)
 	user.visible_message("<span class='notice'>[user] has connected tendons and muscles in [target]'s [E.amputation_point] with [tool].</span>",	\
 	"<span class='notice'>You have connected tendons and muscles in [target]'s [E.amputation_point] with [tool].</span>")
-	E.status &= ~ORGAN_DESTROYED
-	if(E.children)
-		for(var/obj/item/organ/external/C in E.children)
-			C.status &= ~ORGAN_DESTROYED
-	target.update_icons_body(FALSE)
+	E.status &= ~ORGAN_CUT_AWAY
+	target.update_icons_body()
 	target.updatehealth()
 	target.UpdateDamageIcon()
 


### PR DESCRIPTION
Current state of affairs:
* Removing/attaching robotic limbs sets/unsets ORGAN_CUT_AWAY
* Removing/attaching organic limbs does nothing to status, only 1 step
* Bioprinter always prints organic limbs with ORGAN_CUT_AWAY
* Organic limb attachment surgery does not unset ORGAN_CUT_AWAY
* Orphaned surgery 'nerve reattachment' checks for unused ORGAN_DESTROYED flag

New state of affairs:
* Removing/attaching organic **AND** robotic limbs sets/unsets ORGAN_CUT_AWAY
* Bioprinter prints limbs with ORGAN_CUT_AWAY (so no change)
* Un-orphaned 'nerve reattachment' surgery to clean ORGAN_CUT_AWAY as the second step in organic limb reattachment
