### PR TITLE
Add a procedure for repairing limbs via surgery.

### DIFF
--- a/code/game/objects/items/weapons/autopsy.dm
+++ b/code/game/objects/items/weapons/autopsy.dm
@@ -167,21 +167,24 @@
 	if(!istype(M))
 		return 0
 
+	if (user.a_intent == I_HELP)
+		return ..()
+
 	if(target_name != M.name)
 		target_name = M.name
 		src.wdata = list()
 		src.chemtraces = list()
 		src.timeofdeath = null
-		user << "<span class='notice'>A new patient has been registered. Purging data for previous patient.</span>"
+		to_chat(user, "<span class='notice'>A new patient has been registered. Purging data for previous patient.</span>")
 
 	src.timeofdeath = M.timeofdeath
 
 	var/obj/item/organ/external/S = M.get_organ(user.zone_sel.selecting)
 	if(!S)
-		usr << "<span class='warning'>You can't scan this body part.</span>"
+		to_chat(user, "<span class='warning'>You can't scan this body part.</span>")
 		return
 	if(!S.open)
-		usr << "<span class='warning'>You have to cut [S] open first!</span>"
+		to_chat(user, "<span class='warning'>You have to cut [S] open first!</span>")
 		return
 	M.visible_message("<span class='notice'>\The [user] scans the wounds on [M]'s [S.name] with [src]</span>")
 

--- a/code/game/objects/items/weapons/policetape.dm
+++ b/code/game/objects/items/weapons/policetape.dm
@@ -4,6 +4,9 @@
 	icon = 'icons/policetape.dmi'
 	icon_state = "tape"
 	w_class = ITEMSIZE_SMALL
+
+	toolspeed = 3 //You can use it in surgery. It's stupid, but you can.
+
 	var/turf/start
 	var/turf/end
 	var/tape_type = /obj/item/tape

--- a/code/game/objects/items/weapons/tape.dm
+++ b/code/game/objects/items/weapons/tape.dm
@@ -5,8 +5,12 @@
 	icon_state = "taperoll"
 	w_class = ITEMSIZE_TINY
 
+	toolspeed = 2 //It is now used in surgery as a not awful, but probably dangerous option, due to speed.
+
 /obj/item/weapon/tape_roll/attack(var/mob/living/carbon/human/H, var/mob/user)
 	if(istype(H))
+		if(user.a_intent == I_HELP)
+			return
 		var/can_place = 0
 		if(istype(user, /mob/living/silicon/robot))
 			can_place = 1

--- a/code/modules/mob/living/silicon/robot/robot_modules/station.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules/station.dm
@@ -213,6 +213,7 @@ var/global/list/robot_modules = list(
 	..()
 	src.modules += new /obj/item/device/healthanalyzer(src)
 	src.modules += new /obj/item/weapon/reagent_containers/borghypo/surgeon(src)
+	src.modules += new /obj/item/weapon/autopsy_scanner(src)
 	src.modules += new /obj/item/weapon/surgical/scalpel/cyborg(src)
 	src.modules += new /obj/item/weapon/surgical/hemostat/cyborg(src)
 	src.modules += new /obj/item/weapon/surgical/retractor/cyborg(src)

--- a/code/modules/mob/living/silicon/robot/robot_modules/syndicate.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules/syndicate.dm
@@ -148,6 +148,7 @@
 	src.modules += new /obj/item/weapon/reagent_containers/borghypo/merc(src)
 
 	// Surgery things.
+	src.modules += new /obj/item/weapon/autopsy_scanner(src)
 	src.modules += new /obj/item/weapon/surgical/scalpel/cyborg(src)
 	src.modules += new /obj/item/weapon/surgical/hemostat/cyborg(src)
 	src.modules += new /obj/item/weapon/surgical/retractor/cyborg(src)

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -72,6 +72,8 @@
 	var/open = 0
 	var/stage = 0
 	var/cavity = 0
+	var/burn_stage = 0		//Surgical repair stage for burn.
+	var/brute_stage = 0		//Surgical repair stage for brute.
 
 	// HUD element variable, see organ_icon.dm get_damage_hud_image()
 	var/image/hud_damage_image

--- a/code/modules/surgery/external_repair.dm
+++ b/code/modules/surgery/external_repair.dm
@@ -1,0 +1,215 @@
+//Procedures in this file: Organic limb repair
+//////////////////////////////////////////////////////////////////
+//						LIMB REPAIR SURGERY						//
+//////////////////////////////////////////////////////////////////
+/datum/surgery_step/repairflesh/
+	priority = 1
+	can_infect = 1
+	blood_level = 1
+	req_open = 1
+
+/datum/surgery_step/repairflesh/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+	if (target.stat == DEAD) // Sorry defibs, your subjects need to have pumping fluids for these to work.
+		return 0
+	if (isslime(target))
+		return 0
+	if (target_zone == O_EYES || target_zone == O_MOUTH)
+		return 0
+	if (!hasorgans(target))
+		return 0
+	var/obj/item/organ/external/affected = target.get_organ(target_zone)
+	if (affected == null)
+		return 0
+	if (affected.is_stump())
+		return 0
+	if (affected.robotic >= ORGAN_ROBOT)
+		return 0
+	return 1
+
+
+//////////////////////////////////////////////////////////////////
+//						SCAN STEP								//
+//////////////////////////////////////////////////////////////////
+
+/datum/surgery_step/repairflesh/scan_injury
+	allowed_tools = list(
+	/obj/item/weapon/autopsy_scanner = 100,
+	/obj/item/device/healthanalyzer = 80,
+	/obj/item/device/analyzer = 10
+	)
+
+	priority = 2
+
+	can_infect = 0 //The only exception here. Sweeping a scanner probably won't transfer many germs.
+
+	min_duration = 20
+	max_duration = 40
+
+/datum/surgery_step/repairflesh/scan_injury/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+	if(..())
+		var/obj/item/organ/external/affected = target.get_organ(target_zone)
+		if(affected.burn_stage || affected.brute_stage)
+			return 0
+		return 1
+	return 0
+
+/datum/surgery_step/repairflesh/scan_injury/begin_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+	var/obj/item/organ/external/affected = target.get_organ(target_zone)
+	user.visible_message("<span class='notice'>[user] begins scanning [target]'s [affected] with \the [tool].</span>", \
+	"<span class='notice'>You begin scanning [target]'s [affected] with \the [tool].</span>")
+	..()
+
+/datum/surgery_step/repairflesh/scan_injury/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+	var/obj/item/organ/external/affected = target.get_organ(target_zone)
+	user.visible_message("<span class='notice'>[user] finishes scanning [target]'s [affected].</span>", \
+	"<span class='notice'>You finish scanning [target]'s [affected].</span>")
+	if(affected.brute_dam)
+		to_chat(user, "<span class='notice'>The muscle in [target]'s [affected] is notably bruised.</span>")
+		if(affected.status & ORGAN_BROKEN)
+			to_chat(user, "<span class='warning'>\The [target]'s [affected] is broken!</span>")
+		affected.brute_stage = max(1, affected.brute_stage)
+	if(affected.burn_dam)
+		to_chat(user, "<span class='notice'>\The muscle in [target]'s [affected] is notably charred.</span>")
+		affected.burn_stage = max(1, affected.burn_stage)
+
+/datum/surgery_step/repairflesh/scan_injury/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+	var/obj/item/organ/external/affected = target.get_organ(target_zone)
+	user.visible_message("<span class='warning'>[user]'s hand slips, dropping \the [tool] onto [target]'s [affected]!</span>" , \
+	"<span class='warning'>Your hand slips, dropping \the [tool] onto [target]'s [affected]!</span>" )
+	affected.createwound(BRUISE, 10)
+
+//////////////////////////////////////////////////////////////////
+//						BURN STEP								//
+//////////////////////////////////////////////////////////////////
+
+/datum/surgery_step/repairflesh/repair_burns
+	allowed_tools = list(
+	/obj/item/stack/medical/advanced/ointment = 100,
+	/obj/item/weapon/surgical/FixOVein = 100,
+	/obj/item/weapon/surgical/hemostat = 60,
+	/obj/item/stack/medical/ointment = 50,
+	/obj/item/weapon/tape_roll = 30,
+	/obj/item/taperoll = 10
+	)
+
+	priority = 3
+
+	min_duration = 90
+	max_duration = 120
+
+/datum/surgery_step/repairflesh/repair_burns/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+	if(..())
+		var/obj/item/organ/external/affected = target.get_organ(target_zone)
+		if(affected.burn_stage < 1 || !(affected.burn_dam))
+			return 0
+		if(affected.burn_dam < affected.brute_dam)
+			return 0
+		return 1
+	return 0
+
+/datum/surgery_step/repairflesh/repair_burns/begin_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+	var/obj/item/organ/external/affected = target.get_organ(target_zone)
+	if(istype(tool, /obj/item/weapon/tape_roll) || istype(tool, /obj/item/taperoll))
+		user.visible_message("<span class='warning'>[user] begins taping up [target]'s [affected] with \the [tool].</span>", \
+	"<span class='notice'>You begin taping up [target]'s [affected] with \the [tool].</span>")
+		affected.jostle_bone(10)
+	else if(istype(tool, /obj/item/weapon/surgical/hemostat) || istype(tool, /obj/item/weapon/surgical/FixOVein))
+		user.visible_message("<span class='notice'>[user] begins mending the charred blood vessels in [target]'s [affected] with \the [tool].</span>", \
+	"<span class='notice'>You begin mending the charred blood vessels in [target]'s [affected] with \the [tool].</span>")
+	else
+		user.visible_message("<span class='notice'>[user] begins coating the charred tissue in [target]'s [affected] with \the [tool].</span>", \
+	"<span class='notice'>You begin coating the charred tissue in [target]'s [affected] with \the [tool].</span>")
+	..()
+
+/datum/surgery_step/repairflesh/repair_burns/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+	var/obj/item/organ/external/affected = target.get_organ(target_zone)
+	if(istype(tool, /obj/item/weapon/tape_roll) || istype(tool, /obj/item/taperoll))
+		user.visible_message("<span class='notice'>[user] finishes taping up [target]'s [affected] with \the [tool].</span>", \
+	"<span class='notice'>You finish taping up [target]'s [affected] with \the [tool].</span>")
+		affected.createwound(BRUISE, 10)
+	affected.heal_damage(0, 25, 0, 0)
+	if(!(affected.burn_dam))
+		affected.burn_stage = 0
+	if(istype(tool, /obj/item/stack))
+		var/obj/item/stack/T = tool
+		T.use(1)
+	..()
+
+/datum/surgery_step/repairflesh/repair_burns/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+	var/obj/item/organ/external/affected = target.get_organ(target_zone)
+	user.visible_message("<span class='danger'>[user]'s hand slips, tearing up [target]'s [affected] with \the [tool].</span>", \
+	"<span class='danger'>Your hand slips, tearing up [target]'s [affected] with \the [tool].</span>")
+	affected.createwound(BRUISE, 10)
+	affected.createwound(CUT, 5)
+	if(istype(tool, /obj/item/stack) && prob(30))
+		var/obj/item/stack/T = tool
+		T.use(1)
+	..()
+
+//////////////////////////////////////////////////////////////////
+//						BRUTE STEP								//
+//////////////////////////////////////////////////////////////////
+
+/datum/surgery_step/repairflesh/repair_brute
+	allowed_tools = list(
+	/obj/item/stack/medical/advanced/bruise_pack = 100,
+	/obj/item/weapon/surgical/cautery = 100,
+	/obj/item/weapon/surgical/bonesetter = 60,
+	/obj/item/stack/medical/bruise_pack = 50,
+	/obj/item/weapon/tape_roll = 40,
+	/obj/item/taperoll = 10
+	)
+
+	priority = 3
+
+	min_duration = 90
+	max_duration = 120
+
+/datum/surgery_step/repairflesh/repair_brute/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+	if(..())
+		var/obj/item/organ/external/affected = target.get_organ(target_zone)
+		if(affected.brute_stage < 1 || !(affected.brute_dam))
+			return 0
+		if(affected.brute_dam < affected.burn_dam)
+			return 0
+		return 1
+	return 0
+
+/datum/surgery_step/repairflesh/repair_brute/begin_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+	var/obj/item/organ/external/affected = target.get_organ(target_zone)
+	if(istype(tool, /obj/item/weapon/tape_roll) || istype(tool, /obj/item/taperoll))
+		user.visible_message("<span class='warning'>[user] begins taping up [target]'s [affected] with \the [tool].</span>", \
+	"<span class='notice'>You begin taping up [target]'s [affected] with \the [tool].</span>")
+		affected.jostle_bone(10)
+	else if(istype(tool, /obj/item/weapon/surgical/FixOVein) || istype(tool, /obj/item/weapon/surgical/bonesetter))
+		user.visible_message("<span class='notice'>[user] begins mending the torn tissue in [target]'s [affected] with \the [tool].</span>", \
+	"<span class='notice'>You begin mending the torn tissue in [target]'s [affected] with \the [tool].</span>")
+	else
+		user.visible_message("<span class='notice'>[user] begins coating the tissue in [target]'s [affected] with \the [tool].</span>", \
+	"<span class='notice'>You begin coating the tissue in [target]'s [affected] with \the [tool].</span>")
+	..()
+
+/datum/surgery_step/repairflesh/repair_brute/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+	var/obj/item/organ/external/affected = target.get_organ(target_zone)
+	if(istype(tool, /obj/item/weapon/tape_roll) || istype(tool, /obj/item/taperoll))
+		user.visible_message("<span class='notice'>[user] finishes taping up [target]'s [affected] with \the [tool].</span>", \
+	"<span class='notice'>You finish taping up [target]'s [affected] with \the [tool].</span>")
+		affected.createwound(BRUISE, 10)
+	affected.heal_damage(25, 0, 0, 0)
+	if(!(affected.brute_dam))
+		affected.brute_stage = 0
+	if(istype(tool, /obj/item/stack))
+		var/obj/item/stack/T = tool
+		T.use(1)
+	..()
+
+/datum/surgery_step/repairflesh/repair_brute/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+	var/obj/item/organ/external/affected = target.get_organ(target_zone)
+	user.visible_message("<span class='danger'>[user]'s hand slips, tearing up [target]'s [affected] with \the [tool].</span>", \
+	"<span class='danger'>Your hand slips, tearing up [target]'s [affected] with \the [tool].</span>")
+	affected.createwound(BRUISE, 10)
+	affected.createwound(CUT, 5)
+	if(istype(tool, /obj/item/stack) && prob(30))
+		var/obj/item/stack/T = tool
+		T.use(1)
+	..()

--- a/html/changelogs/Mechoid - Surgical.yml
+++ b/html/changelogs/Mechoid - Surgical.yml
@@ -1,0 +1,7 @@
+
+author: Mechoid
+
+delete-after: True
+
+changes: 
+  - rscadd: "Adds a new surgical procedure for fixing brute and burn on limbs."

--- a/polaris.dme
+++ b/polaris.dme
@@ -2325,6 +2325,7 @@
 #include "code\modules\surgery\_defines.dm"
 #include "code\modules\surgery\bones.dm"
 #include "code\modules\surgery\encased.dm"
+#include "code\modules\surgery\external_repair.dm"
 #include "code\modules\surgery\face.dm"
 #include "code\modules\surgery\generic.dm"
 #include "code\modules\surgery\implant.dm"


### PR DESCRIPTION
Tweaks:
- Toolspeed on tape has been adjusted for use as surgical tools. If.. you're insane. Slightly better for Brute damage.
- Autopsy scanner can now be used as a proper surgical tool.
- Surgical cyborgs and Combat Medic cyborgs now have autopsy scanners.

Features:
- Surgical repair of brute and burn on living patients.
- If you do not have access to an advanced scanner, the autopsy scanner will inform you upon completion of the step what damage types are present, and if the limb is fractured.
Steps:
Scalpel, Hemostat, Retractor [Standard Opening] - > Autopsy Scanner  - > Trauma kit or Adv Burn Kit, depending on damage type(s) present.