### PR TITLE
~Promethean Tweaks: The one with the chemicals, and the other thing.

### DIFF
--- a/code/__defines/chemistry.dm
+++ b/code/__defines/chemistry.dm
@@ -33,6 +33,7 @@
 #define CE_ALCOHOL "alcohol" // Liver filtering
 #define CE_ALCOHOL_TOXIC "alcotoxic" // Liver damage
 #define CE_SPEEDBOOST "gofast" // Hyperzine
+#define CE_SLOWDOWN "goslow" // Slowdown
 
 #define REAGENTS_PER_SHEET 20
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -661,12 +661,13 @@
 		I = internal_organs_by_name[O_EYES]
 		if(I.is_broken())
 			return FLASH_PROTECTION_MAJOR
-	else // They can't be flashed if they don't have eyes.
+	else if(!species.dispersed_eyes) // They can't be flashed if they don't have eyes, or widespread sensing surfaces.
 		return FLASH_PROTECTION_MAJOR
 
 	var/number = get_equipment_flash_protection()
-	number = I.get_total_protection(number)
-	I.additional_flash_effects(number)
+	if(I)
+		number = I.get_total_protection(number)
+		I.additional_flash_effects(number)
 	return number
 
 #define add_clothing_protection(A)	\

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -107,6 +107,11 @@
 
 	tally += item_tally
 
+	if(CE_SLOWDOWN in chem_effects)
+		if (tally >= 0 )
+			tally = (tally + tally/4) //Add a quarter of penalties on top.
+		tally += 1
+
 	if(CE_SPEEDBOOST in chem_effects)
 		if (tally >= 0)	// cut any penalties in half
 			tally = tally/2

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -81,6 +81,7 @@
 	var/toxins_mod =    1                    // Toxloss modifier
 	var/radiation_mod = 1                    // Radiation modifier
 	var/flash_mod =     1                    // Stun from blindness modifier.
+	var/sound_mod =     1					 // Stun from sounds, I.E. flashbangs.
 	var/chemOD_mod =	1					 // Damage modifier for overdose
 	var/vision_flags = SEE_SELF              // Same flags as glasses.
 
@@ -186,6 +187,7 @@
 		O_EYES =     /obj/item/organ/internal/eyes
 		)
 	var/vision_organ              // If set, this organ is required for vision. Defaults to "eyes" if the species has them.
+	var/dispersed_eyes            // If set, the species will be affected by flashbangs regardless if they have eyes or not, as they see in large areas.
 
 	var/list/has_limbs = list(
 		BP_TORSO =  list("path" = /obj/item/organ/external/chest),

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Core.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Core.dm
@@ -172,6 +172,11 @@
 	else
 		..()
 
+/datum/reagent/water/affect_touch(var/mob/living/carbon/M, var/alien, var/removed)
+	if(alien == IS_SLIME)
+		M.visible_message("<span class='warning'>[M]'s flesh sizzles where the water touches it!</span>", "<span class='danger'>Your flesh burns in the water!</span>")
+	..()
+
 /datum/reagent/fuel
 	name = "Welding fuel"
 	id = "fuel"

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Dispenser.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Dispenser.dm
@@ -94,6 +94,8 @@
 		strength_mod *= 0.75
 	if(alien == IS_DIONA)
 		strength_mod = 0
+	if(alien == IS_SLIME)
+		M.adjustToxLoss(removed * 2) //Sterilizing, if only by a little bit.
 
 	M.add_chemical_effect(CE_ALCOHOL, 1)
 
@@ -136,6 +138,8 @@
 		strength_mod *= 0.75
 	if(alien == IS_DIONA)
 		strength_mod = 0
+	if(alien == IS_SLIME)
+		M.adjustToxLoss(removed * 2) //Sterilizing, if only by a little bit.
 
 	M.add_chemical_effect(CE_ALCOHOL, 1)
 

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
@@ -34,7 +34,7 @@
 				data -= taste
 
 /datum/reagent/nutriment/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
-	if(!injectable)
+	if(!injectable && alien != IS_SLIME)
 		M.adjustToxLoss(0.1 * removed)
 		return
 	affect_ingest(M, alien, removed)
@@ -94,7 +94,7 @@
 	nutriment_factor = 10
 	color = "#FFFF00"
 
-/datum/reagent/honey/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed)
+/datum/reagent/nutriment/honey/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed)
 	..()
 
 	var/effective_dose = dose
@@ -255,6 +255,16 @@
 	overdose = REAGENTS_OVERDOSE
 	ingest_met = REM
 
+/datum/reagent/sodiumchloride/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
+	..()
+	if(alien == IS_SLIME)
+		M.adjustFireLoss(removed)
+
+/datum/reagent/sodiumchloride/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed)
+	var/pass_mod = rand(3,5)
+	var/passthrough = (removed - (removed/pass_mod)) //Some may be nullified during consumption, between one third and one fifth.
+	affect_blood(M, alien, passthrough)
+
 /datum/reagent/blackpepper
 	name = "Black Pepper"
 	id = "blackpepper"
@@ -354,6 +364,15 @@
 /datum/reagent/condensedcapsaicin/affect_touch(var/mob/living/carbon/M, var/alien, var/removed)
 	var/eyes_covered = 0
 	var/mouth_covered = 0
+
+	var/head_covered = 0
+	var/arms_covered = 0 //These are used for the effects on slime-based species.
+	var/legs_covered = 0
+	var/hands_covered = 0
+	var/feet_covered = 0
+	var/chest_covered = 0
+	var/groin_covered = 0
+
 	var/obj/item/safe_thing = null
 
 	var/effective_strength = 5
@@ -384,27 +403,78 @@
 				eyes_covered = 1
 				if(!safe_thing)
 					safe_thing = H.glasses
+		if(alien == IS_SLIME)
+			for(var/obj/item/clothing/C in H.worn_clothing)
+				if(C.body_parts_covered & HEAD)
+					head_covered = 1
+				if(C.body_parts_covered & UPPER_TORSO)
+					chest_covered = 1
+				if(C.body_parts_covered & LOWER_TORSO)
+					groin_covered = 1
+				if(C.body_parts_covered & LEGS)
+					legs_covered = 1
+				if(C.body_parts_covered & ARMS)
+					arms_covered = 1
+				if(C.body_parts_covered & HANDS)
+					hands_covered = 1
+				if(C.body_parts_covered & FEET)
+					feet_covered = 1
+				if(head_covered && chest_covered && groin_covered && legs_covered && arms_covered && hands_covered && feet_covered)
+					break
 	if(eyes_covered && mouth_covered)
-		M << "<span class='warning'>Your [safe_thing] protects you from the pepperspray!</span>"
-		return
+		to_chat(M, "<span class='warning'>Your [safe_thing] protects you from the pepperspray!</span>")
+		if(alien != IS_SLIME)
+			return
 	else if(eyes_covered)
-		M << "<span class='warning'>Your [safe_thing] protect you from most of the pepperspray!</span>"
+		to_chat(M, "<span class='warning'>Your [safe_thing] protect you from most of the pepperspray!</span>")
 		M.eye_blurry = max(M.eye_blurry, effective_strength * 3)
 		M.Blind(effective_strength)
 		M.Stun(5)
 		M.Weaken(5)
-		return
-	else if (mouth_covered) // Mouth cover is better than eye cover
-		M << "<span class='warning'>Your [safe_thing] protects your face from the pepperspray!</span>"
+		if(alien != IS_SLIME)
+			return
+	else if(mouth_covered) // Mouth cover is better than eye cover
+		to_chat(M, "<span class='warning'>Your [safe_thing] protects your face from the pepperspray!</span>")
 		M.eye_blurry = max(M.eye_blurry, effective_strength)
-		return
-	else // Oh dear :D
-		M << "<span class='warning'>You're sprayed directly in the eyes with pepperspray!</span>"
+		if(alien != IS_SLIME)
+			return
+	else// Oh dear :D
+		to_chat(M, "<span class='warning'>You're sprayed directly in the eyes with pepperspray!</span>")
 		M.eye_blurry = max(M.eye_blurry, effective_strength * 5)
 		M.Blind(effective_strength * 2)
 		M.Stun(5)
 		M.Weaken(5)
-		return
+		if(alien != IS_SLIME)
+			return
+	if(alien == IS_SLIME)
+		if(!head_covered)
+			if(prob(33))
+				to_chat(M, "<span class='warning'>The exposed flesh on your head burns!</span>")
+			M.apply_effect(5 * effective_strength, AGONY, 0)
+		if(!chest_covered)
+			if(prob(33))
+				to_chat(M, "<span class='warning'>The exposed flesh on your chest burns!</span>")
+			M.apply_effect(5 * effective_strength, AGONY, 0)
+		if(!groin_covered && prob(75))
+			if(prob(33))
+				to_chat(M, "<span class='warning'>The exposed flesh on your groin burns!</span>")
+			M.apply_effect(3 * effective_strength, AGONY, 0)
+		if(!arms_covered && prob(45))
+			if(prob(33))
+				to_chat(M, "<span class='warning'>The exposed flesh on your arms burns!</span>")
+			M.apply_effect(3 * effective_strength, AGONY, 0)
+		if(!legs_covered && prob(45))
+			if(prob(33))
+				to_chat(M, "<span class='warning'>The exposed flesh on your legs burns!</span>")
+			M.apply_effect(3 * effective_strength, AGONY, 0)
+		if(!hands_covered && prob(20))
+			if(prob(33))
+				to_chat(M, "<span class='warning'>The exposed flesh on your hands burns!</span>")
+			M.apply_effect(effective_strength / 2, AGONY, 0)
+		if(!feet_covered && prob(20))
+			if(prob(33))
+				to_chat(M, "<span class='warning'>The exposed flesh on your feet burns!</span>")
+			M.apply_effect(effective_strength / 2, AGONY, 0)
 
 /datum/reagent/condensedcapsaicin/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed)
 	if(ishuman(M))
@@ -437,7 +507,10 @@
 	var/adj_temp = 0
 
 /datum/reagent/drink/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
-	M.adjustToxLoss(removed) // Probably not a good idea; not very deadly though
+	var/strength_mod = 1
+	if(alien == IS_SLIME)
+		strength_mod = 4
+	M.adjustToxLoss(removed * strength_mod) // Probably not a good idea; not very deadly though
 	return
 
 /datum/reagent/drink/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed)
@@ -449,6 +522,8 @@
 		M.bodytemperature = min(310, M.bodytemperature + (adj_temp * TEMPERATURE_DAMAGE_COEFFICIENT))
 	if(adj_temp < 0 && M.bodytemperature > 310)
 		M.bodytemperature = min(310, M.bodytemperature - (adj_temp * TEMPERATURE_DAMAGE_COEFFICIENT))
+	if(alien == IS_SLIME)
+		M.adjustToxLoss(removed * 4)
 
 /datum/reagent/drink/overdose(var/mob/living/carbon/M, var/alien) //Add special interactions here in the future if desired.
 	..()
@@ -499,7 +574,7 @@
 	glass_name = "grape juice"
 	glass_desc = "It's grrrrrape!"
 
-/datum/reagent/juice/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed)
+/datum/reagent/drink/juice/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed)
 	..()
 
 	var/effective_dose = dose/2
@@ -825,7 +900,7 @@
 	if(adj_temp > 0)
 		holder.remove_reagent("frostoil", 10 * removed)
 
-/datum/reagent/nutriment/coffee/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
+/datum/reagent/drink/coffee/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	..()
 	if(alien == IS_TAJARA)
 		M.adjustToxLoss(2 * removed)
@@ -1047,13 +1122,13 @@
 	adj_dizzy = -5
 	adj_drowsy = -3
 	adj_sleepy = -2
-	
+
 
 	glass_name = "Coffee Milkshake"
 	glass_desc = "An energizing coffee milkshake, perfect for hot days at work.."
 
 /datum/reagent/drink/milkshake/coffeeshake/overdose(var/mob/living/carbon/M, var/alien)
-	M.make_jittery(5) 
+	M.make_jittery(5)
 
 /datum/reagent/drink/rewriter
 	name = "Rewriter"

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -28,8 +28,11 @@
 	scannable = 1
 
 /datum/reagent/bicaridine/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
+	var/chem_effective = 1
+	if(alien == IS_SLIME)
+		chem_effective = 0.75
 	if(alien != IS_DIONA)
-		M.heal_organ_damage(6 * removed, 0)
+		M.heal_organ_damage(6 * removed * chem_effective, 0)
 
 /datum/reagent/bicaridine/overdose(var/mob/living/carbon/M, var/alien, var/removed)
 	..()
@@ -59,8 +62,12 @@
 	scannable = 1
 
 /datum/reagent/kelotane/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
+	var/chem_effective = 1
+	if(alien == IS_SLIME)
+		chem_effective = 0.5
+		M.adjustBruteLoss(2 * removed) //Mends burns, but has negative effects with a Promethean's skeletal structure.
 	if(alien != IS_DIONA)
-		M.heal_organ_damage(0, 6 * removed)
+		M.heal_organ_damage(0, 6 * removed * chem_effective)
 
 /datum/reagent/dermaline
 	name = "Dermaline"
@@ -74,8 +81,11 @@
 	scannable = 1
 
 /datum/reagent/dermaline/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
+	var/chem_effective = 1
+	if(alien == IS_SLIME)
+		chem_effective = 0.75
 	if(alien != IS_DIONA)
-		M.heal_organ_damage(0, 12 * removed)
+		M.heal_organ_damage(0, 12 * removed * chem_effective)
 
 /datum/reagent/dylovene
 	name = "Dylovene"
@@ -87,10 +97,15 @@
 	scannable = 1
 
 /datum/reagent/dylovene/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
+	var/chem_effective = 1
+	if(alien == IS_SLIME)
+		chem_effective = 0.66
+		if(dose >= 15)
+			M.druggy = max(M.druggy, 5)
 	if(alien != IS_DIONA)
-		M.drowsyness = max(0, M.drowsyness - 6 * removed)
-		M.hallucination = max(0, M.hallucination - 9 * removed)
-		M.adjustToxLoss(-4 * removed)
+		M.drowsyness = max(0, M.drowsyness - 6 * removed * chem_effective = 0.66)
+		M.hallucination = max(0, M.hallucination - 9 * removed * chem_effective = 0.66)
+		M.adjustToxLoss(-4 * removed * chem_effective = 0.66)
 
 /datum/reagent/carthatoline
 	name = "Carthatoline"
@@ -114,6 +129,8 @@
 				return
 			if(L.damage > 0)
 				L.damage = max(L.damage - 2 * removed, 0)
+		if(alien == IS_SLIME)
+			H.druggy = max(M.druggy, 5)
 
 /datum/reagent/dexalin
 	name = "Dexalin"
@@ -128,6 +145,12 @@
 /datum/reagent/dexalin/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	if(alien == IS_VOX)
 		M.adjustToxLoss(removed * 6)
+	else if(alien == IS_SLIME && dose >= 15)
+		M.add_chemical_effect(CE_PAINKILLER, 15)
+		if(prob(15))
+			to_chat(M, "<span class='notice'>You have a moment of clarity as you collapse.</span>")
+			M.adjustBrainLoss(-5 * removed)
+			M.Weaken(6)
 	else if(alien != IS_DIONA)
 		M.adjustOxyLoss(-15 * removed)
 
@@ -146,6 +169,12 @@
 /datum/reagent/dexalinp/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	if(alien == IS_VOX)
 		M.adjustToxLoss(removed * 9)
+	else if(alien == IS_SLIME && dose >= 10)
+		M.add_chemical_effect(CE_PAINKILLER, 25)
+		if(prob(25))
+			to_chat(M, "<span class='notice'>You have a moment of clarity, as you feel your tubes lose pressure rapidly.</span>")
+			M.adjustBrainLoss(-8 * removed)
+			M.Weaken(3)
 	else if(alien != IS_DIONA)
 		M.adjustOxyLoss(-150 * removed)
 
@@ -162,9 +191,12 @@
 
 /datum/reagent/tricordrazine/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	if(alien != IS_DIONA)
-		M.adjustOxyLoss(-3 * removed)
-		M.heal_organ_damage(1.5 * removed, 1.5 * removed)
-		M.adjustToxLoss(-1.5 * removed)
+		var/chem_effective = 1
+		if(alien == IS_SLIME)
+			chem_effective = 0.5
+		M.adjustOxyLoss(-3 * removed * chem_effective)
+		M.heal_organ_damage(1.5 * removed, 1.5 * removed * chem_effective)
+		M.adjustToxLoss(-1.5 * removed * chem_effective)
 
 /datum/reagent/cryoxadone
 	name = "Cryoxadone"
@@ -179,10 +211,17 @@
 
 /datum/reagent/cryoxadone/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	if(M.bodytemperature < 170)
-		M.adjustCloneLoss(-10 * removed)
-		M.adjustOxyLoss(-10 * removed)
-		M.heal_organ_damage(10 * removed, 10 * removed)
-		M.adjustToxLoss(-10 * removed)
+		var/chem_effective = 1
+		if(alien == IS_SLIME)
+			chem_effective = 0.25
+			to_chat(M, "<span class='danger'>It's cold. Something causes your cellular mass to harden occasionally, resulting in vibration.</span>")
+			M.Weaken(10)
+			M.silent = max(M.silent, 10)
+			M.make_jittery(4)
+		M.adjustCloneLoss(-10 * removed * chem_effective)
+		M.adjustOxyLoss(-10 * removed * chem_effective)
+		M.heal_organ_damage(10 * removed, 10 * removed * chem_effective)
+		M.adjustToxLoss(-10 * removed * chem_effective)
 
 /datum/reagent/clonexadone
 	name = "Clonexadone"
@@ -197,10 +236,18 @@
 
 /datum/reagent/clonexadone/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	if(M.bodytemperature < 170)
-		M.adjustCloneLoss(-30 * removed)
-		M.adjustOxyLoss(-30 * removed)
-		M.heal_organ_damage(30 * removed, 30 * removed)
-		M.adjustToxLoss(-30 * removed)
+		var/chem_effective = 1
+		if(alien == IS_SLIME)
+			if(prob(10))
+				to_chat(M, "<span class='danger'>It's so cold. Something causes your cellular mass to harden sporadically, resulting in seizure-like twitching.</span>")
+			chem_effective = 0.5
+			M.Weaken(20)
+			M.silent = max(M.silent, 20)
+			M.make_jittery(4)
+		M.adjustCloneLoss(-30 * removed * chem_effective)
+		M.adjustOxyLoss(-30 * removed * chem_effective)
+		M.heal_organ_damage(30 * removed, 30 * removed * chem_effective)
+		M.adjustToxLoss(-30 * removed * chem_effective)
 
 /* Painkillers */
 
@@ -217,10 +264,15 @@
 	mrate_static = TRUE
 
 /datum/reagent/paracetamol/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
-	M.add_chemical_effect(CE_PAINKILLER, 25)
+	var/chem_effective = 1
+	if(alien == IS_SLIME)
+		chem_effective = 0.75
+	M.add_chemical_effect(CE_PAINKILLER, 25 * chem_effective)
 
 /datum/reagent/paracetamol/overdose(var/mob/living/carbon/M, var/alien)
 	..()
+	if(alien == IS_SLIME)
+		M.add_chemical_effect(CE_SLOWDOWN, 1)
 	M.hallucination = max(M.hallucination, 2)
 
 /datum/reagent/tramadol
@@ -236,7 +288,11 @@
 	mrate_static = TRUE
 
 /datum/reagent/tramadol/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
-	M.add_chemical_effect(CE_PAINKILLER, 80)
+	var/chem_effective = 1
+	if(alien == IS_SLIME)
+		chem_effective = 0.8
+		M.add_chemical_effect(CE_SLOWDOWN, 1)
+	M.add_chemical_effect(CE_PAINKILLER, 80 * chem_effective)
 
 /datum/reagent/tramadol/overdose(var/mob/living/carbon/M, var/alien)
 	..()
@@ -255,8 +311,13 @@
 	mrate_static = TRUE
 
 /datum/reagent/oxycodone/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
-	M.add_chemical_effect(CE_PAINKILLER, 200)
-	M.eye_blurry = min(M.eye_blurry + 10, 250)
+	var/chem_effective = 1
+	if(alien == IS_SLIME)
+		chem_effective = 0.75
+		M.stuttering = min(50, max(0, M.stuttering + 5)) //If you can't feel yourself, and your main mode of speech is resonation, there's a problem.
+		M.add_chemical_effect(CE_SLOWDOWN, 1)
+	M.add_chemical_effect(CE_PAINKILLER, 200 * chem_effective)
+	M.eye_blurry = min(M.eye_blurry + 10, 250 * chem_effective)
 	M.Confuse(5)
 
 /datum/reagent/oxycodone/overdose(var/mob/living/carbon/M, var/alien)
@@ -278,16 +339,23 @@
 	scannable = 1
 
 /datum/reagent/synaptizine/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
+	var/chem_effective = 1
 	if(alien == IS_DIONA)
 		return
+	if(alien == IS_SLIME)
+		if(dose >= 5) //Not effective in small doses, though it causes toxloss at higher ones, it will make the regeneration for brute and burn more 'efficient' at the cost of more nutrition.
+			M.nutrition = (M.nutrition - (removed * 2))
+			M.adjustBruteLoss(-2 * removed)
+			M.adjustFireLoss(-1 * removed)
+		chem_effective = 0.5
 	M.drowsyness = max(M.drowsyness - 5, 0)
 	M.AdjustParalysis(-1)
 	M.AdjustStunned(-1)
 	M.AdjustWeakened(-1)
 	holder.remove_reagent("mindbreaker", 5)
 	M.hallucination = max(0, M.hallucination - 10)
-	M.adjustToxLoss(5 * removed) // It used to be incredibly deadly due to an oversight. Not anymore!
-	M.add_chemical_effect(CE_PAINKILLER, 20)
+	M.adjustToxLoss(5 * removed * chem_effective) // It used to be incredibly deadly due to an oversight. Not anymore!
+	M.add_chemical_effect(CE_PAINKILLER, 20 * chem_effective)
 
 /datum/reagent/hyperzine
 	name = "Hyperzine"
@@ -301,6 +369,10 @@
 /datum/reagent/hyperzine/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	if(alien == IS_TAJARA)
 		removed *= 1.25
+	if(alien == IS_SLIME)
+		M.make_jittery(4) //Hyperactive fluid pumping results in unstable 'skeleton', resulting in vibration.
+		if(dose >= 5)
+			M.nutrition = (M.nutrition - (removed * 2)) //Sadly this movement starts burning food in higher doses.
 	..()
 	if(prob(5))
 		M.emote(pick("twitch", "blink_r", "shiver"))
@@ -320,8 +392,16 @@
 /datum/reagent/alkysine/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	if(alien == IS_DIONA)
 		return
-	M.adjustBrainLoss(-30 * removed)
-	M.add_chemical_effect(CE_PAINKILLER, 10)
+	var/
+	var/chem_effective = 1
+	if(alien == IS_SLIME)
+		chem_effective = 0.25
+		if(M.brainloss >= 10)
+			M.Weaken(5)
+		if(dose >= 10 && M.paralysis < 40)
+			M.AdjustParalysis(1) //Messing with the core with a simple chemical probably isn't the best idea.
+	M.adjustBrainLoss(-30 * removed * chem_effective)
+	M.add_chemical_effect(CE_PAINKILLER, 10 * chem_effective)
 
 /datum/reagent/imidazoline
 	name = "Imidazoline"
@@ -369,6 +449,10 @@
 			if(I.damage <= 5 && I.organ_tag == O_EYES)
 				H.eye_blurry = min(M.eye_blurry + 10, 250) //Eyes need to reset, or something
 				H.sdisabilities &= ~BLIND
+		if(alien == IS_SLIME)
+			H.add_chemical_effect(CE_PAINKILLER, 20)
+			if(prob(33))
+				H.Confuse(10)
 
 /datum/reagent/osteodaxon
 	name = "Osteodaxon"
@@ -437,9 +521,35 @@
 	M.disabilities = 0
 	M.sdisabilities = 0
 
+	var/mob/living/carbon/human/H = M
+	if(alien == IS_SLIME && istype(H)) //Shifts them toward white, faster than Rezadone does toward grey.
+		if(prob(50))
+			if(H.r_skin)
+				H.r_skin = round((H.r_skin + 510)/3)
+			if(H.r_hair)
+				H.r_hair = round((H.r_hair + 510)/3)
+			if(H.r_facial)
+				H.r_facial = round((H.r_facial + 510)/3)
+			H.adjustToxLoss(6 * removed)
+		if(prob(50))
+			if(H.g_skin)
+				H.g_skin = round((H.g_skin + 510)/3)
+			if(H.g_hair)
+				H.g_hair = round((H.g_hair + 510)/3)
+			if(H.g_facial)
+				H.g_facial = round((H.g_facial + 510)/3)
+			H.adjustToxLoss(6 * removed)
+		if(prob(50))
+			if(H.b_skin)
+				H.b_skin = round((H.b_skin + 510)/3)
+			if(H.b_hair)
+				H.b_hair = round((H.b_hair + 510)/3)
+			if(H.b_facial)
+				H.b_facial = round((H.b_facial + 510)/3)
+			H.adjustToxLoss(6 * removed)
+
 	// Might need to update appearance for hulk etc.
 	if(needs_update && ishuman(M))
-		var/mob/living/carbon/human/H = M
 		H.update_mutations()
 
 /datum/reagent/ethylredoxrazine
@@ -513,9 +623,19 @@
 	mrate_static = TRUE
 	overdose = REAGENTS_OVERDOSE
 	scannable = 1
+	data = 0
 
 /datum/reagent/spaceacillin/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	..()
+	if(alien == IS_SLIME)
+		if(volume <= 0.1 && data != -1)
+			data = -1
+			to_chat(M, "<span class='notice'>You regain focus...</span>")
+		else
+			var/delay = (5 MINUTES)
+			if(world.time > data + delay)
+				data = world.time
+				to_chat(M, "<span class='warning'>Your senses feel unfocused, and divided.</span>")
 	M.add_chemical_effect(CE_ANTIBIOTIC, dose >= overdose ? ANTIBIO_OD : ANTIBIO_NORM)
 
 /datum/reagent/corophizine
@@ -528,10 +648,47 @@
 	mrate_static = TRUE
 	overdose = 10
 	scannable = 1
+	data = 0
 
 /datum/reagent/corophizine/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	..()
 	M.add_chemical_effect(CE_ANTIBIOTIC, ANTIBIO_SUPER)
+
+	var/mob/living/carbon/human/H = M
+
+	if(ishuman(M) && alien == IS_SLIME) //Everything about them is treated like a targetted organism. Widespread bodily function begins to fail.
+		if(volume <= 0.1 && data != -1)
+			data = -1
+			to_chat(M, "<span class='notice'>Your body ceases its revolt.</span>")
+		else
+			var/delay = (3 MINUTES)
+			if(world.time > data + delay)
+				data = world.time
+				to_chat(M, "<span class='critical'>It feels like your body is revolting!</span>")
+		M.Confuse(7)
+		M.adjustFireLoss(removed * 2)
+		M.adjustToxLoss(removed * 2)
+		if(dose >= 5 && M.toxloss >= 10) //It all starts going wrong.
+			M.adjustBruteLoss(removed * 3)
+			M.eye_blurry = min(20, max(0, M.eye_blurry + 10))
+			if(prob(25))
+				if(prob(25))
+					to_chat(M, "<span class='danger'>Your pneumatic fluids seize for a moment.</span>")
+				M.Stun(2)
+				spawn(30)
+					M.Weaken(2)
+		if(dose >= 10 || M.toxloss >= 25) //Internal skeletal tubes are rupturing, allowing the chemical to breach them.
+			M.adjustToxLoss(removed * 4)
+			M.make_jittery(5)
+		if(dose >= 20 || M.toxloss >= 60) //Core disentigration, cellular mass begins treating itself as an enemy, while maintaining regeneration. Slime-cancer.
+			M.adjustBrainLoss(2 * removed)
+			M.nutrition = max(H.nutrition - 20, 0)
+		if(M.bruteloss >= 60 && M.toxloss >= 60 && M.brainloss >= 30) //Total Structural Failure. Limbs start splattering.
+			var/obj/item/organ/external/O = pick(H.organs)
+			if(prob(20) && !istype(O, /obj/item/organ/external/chest/unbreakable/slime) && !istype(O, /obj/item/organ/external/groin/unbreakable/slime))
+				to_chat(M, "<span class='critical'>You feel your [O] begin to dissolve, before it sloughs from your body.</span>")
+				O.droplimb() //Splat.
+		return
 
 	//Based roughly on Levofloxacin's rather severe side-effects
 	if(prob(20))
@@ -545,7 +702,6 @@
 
 	//One of the levofloxacin side effects is 'spontaneous tendon rupture', which I'll immitate here. 1:1000 chance, so, pretty darn rare.
 	if(ishuman(M) && rand(1,1000) == 1)
-		var/mob/living/carbon/human/H = M
 		var/obj/item/organ/external/eo = pick(H.organs) //Misleading variable name, 'organs' is only external organs
 		eo.fracture()
 
@@ -558,11 +714,20 @@
 	color = "#C8A5DC"
 	touch_met = 5
 
+/datum/reagent/sterilizine/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
+	if(alien == IS_SLIME)
+		M.adjustFireLoss(removed)
+		M.adjustToxLoss(2 * removed)
+	return
+
 /datum/reagent/sterilizine/affect_touch(var/mob/living/carbon/M, var/alien, var/removed)
 	M.germ_level -= min(removed*20, M.germ_level)
 	for(var/obj/item/I in M.contents)
 		I.was_bloodied = null
 	M.was_bloodied = null
+	if(alien == IS_SLIME)
+		M.adjustFireLoss(removed)
+		M.adjustToxLoss(2 * removed)
 
 /datum/reagent/sterilizine/touch_obj(var/obj/O)
 	O.germ_level -= min(volume*20, O.germ_level)
@@ -606,6 +771,29 @@
 /datum/reagent/rezadone/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	if(alien == IS_DIONA)
 		return
+	var/mob/living/carbon/human/H = M
+	if(alien == IS_SLIME && istype(H))
+		if(prob(50))
+			if(H.r_skin)
+				H.r_skin = round((H.r_skin + 50)/2)
+			if(H.r_hair)
+				H.r_hair = round((H.r_hair + 50)/2)
+			if(H.r_facial)
+				H.r_facial = round((H.r_facial + 50)/2)
+		if(prob(50))
+			if(H.g_skin)
+				H.g_skin = round((H.g_skin + 50)/2)
+			if(H.g_hair)
+				H.g_hair = round((H.g_hair + 50)/2)
+			if(H.g_facial)
+				H.g_facial = round((H.g_facial + 50)/2)
+		if(prob(50))
+			if(H.b_skin)
+				H.b_skin = round((H.b_skin + 50)/2)
+			if(H.b_hair)
+				H.b_hair = round((H.b_hair + 50)/2)
+			if(H.b_facial)
+				H.b_facial = round((H.b_facial + 50)/2)
 	M.adjustCloneLoss(-20 * removed)
 	M.adjustOxyLoss(-2 * removed)
 	M.heal_organ_damage(20 * removed, 20 * removed)

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
@@ -16,7 +16,10 @@
 		if(issmall(M)) removed *= 2 // Small bodymass, more effect from lower volume.
 		if(alien == IS_SLIME)
 			removed *= 0.25 // Results in half the standard tox as normal. Prometheans are 'Small' for flaps.
-			M.nutrition += strength * removed
+			if(dose >= 10)
+				M.nutrition += strength * removed //Body has to deal with the massive influx of toxins, rather than try using them to repair.
+			else
+				M.heal_organ_damage((10/strength) * removed, (10/strength) * removed) //Doses of toxins below 10 units, and 10 strength, are capable of providing useful compounds for repair.
 		M.adjustToxLoss(strength * removed)
 
 /datum/reagent/toxin/plasticide
@@ -73,6 +76,15 @@
 		spawn (0) target_tile.hotspot_expose(700, 400)
 	remove_self(volume)
 
+/datum/reagent/toxin/hydrophoron/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
+	..()
+	if(alien == IS_SLIME)
+		M.adjust_fire_stacks(removed * 10)
+		if(prob(10))
+			to_chat(M, "<span class='critical'>You feel something boiling within you!</span>")
+			spawn(rand(30, 60))
+				M.IgniteMob()
+
 /datum/reagent/toxin/spidertoxin
 	name = "Spidertoxin"
 	id = "spidertoxin"
@@ -107,6 +119,8 @@
 	if(alien == IS_VOX)
 		M.adjustOxyLoss(-100 * removed) //5 oxyloss healed per tick.
 		return //You're wasting plasma (a semi-limited chemical) to save someone, so it might as well be somewhat strong.
+	if(alien == IS_SLIME)
+		M.adjust_fire_stacks(removed * 3) //Not quite 'converting' it. It's like mixing fuel into a jelly. You get explosive, or at least combustible, jelly.
 	..()
 
 /datum/reagent/toxin/phoron/touch_turf(var/turf/simulated/T, var/amount)
@@ -177,6 +191,11 @@
 	strength = 0
 	overdose = REAGENTS_OVERDOSE
 
+/datum/reagent/toxin/potassium_chloride/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
+	..()
+	if(alien == IS_SLIME)
+		M.adjustFireLoss(removed * 2)
+
 /datum/reagent/toxin/potassium_chloride/overdose(var/mob/living/carbon/M, var/alien)
 	..()
 	if(ishuman(M))
@@ -206,6 +225,8 @@
 				H.losebreath = max(10, M.losebreath-10)
 			H.adjustOxyLoss(2)
 			H.Weaken(10)
+	if(alien == IS_SLIME)
+		M.adjustFireLoss(removed * 3)
 
 /datum/reagent/toxin/zombiepowder
 	name = "Zombie Powder"
@@ -353,6 +374,13 @@
 /datum/reagent/lexorin/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	if(alien == IS_DIONA)
 		return
+	if(alien == IS_SLIME)
+		M.apply_effect(5, AGONY, 0)
+		M.adjustToxLoss(3 * removed)
+		if(prob(10))
+			to_chat(M, "<span class='warning'>Your cellular mass hardens for a moment.</span>")
+			M.Stun(6)
+		return
 	if(alien == IS_SKRELL)
 		M.take_organ_damage(2.4 * removed, 0)
 		if(M.losebreath < 10)
@@ -385,8 +413,33 @@
 		return
 
 	var/mob/living/carbon/human/H = M
-	if(istype(H) && (H.species.flags & NO_SCAN))
-		return
+	if(istype(H))
+		if(alien == IS_SLIME && prob(25))
+			var/color_shift = rand(-100, 100)
+			spawn(1)
+				if(prob(33))
+					if(H.r_skin)
+						H.r_skin = max(0, min(255, H.r_skin + color_shift))
+					if(H.r_hair)
+						H.r_hair = max(0, min(255, H.r_hair + color_shift))
+					if(H.r_facial)
+						H.r_facial = max(0, min(255, H.r_facial + color_shift))
+				if(prob(33))
+					if(H.g_skin)
+						H.g_skin = max(0, min(255, H.g_skin + color_shift))
+					if(H.g_hair)
+						H.g_hair = max(0, min(255, H.g_hair + color_shift))
+					if(H.g_facial)
+						H.g_facial = max(0, min(255, H.g_facial + color_shift))
+				if(prob(33))
+					if(H.b_skin)
+						H.b_skin = max(0, min(255, H.b_skin + color_shift))
+					if(H.b_hair)
+						H.b_hair = max(0, min(255, H.b_hair + color_shift))
+					if(H.b_facial)
+						H.b_facial = max(0, min(255, H.b_facial + color_shift))
+		if(H.species.flags & NO_SCAN)
+			return
 
 //The original coder comment here wanted it to be "Approx. one mutation per 10 injected/20 ingested/30 touching units"
 //The issue was, it was removed (.2) multiplied by .1, which resulted in a .02% chance per tick to have a mutation occur. Or more accurately, 5000 injected for a single mutation.


### PR DESCRIPTION
The list of stuff is long, so it's going to be kind of bare here until I'm done. Things of high note:

Universal (Tangential Changes):
- Flashbangs can affect people at different ranges, up to a max of 10 tiles, depending on their Flash mod. - Capability for a 'sound mod' for species is also now an option, though it has been added to none, to match the flash mod.
- Skrell can be hit by an off-screen flashbang's flash if they have no eye protection. 8 tiles, due to larger eyes. [Note: Spoke to Elge and Ice before implementing this change.]
- Species can have 'dispersed eyes', which will mean they are susceptible to flashbangs regardless of the existance of their eyes. Protection still functions as normal, however. [Sunglasses, Welding masks].

**_Prometheans:_**
- Promethean passive regen will take nutrition based on how much it's fixing over time. Starving will result in a decreased effectiveness of this regen.
- Flashbangs now affect them at a distance of five tiles.
- Flashes now affect them, though they are less effective than on other species due to non-centralized eyes.

**Chemicals:**

Food/Drink:
- Nutrients can be absorbed when injected.
- Non-alcoholic drinks are mildly toxic. Not quite dangerous on their own, unless consumed in large quantities in a short period of time, or mixed.
- Alcoholic drinks are more toxic.
- The three salts do varying amounts of burn damage.
- Pepperspray can affect a Promethean with Agony when spraying them dependent on uncovered bodyparts. Head and Chest are guaranteed if uncovered, while the groin, arms, legs, hands, and feet, are increasingly less likely due to physical size. Glasses and Masks will still prevent the instant knockdown, however.

Medicines:
- Many healing chemicals are less effective due to the natural regeneration.

1. Bicaridine: 75%
2. Kelotane: 50%. Also deals brute damage.
3. Dermaline: 75%, no Brute.
4. Dylovene: 66%. Doses over 15 cause loss of focus / 'high' overlay.
5. Carthatoline: Unaffected percentage, guaranteed 'high' overlay.
6. Dexalin: No modifier, because they don't breathe. Doses over 15 units result in mild painkilling ability, but a 15% chance to collapse and repair core damage.
7. Dexalin Plus: No modifier. Stronger painkiller, 25% chance to collapse and repair core damage.
8. Tricord: 50%.
9. Cryoxadone: 25%. Causes twitching and paralysis when going into effect. Mutes the Promethean.
10. Clonexadone: 50%. Causes seizures when going into effect. Mutes the Promethean.
11. Paracetamol: 75%. Overdose causes slowdown.
12. Tramadol: 80% Slowdown.
13. Oxycodone: 75%. Slowdown, and stuttering.
14. Synaptizine: 50%. Doses over 5 will kick their physical regeneration into overdrive at higher nutrition burn.
15. Hyperzine: No mod. Causes twitching, doses over 5 will cause nutrition burning with no benefit.
16. Alkysine: 25%. Brain damage over 10 being repaired will result in collapsing. Doses over than 10 will result in paralysis.
17. Peridaxon: No mod. Weak painkiller. 33% chance to confuse.
18. Ryetalyn: No mod. 50% chance for body, 50% chance for hair, 50% chance for facial hair, to all shift toward White.
19. Spaceacillin: No mod. Causes loss of focus in senses, an inversion of methylphenidate.
20. Corophizine: Systemic body failure in incrementally higher doses. Causes Slime Cancer.
21. Sterilizine: No mod. Causes burns and toxin.
22. Rezadone: No mod. 50% chance for body, 50% chance for hair, 50% chance for facial hair, to all shift toward Grey.

Toxins:

1. Toxin subtypes, in low doses, will act as a brute and burn healing chem. Strength results in an inverted scale for effectiveness. High strength = low healing. Doses over 10 will instead only convert partially to nutrition.
2. Hydrophoron: Boils them from the inside. Increases fire-stacks. 10% chance to ignite.
3. Phoron: Increases fire stacks. Flammable slime jelly. Living Napalm. Ohhhh yeeeeah.
4. Potassium Chloro/phor/ide: Causes burn.
5. Lexorin: Causes agony, toxins. 10% chance to stun.
6. Mutagen: 33% chance for each: hair, facial hair, or body color, to randomize. Disco party.

General Prom:
- Item slowdown modifier of 1.33.