### PR TITLE
Global list boilerplates cause the target path to actually add to the list

### DIFF
--- a/code/game/objects/effects/portals.dm
+++ b/code/game/objects/effects/portals.dm
@@ -31,6 +31,7 @@ GLOBAL_LIST_BOILERPLATE(all_portals, /obj/effect/portal)
 	return
 
 /obj/effect/portal/New()
+	..() // Necessary for the list boilerplate to work
 	spawn(300)
 		qdel(src)
 		return

--- a/code/game/objects/items/weapons/mop.dm
+++ b/code/game/objects/items/weapons/mop.dm
@@ -16,6 +16,7 @@ GLOBAL_LIST_BOILERPLATE(all_mops, /obj/item/weapon/mop)
 
 /obj/item/weapon/mop/New()
 	create_reagents(30)
+	..()
 
 /obj/item/weapon/mop/afterattack(atom/A, mob/user, proximity)
 	if(!proximity) return

--- a/code/game/objects/structures/janicart.dm
+++ b/code/game/objects/structures/janicart.dm
@@ -20,6 +20,7 @@ GLOBAL_LIST_BOILERPLATE(all_janitorial_carts, /obj/structure/janitorialcart)
 
 /obj/structure/janitorialcart/New()
 	create_reagents(300)
+	..()
 
 
 /obj/structure/janitorialcart/examine(mob/user)


### PR DESCRIPTION
Without the super, as I discovered while working on the janitorial supply locator, the objects aren't actually added when the object is `new()`'d (Or presumably removed, but I didn't see any `destroy()`s without a super)