### PR TITLE
Fixes chem master dumping reagents.

### DIFF
--- a/code/modules/reagents/Chemistry-Machinery.dm
+++ b/code/modules/reagents/Chemistry-Machinery.dm
@@ -31,8 +31,8 @@
 
 /obj/machinery/chem_master/New()
 	..()
-	var/datum/reagents/R = new/datum/reagents(120)
-	reagents = R
+	var/datum/reagents/R = new/datum/reagents(900)	//Just a huge random number so the buffer should (probably) never dump your reagents. 
+	reagents = R	//There should be a nano ui thingy to warn of this.
 	R.my_atom = src
 
 /obj/machinery/chem_master/ex_act(severity)


### PR DESCRIPTION
Previously, if you used a bluespace beaker and transferred all of it's contents, the chem master buffer would silently drop all of those chemicals without warning.

https://github.com/VOREStation/VOREStation/issues/3756