### PR TITLE
Various things and floors no longer associate with dirt

### DIFF
--- a/code/game/turfs/simulated/outdoors/outdoors.dm
+++ b/code/game/turfs/simulated/outdoors/outdoors.dm
@@ -14,6 +14,8 @@ var/list/turf_edge_cache = list()
 	icon_state = null
 	edge_blending_priority = 1
 	outdoors = TRUE					// This variable is used for weather effects.
+	can_dirty = FALSE				// Looks hideous with dirt on it.
+
 	// When a turf gets demoted or promoted, this list gets adjusted.  The top-most layer is the layer on the bottom of the list, due to how pop() works.
 	var/list/turf_layers = list(/turf/simulated/floor/outdoors/rocks)
 

--- a/code/game/turfs/simulated/water.dm
+++ b/code/game/turfs/simulated/water.dm
@@ -9,6 +9,8 @@
 	edge_blending_priority = -1
 	movement_cost = 4
 	outdoors = TRUE
+	can_dirty = FALSE	// It's water
+
 	var/depth = 1 // Higher numbers indicates deeper water.
 
 /turf/simulated/floor/water/initialize()

--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -18,6 +18,8 @@ var/list/mining_overlay_cache = list()
 	blocks_air = 1
 	temperature = T0C
 
+	can_dirty = FALSE
+
 	var/ore/mineral
 	var/sand_dug
 	var/mined_ore = 0

--- a/code/modules/mob/living/bot/bot.dm
+++ b/code/modules/mob/living/bot/bot.dm
@@ -7,6 +7,8 @@
 	universal_speak = 1
 	density = 0
 
+	makes_dirt = FALSE	// No more dirt from Beepsky
+
 	var/obj/item/weapon/card/id/botcard = null
 	var/list/botcard_access = list()
 	var/on = 1

--- a/code/modules/mob/living/simple_animal/slime/slime.dm
+++ b/code/modules/mob/living/simple_animal/slime/slime.dm
@@ -11,6 +11,8 @@
 	var/icon_state_override = null // Used for special slime appearances like the rainbow slime.
 	pass_flags = PASSTABLE
 
+	makes_dirt = FALSE	// Goop
+
 	speak_emote = list("chirps")
 
 	maxHealth = 150


### PR DESCRIPTION
- Bots and Slimes no longer make dirt. I blame magnets and goop, respectively.
- Water, Outdoor, and Mining turfs no longer get dirty.