### PR TITLE
Fixes two anchored-related bugs, taped papers and the medbay phone.

### DIFF
--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -769,6 +769,7 @@ var/global/list/default_medbay_channels = list(
 	icon_state = "red_phone"
 	listening = 1
 	name = "phone"
+	anchored = FALSE
 
 /obj/item/device/radio/phone/medbay
 	frequency = MED_I_FREQ

--- a/code/game/objects/items/weapons/tape.dm
+++ b/code/game/objects/items/weapons/tape.dm
@@ -140,7 +140,7 @@
 	icon_state = "tape"
 	w_class = ITEMSIZE_TINY
 	plane = MOB_PLANE
-	anchored = 1 //it's sticky, no you cant move it
+	anchored = FALSE
 
 	var/obj/item/weapon/stuck = null
 
@@ -180,6 +180,10 @@
 		qdel(I)
 		to_chat(user, "<span-class='notice'>You place \the [I] back into \the [src].</span>")
 
+/obj/item/weapon/ducttape/attack_hand(mob/living/L)
+	anchored = FALSE
+	return ..() // Pick it up now that it's unanchored.
+
 /obj/item/weapon/ducttape/afterattack(var/A, mob/user, flag, params)
 
 	if(!in_range(user, A) || istype(A, /obj/machinery/door) || !stuck)
@@ -198,6 +202,7 @@
 	user.drop_from_inventory(src)
 	playsound(src, 'sound/effects/tape.ogg',25)
 	forceMove(source_turf)
+	anchored = TRUE
 
 	if(params)
 		var/list/mouse_control = params2list(params)


### PR DESCRIPTION
Anchored objects are not supposed to be able to be picked up or moved.
This makes those objects work again as before.