### PR TITLE
Adds roofing tiles

### DIFF
--- a/code/game/objects/items/stacks/tiles/tile_types.dm
+++ b/code/game/objects/items/stacks/tiles/tile_types.dm
@@ -199,3 +199,9 @@
 	throw_range = 20
 	flags = 0
 	no_variants = FALSE
+
+/obj/item/stack/tile/roofing
+	name = "roofing"
+	singular_name = "roofing"
+	desc = "A section of roofing material. You can use it to repair the ceiling, or expand it."
+	icon_state = "techtile_grid"

--- a/code/game/turfs/simulated/floor_attackby.dm
+++ b/code/game/turfs/simulated/floor_attackby.dm
@@ -9,6 +9,51 @@
 			attack_tile(C, L) // Be on help intent if you want to decon something.
 			return
 
+	if(istype(C, /obj/item/stack/tile/roofing))
+		var/expended_tile = FALSE // To track the case. If a ceiling is built in a multiz zlevel, it also necessarily roofs it against weather
+		var/turf/T = GetAbove(src)
+		var/obj/item/stack/tile/roofing/R = C
+
+		// Patch holes in the ceiling
+		if(T)
+			if(istype(T, /turf/simulated/open) || istype(T, /turf/space))
+			 	// Must be build adjacent to an existing floor/wall, no floating floors
+				var/list/cardinalTurfs = list() // Up a Z level
+				for(var/dir in cardinal)
+					var/turf/B = get_step(T, dir)
+					if(B)
+						cardinalTurfs += B
+
+				var/turf/simulated/A = locate(/turf/simulated/floor) in cardinalTurfs
+				if(!A)
+					A = locate(/turf/simulated/wall) in cardinalTurfs
+				if(!A)
+					to_chat(user, "<span class='warning'>There's nothing to attach the ceiling to!</span>")
+					return
+
+				if(R.use(1)) // Cost of roofing tiles is 1:1 with cost to place lattice and plating
+					T.ReplaceWithLattice()
+					T.ChangeTurf(/turf/simulated/floor)
+					playsound(src, 'sound/weapons/Genhit.ogg', 50, 1)
+					user.visible_message("<span class='notice'>[user] patches a hole in the ceiling.</span>", "<span class='notice'>You patch a hole in the ceiling.</span>")
+					expended_tile = TRUE
+			else
+				to_chat(user, "<span class='warning'>There aren't any holes in the ceiling to patch here.</span>")
+				return
+
+		// Create a ceiling to shield from the weather
+		if(src.outdoors)
+			for(var/dir in cardinal)
+				var/turf/A = get_step(src, dir)
+				if(A && !A.outdoors)
+					if(expended_tile || R.use(1))
+						src.outdoors = FALSE
+						SSplanets.unallocateTurf(src)
+						playsound(src, 'sound/weapons/Genhit.ogg', 50, 1)
+						user.visible_message("<span class='notice'>[user] roofs a tile, shielding it from the elements.</span>", "<span class='notice>You roof this tile, shielding it from the elements.</span>")
+					break
+		return
+
 	if(flooring)
 		if(istype(C, /obj/item/weapon))
 			try_deconstruct_tile(C, user)

--- a/code/game/turfs/simulated/wall_attacks.dm
+++ b/code/game/turfs/simulated/wall_attacks.dm
@@ -84,16 +84,16 @@
 
 	if(rotting)
 		if(reinf_material)
-			user << "<span class='danger'>\The [reinf_material.display_name] feels porous and crumbly.</span>"
+			to_chat(user, "<span class='danger'>\The [reinf_material.display_name] feels porous and crumbly.</span>")
 		else
-			user << "<span class='danger'>\The [material.display_name] crumbles under your touch!</span>"
+			to_chat(user, "<span class='danger'>\The [material.display_name] crumbles under your touch!</span>")
 			dismantle_wall()
 			return 1
 
 	if(..()) return 1
 
 	if(!can_open)
-		user << "<span class='notice'>You push the wall, but nothing happens.</span>"
+		to_chat(user, "<span class='notice'>You push the wall, but nothing happens.</span>")
 		playsound(src, 'sound/weapons/Genhit.ogg', 25, 1)
 	else
 		toggle_open(user)
@@ -138,28 +138,58 @@
 
 	user.setClickCooldown(user.get_attack_speed(W))
 	if (!user.)
-		user << "<span class='warning'>You don't have the dexterity to do this!</span>"
+		to_chat(user, "<span class='warning'>You don't have the dexterity to do this!</span>")
 		return
 
 	//get the user's location
-	if(!istype(user.loc, /turf))	return	//can't do this stuff whilst inside objects and such
+	if(!istype(user.loc, /turf))
+		return	//can't do this stuff whilst inside objects and such
 
 	if(W)
 		radiate()
 		if(is_hot(W))
 			burn(is_hot(W))
 
+	if(istype(W, /obj/item/stack/tile/roofing))
+		var/expended_tile = FALSE // To track the case. If a ceiling is built in a multiz zlevel, it also necessarily roofs it against weather
+		var/turf/T = GetAbove(src)
+		var/obj/item/stack/tile/roofing/R = W
+
+		// Place plating over a wall
+		if(T)
+			if(istype(T, /turf/simulated/open) || istype(T, /turf/space))
+				if(R.use(1)) // Cost of roofing tiles is 1:1 with cost to place lattice and plating
+					T.ReplaceWithLattice()
+					T.ChangeTurf(/turf/simulated/floor)
+					playsound(src, 'sound/weapons/Genhit.ogg', 50, 1)
+					user.visible_message("<span class='notice'>[user] patches a hole in the ceiling.</span>", "<span class='notice'>You patch a hole in the ceiling.</span>")
+					expended_tile = TRUE
+			else
+				to_chat(user, "<span class='warning'>There aren't any holes in the ceiling to patch here.</span>")
+				return
+
+		// Create a ceiling to shield from the weather
+		if(outdoors)
+			if(expended_tile || R.use(1)) // Don't need to check adjacent turfs for a wall, we're building on one
+				outdoors = FALSE
+				SSplanets.unallocateTurf(src)
+				if(!expended_tile) // Would've already played a sound
+					playsound(src, 'sound/weapons/Genhit.ogg', 50, 1)
+				user.visible_message("<span class='notice'>[user] roofs \the [src], shielding it from the elements.</span>", "<span class='notice>You roof \the [src] tile, shielding it from the elements.</span>")
+		return
+
+
 	if(locate(/obj/effect/overlay/wallrot) in src)
 		if(istype(W, /obj/item/weapon/weldingtool) )
 			var/obj/item/weapon/weldingtool/WT = W
 			if( WT.remove_fuel(0,user) )
-				user << "<span class='notice'>You burn away the fungi with \the [WT].</span>"
+				to_chat(user, "<span class='notice'>You burn away the fungi with \the [WT].</span>")
 				playsound(src, WT.usesound, 10, 1)
 				for(var/obj/effect/overlay/wallrot/WR in src)
 					qdel(WR)
 				return
 		else if(!is_sharp(W) && W.force >= 10 || W.force >= 20)
-			user << "<span class='notice'>\The [src] crumbles away under the force of your [W.name].</span>"
+			to_chat(user, "<span class='notice'>\The [src] crumbles away under the force of your [W.name].</span>")
 			src.dismantle_wall(1)
 			return
 
@@ -179,7 +209,7 @@
 			var/obj/item/weapon/melee/energy/blade/EB = W
 
 			EB.spark_system.start()
-			user << "<span class='notice'>You slash \the [src] with \the [EB]; the thermite ignites!</span>"
+			to_chat(user, "<span class='notice'>You slash \the [src] with \the [EB]; the thermite ignites!</span>")
 			playsound(src, "sparks", 50, 1)
 			playsound(src, 'sound/weapons/blade1.ogg', 50, 1)
 
@@ -196,13 +226,13 @@
 			return
 
 		if(WT.remove_fuel(0,user))
-			user << "<span class='notice'>You start repairing the damage to [src].</span>"
+			to_chat(user, "<span class='notice'>You start repairing the damage to [src].</span>")
 			playsound(src.loc, WT.usesound, 100, 1)
 			if(do_after(user, max(5, damage / 5) * WT.toolspeed) && WT && WT.isOn())
-				user << "<span class='notice'>You finish repairing the damage to [src].</span>"
+				to_chat(user, "<span class='notice'>You finish repairing the damage to [src].</span>")
 				take_damage(-damage)
 		else
-			user << "<span class='notice'>You need more welding fuel to complete this task.</span>"
+			to_chat(user, "<span class='notice'>You need more welding fuel to complete this task.</span>")
 			return
 		user.update_examine_panel(src)
 		return
@@ -219,7 +249,7 @@
 			if(!WT.isOn())
 				return
 			if(!WT.remove_fuel(0,user))
-				user << "<span class='notice'>You need more welding fuel to complete this task.</span>"
+				to_chat(user, "<span class='notice'>You need more welding fuel to complete this task.</span>")
 				return
 			dismantle_verb = "cutting"
 			dismantle_sound = W.usesound
@@ -236,7 +266,7 @@
 
 		if(dismantle_verb)
 
-			user << "<span class='notice'>You begin [dismantle_verb] through the outer plating.</span>"
+			to_chat(user, "<span class='notice'>You begin [dismantle_verb] through the outer plating.</span>")
 			if(dismantle_sound)
 				playsound(src, dismantle_sound, 100, 1)
 
@@ -246,7 +276,7 @@
 			if(!do_after(user,cut_delay * W.toolspeed))
 				return
 
-			user << "<span class='notice'>You remove the outer plating.</span>"
+			to_chat(user, "<span class='notice'>You remove the outer plating.</span>")
 			dismantle_wall()
 			user.visible_message("<span class='warning'>The wall was torn open by [user]!</span>")
 			return
@@ -259,24 +289,24 @@
 					playsound(src, W.usesound, 100, 1)
 					construction_stage = 5
 					user.update_examine_panel(src)
-					user << "<span class='notice'>You cut through the outer grille.</span>"
+					to_chat(user, "<span class='notice'>You cut through the outer grille.</span>")
 					update_icon()
 					return
 			if(5)
 				if (istype(W, /obj/item/weapon/screwdriver))
-					user << "<span class='notice'>You begin removing the support lines.</span>"
+					to_chat(user, "<span class='notice'>You begin removing the support lines.</span>")
 					playsound(src, W.usesound, 100, 1)
 					if(!do_after(user,40 * W.toolspeed) || !istype(src, /turf/simulated/wall) || construction_stage != 5)
 						return
 					construction_stage = 4
 					user.update_examine_panel(src)
 					update_icon()
-					user << "<span class='notice'>You unscrew the support lines.</span>"
+					to_chat(user, "<span class='notice'>You unscrew the support lines.</span>")
 					return
 				else if (istype(W, /obj/item/weapon/wirecutters))
 					construction_stage = 6
 					user.update_examine_panel(src)
-					user << "<span class='notice'>You mend the outer grille.</span>"
+					to_chat(user, "<span class='notice'>You mend the outer grille.</span>")
 					playsound(src, W.usesound, 100, 1)
 					update_icon()
 					return
@@ -289,51 +319,51 @@
 					if(WT.remove_fuel(0,user))
 						cut_cover=1
 					else
-						user << "<span class='notice'>You need more welding fuel to complete this task.</span>"
+						to_chat(user, "<span class='notice'>You need more welding fuel to complete this task.</span>")
 						return
 				else if (istype(W, /obj/item/weapon/pickaxe/plasmacutter))
 					cut_cover = 1
 				if(cut_cover)
-					user << "<span class='notice'>You begin slicing through the metal cover.</span>"
+					to_chat(user, "<span class='notice'>You begin slicing through the metal cover.</span>")
 					playsound(src, W.usesound, 100, 1)
 					if(!do_after(user, 60 * W.toolspeed) || !istype(src, /turf/simulated/wall) || construction_stage != 4)
 						return
 					construction_stage = 3
 					user.update_examine_panel(src)
 					update_icon()
-					user << "<span class='notice'>You press firmly on the cover, dislodging it.</span>"
+					to_chat(user, "<span class='notice'>You press firmly on the cover, dislodging it.</span>")
 					return
 				else if (istype(W, /obj/item/weapon/screwdriver))
-					user << "<span class='notice'>You begin screwing down the support lines.</span>"
+					to_chat(user, "<span class='notice'>You begin screwing down the support lines.</span>")
 					playsound(src, W.usesound, 100, 1)
 					if(!do_after(user,40 * W.toolspeed) || !istype(src, /turf/simulated/wall) || construction_stage != 4)
 						return
 					construction_stage = 5
 					user.update_examine_panel(src)
 					update_icon()
-					user << "<span class='notice'>You screw down the support lines.</span>"
+					to_chat(user, "<span class='notice'>You screw down the support lines.</span>")
 					return
 			if(3)
 				if (istype(W, /obj/item/weapon/crowbar))
-					user << "<span class='notice'>You struggle to pry off the cover.</span>"
+					to_chat(user, "<span class='notice'>You struggle to pry off the cover.</span>")
 					playsound(src, W.usesound, 100, 1)
 					if(!do_after(user,100 * W.toolspeed) || !istype(src, /turf/simulated/wall) || construction_stage != 3)
 						return
 					construction_stage = 2
 					user.update_examine_panel(src)
 					update_icon()
-					user << "<span class='notice'>You pry off the cover.</span>"
+					to_chat(user, "<span class='notice'>You pry off the cover.</span>")
 					return
 			if(2)
 				if (istype(W, /obj/item/weapon/wrench))
-					user << "<span class='notice'>You start loosening the anchoring bolts which secure the support rods to their frame.</span>"
+					to_chat(user, "<span class='notice'>You start loosening the anchoring bolts which secure the support rods to their frame.</span>")
 					playsound(src, W.usesound, 100, 1)
 					if(!do_after(user,40 * W.toolspeed) || !istype(src, /turf/simulated/wall) || construction_stage != 2)
 						return
 					construction_stage = 1
 					user.update_examine_panel(src)
 					update_icon()
-					user << "<span class='notice'>You remove the bolts anchoring the support rods.</span>"
+					to_chat(user, "<span class='notice'>You remove the bolts anchoring the support rods.</span>")
 					return
 			if(1)
 				var/cut_cover
@@ -342,28 +372,28 @@
 					if( WT.remove_fuel(0,user) )
 						cut_cover=1
 					else
-						user << "<span class='notice'>You need more welding fuel to complete this task.</span>"
+						to_chat(user, "<span class='notice'>You need more welding fuel to complete this task.</span>")
 						return
 				else if(istype(W, /obj/item/weapon/pickaxe/plasmacutter))
 					cut_cover = 1
 				if(cut_cover)
-					user << "<span class='notice'>You begin slicing through the support rods.</span>"
+					to_chat(user, "<span class='notice'>You begin slicing through the support rods.</span>")
 					playsound(src, W.usesound, 100, 1)
 					if(!do_after(user,70 * W.toolspeed) || !istype(src, /turf/simulated/wall) || construction_stage != 1)
 						return
 					construction_stage = 0
 					user.update_examine_panel(src)
 					update_icon()
-					user << "<span class='notice'>The slice through the support rods.</span>"
+					to_chat(user, "<span class='notice'>The slice through the support rods.</span>")
 					return
 			if(0)
 				if(istype(W, /obj/item/weapon/crowbar))
-					user << "<span class='notice'>You struggle to pry off the outer sheath.</span>"
+					to_chat(user, "<span class='notice'>You struggle to pry off the outer sheath.</span>")
 					playsound(src, W.usesound, 100, 1)
 					if(!do_after(user,100 * W.toolspeed) || !istype(src, /turf/simulated/wall) || !user || !W || !T )
 						return
 					if(user.loc == T && user.get_active_hand() == W )
-						user << "<span class='notice'>You pry off the outer sheath.</span>"
+						to_chat(user, "<span class='notice'>You pry off the outer sheath.</span>")
 						dismantle_wall()
 					return
 

--- a/code/game/turfs/space/space.dm
+++ b/code/game/turfs/space/space.dm
@@ -33,18 +33,18 @@
 
 /turf/space/attackby(obj/item/C as obj, mob/user as mob)
 
-	if (istype(C, /obj/item/stack/rods))
+	if(istype(C, /obj/item/stack/rods))
 		var/obj/structure/lattice/L = locate(/obj/structure/lattice, src)
 		if(L)
 			return
 		var/obj/item/stack/rods/R = C
 		if (R.use(1))
-			user << "<span class='notice'>Constructing support lattice ...</span>"
+			to_chat(user, "<span class='notice'>Constructing support lattice ...</span>")
 			playsound(src, 'sound/weapons/Genhit.ogg', 50, 1)
 			ReplaceWithLattice()
 		return
 
-	if (istype(C, /obj/item/stack/tile/floor))
+	if(istype(C, /obj/item/stack/tile/floor))
 		var/obj/structure/lattice/L = locate(/obj/structure/lattice, src)
 		if(L)
 			var/obj/item/stack/tile/floor/S = C
@@ -56,7 +56,33 @@
 			ChangeTurf(/turf/simulated/floor/airless)
 			return
 		else
-			user << "<span class='warning'>The plating is going to need some support.</span>"
+			to_chat(user, "<span class='warning'>The plating is going to need some support.</span>")
+
+	if(istype(C, /obj/item/stack/tile/roofing))
+		var/turf/T = GetAbove(src)
+		var/obj/item/stack/tile/roofing/R = C
+
+		// Patch holes in the ceiling
+		if(T)
+			if(istype(T, /turf/simulated/open) || istype(T, /turf/space))
+			 	// Must be build adjacent to an existing floor/wall, no floating floors
+				var/turf/simulated/A = locate(/turf/simulated/floor) in T.CardinalTurfs()
+				if(!A)
+					A = locate(/turf/simulated/wall) in T.CardinalTurfs()
+				if(!A)
+					to_chat(user, "<span class='warning'>There's nothing to attach the ceiling to!</span>")
+					return
+
+				if(R.use(1)) // Cost of roofing tiles is 1:1 with cost to place lattice and plating
+					T.ReplaceWithLattice()
+					T.ChangeTurf(/turf/simulated/floor)
+					playsound(src, 'sound/weapons/Genhit.ogg', 50, 1)
+					user.visible_message("<span class='notice'>[user] expands the ceiling.</span>", "<span class='notice'>You expand the ceiling.</span>")
+			else
+				to_chat(user, "<span class='warning'>There aren't any holes in the ceiling to patch here.</span>")
+				return
+		// Space shouldn't have weather of the sort planets with atmospheres do.
+		// If that's changed, then you'll want to swipe the rest of the roofing code from code/game/turfs/simulated/floor_attackby.dm
 	return
 
 
@@ -64,7 +90,7 @@
 
 /turf/space/Entered(atom/movable/A as mob|obj)
 	if(movement_disabled)
-		usr << "<span class='warning'>Movement is admin-disabled.</span>" //This is to identify lag problems
+		to_chat(usr, "<span class='warning'>Movement is admin-disabled.</span>") //This is to identify lag problems
 		return
 	..()
 	if ((!(A) || src != A.loc))	return

--- a/code/game/turfs/turf_changing.dm
+++ b/code/game/turfs/turf_changing.dm
@@ -38,6 +38,7 @@
 	var/old_affecting_lights = affecting_lights
 	var/old_lighting_overlay = lighting_overlay
 	var/old_corners = corners
+	var/old_outdoors = outdoors
 
 	//world << "Replacing [src.type] with [N]"
 
@@ -106,3 +107,4 @@
 				lighting_build_overlay()
 			else
 				lighting_clear_overlay()
+	outdoors = old_outdoors

--- a/code/modules/materials/material_recipes.dm
+++ b/code/modules/materials/material_recipes.dm
@@ -53,6 +53,7 @@
 	recipes += new/datum/stack_recipe("canister", /obj/machinery/portable_atmospherics/canister, 10, time = 15, one_per_turf = 1, on_floor = 1)
 	recipes += new/datum/stack_recipe("cannon frame", /obj/item/weapon/cannonframe, 10, time = 15, one_per_turf = 0, on_floor = 0)
 	recipes += new/datum/stack_recipe("regular floor tile", /obj/item/stack/tile/floor, 1, 4, 20)
+	recipes += new/datum/stack_recipe("roofing tile", /obj/item/stack/tile/roofing, 3, 4, 20)
 	recipes += new/datum/stack_recipe("metal rod", /obj/item/stack/rods, 1, 2, 60)
 	recipes += new/datum/stack_recipe("frame", /obj/item/frame, 5, time = 25, one_per_turf = 1, on_floor = 1)
 	recipes += new/datum/stack_recipe("mirror frame", /obj/item/frame/mirror, 1, time = 5, one_per_turf = 0, on_floor = 1)

--- a/html/changelogs/Atermonera - Ceilings.yml
+++ b/html/changelogs/Atermonera - Ceilings.yml
@@ -1,0 +1,7 @@
+author: Atermonera
+delete-after: True
+changes: 
+  - rscadd: "Steel sheets can be used to construct Roofing Tiles"
+  - rscadd: "Roofing tiles can be used on tiles under open spaces or space tiles in multiZ maps to place a lattice and plating on the space above"
+  - rscadd: "Roofing tiles can be used on outdoor turfs to make them indoors"
+  - rscadd: "Both functions work together on multiZ maps with outdoor turfs, only one roofing tile is used per tile roofed."


### PR DESCRIPTION
They're used to place plating overhead without going up a floor, and to remove weather effects. Must be placed such that the new section of roofing/plating is over a wall or adjacent to an existing section, i.e., actually physically supported by something. Roofs still won't collapse, however, that sounds computationally expensive and out of scope.

Changing a turf with ChangeTurf() will correctly inherit the old outdoors variable, so that roofing tiles can check it when deciding whether to roof an area

![Tested](https://puu.sh/AVmfZ/4b4522cfae.mp4) and working

Oh, and a bunch of `to_chat()`s while I was in there