### PR TITLE
Fixes missing sprites when excavating rocks

### DIFF
--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -452,6 +452,8 @@ var/list/mining_overlay_cache = list()
 				//update overlays displaying excavation level
 				if( !(excav_overlay && excavation_level > 0) || update_excav_overlay )
 					var/excav_quadrant = round(excavation_level / 25) + 1
+					if(excav_quadrant > 5)
+						excav_quadrant = 5
 					cut_overlay(excav_overlay)
 					excav_overlay = "overlay_excv[excav_quadrant]_[rand(1,3)]"
 					add_overlay(excav_overlay)


### PR DESCRIPTION
Fixes issue #5606 
Problem was caused by #5308 unintionally. That PR changed overlays to be cleared, updated and replaced but if "excav_quadrant" was greater than 5 it tried to forcibly add a 'level' of overlay sprite that didn't exist.  (Presumably previously the overlays were misbehaving anyway, hence the need for that PR)

Now that number can't exceed 5 so the overlay will remain at the highest level we actually have.