### PR TITLE
AOOC for team traitor

### DIFF
--- a/code/game/antagonist/station/infiltrator.dm
+++ b/code/game/antagonist/station/infiltrator.dm
@@ -13,6 +13,7 @@ var/datum/antagonist/traitor/infiltrator/infiltrators
 	welcome_text = "To speak on your team's private channel, use :t."
 	protected_jobs = list("Security Officer", "Warden", "Detective", "Internal Affairs Agent", "Head of Security", "Colony Director")
 	flags = ANTAG_SUSPICIOUS | ANTAG_RANDSPAWN | ANTAG_VOTABLE
+	can_speak_aooc = TRUE
 
 /datum/antagonist/traitor/infiltrator/New()
 	..()


### PR DESCRIPTION
Team traitors (infiltrators) can now use AOOC as intended.
Fixes #5437