### PR TITLE
Adds Autolathe Cost to Knuckledusters

### DIFF
--- a/code/modules/clothing/gloves/miscellaneous.dm
+++ b/code/modules/clothing/gloves/miscellaneous.dm
@@ -119,6 +119,7 @@
 	name = "knuckle dusters"
 	desc = "A pair of brass knuckles. Generally used to enhance the user's punches."
 	icon_state = "knuckledusters"
+	matter = list(DEFAULT_WALL_MATERIAL = 500)
 	attack_verb = list("punched", "beaten", "struck")
 	flags = THICKMATERIAL	// Stops rings from increasing hit strength
 	siemens_coefficient = 1


### PR DESCRIPTION
Fixes #5716 

The matter cost is the same as the tactical knife (500 steel which translates to 625 steel in an autolathe without upgrades).