### PR TITLE
Adds Mods/Dev perms to ticket permission checks

### DIFF
--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -11,7 +11,7 @@
 		return
 
 	if(href_list["ahelp"])
-		if(!check_rights(R_ADMIN))
+		if(!check_rights(R_ADMIN|R_MOD|R_DEBUG))
 			return
 
 		var/ahelp_ref = href_list["ahelp"]

--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -503,7 +503,7 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 	set name = "Show Ticket List"
 	set category = "Admin"
 
-	if(!check_rights(R_ADMIN, TRUE))
+	if(!check_rights(R_ADMIN|R_MOD|R_DEBUG, TRUE))
 		return
 
 	var/browse_to


### PR DESCRIPTION
Currently, moderation staff can't answer tickets. That's pretty bad.
This changes it so that moderators, admins, and developers can answer tickets (Remember, an adminhelp isn't always about 'pls ban he', but might also be questions on how to do something, which a dev is generally an expert in how the game ~~doesn't~~ work).

Downstream servers might want to skip on this PR if their staff structure/permission setup is radically different from ours.