### PR TITLE
Water tiles clear underlays in update_icon

### DIFF
--- a/code/game/turfs/simulated/water.dm
+++ b/code/game/turfs/simulated/water.dm
@@ -19,6 +19,7 @@
 	..() // To get the edges.
 	icon_state = water_state
 	var/image/floorbed_sprite = image(icon = 'icons/turf/outdoors.dmi', icon_state = under_state)
+	underlays.Cut() // To clear the old underlay, so the list doesn't expand infinitely
 	underlays.Add(floorbed_sprite)
 	update_icon_edge()
 


### PR DESCRIPTION
Previously they did not, which made changing the base sprite from a rocky seafloor to, say, sand, much more difficult, as VV cannot expand under-/over-lays and there aren't existing procs to manually clear them.