### PR TITLE
Adds a generic proc to the mining vendor to add custom / blank entries.

### DIFF
--- a/code/modules/mining/ore_redemption_machine/equipment_vendor.dm
+++ b/code/modules/mining/ore_redemption_machine/equipment_vendor.dm
@@ -177,6 +177,15 @@
 		// 	new /obj/item/twohanded/required/mining_hammer(drop_location)
 	qdel(voucher)
 
+/obj/machinery/mineral/equipment_vendor/proc/new_prize(var/name, var/path, var/cost) // Generic proc for adding new entries. Good for abusing for FUN and PROFIT.
+	if(!cost)
+		cost = 100
+	if(!path)
+		path = /obj/item/stack/marker_beacon
+	if(!name)
+		name = "Generic Entry"
+	prize_list += new /datum/data/mining_equipment(name, path, cost)
+
 /obj/machinery/mineral/equipment_vendor/ex_act(severity, target)
 	var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
 	s.set_up(5, 1, src)


### PR DESCRIPTION
On the tin, just background code for now.
May eventually be useful for cargo or science or illegal or looted designs for the vendor's bluespace 3D printer.