### PR TITLE
Fixes a UI bug with emptying currently-open bags into smartfridges...hopefully.

### DIFF
--- a/code/game/machinery/kitchen/smartfridge.dm
+++ b/code/game/machinery/kitchen/smartfridge.dm
@@ -241,6 +241,7 @@
 		var/plants_loaded = 0
 		for(var/obj/G in P.contents)
 			if(accept_check(G))
+				P.remove_from_storage(G)
 				stock(G)
 				plants_loaded = 1
 		if(plants_loaded)

--- a/code/game/machinery/kitchen/smartfridge.dm
+++ b/code/game/machinery/kitchen/smartfridge.dm
@@ -241,7 +241,7 @@
 		var/plants_loaded = 0
 		for(var/obj/G in P.contents)
 			if(accept_check(G))
-				P.remove_from_storage(G)
+				P.remove_from_storage(G) //fixes ui bug - Pull Request 5515
 				stock(G)
 				plants_loaded = 1
 		if(plants_loaded)


### PR DESCRIPTION
All seems to work on my end, but then I'm no expert - would love to know if there was a better way to fix this. Bug was that if you empty a plant bag with plants in it into a smartfridge whilst looking in the bag (i.e. you can see the plants) the icons of the plants remain frozen above your hands even when the bag is closed.