### PR TITLE
Ported Bugfixes - April MkII

### DIFF
--- a/code/modules/integrated_electronics/core/printer.dm
+++ b/code/modules/integrated_electronics/core/printer.dm
@@ -168,6 +168,8 @@
 		else if(ispath(build_type, /obj/item/integrated_circuit))
 			var/obj/item/integrated_circuit/IC = build_type
 			cost = initial(IC.w_class)
+		else
+			return
 
 		if(metal - cost < 0)
 			to_chat(usr, "<span class='warning'>You need [cost] metal to build that!.</span>")

--- a/code/modules/mob/living/simple_animal/aliens/mimic.dm
+++ b/code/modules/mob/living/simple_animal/aliens/mimic.dm
@@ -49,10 +49,7 @@
 	qdel(src)
 
 /mob/living/simple_animal/hostile/mimic/MouseEntered(location, control, params)
-	..()
-	closeToolTip(usr) 
-	// ideally, we'd remove the code in ..() that opens the tooltip, 
-	// but then we'd need to duplicate all the other code in ..()
+	return // Do not call parent: Mimics shouldn't have tooltips!
 
 //
 // Crate Mimic

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -712,7 +712,7 @@
 		recoil = initial(recoil)
 
 /obj/item/weapon/gun/examine(mob/user)
-	..()
+	. = ..()
 	if(firemodes.len > 1)
 		var/datum/firemode/current_mode = firemodes[sel_mode]
 		to_chat(user, "The fire selector is set to [current_mode.name].")

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -144,7 +144,7 @@
 	return null
 
 /obj/item/weapon/gun/energy/examine(mob/user)
-	..(user)
+	. = ..()
 	if(power_supply)
 		var/shots_remaining = round(power_supply.charge / charge_cost)
 		user << "Has [shots_remaining] shot\s remaining."


### PR DESCRIPTION
Ports bugfixes:
- VOREStation/VOREStation#3563
Fix missing examine descriptions on guns. - Subtypes of `/obj/item/weapon/gun` couldn't properly append extra info to examine.
- VOREStation/VOREStation#3561
Fixes an exploit with circuit printers that allowed ref hackers to spawn anything.
- Also includes faster fix for PolarisSS13/Polaris#5173
Instead of opening & closing tooltip, avoid opening at all.