### PR TITLE
Swapping hands cancels zoom

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -680,6 +680,10 @@ modules/mob/living/carbon/human/life.dm if you die, you will be zoomed out.
 /obj/item/proc/is_hot()
 	return FALSE
 
+// Called when you swap hands away from the item
+/obj/item/proc/in_inactive_hand(mob/user)
+	return
+
 // My best guess as to why this is here would be that it does so little. Still, keep it under all the procs, for sanity's sake.
 /obj/item/device
 	icon = 'icons/obj/device.dmi'

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -340,6 +340,11 @@ This saves us from having to call add_fingerprint() any time something is put in
 	if(W.action_button_name)
 		update_action_buttons()
 
+	if(W.zoom)
+		W.zoom()
+
+	W.in_inactive_hand(src)
+
 	return 1
 
 //Checks if a given slot can be accessed at this time, either to equip or unequip I

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1113,6 +1113,13 @@ default behaviour is:
 		else
 			hud_used.l_hand_hud_object.icon_state = "l_hand_inactive"
 			hud_used.r_hand_hud_object.icon_state = "r_hand_active"
+
+	// We just swapped hands, so the thing in our inactive hand will notice it's not the focus
+	var/obj/item/I = get_inactive_hand()
+	if(I)
+		if(I.zoom)
+			I.zoom()
+		I.in_inactive_hand(src)	//This'll do specific things, determined by the item
 	return
 
 /mob/living/proc/activate_hand(var/selhand) //0 or "r" or "right" for right hand; 1 or "l" or "left" for left hand.

--- a/html/changelogs/Anewbe - Item Zoom.yml
+++ b/html/changelogs/Anewbe - Item Zoom.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Anewbe
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Moving items out of one's active hand cancels any zoom-in they may be providing."


### PR DESCRIPTION
- Swapping hands from a zoom-in item (snipers, binoculars, etc) cancels the zoom
- Equipping a zoom-in item cancels the zoom
- Added a background proc for letting items check if they're moved out of the active hand