### PR TITLE
Reverse use of global lists where they hurt performance.

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -1,5 +1,3 @@
-GLOBAL_LIST_BOILERPLATE(all_atoms, /atom) // Use with care, its likely barely better than using world.
-
 /atom
 	layer = TURF_LAYER //This was here when I got here. Why though?
 	var/level = 2

--- a/code/game/machinery/computer3/computers/crew.dm
+++ b/code/game/machinery/computer3/computers/crew.dm
@@ -56,7 +56,7 @@
 
 
 /datum/file/program/crew/proc/scan()
-	for(var/obj/item/clothing/under/C in all_clothing)
+	for(var/obj/item/clothing/under/C in world)
 		if((C.has_sensor) && (istype(C.loc, /mob/living/carbon/human)))
 			tracked |= C
 	return 1

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -1,5 +1,3 @@
-GLOBAL_LIST_BOILERPLATE(all_items, /obj/item)
-
 /obj/item
 	name = "item"
 	icon = 'icons/obj/items.dmi'
@@ -588,7 +586,7 @@ var/list/global/slot_flags_enumeration = list(
 	I.Blend(new /icon('icons/effects/blood.dmi', "itemblood"),ICON_MULTIPLY) //adds blood and the remaining white areas become transparant
 
 	//not sure if this is worth it. It attaches the blood_overlay to every item of the same type if they don't have one already made.
-	for(var/obj/item/A in all_items)
+	for(var/obj/item/A in world)
 		if(A.type == type && !A.blood_overlay)
 			A.blood_overlay = image(I)
 

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -1,5 +1,3 @@
-GLOBAL_LIST_BOILERPLATE(all_objs, /obj)
-
 /obj
 	layer = OBJ_LAYER
 	plane = OBJ_PLANE

--- a/code/modules/admin/secrets/fun_secrets/remove_all_clothing.dm
+++ b/code/modules/admin/secrets/fun_secrets/remove_all_clothing.dm
@@ -6,5 +6,5 @@
 	if(!.)
 		return
 
-	for(var/obj/item/clothing/O in all_clothing)
+	for(var/obj/item/clothing/O in world)
 		qdel(O)

--- a/code/modules/admin/secrets/fun_secrets/remove_internal_clothing.dm
+++ b/code/modules/admin/secrets/fun_secrets/remove_internal_clothing.dm
@@ -6,5 +6,5 @@
 	if(!.)
 		return
 
-	for(var/obj/item/clothing/under/O in all_clothing)
+	for(var/obj/item/clothing/under/O in world)
 		qdel(O)

--- a/code/modules/admin/verbs/SDQL.dm
+++ b/code/modules/admin/verbs/SDQL.dm
@@ -115,7 +115,7 @@
 							from_objs += m
 
 				else if(text_starts_with(f, "/obj/item"))
-					for(var/obj/item/m in all_items)
+					for(var/obj/item/m in world)
 						if(istype(m, f2))
 							from_objs += m
 
@@ -125,12 +125,12 @@
 							from_objs += m
 
 				else if(text_starts_with(f, "/obj"))
-					for(var/obj/m in all_objs)
+					for(var/obj/m in world)
 						if(istype(m, f2))
 							from_objs += m
 
 				else if(text_starts_with(f, "/atom"))
-					for(var/atom/m in all_atoms)
+					for(var/atom/m in world)
 						if(istype(m, f2))
 							from_objs += m
 /*

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -183,7 +183,7 @@
 	var/blocked = list(/obj, /mob, /mob/living, /mob/living/carbon, /mob/living/carbon/human, /mob/observer/dead, /mob/living/silicon, /mob/living/silicon/robot, /mob/living/silicon/ai)
 	var/hsbitem = input(usr, "Choose an object to delete.", "Delete:") as null|anything in typesof(/obj) + typesof(/mob) - blocked
 	if(hsbitem)
-		for(var/atom/O in all_atoms)
+		for(var/atom/O in world)
 			if(istype(O, hsbitem))
 				qdel(O)
 		log_admin("[key_name(src)] has deleted all instances of [hsbitem].")

--- a/code/modules/admin/verbs/mapping.dm
+++ b/code/modules/admin/verbs/mapping.dm
@@ -296,7 +296,7 @@ var/list/debug_verbs = list (
 
 	var/list/atom/atom_list = list()
 
-	for(var/atom/A in all_atoms)
+	for(var/atom/A in world)
 		if(istype(A,type_path))
 			var/atom/B = A
 			while(!(isturf(B.loc)))
@@ -332,7 +332,7 @@ var/list/debug_verbs = list (
 
 	var/count = 0
 
-	for(var/atom/A in all_atoms)
+	for(var/atom/A in world)
 		if(istype(A,type_path))
 			count++
 	/*

--- a/code/modules/admin/verbs/massmodvar.dm
+++ b/code/modules/admin/verbs/massmodvar.dm
@@ -139,7 +139,7 @@
 							M.vars[variable] = O.vars[variable]
 
 				else if(istype(O, /obj))
-					for(var/obj/A in all_objs)
+					for(var/obj/A in world)
 						if ( istype(A , O.type) )
 							A.vars[variable] = O.vars[variable]
 
@@ -155,7 +155,7 @@
 							M.vars[variable] = O.vars[variable]
 
 				else if(istype(O, /obj))
-					for(var/obj/A in all_objs)
+					for(var/obj/A in world)
 						if (A.type == O.type)
 							A.vars[variable] = O.vars[variable]
 
@@ -179,7 +179,7 @@
 							M.vars[variable] = O.vars[variable]
 
 				else if(istype(O, /obj))
-					for(var/obj/A in all_objs)
+					for(var/obj/A in world)
 						if ( istype(A , O.type) )
 							A.vars[variable] = O.vars[variable]
 
@@ -194,7 +194,7 @@
 							M.vars[variable] = O.vars[variable]
 
 				else if(istype(O, /obj))
-					for(var/obj/A in all_objs)
+					for(var/obj/A in world)
 						if (A.type == O.type)
 							A.vars[variable] = O.vars[variable]
 
@@ -223,7 +223,7 @@
 								M.vars[variable] = O.vars[variable]
 
 				else if(istype(O, /obj))
-					for(var/obj/A in all_objs)
+					for(var/obj/A in world)
 						if ( istype(A , O.type) )
 							if(variable=="light_range")
 								A.set_light(new_value)
@@ -248,7 +248,7 @@
 								M.vars[variable] = O.vars[variable]
 
 				else if(istype(O, /obj))
-					for(var/obj/A in all_objs)
+					for(var/obj/A in world)
 						if (A.type == O.type)
 							if(variable=="light_range")
 								A.set_light(new_value)
@@ -275,7 +275,7 @@
 							M.vars[variable] = O.vars[variable]
 
 				else if(istype(O, /obj))
-					for(var/obj/A in all_objs)
+					for(var/obj/A in world)
 						if ( istype(A , O.type) )
 							A.vars[variable] = O.vars[variable]
 
@@ -290,7 +290,7 @@
 							M.vars[variable] = O.vars[variable]
 
 				else if(istype(O, /obj))
-					for(var/obj/A in all_objs)
+					for(var/obj/A in world)
 						if (A.type == O.type)
 							A.vars[variable] = O.vars[variable]
 
@@ -311,7 +311,7 @@
 							M.vars[variable] = O.vars[variable]
 
 				else if(istype(O.type, /obj))
-					for(var/obj/A in all_objs)
+					for(var/obj/A in world)
 						if ( istype(A , O.type) )
 							A.vars[variable] = O.vars[variable]
 
@@ -326,7 +326,7 @@
 							M.vars[variable] = O.vars[variable]
 
 				else if(istype(O.type, /obj))
-					for(var/obj/A in all_objs)
+					for(var/obj/A in world)
 						if (A.type == O.type)
 							A.vars[variable] = O.vars[variable]
 
@@ -346,7 +346,7 @@
 							M.vars[variable] = O.vars[variable]
 
 				else if(istype(O, /obj))
-					for(var/obj/A in all_objs)
+					for(var/obj/A in world)
 						if ( istype(A , O.type) )
 							A.vars[variable] = O.vars[variable]
 
@@ -362,7 +362,7 @@
 							M.vars[variable] = O.vars[variable]
 
 				else if(istype(O, /obj))
-					for(var/obj/A in all_objs)
+					for(var/obj/A in world)
 						if (A.type == O.type)
 							A.vars[variable] = O.vars[variable]
 

--- a/code/modules/admin/view_variables/topic.dm
+++ b/code/modules/admin/view_variables/topic.dm
@@ -184,7 +184,7 @@
 		switch(action_type)
 			if("Strict type")
 				var/i = 0
-				for(var/obj/Obj in all_objs)
+				for(var/obj/Obj in world)
 					if(Obj.type == O_type)
 						i++
 						qdel(Obj)
@@ -195,7 +195,7 @@
 				message_admins("<span class='notice'>[key_name(usr)] deleted all objects of type [O_type] ([i] objects deleted)</span>")
 			if("Type and subtypes")
 				var/i = 0
-				for(var/obj/Obj in all_objs)
+				for(var/obj/Obj in world)
 					if(istype(Obj,O_type))
 						i++
 						qdel(Obj)

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -1,5 +1,3 @@
-GLOBAL_LIST_BOILERPLATE(all_clothing, /obj/item/clothing)
-
 /obj/item/clothing
 	name = "clothing"
 	siemens_coefficient = 0.9

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -967,7 +967,7 @@
 
 // *** TEST verb
 //client/verb/dispstop()
-//	for(var/obj/structure/disposalholder/H in all_objs)
+//	for(var/obj/structure/disposalholder/H in world)
 //		H.active = 0
 
 // a straight or bent segment


### PR DESCRIPTION
Removes the use of `GLOBAL_LIST_BOILERPLATE` for: `all_clothing`, `all_items`, `all_objs`, and `all_atoms` setting them back to use `for(X in world)` to speed up performance.

GLOBAL_LIST_BOILERPLATE is not free, it adds overhead to both creation and destruction of every instance of the tracked type and subtypes.   Its only worth it if the benefit of having the list outweighs this overhead.

- `all_atoms` and `all_obj`- These were referenced **only** in debugging verbs.  These are almost never called but atoms are created/destroyed millions of times per round.
- `all_items` - Aside from debugger code, this used by only one proc (which could use some optimization)
- `all_clothing`  - Aside from debugger code, this is used only in on place (computer3 version of crew monitor), which is obsolete code, proper fix is update that proc to use the same logic as the other crew monitor computers.
