### PR TITLE
Fixes a bug with integrated circuit printers.

### DIFF
--- a/code/modules/integrated_electronics/core/printer.dm
+++ b/code/modules/integrated_electronics/core/printer.dm
@@ -162,13 +162,16 @@
 			return 1
 
 		var/cost = 1
+		
+		if(isnull(current_category))
+			current_category = recipe_list[1]
 		if(ispath(build_type, /obj/item/device/electronic_assembly))
 			var/obj/item/device/electronic_assembly/E = build_type
 			cost = round( (initial(E.max_complexity) + initial(E.max_components) ) / 4)
-		else if(ispath(build_type, /obj/item/integrated_circuit))
-			var/obj/item/integrated_circuit/IC = build_type
-			cost = initial(IC.w_class)
 		else
+			var/obj/item/I = build_type
+			cost = initial(I.w_class)
+		if(!(locate(build_type) in recipe_list[current_category])
 			return
 
 		if(metal - cost < 0)

--- a/code/modules/integrated_electronics/core/printer.dm
+++ b/code/modules/integrated_electronics/core/printer.dm
@@ -171,7 +171,7 @@
 		else
 			var/obj/item/I = build_type
 			cost = initial(I.w_class)
-		if(!(locate(build_type) in recipe_list[current_category])
+		if(!(locate(build_type) in recipe_list[current_category]))
 			return
 
 		if(metal - cost < 0)


### PR DESCRIPTION
This fixes a bug where tools, implants, and presumably (though I have yet to test it) device assemblies cannot be printed from the integrated circuit printer.
This is a much more robust solution for the print-anything bug than the previous one, as it expands the cost to the w_class of objects in it as well as lets you print anything in the current category. (This may be an issue when two people use it at once, but I mean, just learn to take turns or something.)