### PR TITLE
Alien Cable Coil Fix

### DIFF
--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -940,3 +940,22 @@ obj/structure/cable/proc/cableColor(var/colorC)
 		msg += " It doesn't seem to have a beginning, or an end."
 
 	to_chat(user, msg)
+
+/obj/item/stack/cable_coil/alien/attack_hand(mob/user as mob)
+	if (user.get_inactive_hand() == src)
+		var/N = input("How many units of wire do you want to take from [src]?  You can only take up to [amount] at a time.", "Split stacks", 1) as num|null
+		if(N)
+			var/obj/item/stack/cable_coil/CC = new/obj/item/stack/cable_coil(user.loc)
+			CC.amount = N
+			CC.update_icon()
+			user << "<font color='blue'>You take [N] units of wire from the [src].</font>"
+			if (CC)
+				user.put_in_hands(CC)
+				src.add_fingerprint(user)
+				CC.add_fingerprint(user)
+				spawn(0)
+					if (src && usr.machine==src)
+						src.interact(usr)
+	else
+		..()
+	return

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -944,7 +944,7 @@ obj/structure/cable/proc/cableColor(var/colorC)
 /obj/item/stack/cable_coil/alien/attack_hand(mob/user as mob)
 	if (user.get_inactive_hand() == src)
 		var/N = input("How many units of wire do you want to take from [src]?  You can only take up to [amount] at a time.", "Split stacks", 1) as num|null
-		if(N)
+		if(N && N <= amount)
 			var/obj/item/stack/cable_coil/CC = new/obj/item/stack/cable_coil(user.loc)
 			CC.amount = N
 			CC.update_icon()
@@ -956,6 +956,8 @@ obj/structure/cable/proc/cableColor(var/colorC)
 				spawn(0)
 					if (src && usr.machine==src)
 						src.interact(usr)
+		else
+			return
 	else
 		..()
 	return


### PR DESCRIPTION
- Prevents you from duplicating the alien cable coil tool to make more infinite alien cable coil tools

- Allows you to take up to 30 wire off of it at a time. Makes it so you don't have to place it down, & snip the wire to get it in usable stacks.