### PR TITLE
Update silicon manifest to discord dark theme.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ sudo: false
 env:
   global:
     - BYOND_MAJOR="512"
-    - BYOND_MINOR="1453"
+    - BYOND_MINOR="1414"
     - MACRO_COUNT=4
   matrix:
     - TEST_DEFINE="MAP_TEST" TEST_FILE="code/_map_tests.dm" RUN="0"

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -174,6 +174,9 @@
 // this function displays the stations manifest in a separate window
 /mob/living/silicon/proc/show_station_manifest()
 	var/dat = "<div align='center'>"
+	if(!data_core)
+		to_chat(src,"<span class='notice'>There is no data to form a manifest with. Contact your Nanotrasen administrator.</span>")
+		return
 	dat += data_core.get_manifest(1) //The 1 makes it monochrome.
 
 	var/datum/browser/popup = new(src, "Crew Manifest", "Crew Manifest", 370, 420, src)


### PR DESCRIPTION
It's actually just the same theme as ghosts but in monochrome.
![thing](https://cdn.discordapp.com/attachments/309966494199185409/504439495437844480/2018-10-24_01-41-48.png)