### PR TITLE
Fix Engi Material Synths

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_modules/station.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules/station.dm
@@ -433,6 +433,8 @@ var/global/list/robot_modules = list(
 	synths += metal
 	synths += glass
 	synths += plasteel
+	synths += wood
+	synths += plastic
 	synths += wire
 
 	var/obj/item/weapon/matter_decompiler/MD = new /obj/item/weapon/matter_decompiler(src)


### PR DESCRIPTION
Engineering borgs' wood and plastic synthesizers now replenish as they should.