### PR TITLE
Buttons appear over tables

### DIFF
--- a/code/game/machinery/buttons.dm
+++ b/code/game/machinery/buttons.dm
@@ -2,8 +2,6 @@
 	name = "button"
 	icon = 'icons/obj/objects.dmi'
 	icon_state = "launcherbtt"
-	plane = TURF_PLANE
-	layer = ABOVE_TURF_LAYER
 	desc = "A remote control switch for something."
 	var/id = null
 	var/active = 0


### PR DESCRIPTION
I swear I saw this fix somewhere, but I can't remember where it came from. Either way, buttons should now show up over tables again.

EDIT: Found it, hiding in plain sight. https://github.com/VOREStation/VOREStation/pull/3712