### PR TITLE
Fixes invisible toy

### DIFF
--- a/code/modules/clothing/suits/miscellaneous.dm
+++ b/code/modules/clothing/suits/miscellaneous.dm
@@ -128,6 +128,7 @@
 
 /obj/item/clothing/suit/syndicatefake
 	name = "red space suit replica"
+	icon = 'icons/obj/clothing/spacesuits.dmi'
 	icon_state = "syndicate"
 	desc = "A plastic replica of the syndicate space suit, you'll look just like a real murderous syndicate agent in this! This is a toy, it is not made for use in space!"
 	w_class = ITEMSIZE_NORMAL


### PR DESCRIPTION
The Toy Red Jumpsuit was pointing to the wrong icon sheet, giving it an invisible item sprite. Redirects it to proper one. Minor bugfix, reported two tiers downstream.