### PR TITLE
Change accessories to use bitflags

### DIFF
--- a/code/__defines/items_clothing.dm
+++ b/code/__defines/items_clothing.dm
@@ -22,19 +22,23 @@
 #define SLOT_TIE        0x4000
 #define SLOT_HOLSTER	0x8000 //16th bit - higher than this will overflow
 
-#define ACCESSORY_SLOT_UTILITY  "Utility"
-#define ACCESSORY_SLOT_ARMBAND  "Armband"
-#define ACCESSORY_SLOT_RANK     "Rank"
-#define ACCESSORY_SLOT_DEPT		"Department"
-#define ACCESSORY_SLOT_DECOR    "Decor"
-#define ACCESSORY_SLOT_MEDAL    "Medal"
-#define ACCESSORY_SLOT_INSIGNIA "Insignia"
-#define ACCESSORY_SLOT_ARMOR_C  "Chest armor"
-#define ACCESSORY_SLOT_ARMOR_A  "Arm armor"
-#define ACCESSORY_SLOT_ARMOR_L  "Leg armor"
-#define ACCESSORY_SLOT_ARMOR_S  "Armor storage"
-#define ACCESSORY_SLOT_ARMOR_M  "Misc armor"
-#define ACCESSORY_SLOT_HELM_C	"Helmet cover"
+#define ACCESSORY_SLOT_UTILITY	0x1
+#define ACCESSORY_SLOT_WEAPON	0x2
+#define ACCESSORY_SLOT_ARMBAND  0x4
+#define ACCESSORY_SLOT_DECOR    0x8
+#define ACCESSORY_SLOT_MEDAL    0x20
+#define ACCESSORY_SLOT_TIE		0x40
+#define ACCESSORY_SLOT_INSIGNIA 0x80
+#define ACCESSORY_SLOT_OVER		0x100
+//Should these really be 'accessory' accessories
+#define ACCESSORY_SLOT_ARMOR_C  0x200
+#define ACCESSORY_SLOT_ARMOR_A  0x400
+#define ACCESSORY_SLOT_ARMOR_L  0x800
+#define ACCESSORY_SLOT_ARMOR_S  0x1000
+#define ACCESSORY_SLOT_ARMOR_M  0x2000
+#define ACCESSORY_SLOT_HELM_C	0x4000
+
+#define ACCESSORY_SLOT_TORSO 	(ACCESSORY_SLOT_UTILITY|ACCESSORY_SLOT_WEAPON)
 
 // Flags bitmasks. - Used in /atom/var/flags
 #define NOBLUDGEON         0x1    // When an item has this it produces no "X has been hit by Y with Z" message with the default handler.

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -6,7 +6,7 @@ GLOBAL_LIST_BOILERPLATE(all_clothing, /obj/item/clothing)
 	var/list/species_restricted = null //Only these species can wear this kit.
 	var/gunshot_residue //Used by forensics.
 
-	var/list/accessories = list()
+	var/list/accessories
 	var/list/valid_accessory_slots
 	var/list/restricted_accessory_slots
 	var/list/starting_accessories
@@ -584,8 +584,8 @@ GLOBAL_LIST_BOILERPLATE(all_clothing, /obj/item/clothing)
 		SPECIES_VOX = 'icons/mob/species/vox/suit.dmi'
 		)
 
-	valid_accessory_slots = list("over", "armband")
-	restricted_accessory_slots = list("armband")
+	valid_accessory_slots = (ACCESSORY_SLOT_OVER | ACCESSORY_SLOT_ARMBAND)
+	restricted_accessory_slots = (ACCESSORY_SLOT_ARMBAND)
 
 /obj/item/clothing/suit/update_clothing_icon()
 	if (ismob(src.loc))
@@ -627,15 +627,26 @@ GLOBAL_LIST_BOILERPLATE(all_clothing, /obj/item/clothing)
 	//convenience var for defining the icon state for the overlay used when the clothing is worn.
 	//Also used by rolling/unrolling.
 	var/worn_state = null
-	valid_accessory_slots = list("utility","armband","decor","over")
-	restricted_accessory_slots = list("utility", "armband")
+	valid_accessory_slots = (\
+		ACCESSORY_SLOT_UTILITY\
+		|ACCESSORY_SLOT_WEAPON\
+		|ACCESSORY_SLOT_ARMBAND\
+		|ACCESSORY_SLOT_DECOR\
+		|ACCESSORY_SLOT_MEDAL\
+		|ACCESSORY_SLOT_TIE\
+		|ACCESSORY_SLOT_OVER)
+	restricted_accessory_slots = (\
+		ACCESSORY_SLOT_UTILITY\
+		|ACCESSORY_SLOT_WEAPON\
+		|ACCESSORY_SLOT_ARMBAND\
+		|ACCESSORY_SLOT_TIE\
+		|ACCESSORY_SLOT_OVER)
 
 	var/icon/rolled_down_icon = 'icons/mob/uniform_rolled_down.dmi'
 	var/icon/rolled_down_sleeves_icon = 'icons/mob/uniform_sleeves_rolled.dmi'
 
-
 /obj/item/clothing/under/attack_hand(var/mob/user)
-	if(accessories && accessories.len)
+	if(LAZYLEN(accessories))
 		..()
 	if ((ishuman(usr) || issmall(usr)) && src.loc == user)
 		return

--- a/code/modules/clothing/clothing_accessories.dm
+++ b/code/modules/clothing/clothing_accessories.dm
@@ -1,12 +1,26 @@
 /obj/item/clothing/proc/can_attach_accessory(obj/item/clothing/accessory/A)
-	if(src.valid_accessory_slots && (A.slot in src.valid_accessory_slots))
-		if(accessories.len && restricted_accessory_slots && (A.slot in restricted_accessory_slots))
-			for(var/obj/item/clothing/accessory/AC in accessories)
-				if (AC.slot == A.slot)
-					return FALSE
-		return TRUE
-	else
+	//Just no, okay
+	if(!A.slot)
 		return FALSE
+
+	//Not valid at all, not in the valid list period.
+	if((valid_accessory_slots & A.slot) != A.slot)
+		return FALSE
+
+	//Find all consumed slots
+	var/consumed_slots = 0
+	for(var/thing in accessories)
+		var/obj/item/clothing/accessory/AC = thing
+		consumed_slots |= AC.slot
+
+	//Mask to just consumed restricted
+	var/consumed_restricted = restricted_accessory_slots & consumed_slots
+	
+	//They share at least one bit with the restricted slots
+	if(consumed_restricted & A.slot)
+		return FALSE
+
+	return TRUE
 
 /obj/item/clothing/attackby(var/obj/item/I, var/mob/user)
 	if(istype(I, /obj/item/clothing/accessory))
@@ -14,7 +28,7 @@
 		if(attempt_attach_accessory(A, user))
 			return
 
-	if(accessories.len)
+	if(LAZYLEN(accessories))
 		for(var/obj/item/clothing/accessory/A in accessories)
 			A.attackby(I, user)
 		return
@@ -23,7 +37,7 @@
 
 /obj/item/clothing/attack_hand(var/mob/user)
 	//only forward to the attached accessory if the clothing is equipped (not in a storage)
-	if(accessories.len && src.loc == user)
+	if(LAZYLEN(accessories) && src.loc == user)
 		for(var/obj/item/clothing/accessory/A in accessories)
 			A.attack_hand(user)
 		return
@@ -54,7 +68,7 @@
 
 /obj/item/clothing/examine(var/mob/user)
 	..(user)
-	if(accessories.len)
+	if(LAZYLEN(accessories))
 		for(var/obj/item/clothing/accessory/A in accessories)
 			user << "\A [A] is attached to it."
 
@@ -65,7 +79,7 @@
  *  items on spawn
  */
 /obj/item/clothing/proc/attempt_attach_accessory(obj/item/clothing/accessory/A, mob/user)
-	if(!valid_accessory_slots || !valid_accessory_slots.len)
+	if(!valid_accessory_slots)
 		if(user)
 			to_chat(user, "<span class='warning'>You cannot attach accessories of any kind to \the [src].</span>")
 		return FALSE
@@ -83,14 +97,14 @@
 
 
 /obj/item/clothing/proc/attach_accessory(mob/user, obj/item/clothing/accessory/A)
-	accessories += A
+	LAZYADD(accessories,A)
 	A.on_attached(src, user)
 	src.verbs |= /obj/item/clothing/proc/removetie_verb
 	update_accessory_slowdown()
 	update_clothing_icon()
 
 /obj/item/clothing/proc/remove_accessory(mob/user, obj/item/clothing/accessory/A)
-	if(!(A in accessories))
+	if(!LAZYLEN(accessories) || !(A in accessories))
 		return
 
 	A.on_removed(user)
@@ -111,13 +125,13 @@
 	if(usr.stat) return
 	if(!accessories.len) return
 	var/obj/item/clothing/accessory/A
-	if(accessories.len > 1)
+	if(LAZYLEN(accessories))
 		A = input("Select an accessory to remove from [src]") as null|anything in accessories
-	else
-		A = accessories[1]
-	src.remove_accessory(usr,A)
-	if(!accessories.len)
+	if(A)
+		remove_accessory(usr,A)
+	if(!LAZYLEN(accessories))
 		src.verbs -= /obj/item/clothing/proc/removetie_verb
+		accessories = null
 
 /obj/item/clothing/emp_act(severity)
 	if(accessories.len)

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -2,8 +2,8 @@
 	name = "helmet"
 	desc = "Standard Security gear. Protects the head from impacts."
 	icon_state = "helmet"
-	valid_accessory_slots = list(ACCESSORY_SLOT_HELM_C)
-	restricted_accessory_slots = list(ACCESSORY_SLOT_HELM_C)
+	valid_accessory_slots = (ACCESSORY_SLOT_HELM_C)
+	restricted_accessory_slots = (ACCESSORY_SLOT_HELM_C)
 	flags = THICKMATERIAL
 	armor = list(melee = 40, bullet = 30, laser = 30, energy = 10, bomb = 10, bio = 0, rad = 0)
 	flags_inv = HIDEEARS|HIDEEYES

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -492,8 +492,20 @@
 	icon = 'icons/obj/clothing/modular_armor.dmi'
 	item_icons = list(slot_wear_suit_str = 'icons/mob/modular_armor.dmi')
 	icon_state = "pcarrier"
-	valid_accessory_slots = list(ACCESSORY_SLOT_INSIGNIA, ACCESSORY_SLOT_ARMOR_C, ACCESSORY_SLOT_ARMOR_A, ACCESSORY_SLOT_ARMOR_L, ACCESSORY_SLOT_ARMOR_S, ACCESSORY_SLOT_ARMOR_M)
-	restricted_accessory_slots = list(ACCESSORY_SLOT_INSIGNIA, ACCESSORY_SLOT_ARMOR_C, ACCESSORY_SLOT_ARMOR_A, ACCESSORY_SLOT_ARMOR_L, ACCESSORY_SLOT_ARMOR_S)
+	valid_accessory_slots = (\
+		ACCESSORY_SLOT_INSIGNIA\
+		|ACCESSORY_SLOT_ARMOR_C\
+		|ACCESSORY_SLOT_ARMOR_A\
+		|ACCESSORY_SLOT_ARMOR_L\
+		|ACCESSORY_SLOT_ARMOR_S\
+		|ACCESSORY_SLOT_ARMOR_M)
+	restricted_accessory_slots = (\
+		ACCESSORY_SLOT_INSIGNIA\
+		|ACCESSORY_SLOT_ARMOR_C\
+		|ACCESSORY_SLOT_ARMOR_A\
+		|ACCESSORY_SLOT_ARMOR_L\
+		|ACCESSORY_SLOT_ARMOR_S\
+		|ACCESSORY_SLOT_ARMOR_M)
 	blood_overlay_type = "armor"
 
 /obj/item/clothing/suit/armor/pcarrier/light

--- a/code/modules/clothing/under/accessories/accessory.dm
+++ b/code/modules/clothing/under/accessories/accessory.dm
@@ -6,7 +6,7 @@
 	item_state_slots = list(slot_r_hand_str = "", slot_l_hand_str = "")
 	slot_flags = SLOT_TIE
 	w_class = ITEMSIZE_SMALL
-	var/slot = "decor"
+	var/slot = ACCESSORY_SLOT_DECOR
 	var/obj/item/clothing/has_suit = null		//the suit the tie may be attached to
 	var/image/inv_overlay = null	//overlay used when attached to clothing.
 	var/image/mob_overlay = null
@@ -95,6 +95,7 @@
 /obj/item/clothing/accessory/tie
 	name = "blue tie"
 	icon_state = "bluetie"
+	slot = ACCESSORY_SLOT_TIE
 
 /obj/item/clothing/accessory/tie/red
 	name = "red tie"
@@ -145,6 +146,7 @@
 	name = "stethoscope"
 	desc = "An outdated medical apparatus for listening to the sounds of the human body. It also makes you look like you know what you're doing."
 	icon_state = "stethoscope"
+	slot = ACCESSORY_SLOT_TIE
 
 /obj/item/clothing/accessory/stethoscope/do_surgery(mob/living/carbon/human/M, mob/living/user)
 	if(user.a_intent != I_HELP) //in case it is ever used as a surgery tool
@@ -206,6 +208,7 @@
 	name = "bronze medal"
 	desc = "A bronze medal."
 	icon_state = "bronze"
+	slot = ACCESSORY_SLOT_MEDAL
 
 /obj/item/clothing/accessory/medal/conduct
 	name = "distinguished conduct medal"
@@ -260,6 +263,7 @@
 	name = "green scarf"
 	desc = "A stylish scarf. The perfect winter accessory for those with a keen fashion sense, and those who just can't handle a cold breeze on their necks."
 	icon_state = "greenscarf"
+	slot = ACCESSORY_SLOT_DECOR
 
 /obj/item/clothing/accessory/scarf/red
 	name = "red scarf"
@@ -322,6 +326,7 @@
 	icon_state = "bracelet"
 	w_class = ITEMSIZE_TINY
 	slot_flags = SLOT_TIE
+	slot = ACCESSORY_SLOT_DECOR
 
 /obj/item/clothing/accessory/bracelet/friendship
 	name = "friendship bracelet"

--- a/code/modules/clothing/under/accessories/armband.dm
+++ b/code/modules/clothing/under/accessories/armband.dm
@@ -2,7 +2,7 @@
 	name = "red armband"
 	desc = "A fancy red armband!"
 	icon_state = "red"
-	slot = "armband"
+	slot = ACCESSORY_SLOT_ARMBAND
 
 /obj/item/clothing/accessory/armband/cargo
 	name = "cargo armband"

--- a/code/modules/clothing/under/accessories/badges.dm
+++ b/code/modules/clothing/under/accessories/badges.dm
@@ -9,6 +9,7 @@
 	desc = "Security Department detective's badge, made from gold."
 	icon_state = "badge"
 	slot_flags = SLOT_BELT | SLOT_TIE
+	slot = ACCESSORY_SLOT_MEDAL
 
 	var/stored_name
 	var/badge_string = "Corporate Security"

--- a/code/modules/clothing/under/accessories/clothing.dm
+++ b/code/modules/clothing/under/accessories/clothing.dm
@@ -2,11 +2,13 @@
 	name = "black vest"
 	desc = "Slick black suit vest."
 	icon_state = "det_vest"
+	slot = ACCESSORY_SLOT_OVER
 
-/obj/item/clothing/accessory/jacket/
+/obj/item/clothing/accessory/jacket
 	name = "tan suit jacket"
 	desc = "Cozy suit jacket."
 	icon_state = "tan_jacket"
+	slot = ACCESSORY_SLOT_OVER
 
 /obj/item/clothing/accessory/jacket/charcoal
 	name = "charcoal suit jacket"
@@ -55,7 +57,7 @@
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|ARMS|LEGS
 	siemens_coefficient = 0.9
 	w_class = ITEMSIZE_NORMAL
-	slot = "over"
+	slot = ACCESSORY_SLOT_OVER
 
 	sprite_sheets = list(
 		"Teshari" = 'icons/mob/species/seromi/suit.dmi'
@@ -176,6 +178,7 @@
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO
 	siemens_coefficient = 0.9
 	w_class = ITEMSIZE_NORMAL
+	slot = ACCESSORY_SLOT_OVER
 
 /obj/item/clothing/accessory/hawaii/red
 	icon_state = "hawaii2"
@@ -201,6 +204,7 @@
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO
 	siemens_coefficient = 0.9
 	w_class = ITEMSIZE_NORMAL
+	slot = ACCESSORY_SLOT_OVER
 
 /obj/item/clothing/accessory/wcoat/red
 	name = "red waistcoat"
@@ -242,6 +246,7 @@
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|ARMS
 	siemens_coefficient = 0.9
 	w_class = ITEMSIZE_NORMAL
+	slot = ACCESSORY_SLOT_OVER
 
 /obj/item/clothing/accessory/sweater/pink
 	name = "pink sweater"

--- a/code/modules/clothing/under/accessories/holster.dm
+++ b/code/modules/clothing/under/accessories/holster.dm
@@ -2,7 +2,7 @@
 	name = "shoulder holster"
 	desc = "A handgun holster."
 	icon_state = "holster"
-	slot = "utility"
+	slot = ACCESSORY_SLOT_TORSO //Legacy/balance purposes
 	concealed_holster = 1
 	var/obj/item/holstered = null
 

--- a/code/modules/clothing/under/accessories/lockets.dm
+++ b/code/modules/clothing/under/accessories/lockets.dm
@@ -2,9 +2,9 @@
 	name = "silver locket"
 	desc = "A small locket of high-quality metal."
 	icon_state = "locket"
-	slot_flags = 0
 	w_class = ITEMSIZE_SMALL
 	slot_flags = SLOT_MASK | SLOT_TIE
+	slot = ACCESSORY_SLOT_DECOR
 	var/base_icon
 	var/open
 	var/obj/item/held //Item inside locket.

--- a/code/modules/clothing/under/accessories/permits.dm
+++ b/code/modules/clothing/under/accessories/permits.dm
@@ -6,6 +6,7 @@
 	icon = 'icons/obj/card.dmi'
 	icon_state = "permit"
 	w_class = ITEMSIZE_TINY
+	slot = ACCESSORY_SLOT_MEDAL
 	var/owner = 0	//To prevent people from just renaming the thing if they steal it
 
 /obj/item/clothing/accessory/permit/attack_self(mob/user as mob)

--- a/code/modules/clothing/under/accessories/storage.dm
+++ b/code/modules/clothing/under/accessories/storage.dm
@@ -2,10 +2,10 @@
 	name = "load bearing equipment"
 	desc = "Used to hold things when you don't have enough hands."
 	icon_state = "webbing"
-	slot = "utility"
+	slot = ACCESSORY_SLOT_UTILITY
 	show_messages = 1
 
-	var/slots = 3
+	var/slots = 5
 	var/obj/item/weapon/storage/internal/hold
 	w_class = ITEMSIZE_NORMAL
 
@@ -49,45 +49,40 @@
 	name = "webbing"
 	desc = "Sturdy mess of synthcotton belts and buckles, ready to share your burden."
 	icon_state = "webbing"
+	slots = 3
 
 /obj/item/clothing/accessory/storage/black_vest
 	name = "black webbing vest"
 	desc = "Robust black synthcotton vest with lots of pockets to hold whatever you need, but cannot hold in hands."
 	icon_state = "vest_black"
-	slots = 5
 
 /obj/item/clothing/accessory/storage/brown_vest
 	name = "brown webbing vest"
 	desc = "Worn brownish synthcotton vest with lots of pockets to unload your hands."
 	icon_state = "vest_brown"
-	slots = 5
 
 /obj/item/clothing/accessory/storage/white_vest
 	name = "white webbing vest"
 	desc = "Durable white synthcotton vest with lots of pockets to carry essentials."
 	icon_state = "vest_white"
-	slots = 5
 
 /obj/item/clothing/accessory/storage/black_drop_pouches
 	name = "black drop pouches"
 	gender = PLURAL
 	desc = "Robust black synthcotton bags to hold whatever you need, but cannot hold in hands."
 	icon_state = "thigh_black"
-	slots = 5
 
 /obj/item/clothing/accessory/storage/brown_drop_pouches
 	name = "brown drop pouches"
 	gender = PLURAL
 	desc = "Worn brownish synthcotton bags to hold whatever you need, but cannot hold in hands."
 	icon_state = "thigh_brown"
-	slots = 5
 
 /obj/item/clothing/accessory/storage/white_drop_pouches
 	name = "white drop pouches"
 	gender = PLURAL
 	desc = "Durable white synthcotton bags to hold whatever you need, but cannot hold in hands."
 	icon_state = "thigh_white"
-	slots = 5
 
 /obj/item/clothing/accessory/storage/knifeharness
 	name = "decorated harness"

--- a/code/modules/clothing/under/xenos/vox.dm
+++ b/code/modules/clothing/under/xenos/vox.dm
@@ -1,8 +1,8 @@
 /obj/item/clothing/under/vox
 	has_sensor = 0
 	species_restricted = list(SPECIES_VOX)
-	valid_accessory_slots = list("vox")
-	restricted_accessory_slots = list("vox")
+	valid_accessory_slots = "vox"
+	restricted_accessory_slots = "vox"
 	phoronproof = 1
 
 /obj/item/clothing/under/vox/vox_casual

--- a/maps/southern_cross/items/clothing/sc_suit.dm
+++ b/maps/southern_cross/items/clothing/sc_suit.dm
@@ -21,4 +21,4 @@
 	item_icons = list(slot_wear_suit_str = 'maps/southern_cross/icons/mob/sc_suit.dmi')
 	icon = 'maps/southern_cross/icons/obj/sc_suit.dmi'
 	armor = list(melee = 15, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 50, rad = 5)
-	valid_accessory_slots = list(ACCESSORY_SLOT_INSIGNIA)
+	valid_accessory_slots = (ACCESSORY_SLOT_INSIGNIA)


### PR DESCRIPTION
Allows accessories to 'block' multiple slots. An example of why this is useful:

(Example given in current system)
A uniform contains "utility" as a valid accessory slot, and "utility" is also 'restricted' on the uniform (which means that only 1 can be installed at a time). Webbing and Holster cannot be used together, they are both slot "utility". Webbing and holster are both limited to 1 each per uniform.

I want to add an item (particularly a machette sheath) that can be used with webbing, but not with holsters. This is impossible given the above system. If I make the machette "utility", it cannot be used with webbing. If I make a new slot type "weapon" and put holster in it along with machette, then holsters can now be used with webbing, an unintended change.

So, changing them to bitfields allows them to essentially occupy more than one slot. Holsters now occupy 'utility' and 'weapon' which has the same effect as before. Basically this PR does nothing that anyone will notice, but makes it so you can make accessories exclude each other better.