### PR TITLE
Hallucinations now use the old system again.

### DIFF
--- a/code/modules/flufftext/Hallucination.dm
+++ b/code/modules/flufftext/Hallucination.dm
@@ -349,19 +349,22 @@ var/list/non_fakeattack_weapons = list(/obj/item/weapon/gun/projectile, /obj/ite
 	/obj/item/clothing/suit/space/void, /obj/item/weapon/tank)
 
 /proc/fake_attack(var/mob/living/target)
-//	var/list/possible_clones = new/list()
+	var/list/possible_clones = new/list()
 	var/mob/living/carbon/human/clone = null
 	var/clone_weapon = null
 
 	for(var/mob/living/carbon/human/H in living_mob_list)
-		if(H.stat || H.lying) continue
-//		possible_clones += H
-		clone = H
-		break	//changed the code a bit. Less randomised, but less work to do. Should be ok, world.contents aren't stored in any particular order.
+		if(H.stat || H.lying)
+			continue
+		possible_clones += H
+//		clone = H
+//		break	//changed the code a bit. Less randomised, but less work to do. Should be ok, world.contents aren't stored in any particular order.
 
-//	if(!possible_clones.len) return
-//	clone = pick(possible_clones)
-	if(!clone)	return
+	if(!possible_clones.len)
+		return
+	clone = pick(possible_clones)
+	if(!clone)
+		return
 
 	//var/obj/effect/fake_attacker/F = new/obj/effect/fake_attacker(outside_range(target))
 	var/obj/effect/fake_attacker/F = new/obj/effect/fake_attacker(target.loc)

--- a/html/changelogs/Mechoid - Hallucinations.yml
+++ b/html/changelogs/Mechoid - Hallucinations.yml
@@ -1,0 +1,7 @@
+
+author: Mechoid
+
+delete-after: True
+
+changes: 
+  - rsctweak: "Hallucinations are no longer only Pun Pun."


### PR DESCRIPTION
Pun Pun is being demoted from being chief of the Psi Corps, his access to the mental imagery broadcast network has been given to everyone subconsciously instead.

* It uses the list of living mobs to find human mobs who are applicable for hallucinating instead of just saying 'Pun Pun is first!' and picking him always.