### PR TITLE
Refactors poi rotation to use degrees instead of dir

### DIFF
--- a/code/modules/admin/verbs/map_template_loadverb.dm
+++ b/code/modules/admin/verbs/map_template_loadverb.dm
@@ -14,6 +14,9 @@
 	if(!orientation)
 		return
 
+	// Convert dir to degrees rotation
+	orientation = dir2angle(orientation)
+
 	var/turf/T = get_turf(mob)
 	if(!T)
 		return
@@ -50,7 +53,10 @@
 	if(!orientation)
 		return
 
-	if(((orientation & (NORTH|SOUTH) && template.width > world.maxx || template.height > world.maxy) || ((orientation & (EAST|WEST)) && template.width > world.maxy || template.height > world.maxx)))
+	// Convert dir to degrees rotation
+	orientation = dir2angle(orientation)
+
+	if((!(orientation%180) && template.width > world.maxx || template.height > world.maxy) || (orientation%180 && template.width > world.maxy || template.height > world.maxx))
 		if(alert(usr,"This template is larger than the existing z-levels. It will EXPAND ALL Z-LEVELS to match the size of the template. This may cause chaos. Are you sure you want to do this?","DANGER!!!","Cancel","Yes") == "Cancel")
 			to_chat(usr,"Template placement aborted.")
 			return

--- a/code/modules/maps/tg/map_template.dm
+++ b/code/modules/maps/tg/map_template.dm
@@ -38,7 +38,7 @@ var/list/global/map_templates = list()
 	if(rename)
 		name = rename
 
-/datum/map_template/proc/preload_size(path, orientation = SOUTH)
+/datum/map_template/proc/preload_size(path, orientation = 0)
 	var/bounds = maploader.load_map(file(path), 1, 1, 1, cropMap=FALSE, measureOnly=TRUE, orientation=orientation)
 	if(bounds)
 		width = bounds[MAP_MAXX] // Assumes all templates are rectangular, have a single Z level, and begin at 1,1,1
@@ -83,7 +83,7 @@ var/list/global/map_templates = list()
 
 	admin_notice("<span class='danger'>Submap initializations finished.</span>", R_DEBUG)
 
-/datum/map_template/proc/load_new_z(var/centered = FALSE, var/orientation = SOUTH)
+/datum/map_template/proc/load_new_z(var/centered = FALSE, var/orientation = 0)
 	var/x = 1
 	var/y = 1
 
@@ -102,10 +102,10 @@ var/list/global/map_templates = list()
 	log_game("Z-level [name] loaded at at [x],[y],[world.maxz]")
 	return TRUE
 
-/datum/map_template/proc/load(turf/T, centered = FALSE, orientation = SOUTH)
+/datum/map_template/proc/load(turf/T, centered = FALSE, orientation = 0)
 	var/old_T = T
 	if(centered)
-		T = locate(T.x - round(((orientation & NORTH|SOUTH) ? width : height)/2) , T.y - round(((orientation & NORTH|SOUTH) ? height : width)/2) , T.z)
+		T = locate(T.x - round(((orientation%180) ? height : width)/2) , T.y - round(((orientation%180) ? width : height)/2) , T.z) // %180 catches East/West (90,270) rotations on true, North/South (0,180) rotations on false
 	if(!T)
 		return
 	if(T.x+width > world.maxx)
@@ -130,15 +130,15 @@ var/list/global/map_templates = list()
 	loaded++
 	return TRUE
 
-/datum/map_template/proc/get_affected_turfs(turf/T, centered = FALSE, orientation = SOUTH)
+/datum/map_template/proc/get_affected_turfs(turf/T, centered = FALSE, orientation = 0)
 	var/turf/placement = T
 	if(centered)
-		var/turf/corner = locate(placement.x - round(((orientation & NORTH|SOUTH) ? width : height)/2), placement.y - round(((orientation & NORTH|SOUTH) ? height : width)/2), placement.z)
+		var/turf/corner = locate(placement.x - round(((orientation%180) ? height : width)/2), placement.y - round(((orientation%180) ? width : height)/2), placement.z) // %180 catches East/West (90,270) rotations on true, North/South (0,180) rotations on false
 		if(corner)
 			placement = corner
-	return block(placement, locate(placement.x+((orientation & NORTH|SOUTH) ? width : height)-1, placement.y+((orientation & NORTH|SOUTH) ? height : width)-1, placement.z))
+	return block(placement, locate(placement.x+((orientation%180) ? height : width)-1, placement.y+((orientation%180) ? width : height)-1, placement.z))
 
-/datum/map_template/proc/annihilate_bounds(turf/origin, centered = FALSE, orientation = SOUTH)
+/datum/map_template/proc/annihilate_bounds(turf/origin, centered = FALSE, orientation = 0)
 	var/deleted_atoms = 0
 	admin_notice("<span class='danger'>Annihilating objects in submap loading locatation.</span>", R_DEBUG)
 	var/list/turfs_to_clean = get_affected_turfs(origin, centered, orientation)
@@ -152,7 +152,7 @@ var/list/global/map_templates = list()
 
 //for your ever biggening badminnery kevinz000
 //❤ - Cyberboss
-/proc/load_new_z_level(var/file, var/name, var/orientation = SOUTH)
+/proc/load_new_z_level(var/file, var/name, var/orientation = 0)
 	var/datum/map_template/template = new(file, name)
 	template.load_new_z(orientation)
 
@@ -229,13 +229,13 @@ var/list/global/map_templates = list()
 
 			var/orientation
 			if(chosen_template.fixed_orientation || !config.random_submap_orientation)
-				orientation = SOUTH
+				orientation = 0
 			else
-				orientation = pick(cardinal)
+				orientation = pick(list(0, 90, 180, 270))
 
 			chosen_template.preload_size(chosen_template.mappath, orientation)
-			var/width_border = TRANSITIONEDGE + SUBMAP_MAP_EDGE_PAD + round(((orientation & NORTH|SOUTH) ? chosen_template.width : chosen_template.height) / 2)
-			var/height_border = TRANSITIONEDGE + SUBMAP_MAP_EDGE_PAD + round(((orientation & NORTH|SOUTH) ? chosen_template.height : chosen_template.width) / 2)
+			var/width_border = TRANSITIONEDGE + SUBMAP_MAP_EDGE_PAD + round(((orientation%180) ? chosen_template.height : chosen_template.width) / 2) // %180 catches East/West (90,270) rotations on true, North/South (0,180) rotations on false
+			var/height_border = TRANSITIONEDGE + SUBMAP_MAP_EDGE_PAD + round(((orientation%180) ? chosen_template.width : chosen_template.height) / 2)
 			var/z_level = pick(z_levels)
 			var/turf/T = locate(rand(width_border, world.maxx - width_border), rand(height_border, world.maxy - height_border), z_level)
 			var/valid = TRUE

--- a/code/modules/maps/tg/reader.dm
+++ b/code/modules/maps/tg/reader.dm
@@ -63,9 +63,9 @@ var/global/use_preloader = FALSE
 	if(!z_offset)
 		z_offset = world.maxz + 1
 
-	// If it's not a single dir, default to north (Default orientation)
-	if(!orientation in cardinal)
-		orientation = SOUTH
+	// If it's not a single dir, default to 0 degrees rotation (Default orientation)
+	if(!(orientation in list(0, 90, 180, 270)))
+		orientation = 0
 
 	var/list/bounds = list(1.#INF, 1.#INF, 1.#INF, -1.#INF, -1.#INF, -1.#INF)
 	var/list/grid_models = list()
@@ -161,12 +161,12 @@ var/global/use_preloader = FALSE
 				key_list[++key_list.len] = line_keys
 
 			// Rotate the list according to orientation
-			if(orientation != SOUTH)
+			if(orientation != 0)
 				var/num_cols = key_list[1].len
 				var/num_rows = key_list.len
 				var/list/new_key_list = list()
 				// If it's rotated 180 degrees, the dimensions are the same
-				if(orientation == NORTH)
+				if(orientation == 180)
 					new_key_list.len = num_rows
 					for(var/i = 1 to new_key_list.len)
 						new_key_list[i] = list()
@@ -184,11 +184,11 @@ var/global/use_preloader = FALSE
 				for(var/i = 1 to new_key_list.len)
 					for(var/j = 1 to new_key_list[i].len)
 						switch(orientation)
-							if(NORTH)
+							if(180)
 								new_key_list[i][j] = key_list[num_rows - i][num_cols - j]
-							if(EAST)
+							if(270)
 								new_key_list[i][j] = key_list[num_rows - j][i]
-							if(WEST)
+							if(90)
 								new_key_list[i][j] = key_list[j][num_cols - i]
 
 				key_list = new_key_list
@@ -308,12 +308,6 @@ var/global/use_preloader = FALSE
 						if(istext(value))
 							fields[I] = apply_text_macros(value)
 
-			// Rotate dir if orientation isn't south (default)
-			if(fields["dir"])
-				fields["dir"] = turn(fields["dir"], dir2angle(orientation) + 180)
-			else
-				fields["dir"] = turn(SOUTH, dir2angle(orientation) + 180)
-
 			//then fill the members_attributes list with the corresponding variables
 			members_attributes.len++
 			members_attributes[index++] = fields
@@ -374,20 +368,20 @@ var/global/use_preloader = FALSE
 	//instanciate the first /turf
 	var/turf/T
 	if(members[first_turf_index] != /turf/template_noop)
-		T = instance_atom(members[first_turf_index],members_attributes[first_turf_index],crds,no_changeturf)
+		T = instance_atom(members[first_turf_index],members_attributes[first_turf_index],crds,no_changeturf,orientation)
 
 	if(T)
 		//if others /turf are presents, simulates the underlays piling effect
 		index = first_turf_index + 1
 		while(index <= members.len - 1) // Last item is an /area
 			var/underlay = T.appearance
-			T = instance_atom(members[index],members_attributes[index],crds,no_changeturf)//instance new turf
+			T = instance_atom(members[index],members_attributes[index],crds,no_changeturf,orientation)//instance new turf
 			T.underlays += underlay
 			index++
 
 	//finally instance all remainings objects/mobs
 	for(index in 1 to first_turf_index-1)
-		instance_atom(members[index],members_attributes[index],crds,no_changeturf)
+		instance_atom(members[index],members_attributes[index],crds,no_changeturf,orientation)
 	//Restore initialization to the previous value
 	SSatoms.map_loader_stop()
 
@@ -396,7 +390,7 @@ var/global/use_preloader = FALSE
 ////////////////
 
 //Instance an atom at (x,y,z) and gives it the variables in attributes
-/dmm_suite/proc/instance_atom(path,list/attributes, turf/crds, no_changeturf)
+/dmm_suite/proc/instance_atom(path,list/attributes, turf/crds, no_changeturf, orientation=0)
 	_preloader.setup(attributes, path)
 
 	if(crds)
@@ -413,6 +407,11 @@ var/global/use_preloader = FALSE
 		SSatoms.map_loader_stop()
 		stoplag()
 		SSatoms.map_loader_begin()
+
+	// Rotate the atom now that it exists, rather than changing its orientation beforehand through the fields["dir"]
+	if(orientation != 0) // 0 means no rotation
+		var/atom/A = .
+		A.set_dir(turn(A.dir, orientation))
 
 /dmm_suite/proc/create_atom(path, crds)
 	set waitfor = FALSE

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -199,6 +199,17 @@
 
 	return ..()
 
+// APCs are pixel-shifted, so they need to be updated.
+/obj/machinery/power/apc/set_dir(new_dir)
+	..()
+	pixel_x = (src.dir & 3)? 0 : (src.dir == 4 ? 24 : -24)
+	pixel_y = (src.dir & 3)? (src.dir ==1 ? 24 : -24) : 0
+	if(terminal)
+		terminal.disconnect_from_network()
+		terminal.set_dir(src.dir) // Terminal has same dir as master
+		terminal.connect_to_network() // Refresh the network the terminal is connected to.
+	return
+
 /obj/machinery/power/apc/proc/energy_fail(var/duration)
 	failure_timer = max(failure_timer, round(duration))
 


### PR DESCRIPTION
Fixes powernet rotation being totally non-functional
Fixes #5708 

Tested, mostly with Rockybase1, but in this image, with DoomP rotated 180 degrees, because that has the lights on by default. APC is notably charging, and therefore correctly connected to the SMES units.
![tested](https://puu.sh/CfkcM/ae21b2f075.png)

Because this is using set_dir, which probably isn't defined for everything that needs the custom dir-change handling that it's supposed to provide, this should work with everything, but is not guaranteed to. Notable examples that I don't think are currently in PoIs include sleepers and adv body scanners, since they're two-object devices. To that end, I will be pinning a message to discord asking people to report instances where the directions of PoI objects are wonky, asking them to test rotating their in-development PoIs, and asking that they make an issue of it so as to go about fixing that behaviour.
I may also update our coding standards or something to that effect to require that people making PoIs test this, but not requiring that they fix it themselves (Although I'd certainly appreciate it if they did), because I recognize that finding every instance where set_dir() should be defined but is not is even less reasonable than manually updating every << to to_chat() (Since you can at least kinda use find/replace there).