### PR TITLE
Adds Marking Order Changing at Character Creation

### DIFF
--- a/code/modules/client/preference_setup/general/03_body.dm
+++ b/code/modules/client/preference_setup/general/03_body.dm
@@ -303,7 +303,7 @@ var/global/list/valid_bloodtypes = list("A+", "A-", "B+", "B-", "AB+", "AB-", "O
 
 	. += "<br><a href='?src=\ref[src];marking_style=1'>Body Markings +</a><br>"
 	for(var/M in pref.body_markings)
-		. += "[M] <a href='?src=\ref[src];marking_up=[M]'><</a> <a href='?src=\ref[src];marking_down=[M]'>></a> <a href='?src=\ref[src];marking_remove=[M]'>-</a> <a href='?src=\ref[src];marking_color=[M]'>Color</a>"
+		. += "[M] [pref.body_markings.len > 1 ? "<a href='?src=\ref[src];marking_up=[M]'><</a> <a href='?src=\ref[src];marking_down=[M]'>></a> " : ""]<a href='?src=\ref[src];marking_remove=[M]'>-</a> <a href='?src=\ref[src];marking_color=[M]'>Color</a>"
 		. += "<font face='fixedsys' size='3' color='[pref.body_markings[M]]'><table style='display:inline;' bgcolor='[pref.body_markings[M]]'><tr><td>__</td></tr></table></font>"
 		. += "<br>"
 

--- a/code/modules/client/preference_setup/general/03_body.dm
+++ b/code/modules/client/preference_setup/general/03_body.dm
@@ -303,7 +303,7 @@ var/global/list/valid_bloodtypes = list("A+", "A-", "B+", "B-", "AB+", "AB-", "O
 
 	. += "<br><a href='?src=\ref[src];marking_style=1'>Body Markings +</a><br>"
 	for(var/M in pref.body_markings)
-		. += "[M] <a href='?src=\ref[src];marking_remove=[M]'>-</a> <a href='?src=\ref[src];marking_color=[M]'>Color</a>"
+		. += "[M] <a href='?src=\ref[src];marking_up=[M]'><</a> <a href='?src=\ref[src];marking_down=[M]'>></a> <a href='?src=\ref[src];marking_remove=[M]'>-</a> <a href='?src=\ref[src];marking_color=[M]'>Color</a>"
 		. += "<font face='fixedsys' size='3' color='[pref.body_markings[M]]'><table style='display:inline;' bgcolor='[pref.body_markings[M]]'><tr><td>__</td></tr></table></font>"
 		. += "<br>"
 
@@ -496,6 +496,24 @@ var/global/list/valid_bloodtypes = list("A+", "A-", "B+", "B-", "AB+", "AB-", "O
 		if(new_marking && CanUseTopic(user))
 			pref.body_markings[new_marking] = "#000000" //New markings start black
 			return TOPIC_REFRESH_UPDATE_PREVIEW
+
+	else if(href_list["marking_up"])
+		var/M = href_list["marking_up"]
+		var/start = pref.body_markings.Find(M)
+		if(start != 1) //If we're not the beginning of the list, swap with the previous element.
+			moveElement(pref.body_markings, start, start-1)
+		else //But if we ARE, become the final element -ahead- of everything else.
+			moveElement(pref.body_markings, start, pref.body_markings.len+1)
+		return TOPIC_REFRESH_UPDATE_PREVIEW
+
+	else if(href_list["marking_down"])
+		var/M = href_list["marking_down"]
+		var/start = pref.body_markings.Find(M)
+		if(start != pref.body_markings.len) //If we're not the end of the list, swap with the next element.
+			moveElement(pref.body_markings, start, start+2)
+		else //But if we ARE, become the first element -behind- everything else.
+			moveElement(pref.body_markings, start, 1)
+		return TOPIC_REFRESH_UPDATE_PREVIEW
 
 	else if(href_list["marking_remove"])
 		var/M = href_list["marking_remove"]

--- a/code/modules/client/preference_setup/general/03_body.dm
+++ b/code/modules/client/preference_setup/general/03_body.dm
@@ -303,7 +303,7 @@ var/global/list/valid_bloodtypes = list("A+", "A-", "B+", "B-", "AB+", "AB-", "O
 
 	. += "<br><a href='?src=\ref[src];marking_style=1'>Body Markings +</a><br>"
 	for(var/M in pref.body_markings)
-		. += "[M] [pref.body_markings.len > 1 ? "<a href='?src=\ref[src];marking_up=[M]'><</a> <a href='?src=\ref[src];marking_down=[M]'>></a> " : ""]<a href='?src=\ref[src];marking_remove=[M]'>-</a> <a href='?src=\ref[src];marking_color=[M]'>Color</a>"
+		. += "[M] [pref.body_markings.len > 1 ? "<a href='?src=\ref[src];marking_up=[M]'>&#708;</a> <a href='?src=\ref[src];marking_down=[M]'>&#709;</a> " : ""]<a href='?src=\ref[src];marking_remove=[M]'>-</a> <a href='?src=\ref[src];marking_color=[M]'>Color</a>"
 		. += "<font face='fixedsys' size='3' color='[pref.body_markings[M]]'><table style='display:inline;' bgcolor='[pref.body_markings[M]]'><tr><td>__</td></tr></table></font>"
 		. += "<br>"
 

--- a/html/changelogs/KasparoVv - PR - 5429.yml
+++ b/html/changelogs/KasparoVv - PR - 5429.yml
@@ -1,0 +1,4 @@
+author: KasparoVv
+delete-after: True
+changes: 
+  - rscadd: "You can now change the order of your body markings at character creation with the push of a button. Shift markings up or down layers at will to design the character you've always wanted, more easily than ever before."


### PR DESCRIPTION
QOL for folks with numerous markings on their characters.

Testing/adding/manipulating markings becomes massively time consuming the more you have, especially if you're wanting to put it deep in the layer stack and are testing speculatively.
This introduces much convenience to that process: Now you can click a button and move a chosen marking up or down a layer at will, allowing you to simply create a marking as normal then shift it to the desired layer in the stack without having to re-do a ton of other markings just to get it where you think it might work best.

========================================

Clicking the back `<` button on a marking will trade its place with the _previous_ marking or _move it to the end after_ all other markings if it's the _first_ marking.

Clicking the forward `>` button on a marking will trade its place with the _next_ marking or _put it in first before_ all other markings if it's the _last_ marking.

I know the pictures contain non-Polaris markings but that's because the Virgo codebase served as my test-bed. Works the exact same here

**_What the buttons actually look like after being adjusted. Below simply demonstrates the functionality_**
![virgo marking mover proper up and down arrows](https://user-images.githubusercontent.com/12377767/43042319-fe8e8cb4-8d69-11e8-94e3-bed353032b98.png)

_No buttons unless you've got more than one marking._
![virgo marking mover one marking](https://user-images.githubusercontent.com/12377767/43040798-c80ea084-8d3c-11e8-897b-3653a6973e15.PNG)

_Moving markings_
![marking mover 2](https://user-images.githubusercontent.com/12377767/42727886-d459569e-879d-11e8-99da-ebc880eacecf.png)
