### PR TITLE
Fix the condimaster not working.

### DIFF
--- a/nano/templates/chem_master.tmpl
+++ b/nano/templates/chem_master.tmpl
@@ -72,6 +72,11 @@
 				{{:helper.link('', 'pill pill' + data.pillSprite, {'tab_select' : 'pill'}, null, 'link32')}}
 				{{:helper.link('', 'pill bottle' + data.bottleSprite, {'tab_select' : 'bottle'}, null, 'link32')}}
 			</div>
+		{{else}}
+			<hr>
+			<div class='item'>
+				{{:helper.link('Create bottle (50 units max)', null, {'createbottle' : 1})}}
+			</div>
 		{{/if}}
 	{{/if}}
 


### PR DESCRIPTION
Previously, you simply couldn't make any condiment using this machine. Now you can. There was just missing template which is back in with this PR. (Thanks aronai.)
This means you should consider remplacing it in your kitchens.