### PR TITLE
Fixes RCD runtime

### DIFF
--- a/code/datums/observation/turf_changed.dm
+++ b/code/datums/observation/turf_changed.dm
@@ -20,9 +20,9 @@ var/decl/observ/turf_changed/turf_changed_event = new()
 * Turf Changed Handling *
 ************************/
 
-/turf/ChangeTurf()
+/turf/ChangeTurf(var/turf/N, var/tell_universe, var/force_lighting_update, var/preserve_outdoors)
 	var/old_density = density
 	var/old_opacity = opacity
-	. = ..()
+	. = ..(N, tell_universe, force_lighting_update, preserve_outdoors)
 	if(.)
 		turf_changed_event.raise_event(src, old_density, density, old_opacity, opacity)

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -115,9 +115,9 @@
 			plant.pixel_y = 0
 		plant.update_neighbors()
 
-/turf/simulated/wall/ChangeTurf(var/newtype)
+/turf/simulated/wall/ChangeTurf(var/turf/N, var/tell_universe, var/force_lighting_update, var/preserve_outdoors)
 	clear_plants()
-	..(newtype)
+	..(N, tell_universe, force_lighting_update, preserve_outdoors)
 
 //Appearance
 /turf/simulated/wall/examine(mob/user)

--- a/code/game/turfs/space/space.dm
+++ b/code/game/turfs/space/space.dm
@@ -213,5 +213,5 @@
 					A.loc.Entered(A)
 	return
 
-/turf/space/ChangeTurf(var/turf/N, var/tell_universe=1, var/force_lighting_update = 0)
-	return ..(N, tell_universe, 1)
+/turf/space/ChangeTurf(var/turf/N, var/tell_universe, var/force_lighting_update, var/preserve_outdoors)
+	return ..(N, tell_universe, 1, preserve_outdoors)


### PR DESCRIPTION
Named arguments in byond are very picky sometimes.
Makes the RCD and other methods that use ``preserve_outdoors`` work once more.