### PR TITLE
Changes lizard name

### DIFF
--- a/code/modules/mob/living/simple_animal/animals/lizard.dm
+++ b/code/modules/mob/living/simple_animal/animals/lizard.dm
@@ -1,7 +1,7 @@
 /mob/living/simple_animal/lizard
 	name = "Lizard"
 	desc = "A cute tiny lizard."
-	tt_desc = "Gekko gecko"
+	tt_desc = "Anolis carolinensis"
 	icon = 'icons/mob/critter.dmi'
 	icon_state = "lizard"
 	icon_living = "lizard"


### PR DESCRIPTION
Tokay geckos change color to match their surroundings, and thus would likely be far from green- Carolina anoles are small, more lizardy and match the sprite better, and their color is based on social stress rather than physical surroundings.

Also, they're actually the right shade of green.

Anolis cuvieri might make more sense but they're less common, will swap if asked.