### PR TITLE
Hides syndi-synths from the manifest

### DIFF
--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -84,10 +84,8 @@
 
 	for(var/mob/living/silicon/robot/robot in mob_list)
 		// No combat/syndicate cyborgs, no drones.
-		if(robot.module && robot.module.hide_on_manifest)
-			continue
-
-		bot[robot.name] = "[robot.modtype] [robot.braintype]"
+		if(!robot.scrambledcodes && !(robot.module && robot.module.hide_on_manifest))
+			bot[robot.name] = "[robot.modtype] [robot.braintype]"
 
 
 	if(heads.len > 0)

--- a/code/defines/obj.dm
+++ b/code/defines/obj.dm
@@ -144,7 +144,7 @@ var/global/list/PDA_Manifest = list()
 
 	for(var/mob/living/silicon/robot/robot in mob_list)
 		// No combat/syndicate cyborgs, no drones.
-		if(robot.module && robot.module.hide_on_manifest)
+		if(!robot.scrambledcodes && !(robot.module && robot.module.hide_on_manifest))
 			continue
 
 		bot[++bot.len] = list("name" = robot.real_name, "rank" = "[robot.modtype] [robot.braintype]", "active" = "Active")


### PR DESCRIPTION
Fixes #5371 
[Tested](https://puu.sh/AW5Xl/39c6e3cb91.mp4)

The original issue was because spawned in cyborgs of type `/mob/living/silicon/robot/syndicate` spawned without a module, so the check that looked at `module.hide_on_manifest` didn't catch them