### PR TITLE
Hides jobs with the Never pref on late join

### DIFF
--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -2,9 +2,10 @@
 
 /mob/new_player
 	var/ready = 0
-	var/spawning = 0//Referenced when you want to delete the new_player later on in the code.
-	var/totalPlayers = 0		 //Player counts for the Lobby tab
+	var/spawning = 0			//Referenced when you want to delete the new_player later on in the code.
+	var/totalPlayers = 0		//Player counts for the Lobby tab
 	var/totalPlayersReady = 0
+	var/show_hidden_jobs = 0	//Show jobs that are set to "Never" in preferences
 	var/datum/browser/panel
 	universal_speak = 1
 
@@ -115,7 +116,7 @@
 
 		if(alert(src,"Are you sure you wish to observe? You will have to wait 5 minutes before being able to respawn!","Player Setup","Yes","No") == "Yes")
 			if(!client)	return 1
-			
+
 			//Make a new mannequin quickly, and allow the observer to take the appearance
 			var/mob/living/carbon/human/dummy/mannequin = new()
 			client.prefs.dress_preview_mob(mannequin)
@@ -285,6 +286,10 @@
 		handle_server_news()
 		return
 
+	if(href_list["hidden_jobs"])
+		show_hidden_jobs = !show_hidden_jobs
+		LateChoices()
+
 /mob/new_player/proc/handle_server_news()
 	if(!client)
 		return
@@ -412,10 +417,18 @@
 				dat += "<font color='red'>The station is currently undergoing crew transfer procedures.</font><br>"
 
 	dat += "Choose from the following open/valid positions:<br>"
+	dat += "<a href='byond://?src=\ref[src];hidden_jobs=1'>[show_hidden_jobs ? "Hide":"Show"] Hidden Jobs.</a><br>"
 	for(var/datum/job/job in job_master.occupations)
 		if(job && IsJobAvailable(job.title))
+			// Checks for jobs with minimum age requirements
 			if(job.minimum_character_age && (client.prefs.age < job.minimum_character_age))
 				continue
+			// Checks for jobs set to "Never" in preferences	//TODO: Figure out a better way to check for this
+			if(!(client.prefs.GetJobDepartment(job, 1) & job.flag))
+				if(!(client.prefs.GetJobDepartment(job, 2) & job.flag))
+					if(!(client.prefs.GetJobDepartment(job, 3) & job.flag))
+						if(!show_hidden_jobs && job.title != "Assistant")	// Assistant is always an option
+							continue
 			var/active = 0
 			// Only players with the job assigned and AFK for less than 10 minutes count as active
 			for(var/mob/M in player_list) if(M.mind && M.client && M.mind.assigned_role == job.title && M.client.inactivity <= 10 * 60 * 10)

--- a/html/changelogs/Anewbe - Late Join Hidden.yml
+++ b/html/changelogs/Anewbe - Late Join Hidden.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Anewbe
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Jobs that are set to Never on your preferences are hidden by default on the Late Join selection menu. There is a button to reveal them."


### PR DESCRIPTION
When you click the `Join Game!` button now, it will show _only_ jobs that are at least Low in your preference (and Assistant). Want to see the rest of those jobs anyway? There's a `Show Hidden Jobs.` button on the same menu that'll bring them back up.