### PR TITLE
Adds ability to selectively disable submap rotation.

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -228,6 +228,8 @@ var/list/gamemode_cache = list()
 	var/radiation_resistance_multiplier = 6.5
 	var/radiation_lower_limit = 0.35 //If the radiation level for a turf would be below this, ignore it.
 
+	var/random_submap_orientation = FALSE // If true, submaps loaded automatically can be rotated.
+
 /datum/configuration/New()
 	var/list/L = typesof(/datum/game_mode) - /datum/game_mode
 	for (var/T in L)
@@ -747,6 +749,9 @@ var/list/gamemode_cache = list()
 
 				if ("paranoia_logging")
 					config.paranoia_logging = 1
+
+				if("random_submap_orientation")
+					config.random_submap_orientation = 1
 
 				else
 					log_misc("Unknown setting in configuration: '[name]'")

--- a/code/modules/maps/tg/map_template.dm
+++ b/code/modules/maps/tg/map_template.dm
@@ -19,6 +19,7 @@ var/list/global/map_templates = list()
 	var/mappath = null
 	var/loaded = 0 // Times loaded this round
 	var/annihilate = FALSE // If true, all (movable) atoms at the location where the map is loaded will be deleted before the map is loaded in.
+	var/fixed_orientation = FALSE // If true, the submap will not be rotated randomly when loaded.
 
 	var/cost = null // The map generator has a set 'budget' it spends to place down different submaps. It will pick available submaps randomly until \
 	it runs out. The cost of a submap should roughly corrispond with several factors such as size, loot, difficulty, desired scarcity, etc. \
@@ -225,7 +226,13 @@ var/list/global/map_templates = list()
 		var/specific_sanity = 100 // A hundred chances to place the chosen submap.
 		while(specific_sanity > 0)
 			specific_sanity--
-			var/orientation = pick(cardinal)
+
+			var/orientation
+			if(chosen_template.fixed_orientation || !config.random_submap_orientation)
+				orientation = SOUTH
+			else
+				orientation = pick(cardinal)
+
 			chosen_template.preload_size(chosen_template.mappath, orientation)
 			var/width_border = TRANSITIONEDGE + SUBMAP_MAP_EDGE_PAD + round(((orientation & NORTH|SOUTH) ? chosen_template.width : chosen_template.height) / 2)
 			var/height_border = TRANSITIONEDGE + SUBMAP_MAP_EDGE_PAD + round(((orientation & NORTH|SOUTH) ? chosen_template.height : chosen_template.width) / 2)

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -408,3 +408,8 @@ STARLIGHT 0
 
 ## Uncomment to enable Paranoia Logging. This will notify admins and write to a file any time a new player (byond or your server) connects.
 # PARANOIA_LOGGING
+
+## Uncomment to enable submaps to have their orientation rotated randomly during map generation.
+## Submap rotation is an experimental feature and can cause bugs and weirdness if certain objects inside the submap are coded poorly.
+## Submaps can still be rotated when loading manually with the admin verbs, if desired.
+# RANDOM_SUBMAP_ORIENTATION

--- a/maps/submaps/surface_submaps/plains/plains.dm
+++ b/maps/submaps/surface_submaps/plains/plains.dm
@@ -68,6 +68,7 @@
 	desc = "A bunch of marker beacons, scattered in a strange pattern."
 	mappath = 'maps/submaps/surface_submaps/plains/beacons.dmm'
 	cost = 5
+	fixed_orientation = TRUE
 
 /datum/map_template/surface/plains/Epod
 	name = "Emergency Pod"


### PR DESCRIPTION
Submap rotation can be disabled globally with a config change now.
They can also be disabled on a per-map basis, in case there is a submap that really should not be rotated.
Note that admins loading in submaps can still rotate the submap if they choose to do so regardless of what the config or the submap datum says.

The beacon Point of Interest now has a fixed orientation, as changing the orientation caused the perspective to change, and as a result caused the meaning of the map to be loss.