### PR TITLE
Use define constants for subsystem init order and priority.

### DIFF
--- a/code/__defines/subsystems.dm
+++ b/code/__defines/subsystems.dm
@@ -27,6 +27,7 @@ var/global/list/runlevel_flags = list(RUNLEVEL_LOBBY, RUNLEVEL_SETUP, RUNLEVEL_G
 #define INIT_ORDER_ATOMS	15
 #define INIT_ORDER_MACHINES 10
 #define INIT_ORDER_SHUTTLES 3
+#define INIT_ORDER_DEFAULT	0
 #define INIT_ORDER_LIGHTING 0
 #define INIT_ORDER_AIR		-1
 #define INIT_ORDER_OVERLAY	-6
@@ -35,8 +36,14 @@ var/global/list/runlevel_flags = list(RUNLEVEL_LOBBY, RUNLEVEL_SETUP, RUNLEVEL_G
 
 // Subsystem fire priority, from lowest to highest priority
 // If the subsystem isn't listed here it's either DEFAULT or PROCESS (if it's a processing subsystem child)
-
- #define FIRE_PRIORITY_OVERLAYS		500
+#define FIRE_PRIORITY_SHUTTLES		5
+#define FIRE_PRIORITY_ORBIT			8
+#define FIRE_PRIORITY_GARBAGE		15
+#define FIRE_PRIORITY_AIRFLOW		30
+#define FIRE_PRIORITY_AIR			35
+#define FIRE_PRIORITY_DEFAULT		50
+#define FIRE_PRIORITY_MACHINES		100
+#define FIRE_PRIORITY_OVERLAYS		500
 
 // Macro defining the actual code applying our overlays lists to the BYOND overlays list. (I guess a macro for speed)
 // TODO - I don't really like the location of this macro define.  Consider it. ~Leshana

--- a/code/controllers/subsystem.dm
+++ b/code/controllers/subsystem.dm
@@ -1,9 +1,9 @@
 /datum/controller/subsystem
 	// Metadata; you should define these.
 	name = "fire coderbus" //name of the subsystem
-	var/init_order = 0		//order of initialization. Higher numbers are initialized first, lower numbers later. Can be decimal and negative values.
+	var/init_order = INIT_ORDER_DEFAULT	//order of initialization. Higher numbers are initialized first, lower numbers later. Can be decimal and negative values.
 	var/wait = 20			//time to wait (in deciseconds) between each call to fire(). Must be a positive integer.
-	var/priority = 50		//When mutiple subsystems need to run in the same tick, higher priority subsystems will run first and be given a higher share of the tick before MC_TICK_CHECK triggers a sleep
+	var/priority = FIRE_PRIORITY_DEFAULT	//When mutiple subsystems need to run in the same tick, higher priority subsystems will run first and be given a higher share of the tick before MC_TICK_CHECK triggers a sleep
 
 	var/flags = 0			//see MC.dm in __DEFINES Most flags must be set on world start to take full effect. (You can also restart the mc to force them to process again)
 	var/runlevels = RUNLEVELS_DEFAULT	//points of the game at which the SS can fire

--- a/code/controllers/subsystems/air.dm
+++ b/code/controllers/subsystems/air.dm
@@ -9,7 +9,7 @@
 SUBSYSTEM_DEF(air)
 	name = "Air"
 	init_order = INIT_ORDER_AIR
-	priority = 35
+	priority = FIRE_PRIORITY_AIR
 	wait = 2 SECONDS // seconds (We probably can speed this up actually)
 	flags = SS_BACKGROUND // TODO - Should this really be background? It might be important.
 	runlevels = RUNLEVEL_GAME | RUNLEVEL_POSTGAME

--- a/code/controllers/subsystems/airflow.dm
+++ b/code/controllers/subsystems/airflow.dm
@@ -14,7 +14,7 @@ SUBSYSTEM_DEF(airflow)
 	wait = 2
 	flags = SS_NO_INIT
 	runlevels = RUNLEVEL_GAME | RUNLEVEL_POSTGAME
-	priority = 30
+	priority = FIRE_PRIORITY_AIRFLOW
 
 	var/list/processing = list()
 	var/list/currentrun = list()

--- a/code/controllers/subsystems/garbage.dm
+++ b/code/controllers/subsystems/garbage.dm
@@ -3,7 +3,7 @@
 //
 SUBSYSTEM_DEF(garbage)
 	name = "Garbage"
-	priority = 15
+	priority = FIRE_PRIORITY_GARBAGE
 	wait = 2 SECONDS
 	flags = SS_POST_FIRE_TIMING|SS_BACKGROUND|SS_NO_INIT
 	runlevels = RUNLEVELS_DEFAULT | RUNLEVEL_LOBBY

--- a/code/controllers/subsystems/machines.dm
+++ b/code/controllers/subsystems/machines.dm
@@ -12,7 +12,7 @@
 
 SUBSYSTEM_DEF(machines)
 	name = "Machines"
-	priority = 100
+	priority = FIRE_PRIORITY_MACHINES
 	init_order = INIT_ORDER_MACHINES
 	flags = SS_KEEP_TIMING
 	runlevels = RUNLEVEL_GAME|RUNLEVEL_POSTGAME

--- a/code/controllers/subsystems/orbits.dm
+++ b/code/controllers/subsystems/orbits.dm
@@ -1,6 +1,6 @@
 SUBSYSTEM_DEF(orbit)
 	name = "Orbits"
-	priority = 8 // FIRE_PRIORITY_ORBIT
+	priority = FIRE_PRIORITY_ORBIT
 	wait = 2
 	flags = SS_NO_INIT|SS_TICKER
 

--- a/code/controllers/subsystems/shuttles.dm
+++ b/code/controllers/subsystems/shuttles.dm
@@ -8,7 +8,7 @@ var/global/datum/controller/subsystem/shuttles/shuttle_controller
 SUBSYSTEM_DEF(shuttles)
 	name = "Shuttles"
 	wait = 2 SECONDS
-	priority = 5
+	priority = FIRE_PRIORITY_SHUTTLES
 	init_order = INIT_ORDER_SHUTTLES
 	flags = SS_KEEP_TIMING|SS_NO_TICK_CHECK
 	runlevels = RUNLEVEL_GAME|RUNLEVEL_POSTGAME


### PR DESCRIPTION
Replaced all hard coded numbers for subsystem priority with defines in subsystem.dm - Much easier to see them in order that way.