### PR TITLE
MultiZ falling tweaks

### DIFF
--- a/code/game/turfs/turf_changing.dm
+++ b/code/game/turfs/turf_changing.dm
@@ -26,10 +26,9 @@
 	if (!N)
 		return
 
-	// This makes sure that turfs are not changed to space when one side is part of a zone
 	if(N == /turf/space)
 		var/turf/below = GetBelow(src)
-		if(istype(below) && (air_master.has_valid_zone(below) || air_master.has_valid_zone(src)))
+		if(istype(below) && !istype(below,/turf/space))
 			N = /turf/simulated/open
 
 	var/obj/fire/old_fire = fire

--- a/code/modules/multiz/movement.dm
+++ b/code/modules/multiz/movement.dm
@@ -151,6 +151,9 @@
 	if(!below)
 		return
 
+	if(istype(below, /turf/space))
+		return
+
 	var/turf/T = loc
 	if(!T.CanZPass(src, DOWN) || !below.CanZPass(src, DOWN))
 		return


### PR DESCRIPTION
- Blowing up a tile over actual `space` now makes a space tile, rather than an `open space` tile.
- Walking on a `space` tile no longer makes you fall to the deck below.