### PR TITLE
Fixes indoor weather, hopefully for real this time.

### DIFF
--- a/code/controllers/subsystems/planets.dm
+++ b/code/controllers/subsystems/planets.dm
@@ -63,7 +63,7 @@ SUBSYSTEM_DEF(planets)
 	while(currentlist.len)
 		var/turf/simulated/OT = currentlist[currentlist.len]
 		currentlist.len--
-		if(istype(OT) && z_to_planet.len >= OT.z && z_to_planet[OT.z])
+		if(istype(OT) && OT.outdoors && z_to_planet.len >= OT.z && z_to_planet[OT.z])
 			var/datum/planet/P = z_to_planet[OT.z]
 			P.planet_floors |= OT
 			OT.vis_contents |= P.weather_holder.visuals

--- a/code/game/objects/items/weapons/RCD.dm
+++ b/code/game/objects/items/weapons/RCD.dm
@@ -153,7 +153,7 @@
 		return 0
 
 	if(build_turf)
-		T.ChangeTurf(build_turf)
+		T.ChangeTurf(build_turf, preserve_outdoors = TRUE)
 	else if(build_other)
 		new build_other(T)
 	else

--- a/code/game/turfs/simulated/floor_attackby.dm
+++ b/code/game/turfs/simulated/floor_attackby.dm
@@ -33,7 +33,7 @@
 
 				if(R.use(1)) // Cost of roofing tiles is 1:1 with cost to place lattice and plating
 					T.ReplaceWithLattice()
-					T.ChangeTurf(/turf/simulated/floor)
+					T.ChangeTurf(/turf/simulated/floor, preserve_outdoors = TRUE)
 					playsound(src, 'sound/weapons/Genhit.ogg', 50, 1)
 					user.visible_message("<span class='notice'>[user] patches a hole in the ceiling.</span>", "<span class='notice'>You patch a hole in the ceiling.</span>")
 					expended_tile = TRUE

--- a/code/game/turfs/simulated/wall_attacks.dm
+++ b/code/game/turfs/simulated/wall_attacks.dm
@@ -160,7 +160,7 @@
 			if(istype(T, /turf/simulated/open) || istype(T, /turf/space))
 				if(R.use(1)) // Cost of roofing tiles is 1:1 with cost to place lattice and plating
 					T.ReplaceWithLattice()
-					T.ChangeTurf(/turf/simulated/floor)
+					T.ChangeTurf(/turf/simulated/floor, preserve_outdoors = TRUE)
 					playsound(src, 'sound/weapons/Genhit.ogg', 50, 1)
 					user.visible_message("<span class='notice'>[user] patches a hole in the ceiling.</span>", "<span class='notice'>You patch a hole in the ceiling.</span>")
 					expended_tile = TRUE

--- a/code/game/turfs/turf_changing.dm
+++ b/code/game/turfs/turf_changing.dm
@@ -22,7 +22,7 @@
 		below.update_icon() // To add or remove the 'ceiling-less' overlay.
 
 //Creates a new turf
-/turf/proc/ChangeTurf(var/turf/N, var/tell_universe=1, var/force_lighting_update = 0)
+/turf/proc/ChangeTurf(var/turf/N, var/tell_universe=1, var/force_lighting_update = 0, var/preserve_outdoors = FALSE)
 	if (!N)
 		return
 
@@ -107,4 +107,6 @@
 				lighting_build_overlay()
 			else
 				lighting_clear_overlay()
-	outdoors = old_outdoors
+
+	if(preserve_outdoors)
+		outdoors = old_outdoors


### PR DESCRIPTION
The visuals were only half of the story, apparently.
ChangeTurf was changed to implicitly preserve tile's 'outdoor-ness' state.
It turns out this breaks a lot of things, such as weather effects in shuttles, buildmode, late-loading PoIs for events, and likely others.
To fix this, I've made it so copying the previous tile's outdoor state must be explicit, with an argument. The default is to not copy the previous tile, as that is what it was before the change. This fixes the above-mentioned issues while still allowing for things like building floors outside to not become magically roofed, by being explicit.