### PR TITLE
Originalize window title

### DIFF
--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -1811,7 +1811,7 @@ window "mainwindow"
 		right-click = false
 		saved-params = "pos;size;is-minimized;is-maximized"
 		on-size = ""
-		title = "Space Station 13"
+		title = "Polaris Station 13"
 		titlebar = true
 		statusbar = true
 		can-close = true


### PR DESCRIPTION
Reasons:

* It looks better
* Many servers do it
* I want to add support for Polaris on [ss13rp](https://github.com/qwertyquerty/ss13rp)
* Why not?