### PR TITLE
Cybersuit is now a space rig.

### DIFF
--- a/code/modules/clothing/spacesuits/rig/suits/light.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/light.dm
@@ -39,12 +39,12 @@
 
 	req_access = list(access_syndicate)
 
-	airtight = 0
-	seal_delay = 5 //not being vaccum-proof has an upside I guess
+	airtight = 1
+	seal_delay = 5 //Being straight out of a cyberpunk space movie has its perks.
 
-	helm_type = /obj/item/clothing/head/lightrig/hacker
-	chest_type = /obj/item/clothing/suit/lightrig/hacker
-	glove_type = /obj/item/clothing/gloves/gauntlets/lightrig/hacker
+	helm_type = /obj/item/clothing/head/helmet/space/rig/light/hacker
+	chest_type = /obj/item/clothing/suit/space/rig/light/hacker
+	glove_type = /obj/item/clothing/gloves/gauntlets/rig/light/hacker
 	boot_type = /obj/item/clothing/shoes/lightrig/hacker
 
 	initial_modules = list(
@@ -57,19 +57,20 @@
 		)
 
 //The cybersuit is not space-proof. It does however, have good siemens_coefficient values
-/obj/item/clothing/head/lightrig/hacker
-	name = "HUD"
+/obj/item/clothing/head/helmet/space/rig/light/hacker
+	name = "headgear"
 	siemens_coefficient = 0.4
-	flags = 0
+	flags_inv = HIDEEARS
 
-/obj/item/clothing/suit/lightrig/hacker
+/obj/item/clothing/suit/space/rig/light/hacker
 	siemens_coefficient = 0.4
 
 /obj/item/clothing/shoes/lightrig/hacker
 	siemens_coefficient = 0.4
-	flags = NOSLIP //All the other rigs have magboots anyways, hopefully gives the hacker suit something more going for it.
+	step_volume_mod = 0.3 //Special sneaky cyber-soles, for infiltration.
+	flags = NOSLIP //They're not magboots, so they're not super good for exterior hull walking, BUT for interior infiltration they'll do swell.
 
-/obj/item/clothing/gloves/gauntlets/lightrig/hacker
+/obj/item/clothing/gloves/gauntlets/rig/light/hacker
 	siemens_coefficient = 0
 
 /obj/item/weapon/rig/light/ninja


### PR DESCRIPTION
The cybersuit is now a space-rig, and you can see your hair / face and all your grimdark spacefuture cyberpunk facial scars while wearing it.

The shoes were made quieter because they aren't magboots, and this is still a light rig, so it may as well be damn good at its sneaking job.