### PR TITLE
Tweak i_beam qdel logic

### DIFF
--- a/code/modules/assembly/infrared.dm
+++ b/code/modules/assembly/infrared.dm
@@ -250,9 +250,8 @@
 	return
 
 /obj/effect/beam/i_beam/Destroy()
+	. = ..()
 	if(master.first == src)
 		master.first = null
-	if(next)
-		qdel(next)
-		next = null
-	..()
+	if(next && !next.gc_destroyed)
+		qdel_null(next)


### PR DESCRIPTION
Seems sketchy!

Doesn't return a qdel() hint and apparently sometimes enters infinite loops, perhaps next is sometimes circular? This makes it slightly more robust, anyway.