### PR TITLE
Fix signlang being totally broken

### DIFF
--- a/code/modules/mob/hear_say.dm
+++ b/code/modules/mob/hear_say.dm
@@ -302,7 +302,7 @@
 			else			adverb = " a very lengthy message"
 		message = "<B>[speaker]</B> [verb][adverb]."
 
-	src.show_message(message)
+	show_message(message, type = 1) // Type 1 is visual message
 
 /mob/proc/hear_sleep(var/message)
 	var/heard = ""

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -265,13 +265,13 @@ proc/get_radio_key_from_channel(var/channel)
 
 	//Handle nonverbal and sign languages here
 	if (speaking)
-		if (speaking.flags & NONVERBAL)
-			if (prob(30))
-				src.custom_emote(1, "[pick(speaking.signlang_verb)].")
-
 		if (speaking.flags & SIGNLANG)
 			log_say("(SIGN) [message]", src)
 			return say_signlang(message, pick(speaking.signlang_verb), speaking)
+
+		if (speaking.flags & NONVERBAL)
+			if (prob(30))
+				src.custom_emote(1, "[pick(speaking.signlang_verb)].")
 
 	//These will contain the main receivers of the message
 	var/list/listening = list()
@@ -371,11 +371,19 @@ proc/get_radio_key_from_channel(var/channel)
 	return 1
 
 /mob/living/proc/say_signlang(var/message, var/verb="gestures", var/datum/language/language)
-	var/list/potentials = get_mobs_and_objs_in_view_fast(src, world.view)
-	var/list/mobs = potentials["mobs"]
-	for(var/hearer in mobs)
-		var/mob/M = hearer
-		M.hear_signlang(message, verb, language, src)
+	var/turf/T = get_turf(src)
+	//We're in something, gesture to people inside the same thing
+	if(loc != T)
+		for(var/mob/M in loc)
+			M.hear_signlang(message, verb, language, src)
+
+	//We're on a turf, gesture to visible as if we were a normal language
+	else
+		var/list/potentials = get_mobs_and_objs_in_view_fast(T, world.view)
+		var/list/mobs = potentials["mobs"]
+		for(var/hearer in mobs)
+			var/mob/M = hearer
+			M.hear_signlang(message, verb, language, src)
 	return 1
 
 /obj/effect/speech_bubble


### PR DESCRIPTION
As reported in https://github.com/VOREStation/VOREStation/issues/3584, signlang is totally broken. The reason being is that it uses get_mobs_and_objs_in_view_fast but passes it a mob when it expects a turf.

Also makes two other tweaks: signlang only signs to people 'in' the thing you're 'in' if you're not on a turf (aka lockers, ~stomachs~), and signlang doesn't produce an extra 'X gestures' emote 30% of the time, given that it always produces either the message if they know signlang, or a 'gestures a long message' or whatever if they don't.