### PR TITLE
Renames Taj Sign Language

### DIFF
--- a/code/__defines/species_languages.dm
+++ b/code/__defines/species_languages.dm
@@ -50,7 +50,7 @@
 #define LANGUAGE_MINBUS "Minbus"
 #define LANGUAGE_EVENT1 "Occursus"
 #define LANGUAGE_AKHANI "Akhani"
-#define LANGUAGE_SIIK_TAJR "Siik'Tajr"
+#define LANGUAGE_SIIK_ALAI "Siik'alai"
 
 // Language flags.
 #define WHITELISTED  1   // Language is available if the speaker is whitelisted.

--- a/code/modules/mob/language/station.dm
+++ b/code/modules/mob/language/station.dm
@@ -78,9 +78,10 @@
 	"nai","ou","kah","oa","ama","uuk","bel","chi","ayt","kay","kas","akor","tam","yir","enai")
 
 /datum/language/tajsign
-	name = LANGUAGE_SIIK_TAJR
-	desc = "A type of sign language mostly based on tail movements that was used during the Tajaran rebellion."
-	signlang_verb = list("uses their tail to convey", "gestures with their tail", "gestures with their tail elaborately")
+	name = LANGUAGE_SIIK_ALAI
+	desc = "A standardized Tajaran sign language that was developed in Zarraya and gradually adopted by other nations, incorporating \
+			hand gestures and movements of the ears and tail."
+	signlang_verb = list("gestures with their hands", "gestures with their ears and tail", "gestures with their ears, tail and hands")
 	colour = "tajaran"
 	key = "l"
 	flags = WHITELISTED | SIGNLANG | NO_STUTTER | NONVERBAL

--- a/code/modules/mob/living/carbon/human/species/station/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station.dm
@@ -157,7 +157,7 @@
 	metabolic_rate = 1.1
 	gluttonous = 1
 	num_alternate_languages = 3
-	secondary_langs = list(LANGUAGE_SIIK, LANGUAGE_AKHANI, LANGUAGE_SIIK_TAJR)
+	secondary_langs = list(LANGUAGE_SIIK, LANGUAGE_AKHANI, LANGUAGE_SIIK_ALAI)
 	name_language = LANGUAGE_SIIK
 	species_language = LANGUAGE_SIIK
 	health_hud_intensity = 2.5


### PR DESCRIPTION
As requested by the Taj LoreMaster, refluffs the new Taj sign language.

Marked as high priority because I'd rather not have people, or save files, confused about where their shiny new catspeak went.