### PR TITLE
Makes lighting a little fancier, reduces the amount of light sources with a power greater than 1

### DIFF
--- a/code/__defines/lighting.dm
+++ b/code/__defines/lighting.dm
@@ -74,5 +74,12 @@
 #define LIGHT_COLOR_TUNGSTEN   "#FAE1AF" //Extremely diluted yellow, close to skin color (for some reason). rgb(250, 225, 175)
 #define LIGHT_COLOR_HALOGEN    "#F0FAFA" //Barely visible cyan-ish hue, as the doctor prescribed. rgb(240, 250, 250)
 
+//Lighting values used by the station lights
+#define LIGHT_COLOR_FLUORESCENT_TUBE "#E0EFFF"
+#define LIGHT_COLOR_FLUORESCENT_FLASHLIGHT "#CDDDFF"
+#define LIGHT_COLOR_INCANDESCENT_TUBE "#FFEEDD"
+#define LIGHT_COLOR_INCANDESCENT_BULB "#FFDDBB"
+#define LIGHT_COLOR_INCANDESCENT_FLASHLIGHT "#FFCC66"
+
 //Fake ambient occlusion filter
 #define AMBIENT_OCCLUSION filter(type="drop_shadow", x=0, y=-2, size=4, border=4, color="#04080FAA")

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -322,7 +322,7 @@
 			icon_state = "alarm1"
 			new_color = "#DA0205"
 
-	set_light(l_range = 2, l_power = 0.5, l_color = new_color)
+	set_light(l_range = 2, l_power = 0.25, l_color = new_color)
 
 /obj/machinery/alarm/receive_signal(datum/signal/signal)
 	if(stat & (NOPOWER|BROKEN))
@@ -838,14 +838,14 @@ FIRE ALARM
 	else
 		if(!detecting)
 			icon_state = "fire1"
-			set_light(l_range = 4, l_power = 2, l_color = "#ff0000")
+			set_light(l_range = 4, l_power = 0.9, l_color = "#ff0000")
 		else
 			icon_state = "fire0"
 			switch(seclevel)
-				if("green")	set_light(l_range = 2, l_power = 0.5, l_color = "#00ff00")
-				if("blue")	set_light(l_range = 2, l_power = 0.5, l_color = "#1024A9")
-				if("red")	set_light(l_range = 4, l_power = 2, l_color = "#ff0000")
-				if("delta")	set_light(l_range = 4, l_power = 2, l_color = "#FF6633")
+				if("green")	set_light(l_range = 2, l_power = 0.25, l_color = "#00ff00")
+				if("blue")	set_light(l_range = 2, l_power = 0.25, l_color = "#1024A9")
+				if("red")	set_light(l_range = 4, l_power = 0.9, l_color = "#ff0000")
+				if("delta")	set_light(l_range = 4, l_power = 0.9, l_color = "#FF6633")
 		add_overlay("overlay_[seclevel]")
 
 /obj/machinery/firealarm/fire_act(datum/gas_mixture/air, temperature, volume)

--- a/code/game/machinery/floor_light.dm
+++ b/code/game/machinery/floor_light.dm
@@ -16,8 +16,8 @@ var/list/floor_light_cache = list()
 	var/on
 	var/damaged
 	var/default_light_range = 4
-	var/default_light_power = 2
-	var/default_light_colour = "#FFFFFF"
+	var/default_light_power = 0.75
+	var/default_light_colour = LIGHT_COLOR_INCANDESCENT_BULB
 
 /obj/machinery/floor_light/prebuilt
 	anchored = 1

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -10,6 +10,8 @@
 	action_button_name = "Toggle Flashlight"
 	var/on = 0
 	var/brightness_on = 4 //luminosity when on
+	var/flashlight_power = 0.8	//lighting power when on
+	var/flashlight_colour = LIGHT_COLOR_INCANDESCENT_FLASHLIGHT	//lighting colour when on
 	var/obj/item/weapon/cell/cell
 	var/cell_type = /obj/item/weapon/cell/device
 	var/list/brightness_levels
@@ -71,11 +73,11 @@
 		icon_state = "[initial(icon_state)]-on"
 
 		if(brightness_level == "low")
-			set_light(brightness_on/2)
+			set_light(brightness_on/2, flashlight_power*0.75, flashlight_colour)
 		else if(brightness_level == "high")
-			set_light(brightness_on*1.5)
+			set_light(brightness_on*1.5, flashlight_power*1.1, flashlight_colour)
 		else
-			set_light(brightness_on)
+			set_light(brightness_on, flashlight_power, flashlight_colour)
 
 	else
 		icon_state = "[initial(icon_state)]"
@@ -267,6 +269,7 @@
 	name = "maglight"
 	desc = "A very, very heavy duty flashlight."
 	icon_state = "maglight"
+	flashlight_colour = LIGHT_COLOR_FLUORESCENT_FLASHLIGHT
 	force = 10
 	flags = CONDUCT
 	slot_flags = SLOT_BELT
@@ -303,7 +306,7 @@
 	desc = "A classic green-shaded desk lamp."
 	icon_state = "lampgreen"
 	brightness_on = 5
-	light_color = "#FFC58F"
+	flashlight_colour = "#FFC58F"
 
 /obj/item/device/flashlight/lamp/verb/toggle_light()
 	set name = "Toggle light"
@@ -320,8 +323,8 @@
 	desc = "A red standard-issue flare. There are instructions on the side reading 'pull cord, make light'."
 	w_class = ITEMSIZE_SMALL
 	brightness_on = 8 // Pretty bright.
-	light_power = 3
-	light_color = LIGHT_COLOR_FLARE
+	flashlight_power = 0.8
+	flashlight_colour = LIGHT_COLOR_FLARE
 	icon_state = "flare"
 	item_state = "flare"
 	action_button_name = null //just pull it manually, neckbeard.
@@ -383,8 +386,8 @@
 	desc = "A green military-grade glowstick."
 	w_class = ITEMSIZE_SMALL
 	brightness_on = 4
-	light_power = 2
-	light_color = "#49F37C"
+	flashlight_power = 0.9
+	flashlight_colour = "#49F37C"
 	icon_state = "glowstick"
 	item_state = "glowstick"
 	var/fuel = 0
@@ -422,28 +425,28 @@
 /obj/item/device/flashlight/glowstick/red
 	name = "red glowstick"
 	desc = "A red military-grade glowstick."
-	light_color = "#FC0F29"
+	flashlight_colour = "#FC0F29"
 	icon_state = "glowstick_red"
 	item_state = "glowstick_red"
 
 /obj/item/device/flashlight/glowstick/blue
 	name = "blue glowstick"
 	desc = "A blue military-grade glowstick."
-	light_color = "#599DFF"
+	flashlight_colour = "#599DFF"
 	icon_state = "glowstick_blue"
 	item_state = "glowstick_blue"
 
 /obj/item/device/flashlight/glowstick/orange
 	name = "orange glowstick"
 	desc = "A orange military-grade glowstick."
-	light_color = "#FA7C0B"
+	flashlight_colour = "#FA7C0B"
 	icon_state = "glowstick_orange"
 	item_state = "glowstick_orange"
 
 /obj/item/device/flashlight/glowstick/yellow
 	name = "yellow glowstick"
 	desc = "A yellow military-grade glowstick."
-	light_color = "#FEF923"
+	flashlight_colour = "#FEF923"
 	icon_state = "glowstick_yellow"
 	item_state = "glowstick_yellow"
 
@@ -454,7 +457,7 @@
 	icon = 'icons/obj/lighting.dmi'
 	icon_state = "floor1" //not a slime extract sprite but... something close enough!
 	item_state = "slime"
-	light_color = "#FFF423"
+	flashlight_colour = "#FFF423"
 	w_class = ITEMSIZE_TINY
 	brightness_on = 6
 	on = 1 //Bio-luminesence has one setting, on.
@@ -462,7 +465,7 @@
 
 /obj/item/device/flashlight/slime/New()
 	..()
-	set_light(brightness_on)
+	set_light(brightness_on, flashlight_power, flashlight_colour)
 
 /obj/item/device/flashlight/slime/update_icon()
 	return

--- a/code/game/objects/items/stacks/marker_beacons.dm
+++ b/code/game/objects/items/stacks/marker_beacons.dm
@@ -83,7 +83,7 @@ var/list/marker_beacon_colors = list(
 //	layer = BELOW_OPEN_DOOR_LAYER
 	anchored = TRUE
 	light_range = 2
-	light_power = 3
+	light_power = 0.8
 	var/remove_speed = 15
 	var/picked_color
 

--- a/code/game/objects/structures/flora.dm
+++ b/code/game/objects/structures/flora.dm
@@ -197,7 +197,7 @@
 	desc = "This is an unusual plant. It's bulbous ends emit a soft blue light."
 	icon_state = "plant-09"
 	light_range = 2
-	light_power = 1
+	light_power = 0.6
 	light_color = "#33CCFF"
 
 /obj/structure/flora/pottedplant/orientaltree
@@ -255,7 +255,7 @@
 	desc = "This is a subterranean plant. It's bulbous ends glow faintly."
 	icon_state = "plant-20"
 	light_range = 2
-	light_power = 1
+	light_power = 0.6
 	light_color = "#FF6633"
 
 /obj/structure/flora/pottedplant/minitree
@@ -301,7 +301,7 @@
 	desc = "This is a subterranean plant. It's bulbous ends glow faintly."
 	icon_state = "glowplant"
 	light_range = 2
-	light_power = 1
+	light_power = 0.6
 	light_color = "#FF6633"
 
 /obj/structure/flora/sif/subterranean/initialize()

--- a/code/game/turfs/simulated/floor_types.dm
+++ b/code/game/turfs/simulated/floor_types.dm
@@ -181,7 +181,7 @@
 /turf/simulated/shuttle/floor/alien
 	icon_state = "alienpod1"
 	light_range = 3
-	light_power = 3
+	light_power = 0.6
 	light_color = "#66ffff" // Bright cyan.
 	block_tele = TRUE
 

--- a/code/game/turfs/simulated/wall_types.dm
+++ b/code/game/turfs/simulated/wall_types.dm
@@ -118,7 +118,7 @@
 	icon_state = "alien"
 	base_state = "alien"
 	light_range = 3
-	light_power = 3
+	light_power = 0.75
 	light_color = "#ff0066" // Pink-ish
 	block_tele = TRUE // Will be used for dungeons so this is needed to stop cheesing with handteles.
 

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -346,7 +346,7 @@
 
 	if(update & 3)
 		if(update_state & UPDATE_BLUESCREEN)
-			set_light(l_range = 2, l_power = 0.5, l_color = "#0000FF")
+			set_light(l_range = 2, l_power = 0.25, l_color = "#0000FF")
 		else if(!(stat & (BROKEN|MAINT)) && update_state & UPDATE_ALLGOOD)
 			var/color
 			switch(charging)
@@ -356,7 +356,7 @@
 					color = "#A8B0F8"
 				if(2)
 					color = "#82FF4C"
-			set_light(l_range = 2, l_power = 0.5, l_color = color)
+			set_light(l_range = 2, l_power = 0.25, l_color = color)
 		else
 			set_light(0)
 

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -165,8 +165,8 @@
 	power_channel = LIGHT //Lights are calc'd via area so they dont need to be in the machine list
 	var/on = 0					// 1 if on, 0 if off
 	var/brightness_range = 6	// luminosity when on, also used in power calculation
-	var/brightness_power = 3
-	var/brightness_color = null
+	var/brightness_power = 0.8
+	var/brightness_color = LIGHT_COLOR_INCANDESCENT_TUBE
 	var/status = LIGHT_OK		// LIGHT_OK, _EMPTY, _BURNED or _BROKEN
 	var/flickering = 0
 	var/light_type = /obj/item/weapon/light/tube		// the type of light item
@@ -183,8 +183,7 @@
 	base_state = "bulb"
 	fitting = "bulb"
 	brightness_range = 4
-	brightness_power = 2
-	brightness_color = "#FFF4E5"
+	brightness_color = LIGHT_COLOR_INCANDESCENT_BULB
 	desc = "A small lighting fixture."
 	light_type = /obj/item/weapon/light/bulb
 
@@ -193,17 +192,15 @@
 	base_state = "flamp"
 	fitting = "bulb"
 	brightness_range = 5
-	brightness_power = 2
 	plane = OBJ_PLANE
 	layer = OBJ_LAYER
-	brightness_color = "#FFF4E5"
+	brightness_color = LIGHT_COLOR_INCANDESCENT_BULB
 	desc = "A floor lamp."
 	light_type = /obj/item/weapon/light/bulb
 	var/lamp_shade = 1
 
 /obj/machinery/light/small/emergency
 	brightness_range = 4
-	brightness_power = 2
 	brightness_color = "#da0205"
 
 /obj/machinery/light/spot
@@ -211,7 +208,7 @@
 	fitting = "large tube"
 	light_type = /obj/item/weapon/light/tube/large
 	brightness_range = 12
-	brightness_power = 4
+	brightness_power = 0.9
 
 /obj/machinery/light/built/New()
 	status = LIGHT_EMPTY
@@ -716,8 +713,8 @@
 	matter = list(DEFAULT_WALL_MATERIAL = 60)
 	var/rigged = 0		// true if rigged to explode
 	var/brightness_range = 2 //how much light it gives off
-	var/brightness_power = 1
-	var/brightness_color = null
+	var/brightness_power = 0.8
+	var/brightness_color = LIGHT_COLOR_INCANDESCENT_TUBE
 
 /obj/item/weapon/light/tube
 	name = "light tube"
@@ -727,13 +724,12 @@
 	item_state = "c_tube"
 	matter = list("glass" = 100)
 	brightness_range = 8
-	brightness_power = 3
 
 /obj/item/weapon/light/tube/large
 	w_class = ITEMSIZE_SMALL
 	name = "large light tube"
 	brightness_range = 15
-	brightness_power = 4
+	brightness_power = 0.9
 
 /obj/item/weapon/light/bulb
 	name = "light bulb"
@@ -743,8 +739,7 @@
 	item_state = "contvapour"
 	matter = list("glass" = 100)
 	brightness_range = 5
-	brightness_power = 2
-	brightness_color = "#a0a080"
+	brightness_color = LIGHT_COLOR_INCANDESCENT_BULB
 
 /obj/item/weapon/light/throw_impact(atom/hit_atom)
 	..()
@@ -758,7 +753,6 @@
 	item_state = "egg4"
 	matter = list("glass" = 100)
 	brightness_range = 5
-	brightness_power = 2
 
 // update the icon state and description of the light
 


### PR DESCRIPTION
Title. The new values are based off of my own studies of lights in the real world. This should make lighting look a lot more realistic, instead of lighting being pure white against pure black in most areas.
This PR also reduces quite a few light power values. With robustlight2/goonlights/vglights, the light_power variable is essentially the alpha of a light source, so having it exceed 1 can result in some pretty binary light behavior. Reducing the light_power variable will result in the station being darker across the board, but will make most light sources behave in a slightly more realistic manner.
This also makes some minor tweaks to how flashlights handle their light values. This allows lights to actually shine a little brighter when their brightness is set to high, and makes flashlights glow darker when their brightness is set to low.

Before
![image](https://user-images.githubusercontent.com/6356337/40098710-e49a401c-58aa-11e8-8712-39cc500cc7d4.png)

After
![image](https://user-images.githubusercontent.com/6356337/40098699-da666062-58aa-11e8-9fdc-4a18c8f1c5d4.png)
