### PR TITLE
Adds armor to certain mobs, mercs have knives

### DIFF
--- a/code/modules/mob/living/simple_animal/aliens/drone.dm
+++ b/code/modules/mob/living/simple_animal/aliens/drone.dm
@@ -27,6 +27,7 @@
 	destroy_surroundings = 0
 	hovering = TRUE
 
+	armor = list(melee = 25, bullet = 25, laser = 25, energy = 10, bomb = 25, bio = 100, rad = 100)	// Some level of armor plating makes sense
 	//Drones aren't affected by atmos.
 	min_oxy = 0
 	max_oxy = 0

--- a/code/modules/mob/living/simple_animal/humanoids/mechamobs.dm
+++ b/code/modules/mob/living/simple_animal/humanoids/mechamobs.dm
@@ -31,6 +31,8 @@
 	attacktext = list("slashed")
 	attack_sound = 'sound/weapons/bladeslice.ogg'
 
+	armor = list(melee = 40, bullet = 40, laser = 50, energy = 45, bomb = 20, bio = 100, rad = 100)	// As close to the actual Dark Gygax as possible
+
 	min_oxy = 0
 	max_oxy = 0
 	min_tox = 0
@@ -43,7 +45,7 @@
 
 	ranged = 1
 	rapid = 1
-	projectiletype = /obj/item/projectile/beam
+	projectiletype = /obj/item/projectile/beam/midlaser
 	projectilesound = 'sound/weapons/laser.ogg'
 
 	speak_chance = 1

--- a/code/modules/mob/living/simple_animal/humanoids/syndicate.dm
+++ b/code/modules/mob/living/simple_animal/humanoids/syndicate.dm
@@ -29,10 +29,14 @@
 	response_harm = "hits"
 
 	harm_intent_damage = 5
-	melee_damage_lower = 10
+	melee_damage_lower = 15		//Tac Knife damage
 	melee_damage_upper = 15
 	environment_smash = 1
-	attacktext = list("punched")
+	attack_sharp = 1
+	attack_edge = 1
+	attacktext = list("slashed", "stabbed")
+
+	armor = list(melee = 40, bullet = 30, laser = 30, energy = 10, bomb = 10, bio = 100, rad = 100)	// Same armor values as the vest they drop, plus simple mob immunities
 
 	min_oxy = 5
 	max_oxy = 0
@@ -118,6 +122,8 @@
 	icon_living = "syndicatemeleespace"
 
 	speed = 0
+
+	armor = list(melee = 60, bullet = 50, laser = 30, energy = 15, bomb = 35, bio = 100, rad = 100)	// Same armor as their voidsuit
 
 	min_oxy = 0
 	max_oxy = 0

--- a/html/changelogs/Anewbe - More Merc PoIs.yml
+++ b/html/changelogs/Anewbe - More Merc PoIs.yml
@@ -1,0 +1,37 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Anewbe
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Certain mobs, namely robots and mercs, now have some amount of armor."
+  - rscadd: "Ranged mercs will now knife people when cornered, rather than punch them really hard."


### PR DESCRIPTION
Thought of this early this morning, would have folded it into the last PR but that'd be bloat.

What this does is add armor values to merc mobs and drones, and bit of extra oomph to ranged mercs and the gygax mob. None of those mobs are really supposed to be faced while unprepared, and this reinforces that idea. Further mob changes are incoming, and these numbers will likely be tweaked soon anyway.
- Mercs have armor equal to the armor they wear, as decided through their corpse spawners. It's roughly equal to a security vest. The space variant (that isn't used anywhere) has merc space armor values, so if you see it, use AP.
- Ranged mercs now use a "tac knife", meaning they do a stable amount of damage that is sharp and edged.
- Drones have a fairly small amount of armor, because they're literally designed for combat, but they shouldn't be unkillable. AP is still your friend, as always.
- The Dark Gygax mob mob has armor roughly equal to the actual Dark Gygax mech. The systems don't translate perfectly, but mech code is old.
- The Dark Gygax mob uses the midlaser projectile. Damage is the same, but it has 10 armor pen.