### PR TITLE
Fixes the Ultra AC2's burstfire bug.

### DIFF
--- a/code/game/mecha/equipment/weapons/weapons.dm
+++ b/code/game/mecha/equipment/weapons/weapons.dm
@@ -38,11 +38,13 @@
 		projectiles--
 		var/P = new projectile(curloc)
 		Fire(P, target)
+		if(i == 1)
+			set_ready_state(0)
 		if(fire_cooldown)
 			sleep(fire_cooldown)
 	if(auto_rearm)
 		projectiles = projectiles_per_shot
-	set_ready_state(0)
+//	set_ready_state(0)
 	do_after_cooldown()
 	return
 


### PR DESCRIPTION
Mech weapons now set their cooldown-prep on the first projectile fired, to fix spam-clicking to fire more than the intended number of projectiles.