### PR TITLE
Descriptors now properly respect species differences

### DIFF
--- a/code/modules/mob/living/carbon/human/descriptors/_descriptors.dm
+++ b/code/modules/mob/living/carbon/human/descriptors/_descriptors.dm
@@ -38,7 +38,8 @@
 	..()
 
 /datum/mob_descriptor/proc/get_third_person_message_start(var/datum/gender/my_gender)
-	return "[my_gender.He] [my_gender.is]"
+	return "They are"
+//	return "[my_gender.He] [my_gender.is]"	// Doesn't respect ambiguous_genders species var, can't figure out a fix at the moment
 
 /datum/mob_descriptor/proc/get_first_person_message_start()
 	return "You are"

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -237,6 +237,7 @@
 		var/list/descriptor_datums = list()
 		for(var/desctype in descriptors)
 			var/datum/mob_descriptor/descriptor = new desctype
+			descriptor.comparison_offset = descriptors[desctype]
 			descriptor_datums[descriptor.name] = descriptor
 		descriptors = descriptor_datums
 

--- a/code/modules/mob/living/carbon/human/species/station/seromi.dm
+++ b/code/modules/mob/living/carbon/human/species/station/seromi.dm
@@ -122,6 +122,11 @@
 		/mob/living/proc/hide
 		)
 
+	descriptors = list(
+		/datum/mob_descriptor/height = -3,
+		/datum/mob_descriptor/build = -3
+		)
+
 /datum/species/teshari/equip_survival_gear(var/mob/living/carbon/human/H)
 	..()
 	H.equip_to_slot_or_del(new /obj/item/clothing/shoes/sandal(H),slot_shoes)


### PR DESCRIPTION
Unathi will show up as big and tall, Teshari will show up as small and thin.

Everyone now compares as a `They`, because I can't figure out how to make this thing respect `ambiguous_genders`.