### PR TITLE
Fixes Area Initialization

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -68,10 +68,8 @@
 		power_light = 0
 		power_equip = 0
 		power_environ = 0
-	return INITIALIZE_HINT_LATELOAD
-
-/area/LateInitialize()
 	power_change()		// all machines set to current power level, also updates lighting icon
+	return INITIALIZE_HINT_LATELOAD
 
 /area/proc/get_contents()
 	return contents


### PR DESCRIPTION
Two procs had the exact same name, so the first one never got ran.

This fixes it, meaning now that areas without APCs are not considered powered.
This will make PoIs w/o an APC not function as a source of power unless explicitly given magic power like the UFO.