### PR TITLE
Adds the Biopsy Scanner to the Surgery Kit

### DIFF
--- a/code/game/objects/items/weapons/storage/firstaid.dm
+++ b/code/game/objects/items/weapons/storage/firstaid.dm
@@ -133,6 +133,7 @@
 		/obj/item/stack/medical/advanced/bruise_pack,
 		/obj/item/stack/nanopaste,
 		/obj/item/device/healthanalyzer/advanced
+		/obj/item/weapon/autopsy_scanner
 		)
 
 	starts_with = list(
@@ -147,6 +148,7 @@
 		/obj/item/weapon/surgical/FixOVein,
 		/obj/item/stack/medical/advanced/bruise_pack,
 		/obj/item/device/healthanalyzer/advanced
+		/obj/item/weapon/autopsy_scanner
 		)
 
 /obj/item/weapon/storage/firstaid/clotting

--- a/code/game/objects/items/weapons/storage/firstaid.dm
+++ b/code/game/objects/items/weapons/storage/firstaid.dm
@@ -132,7 +132,7 @@
 		/obj/item/weapon/surgical/FixOVein,
 		/obj/item/stack/medical/advanced/bruise_pack,
 		/obj/item/stack/nanopaste,
-		/obj/item/device/healthanalyzer/advanced
+		/obj/item/device/healthanalyzer/advanced,
 		/obj/item/weapon/autopsy_scanner
 		)
 
@@ -147,7 +147,7 @@
 		/obj/item/weapon/surgical/bonegel,
 		/obj/item/weapon/surgical/FixOVein,
 		/obj/item/stack/medical/advanced/bruise_pack,
-		/obj/item/device/healthanalyzer/advanced
+		/obj/item/device/healthanalyzer/advanced,
 		/obj/item/weapon/autopsy_scanner
 		)
 


### PR DESCRIPTION
Since it's actually used in a surgical operation, it should proooobably be in the kit. Iunno if the kit is really used here aside from antag shuttles, but they might as well have it.