### PR TITLE
Deconstructing a Technomancer Core now does Bad Things

### DIFF
--- a/code/game/gamemodes/technomancer/core_obj.dm
+++ b/code/game/gamemodes/technomancer/core_obj.dm
@@ -134,6 +134,23 @@
 		wards_in_use -= ward
 		qdel(ward)
 
+// This makes a variety of bad things happen if someone decons the core.
+/obj/item/weapon/technomancer_core/decon_act(var/mob/M)
+	var/turf/T = get_turf(src)	// This should only be used for the coordinates, below. Everything else should use get_turf(src) to stop research borgs from fleeing their own deconstructors
+	log_admin("[key_name(M)] deconstructed a Technomancer Core at [T.x],[T.y],[T.z].", 1)	// Tell the admins who done it
+	var/badtimes = rand(1,2)	// What sort of bad time do we get?
+	switch(badtimes)
+		if(1)
+			loc.visible_message("\The [loc.name] starts to rattle and spark!")
+			spawn(5 SECONDS)
+				new /obj/singularity/energy_ball(get_turf(src), 25)	// Drops a big dumb tesla ball
+				..()
+		if(2)
+			loc.visible_message("\The [loc.name] starts to rumble!")
+			spawn(5 SECONDS)
+				explosion(T, 8, 16, 24)	//And this one's a supermatter
+				..()
+
 // This is what is clicked on to place a spell in the user's hands.
 /obj/spellbutton
 	name = "generic spellbutton"
@@ -165,6 +182,7 @@
 	if(. && istype(back,/obj/item/weapon/technomancer_core))
 		var/obj/item/weapon/technomancer_core/core = back
 		setup_technomancer_stat(core)
+
 
 /mob/living/carbon/human/proc/setup_technomancer_stat(var/obj/item/weapon/technomancer_core/core)
 	if(core && statpanel("Spell Core"))

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -163,3 +163,6 @@
 
 /obj/proc/show_message(msg, type, alt, alt_type)//Message, type of message (1 or 2), alternative message, alt message type (1 or 2)
 	return
+
+/obj/proc/decon_act(mob/M as mob) //Called when an item is deconstructed
+	qdel_null(src)

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -255,11 +255,11 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 									S.use(1)
 									linked_destroy.loaded_item = S
 								else
-									qdel(S)
+									qdel(I)
 									linked_destroy.icon_state = "d_analyzer"
 							else
 								if(I != linked_destroy.circuit && !(I in linked_destroy.component_parts))
-									qdel(I)
+									I.decon_act(usr)
 									linked_destroy.icon_state = "d_analyzer"
 
 						use_power(linked_destroy.active_power_usage)

--- a/html/changelogs/Anewbe - Core Deconstruct.yml
+++ b/html/changelogs/Anewbe - Core Deconstruct.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Anewbe
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Deconstructing a Technomancer Core now does Bad Things."


### PR DESCRIPTION
Currently either makes a Supermatter explosion or a smallish Tesla ball, directly on the deconstructor after a five second delay. I couldn't think of anything else suitable to have happen, so until then it's a two item switch. Sorry 'bout that.