### PR TITLE
Promethean Regen tweaks. (The one with the devil's deal.)

### DIFF
--- a/code/modules/mob/living/carbon/human/human_powers.dm
+++ b/code/modules/mob/living/carbon/human/human_powers.dm
@@ -307,7 +307,7 @@
 				organ_data["descriptor"] = O.name
 				to_chat(src, "<span class='notice'>You feel a slithering sensation as your [O.name] reform.</span>")
 
-				var/agony_to_apply = round(0.66 * O.max_damage) // 60% of the limb's health is converted into pain
+				var/agony_to_apply = round(0.66 * O.max_damage) // 60% of the limb's health is converted into pain.
 				src.apply_damage(agony_to_apply, HALLOSS)
 
 		update_icons_body()

--- a/code/modules/mob/living/carbon/human/human_powers.dm
+++ b/code/modules/mob/living/carbon/human/human_powers.dm
@@ -293,6 +293,7 @@
 		// Replace completely missing limbs.
 		for(var/limb_type in src.species.has_limbs)
 			var/obj/item/organ/external/E = src.organs_by_name[limb_type]
+
 			if(E && E.disfigured)
 				E.disfigured = 0
 			if(E && (E.is_stump() || (E.status & (ORGAN_DESTROYED|ORGAN_DEAD|ORGAN_MUTATED))))
@@ -305,6 +306,10 @@
 				var/obj/item/organ/O = new limb_path(src)
 				organ_data["descriptor"] = O.name
 				to_chat(src, "<span class='notice'>You feel a slithering sensation as your [O.name] reform.</span>")
+
+				var/agony_to_apply = round(0.66 * O.max_damage) // 60% of the limb's health is converted into pain
+				src.apply_damage(agony_to_apply, HALLOSS)
+
 		update_icons_body()
 		active_regen = FALSE
 	else

--- a/code/modules/mob/living/carbon/human/human_powers.dm
+++ b/code/modules/mob/living/carbon/human/human_powers.dm
@@ -307,7 +307,7 @@
 				organ_data["descriptor"] = O.name
 				to_chat(src, "<span class='notice'>You feel a slithering sensation as your [O.name] reform.</span>")
 
-				var/agony_to_apply = round(0.66 * O.max_damage) // 60% of the limb's health is converted into pain.
+				var/agony_to_apply = round(0.66 * O.max_damage) // 66% of the limb's health is converted into pain.
 				src.apply_damage(agony_to_apply, HALLOSS)
 
 		update_icons_body()

--- a/code/modules/mob/living/carbon/human/species/station/prometheans.dm
+++ b/code/modules/mob/living/carbon/human/species/station/prometheans.dm
@@ -206,7 +206,8 @@ var/datum/species/shapeshifter/promethean/prometheans
 			H.nutrition = max(0, H.nutrition) //Ensure it's not below 0.
 
 			var/agony_to_apply = ((1 / starve_mod) * nutrition_cost) //Regenerating damage causes minor pain over time. Small injures will be no issue, large ones will cause problems.
-			H.apply_damage(agony_to_apply, HALLOSS)
+			if((H.getHalLoss() + agony_to_apply) <= 70) // Don't permalock, but make it far easier to knock them down.
+				H.apply_damage(agony_to_apply, HALLOSS)
 
 	else
 		H.adjustToxLoss(2*heal_rate)	// Doubled because 0.5 is miniscule, and fire_stacks are capped in both directions

--- a/code/modules/mob/living/carbon/human/species/station/prometheans.dm
+++ b/code/modules/mob/living/carbon/human/species/station/prometheans.dm
@@ -182,8 +182,12 @@ var/datum/species/shapeshifter/promethean/prometheans
 			nutrition_debt = H.getToxLoss()
 			H.adjustToxLoss(-heal_rate * starve_mod)
 			nutrition_cost += nutrition_debt - H.getToxLoss()
-			H.nutrition -= (2 * nutrition_cost) //Costs Nutrition when damage is being repaired, corresponding to the amount of damage being repaired.
+			H.nutrition -= (3 * nutrition_cost) //Costs Nutrition when damage is being repaired, corresponding to the amount of damage being repaired.
 			H.nutrition = max(0, H.nutrition) //Ensure it's not below 0.
+
+			var/agony_to_apply = ((1 / starve_mod) * nutrition_cost) //Regenerating damage causes minor pain over time. Small injures will be no issue, large ones will cause problems.
+			H.apply_damage(agony_to_apply, HALLOSS)
+
 	else
 		H.adjustToxLoss(2*heal_rate)	// Doubled because 0.5 is miniscule, and fire_stacks are capped in both directions
 

--- a/code/modules/mob/living/carbon/human/species/station/prometheans.dm
+++ b/code/modules/mob/living/carbon/human/species/station/prometheans.dm
@@ -149,6 +149,10 @@ var/datum/species/shapeshifter/promethean/prometheans
 			H.gib()
 
 /datum/species/shapeshifter/promethean/handle_environment_special(var/mob/living/carbon/human/H)
+	var/regen_brute = 1
+	var/regen_burn = 1
+	var/regen_tox = 1
+	var/regen_oxy = 1
 
 	var/turf/T = H.loc
 	if(istype(T))
@@ -160,28 +164,44 @@ var/datum/species/shapeshifter/promethean/prometheans
 				S.dirt = 0
 			H.nutrition = min(500, max(0, H.nutrition + rand(15, 30)))
 
+	T = get_turf(H) // Swap over to an actual turf, because we need to get the pressure.
+	if(istype(T)) // Make sure it exists, and is a turf again.
+		var/datum/gas_mixture/environment = T.return_air()
+		var/pressure = environment.return_pressure()
+		var/affecting_pressure = H.calculate_affecting_pressure(pressure)
+		if(affecting_pressure <= hazard_low_pressure) // Dangerous low pressure stops the regeneration of physical wounds. Body is focusing on keeping them intact rather than sealing.
+			regen_brute = 0
+			regen_burn = 0
+
 	// Heal remaining damage.
 	if(H.fire_stacks >= 0)
 		if(H.getBruteLoss() || H.getFireLoss() || H.getOxyLoss() || H.getToxLoss())
 			var/nutrition_cost = 0
-			var/nutrition_debt = H.getBruteLoss()
+			var/nutrition_debt = 0
 			var/starve_mod = 1
 			if(H.nutrition <= 25)
 				starve_mod = 0.75
-			H.adjustBruteLoss(-heal_rate * starve_mod)
-			nutrition_cost += nutrition_debt - H.getBruteLoss()
 
-			nutrition_debt = H.getFireLoss()
-			H.adjustFireLoss(-heal_rate * starve_mod)
-			nutrition_cost += nutrition_debt - H.getFireLoss()
+			if(regen_brute)
+				nutrition_debt = H.getBruteLoss()
+				H.adjustBruteLoss(-heal_rate * starve_mod)
+				nutrition_cost += nutrition_debt - H.getBruteLoss()
 
-			nutrition_debt = H.getOxyLoss()
-			H.adjustOxyLoss(-heal_rate * starve_mod)
-			nutrition_cost += nutrition_debt - H.getOxyLoss()
+			if(regen_burn)
+				nutrition_debt = H.getFireLoss()
+				H.adjustFireLoss(-heal_rate * starve_mod)
+				nutrition_cost += nutrition_debt - H.getFireLoss()
 
-			nutrition_debt = H.getToxLoss()
-			H.adjustToxLoss(-heal_rate * starve_mod)
-			nutrition_cost += nutrition_debt - H.getToxLoss()
+			if(regen_oxy)
+				nutrition_debt = H.getOxyLoss()
+				H.adjustOxyLoss(-heal_rate * starve_mod)
+				nutrition_cost += nutrition_debt - H.getOxyLoss()
+
+			if(regen_tox)
+				nutrition_debt = H.getToxLoss()
+				H.adjustToxLoss(-heal_rate * starve_mod)
+				nutrition_cost += nutrition_debt - H.getToxLoss()
+
 			H.nutrition -= (3 * nutrition_cost) //Costs Nutrition when damage is being repaired, corresponding to the amount of damage being repaired.
 			H.nutrition = max(0, H.nutrition) //Ensure it's not below 0.
 


### PR DESCRIPTION
Promethean passive regeneration and universal active regeneration now cause pain. Active regeneration is, percentage wise, less painful than passive regeneration at 50% pain conversion to passive 66%. This makes both regeneration forms something better for use outside of combat or high-risk situations, as it will eventually cause incapacitation if left unchecked, on top of normal injury pain.

Promethean brute and burn regeneration will not function in dangerously low pressure, however toxin and oxy (the latter not currently used) will continue as normal. Voidsuits and other sealed suits keep the regeneration active.