### PR TITLE
Tweaks emitters and Pacman

### DIFF
--- a/code/modules/power/port_gen.dm
+++ b/code/modules/power/port_gen.dm
@@ -282,6 +282,7 @@
 				to_chat(user, "<span class='notice'>You unsecure the generator from the floor.</span>")
 			playsound(src.loc, 'sound/items/Deconstruct.ogg', 50, 1)
 			anchored = !anchored
+			return
 		else if(default_deconstruction_screwdriver(user, O))
 			return
 		else if(default_deconstruction_crowbar(user, O))

--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -65,18 +65,18 @@
 /obj/machinery/power/emitter/proc/activate(mob/user as mob)
 	if(state == 2)
 		if(!powernet)
-			user << "\The [src] isn't connected to a wire."
+			to_chat(user, "\The [src] isn't connected to a wire.")
 			return 1
 		if(!src.locked)
 			if(src.active==1)
 				src.active = 0
-				user << "You turn off [src]."
+				to_chat(user, "You turn off [src].")
 				message_admins("Emitter turned off by [key_name(user, user.client)](<A HREF='?_src_=holder;adminmoreinfo=\ref[user]'>?</A>) in ([x],[y],[z] - <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'>JMP</a>)",0,1)
 				log_game("EMITTER([x],[y],[z]) OFF by [key_name(user)]")
 				investigate_log("turned <font color='red'>off</font> by [user.key]","singulo")
 			else
 				src.active = 1
-				user << "You turn on [src]."
+				to_chat(user, "You turn on [src].")
 				src.shot_number = 0
 				src.fire_delay = get_initial_fire_delay()
 				message_admins("Emitter turned on by [key_name(user, user.client)](<A HREF='?_src_=holder;adminmoreinfo=\ref[user]'>?</A>) in ([x],[y],[z] - <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'>JMP</a>)",0,1)
@@ -84,9 +84,9 @@
 				investigate_log("turned <font color='green'>on</font> by [user.key]","singulo")
 			update_icon()
 		else
-			user << "<span class='warning'>The controls are locked!</span>"
+			to_chat(user, "<span class='warning'>The controls are locked!</span>")
 	else
-		user << "<span class='warning'>\The [src] needs to be firmly secured to the floor first.</span>"
+		to_chat(user, "<span class='warning'>\The [src] needs to be firmly secured to the floor first.</span>")
 		return 1
 
 
@@ -148,7 +148,7 @@
 
 	if(W.is_wrench())
 		if(active)
-			user << "Turn off [src] first."
+			to_chat(user, "Turn off [src] first.")
 			return
 		switch(state)
 			if(0)
@@ -167,17 +167,17 @@
 				src.anchored = 0
 				disconnect_from_network()
 			if(2)
-				user << "<span class='warning'>\The [src] needs to be unwelded from the floor.</span>"
+				to_chat(user, "<span class='warning'>\The [src] needs to be unwelded from the floor.</span>")
 		return
 
 	if(istype(W, /obj/item/weapon/weldingtool))
 		var/obj/item/weapon/weldingtool/WT = W
 		if(active)
-			user << "Turn off [src] first."
+			to_chat(user, "Turn off [src] first.")
 			return
 		switch(state)
 			if(0)
-				user << "<span class='warning'>\The [src] needs to be wrenched to the floor.</span>"
+				to_chat(user, "<span class='warning'>\The [src] needs to be wrenched to the floor.</span>")
 			if(1)
 				if (WT.remove_fuel(0,user))
 					playsound(loc, WT.usesound, 50, 1)
@@ -187,10 +187,10 @@
 					if (do_after(user,20 * WT.toolspeed))
 						if(!src || !WT.isOn()) return
 						state = 2
-						user << "You weld [src] to the floor."
+						to_chat(user, "You weld [src] to the floor.")
 						connect_to_network()
 				else
-					user << "<span class='warning'>You need more welding fuel to complete this task.</span>"
+					to_chat(user, "<span class='warning'>You need more welding fuel to complete this task.</span>")
 			if(2)
 				if (WT.remove_fuel(0,user))
 					playsound(loc, WT.usesound, 50, 1)
@@ -200,44 +200,40 @@
 					if (do_after(user,20 * WT.toolspeed))
 						if(!src || !WT.isOn()) return
 						state = 1
-						user << "You cut [src] free from the floor."
+						to_chat(user, "You cut [src] free from the floor.")
 						disconnect_from_network()
 				else
-					user << "<span class='warning'>You need more welding fuel to complete this task.</span>"
+					to_chat(user, "<span class='warning'>You need more welding fuel to complete this task.</span>")
 		return
 
 	if(istype(W, /obj/item/stack/material) && W.get_material_name() == DEFAULT_WALL_MATERIAL)
 		var/amt = Ceiling(( initial(integrity) - integrity)/10)
 		if(!amt)
-			user << "<span class='notice'>\The [src] is already fully repaired.</span>"
+			to_chat(user, "<span class='notice'>\The [src] is already fully repaired.</span>")
 			return
 		var/obj/item/stack/P = W
 		if(P.amount < amt)
-			user << "<span class='warning'>You don't have enough sheets to repair this! You need at least [amt] sheets.</span>"
+			to_chat(user, "<span class='warning'>You don't have enough sheets to repair this! You need at least [amt] sheets.</span>")
 			return
-		user << "<span class='notice'>You begin repairing \the [src]...</span>"
+		to_chat(user, "<span class='notice'>You begin repairing \the [src]...</span>")
 		if(do_after(user, 30))
 			if(P.use(amt))
-				user << "<span class='notice'>You have repaired \the [src].</span>"
+				to_chat(user, "<span class='notice'>You have repaired \the [src].</span>")
 				integrity = initial(integrity)
 				return
 			else
-				user << "<span class='warning'>You don't have enough sheets to repair this! You need at least [amt] sheets.</span>"
+				to_chat(user, "<span class='warning'>You don't have enough sheets to repair this! You need at least [amt] sheets.</span>")
 				return
 
 	if(istype(W, /obj/item/weapon/card/id) || istype(W, /obj/item/device/pda))
 		if(emagged)
-			user << "<span class='warning'>The lock seems to be broken.</span>"
+			to_chat(user, "<span class='warning'>The lock seems to be broken.</span>")
 			return
 		if(src.allowed(user))
-			if(active)
-				src.locked = !src.locked
-				user << "The controls are now [src.locked ? "locked." : "unlocked."]"
-			else
-				src.locked = 0 //just in case it somehow gets locked
-				user << "<span class='warning'>The controls can only be locked when [src] is online.</span>"
+			src.locked = !src.locked
+			to_chat(user, "The controls are now [src.locked ? "locked." : "unlocked."]")
 		else
-			user << "<span class='warning'>Access denied.</span>"
+			to_chat(user, "<span class='warning'>Access denied.</span>")
 		return
 	..()
 	return
@@ -274,11 +270,11 @@
 	var/integrity_percentage = round((integrity / initial(integrity)) * 100)
 	switch(integrity_percentage)
 		if(0 to 30)
-			user << "<span class='danger'>\The [src] is close to falling apart!</span>"
+			to_chat(user, "<span class='danger'>\The [src] is close to falling apart!</span>")
 		if(31 to 70)
-			user << "<span class='danger'>\The [src] is damaged.</span>"
+			to_chat(user, "<span class='danger'>\The [src] is damaged.</span>")
 		if(77 to 99)
-			user << "<span class='warning'>\The [src] is slightly damaged.</span>"
+			to_chat(user, "<span class='warning'>\The [src] is slightly damaged.</span>")
 
 //R-UST port
 /obj/machinery/power/emitter/proc/get_initial_fire_delay()

--- a/html/changelogs/Anewbe - Emitters.yml
+++ b/html/changelogs/Anewbe - Emitters.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Anewbe
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Emitters can be locked while off, too."


### PR DESCRIPTION
- Emitters can be locked in the `off` state, so that feature can actually protect the Supermatter.
- Pacman generator doesn't have a big red message when you anchor it, there was a missing return.