### PR TITLE
Cleave changes, attack code cleanup

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -28,20 +28,20 @@ avoid code duplication. This includes items that may sometimes act as a standard
 	return
 
 //I would prefer to rename this to attack(), but that would involve touching hundreds of files.
-/obj/item/proc/resolve_attackby(atom/A, mob/user)
+/obj/item/proc/resolve_attackby(atom/A, mob/user, var/attack_modifier = 1)
 	pre_attack(A, user)
 	add_fingerprint(user)
-	return A.attackby(src, user)
+	return A.attackby(src, user, attack_modifier)
 
 // No comment
-/atom/proc/attackby(obj/item/W, mob/user)
+/atom/proc/attackby(obj/item/W, mob/user, var/attack_modifier)
 	return
 
-/atom/movable/attackby(obj/item/W, mob/user)
+/atom/movable/attackby(obj/item/W, mob/user, var/attack_modifier)
 	if(!(W.flags & NOBLUDGEON))
 		visible_message("<span class='danger'>[src] has been hit by [user] with [W].</span>")
 
-/mob/living/attackby(obj/item/I, mob/user)
+/mob/living/attackby(obj/item/I, mob/user, var/attack_modifier)
 	if(!ismob(user))
 		return 0
 	if(can_operate(src) && I.do_surgery(src,user))
@@ -49,7 +49,7 @@ avoid code duplication. This includes items that may sometimes act as a standard
 			return 1
 		else
 			return 0
-	return I.attack(src, user, user.zone_sel.selecting)
+	return I.attack(src, user, user.zone_sel.selecting, attack_modifier)
 
 // Used to get how fast a mob should attack, and influences click delay.
 // This is just for inheritence.
@@ -73,7 +73,7 @@ avoid code duplication. This includes items that may sometimes act as a standard
 	return
 
 //I would prefer to rename this attack_as_weapon(), but that would involve touching hundreds of files.
-/obj/item/proc/attack(mob/living/M, mob/living/user, var/target_zone)
+/obj/item/proc/attack(mob/living/M, mob/living/user, var/target_zone, var/attack_modifier)
 	if(!force || (flags & NOBLUDGEON))
 		return 0
 	if(M == user && user.a_intent != I_HURT)
@@ -92,12 +92,12 @@ avoid code duplication. This includes items that may sometimes act as a standard
 
 	var/hit_zone = M.resolve_item_attack(src, user, target_zone)
 	if(hit_zone)
-		apply_hit_effect(M, user, hit_zone)
+		apply_hit_effect(M, user, hit_zone, attack_modifier)
 
 	return 1
 
 //Called when a weapon is used to make a successful melee attack on a mob. Returns the blocked result
-/obj/item/proc/apply_hit_effect(mob/living/target, mob/living/user, var/hit_zone)
+/obj/item/proc/apply_hit_effect(mob/living/target, mob/living/user, var/hit_zone, var/attack_modifier)
 	user.break_cloak()
 	if(hitsound)
 		playsound(loc, hitsound, 50, 1, -1)
@@ -106,7 +106,10 @@ avoid code duplication. This includes items that may sometimes act as a standard
 	for(var/datum/modifier/M in user.modifiers)
 		if(!isnull(M.outgoing_melee_damage_percent))
 			power *= M.outgoing_melee_damage_percent
+
 	if(HULK in user.mutations)
 		power *= 2
-	return target.hit_with_weapon(src, user, power, hit_zone)
 
+	power *= attack_modifier
+
+	return target.hit_with_weapon(src, user, power, hit_zone)

--- a/code/game/objects/weapons.dm
+++ b/code/game/objects/weapons.dm
@@ -34,11 +34,9 @@
 			continue
 		if(SA == target) // We (presumably) already hit the target before cleave() was called.  orange() should prevent this but just to be safe...
 			continue
-		if(user.faction == SA.faction) // Avoid friendly fire.
-			continue
 		if(!SA.Adjacent(user) || !SA.Adjacent(target)) // Cleaving only hits mobs near the target mob and user.
 			continue
-		if(resolve_attackby(SA, user)) // Hit them with the weapon.  This won't cause recursive cleaving due to the cleaving variable being set to true.
+		if(resolve_attackby(SA, user, attack_modifier = 0.5)) // Hit them with the weapon.  This won't cause recursive cleaving due to the cleaving variable being set to true.
 			hit_mobs++
 
 	cleave_visual(user, target)

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -8,10 +8,6 @@
 	if(!effective_force || blocked >= 100)
 		return 0
 
-	//Hulk modifier
-	if(HULK in user.mutations)
-		effective_force *= 2
-
 	//If the armor soaks all of the damage, it just skips the rest of the checks
 	if(effective_force <= soaked)
 		return 0

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -221,11 +221,6 @@
 /mob/living/proc/standard_weapon_hit_effects(obj/item/I, mob/living/user, var/effective_force, var/blocked, var/soaked, var/hit_zone)
 	if(!effective_force || blocked >= 100)
 		return 0
-
-	//Hulk modifier
-	if(HULK in user.mutations)
-		effective_force *= 2
-
 	//Apply weapon damage
 	var/weapon_sharp = is_sharp(I)
 	var/weapon_edge = has_edge(I)

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -659,7 +659,6 @@
 	return ..()
 
 /mob/living/simple_animal/hit_with_weapon(obj/item/O, mob/living/user, var/effective_force, var/hit_zone)
-	effective_force = O.force
 
 	//Animals can't be stunned(?)
 	if(O.damtype == HALLOSS)


### PR DESCRIPTION
- Melee attacks can now be passed an `attack_modifier`, a multiplicative value that changes how much damage they do.
- Melee attack damage no longer checks for HULK multiple times, fixing a bug where human mobs took quadruple damage.
- Simple Animal `hit_with_weapon` no longer sets `effective_force` to the force of whatever object it gets passed. Instead, it uses the `effective_force` passed into the proc.
- Cleave does half damage against secondary targets, and will now cleave on "neutral" mobs.