### PR TITLE
improves and adds onto tt_descs

### DIFF
--- a/code/modules/mob/living/simple_animal/animals/bat.dm
+++ b/code/modules/mob/living/simple_animal/animals/bat.dm
@@ -1,7 +1,7 @@
 /mob/living/simple_animal/hostile/scarybat
 	name = "space bats"
 	desc = "A swarm of cute little blood sucking bats that looks pretty upset."
-	tt_desc = "N Bestia gregaria" //Common vampire bat
+	tt_desc = "N Bestia gregaria" //Nispean swarm bats, because of course Nisp has swarm bats
 	icon = 'icons/mob/bats.dmi'
 	icon_state = "bat"
 	icon_living = "bat"

--- a/code/modules/mob/living/simple_animal/animals/bat.dm
+++ b/code/modules/mob/living/simple_animal/animals/bat.dm
@@ -1,7 +1,7 @@
 /mob/living/simple_animal/hostile/scarybat
 	name = "space bats"
 	desc = "A swarm of cute little blood sucking bats that looks pretty upset."
-	tt_desc = "Desmodus rotundus" //Common vampire bat
+	tt_desc = "N Bestia gregaria" //Common vampire bat
 	icon = 'icons/mob/bats.dmi'
 	icon_state = "bat"
 	icon_living = "bat"

--- a/code/modules/mob/living/simple_animal/animals/bear.dm
+++ b/code/modules/mob/living/simple_animal/animals/bear.dm
@@ -1,8 +1,8 @@
 //Space bears!
 /mob/living/simple_animal/hostile/bear
 	name = "space bear"
-	desc = "RawrRawr!!"
-	tt_desc = "Ursinae aetherius" //...bearspace? Maybe.
+	desc = "A product of Space Russia?"
+	tt_desc = "U Ursinae aetherius" //...bearspace? Maybe.
 	icon_state = "bear"
 	icon_living = "bear"
 	icon_dead = "bear_dead"

--- a/code/modules/mob/living/simple_animal/animals/carp.dm
+++ b/code/modules/mob/living/simple_animal/animals/carp.dm
@@ -1,7 +1,7 @@
 /mob/living/simple_animal/hostile/carp
 	name = "space carp"
 	desc = "A ferocious, fang-bearing creature that resembles a fish."
-	tt_desc = "Cyprinus aetherius" //carpspace? maybe
+	tt_desc = "U Cyprinus aetherius" //carpspace? maybe
 	icon_state = "carp"
 	icon_living = "carp"
 	icon_dead = "carp_dead"

--- a/code/modules/mob/living/simple_animal/animals/cat.dm
+++ b/code/modules/mob/living/simple_animal/animals/cat.dm
@@ -156,7 +156,7 @@
 /mob/living/simple_animal/cat/fluff/Runtime
 	name = "Runtime"
 	desc = "Her fur has the look and feel of velvet, and her tail quivers occasionally."
-	tt_desc = "E Felis catus medicalis"
+	tt_desc = "E Felis silvestris medicalis" //a hypoallergenic breed produced by NT for... medical purposes? Sure.
 	gender = FEMALE
 	icon_state = "cat"
 	item_state = "cat"

--- a/code/modules/mob/living/simple_animal/animals/cat.dm
+++ b/code/modules/mob/living/simple_animal/animals/cat.dm
@@ -2,7 +2,7 @@
 /mob/living/simple_animal/cat
 	name = "cat"
 	desc = "A domesticated, feline pet. Has a tendency to adopt crewmembers."
-	tt_desc = "Felis catus"
+	tt_desc = "E Felis silvestris catus"
 	intelligence_level = SA_ANIMAL
 	icon_state = "cat2"
 	item_state = "cat2"
@@ -156,7 +156,7 @@
 /mob/living/simple_animal/cat/fluff/Runtime
 	name = "Runtime"
 	desc = "Her fur has the look and feel of velvet, and her tail quivers occasionally."
-	tt_desc = "Felis medicalis"
+	tt_desc = "E Felis catus medicalis"
 	gender = FEMALE
 	icon_state = "cat"
 	item_state = "cat"

--- a/code/modules/mob/living/simple_animal/animals/corgi.dm
+++ b/code/modules/mob/living/simple_animal/animals/corgi.dm
@@ -3,7 +3,7 @@
 	name = "corgi"
 	real_name = "corgi"
 	desc = "It's a corgi."
-	tt_desc = "Canis familiaris"
+	tt_desc = "E Canis lupus familiaris"
 	intelligence_level = SA_ANIMAL
 	icon_state = "corgi"
 	icon_living = "corgi"
@@ -38,7 +38,6 @@
 	real_name = "Ian"	//Intended to hold the name without altering it.
 	gender = MALE
 	desc = "It's a corgi."
-	tt_desc = "Canis commandus"
 	var/turns_since_scan = 0
 	var/obj/movement_target
 	response_help  = "pets"

--- a/code/modules/mob/living/simple_animal/animals/crab.dm
+++ b/code/modules/mob/living/simple_animal/animals/crab.dm
@@ -2,7 +2,7 @@
 /mob/living/simple_animal/crab
 	name = "crab"
 	desc = "A hard-shelled crustacean. Seems quite content to lounge around all the time."
-	tt_desc = "Ranina ranina"
+	tt_desc = "E Cancer bellianus"
 	icon_state = "crab"
 	icon_living = "crab"
 	icon_dead = "crab_dead"
@@ -52,6 +52,7 @@
 /mob/living/simple_animal/giant_crab
 	name = "giant crab"
 	desc = "A large, hard-shelled crustacean. This one is mostly grey."
+	tt_desc = "S Cancer holligus"
 	icon_state = "sif_crab"
 	icon_living = "sif_crab"
 	icon_dead = "sif_crab_dead"

--- a/code/modules/mob/living/simple_animal/animals/farm_animals.dm
+++ b/code/modules/mob/living/simple_animal/animals/farm_animals.dm
@@ -155,7 +155,7 @@
 /mob/living/simple_animal/chick
 	name = "\improper chick"
 	desc = "Adorable! They make such a racket though."
-	tt_desc = "E Gallus gallus domesticus"
+	tt_desc = "E Gallus gallus"
 	icon_state = "chick"
 	icon_living = "chick"
 	icon_dead = "chick_dead"
@@ -206,7 +206,7 @@ var/global/chicken_count = 0
 /mob/living/simple_animal/chicken
 	name = "\improper chicken"
 	desc = "Hopefully the eggs are good this season."
-	tt_desc = "E Gallus gallus domesticus"
+	tt_desc = "E Gallus gallus"
 	icon_state = "chicken"
 	icon_living = "chicken"
 	icon_dead = "chicken_dead"

--- a/code/modules/mob/living/simple_animal/animals/farm_animals.dm
+++ b/code/modules/mob/living/simple_animal/animals/farm_animals.dm
@@ -2,7 +2,7 @@
 /mob/living/simple_animal/retaliate/goat
 	name = "goat"
 	desc = "Not known for their pleasant disposition."
-	tt_desc = "Oreamnos americanus"
+	tt_desc = "E Oreamnos americanus"
 	icon_state = "goat"
 	icon_living = "goat"
 	icon_dead = "goat_dead"
@@ -86,7 +86,7 @@
 /mob/living/simple_animal/cow
 	name = "cow"
 	desc = "Known for their milk, just don't tip them over."
-	tt_desc = "Bos taurus"
+	tt_desc = "E Bos taurus"
 	icon_state = "cow"
 	icon_living = "cow"
 	icon_dead = "cow_dead"
@@ -155,7 +155,7 @@
 /mob/living/simple_animal/chick
 	name = "\improper chick"
 	desc = "Adorable! They make such a racket though."
-	tt_desc = "Gallus domesticus"
+	tt_desc = "E Gallus gallus domesticus"
 	icon_state = "chick"
 	icon_living = "chick"
 	icon_dead = "chick_dead"
@@ -206,7 +206,7 @@ var/global/chicken_count = 0
 /mob/living/simple_animal/chicken
 	name = "\improper chicken"
 	desc = "Hopefully the eggs are good this season."
-	tt_desc = "Gallus domesticus"
+	tt_desc = "E Gallus gallus domesticus"
 	icon_state = "chicken"
 	icon_living = "chicken"
 	icon_dead = "chicken_dead"

--- a/code/modules/mob/living/simple_animal/animals/fish.dm
+++ b/code/modules/mob/living/simple_animal/animals/fish.dm
@@ -39,24 +39,28 @@
 
 /mob/living/simple_animal/fish/bass
 	name = "bass"
+	tt_desc = "E Micropterus notius"
 	icon_state = "bass-swim"
 	icon_living = "bass-swim"
 	icon_dead = "bass-dead"
 
 /mob/living/simple_animal/fish/trout
 	name = "trout"
+	tt_desc = "E salmo trutta"
 	icon_state = "trout-swim"
 	icon_living = "trout-swim"
 	icon_dead = "trout-dead"
 
 /mob/living/simple_animal/fish/salmon
 	name = "salmon"
+	tt_desc = "E Oncorhynchus nerka"
 	icon_state = "salmon-swim"
 	icon_living = "salmon-swim"
 	icon_dead = "salmon-dead"
 
 /mob/living/simple_animal/fish/perch
 	name = "perch"
+	tt_desc = "E Perca flavescens"
 	icon_state = "perch-swim"
 	icon_living = "perch-swim"
 	icon_dead = "perch-dead"
@@ -69,6 +73,7 @@
 
 /mob/living/simple_animal/fish/koi
 	name = "koi"
+	tt_desc = "E Cyprinus rubrofuscus"
 	icon_state = "koi-swim"
 	icon_living = "koi-swim"
 	icon_dead = "koi-dead"

--- a/code/modules/mob/living/simple_animal/animals/fish.dm
+++ b/code/modules/mob/living/simple_animal/animals/fish.dm
@@ -46,7 +46,7 @@
 
 /mob/living/simple_animal/fish/trout
 	name = "trout"
-	tt_desc = "E salmo trutta"
+	tt_desc = "E Salmo trutta"
 	icon_state = "trout-swim"
 	icon_living = "trout-swim"
 	icon_dead = "trout-dead"
@@ -67,6 +67,7 @@
 
 /mob/living/simple_animal/fish/pike
 	name = "pike"
+	tt_desc = "E Esox aquitanicus"
 	icon_state = "pike-swim"
 	icon_living = "pike-swim"
 	icon_dead = "pike-dead"

--- a/code/modules/mob/living/simple_animal/animals/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/animals/giant_spider.dm
@@ -8,7 +8,7 @@
 /mob/living/simple_animal/hostile/giant_spider
 	name = "giant spider"
 	desc = "Furry and brown, it makes you shudder to look at it. This one has deep red eyes."
-	tt_desc = "Atrax robustus gigantus"
+	tt_desc = "X Brachypelma phorus"
 	icon_state = "guard"
 	icon_living = "guard"
 	icon_dead = "guard_dead"
@@ -66,6 +66,7 @@ Nurse Family
 //nursemaids - these create webs and eggs
 /mob/living/simple_animal/hostile/giant_spider/nurse
 	desc = "Furry and beige, it makes you shudder to look at it. This one has brilliant green eyes."
+	tt_desc = "X Brachypelma phorus laetus"
 	icon_state = "nurse"
 	icon_living = "nurse"
 	icon_dead = "nurse_dead"
@@ -93,6 +94,7 @@ Nurse Family
 
 /mob/living/simple_animal/hostile/giant_spider/nurse/queen
 	desc = "Absolutely gigantic, this creature is horror itself."
+	tt_desc = "X Brachypelma phorus tyrannus"
 	icon = 'icons/mob/64x64.dmi'
 	icon_state = "spider_queen"
 	icon_living = "spider_queen"
@@ -115,6 +117,7 @@ Nurse Family
 
 /mob/living/simple_animal/hostile/giant_spider/webslinger
 	desc = "Furry and green, it makes you shudder to look at it. This one has brilliant green eyes, and a cloak of web."
+	tt_desc = "X Brachypelma phorus balisticus"
 	icon_state = "webslinger"
 	icon_living = "webslinger"
 	icon_dead = "webslinger_dead"
@@ -155,6 +158,7 @@ Nurse Family
 
 /mob/living/simple_animal/hostile/giant_spider/carrier
 	desc = "Furry, beige, and red, it makes you shudder to look at it. This one has luminous green eyes."
+	tt_desc = "X Brachypelma phorus gerulus"
 	icon_state = "carrier"
 	icon_living = "carrier"
 	icon_dead = "carrier_dead"
@@ -214,6 +218,7 @@ Hunter Family
 
 /mob/living/simple_animal/hostile/giant_spider/hunter
 	desc = "Furry and black, it makes you shudder to look at it. This one has sparkling purple eyes."
+	tt_desc = "X Brachypelma phorus venandi"
 	icon_state = "hunter"
 	icon_living = "hunter"
 	icon_dead = "hunter_dead"
@@ -226,6 +231,7 @@ Hunter Family
 
 /mob/living/simple_animal/hostile/giant_spider/lurker
 	desc = "Translucent and white, it makes you shudder to look at it. This one has incandescent red eyes."
+	tt_desc = "X Brachypelma phorus insidator"
 	icon_state = "lurker"
 	icon_living = "lurker"
 	icon_dead = "lurker_dead"
@@ -249,6 +255,7 @@ Hunter Family
 
 /mob/living/simple_animal/hostile/giant_spider/tunneler
 	desc = "Sandy and brown, it makes you shudder to look at it. This one has glittering yellow eyes."
+	tt_desc = "X Brachypelma phorus cannalis"
 	icon_state = "tunneler"
 	icon_living = "tunneler"
 	icon_dead = "tunneler_dead"
@@ -279,6 +286,7 @@ Guard Family
 
 /mob/living/simple_animal/hostile/giant_spider/pepper
 	desc = "Red and brown, it makes you shudder to look at it. This one has glinting red eyes."
+	tt_desc = "X Brachypelma phorus ignis"
 	icon_state = "pepper"
 	icon_living = "pepper"
 	icon_dead = "pepper_dead"
@@ -299,6 +307,7 @@ Guard Family
 
 /mob/living/simple_animal/hostile/giant_spider/thermic
 	desc = "Mirage-cloaked and orange, it makes you shudder to look at it. This one has simmering orange eyes."
+	tt_desc = "X Brachypelma phorus incaendium"
 	icon_state = "pit"
 	icon_living = "pit"
 	icon_dead = "pit_dead"
@@ -315,6 +324,7 @@ Guard Family
 
 /mob/living/simple_animal/hostile/giant_spider/electric
 	desc = "Spined and yellow, it makes you shudder to look at it. This one has flickering gold eyes."
+	tt_desc = "X Brachypelma phorus aromatitis"
 	icon_state = "spark"
 	icon_living = "spark"
 	icon_dead = "spark_dead"
@@ -338,6 +348,7 @@ Guard Family
 
 /mob/living/simple_animal/hostile/giant_spider/phorogenic
 	desc = "Crystalline and purple, it makes you shudder to look at it. This one has haunting purple eyes."
+	tt_desc = "X Brachypelma phorus phorus"
 	icon_state = "phoron"
 	icon_living = "phoron"
 	icon_dead = "phoron_dead"
@@ -371,6 +382,7 @@ Guard Family
 
 /mob/living/simple_animal/hostile/giant_spider/frost
 	desc = "Icy and blue, it makes you shudder to look at it. This one has brilliant blue eyes."
+	tt_desc = "X Brachypelma phorus pruinae"
 	icon_state = "frost"
 	icon_living = "frost"
 	icon_dead = "frost_dead"

--- a/code/modules/mob/living/simple_animal/animals/goose.dm
+++ b/code/modules/mob/living/simple_animal/animals/goose.dm
@@ -1,7 +1,7 @@
-/mob/living/simple_animal/hostile/goose
-	name = "space goose"
-	desc = "That's no duck. That's a space goose. You have a bad feeling about this."
-	tt_desc = "Anser aetherius" //Goose space?!
+/mob/living/simple_animal/hostile/goose //hey are these even in the game
+	name = "goose"
+	desc = "It looks pretty angry!"
+	tt_desc = "E Branta canadensis" //that iconstate is just a regular goose
 	icon_state = "goose"
 	icon_living = "goose"
 	icon_dead = "goose_dead"

--- a/code/modules/mob/living/simple_animal/animals/lizard.dm
+++ b/code/modules/mob/living/simple_animal/animals/lizard.dm
@@ -1,7 +1,7 @@
 /mob/living/simple_animal/lizard
 	name = "Lizard"
 	desc = "A cute tiny lizard."
-	tt_desc = "Gekko gecko"
+	tt_desc = "E Anolis cuvieri"
 	icon = 'icons/mob/critter.dmi'
 	icon_state = "lizard"
 	icon_living = "lizard"

--- a/code/modules/mob/living/simple_animal/animals/miscellaneous.dm
+++ b/code/modules/mob/living/simple_animal/animals/miscellaneous.dm
@@ -1,6 +1,7 @@
 /mob/living/simple_animal/yithian
 	name = "yithian"
 	desc = "A friendly creature vaguely resembling an oversized snail without a shell."
+	tt_desc = "J Escargot escargot" // a product of Jade, which is a planet that totally exists
 	icon_state = "yithian"
 	icon_living = "yithian"
 	icon_dead = "yithian_dead"
@@ -11,6 +12,7 @@
 /mob/living/simple_animal/tindalos
 	name = "tindalos"
 	desc = "It looks like a large, flightless grasshopper."
+	tt_desc = "J Locusta bruchus"
 	icon_state = "tindalos"
 	icon_living = "tindalos"
 	icon_dead = "tindalos_dead"

--- a/code/modules/mob/living/simple_animal/animals/mouse.dm
+++ b/code/modules/mob/living/simple_animal/animals/mouse.dm
@@ -2,7 +2,7 @@
 	name = "mouse"
 	real_name = "mouse"
 	desc = "It's a small rodent."
-	tt_desc = "Mus musculus"
+	tt_desc = "E Mus musculus"
 	icon_state = "mouse_gray"
 	item_state = "mouse_gray"
 	icon_living = "mouse_gray"

--- a/code/modules/mob/living/simple_animal/animals/parrot.dm
+++ b/code/modules/mob/living/simple_animal/animals/parrot.dm
@@ -31,7 +31,7 @@
 /mob/living/simple_animal/parrot
 	name = "parrot"
 	desc = "The parrot squawks, \"It's a parrot! BAWWK!\""
-	tt_desc = "Poicephalus robustus"
+	tt_desc = "E Ara macao"
 	icon = 'icons/mob/animal.dmi'
 	icon_state = "parrot_fly"
 	icon_living = "parrot_fly"

--- a/code/modules/mob/living/simple_animal/animals/sif_wildlife/diyaab.dm
+++ b/code/modules/mob/living/simple_animal/animals/sif_wildlife/diyaab.dm
@@ -1,6 +1,7 @@
 /mob/living/simple_animal/retaliate/diyaab
 	name = "diyaab"
 	desc = "A small pack animal. Although omnivorous, it will hunt meat on occasion."
+	tt_desc = "S Choeros hirtus" //diyaab and shantak are technically reletives!
 	faction = "diyaab"
 	icon_state = "diyaab"
 	icon_living = "diyaab"

--- a/code/modules/mob/living/simple_animal/animals/sif_wildlife/savik.dm
+++ b/code/modules/mob/living/simple_animal/animals/sif_wildlife/savik.dm
@@ -1,6 +1,7 @@
 /mob/living/simple_animal/hostile/savik
 	name = "savik"
 	desc = "A fast, armoured predator accustomed to hiding and ambushing in cold terrain."
+	tt_desc = "S Pistris tellus" //landshark
 	faction = "savik"
 	icon_state = "savik"
 	icon_living = "savik"

--- a/code/modules/mob/living/simple_animal/animals/sif_wildlife/shantak.dm
+++ b/code/modules/mob/living/simple_animal/animals/sif_wildlife/shantak.dm
@@ -1,6 +1,7 @@
 /mob/living/simple_animal/hostile/shantak
 	name = "shantak"
 	desc = "A piglike creature with a bright iridiscent mane that sparkles as though lit by an inner light. Don't be fooled by its beauty though."
+	tt_desc = "S Choeros shantak"
 	faction = "shantak"
 	icon_state = "shantak"
 	icon_living = "shantak"

--- a/code/modules/mob/living/simple_animal/animals/tomato.dm
+++ b/code/modules/mob/living/simple_animal/animals/tomato.dm
@@ -1,6 +1,7 @@
 /mob/living/simple_animal/hostile/tomato
 	name = "tomato"
 	desc = "It's a horrifyingly enormous beef tomato, and it's packing extra beef!"
+	tt_desc = "X Solanum abominable"
 	icon_state = "tomato"
 	icon_living = "tomato"
 	icon_dead = "tomato_dead"

--- a/code/modules/mob/living/simple_animal/animals/tree.dm
+++ b/code/modules/mob/living/simple_animal/animals/tree.dm
@@ -1,6 +1,7 @@
 /mob/living/simple_animal/hostile/tree
 	name = "pine tree"
 	desc = "A pissed off tree-like alien. It seems annoyed with the festivities..."
+	tt_desc = "X Festivus tyrannus"
 	icon = 'icons/obj/flora/pinetrees.dmi'
 	icon_state = "pine_1"
 	icon_living = "pine_1"

--- a/code/modules/mob/living/simple_animal/humanoids/clown.dm
+++ b/code/modules/mob/living/simple_animal/humanoids/clown.dm
@@ -1,6 +1,7 @@
 /mob/living/simple_animal/hostile/clown
 	name = "clown"
 	desc = "A denizen of clown planet"
+	tt_desc = "E Homo sapiens corydon" //this is an actual clown, as opposed to someone dressed up as one
 	icon_state = "clown"
 	icon_living = "clown"
 	icon_dead = "clown_dead"

--- a/code/modules/mob/living/simple_animal/humanoids/pirate.dm
+++ b/code/modules/mob/living/simple_animal/humanoids/pirate.dm
@@ -1,6 +1,7 @@
 /mob/living/simple_animal/hostile/pirate
 	name = "Pirate"
 	desc = "Does what he wants cause a pirate is free."
+	tt_desc = "E Homo sapiens"
 	icon_state = "piratemelee"
 	icon_living = "piratemelee"
 	icon_dead = "piratemelee_dead"

--- a/code/modules/mob/living/simple_animal/humanoids/russian.dm
+++ b/code/modules/mob/living/simple_animal/humanoids/russian.dm
@@ -1,6 +1,7 @@
 /mob/living/simple_animal/hostile/russian
 	name = "russian"
 	desc = "For the Motherland!"
+	tt_desc = "E Homo sapiens"
 	icon_state = "russianmelee"
 	icon_living = "russianmelee"
 	icon_dead = "russianmelee_dead"

--- a/code/modules/mob/living/simple_animal/humanoids/syndicate.dm
+++ b/code/modules/mob/living/simple_animal/humanoids/syndicate.dm
@@ -1,6 +1,7 @@
 /mob/living/simple_animal/hostile/syndicate
 	name = "mercenary"
 	desc = "Death to the Company."
+	tt_desc = "E Homo sapiens"
 	icon_state = "syndicate"
 	icon_living = "syndicate"
 	icon_dead = "syndicate_dead"

--- a/code/modules/mob/living/simple_animal/slime/slime.dm
+++ b/code/modules/mob/living/simple_animal/slime/slime.dm
@@ -1,6 +1,7 @@
 /mob/living/simple_animal/slime
 	name = "slime"
 	desc = "The most basic of slimes.  The grey slime has no remarkable qualities, however it remains one of the most useful colors for scientists."
+	tt_desc = "A Macrolimbus vulgaris"
 	icon = 'icons/mob/slime2.dmi'
 	icon_state = "grey baby slime"
 	intelligence_level = SA_ANIMAL


### PR DESCRIPTION
previously: a best-attempt at binomial nomenclature for earth species (though often making questionable choice of species and using subspecies names in place of species names). Memetastic pseudolatin names for anything else.

currently: a trinomial system using biosphere of origin in addition to genus and species name. Earth species have improved identifications courtesy of belsima, who is a huge fucking nerd. Alien species have vaguely scientific names in any case where they might be regularly encountered. Rare and adminspawn-only mobs get funny names because I'm not totally joyless.

(For reference:

E = Earth
J = Jade
S = Sif
N = Nisp
A = Aetolus
X = Artificially created
U = Unknown origin)