### PR TITLE
Weather is shorter, hail is less deadly.

### DIFF
--- a/code/modules/planet/sif.dm
+++ b/code/modules/planet/sif.dm
@@ -184,6 +184,7 @@ datum/weather/sif
 		)
 
 /datum/weather/sif/snow/process_effects()
+	..()
 	for(var/turf/simulated/floor/outdoors/snow/S in SSplanets.new_outdoor_turfs) //This didn't make any sense before SSplanets, either
 		if(S.z in holder.our_planet.expected_z_levels)
 			for(var/dir_checked in cardinal)
@@ -207,6 +208,7 @@ datum/weather/sif
 		)
 
 /datum/weather/sif/blizzard/process_effects()
+	..()
 	for(var/turf/simulated/floor/outdoors/snow/S in SSplanets.new_outdoor_turfs) //This didn't make any sense before SSplanets, either
 		if(S.z in holder.our_planet.expected_z_levels)
 			for(var/dir_checked in cardinal)
@@ -219,6 +221,8 @@ datum/weather/sif
 	name = "rain"
 	icon_state = "rain"
 	light_modifier = 0.5
+	effect_message = "<span class='warning'>Rain falls on you.</span>"
+
 	transition_chances = list(
 		WEATHER_OVERCAST = 25,
 		WEATHER_LIGHT_SNOW = 10,
@@ -228,6 +232,7 @@ datum/weather/sif
 		)
 
 /datum/weather/sif/rain/process_effects()
+	..()
 	for(var/mob/living/L in living_mob_list)
 		if(L.z in holder.our_planet.expected_z_levels)
 			var/turf/T = get_turf(L)
@@ -238,16 +243,19 @@ datum/weather/sif
 			if(istype(L.get_active_hand(), /obj/item/weapon/melee/umbrella))
 				var/obj/item/weapon/melee/umbrella/U = L.get_active_hand()
 				if(U.open)
-					to_chat(L, "<span class='notice'>Rain patters softly onto your umbrella</span>")
+					if(show_message)
+						to_chat(L, "<span class='notice'>Rain patters softly onto your umbrella</span>")
 					continue
 			else if(istype(L.get_inactive_hand(), /obj/item/weapon/melee/umbrella))
 				var/obj/item/weapon/melee/umbrella/U = L.get_inactive_hand()
 				if(U.open)
-					to_chat(L, "<span class='notice'>Rain patters softly onto your umbrella</span>")
+					if(show_message)
+						to_chat(L, "<span class='notice'>Rain patters softly onto your umbrella</span>")
 					continue
 
 			L.water_act(1)
-			to_chat(L, "<span class='warning'>Rain falls on you.</span>")
+			if(show_message)
+				to_chat(L, effect_message)
 
 /datum/weather/sif/storm
 	name = "storm"
@@ -256,6 +264,8 @@ datum/weather/sif
 	temp_low = 233.15  // -40c
 	light_modifier = 0.3
 	flight_failure_modifier = 10
+
+
 	transition_chances = list(
 		WEATHER_RAIN = 45,
 		WEATHER_STORM = 40,
@@ -264,6 +274,7 @@ datum/weather/sif
 		)
 
 /datum/weather/sif/storm/process_effects()
+	..()
 	for(var/mob/living/L in living_mob_list)
 		if(L.z in holder.our_planet.expected_z_levels)
 			var/turf/T = get_turf(L)
@@ -294,6 +305,10 @@ datum/weather/sif
 	temp_low = 243.15	// -30c
 	light_modifier = 0.3
 	flight_failure_modifier = 15
+	timer_low_bound = 2
+	timer_high_bound = 5
+	effect_message = "<span class='warning'>The hail smacks into you!</span>"
+
 	transition_chances = list(
 		WEATHER_RAIN = 45,
 		WEATHER_STORM = 40,
@@ -302,6 +317,7 @@ datum/weather/sif
 		)
 
 /datum/weather/sif/hail/process_effects()
+	..()
 	for(var/mob/living/carbon/human/H in living_mob_list)
 		if(H.z in holder.our_planet.expected_z_levels)
 			var/turf/T = get_turf(H)
@@ -309,15 +325,18 @@ datum/weather/sif
 				continue // They're indoors, so no need to pelt them with ice.
 
 			// If they have an open umbrella, it'll guard from rain
+			// Message plays every time the umbrella gets stolen, just so they're especially aware of what's happening
 			if(istype(H.get_active_hand(), /obj/item/weapon/melee/umbrella))
 				var/obj/item/weapon/melee/umbrella/U = H.get_active_hand()
 				if(U.open)
-					to_chat(H, "<span class='notice'>Hail patters gently onto your umbrella.</span>")
+					if(show_message)
+						to_chat(H, "<span class='notice'>Hail patters gently onto your umbrella.</span>")
 					continue
 			else if(istype(H.get_inactive_hand(), /obj/item/weapon/melee/umbrella))
 				var/obj/item/weapon/melee/umbrella/U = H.get_inactive_hand()
 				if(U.open)
-					to_chat(H, "<span class='notice'>Hail patters gently onto your umbrella.</span>")
+					if(show_message)
+						to_chat(H, "<span class='notice'>Hail patters gently onto your umbrella.</span>")
 					continue
 
 			var/target_zone = pick(BP_ALL)
@@ -330,8 +349,9 @@ datum/weather/sif
 			if(amount_soaked >= 10)
 				continue // No need to apply damage.
 
-			H.apply_damage(rand(5, 10), BRUTE, target_zone, amount_blocked, amount_soaked, used_weapon = "hail")
-			to_chat(H, "<span class='warning'>The hail smacks into you!</span>")
+			H.apply_damage(rand(1, 3), BRUTE, target_zone, amount_blocked, amount_soaked, used_weapon = "hail")
+			if(show_message)
+				to_chat(H, effect_message)
 
 /datum/weather/sif/blood_moon
 	name = "blood moon"

--- a/code/modules/planet/weather.dm
+++ b/code/modules/planet/weather.dm
@@ -25,7 +25,7 @@
 	if(current_weather)
 		old_light_modifier = current_weather.light_modifier // We store the old one, so we can determine if recalculating the sun is needed.
 	current_weather = allowed_weather_types[new_weather]
-	next_weather_shift = world.time + rand(20, 30) MINUTES
+	next_weather_shift = world.time + rand(current_weather.timer_low_bound, current_weather.timer_high_bound) MINUTES
 
 	update_icon_effects()
 	update_temperature()
@@ -66,8 +66,20 @@
 	var/flight_failure_modifier = 0 // Some types of weather make flying harder, and therefore make crashes more likely.
 	var/transition_chances = list() // Assoc list
 	var/datum/weather_holder/holder = null
+	var/timer_low_bound = 5			// How long this weather must run before it tries to change, in minutes
+	var/timer_high_bound = 10		// How long this weather can run before it tries to change, in minutes
+
+	var/effect_message = null		// Should be a string, this is what is shown to a mob caught in the weather
+	var/last_message = 0			// Keeps track of when the weather last tells EVERY player it's hitting them
+	var/message_delay = 10 SECONDS	// Delay in between weather hit messages
+	var/show_message = FALSE		// Is set to TRUE and plays the messsage every [message_delay]
 
 /datum/weather/proc/process_effects()
+	show_message = FALSE	// Need to reset the show_message var, just in case
+	if(effect_message)	// Only bother with the code below if we actually need to display something
+		if(world.time >= last_message + message_delay)
+			last_message = world.time	// Reset the timer
+			show_message = TRUE			// Tell the rest of the process that we need to make a message
 	return
 
 // All this does is hold the weather icon.


### PR DESCRIPTION
Weather now has a pair of variables attached to it that tell it how long to run before it tries to make a change, rather than having a hardcoded timer on all weather. Weather timers have been dropped from 20-30 minutes down to 5-10. Variety is the spice of life, after all.

Hail has also been tweaked, in anticipation of #5322, which will make it tick far more often, turning a relatively minor annoyance into a deadly storm.
- Hail checks for new weather every 2-5 minutes, so people won't be trapped in shelter waiting for it to change.
- Hail's damage has been dropped from 5-10, down to 1-3. That _should_ give people time to get to cover, but if not, other systems can be implemented later.