### PR TITLE
Add scheduled callbacks

### DIFF
--- a/code/_helpers/unsorted.dm
+++ b/code/_helpers/unsorted.dm
@@ -1436,5 +1436,24 @@ var/mob/dview/dview_mob = new
 		if(337.5)
 			return "North-Northwest"
 
+//This is used to force compiletime errors if you incorrectly supply variable names. Crafty!
+#define NAMEOF(datum, X) (#X || ##datum.##X)
+
+//Creates a callback with the specific purpose of setting a variable
+#define VARSET_CALLBACK(datum, var, var_value) CALLBACK(GLOBAL_PROC, /proc/___callbackvarset, weakref(##datum), NAMEOF(##datum, ##var), ##var_value)
+
+//Helper for the above
+/proc/___callbackvarset(list_or_datum, var_name, var_value)
+	if(isweakref(list_or_datum))
+		var/weakref/wr = list_or_datum
+		list_or_datum = wr.resolve()
+	if(!list_or_datum)
+		return
+	if(length(list_or_datum))
+		list_or_datum[var_name] = var_value
+		return
+	var/datum/D = list_or_datum
+	D.vars[var_name] = var_value
+
 /proc/pass()
 	return

--- a/code/controllers/Processes/scheduler.dm
+++ b/code/controllers/Processes/scheduler.dm
@@ -58,11 +58,19 @@
 /proc/schedule_task_in(var/in_time, var/procedure, var/list/arguments = list())
 	return schedule_task(world.time + in_time, procedure, arguments)
 
+/proc/schedule_callback_in(var/in_time, var/datum/callback)
+	return schedule_callback(world.time + in_time, callback)
+
 /proc/schedule_task_with_source_in(var/in_time, var/source, var/procedure, var/list/arguments = list())
 	return schedule_task_with_source(world.time + in_time, source, procedure, arguments)
 
 /proc/schedule_task(var/trigger_time, var/procedure, var/list/arguments)
 	var/datum/scheduled_task/st = new/datum/scheduled_task(trigger_time, procedure, arguments, /proc/destroy_scheduled_task, list())
+	scheduler.schedule(st)
+	return st
+
+/proc/schedule_callback(var/trigger_time, var/datum/callback)
+	var/datum/scheduled_task/callback/st = new/datum/scheduled_task/callback(trigger_time, callback, /proc/destroy_scheduled_task, list())
 	scheduler.schedule(st)
 	return st
 
@@ -124,6 +132,15 @@
 // Resets the trigger time, has no effect if the task has already triggered
 /datum/scheduled_task/proc/trigger_task_in(var/trigger_in)
 	src.trigger_time = world.time + trigger_in
+
+/datum/scheduled_task/callback
+	var/datum/callback/callback
+
+/datum/scheduled_task/callback/New(var/trigger_time, var/datum/callback, var/proc/task_after_process, var/list/task_after_process_args)
+	..(trigger_time = trigger_time, task_after_process = task_after_process, task_after_process_args = task_after_process_args)
+
+/datum/scheduled_task/callback/process()
+	callback.Invoke()
 
 /datum/scheduled_task/source
 	var/datum/source


### PR DESCRIPTION
And include a callback for setting vars.

You'd use it like `schedule_callback_in(5 SECONDS, VARSET_CALLBACK(src, myvarname, FALSE))` if you wanted to set `myvarname` to `FALSE` in 5 seconds.

This was originally going to be a bugfix to you but I guess I totally forgot that I didn't actually send this to you originally.