### PR TITLE
Fix surgery breaking bones when performed correctly

### DIFF
--- a/code/modules/surgery/encased.dm
+++ b/code/modules/surgery/encased.dm
@@ -103,10 +103,6 @@
 
 	affected.open = 3
 
-	// Whoops!
-	if(prob(10))
-		affected.fracture()
-
 /datum/surgery_step/open_encased/retract/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	if (!hasorgans(target))
 		return


### PR DESCRIPTION
I have to believe this is somehow misplaced. "Whoops!"

Breaking bones when performing a surgery correctly even with the best tools in the best environment makes for bad gameplay. The failure step fractures the bones already. Why does the SUCCESS step sometimes also fracture the bones too?