### PR TITLE
Fix invalid logic in clonepod beaker function

### DIFF
--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -244,20 +244,14 @@
 			locked = 0
 			to_chat(user, "System unlocked.")
 	else if(istype(W,/obj/item/weapon/reagent_containers/glass))
-		var/obj/item/weapon/reagent_containers/glass/G = W
-		if(LAZYLEN(containers))
-			if(containers.len >= container_limit)
-				to_chat(user, "<span class='warning'>\The [src] has too many containers loaded!</span>")
-				return
-			else if(do_after(user, 1 SECOND))
-				user.visible_message("[user] has loaded \the [G] into \the [src].", "You load \the [G] into \the [src].")
-				containers += G
-				user.drop_item()
-				G.forceMove(src)
-				return
-		else
-			to_chat(user, "<span class='warning'>\The [src] doesn't have room for \the [G.name].</span>")
-			return
+		if(LAZYLEN(containers) >= container_limit)
+			to_chat(user, "<span class='warning'>\The [src] has too many containers loaded!</span>")
+		else if(do_after(user, 1 SECOND))
+			user.visible_message("[user] has loaded \the [W] into \the [src].", "You load \the [W] into \the [src].")
+			containers += W
+			user.drop_item()
+			W.forceMove(src)
+		return
 	else if(istype(W, /obj/item/weapon/wrench))
 		if(locked && (anchored || occupant))
 			to_chat(user, "<span class='warning'>Can not do that while [src] is in use.</span>")


### PR DESCRIPTION
Reported in: https://github.com/VOREStation/VOREStation/issues/3926

This logic doesn't do what you think it does, perhaps. If you have 0 beakers in the clonepod, then you will never be able to add another beaker. The flow will go thus:
![sourcetree_2018-06-24_15-12-22](https://user-images.githubusercontent.com/15028025/41822696-ccaeaea8-77c1-11e8-9c46-479b41997ca4.png)

Lazylen will be 'false' because it will be 0, and therefore you will be told you can't put any beakers in. If you have any beakers in, you can add more, but if you remove all of them or ever reach 0 beakers, you cannot insert any more.