### PR TITLE
I don't know how we keep breaking falling

### DIFF
--- a/code/game/objects/effects/step_triggers.dm
+++ b/code/game/objects/effects/step_triggers.dm
@@ -158,7 +158,14 @@ var/global/list/tele_landmarks = list() // Terrible, but the alternative is loop
 /obj/effect/step_trigger/teleporter/planetary_fall
 	var/datum/planet/planet = null
 
+// First time setup, which planet are we aiming for?
+/obj/effect/step_trigger/teleporter/planetary_fall/proc/find_planet()
+	return
+
 /obj/effect/step_trigger/teleporter/planetary_fall/Trigger(var/atom/movable/A)
+	if(!planet)
+		find_planet()
+
 	if(planet)
 		if(!planet.planet_floors.len)
 			message_admins("ERROR: planetary_fall step trigger's list of outdoor floors was empty.")

--- a/maps/southern_cross/turfs/outdoors.dm
+++ b/maps/southern_cross/turfs/outdoors.dm
@@ -161,6 +161,5 @@
 	temperature = TCMB
 
 // Step trigger to fall down to planet Sif
-/obj/effect/step_trigger/teleporter/planetary_fall/sif/initialize()
+/obj/effect/step_trigger/teleporter/planetary_fall/sif/find_planet()
 	planet = planet_sif
-	. = ..()


### PR DESCRIPTION
- planetary_fall teleporters now try to find their target planet the first time they're used.

This isn't at all the prettiest code, but I don't have any idea how it worked before it broke, or even when it broke.