### PR TITLE
Adds BIOACID damage type

### DIFF
--- a/code/__defines/damage_organs.dm
+++ b/code/__defines/damage_organs.dm
@@ -7,6 +7,7 @@
 #define CLONE     "clone"
 #define HALLOSS   "halloss"
 #define ELECTROCUTE "electrocute"
+#define BIOACID   "bioacid"
 
 #define CUT       "cut"
 #define BRUISE    "bruise"

--- a/code/modules/mob/living/damage_procs.dm
+++ b/code/modules/mob/living/damage_procs.dm
@@ -36,6 +36,11 @@
 			adjustHalLoss(damage * blocked)
 		if(ELECTROCUTE)
 			electrocute_act(damage, used_weapon, 1.0, def_zone)
+		if(BIOACID)
+			if(isSynthetic())
+				adjustFireLoss(damage * blocked)
+			else
+				adjustToxLoss(damage * blocked)
 	flash_weak_pain()
 	updatehealth()
 	return 1

--- a/code/modules/projectiles/projectile/energy.dm
+++ b/code/modules/projectiles/projectile/energy.dm
@@ -123,6 +123,7 @@
 	damage_type = BURN
 	agony = 10
 	check_armour = "bio"
+	armor_penetration = 25	// It's acid
 
 	combustion = FALSE
 
@@ -130,9 +131,10 @@
 	name = "neurotoxic spit"
 	icon_state = "neurotoxin"
 	damage = 5
-	damage_type = TOX
+	damage_type = BIOACID
 	agony = 80
 	check_armour = "bio"
+	armor_penetration = 25	// It's acid-based
 
 	combustion = FALSE
 
@@ -140,9 +142,10 @@
 	name = "neurotoxic spit"
 	icon_state = "neurotoxin"
 	damage = 20
-	damage_type = TOX
+	damage_type = BIOACID
 	agony = 20
 	check_armour = "bio"
+	armor_penetration = 25	// It's acid-based
 
 /obj/item/projectile/energy/phoron
 	name = "phoron bolt"


### PR DESCRIPTION
Adds a new BIOACID damage type, that burns synthetics and poisons organics. Feels more sensible than having neurotoxin cause robots to start glitching out.

Two of the alien spits now do BIOACID, rather than TOX.

Alien spits now have 25 armor pen, because it's acid. Biosuit ain't gon' save you from melting.