### PR TITLE
Fix wonky PDA eject messages

### DIFF
--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -1247,19 +1247,24 @@ var/global/list/obj/item/device/pda/PDAs = list()
 	if(issilicon(usr))
 		return
 
-	if(can_use(usr) && !isnull(cartridge))
-		cartridge.forceMove(get_turf(src))
-		if(ismob(loc))
-			var/mob/M = loc
-			M.put_in_hands(cartridge)
-		mode = 0
-		scanmode = 0
-		if (cartridge.radio)
-			cartridge.radio.hostpda = null
-		to_chat(usr, "<span class='notice'>You remove \the [cartridge] from the [name].</span>")
-		cartridge = null
-	else
+	if(!can_use(usr))
 		to_chat(usr, "<span class='notice'>You cannot do this while restrained.</span>")
+		return
+
+	if(isnull(cartridge))
+		to_chat(usr, "<span class='notice'>There's no cartridge to eject.</span>")
+		return		
+
+	cartridge.forceMove(get_turf(src))
+	if(ismob(loc))
+		var/mob/M = loc
+		M.put_in_hands(cartridge)
+	mode = 0
+	scanmode = 0
+	if (cartridge.radio)
+		cartridge.radio.hostpda = null
+	to_chat(usr, "<span class='notice'>You remove \the [cartridge] from the [name].</span>")
+	cartridge = null
 
 /obj/item/device/pda/proc/id_check(mob/user as mob, choice as num)//To check for IDs; 1 for in-pda use, 2 for out of pda use.
 	if(choice == 1)


### PR DESCRIPTION
As reported in https://github.com/VOREStation/VOREStation/issues/3611, attempting to eject a cart on a PDA when there's no cart tells you that you can't do that while you're restrained, which isn't very explanatory.