### PR TITLE
(HOPEFULLY) fixes advanced who highlighting the fake ckeys of stealth admins

### DIFF
--- a/code/game/verbs/advanced_who.dm
+++ b/code/game/verbs/advanced_who.dm
@@ -53,30 +53,22 @@
 			Lines += entry
 	else
 		for(var/client/C in clients)
+			var/entry = "\t"
 			if(C.holder && C.holder.fakekey)
-				var/entry = "\t[C.key]"
-				var/mob/observer/dead/O = C.mob
-				entry = C.holder.fakekey
-				if(isobserver(O))
-					entry += " - <font color='gray'>Observing</font>"
-				else if(istype(O,/mob/new_player))
-					entry += " - <font color='blue'>In Lobby</font>"
-				else
-					entry += " - <font color='green'>Playing</font>"
-				Lines += entry
+				entry += "[C.holder.fakekey]"
 			else
-				var/entry = "\t[C.key]"
-				var/mob/observer/dead/O = C.mob
-				if(isobserver(O)) //Woo, players can see
-					entry += " - <font color='gray'>Observing</font>"
-				else if(istype(O,/mob/new_player))
-					entry += " - <font color='blue'>In Lobby</font>"
-				else
-					entry += " - <font color='green'>Playing</font>"
-				Lines += entry
+				entry += "[C.key]"
+			var/mob/observer/dead/O = C.mob
+			if(isobserver(O))
+				entry += " - <font color='gray'>Observing</font>"
+			else if(istype(O,/mob/new_player))
+				entry += " - <font color='blue'>In Lobby</font>"
+			else
+				entry += " - <font color='green'>Playing</font>"
+			Lines += entry
 
 	for(var/line in sortList(Lines))
 		msg += "[line]\n"
 
 	msg += "<b>Total Players: [length(Lines)]</b>"
-	src << msg
+	to_chat(src, msg)


### PR DESCRIPTION
Port of VOREStation/VOREStation#4165, i forgot to check to make sure that advanced who was a thing here or not.

Does as the title says. It also shaves off a little bit of redundant code from the player half of advanced who, and replaces the `src << msg` with a `to_chat(src, msg)`