### PR TITLE
Iced beer no longer drops you to 3 degrees centigrade.

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
@@ -2148,7 +2148,7 @@
 	color = "#FFD300"
 	strength = 50
 	adj_temp = -20
-	targ_temp = 270
+	targ_temp = 280
 
 	glass_name = "iced beer"
 	glass_desc = "A beer so frosty, the air around it freezes."


### PR DESCRIPTION
Target temperature for iced beer is now 280 rather than 270, because it's a normal drink, and shouldn't seriously burn someone who drinks it, even if they're a Skrell.