### PR TITLE
Standardizes rotation verbs

### DIFF
--- a/code/ATMOSPHERICS/components/binary_devices/circulator.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/circulator.dm
@@ -125,24 +125,24 @@
 		..()
 
 /obj/machinery/atmospherics/binary/circulator/verb/rotate_clockwise()
+	set name = "Rotate Circulator Clockwise"
 	set category = "Object"
-	set name = "Rotate Circulator (Clockwise)"
+	set src in view(1)
+
+	if (usr.stat || usr.restrained() || anchored)
+		return
+
+	src.set_dir(turn(src.dir, 270))
+	desc = initial(desc) + " Its outlet port is to the [dir2text(dir)]."
+
+
+/obj/machinery/atmospherics/binary/circulator/verb/rotate_counterclockwise()
+	set name = "Rotate Circulator Counterclockwise"
+	set category = "Object"
 	set src in view(1)
 
 	if (usr.stat || usr.restrained() || anchored)
 		return
 
 	src.set_dir(turn(src.dir, 90))
-	desc = initial(desc) + " Its outlet port is to the [dir2text(dir)]."
-
-
-/obj/machinery/atmospherics/binary/circulator/verb/rotate_anticlockwise()
-	set category = "Object"
-	set name = "Rotate Circulator (Counterclockwise)"
-	set src in view(1)
-
-	if (usr.stat || usr.restrained() || anchored)
-		return
-
-	src.set_dir(turn(src.dir, -90))
 	desc = initial(desc) + " Its outlet port is to the [dir2text(dir)]."

--- a/code/ATMOSPHERICS/components/binary_devices/pipeturbine.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/pipeturbine.dm
@@ -20,209 +20,210 @@
 	var/datum/pipe_network/network1
 	var/datum/pipe_network/network2
 
-	New()
-		..()
-		air_in.volume = 200
-		air_out.volume = 800
-		volume_ratio = air_in.volume / (air_in.volume + air_out.volume)
-		switch(dir)
-			if(NORTH)
+/obj/machinery/atmospherics/pipeturbine/New()
+	..()
+	air_in.volume = 200
+	air_out.volume = 800
+	volume_ratio = air_in.volume / (air_in.volume + air_out.volume)
+	switch(dir)
+		if(NORTH)
+			initialize_directions = EAST|WEST
+		if(SOUTH)
+			initialize_directions = EAST|WEST
+		if(EAST)
+			initialize_directions = NORTH|SOUTH
+		if(WEST)
+			initialize_directions = NORTH|SOUTH
+
+/obj/machinery/atmospherics/pipeturbine/Destroy()
+	. = ..()
+
+	if(node1)
+		node1.disconnect(src)
+		qdel(network1)
+	if(node2)
+		node2.disconnect(src)
+		qdel(network2)
+
+	node1 = null
+	node2 = null
+
+/obj/machinery/atmospherics/pipeturbine/process()
+	..()
+	if(anchored && !(stat&BROKEN))
+		kin_energy *= 1 - kin_loss
+		dP = max(air_in.return_pressure() - air_out.return_pressure(), 0)
+		if(dP > 10)
+			kin_energy += 1/ADIABATIC_EXPONENT * dP * air_in.volume * (1 - volume_ratio**ADIABATIC_EXPONENT) * efficiency
+			air_in.temperature *= volume_ratio**ADIABATIC_EXPONENT
+
+			var/datum/gas_mixture/air_all = new
+			air_all.volume = air_in.volume + air_out.volume
+			air_all.merge(air_in.remove_ratio(1))
+			air_all.merge(air_out.remove_ratio(1))
+
+			air_in.merge(air_all.remove(volume_ratio))
+			air_out.merge(air_all)
+
+		update_icon()
+
+	if (network1)
+		network1.update = 1
+	if (network2)
+		network2.update = 1
+
+/obj/machinery/atmospherics/pipeturbine/update_icon()
+	overlays.Cut()
+	if (dP > 10)
+		overlays += image('icons/obj/pipeturbine.dmi', "moto-turb")
+	if (kin_energy > 100000)
+		overlays += image('icons/obj/pipeturbine.dmi', "low-turb")
+	if (kin_energy > 500000)
+		overlays += image('icons/obj/pipeturbine.dmi', "med-turb")
+	if (kin_energy > 1000000)
+		overlays += image('icons/obj/pipeturbine.dmi', "hi-turb")
+
+/obj/machinery/atmospherics/pipeturbine/attackby(obj/item/weapon/W as obj, mob/user as mob)
+	if(W.is_wrench())
+		anchored = !anchored
+		playsound(src, W.usesound, 50, 1)
+		to_chat(user, "<span class='notice'>You [anchored ? "secure" : "unsecure"] the bolts holding \the [src] to the floor.</span>")
+
+		if(anchored)
+			if(dir & (NORTH|SOUTH))
 				initialize_directions = EAST|WEST
-			if(SOUTH)
-				initialize_directions = EAST|WEST
-			if(EAST)
-				initialize_directions = NORTH|SOUTH
-			if(WEST)
+			else if(dir & (EAST|WEST))
 				initialize_directions = NORTH|SOUTH
 
-	Destroy()
-		. = ..()
-
-		if(node1)
-			node1.disconnect(src)
-			qdel(network1)
-		if(node2)
-			node2.disconnect(src)
-			qdel(network2)
-
-		node1 = null
-		node2 = null
-
-	process()
-		..()
-		if(anchored && !(stat&BROKEN))
-			kin_energy *= 1 - kin_loss
-			dP = max(air_in.return_pressure() - air_out.return_pressure(), 0)
-			if(dP > 10)
-				kin_energy += 1/ADIABATIC_EXPONENT * dP * air_in.volume * (1 - volume_ratio**ADIABATIC_EXPONENT) * efficiency
-				air_in.temperature *= volume_ratio**ADIABATIC_EXPONENT
-
-				var/datum/gas_mixture/air_all = new
-				air_all.volume = air_in.volume + air_out.volume
-				air_all.merge(air_in.remove_ratio(1))
-				air_all.merge(air_out.remove_ratio(1))
-
-				air_in.merge(air_all.remove(volume_ratio))
-				air_out.merge(air_all)
-
-			update_icon()
-
-		if (network1)
-			network1.update = 1
-		if (network2)
-			network2.update = 1
-
-	update_icon()
-		overlays.Cut()
-		if (dP > 10)
-			overlays += image('icons/obj/pipeturbine.dmi', "moto-turb")
-		if (kin_energy > 100000)
-			overlays += image('icons/obj/pipeturbine.dmi', "low-turb")
-		if (kin_energy > 500000)
-			overlays += image('icons/obj/pipeturbine.dmi', "med-turb")
-		if (kin_energy > 1000000)
-			overlays += image('icons/obj/pipeturbine.dmi', "hi-turb")
-
-	attackby(obj/item/weapon/W as obj, mob/user as mob)
-		if(W.is_wrench())
-			anchored = !anchored
-			playsound(src, W.usesound, 50, 1)
-			to_chat(user, "<span class='notice'>You [anchored ? "secure" : "unsecure"] the bolts holding \the [src] to the floor.</span>")
-
-			if(anchored)
-				if(dir & (NORTH|SOUTH))
-					initialize_directions = EAST|WEST
-				else if(dir & (EAST|WEST))
-					initialize_directions = NORTH|SOUTH
-
-				atmos_init()
-				build_network()
-				if (node1)
-					node1.atmos_init()
-					node1.build_network()
-				if (node2)
-					node2.atmos_init()
-					node2.build_network()
-			else
-				if(node1)
-					node1.disconnect(src)
-					qdel(network1)
-				if(node2)
-					node2.disconnect(src)
-					qdel(network2)
-
-				node1 = null
-				node2 = null
-
+			atmos_init()
+			build_network()
+			if (node1)
+				node1.atmos_init()
+				node1.build_network()
+			if (node2)
+				node2.atmos_init()
+				node2.build_network()
 		else
-			..()
+			if(node1)
+				node1.disconnect(src)
+				qdel(network1)
+			if(node2)
+				node2.disconnect(src)
+				qdel(network2)
 
-	verb/rotate_clockwise()
-		set category = "Object"
-		set name = "Rotate Circulator (Clockwise)"
-		set src in view(1)
-
-		if (usr.stat || usr.restrained() || anchored)
-			return
-
-		src.set_dir(turn(src.dir, -90))
-
-
-	verb/rotate_anticlockwise()
-		set category = "Object"
-		set name = "Rotate Circulator (Counterclockwise)"
-		set src in view(1)
-
-		if (usr.stat || usr.restrained() || anchored)
-			return
-
-		src.set_dir(turn(src.dir, 90))
-
-//Goddamn copypaste from binary base class because atmospherics machinery API is not damn flexible
-	get_neighbor_nodes_for_init()
-		return list(node1, node2)
-
-	network_expand(datum/pipe_network/new_network, obj/machinery/atmospherics/pipe/reference)
-		if(reference == node1)
-			network1 = new_network
-
-		else if(reference == node2)
-			network2 = new_network
-
-		if(new_network.normal_members.Find(src))
-			return 0
-
-		new_network.normal_members += src
-
-		return null
-
-	atmos_init()
-		if(node1 && node2) return
-
-		var/node2_connect = turn(dir, -90)
-		var/node1_connect = turn(dir, 90)
-
-		for(var/obj/machinery/atmospherics/target in get_step(src,node1_connect))
-			if(target.initialize_directions & get_dir(target,src))
-				node1 = target
-				break
-
-		for(var/obj/machinery/atmospherics/target in get_step(src,node2_connect))
-			if(target.initialize_directions & get_dir(target,src))
-				node2 = target
-				break
-
-	build_network()
-		if(!network1 && node1)
-			network1 = new /datum/pipe_network()
-			network1.normal_members += src
-			network1.build_network(node1, src)
-
-		if(!network2 && node2)
-			network2 = new /datum/pipe_network()
-			network2.normal_members += src
-			network2.build_network(node2, src)
-
-
-	return_network(obj/machinery/atmospherics/reference)
-		build_network()
-
-		if(reference==node1)
-			return network1
-
-		if(reference==node2)
-			return network2
-
-		return null
-
-	reassign_network(datum/pipe_network/old_network, datum/pipe_network/new_network)
-		if(network1 == old_network)
-			network1 = new_network
-		if(network2 == old_network)
-			network2 = new_network
-
-		return 1
-
-	return_network_air(datum/pipe_network/reference)
-		var/list/results = list()
-
-		if(network1 == reference)
-			results += air_in
-		if(network2 == reference)
-			results += air_out
-
-		return results
-
-	disconnect(obj/machinery/atmospherics/reference)
-		if(reference==node1)
-			qdel(network1)
 			node1 = null
-
-		else if(reference==node2)
-			qdel(network2)
 			node2 = null
 
-		return null
+		return
+	..()
+
+/obj/machinery/atmospherics/pipeturbine/verb/rotate_clockwise()
+	set name = "Rotate Turbine Clockwise"
+	set category = "Object"
+	set src in view(1)
+
+	if (usr.stat || usr.restrained() || anchored)
+		return
+
+	src.set_dir(turn(src.dir, 270))
+
+
+/obj/machinery/atmospherics/pipeturbine/verb/rotate_counterclockwise()
+	set name = "Rotate Turbine Counterclockwise"
+	set category = "Object"
+	set src in view(1)
+
+	if (usr.stat || usr.restrained() || anchored)
+		return
+
+	src.set_dir(turn(src.dir, 90))
+
+//Goddamn copypaste from binary base class because atmospherics machinery API is not damn flexible
+/obj/machinery/atmospherics/pipeturbine/get_neighbor_nodes_for_init()
+	return list(node1, node2)
+
+/obj/machinery/atmospherics/pipeturbine/network_expand(datum/pipe_network/new_network, obj/machinery/atmospherics/pipe/reference)
+	if(reference == node1)
+		network1 = new_network
+
+	else if(reference == node2)
+		network2 = new_network
+
+	if(new_network.normal_members.Find(src))
+		return 0
+
+	new_network.normal_members += src
+
+	return null
+
+/obj/machinery/atmospherics/pipeturbine/atmos_init()
+	if(node1 && node2)
+		return
+
+	var/node2_connect = turn(dir, -90)
+	var/node1_connect = turn(dir, 90)
+
+	for(var/obj/machinery/atmospherics/target in get_step(src,node1_connect))
+		if(target.initialize_directions & get_dir(target,src))
+			node1 = target
+			break
+
+	for(var/obj/machinery/atmospherics/target in get_step(src,node2_connect))
+		if(target.initialize_directions & get_dir(target,src))
+			node2 = target
+			break
+
+/obj/machinery/atmospherics/pipeturbine/build_network()
+	if(!network1 && node1)
+		network1 = new /datum/pipe_network()
+		network1.normal_members += src
+		network1.build_network(node1, src)
+
+	if(!network2 && node2)
+		network2 = new /datum/pipe_network()
+		network2.normal_members += src
+		network2.build_network(node2, src)
+
+
+/obj/machinery/atmospherics/pipeturbine/return_network(obj/machinery/atmospherics/reference)
+	build_network()
+
+	if(reference==node1)
+		return network1
+
+	if(reference==node2)
+		return network2
+
+	return null
+
+/obj/machinery/atmospherics/pipeturbine/reassign_network(datum/pipe_network/old_network, datum/pipe_network/new_network)
+	if(network1 == old_network)
+		network1 = new_network
+	if(network2 == old_network)
+		network2 = new_network
+
+	return 1
+
+/obj/machinery/atmospherics/pipeturbine/return_network_air(datum/pipe_network/reference)
+	var/list/results = list()
+
+	if(network1 == reference)
+		results += air_in
+	if(network2 == reference)
+		results += air_out
+
+	return results
+
+/obj/machinery/atmospherics/pipeturbine/disconnect(obj/machinery/atmospherics/reference)
+	if(reference==node1)
+		qdel(network1)
+		node1 = null
+
+	else if(reference==node2)
+		qdel(network2)
+		node2 = null
+
+	return null
 
 
 /obj/machinery/power/turbinemotor
@@ -236,54 +237,53 @@
 	var/kin_to_el_ratio = 0.1	//How much kinetic energy will be taken from turbine and converted into electricity
 	var/obj/machinery/atmospherics/pipeturbine/turbine
 
-	New()
-		..()
-		spawn(1)
-			updateConnection()
-
-	proc/updateConnection()
-		turbine = null
-		if(src.loc && anchored)
-			turbine = locate(/obj/machinery/atmospherics/pipeturbine) in get_step(src,dir)
-			if (turbine.stat & (BROKEN) || !turbine.anchored || turn(turbine.dir,180) != dir)
-				turbine = null
-
-	process()
+/obj/machinery/power/turbinemotor/New()
+	..()
+	spawn(1)
 		updateConnection()
-		if(!turbine || !anchored || stat & (BROKEN))
-			return
 
-		var/power_generated = kin_to_el_ratio * turbine.kin_energy
-		turbine.kin_energy -= power_generated
-		add_avail(power_generated)
-
-
-	attackby(obj/item/weapon/W as obj, mob/user as mob)
-		if(W.is_wrench())
-			anchored = !anchored
-			playsound(src, W.usesound, 50, 1)
+/obj/machinery/power/turbinemotor/proc/updateConnection()
+	turbine = null
+	if(src.loc && anchored)
+		turbine = locate(/obj/machinery/atmospherics/pipeturbine) in get_step(src,dir)
+		if (turbine.stat & (BROKEN) || !turbine.anchored || turn(turbine.dir,180) != dir)
 			turbine = null
-			to_chat(user, "<span class='notice'>You [anchored ? "secure" : "unsecure"] the bolts holding \the [src] to the floor.</span>")
-			updateConnection()
-		else
-			..()
 
-	verb/rotate_clock()
-		set category = "Object"
-		set name = "Rotate Motor Clockwise"
-		set src in view(1)
+/obj/machinery/power/turbinemotor/process()
+	updateConnection()
+	if(!turbine || !anchored || stat & (BROKEN))
+		return
 
-		if (usr.stat || usr.restrained()  || anchored)
-			return
+	var/power_generated = kin_to_el_ratio * turbine.kin_energy
+	turbine.kin_energy -= power_generated
+	add_avail(power_generated)
 
-		src.set_dir(turn(src.dir, -90))
+/obj/machinery/power/turbinemotor/attackby(obj/item/weapon/W as obj, mob/user as mob)
+	if(W.is_wrench())
+		anchored = !anchored
+		playsound(src, W.usesound, 50, 1)
+		turbine = null
+		to_chat(user, "<span class='notice'>You [anchored ? "secure" : "unsecure"] the bolts holding \the [src] to the floor.</span>")
+		updateConnection()
+	else
+		..()
 
-	verb/rotate_anticlock()
-		set category = "Object"
-		set name = "Rotate Motor Counterclockwise"
-		set src in view(1)
+/obj/machinery/power/turbinemotor/verb/rotate_clockwise()
+	set name = "Rotate Motor Clockwise"
+	set category = "Object"
+	set src in view(1)
 
-		if (usr.stat || usr.restrained()  || anchored)
-			return
+	if (usr.stat || usr.restrained()  || anchored)
+		return
 
-		src.set_dir(turn(src.dir, 90))
+	src.set_dir(turn(src.dir, 270))
+
+/obj/machinery/power/turbinemotor/verb/rotate_counterclockwise()
+	set name = "Rotate Motor Counterclockwise"
+	set category = "Object"
+	set src in view(1)
+
+	if (usr.stat || usr.restrained()  || anchored)
+		return
+
+	src.set_dir(turn(src.dir, 90))

--- a/code/game/machinery/frame.dm
+++ b/code/game/machinery/frame.dm
@@ -569,7 +569,7 @@
 
 	update_icon()
 
-/obj/structure/frame/verb/rotate()
+/obj/structure/frame/verb/rotate_counterclockwise()
 	set name = "Rotate Frame Counter-Clockwise"
 	set category = "Object"
 	set src in oview(1)
@@ -581,14 +581,14 @@
 		to_chat(usr, "It is fastened to the floor therefore you can't rotate it!")
 		return 0
 
-	set_dir(turn(dir, 90))
+	src.set_dir(turn(src.dir, 90))
 
 	to_chat(usr, "<span class='notice'>You rotate the [src] to face [dir2text(dir)]!</span>")
 
 	return
 
 
-/obj/structure/frame/verb/revrotate()
+/obj/structure/frame/verb/rotate_clockwise()
 	set name = "Rotate Frame Clockwise"
 	set category = "Object"
 	set src in oview(1)
@@ -600,7 +600,7 @@
 		to_chat(usr, "It is fastened to the floor therefore you can't rotate it!")
 		return 0
 
-	set_dir(turn(dir, 270))
+	src.set_dir(turn(src.dir, 270))
 
 	to_chat(usr, "<span class='notice'>You rotate the [src] to face [dir2text(dir)]!</span>")
 

--- a/code/game/machinery/pipe/construction.dm
+++ b/code/game/machinery/pipe/construction.dm
@@ -115,15 +115,15 @@ Buildable meters
 	var/obj/machinery/atmospherics/fakeA = pipe_type
 	icon_state = "[initial(fakeA.pipe_state)][mirrored ? "m" : ""]"
 
-/obj/item/pipe/verb/rotate()
+/obj/item/pipe/verb/rotate_clockwise()
 	set category = "Object"
-	set name = "Rotate Pipe"
+	set name = "Rotate Pipe Clockwise"
 	set src in view(1)
 
 	if ( usr.stat || usr.restrained() || !usr.canmove )
 		return
 
-	set_dir(turn(src.dir, -90)) // Rotate clockwise
+	src.set_dir(turn(src.dir, 270))
 	fixdir()
 
 // If you want to disable pipe dir changing when pulled, uncomment this

--- a/code/game/objects/structures/electricchair.dm
+++ b/code/game/objects/structures/electricchair.dm
@@ -34,10 +34,10 @@
 	else
 		on = 1
 		icon_state = "echair1"
-	usr << "<span class='notice'>You switch [on ? "on" : "off"] [src].</span>"
+	to_chat(usr, "<span class='notice'>You switch [on ? "on" : "off"] [src].</span>")
 	return
 
-/obj/structure/bed/chair/e_chair/rotate()
+/obj/structure/bed/chair/e_chair/rotate_clockwise()
 	..()
 	overlays.Cut()
 	overlays += image('icons/obj/objects.dmi', src, "echair_over", MOB_LAYER + 1, dir)	//there's probably a better way of handling this, but eh. -Pete

--- a/code/game/objects/structures/gravemarker.dm
+++ b/code/game/objects/structures/gravemarker.dm
@@ -115,23 +115,20 @@
 	return
 
 
-/obj/structure/gravemarker/verb/rotate()
-	set name = "Rotate Grave Marker"
+/obj/structure/gravemarker/verb/rotate_clockwise()
+	set name = "Rotate Grave Marker Clockwise"
 	set category = "Object"
 	set src in oview(1)
 
 	if(anchored)
 		return
-	if(config.ghost_interaction)
-		src.set_dir(turn(src.dir, 90))
-		return
-	else
-		if(ismouse(usr))
-			return
-		if(!usr || !isturf(usr.loc))
-			return
-		if(usr.stat || usr.restrained())
-			return
 
-		src.set_dir(turn(src.dir, 90))
+	if(!usr || !isturf(usr.loc))
 		return
+	if(usr.stat || usr.restrained())
+		return
+	if(ismouse(usr) || (isobserver(usr) && !config.ghost_interaction))
+		return
+
+	src.set_dir(turn(src.dir, 270))
+	return

--- a/code/game/objects/structures/musician.dm
+++ b/code/game/objects/structures/musician.dm
@@ -210,12 +210,12 @@
 			else
 				tempo = sanitize_tempo(5) // default 120 BPM
 			if(lines.len > INSTRUMENT_MAX_LINE_NUMBER)
-				usr << "Too many lines!"
+				to_chat(usr, "Too many lines!")
 				lines.Cut(INSTRUMENT_MAX_LINE_NUMBER+1)
 			var/linenum = 1
 			for(var/l in lines)
 				if(lentext(l) > INSTRUMENT_MAX_LINE_LENGTH)
-					usr << "Line [linenum] too long!"
+					to_chat(usr, "Line [linenum] too long!")
 					lines.Remove(l)
 				else
 					linenum++
@@ -316,22 +316,18 @@
 	song = null
 	..()
 
-/obj/structure/device/piano/verb/rotate()
-	set name = "Rotate Piano"
+/obj/structure/device/piano/verb/rotate_clockwise()
+	set name = "Rotate Piano Clockwise"
 	set category = "Object"
 	set src in oview(1)
 
-	if(istype(usr,/mob/living/simple_mob/animal/passive/mouse))
+	if(ismouse(usr))
 		return
-	else if(!usr || !isturf(usr.loc))
+	if(!usr || !isturf(usr.loc) || usr.stat || usr.restrained())
 		return
-	else if(usr.stat || usr.restrained())
+	if (isobserver(usr) && !config.ghost_interaction)
 		return
-	else if (istype(usr,/mob/observer/ghost) && !config.ghost_interaction)
-		return
-	else
-		src.set_dir(turn(src.dir, 90))
-		return
+	src.set_dir(turn(src.dir, 270))
 
 /obj/structure/device/piano/attack_hand(mob/user)
 	if(!user.IsAdvancedToolUser())
@@ -350,7 +346,7 @@
 	if(O.is_wrench())
 		if(anchored)
 			playsound(src.loc, O.usesound, 50, 1)
-			user << "<span class='notice'>You begin to loosen \the [src]'s casters...</span>"
+			to_chat(user, "<span class='notice'>You begin to loosen \the [src]'s casters...</span>")
 			if (do_after(user, 40 * O.toolspeed))
 				user.visible_message( \
 					"[user] loosens \the [src]'s casters.", \
@@ -359,7 +355,7 @@
 				src.anchored = 0
 		else
 			playsound(src.loc, O.usesound, 50, 1)
-			user << "<span class='notice'>You begin to tighten \the [src] to the floor...</span>"
+			to_chat(user, "<span class='notice'>You begin to tighten \the [src] to the floor...</span>")
 			if (do_after(user, 20 * O.toolspeed))
 				user.visible_message( \
 					"[user] tightens \the [src]'s casters.", \

--- a/code/game/objects/structures/railing.dm
+++ b/code/game/objects/structures/railing.dm
@@ -126,7 +126,7 @@
 					if (WEST)
 						overlays += image ('icons/obj/railing.dmi', src, "mcorneroverlay", pixel_y = 32)
 
-/obj/structure/railing/verb/rotate()
+/obj/structure/railing/verb/rotate_counterclockwise()
 	set name = "Rotate Railing Counter-Clockwise"
 	set category = "Object"
 	set src in oview(1)
@@ -141,11 +141,11 @@
 		to_chat(usr, "It is fastened to the floor therefore you can't rotate it!")
 		return 0
 
-	set_dir(turn(dir, 90))
+	src.set_dir(turn(src.dir, 90))
 	update_icon()
 	return
 
-/obj/structure/railing/verb/revrotate()
+/obj/structure/railing/verb/rotate_clockwise()
 	set name = "Rotate Railing Clockwise"
 	set category = "Object"
 	set src in oview(1)
@@ -160,7 +160,7 @@
 		to_chat(usr, "It is fastened to the floor therefore you can't rotate it!")
 		return 0
 
-	set_dir(turn(dir, -90))
+	src.set_dir(turn(src.dir, 270))
 	update_icon()
 	return
 

--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -19,7 +19,7 @@
 	if(!padding_material && istype(W, /obj/item/assembly/shock_kit))
 		var/obj/item/assembly/shock_kit/SK = W
 		if(!SK.status)
-			user << "<span class='notice'>\The [SK] is not ready to be attached!</span>"
+			to_chat(user, "<span class='notice'>\The [SK] is not ready to be attached!</span>")
 			return
 		user.drop_item()
 		var/obj/structure/bed/chair/e_chair/E = new (src.loc, material.name)
@@ -34,7 +34,7 @@
 	if(has_buckled_mobs())
 		..()
 	else
-		rotate()
+		rotate_clockwise()
 	return
 
 /obj/structure/bed/chair/post_buckle_mob()
@@ -67,24 +67,19 @@
 			var/mob/living/L = A
 			L.set_dir(dir)
 
-/obj/structure/bed/chair/verb/rotate()
-	set name = "Rotate Chair"
+/obj/structure/bed/chair/verb/rotate_clockwise()
+	set name = "Rotate Chair Clockwise"
 	set category = "Object"
 	set src in oview(1)
 
-	if(config.ghost_interaction)
-		src.set_dir(turn(src.dir, 90))
+	if(!usr || !isturf(usr.loc))
 		return
-	else
-		if(istype(usr,/mob/living/simple_mob/animal/passive/mouse))
-			return
-		if(!usr || !isturf(usr.loc))
-			return
-		if(usr.stat || usr.restrained())
-			return
+	if(usr.stat || usr.restrained())
+		return
+	if(ismouse(usr) || (isobserver(usr) && !config.ghost_interaction))
+		return
 
-		src.set_dir(turn(src.dir, 90))
-		return
+	src.set_dir(turn(src.dir, 270))
 
 /obj/structure/bed/chair/shuttle
 	name = "chair"

--- a/code/game/objects/structures/windoor_assembly.dm
+++ b/code/game/objects/structures/windoor_assembly.dm
@@ -273,8 +273,8 @@ obj/structure/windoor_assembly/Destroy()
 	name += "[secure ? "secure " : ""]windoor assembly[created_name ? " ([created_name])" : ""]"
 
 //Rotates the windoor assembly clockwise
-/obj/structure/windoor_assembly/verb/revrotate()
-	set name = "Rotate Windoor Assembly"
+/obj/structure/windoor_assembly/verb/rotate_clockwise()
+	set name = "Rotate Windoor Assembly Clockwise"
 	set category = "Object"
 	set src in oview(1)
 

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -27,24 +27,24 @@
 	. = ..(user)
 
 	if(health == maxhealth)
-		user << "<span class='notice'>It looks fully intact.</span>"
+		to_chat(user, "<span class='notice'>It looks fully intact.</span>")
 	else
 		var/perc = health / maxhealth
 		if(perc > 0.75)
-			user << "<span class='notice'>It has a few cracks.</span>"
+			to_chat(user, "<span class='notice'>It has a few cracks.</span>")
 		else if(perc > 0.5)
-			user << "<span class='warning'>It looks slightly damaged.</span>"
+			to_chat(user, "<span class='warning'>It looks slightly damaged.</span>")
 		else if(perc > 0.25)
-			user << "<span class='warning'>It looks moderately damaged.</span>"
+			to_chat(user, "<span class='warning'>It looks moderately damaged.</span>")
 		else
-			user << "<span class='danger'>It looks heavily damaged.</span>"
+			to_chat(user, "<span class='danger'>It looks heavily damaged.</span>")
 	if(silicate)
 		if (silicate < 30)
-			user << "<span class='notice'>It has a thin layer of silicate.</span>"
+			to_chat(user, "<span class='notice'>It has a thin layer of silicate.</span>")
 		else if (silicate < 70)
-			user << "<span class='notice'>It is covered in silicate.</span>"
+			to_chat(user, "<span class='notice'>It is covered in silicate.</span>")
 		else
-			user << "<span class='notice'>There is a thick layer of silicate covering it.</span>"
+			to_chat(user, "<span class='notice'>There is a thick layer of silicate covering it.</span>")
 
 /obj/structure/window/proc/take_damage(var/damage = 0,  var/sound_effect = 1)
 	var/initialhealth = health
@@ -262,26 +262,26 @@
 			state = 3 - state
 			update_nearby_icons()
 			playsound(src, W.usesound, 75, 1)
-			user << (state == 1 ? "<span class='notice'>You have unfastened the window from the frame.</span>" : "<span class='notice'>You have fastened the window to the frame.</span>")
+			to_chat(user, "<span class='notice'>You have [state ? "un" : ""]fastened the window [state ? "from" : "to"] the frame.</span>")
 		else if(reinf && state == 0)
 			anchored = !anchored
 			update_nearby_icons()
 			update_verbs()
 			playsound(src, W.usesound, 75, 1)
-			user << (anchored ? "<span class='notice'>You have fastened the frame to the floor.</span>" : "<span class='notice'>You have unfastened the frame from the floor.</span>")
+			to_chat(user, "<span class='notice'>You have [anchored ? "" : "un"]fastened the frame [anchored ? "to" : "from"] the floor.</span>")
 		else if(!reinf)
 			anchored = !anchored
 			update_nearby_icons()
 			update_verbs()
 			playsound(src, W.usesound, 75, 1)
-			user << (anchored ? "<span class='notice'>You have fastened the window to the floor.</span>" : "<span class='notice'>You have unfastened the window.</span>")
+			to_chat(user, "<span class='notice'>You have [anchored ? "" : "un"]fastened the window [anchored ? "to" : "from"] the floor.</span>")
 	else if(W.is_crowbar() && reinf && state <= 1)
 		state = 1 - state
 		playsound(src, W.usesound, 75, 1)
-		user << (state ? "<span class='notice'>You have pried the window into the frame.</span>" : "<span class='notice'>You have pried the window out of the frame.</span>")
+		to_chat(user, "<span class='notice'>You have pried the window [state ? "into" : "out of"] the frame.</span>")
 	else if(W.is_wrench() && !anchored && (!state || !reinf))
 		if(!glasstype)
-			user << "<span class='notice'>You're not sure how to dismantle \the [src] properly.</span>"
+			to_chat(user, "<span class='notice'>You're not sure how to dismantle \the [src] properly.</span>")
 		else
 			playsound(src, W.usesound, 75, 1)
 			visible_message("<span class='notice'>[user] dismantles \the [src].</span>")
@@ -329,8 +329,8 @@
 	return
 
 
-/obj/structure/window/proc/rotate()
-	set name = "Rotate Window Counter-Clockwise"
+/obj/structure/window/verb/rotate_counterclockwise()
+	set name = "Rotate Window Counterclockwise"
 	set category = "Object"
 	set src in oview(1)
 
@@ -341,17 +341,17 @@
 		return 0
 
 	if(anchored)
-		usr << "It is fastened to the floor therefore you can't rotate it!"
+		to_chat(usr, "It is fastened to the floor therefore you can't rotate it!")
 		return 0
 
 	update_nearby_tiles(need_rebuild=1) //Compel updates before
-	set_dir(turn(dir, 90))
+	src.set_dir(turn(src.dir, 90))
 	updateSilicate()
 	update_nearby_tiles(need_rebuild=1)
 	return
 
 
-/obj/structure/window/proc/revrotate()
+/obj/structure/window/verb/rotate_clockwise()
 	set name = "Rotate Window Clockwise"
 	set category = "Object"
 	set src in oview(1)
@@ -363,11 +363,11 @@
 		return 0
 
 	if(anchored)
-		usr << "It is fastened to the floor therefore you can't rotate it!"
+		to_chat(usr, "It is fastened to the floor therefore you can't rotate it!")
 		return 0
 
 	update_nearby_tiles(need_rebuild=1) //Compel updates before
-	set_dir(turn(dir, 270))
+	src.set_dir(turn(src.dir, 270))
 	updateSilicate()
 	update_nearby_tiles(need_rebuild=1)
 	return
@@ -420,11 +420,11 @@
 //Updates the availabiliy of the rotation verbs
 /obj/structure/window/proc/update_verbs()
 	if(anchored || is_fulltile())
-		verbs -= /obj/structure/window/proc/rotate
-		verbs -= /obj/structure/window/proc/revrotate
+		verbs -= /obj/structure/window/verb/rotate_counterclockwise
+		verbs -= /obj/structure/window/verb/rotate_clockwise
 	else if(!is_fulltile())
-		verbs += /obj/structure/window/proc/rotate
-		verbs += /obj/structure/window/proc/revrotate
+		verbs += /obj/structure/window/verb/rotate_counterclockwise
+		verbs += /obj/structure/window/verb/rotate_clockwise
 
 //merges adjacent full-tile windows into one (blatant ripoff from game/smoothwall.dm)
 /obj/structure/window/update_icon()

--- a/code/modules/assembly/infrared.dm
+++ b/code/modules/assembly/infrared.dm
@@ -142,12 +142,12 @@
 	return
 
 
-/obj/item/device/assembly/infra/verb/rotate()//This could likely be better
-	set name = "Rotate Infrared Laser"
+/obj/item/device/assembly/infra/verb/rotate_clockwise()
+	set name = "Rotate Infrared Laser Clockwise"
 	set category = "Object"
 	set src in usr
 
-	set_dir(turn(dir, 90))
+	src.set_dir(turn(src.dir, 270))
 	return
 
 

--- a/code/modules/mining/drilling/drill.dm
+++ b/code/modules/mining/drilling/drill.dm
@@ -363,8 +363,8 @@
 	connected.check_supports()
 	connected = null
 
-/obj/machinery/mining/brace/verb/rotate()
-	set name = "Rotate"
+/obj/machinery/mining/brace/verb/rotate_clockwise()
+	set name = "Rotate Brace Clockwise"
 	set category = "Object"
 	set src in oview(1)
 
@@ -374,5 +374,5 @@
 		to_chat(usr, "It is anchored in place!")
 		return 0
 
-	src.set_dir(turn(src.dir, 90))
+	src.set_dir(turn(src.dir, 270))
 	return 1

--- a/code/modules/overmap/ships/ship.dm
+++ b/code/modules/overmap/ships/ship.dm
@@ -112,5 +112,5 @@
 		var/turf/newloc = locate(x + deltas[1], y + deltas[2], z)
 		if(newloc)
 			Move(newloc)
-		if(rotate)	
+		if(rotate)
 			rotate(get_heading())

--- a/code/modules/power/fusion/fuel_assembly/fuel_injector.dm
+++ b/code/modules/power/fusion/fuel_assembly/fuel_injector.dm
@@ -134,22 +134,22 @@ var/list/fuel_injectors = list()
 	else
 		StopInjecting()
 
-/obj/machinery/fusion_fuel_injector/verb/rotate_clock()
+/obj/machinery/fusion_fuel_injector/verb/rotate_clockwise()
 	set category = "Object"
-	set name = "Rotate Generator (Clockwise)"
+	set name = "Rotate Generator Clockwise"
 	set src in view(1)
 
 	if (usr.incapacitated() || usr.restrained()  || anchored)
 		return
 
-	src.dir = turn(src.dir, -90)
+	src.set_dir(turn(src.dir, 270))
 
-/obj/machinery/fusion_fuel_injector/verb/rotate_anticlock()
+/obj/machinery/fusion_fuel_injector/verb/rotate_counterclockwise()
 	set category = "Object"
-	set name = "Rotate Generator (Counter-clockwise)"
+	set name = "Rotate Generator Counterclockwise"
 	set src in view(1)
 
 	if (usr.incapacitated() || usr.restrained()  || anchored)
 		return
 
-	src.dir = turn(src.dir, 90)
+	src.set_dir(turn(src.dir, 90))

--- a/code/modules/power/generator.dm
+++ b/code/modules/power/generator.dm
@@ -215,25 +215,25 @@
 	updateicon()
 
 
-/obj/machinery/power/generator/verb/rotate_clock()
+/obj/machinery/power/generator/verb/rotate_clockwise()
 	set category = "Object"
-	set name = "Rotate Generator (Clockwise)"
+	set name = "Rotate Generator Clockwise"
+	set src in view(1)
+
+	if (usr.stat || usr.restrained()  || anchored)
+		return
+
+	src.set_dir(turn(src.dir, 270))
+
+/obj/machinery/power/generator/verb/rotate_counterclockwise()
+	set category = "Object"
+	set name = "Rotate Generator Counterclockwise"
 	set src in view(1)
 
 	if (usr.stat || usr.restrained()  || anchored)
 		return
 
 	src.set_dir(turn(src.dir, 90))
-
-/obj/machinery/power/generator/verb/rotate_anticlock()
-	set category = "Object"
-	set name = "Rotate Generator (Counterclockwise)"
-	set src in view(1)
-
-	if (usr.stat || usr.restrained()  || anchored)
-		return
-
-	src.set_dir(turn(src.dir, -90))
 
 /obj/machinery/power/generator/power_spike()
 //	if(!effective_gen >= max_power / 2 && powernet) // Don't make a spike if we're not making a whole lot of power.

--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -30,15 +30,15 @@
 	var/integrity = 80
 
 
-/obj/machinery/power/emitter/verb/rotate()
-	set name = "Rotate"
+/obj/machinery/power/emitter/verb/rotate_clockwise()
+	set name = "Rotate Emitter Clockwise"
 	set category = "Object"
 	set src in oview(1)
 
 	if (src.anchored || usr:stat)
-		usr << "It is fastened to the floor!"
+		to_chat(usr, "It is fastened to the floor!")
 		return 0
-	src.set_dir(turn(src.dir, 90))
+	src.set_dir(turn(src.dir, 270))
 	return 1
 
 /obj/machinery/power/emitter/initialize()

--- a/code/modules/power/singularity/particle_accelerator/particle_accelerator.dm
+++ b/code/modules/power/singularity/particle_accelerator/particle_accelerator.dm
@@ -89,24 +89,24 @@ So, hopefully this is helpful if any more icons are to be added/changed/wonderin
 	return
 
 
-/obj/structure/particle_accelerator/verb/rotate()
+/obj/structure/particle_accelerator/verb/rotate_clockwise()
 	set name = "Rotate Clockwise"
 	set category = "Object"
 	set src in oview(1)
 
 	if (src.anchored || usr:stat)
-		usr << "It is fastened to the floor!"
+		to_chat(usr, "It is fastened to the floor!")
 		return 0
 	src.set_dir(turn(src.dir, 270))
 	return 1
 
-/obj/structure/particle_accelerator/verb/rotateccw()
+/obj/structure/particle_accelerator/verb/rotate_counterclockwise()
 	set name = "Rotate Counter Clockwise"
 	set category = "Object"
 	set src in oview(1)
 
 	if (src.anchored || usr:stat)
-		usr << "It is fastened to the floor!"
+		to_chat(usr, "It is fastened to the floor!")
 		return 0
 	src.set_dir(turn(src.dir, 90))
 	return 1
@@ -269,24 +269,24 @@ So, hopefully this is helpful if any more icons are to be added/changed/wonderin
 	var/desc_holder = null
 
 
-/obj/machinery/particle_accelerator/verb/rotate()
+/obj/machinery/particle_accelerator/verb/rotate_clockwise()
 	set name = "Rotate Clockwise"
 	set category = "Object"
 	set src in oview(1)
 
 	if (src.anchored || usr:stat)
-		usr << "It is fastened to the floor!"
+		to_chat(usr, "It is fastened to the floor!")
 		return 0
 	src.set_dir(turn(src.dir, 270))
 	return 1
 
-/obj/machinery/particle_accelerator/verb/rotateccw()
+/obj/machinery/particle_accelerator/verb/rotate_counterclockwise()
 	set name = "Rotate Counter-Clockwise"
 	set category = "Object"
 	set src in oview(1)
 
 	if (src.anchored || usr:stat)
-		usr << "It is fastened to the floor!"
+		to_chat(usr, "It is fastened to the floor!")
 		return 0
 	src.set_dir(turn(src.dir, 90))
 	return 1
@@ -333,10 +333,8 @@ So, hopefully this is helpful if any more icons are to be added/changed/wonderin
 		else
 	return
 
-
 /obj/machinery/particle_accelerator/proc/update_state()
 	return 0
-
 
 /obj/machinery/particle_accelerator/proc/process_tool_hit(var/obj/item/O, var/mob/user)
 	if(!(O) || !(user))

--- a/code/modules/recycling/disposal-construction.dm
+++ b/code/modules/recycling/disposal-construction.dm
@@ -20,307 +20,299 @@
 	var/base_state = "pipe-s"
 
 	// update iconstate and dpdir due to dir and type
-	proc/update()
-		var/flip = turn(dir, 180)
-		var/left = turn(dir, 90)
-		var/right = turn(dir, -90)
+/obj/structure/disposalconstruct/proc/update()
+	var/flip = turn(dir, 180)
+	var/left = turn(dir, 90)
+	var/right = turn(dir, -90)
 
-		switch(ptype)
-			if(0)
-				base_state = "pipe-s"
-				dpdir = dir | flip
-			if(1)
-				base_state = "pipe-c"
-				dpdir = dir | right
-			if(2)
-				base_state = "pipe-j1"
-				dpdir = dir | right | flip
-			if(3)
-				base_state = "pipe-j2"
-				dpdir = dir | left | flip
-			if(4)
-				base_state = "pipe-y"
-				dpdir = dir | left | right
-			if(5)
-				base_state = "pipe-t"
-				dpdir = dir
-			 // disposal bin has only one dir, thus we don't need to care about setting it
-			if(6)
-				if(anchored)
-					base_state = "disposal"
-				else
-					base_state = "condisposal"
-
-			if(7)
-				base_state = "outlet"
-				dpdir = dir
-
-			if(8)
-				base_state = "intake"
-				dpdir = dir
-
-			if(9)
-				base_state = "pipe-j1s"
-				dpdir = dir | right | flip
-
-			if(10)
-				base_state = "pipe-j2s"
-				dpdir = dir | left | flip
+	switch(ptype)
+		if(0)
+			base_state = "pipe-s"
+			dpdir = dir | flip
+		if(1)
+			base_state = "pipe-c"
+			dpdir = dir | right
+		if(2)
+			base_state = "pipe-j1"
+			dpdir = dir | right | flip
+		if(3)
+			base_state = "pipe-j2"
+			dpdir = dir | left | flip
+		if(4)
+			base_state = "pipe-y"
+			dpdir = dir | left | right
+		if(5)
+			base_state = "pipe-t"
+			dpdir = dir
+		 // disposal bin has only one dir, thus we don't need to care about setting it
+		if(6)
+			if(anchored)
+				base_state = "disposal"
+			else
+				base_state = "condisposal"
+		if(7)
+			base_state = "outlet"
+			dpdir = dir
+		if(8)
+			base_state = "intake"
+			dpdir = dir
+		if(9)
+			base_state = "pipe-j1s"
+			dpdir = dir | right | flip
+		if(10)
+			base_state = "pipe-j2s"
+			dpdir = dir | left | flip
 ///// Z-Level stuff
-			if(11)
-				base_state = "pipe-u"
-				dpdir = dir
-			if(12)
-				base_state = "pipe-d"
-				dpdir = dir
-///// Z-Level stuff
-			if(13)
-				base_state = "pipe-tagger"
-				dpdir = dir | flip
-			if(14)
-				base_state = "pipe-tagger-partial"
-				dpdir = dir | flip
+		if(11)
+			base_state = "pipe-u"
+			dpdir = dir
+		if(12)
+			base_state = "pipe-d"
+			dpdir = dir
+		if(13)
+			base_state = "pipe-tagger"
+			dpdir = dir | flip
+		if(14)
+			base_state = "pipe-tagger-partial"
+			dpdir = dir | flip
 
 
 ///// Z-Level stuff
-		if(!(ptype in list(6, 7, 8, 11, 12, 13, 14)))
-///// Z-Level stuff
-			icon_state = "con[base_state]"
-		else
-			icon_state = base_state
+	if(!(ptype in list(6, 7, 8, 11, 12, 13, 14)))
+		icon_state = "con[base_state]"
+	else
+		icon_state = base_state
 
-		if(invisibility)				// if invisible, fade icon
-			alpha = 128
-		else
-			alpha = 255
-			//otherwise burying half-finished pipes under floors causes them to half-fade
+	if(invisibility)				// if invisible, fade icon
+		alpha = 128
+	else
+		alpha = 255
+		//otherwise burying half-finished pipes under floors causes them to half-fade
 
-	// hide called by levelupdate if turf intact status changes
-	// change visibility status and force update of icon
-	hide(var/intact)
-		invisibility = (intact && level==1) ? 101: 0	// hide if floor is intact
-		update()
+// hide called by levelupdate if turf intact status changes
+// change visibility status and force update of icon
+/obj/structure/disposalconstruct/hide(var/intact)
+	invisibility = (intact && level==1) ? 101: 0	// hide if floor is intact
+	update()
 
 
-	// flip and rotate verbs
-	verb/rotate()
-		set category = "Object"
-		set name = "Rotate Pipe"
-		set src in view(1)
+// flip and rotate verbs
+/obj/structure/disposalconstruct/verb/rotate_clockwise()
+	set category = "Object"
+	set name = "Rotate Pipe Clockwise"
+	set src in view(1)
 
-		if(usr.stat)
-			return
-
-		if(anchored)
-			to_chat(usr, "You must unfasten the pipe before rotating it.")
-			return
-
-		set_dir(turn(dir, -90))
-		update()
-
-	verb/flip()
-		set category = "Object"
-		set name = "Flip Pipe"
-		set src in view(1)
-		if(usr.stat)
-			return
-
-		if(anchored)
-			to_chat(usr, "You must unfasten the pipe before flipping it.")
-			return
-
-		set_dir(turn(dir, 180))
-		switch(ptype)
-			if(2)
-				ptype = 3
-			if(3)
-				ptype = 2
-			if(9)
-				ptype = 10
-			if(10)
-				ptype = 9
-
-		update()
-
-	// returns the type path of disposalpipe corresponding to this item dtype
-	proc/dpipetype()
-		switch(ptype)
-			if(0,1)
-				return /obj/structure/disposalpipe/segment
-			if(2,3,4)
-				return /obj/structure/disposalpipe/junction
-			if(5)
-				return /obj/structure/disposalpipe/trunk
-			if(6)
-				return /obj/machinery/disposal
-			if(7)
-				return /obj/structure/disposaloutlet
-			if(8)
-				return /obj/machinery/disposal/deliveryChute
-			if(9)
-				switch(subtype)
-					if(0)
-						return /obj/structure/disposalpipe/sortjunction
-					if(1)
-						return /obj/structure/disposalpipe/sortjunction/wildcard
-					if(2)
-						return /obj/structure/disposalpipe/sortjunction/untagged
-			if(10)
-				switch(subtype)
-					if(0)
-						return /obj/structure/disposalpipe/sortjunction/flipped
-					if(1)
-						return /obj/structure/disposalpipe/sortjunction/wildcard/flipped
-					if(2)
-						return /obj/structure/disposalpipe/sortjunction/untagged/flipped
-///// Z-Level stuff
-			if(11)
-				return /obj/structure/disposalpipe/up
-			if(12)
-				return /obj/structure/disposalpipe/down
-///// Z-Level stuff
-			if(13)
-				return /obj/structure/disposalpipe/tagger
-			if(14)
-				return /obj/structure/disposalpipe/tagger/partial
+	if(usr.stat)
 		return
 
+	if(anchored)
+		to_chat(usr, "You must unfasten the pipe before rotating it.")
+		return
+
+	src.set_dir(turn(src.dir, 270))
+	update()
+
+/obj/structure/disposalconstruct/verb/flip()
+	set category = "Object"
+	set name = "Flip Pipe"
+	set src in view(1)
+	if(usr.stat)
+		return
+
+	if(anchored)
+		to_chat(usr, "You must unfasten the pipe before flipping it.")
+		return
+
+	set_dir(turn(dir, 180))
+	switch(ptype)
+		if(2)
+			ptype = 3
+		if(3)
+			ptype = 2
+		if(9)
+			ptype = 10
+		if(10)
+			ptype = 9
+
+	update()
+
+// returns the type path of disposalpipe corresponding to this item dtype
+/obj/structure/disposalconstruct/proc/dpipetype()
+	switch(ptype)
+		if(0,1)
+			return /obj/structure/disposalpipe/segment
+		if(2,3,4)
+			return /obj/structure/disposalpipe/junction
+		if(5)
+			return /obj/structure/disposalpipe/trunk
+		if(6)
+			return /obj/machinery/disposal
+		if(7)
+			return /obj/structure/disposaloutlet
+		if(8)
+			return /obj/machinery/disposal/deliveryChute
+		if(9)
+			switch(subtype)
+				if(0)
+					return /obj/structure/disposalpipe/sortjunction
+				if(1)
+					return /obj/structure/disposalpipe/sortjunction/wildcard
+				if(2)
+					return /obj/structure/disposalpipe/sortjunction/untagged
+		if(10)
+			switch(subtype)
+				if(0)
+					return /obj/structure/disposalpipe/sortjunction/flipped
+				if(1)
+					return /obj/structure/disposalpipe/sortjunction/wildcard/flipped
+				if(2)
+					return /obj/structure/disposalpipe/sortjunction/untagged/flipped
+///// Z-Level stuff
+		if(11)
+			return /obj/structure/disposalpipe/up
+		if(12)
+			return /obj/structure/disposalpipe/down
+		if(13)
+			return /obj/structure/disposalpipe/tagger
+		if(14)
+			return /obj/structure/disposalpipe/tagger/partial
+	return
 
 
-	// attackby item
+
+// attackby item
+// wrench: (un)anchor
+// weldingtool: convert to real pipe
+/obj/structure/disposalconstruct/attackby(var/obj/item/I, var/mob/user)
+	var/nicetype = "pipe"
+	var/ispipe = 0 // Indicates if we should change the level of this pipe
+	src.add_fingerprint(user)
+	switch(ptype)
+		if(6)
+			nicetype = "disposal bin"
+		if(7)
+			nicetype = "disposal outlet"
+		if(8)
+			nicetype = "delivery chute"
+		if(9, 10)
+			switch(subtype)
+				if(0)
+					nicetype = "sorting pipe"
+				if(1)
+					nicetype = "wildcard sorting pipe"
+				if(2)
+					nicetype = "untagged sorting pipe"
+			ispipe = 1
+		if(13)
+			nicetype = "tagging pipe"
+			ispipe = 1
+		if(14)
+			nicetype = "partial tagging pipe"
+			ispipe = 1
+		else
+			nicetype = "pipe"
+			ispipe = 1
+
+	var/turf/T = src.loc
+	if(!T.is_plating())
+		to_chat(user, "You can only attach the [nicetype] if the floor plating is removed.")
+		return
+
+	var/obj/structure/disposalpipe/CP = locate() in T
+
 	// wrench: (un)anchor
-	// weldingtool: convert to real pipe
-
-	attackby(var/obj/item/I, var/mob/user)
-		var/nicetype = "pipe"
-		var/ispipe = 0 // Indicates if we should change the level of this pipe
-		src.add_fingerprint(user)
-		switch(ptype)
-			if(6)
-				nicetype = "disposal bin"
-			if(7)
-				nicetype = "disposal outlet"
-			if(8)
-				nicetype = "delivery chute"
-			if(9, 10)
-				switch(subtype)
-					if(0)
-						nicetype = "sorting pipe"
-					if(1)
-						nicetype = "wildcard sorting pipe"
-					if(2)
-						nicetype = "untagged sorting pipe"
-				ispipe = 1
-			if(13)
-				nicetype = "tagging pipe"
-				ispipe = 1
-			if(14)
-				nicetype = "partial tagging pipe"
-				ispipe = 1
+	if(I.is_wrench())
+		if(anchored)
+			anchored = 0
+			if(ispipe)
+				level = 2
+				density = 0
 			else
-				nicetype = "pipe"
-				ispipe = 1
-
-		var/turf/T = src.loc
-		if(!T.is_plating())
-			to_chat(user, "You can only attach the [nicetype] if the floor plating is removed.")
-			return
-
-		var/obj/structure/disposalpipe/CP = locate() in T
-
-		if(I.is_wrench())
-			if(anchored)
-				anchored = 0
-				if(ispipe)
-					level = 2
-					density = 0
-				else
-					density = 1
-				to_chat(user, "You detach the [nicetype] from the underfloor.")
-			else
-				if(ptype>=6 && ptype <= 8) // Disposal or outlet
-					if(CP) // There's something there
-						if(!istype(CP,/obj/structure/disposalpipe/trunk))
-							to_chat(user, "The [nicetype] requires a trunk underneath it in order to work.")
-							return
-					else // Nothing under, fuck.
+				density = 1
+			to_chat(user, "You detach the [nicetype] from the underfloor.")
+		else
+			if(ptype>=6 && ptype <= 8) // Disposal or outlet
+				if(CP) // There's something there
+					if(!istype(CP,/obj/structure/disposalpipe/trunk))
 						to_chat(user, "The [nicetype] requires a trunk underneath it in order to work.")
 						return
-				else
-					if(CP)
-						update()
-						var/pdir = CP.dpdir
-						if(istype(CP, /obj/structure/disposalpipe/broken))
-							pdir = CP.dir
-						if(pdir & dpdir)
-							to_chat(user, "There is already a [nicetype] at that location.")
-							return
-
-				anchored = 1
-				if(ispipe)
-					level = 1 // We don't want disposal bins to disappear under the floors
-					density = 0
-				else
-					density = 1 // We don't want disposal bins or outlets to go density 0
-				to_chat(user, "You attach the [nicetype] to the underfloor.")
-			playsound(loc, I.usesound, 100, 1)
-			update()
-
-		else if(istype(I, /obj/item/weapon/weldingtool))
-			if(anchored)
-				var/obj/item/weapon/weldingtool/W = I
-				if(W.remove_fuel(0,user))
-					playsound(src, W.usesound, 100, 1)
-					to_chat(user, "Welding the [nicetype] in place.")
-					if(do_after(user, 20 * W.toolspeed))
-						if(!src || !W.isOn()) return
-						to_chat(user, "The [nicetype] has been welded in place!")
-						update() // TODO: Make this neat
-						if(ispipe) // Pipe
-
-							var/pipetype = dpipetype()
-							var/obj/structure/disposalpipe/P = new pipetype(src.loc)
-							src.transfer_fingerprints_to(P)
-							P.base_icon_state = base_state
-							P.set_dir(dir)
-							P.dpdir = dpdir
-							P.updateicon()
-
-							//Needs some special treatment ;)
-							if(ptype==9 || ptype==10)
-								var/obj/structure/disposalpipe/sortjunction/SortP = P
-								SortP.sortType = sortType
-								SortP.updatedir()
-								SortP.updatedesc()
-								SortP.updatename()
-
-						else if(ptype==6) // Disposal bin
-							var/obj/machinery/disposal/P = new /obj/machinery/disposal(src.loc)
-							src.transfer_fingerprints_to(P)
-							P.mode = 0 // start with pump off
-
-						else if(ptype==7) // Disposal outlet
-
-							var/obj/structure/disposaloutlet/P = new /obj/structure/disposaloutlet(src.loc)
-							src.transfer_fingerprints_to(P)
-							P.set_dir(dir)
-							var/obj/structure/disposalpipe/trunk/Trunk = CP
-							Trunk.linked = P
-
-						else if(ptype==8) // Disposal outlet
-
-							var/obj/machinery/disposal/deliveryChute/P = new /obj/machinery/disposal/deliveryChute(src.loc)
-							src.transfer_fingerprints_to(P)
-							P.set_dir(dir)
-
-						qdel(src)
-						return
-				else
-					to_chat(user, "You need more welding fuel to complete this task.")
+				else // Nothing under, fuck.
+					to_chat(user, "The [nicetype] requires a trunk underneath it in order to work.")
 					return
 			else
-				to_chat(user, "You need to attach it to the plating first!")
+				if(CP)
+					update()
+					var/pdir = CP.dpdir
+					if(istype(CP, /obj/structure/disposalpipe/broken))
+						pdir = CP.dir
+					if(pdir & dpdir)
+						to_chat(user, "There is already a [nicetype] at that location.")
+						return
+
+			anchored = 1
+			if(ispipe)
+				level = 1 // We don't want disposal bins to disappear under the floors
+				density = 0
+			else
+				density = 1 // We don't want disposal bins or outlets to go density 0
+			to_chat(user, "You attach the [nicetype] to the underfloor.")
+		playsound(loc, I.usesound, 100, 1)
+		update()
+
+	// weldingtool: convert to real pipe
+	else if(istype(I, /obj/item/weapon/weldingtool))
+		if(anchored)
+			var/obj/item/weapon/weldingtool/W = I
+			if(W.remove_fuel(0,user))
+				playsound(src, W.usesound, 100, 1)
+				to_chat(user, "Welding the [nicetype] in place.")
+				if(do_after(user, 20 * W.toolspeed))
+					if(!src || !W.isOn()) return
+					to_chat(user, "The [nicetype] has been welded in place!")
+					update() // TODO: Make this neat
+					if(ispipe) // Pipe
+
+						var/pipetype = dpipetype()
+						var/obj/structure/disposalpipe/P = new pipetype(src.loc)
+						src.transfer_fingerprints_to(P)
+						P.base_icon_state = base_state
+						P.set_dir(dir)
+						P.dpdir = dpdir
+						P.updateicon()
+
+						//Needs some special treatment ;)
+						if(ptype==9 || ptype==10)
+							var/obj/structure/disposalpipe/sortjunction/SortP = P
+							SortP.sortType = sortType
+							SortP.updatedir()
+							SortP.updatedesc()
+							SortP.updatename()
+
+					else if(ptype==6) // Disposal bin
+						var/obj/machinery/disposal/P = new /obj/machinery/disposal(src.loc)
+						src.transfer_fingerprints_to(P)
+						P.mode = 0 // start with pump off
+
+					else if(ptype==7) // Disposal outlet
+						var/obj/structure/disposaloutlet/P = new /obj/structure/disposaloutlet(src.loc)
+						src.transfer_fingerprints_to(P)
+						P.set_dir(dir)
+						var/obj/structure/disposalpipe/trunk/Trunk = CP
+						Trunk.linked = P
+
+					else if(ptype==8) // Disposal outlet
+						var/obj/machinery/disposal/deliveryChute/P = new /obj/machinery/disposal/deliveryChute(src.loc)
+						src.transfer_fingerprints_to(P)
+						P.set_dir(dir)
+
+					qdel(src)
+					return
+			else
+				to_chat(user, "You need more welding fuel to complete this task.")
 				return
+		else
+			to_chat(user, "You need to attach it to the plating first!")
+			return
 
 /obj/structure/disposalconstruct/hides_under_flooring()
 	if(anchored)

--- a/code/modules/shieldgen/shield_capacitor.dm
+++ b/code/modules/shieldgen/shield_capacitor.dm
@@ -28,7 +28,7 @@
 /obj/machinery/shield_capacitor/emag_act(var/remaining_charges, var/mob/user)
 	if(prob(75))
 		src.locked = !src.locked
-		user << "Controls are now [src.locked ? "locked." : "unlocked."]"
+		to_chat(user, "Controls are now [src.locked ? "locked." : "unlocked."]")
 		. = 1
 		updateDialog()
 	var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
@@ -41,10 +41,10 @@
 		var/obj/item/weapon/card/id/C = W
 		if(access_captain in C.access || access_security in C.access || access_engine in C.access)
 			src.locked = !src.locked
-			user << "Controls are now [src.locked ? "locked." : "unlocked."]"
+			to_chat(user, "Controls are now [src.locked ? "locked." : "unlocked."]")
 			updateDialog()
 		else
-			user << "<font color='red'>Access denied.</font>"
+			to_chat(user, "<font color='red'>Access denied.</font>")
 	else if(W.is_wrench())
 		src.anchored = !src.anchored
 		playsound(src, W.usesound, 75, 1)
@@ -127,7 +127,7 @@
 		return
 	if( href_list["toggle"] )
 		if(!active && !anchored)
-			usr << "<font color='red'>The [src] needs to be firmly secured to the floor first.</font>"
+			to_chat(usr, "<font color='red'>The [src] needs to be firmly secured to the floor first.</font>")
 			return
 		active = !active
 	if( href_list["charge_rate"] )
@@ -141,13 +141,14 @@
 	else
 		..()
 
-/obj/machinery/shield_capacitor/verb/rotate()
-	set name = "Rotate capacitor clockwise"
+/obj/machinery/shield_capacitor/verb/rotate_clockwise()
+	set name = "Rotate Capacitor Clockwise"
 	set category = "Object"
 	set src in oview(1)
 
 	if (src.anchored)
-		usr << "It is fastened to the floor!"
+		to_chat(usr, "It is fastened to the floor!")
 		return
+
 	src.set_dir(turn(src.dir, 270))
 	return

--- a/code/modules/xenoarcheaology/tools/suspension_generator.dm
+++ b/code/modules/xenoarcheaology/tools/suspension_generator.dm
@@ -219,25 +219,25 @@
 	deactivate()
 	..()
 
-/obj/machinery/suspension_gen/verb/rotate_ccw()
+/obj/machinery/suspension_gen/verb/rotate_counterclockwise()
 	set src in view(1)
-	set name = "Rotate suspension gen (counter-clockwise)"
+	set name = "Rotate suspension gen Counterclockwise"
 	set category = "Object"
 
 	if(anchored)
 		to_chat(usr, "<font color='red'>You cannot rotate [src], it has been firmly fixed to the floor.</font>")
-	else
-		set_dir(turn(dir, 90))
+		return
+	src.set_dir(turn(src.dir, 90))
 
-/obj/machinery/suspension_gen/verb/rotate_cw()
+/obj/machinery/suspension_gen/verb/rotate_clockwise()
 	set src in view(1)
-	set name = "Rotate suspension gen (clockwise)"
+	set name = "Rotate suspension gen Clockwise"
 	set category = "Object"
 
 	if(anchored)
 		to_chat(usr, "<font color='red'>You cannot rotate [src], it has been firmly fixed to the floor.</font>")
-	else
-		set_dir(turn(dir, -90))
+		return
+	src.set_dir(turn(src.dir, 270))
 
 /obj/effect/suspension_field
 	name = "energy field"


### PR DESCRIPTION
So that they actually indicate what's being rotated in what direction.
Things with rotation in both directions kept both verbs, those with rotation in only one direction now all rotate clockwise.
![tested](https://puu.sh/CeNNK/c0d9357cac.png)

I would've refactored the actual rotation part to a verb/proc on obj but verbs are dumb and I can only name them once in code, even if I name it on a subtype and try to rename it on a completely different subtype (i.e., machinery and structure)

Started this anticipating that I'd need to write a rotate proc for wiring, then discovered that set_dir() exists.