### PR TITLE
Updates Rapid Service Fabricators.

### DIFF
--- a/code/game/objects/items/weapons/RSF.dm
+++ b/code/game/objects/items/weapons/RSF.dm
@@ -7,55 +7,82 @@ RSF
 /obj/item/weapon/rsf
 	name = "\improper Rapid-Service-Fabricator"
 	desc = "A device used to rapidly deploy service items."
-	icon = 'icons/obj/items.dmi'
+	description_info = "Control Clicking on the device will allow you to choose the glass it dispenses when in the proper mode."
+	icon = 'icons/obj/tools.dmi'
 	icon_state = "rcd"
 	opacity = 0
 	density = 0
 	anchored = 0.0
 	var/stored_matter = 30
 	var/mode = 1
+	var/obj/item/weapon/reagent_containers/glasstype = /obj/item/weapon/reagent_containers/food/drinks/metaglass
+
+	var/list/container_types = list(
+		"metamorphic glass" = /obj/item/weapon/reagent_containers/food/drinks/metaglass,
+		"half-pint glass" = /obj/item/weapon/reagent_containers/food/drinks/glass2/square,
+		"rocks glass" = /obj/item/weapon/reagent_containers/food/drinks/glass2/rocks,
+		"milkshake glass" = /obj/item/weapon/reagent_containers/food/drinks/glass2/shake,
+		"cocktail glass" = /obj/item/weapon/reagent_containers/food/drinks/glass2/cocktail,
+		"shot glass" = /obj/item/weapon/reagent_containers/food/drinks/glass2/shot,
+		"pint glass" = /obj/item/weapon/reagent_containers/food/drinks/glass2/pint,
+		"mug" = /obj/item/weapon/reagent_containers/food/drinks/glass2/mug,
+		"wine glass" = /obj/item/weapon/reagent_containers/food/drinks/glass2/wine,
+		"condiment bottle" = /obj/item/weapon/reagent_containers/food/condiment
+		)
+
 	w_class = ITEMSIZE_NORMAL
 
 /obj/item/weapon/rsf/examine(mob/user)
 	if(..(user, 0))
-		user << "It currently holds [stored_matter]/30 fabrication-units."
+		to_chat(user,"<span class='notice'>It currently holds [stored_matter]/30 fabrication-units.</span>")
 
 /obj/item/weapon/rsf/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	..()
 	if (istype(W, /obj/item/weapon/rcd_ammo))
 
 		if ((stored_matter + 10) > 30)
-			user << "The RSF can't hold any more matter."
+			to_chat(user, "<span class='warning'>The RSF can't hold any more matter.</span>")
 			return
 
 		qdel(W)
 
 		stored_matter += 10
 		playsound(src.loc, 'sound/machines/click.ogg', 10, 1)
-		user << "The RSF now holds [stored_matter]/30 fabrication-units."
+		to_chat(user,"<span class='notice'>The RSF now holds [stored_matter]/30 fabrication-units.</span>")
 		return
+
+/obj/item/weapon/rsf/CtrlClick(mob/living/user)
+	if(!Adjacent(user) || !istype(user))
+		to_chat(user,"<span class='notice'>You are too far away.</span>")
+		return
+	var/glass_choice = input(user, "Please choose which type of glass you would like to produce.") as null|anything in container_types
+
+	if(glass_choice)
+		glasstype = container_types[glass_choice]
+	else
+		glasstype = /obj/item/weapon/reagent_containers/food/drinks/metaglass
 
 /obj/item/weapon/rsf/attack_self(mob/user as mob)
 	playsound(src.loc, 'sound/effects/pop.ogg', 50, 0)
 	if (mode == 1)
 		mode = 2
-		user << "Changed dispensing mode to 'Drinking Glass:Pint'"
+		to_chat(user,"<span class='notice'>Changed dispensing mode to 'Container'.</span>")
 		return
 	if (mode == 2)
 		mode = 3
-		user << "Changed dispensing mode to 'Paper'"
+		to_chat(user,"<span class='notice'>Changed dispensing mode to 'Paper'</span>")
 		return
 	if (mode == 3)
 		mode = 4
-		user << "Changed dispensing mode to 'Pen'"
+		to_chat(user,"<span class='notice'>Changed dispensing mode to 'Pen'</span>")
 		return
 	if (mode == 4)
 		mode = 5
-		user << "Changed dispensing mode to 'Dice Pack'"
+		to_chat(user,"<span class='notice'>Changed dispensing mode to 'Dice Pack'</span>")
 		return
 	if (mode == 5)
 		mode = 1
-		user << "Changed dispensing mode to 'Cigarette'"
+		to_chat(user,"<span class='notice'>Changed dispensing mode to 'Cigarette'</span>")
 		return
 
 /obj/item/weapon/rsf/afterattack(atom/A, mob/user as mob, proximity)
@@ -82,7 +109,7 @@ RSF
 			product = new /obj/item/clothing/mask/smokable/cigarette()
 			used_energy = 10
 		if(2)
-			product = new /obj/item/weapon/reagent_containers/food/drinks/glass2/pint()
+			product = new glasstype()
 			used_energy = 50
 		if(3)
 			product = new /obj/item/weapon/paper()
@@ -94,7 +121,7 @@ RSF
 			product = new /obj/item/weapon/storage/pill_bottle/dice()
 			used_energy = 200
 
-	user << "Dispensing [product ? product : "product"]..."
+	to_chat(user,"<span class='notice'>Dispensing [product ? product : "product"]...</span>")
 	product.loc = get_turf(A)
 
 	if(isrobot(user))
@@ -103,4 +130,4 @@ RSF
 			R.cell.use(used_energy)
 	else
 		stored_matter--
-		user << "The RSF now holds [stored_matter]/30 fabrication-units."
+		to_chat(user,"<span class='notice'>The RSF now holds [stored_matter]/30 fabrication-units.</span>")

--- a/html/changelogs/Mechoid-RSFs.yml
+++ b/html/changelogs/Mechoid-RSFs.yml
@@ -1,0 +1,37 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Mechoid
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Ctrl clicking a Rapid Service Fabricator when held will allow you to choose the container it deploys."
+  - bugfix: "The Rapid Service Fabricator's icon is correctly set."


### PR DESCRIPTION
Rapid Service Fabricators now have glorious to_chats.
Ctrl clicking an RSF allows you to choose the container it prints, out of the existing bar containers.
RSFs have a sprite again.