### PR TITLE
Increase zealousness of Portable Freezer item whitelist

### DIFF
--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -445,7 +445,7 @@
 	item_state_slots = list(slot_r_hand_str = "medicalpack", slot_l_hand_str = "medicalpack")
 	foldable = null
 	max_w_class = ITEMSIZE_NORMAL
-	can_hold = list(/obj/item/organ, /obj/item/weapon/reagent_containers/food, /obj/item/weapon/reagent_containers/glass)
+	can_hold = list(/obj/item/organ)
 	max_storage_space = ITEMSIZE_COST_NORMAL * 5 // Formally 21.  Odd numbers are bad.
 	use_to_pickup = 1 // for picking up broken bulbs, not that most people will try
 


### PR DESCRIPTION
```
Normal box:
It is: 4 size-cost
It holds: 8 size-cost
Max size: SMALL (2 size-cost per small item)
Summary: Consumes a NORMAL space in a storage, can hold 4 SMALL items
```
```
Portable freezer:
It is: 4
It holds: 20
Max size: NORMAL (4 size-cost per normal item)
Summary: Consumes a NORMAL space in a storage, can hold 5 NORMAL items
```
***What is 'volume'? We just don't know.***

Being able to carry five large beakers per portable freezer which takes up like no space in a backpack seems silly. The same beakers would take up 5x the space in your backpack.