### PR TITLE
Fixes #5083

### DIFF
--- a/code/modules/assembly/proximity.dm
+++ b/code/modules/assembly/proximity.dm
@@ -39,7 +39,7 @@
 		log_debug("DEBUG: HasProximity called with [AM] on [src] ([usr]).")
 		return
 	if (istype(AM, /obj/effect/beam))	return
-	if (AM.move_speed < 12)	sense()
+	if (!isobserver(AM) && AM.move_speed < 12)	sense()
 	return
 
 


### PR DESCRIPTION
This whole HasProximity() thing should be redone at some point. We discovered earlier that every atom moving into every turf notifies every atom/movable in the surrounding 8 turfs that it's now moved into the turf. Which is silly. There's like 4 things that use the system, including prox sensors.