### PR TITLE
Adjust Promethean limbs.

### DIFF
--- a/code/modules/organs/subtypes/slime.dm
+++ b/code/modules/organs/subtypes/slime.dm
@@ -2,46 +2,57 @@
 	nonsolid = 1
 	max_damage = 50
 	encased = 0
+	spread_dam = 1
 
 /obj/item/organ/external/groin/unbreakable/slime
 	nonsolid = 1
 	max_damage = 30
+	spread_dam = 1
 
 /obj/item/organ/external/arm/unbreakable/slime
 	nonsolid = 1
-	max_damage = 5
+	max_damage = 20
+	spread_dam = 1
 
 /obj/item/organ/external/arm/right/unbreakable/slime
 	nonsolid = 1
-	max_damage = 5
+	max_damage = 20
+	spread_dam = 1
 
 /obj/item/organ/external/leg/unbreakable/slime
 	nonsolid = 1
-	max_damage = 5
+	max_damage = 20
+	spread_dam = 1
 
 /obj/item/organ/external/leg/right/unbreakable/slime
 	nonsolid = 1
-	max_damage = 5
+	max_damage = 20
+	spread_dam = 1
 
 /obj/item/organ/external/foot/unbreakable/slime
 	nonsolid = 1
-	max_damage = 5
+	max_damage = 20
+	spread_dam = 1
 
 /obj/item/organ/external/foot/right/unbreakable/slime
 	nonsolid = 1
-	max_damage = 5
+	max_damage = 20
+	spread_dam = 1
 
 /obj/item/organ/external/hand/unbreakable/slime
 	nonsolid = 1
-	max_damage = 5
+	max_damage = 20
+	spread_dam = 1
 
 /obj/item/organ/external/hand/right/unbreakable/slime
 	nonsolid = 1
-	max_damage = 5
+	max_damage = 20
+	spread_dam = 1
 
 /obj/item/organ/external/head/unbreakable/slime	//They don't need this anymore.
 	nonsolid = 1
 	cannot_gib = 0
 	vital = 0
-	max_damage = 5
+	max_damage = 30
 	encased = 0
+	spread_dam = 1

--- a/html/changelogs/Mechoid - Prometheans.yml
+++ b/html/changelogs/Mechoid - Prometheans.yml
@@ -1,0 +1,9 @@
+
+author: Mechoid
+
+delete-after: True
+
+changes: 
+  - rsctweak: "Promethean limbs store more damage."
+  - rsctweak: "Promethean limbs, in addition to normal severing rules, have a higher chance to be splattered or ashed once they reach maximum damage."
+  - rscadd: "Limbs can now spread their damage with the spread_dam var, when reaching max damage."


### PR DESCRIPTION
One of many PRs I've made in response to a thread on the forums. (Because people think I don't read them or dismiss them?) Took a while to pinpoint the exact issues. This is likely not a final version as nothing is, but it's the numbers I've concluded are 'suitable for testing at this point'.
General:
- Limbs can spread their damage to parent and children limbs via the spread_dam var.

Promethean:
- Limbs have a higher max health of 20, rather than 5. They no longer only take 5 damage on their limbs, then stop taking damage. This Is Not A Buff.
***This is the likely source of 90% of complaints regarding Promethean passive regeneration that I have pinpointed, despite repetitive prodding of it. They never stored a large enough amount of damage on their limbs to make it slow.***
- Limbs can splatter any time they take 5 damage more of brute or burn than the maximum, in addition to normal limb severing.
- Limbs will spread their damage when reaching max damage, to their parent and child at reduced rates, without their sharp or edge bonuses. This damage overflow can splatter limbs as per normal damage.
