### PR TITLE
Species economic modifier is now a species var

### DIFF
--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -61,7 +61,7 @@
 			if(CLASS_LOWER)		income = 0.50
 
 	//give them an account in the station database
-	var/money_amount = (rand(5,50) + rand(5, 50)) * income * economic_modifier * (H.species ? economic_species_modifier[H.species.type] : 2)
+	var/money_amount = (rand(5,50) + rand(5, 50)) * income * economic_modifier * (H.species.economic_modifier)
 	var/datum/money_account/M = create_account(H.real_name, money_amount, null)
 	if(H.mind)
 		var/remembered_info = ""

--- a/code/modules/economy/economy_misc.dm
+++ b/code/modules/economy/economy_misc.dm
@@ -47,17 +47,6 @@
 #define GEAR_EVA 15
 
 
-/var/list/economic_species_modifier = list(
-										/datum/species/human							= 10,
-										/datum/species/human/vatgrown						= 10,
-										/datum/species/skrell							= 12,
-										/datum/species/unathi							= 7,
-										/datum/species/tajaran							= 7,
-										/datum/species/teshari							= 6,
-										/datum/species/diona 							= 4,
-										/datum/species/shapeshifter/promethean			= 3
-											)
-
 //---- The following corporations are friendly with NanoTrasen and loosely enable trade and travel:
 //Corporation NanoTrasen - Generalised / high tech research and phoron exploitation.
 //Corporation Vessel Contracting - Ship and station construction, materials research.

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -5,84 +5,84 @@
 /datum/species
 
 	// Descriptors and strings.
-	var/name                                             // Species name.
-	var/name_plural                                      // Pluralized name (since "[name]s" is not always valid)
-	var/blurb = "A completely nondescript species."      // A brief lore summary for use in the chargen screen.
+	var/name												// Species name.
+	var/name_plural											// Pluralized name (since "[name]s" is not always valid)
+	var/blurb = "A completely nondescript species."			// A brief lore summary for use in the chargen screen.
 
 	// Icon/appearance vars.
-	var/icobase = 'icons/mob/human_races/r_human.dmi'    // Normal icon set.
-	var/deform = 'icons/mob/human_races/r_def_human.dmi' // Mutated icon set.
+	var/icobase = 'icons/mob/human_races/r_human.dmi'		// Normal icon set.
+	var/deform = 'icons/mob/human_races/r_def_human.dmi'	// Mutated icon set.
 
-	var/speech_bubble_appearance = "normal"              // Part of icon_state to use for speech bubbles when talking.  See talk.dmi for available icons.
-	var/fire_icon_state = "humanoid"                     // The icon_state used inside OnFire.dmi for when on fire.
-	var/suit_storage_icon = 'icons/mob/belt_mirror.dmi'  // Icons used for worn items in suit storage slot.
+	var/speech_bubble_appearance = "normal"					// Part of icon_state to use for speech bubbles when talking.	See talk.dmi for available icons.
+	var/fire_icon_state = "humanoid"						// The icon_state used inside OnFire.dmi for when on fire.
+	var/suit_storage_icon = 'icons/mob/belt_mirror.dmi'		// Icons used for worn items in suit storage slot.
 
 	// Damage overlay and masks.
 	var/damage_overlays = 'icons/mob/human_races/masks/dam_human.dmi'
 	var/damage_mask = 'icons/mob/human_races/masks/dam_mask_human.dmi'
 	var/blood_mask = 'icons/mob/human_races/masks/blood_human.dmi'
 
-	var/prone_icon                                       // If set, draws this from icobase when mob is prone.
-	var/blood_color = "#A10808"                          // Red.
-	var/flesh_color = "#FFC896"                          // Pink.
-	var/base_color                                       // Used by changelings. Should also be used for icon previews.
+	var/prone_icon											// If set, draws this from icobase when mob is prone.
+	var/blood_color = "#A10808"								// Red.
+	var/flesh_color = "#FFC896"								// Pink.
+	var/base_color											// Used by changelings. Should also be used for icon previews.
 
-	var/tail                                             // Name of tail state in species effects icon file.
-	var/tail_animation                                   // If set, the icon to obtain tail animation states from.
+	var/tail												// Name of tail state in species effects icon file.
+	var/tail_animation										// If set, the icon to obtain tail animation states from.
 	var/tail_hair
 
-	var/icon_scale = 1                                   // Makes the icon larger/smaller.
+	var/icon_scale = 1										// Makes the icon larger/smaller.
 
-	var/race_key = 0       	                             // Used for mob icon cache string.
-	var/icon/icon_template                               // Used for mob icon generation for non-32x32 species.
+	var/race_key = 0										// Used for mob icon cache string.
+	var/icon/icon_template									// Used for mob icon generation for non-32x32 species.
 	var/mob_size	= MOB_MEDIUM
 	var/show_ssd = "fast asleep"
 	var/virus_immune
-	var/short_sighted                                    // Permanent weldervision.
-	var/blood_volume = 560                               // Initial blood volume.
-	var/bloodloss_rate = 1								 // Multiplier for how fast a species bleeds out. Higher = Faster
-	var/hunger_factor = 0.05                             // Multiplier for hunger.
-	var/active_regen_mult = 1							 // Multiplier for 'Regenerate' power speed, in human_powers.dm
+	var/short_sighted										// Permanent weldervision.
+	var/blood_volume = 560									// Initial blood volume.
+	var/bloodloss_rate = 1									// Multiplier for how fast a species bleeds out. Higher = Faster
+	var/hunger_factor = 0.05								// Multiplier for hunger.
+	var/active_regen_mult = 1								// Multiplier for 'Regenerate' power speed, in human_powers.dm
 
-	var/taste_sensitivity = TASTE_NORMAL                 // How sensitive the species is to minute tastes.
+	var/taste_sensitivity = TASTE_NORMAL					// How sensitive the species is to minute tastes.
 
 	var/min_age = 17
 	var/max_age = 70
 
 	// Language/culture vars.
-	var/default_language = LANGUAGE_GALCOM // Default language is used when 'say' is used without modifiers.
-	var/language = LANGUAGE_GALCOM         // Default racial language, if any.
-	var/species_language = LANGUAGE_GALCOM	// Used on the Character Setup screen
-	var/list/secondary_langs = list()        // The names of secondary languages that are available to this species.
-	var/list/speech_sounds                   // A list of sounds to potentially play when speaking.
-	var/list/speech_chance                   // The likelihood of a speech sound playing.
-	var/num_alternate_languages = 0          // How many secondary languages are available to select at character creation
-	var/name_language = LANGUAGE_GALCOM    // The language to use when determining names for this species, or null to use the first name/last name generator
+	var/default_language = LANGUAGE_GALCOM					// Default language is used when 'say' is used without modifiers.
+	var/language = LANGUAGE_GALCOM							// Default racial language, if any.
+	var/species_language = LANGUAGE_GALCOM					// Used on the Character Setup screen
+	var/list/secondary_langs = list()						// The names of secondary languages that are available to this species.
+	var/list/speech_sounds									// A list of sounds to potentially play when speaking.
+	var/list/speech_chance									// The likelihood of a speech sound playing.
+	var/num_alternate_languages = 0							// How many secondary languages are available to select at character creation
+	var/name_language = LANGUAGE_GALCOM						// The language to use when determining names for this species, or null to use the first name/last name generator
 
 	//Soundy emotey things.
 	var/scream_verb = "screams"
-	var/male_scream_sound //= 'sound/goonstation/voice/male_scream.ogg' Removed due to licensing, replace!
-	var/female_scream_sound //= 'sound/goonstation/voice/female_scream.ogg' Removed due to licensing, replace!
+	var/male_scream_sound		//= 'sound/goonstation/voice/male_scream.ogg' Removed due to licensing, replace!
+	var/female_scream_sound		//= 'sound/goonstation/voice/female_scream.ogg' Removed due to licensing, replace!
 	var/male_cough_sounds = list('sound/effects/mob_effects/m_cougha.ogg','sound/effects/mob_effects/m_coughb.ogg', 'sound/effects/mob_effects/m_coughc.ogg')
 	var/female_cough_sounds = list('sound/effects/mob_effects/f_cougha.ogg','sound/effects/mob_effects/f_coughb.ogg')
 	var/male_sneeze_sound = 'sound/effects/mob_effects/sneeze.ogg'
 	var/female_sneeze_sound = 'sound/effects/mob_effects/f_sneeze.ogg'
 
 	// Combat vars.
-	var/total_health = 100                   // Point at which the mob will enter crit.
-	var/list/unarmed_types = list(           // Possible unarmed attacks that the mob will use in combat,
+	var/total_health = 100									// Point at which the mob will enter crit.
+	var/list/unarmed_types = list(							// Possible unarmed attacks that the mob will use in combat,
 		/datum/unarmed_attack,
 		/datum/unarmed_attack/bite
 		)
-	var/list/unarmed_attacks = null          // For empty hand harm-intent attack
-	var/brute_mod =     1                    // Physical damage multiplier.
-	var/burn_mod =      1                    // Burn damage multiplier.
-	var/oxy_mod =       1                    // Oxyloss modifier
-	var/toxins_mod =    1                    // Toxloss modifier
-	var/radiation_mod = 1                    // Radiation modifier
-	var/flash_mod =     1                    // Stun from blindness modifier.
-	var/chemOD_mod =	1					 // Damage modifier for overdose
-	var/vision_flags = SEE_SELF              // Same flags as glasses.
+	var/list/unarmed_attacks = null							// For empty hand harm-intent attack
+	var/brute_mod =			1								// Physical damage multiplier.
+	var/burn_mod =			1								// Burn damage multiplier.
+	var/oxy_mod =			1								// Oxyloss modifier
+	var/toxins_mod =		1								// Toxloss modifier
+	var/radiation_mod =		1								// Radiation modifier
+	var/flash_mod =			1								// Stun from blindness modifier.
+	var/chemOD_mod =		1								// Damage modifier for overdose
+	var/vision_flags = SEE_SELF								// Same flags as glasses.
 
 	// Death vars.
 	var/meat_type = /obj/item/weapon/reagent_containers/food/snacks/meat/human
@@ -95,23 +95,23 @@
 	var/cloning_modifier = /datum/modifier/cloning_sickness
 
 	// Environment tolerance/life processes vars.
-	var/reagent_tag                                   //Used for metabolizing reagents.
-	var/breath_type = "oxygen"                        // Non-oxygen gas breathed, if any.
-	var/poison_type = "phoron"                        // Poisonous air.
-	var/exhale_type = "carbon_dioxide"                // Exhaled gas type.
+	var/reagent_tag											//Used for metabolizing reagents.
+	var/breath_type = "oxygen"								// Non-oxygen gas breathed, if any.
+	var/poison_type = "phoron"								// Poisonous air.
+	var/exhale_type = "carbon_dioxide"						// Exhaled gas type.
 
-	var/body_temperature = 310.15	                  // Species will try to stabilize at this temperature. (also affects temperature processing)
+	var/body_temperature = 310.15							// Species will try to stabilize at this temperature. (also affects temperature processing)
 
 	// Cold
-	var/cold_level_1 = 260                            // Cold damage level 1 below this point.
-	var/cold_level_2 = 200                            // Cold damage level 2 below this point.
-	var/cold_level_3 = 120                            // Cold damage level 3 below this point.
+	var/cold_level_1 = 260									// Cold damage level 1 below this point.
+	var/cold_level_2 = 200									// Cold damage level 2 below this point.
+	var/cold_level_3 = 120									// Cold damage level 3 below this point.
 
-	var/breath_cold_level_1 = 240					  // Cold gas damage level 1 below this point.
-	var/breath_cold_level_2 = 180					  // Cold gas damage level 2 below this point.
-	var/breath_cold_level_3 = 100					  // Cold gas damage level 3 below this point.
+	var/breath_cold_level_1 = 240							// Cold gas damage level 1 below this point.
+	var/breath_cold_level_2 = 180							// Cold gas damage level 2 below this point.
+	var/breath_cold_level_3 = 100							// Cold gas damage level 3 below this point.
 
-	var/cold_discomfort_level = 285                   // Aesthetic messages about feeling chilly.
+	var/cold_discomfort_level = 285							// Aesthetic messages about feeling chilly.
 	var/list/cold_discomfort_strings = list(
 		"You feel chilly.",
 		"You shiver suddenly.",
@@ -119,15 +119,15 @@
 		)
 
 	// Hot
-	var/heat_level_1 = 360                            // Heat damage level 1 above this point.
-	var/heat_level_2 = 400                            // Heat damage level 2 above this point.
-	var/heat_level_3 = 1000                           // Heat damage level 3 above this point.
+	var/heat_level_1 = 360									// Heat damage level 1 above this point.
+	var/heat_level_2 = 400									// Heat damage level 2 above this point.
+	var/heat_level_3 = 1000									// Heat damage level 3 above this point.
 
-	var/breath_heat_level_1 = 380					  // Heat gas damage level 1 below this point.
-	var/breath_heat_level_2 = 450					  // Heat gas damage level 2 below this point.
-	var/breath_heat_level_3 = 1250					  // Heat gas damage level 3 below this point.
+	var/breath_heat_level_1 = 380							// Heat gas damage level 1 below this point.
+	var/breath_heat_level_2 = 450							// Heat gas damage level 2 below this point.
+	var/breath_heat_level_3 = 1250							// Heat gas damage level 3 below this point.
 
-	var/heat_discomfort_level = 315                   // Aesthetic messages about feeling warm.
+	var/heat_discomfort_level = 315							// Aesthetic messages about feeling warm.
 	var/list/heat_discomfort_strings = list(
 		"You feel sweat drip down your neck.",
 		"You feel uncomfortably warm.",
@@ -135,13 +135,13 @@
 		)
 
 
-	var/passive_temp_gain = 0		                  // Species will gain this much temperature every second
-	var/hazard_high_pressure = HAZARD_HIGH_PRESSURE   // Dangerously high pressure.
-	var/warning_high_pressure = WARNING_HIGH_PRESSURE // High pressure warning.
-	var/warning_low_pressure = WARNING_LOW_PRESSURE   // Low pressure warning.
-	var/hazard_low_pressure = HAZARD_LOW_PRESSURE     // Dangerously low pressure.
-	var/light_dam                                     // If set, mob will be damaged in light over this value and heal in light below its negative.
-	var/minimum_breath_pressure = 16				  // Minimum required pressure for breath, in kPa
+	var/passive_temp_gain = 0								// Species will gain this much temperature every second
+	var/hazard_high_pressure = HAZARD_HIGH_PRESSURE			// Dangerously high pressure.
+	var/warning_high_pressure = WARNING_HIGH_PRESSURE		// High pressure warning.
+	var/warning_low_pressure = WARNING_LOW_PRESSURE			// Low pressure warning.
+	var/hazard_low_pressure = HAZARD_LOW_PRESSURE			// Dangerously low pressure.
+	var/light_dam											// If set, mob will be damaged in light over this value and heal in light below its negative.
+	var/minimum_breath_pressure = 16						// Minimum required pressure for breath, in kPa
 
 
 	var/metabolic_rate = 1
@@ -149,52 +149,55 @@
 	// HUD data vars.
 	var/datum/hud_data/hud
 	var/hud_type
-	var/health_hud_intensity = 1  // This modifies how intensely the health hud is colored.
+	var/health_hud_intensity = 1							// This modifies how intensely the health hud is colored.
 
 	// Body/form vars.
-	var/list/inherent_verbs 	  // Species-specific verbs.
-	var/has_fine_manipulation = 1 // Can use small items.
-	var/siemens_coefficient = 1   // The lower, the thicker the skin and better the insulation.
-	var/darksight = 2             // Native darksight distance.
-	var/flags = 0                 // Various specific features.
-	var/appearance_flags = 0      // Appearance/display related features.
-	var/spawn_flags = 0           // Flags that specify who can spawn as this species
+	var/list/inherent_verbs									// Species-specific verbs.
+	var/has_fine_manipulation = 1							// Can use small items.
+	var/siemens_coefficient = 1								// The lower, the thicker the skin and better the insulation.
+	var/darksight = 2										// Native darksight distance.
+	var/flags = 0											// Various specific features.
+	var/appearance_flags = 0								// Appearance/display related features.
+	var/spawn_flags = 0										// Flags that specify who can spawn as this species
 
-	var/slowdown = 0              // Passive movement speed malus (or boost, if negative)
+	var/slowdown = 0										// Passive movement speed malus (or boost, if negative)
 	var/obj/effect/decal/cleanable/blood/tracks/move_trail = /obj/effect/decal/cleanable/blood/tracks/footprints // What marks are left when walking
 	var/list/skin_overlays = list()
-	var/has_floating_eyes = 0     // Whether the eyes can be shown above other icons
-	var/has_glowing_eyes = 0      // Whether the eyes are shown above all lighting
-	var/water_movement = 0		  // How much faster or slower the species is in water
-	var/snow_movement = 0		  // How much faster or slower the species is on snow
+	var/has_floating_eyes = 0								// Whether the eyes can be shown above other icons
+	var/has_glowing_eyes = 0								// Whether the eyes are shown above all lighting
+	var/water_movement = 0									// How much faster or slower the species is in water
+	var/snow_movement = 0									// How much faster or slower the species is on snow
 
 
-	var/item_slowdown_mod = 1	  // How affected by item slowdown the species is.
-	var/primitive_form            // Lesser form, if any (ie. monkey for humans)
-	var/greater_form              // Greater form, if any, ie. human for monkeys.
+	var/item_slowdown_mod = 1								// How affected by item slowdown the species is.
+	var/primitive_form										// Lesser form, if any (ie. monkey for humans)
+	var/greater_form										// Greater form, if any, ie. human for monkeys.
 	var/holder_type
-	var/gluttonous                // Can eat some mobs. 1 for mice, 2 for monkeys, 3 for people.
-	var/rarity_value = 1          // Relative rarity/collector value for this species.
-	                              // Determines the organs that the species spawns with and
-	var/list/has_organ = list(    // which required-organ checks are conducted.
-		O_HEART =    /obj/item/organ/internal/heart,
-		O_LUNGS =    /obj/item/organ/internal/lungs,
-		O_LIVER =    /obj/item/organ/internal/liver,
-		O_KIDNEYS =  /obj/item/organ/internal/kidneys,
-		O_BRAIN =    /obj/item/organ/internal/brain,
+	var/gluttonous											// Can eat some mobs. 1 for mice, 2 for monkeys, 3 for people.
+
+	var/rarity_value = 1									// Relative rarity/collector value for this species.
+	var/economic_modifier = 2								// How much money this species makes
+
+	// Determines the organs that the species spawns with and
+	var/list/has_organ = list(								// which required-organ checks are conducted.
+		O_HEART =		/obj/item/organ/internal/heart,
+		O_LUNGS =		/obj/item/organ/internal/lungs,
+		O_LIVER =		/obj/item/organ/internal/liver,
+		O_KIDNEYS =	/obj/item/organ/internal/kidneys,
+		O_BRAIN =		/obj/item/organ/internal/brain,
 		O_APPENDIX = /obj/item/organ/internal/appendix,
-		O_EYES =     /obj/item/organ/internal/eyes
+		O_EYES =		 /obj/item/organ/internal/eyes
 		)
-	var/vision_organ              // If set, this organ is required for vision. Defaults to "eyes" if the species has them.
+	var/vision_organ										// If set, this organ is required for vision. Defaults to "eyes" if the species has them.
 
 	var/list/has_limbs = list(
-		BP_TORSO =  list("path" = /obj/item/organ/external/chest),
-		BP_GROIN =  list("path" = /obj/item/organ/external/groin),
-		BP_HEAD =   list("path" = /obj/item/organ/external/head),
-		BP_L_ARM =  list("path" = /obj/item/organ/external/arm),
-		BP_R_ARM =  list("path" = /obj/item/organ/external/arm/right),
-		BP_L_LEG =  list("path" = /obj/item/organ/external/leg),
-		BP_R_LEG =  list("path" = /obj/item/organ/external/leg/right),
+		BP_TORSO =	list("path" = /obj/item/organ/external/chest),
+		BP_GROIN =	list("path" = /obj/item/organ/external/groin),
+		BP_HEAD =	 list("path" = /obj/item/organ/external/head),
+		BP_L_ARM =	list("path" = /obj/item/organ/external/arm),
+		BP_R_ARM =	list("path" = /obj/item/organ/external/arm/right),
+		BP_L_LEG =	list("path" = /obj/item/organ/external/leg),
+		BP_R_LEG =	list("path" = /obj/item/organ/external/leg/right),
 		BP_L_HAND = list("path" = /obj/item/organ/external/hand),
 		BP_R_HAND = list("path" = /obj/item/organ/external/hand/right),
 		BP_L_FOOT = list("path" = /obj/item/organ/external/foot),
@@ -202,12 +205,12 @@
 		)
 
 	var/list/genders = list(MALE, FEMALE)
-	var/ambiguous_genders = FALSE // If true, people examining a member of this species whom are not also the same species will see them as gender neutral.  Because aliens.
+	var/ambiguous_genders = FALSE // If true, people examining a member of this species whom are not also the same species will see them as gender neutral.	Because aliens.
 
 	// Bump vars
-	var/bump_flag = HUMAN	// What are we considered to be when bumped?
-	var/push_flags = ~HEAVY	// What can we push?
-	var/swap_flags = ~HEAVY	// What can we swap place with?
+	var/bump_flag = HUMAN			// What are we considered to be when bumped?
+	var/push_flags = ~HEAVY			// What can we push?
+	var/swap_flags = ~HEAVY			// What can we swap place with?
 
 	var/pass_flags = 0
 
@@ -283,9 +286,9 @@
 		if((organ in H.organs) || (organ in H.internal_organs))
 			qdel(organ)
 
-	if(H.organs)                  H.organs.Cut()
-	if(H.internal_organs)         H.internal_organs.Cut()
-	if(H.organs_by_name)          H.organs_by_name.Cut()
+	if(H.organs)									H.organs.Cut()
+	if(H.internal_organs)				 H.internal_organs.Cut()
+	if(H.organs_by_name)					H.organs_by_name.Cut()
 	if(H.internal_organs_by_name) H.internal_organs_by_name.Cut()
 
 	H.organs = list()

--- a/code/modules/mob/living/carbon/human/species/station/prometheans.dm
+++ b/code/modules/mob/living/carbon/human/species/station/prometheans.dm
@@ -35,11 +35,14 @@ var/datum/species/shapeshifter/promethean/prometheans
 	male_cough_sounds = list('sound/effects/slime_squish.ogg')
 	female_cough_sounds = list('sound/effects/slime_squish.ogg')
 
+	min_age =		1
+	max_age =		10
+
+	economic_modifier = 3
+
 	gluttonous =	1
 	virus_immune =	1
 	blood_volume =	560
-	min_age =		1
-	max_age =		10
 	brute_mod =		0.75
 	burn_mod =		2
 	oxy_mod =		0

--- a/code/modules/mob/living/carbon/human/species/station/seromi.dm
+++ b/code/modules/mob/living/carbon/human/species/station/seromi.dm
@@ -10,8 +10,12 @@
 	secondary_langs = list(LANGUAGE_SCHECHI, LANGUAGE_SKRELLIAN)
 	name_language = LANGUAGE_SCHECHI
 	species_language = LANGUAGE_SCHECHI
+
 	min_age = 12
 	max_age = 45
+
+	economic_modifier = 6
+
 	health_hud_intensity = 3
 
 	male_cough_sounds = list('sound/effects/mob_effects/tesharicougha.ogg','sound/effects/mob_effects/tesharicoughb.ogg')

--- a/code/modules/mob/living/carbon/human/species/station/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station.dm
@@ -12,8 +12,12 @@
 	species_language = LANGUAGE_SOL_COMMON
 	secondary_langs = list(LANGUAGE_SOL_COMMON, LANGUAGE_TERMINUS)
 	name_language = null // Use the first-name last-name generator rather than a language scrambler
+
 	min_age = 17
 	max_age = 130
+
+	economic_modifier = 10
+
 	health_hud_intensity = 1.5
 
 	spawn_flags = SPECIES_CAN_JOIN
@@ -51,6 +55,8 @@
 
 	min_age = 32
 	max_age = 260
+
+	economic_modifier = 7
 
 	blurb = "A heavily reptillian species, Unathi hail from the \
 	Uuosa-Eso system, which roughly translates to 'burning mother'.<br/><br/>Coming from a harsh, inhospitable \
@@ -156,6 +162,8 @@
 	min_age = 17
 	max_age = 80
 
+	economic_modifier = 7
+
 	blurb = "The Tajaran are a mammalian species resembling roughly felines, hailing from Meralar in the Rarkajar system. \
 	While reaching to the stars independently from outside influences, the humans engaged them in peaceful trade contact \
 	and have accelerated the fledgling culture into the interstellar age. Their history is full of war and highly fractious \
@@ -237,6 +245,8 @@
 	min_age = 19
 	max_age = 130
 
+	economic_modifier = 12
+
 	darksight = 4
 	flash_mod = 1.2
 	chemOD_mod = 0.9
@@ -311,6 +321,8 @@
 
 	min_age = 1
 	max_age = 300
+
+	economic_modifier = 4
 
 	blurb = "Commonly referred to (erroneously) as 'plant people', the Dionaea are a strange space-dwelling collective \
 	species hailing from Epsilon Ursae Minoris. Each 'diona' is a cluster of numerous cat-sized organisms called nymphs; \


### PR DESCRIPTION
Seems to work as before, aka Tested and Working.
- `species.dm` had a million spaces in it, that's why the diff's huge.
- The economic values were copied straight from the current list. Since Vatborn have the same modifier as baseline humans, they should be able to inherit from the human species.