### PR TITLE
Fixes Lead Walls

### DIFF
--- a/code/datums/repositories/radiation.dm
+++ b/code/datums/repositories/radiation.dm
@@ -122,7 +122,7 @@ var/global/repository/radiation/radiation_repository = new()
 
 /turf/simulated/wall/calc_rad_resistance()
 	radiation_repository.resistance_cache[src] = (length(contents) + 1)
-	cached_rad_resistance = (density ? material.weight : 0)
+	cached_rad_resistance = (density ? material.weight + material.radiation_resistance : 0)
 
 /obj
 	var/rad_resistance = 0  // Allow overriding rad resistance


### PR DESCRIPTION
A material's ``radiation_resistance`` was never considered for calculating a wall's cached resistance to radiation. This fixes it. There is another issue involving r-walls not being better at stopping radiation than their normal-wall counterparts made of the same material but fixing that involves a lot of number adjusting to avoid the SM engine from getting twice as protective.