### PR TITLE
Fixes unnecessary submap item rotation on load

### DIFF
--- a/code/modules/maps/tg/reader.dm
+++ b/code/modules/maps/tg/reader.dm
@@ -311,8 +311,6 @@ var/global/use_preloader = FALSE
 			// Rotate dir if orientation isn't south (default)
 			if(fields["dir"])
 				fields["dir"] = turn(fields["dir"], dir2angle(orientation) + 180)
-			else
-				fields["dir"] = turn(SOUTH, dir2angle(orientation) + 180)
 
 			//then fill the members_attributes list with the corresponding variables
 			members_attributes.len++


### PR DESCRIPTION
The comment said "Rotate dir _if_ orientation isn't south (default)". The loading was forcibly rotating everything that either had no relevance of direction, or had been intentionally set to not face a _sideways_ direction (full windows etc), to south during load regardless of conditions.
While the issue priority here was marked low as a PoI exclusive thing, this thing also affects roundstart engine rotation _(and thus half of the engineering)_ where enabled among other things.