### PR TITLE
prevent slimes from spawning on top of people

### DIFF
--- a/code/_helpers/events.dm
+++ b/code/_helpers/events.dm
@@ -13,3 +13,15 @@
 				if(istype(A) && A.z in using_map.player_levels)
 					grand_list_of_areas += A
 	return grand_list_of_areas
+
+/** Checks if any living humans are in a given area! */
+/proc/is_area_occupied(var/area/myarea)
+	// Testing suggests looping over human_mob_list is quicker than looping over area contents
+	for(var/mob/living/carbon/human/H in human_mob_list)
+		if(H.stat >= DEAD) //Conditions for exclusion here, like if disconnected people start blocking it.
+			continue
+		var/area/A = get_area(H)
+		if(A == myarea) //The loc of a turf is the area it is in.
+			return 1
+	return 0
+	

--- a/code/modules/events/atmos_leak.dm
+++ b/code/modules/events/atmos_leak.dm
@@ -51,17 +51,6 @@
 		kill()
 		return
 
-/** Checks if any living humans are in a given area! */
-/datum/event/atmos_leak/proc/is_area_occupied(var/area/myarea)
-	// Testing suggests looping over human_mob_list is quicker than looping over area contents
-	for(var/mob/living/carbon/human/H in human_mob_list)
-		if(H.stat >= DEAD) //Conditions for exclusion here, like if disconnected people start blocking it.
-			continue
-		var/area/A = get_area(H)
-		if(A == myarea) //The loc of a turf is the area it is in.
-			return 1
-	return 0
-
 /datum/event/atmos_leak/announce()
 	command_announcement.Announce("Warning, hazardous [gas_data.name[gas_type]] gas leak detected in \the [target_area], evacuate the area and contain the damage!", "Hazard Alert")
 

--- a/code/modules/events/escaped_slimes.dm
+++ b/code/modules/events/escaped_slimes.dm
@@ -33,7 +33,7 @@
 /datum/event/escaped_slimes/start()
 	var/list/vents = list()
 	for(var/obj/machinery/atmospherics/unary/vent_pump/temp_vent in machines)
-		if(temp_vent.network && temp_vent.loc.z in using_map.station_levels) //borrowed from spiders event, but it works. Distribute the slimes only in rooms with vents
+		if(temp_vent.network && temp_vent.loc.z in using_map.station_levels && !is_area_occupied(temp_vent.loc.loc)) //borrowed from spiders event, but it works. Distribute the slimes only in rooms with vents
 			vents += temp_vent
 
 	while((spawncount > 0) && vents.len)


### PR DESCRIPTION
Minor tweak to the escaped slimes event (which you don't have enabled, if I remember) to prevent slimes from spawning on top of people. Also refactors the relevant function into code/_helpers/events.dm so it can be re-used for events added in the future.