### PR TITLE
communicator_header.tmpl now correctly includes Body

### DIFF
--- a/nano/templates/communicator_header.tmpl
+++ b/nano/templates/communicator_header.tmpl
@@ -14,3 +14,5 @@
 		</div>
 	</div>
 </div>
+
+{{#def.Body}}


### PR DESCRIPTION
[Tested](https://puu.sh/Bsrvj/6376b5938e.mp4)
I don't know how that broke, because it couldn't have lost the include during testing and development or it wouldn't have worked at all. If it's still broken then I'm at a loss.