### PR TITLE
Hail tweaks

### DIFF
--- a/code/modules/planet/sif.dm
+++ b/code/modules/planet/sif.dm
@@ -400,38 +400,38 @@ var/datum/planet/sif/planet_sif = null
 
 /datum/weather/sif/hail/process_effects()
 	..()
-	for(var/mob/living/carbon/human/H in living_mob_list)
+	for(var/humie in human_mob_list)
+		var/mob/living/carbon/human/H = humie
 		if(H.z in holder.our_planet.expected_z_levels)
 			var/turf/T = get_turf(H)
 			if(!T.outdoors)
 				continue // They're indoors, so no need to pelt them with ice.
 
-			// If they have an open umbrella, it'll guard from rain
-			// Message plays every time the umbrella gets stolen, just so they're especially aware of what's happening
+			// If they have an open umbrella, it'll guard from hail
+			var/obj/item/weapon/melee/umbrella/U
 			if(istype(H.get_active_hand(), /obj/item/weapon/melee/umbrella))
-				var/obj/item/weapon/melee/umbrella/U = H.get_active_hand()
-				if(U.open)
-					if(show_message)
-						to_chat(H, "<span class='notice'>Hail patters gently onto your umbrella.</span>")
-					continue
+				U = H.get_active_hand()
 			else if(istype(H.get_inactive_hand(), /obj/item/weapon/melee/umbrella))
-				var/obj/item/weapon/melee/umbrella/U = H.get_inactive_hand()
-				if(U.open)
-					if(show_message)
-						to_chat(H, "<span class='notice'>Hail patters gently onto your umbrella.</span>")
-					continue
-
+				U = H.get_inactive_hand()
+			if(U && U.open)
+				if(show_message)
+					to_chat(H, "<span class='notice'>Hail patters onto your umbrella.</span>")
+				continue
+		
 			var/target_zone = pick(BP_ALL)
 			var/amount_blocked = H.run_armor_check(target_zone, "melee")
 			var/amount_soaked = H.get_armor_soak(target_zone, "melee")
 
-			if(amount_blocked >= 100)
+			var/damage = rand(1,3)
+
+			if(amount_blocked >= 30)
+				continue // No need to apply damage. Hardhats are 30. They should probably protect you from hail on your head.
+				//Voidsuits are likewise 40, and riot, 80. Clothes are all less than 30.
+
+			if(amount_soaked >= damage)
 				continue // No need to apply damage.
 
-			if(amount_soaked >= 10)
-				continue // No need to apply damage.
-
-			H.apply_damage(rand(1, 3), BRUTE, target_zone, amount_blocked, amount_soaked, used_weapon = "hail")
+			H.apply_damage(damage, BRUTE, target_zone, amount_blocked, amount_soaked, used_weapon = "hail")
 			if(show_message)
 				to_chat(H, effect_message)
 


### PR DESCRIPTION
Fixes #5412 
Related to https://github.com/VOREStation/VOREStation/issues/4040

Changes hail to not do damage if you're protected by 30 or more melee armor. So clothes won't protect you, softsuits won't protect you (and might puncture actually), but voidsuits and above will, as well as things like riot armor, combat helmets, hardhats, and generally things that should protect you from a tiny ('gently patters'?) ball of ice. Also makes armor soak not require 10 melee soak, since we're only doing 1-3 damage. Not sure why 10 would be required.

The 'better' way to do this would be to go around and assign soak values on all the armor, but I'm not gonna do that because that's a lot of work to fix hail.

The rest is just refactor, no gameplay/mechanical changes.