### PR TITLE
Resolve shower curtain/steam layering issue

### DIFF
--- a/code/__defines/_planes+layers.dm
+++ b/code/__defines/_planes+layers.dm
@@ -74,9 +74,6 @@ What is the naming convention for planes or layers?
 	#define DOOR_CLOSED_LAYER		3.1	// Doors when closed
 	#define WINDOW_LAYER			3.2	// Windows
 	#define ON_WINDOW_LAYER			3.3 // Ontop of a window
-	#define SHOWER_OPEN_LAYER		3.4	// Showers when open
-	// Obj/Mob layer boundary
-	#define SHOWER_CLOSED_LAYER 	4.2	// Should be converted to plane swaps
 	
 // Mob planes
 #define MOB_PLANE				-25

--- a/code/game/objects/structures/curtains.dm
+++ b/code/game/objects/structures/curtains.dm
@@ -2,13 +2,15 @@
 	name = "curtain"
 	icon = 'icons/obj/curtain.dmi'
 	icon_state = "closed"
-	layer = SHOWER_OPEN_LAYER
+	plane = MOB_PLANE
+	layer = ABOVE_MOB_LAYER
 	opacity = 1
 	density = 0
 
 /obj/structure/curtain/open
 	icon_state = "open"
-	layer = SHOWER_CLOSED_LAYER
+	plane = OBJ_PLANE
+	layer = OBJ_LAYER
 	opacity = 0
 
 /obj/structure/curtain/bullet_act(obj/item/projectile/P, def_zone)
@@ -27,10 +29,12 @@
 	set_opacity(!opacity)
 	if(opacity)
 		icon_state = "closed"
-		layer = SHOWER_CLOSED_LAYER
+		plane = MOB_PLANE
+		layer = ABOVE_MOB_LAYER
 	else
 		icon_state = "open"
-		layer = SHOWER_OPEN_LAYER
+		plane = OBJ_PLANE
+		layer = OBJ_LAYER
 
 /obj/structure/curtain/attackby(obj/item/P, mob/user)
 	if(istype(P, /obj/item/weapon/wirecutters))
@@ -76,6 +80,3 @@
 
 /obj/structure/curtain/open/shower/security
 	color = "#AA0000"
-
-#undef SHOWER_OPEN_LAYER
-#undef SHOWER_CLOSED_LAYER

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -142,7 +142,8 @@
 	name = "mist"
 	icon = 'icons/obj/watercloset.dmi'
 	icon_state = "mist"
-	layer = MOB_LAYER + 1
+	plane = MOB_PLANE
+	layer = ABOVE_MOB_LAYER
 	anchored = 1
 	mouse_opacity = 0
 


### PR DESCRIPTION
Reported in https://github.com/VOREStation/VOREStation/issues/3594, curtains and steam layer under mobs due to the plane update. This fixes that, and causes them to layer correctly.