### PR TITLE
Sundry Fixes - Emitters, Bedsheets, Conveyors

### DIFF
--- a/code/game/objects/structures/bedsheet_bin.dm
+++ b/code/game/objects/structures/bedsheet_bin.dm
@@ -32,7 +32,7 @@ LINEN BINS
 		if(do_after(user, 50))
 			user << "<span class='notice'>You cut [src] into pieces!</span>"
 			for(var/i in 1 to rand(2,5))
-				new /obj/item/weapon/reagent_containers/glass/rag(src.loc)
+				new /obj/item/weapon/reagent_containers/glass/rag(drop_location())
 			qdel(src)
 		return
 	..()

--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -165,6 +165,7 @@
 					"You undo the external reinforcing bolts.", \
 					"You hear a ratchet.")
 				src.anchored = 0
+				disconnect_from_network()
 			if(2)
 				user << "<span class='warning'>\The [src] needs to be unwelded from the floor.</span>"
 		return

--- a/code/modules/recycling/conveyor2.dm
+++ b/code/modules/recycling/conveyor2.dm
@@ -23,8 +23,8 @@
 	id = "round_end_belt"
 
 	// create a conveyor
-/obj/machinery/conveyor/New(loc, newdir, on = 0)
-	..(loc)
+/obj/machinery/conveyor/initialize(mapload, newdir, on = 0)
+	. = ..()
 	if(newdir)
 		set_dir(newdir)
 
@@ -105,7 +105,7 @@
 			id = input
 			for(var/obj/machinery/conveyor_switch/C in world)
 				if(C.id == id)
-					C.conveyors += src
+					C.conveyors |= src
 			return
 
 	user.drop_item(get_turf(src))
@@ -158,12 +158,6 @@
 	if(C)
 		C.set_operable(stepdir, id, op)
 
-/*
-/obj/machinery/conveyor/verb/destroy()
-	set src in view()
-	src.broken()
-*/
-
 /obj/machinery/conveyor/power_change()
 	..()
 	update()
@@ -189,15 +183,16 @@
 
 
 
-/obj/machinery/conveyor_switch/New()
+/obj/machinery/conveyor_switch/initialize()
 	..()
 	update()
+	return INITIALIZE_HINT_LATELOAD
 
-	spawn(5)		// allow map load
-		conveyors = list()
-		for(var/obj/machinery/conveyor/C in world)
-			if(C.id == id)
-				conveyors += C
+/obj/machinery/conveyor_switch/LateInitialize()
+	conveyors = list()
+	for(var/obj/machinery/conveyor/C in world)
+		if(C.id == id)
+			conveyors += C
 
 // update the icon depending on the position
 
@@ -273,6 +268,7 @@
 				usr << "No input found please hang up and try your call again."
 				return
 			id = input
+			conveyors = list() // Clear list so they aren't double added.
 			for(var/obj/machinery/conveyor/C in world)
 				if(C.id == id)
 					conveyors += C


### PR DESCRIPTION
- Fixes edge case allowing emitters to fire without being on a cable knot.
- Fixes VOREStation/VOREStation#3031 - Conveyor belts in cargo shuttle not obeying switches.
- Fixes VOREStation/VOREStation#3475 - Cannot cut up bedsheets (while holding them)
Port of VOREStation/VOREStation#3485
