### PR TITLE
Paranoid logging and byond account age

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -97,6 +97,7 @@ var/list/gamemode_cache = list()
 	var/guests_allowed = 1
 	var/debugparanoid = 0
 	var/panic_bunker = 0
+	var/paranoia_logging = 0
 
 	var/serverurl
 	var/server
@@ -736,6 +737,12 @@ var/list/gamemode_cache = list()
 
 				if("radiation_lower_limit")
 					radiation_lower_limit = text2num(value)
+
+				if ("panic_bunker")
+					config.panic_bunker = 1
+
+				if ("paranoia_logging")
+					config.paranoia_logging = 1
 
 				else
 					log_misc("Unknown setting in configuration: '[name]'")

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -52,6 +52,11 @@ proc/admin_notice(var/message, var/rights)
 	else
 		body += " \[<A href='?src=\ref[src];revive=\ref[M]'>Heal</A>\] "
 
+	if(M.client)
+		body += "<br><b>First connection:</b> [M.client.player_age] days ago"
+		body += "<br><b>BYOND account created:</b> [M.client.account_join_date]"
+		body += "<br><b>BYOND account age (days):</b> [M.client.account_age]"
+
 	body += {"
 		<br><br>\[
 		<a href='?_src_=vars;Vars=\ref[M]'>VV</a> -

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -174,7 +174,8 @@ var/list/admin_verbs_server = list(
 	/client/proc/nanomapgen_DumpImage,
 	/client/proc/modify_server_news,
 	/client/proc/recipe_dump,
-	/client/proc/panicbunker
+	/client/proc/panicbunker,
+	/client/proc/paranoia_logging
 	)
 
 var/list/admin_verbs_debug = list(

--- a/code/modules/admin/verbs/panicbunker.dm
+++ b/code/modules/admin/verbs/panicbunker.dm
@@ -1,15 +1,31 @@
 /client/proc/panicbunker()
 	set category = "Server"
 	set name = "Toggle Panic Bunker"
+	
+	if(!check_rights(R_ADMIN))
+		return
+
 	if (!config.sql_enabled)
 		to_chat(usr, "<span class='adminnotice'>The Database is not enabled!</span>")
 		return
 
 	config.panic_bunker = (!config.panic_bunker)
 
-	log_admin("[key_name(usr)] has toggled the Panic Bunker, it is now [(config.panic_bunker?"on":"off")]")
-	message_admins("[key_name_admin(usr)] has toggled the Panic Bunker, it is now [(config.panic_bunker?"enabled":"disabled")].")
+	log_and_message_admins("[key_name(usr)] has toggled the Panic Bunker, it is now [(config.panic_bunker?"on":"off")]")
 	if (config.panic_bunker && (!dbcon || !dbcon.IsConnected()))
 		message_admins("The Database is not connected! Panic bunker will not work until the connection is reestablished.")
 	feedback_add_details("admin_verb","PANIC") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
+/client/proc/paranoia_logging()
+	set category = "Server"
+	set name = "New Player Warnings"
+
+	if(!check_rights(R_ADMIN))
+		return
+
+	config.paranoia_logging = (!config.paranoia_logging)
+
+	log_and_message_admins("[key_name(usr)] has toggled Paranoia Logging, it is now [(config.paranoia_logging?"on":"off")]")
+	if (config.paranoia_logging && (!dbcon || !dbcon.IsConnected()))
+		message_admins("The Database is not connected! Paranoia logging will not be able to give 'player age' (time since first connection) warnings, only Byond account warnings.")
+	feedback_add_details("admin_verb","PARLOG") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!

--- a/code/modules/client/client defines.dm
+++ b/code/modules/client/client defines.dm
@@ -46,9 +46,11 @@
 		////////////////////////////////////
 		//things that require the database//
 		////////////////////////////////////
-	var/player_age = "Requires database"	//So admins know why it isn't working - Used to determine how old the account is - in days.
-	var/related_accounts_ip = "Requires database"	//So admins know why it isn't working - Used to determine what other accounts previously logged in from this ip
-	var/related_accounts_cid = "Requires database"	//So admins know why it isn't working - Used to determine what other accounts previously logged in from this computer id
+	var/player_age = "(Requires database)"	//So admins know why it isn't working - Used to determine how old the account is - in days.
+	var/related_accounts_ip = "(Requires database)"	//So admins know why it isn't working - Used to determine what other accounts previously logged in from this ip
+	var/related_accounts_cid = "(Requires database)"	//So admins know why it isn't working - Used to determine what other accounts previously logged in from this computer id
+	var/account_join_date = "(Requires database)"
+	var/account_age = "(Requires database)"
 
 	preload_rsc = PRELOAD_RSC
 

--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -162,8 +162,12 @@
 		winset(src, "rpane.changelog", "background-color=#eaeaea;font-style=bold")
 		if(config.aggressive_changelog)
 			src.changes()
-
-
+	
+	if(config.paranoia_logging)
+		if(isnum(player_age) && player_age == 0)
+			log_and_message_admins("PARANOIA: [key_name(src)] has connected here for the first time.")
+		if(isnum(account_age) && account_age <= 2)
+			log_and_message_admins("PARANOIA: [key_name(src)] has a very new BYOND account ([account_age] days).")
 
 	//////////////
 	//DISCONNECT//
@@ -219,6 +223,12 @@
 		sql_id = query.item[1]
 		player_age = text2num(query.item[2])
 		break
+
+	account_join_date = sanitizeSQL(findJoinDate())
+	if(account_join_date && dbcon.IsConnected())
+		var/DBQuery/query_datediff = dbcon.NewQuery("SELECT DATEDIFF(Now(),'[account_join_date]')")
+		if(query_datediff.Execute() && query_datediff.NextRow())
+			account_age = text2num(query_datediff.item[1])
 
 	var/DBQuery/query_ip = dbcon.NewQuery("SELECT ckey FROM erro_player WHERE ip = '[address]'")
 	query_ip.Execute()
@@ -363,3 +373,16 @@ client/verb/character_setup()
 	set category = "Preferences"
 	if(prefs)
 		prefs.ShowChoices(usr)
+
+/client/proc/findJoinDate()
+	var/list/http = world.Export("http://byond.com/members/[ckey]?format=text")
+	if(!http)
+		log_world("Failed to connect to byond age check for [ckey]")
+		return
+	var/F = file2text(http["CONTENT"])
+	if(F)
+		var/regex/R = regex("joined = \"(\\d{4}-\\d{2}-\\d{2})\"")
+		if(R.Find(F))
+			. = R.group[1]
+		else
+			CRASH("Age check regex failed for [src.ckey]")

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -243,8 +243,8 @@ GUEST_BAN
 
 ## Remove the # to allow special 'Easter-egg' events on special holidays such as seasonal holidays and stuff like 'Talk Like a Pirate Day' :3 YAARRR
 ALLOW_HOLIDAYS
-##Defines the ticklag for the world.  0.9 is the normal one, 0.5 is smoother.
-TICKLAG 0.9
+##Defines the ticklag for the world.  0.6 is the normal one, 0.5 is smoother
+TICKLAG 0.6
 
 ## Defines if Tick Compensation is used.  It results in a minor slowdown of movement of all mobs, but attempts to result in a level movement speed across all ticks.  Recommended if tickrate is lowered.
 TICKCOMP 0
@@ -402,3 +402,9 @@ STARLIGHT 0
 
 ## Default language prefix keys, separated with spaces. Only single character keys are supported. If unset, defaults to , # and - 
 # DEFAULT_LANGUAGE_PREFIXES , # -
+
+## Uncomment to enable the Panic Bunker by default. This will prevent all unseen-before players from connecting. Requires SQL.
+# PANIC_BUNKER
+
+## Uncomment to enable Paranoia Logging. This will notify admins and write to a file any time a new player (byond or your server) connects.
+# PARANOIA_LOGGING


### PR DESCRIPTION
Adds the PARANOIA_LOGGING setting to config.txt (and PANIC_BUNKER which was missing for some reason) and updates example.

PARANOIA_LOGGING (also available as a verb for admins in Server) begins notifying admins of any 0day byond accounts, or users who have never joined before. For when you don't quite want to panic bunker.

Also makes this information available in player panel. Requires SQL connection.

![image](https://user-images.githubusercontent.com/15028025/40401462-7e244926-5e14-11e8-932e-b74f51130019.png)
