### PR TITLE
The speed-related chem effects are no longer a one-or-none affair, oxy causes slowdown

### DIFF
--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -110,14 +110,14 @@
 	if(CE_SLOWDOWN in chem_effects)
 		if (tally >= 0 )
 			tally = (tally + tally/4) //Add a quarter of penalties on top.
-		tally += 1
+		tally += chem_effects[CE_SLOWDOWN]
 
 	if(CE_SPEEDBOOST in chem_effects)
 		if (tally >= 0)	// cut any penalties in half
 			tally = tally/2
-		tally -= 1	// give 'em a buff on top.
+		tally -= chem_effects[CE_SPEEDBOOST]	// give 'em a buff on top.
 
-	return (tally+config.human_delay)
+	return max(-3, tally+config.human_delay)	// Minimum return should be the same as force_max_speed
 
 /mob/living/carbon/human/Process_Spacemove(var/check_drift = 0)
 	//Can we act?

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -315,10 +315,9 @@
 	if(alien == IS_SLIME)
 		chem_effective = 0.75
 		M.stuttering = min(50, max(0, M.stuttering + 5)) //If you can't feel yourself, and your main mode of speech is resonation, there's a problem.
-		M.add_chemical_effect(CE_SLOWDOWN, 1)
 	M.add_chemical_effect(CE_PAINKILLER, 200 * chem_effective)
+	M.add_chemical_effect(CE_SLOWDOWN, 1)
 	M.eye_blurry = min(M.eye_blurry + 10, 250 * chem_effective)
-	M.Confuse(5)
 
 /datum/reagent/oxycodone/overdose(var/mob/living/carbon/M, var/alien)
 	..()


### PR DESCRIPTION
- CE_SPEEDBOOST and CE_SLOWDOWN now apply their value as part of the human movement_delay calculation, rather than always 1.
- Human movement_delay can't return less than -3, to be in line with the force_max_speed return.
- Oxycodone now causes slowdown, rather than dizziness. This already happened with Prometheans, now it's universal.