### PR TITLE
Wind in storms slightly nerfed

### DIFF
--- a/code/modules/planet/sif.dm
+++ b/code/modules/planet/sif.dm
@@ -244,13 +244,13 @@ datum/weather/sif
 				var/obj/item/weapon/melee/umbrella/U = L.get_active_hand()
 				if(U.open)
 					if(show_message)
-						to_chat(L, "<span class='notice'>Rain patters softly onto your umbrella</span>")
+						to_chat(L, "<span class='notice'>Rain patters softly onto your umbrella.</span>")
 					continue
 			else if(istype(L.get_inactive_hand(), /obj/item/weapon/melee/umbrella))
 				var/obj/item/weapon/melee/umbrella/U = L.get_inactive_hand()
 				if(U.open)
 					if(show_message)
-						to_chat(L, "<span class='notice'>Rain patters softly onto your umbrella</span>")
+						to_chat(L, "<span class='notice'>Rain patters softly onto your umbrella.</span>")
 					continue
 
 			L.water_act(1)
@@ -264,6 +264,8 @@ datum/weather/sif
 	temp_low = 233.15  // -40c
 	light_modifier = 0.3
 	flight_failure_modifier = 10
+	effect_message = "<span class='warning'>Rain falls on you, drenching you in water.</span>"
+
 	var/next_lightning_strike = 0 // world.time when lightning will strike.
 	var/min_lightning_cooldown = 5 SECONDS
 	var/max_lightning_cooldown = 1 MINUTE
@@ -284,22 +286,41 @@ datum/weather/sif
 			if(!T.outdoors)
 				continue // They're indoors, so no need to rain on them.
 
-			// If they have an open umbrella, it'll get stolen by the wind
+			// Lazy wind code
+			if(prob(10))
+				if(istype(L.get_active_hand(), /obj/item/weapon/melee/umbrella))
+					var/obj/item/weapon/melee/umbrella/U = L.get_active_hand()
+					if(U.open)
+						to_chat(L, "<span class='danger'>You struggle to keep hold of your umbrella!</span>")
+						L.Stun(20)	// This is not nearly as long as it seems
+						playsound(L, 'sound/effects/rustle1.ogg', 100, 1)	// Closest sound I've got to "Umbrella in the wind"
+				else if(istype(L.get_inactive_hand(), /obj/item/weapon/melee/umbrella))
+					var/obj/item/weapon/melee/umbrella/U = L.get_inactive_hand()
+					if(U.open)
+						to_chat(L, "<span class='danger'>A gust of wind yanks the umbrella from your hand!</span>")
+						playsound(L, 'sound/effects/rustle1.ogg', 100, 1)
+						L.drop_from_inventory(U)
+						U.toggle_umbrella()
+						U.throw_at(get_edge_target_turf(U, pick(alldirs)), 8, 1, L)
+
+			// If they have an open umbrella, it'll guard from rain
 			if(istype(L.get_active_hand(), /obj/item/weapon/melee/umbrella))
 				var/obj/item/weapon/melee/umbrella/U = L.get_active_hand()
 				if(U.open)
-					to_chat(L, "<span class='warning'>A gust of wind yanks the umbrella from your hand!</span>")
-					L.drop_from_inventory(U)
-					U.throw_at(get_edge_target_turf(U, pick(alldirs)), 8, 1, L)
+					if(show_message)
+						to_chat(L, "<span class='notice'>Rain showers loudly onto your umbrella!</span>")
+					continue
 			else if(istype(L.get_inactive_hand(), /obj/item/weapon/melee/umbrella))
 				var/obj/item/weapon/melee/umbrella/U = L.get_inactive_hand()
 				if(U.open)
-					to_chat(L, "<span class='warning'>A gust of wind yanks the umbrella from your hand!</span>")
-					L.drop_from_inventory(U)
-					U.throw_at(get_edge_target_turf(U, pick(alldirs)), 8, 1, L)
+					if(show_message)
+						to_chat(L, "<span class='notice'>Rain showers loudly onto your umbrella!</span>")
+					continue
+
 
 			L.water_act(2)
-			to_chat(L, "<span class='warning'>Rain falls on you, drenching you in water.</span>")
+			if(show_message)
+				to_chat(L, effect_message)
 
 	handle_lightning()
 


### PR DESCRIPTION
- Storms no longer automatically throw umbrellas out of hands, and is now RNG based.
- When it does decide to make wind, if the umbrella is in the active hand, it stuns for a few seconds, otherwise it throws the umbrella.