### PR TITLE
Startup runtimes

### DIFF
--- a/code/_global_vars/misc.dm
+++ b/code/_global_vars/misc.dm
@@ -1,4 +1,8 @@
-GLOBAL_LIST_EMPTY(all_observable_events)
+GLOBAL_LIST_EMPTY(error_last_seen)
+GLOBAL_LIST_EMPTY(error_cooldown)
+
+GLOBAL_DATUM_INIT(all_observable_events, /datum/all_observable_events, new) // This is a datum. It is not a list.
+GLOBAL_DATUM_INIT(destroyed_event, /decl/observ/destroyed, new())
 
 GLOBAL_VAR_INIT(timezoneOffset, 0) // The difference betwen midnight (of the host computer) and 0 world.ticks.
 

--- a/code/controllers/Processes/alarm.dm
+++ b/code/controllers/Processes/alarm.dm
@@ -11,7 +11,7 @@
 var/datum/controller/process/alarm/alarm_manager
 
 /datum/controller/process/alarm
-	var/list/datum/alarm/all_handlers
+	var/list/datum/alarm/all_handlers = list()
 
 /datum/controller/process/alarm/setup()
 	name = "alarm"

--- a/code/controllers/Processes/scheduler.dm
+++ b/code/controllers/Processes/scheduler.dm
@@ -40,7 +40,7 @@
 // We are being killed. Least we can do is deregister all those events we registered
 /datum/controller/process/scheduler/onKill()
 	for(var/st in scheduled_tasks)
-		destroyed_event.unregister(st, src)
+		GLOB.destroyed_event.unregister(st, src)
 
 /datum/controller/process/scheduler/statProcess()
 	..()
@@ -130,7 +130,7 @@
 
 /datum/scheduled_task/source/New(var/trigger_time, var/datum/source, var/procedure, var/list/arguments, var/proc/task_after_process, var/list/task_after_process_args)
 	src.source = source
-	destroyed_event.register(src.source, src, /datum/scheduled_task/source/proc/source_destroyed)
+	GLOB.destroyed_event.register(src.source, src, /datum/scheduled_task/source/proc/source_destroyed)
 	..(trigger_time, procedure, arguments, task_after_process, task_after_process_args)
 
 /datum/scheduled_task/source/Destroy()

--- a/code/datums/observation/_debug.dm
+++ b/code/datums/observation/_debug.dm
@@ -1,7 +1,6 @@
 /****************
 * Debug Support *
 ****************/
-var/datum/all_observable_events/all_observable_events = new()
 
 /datum/all_observable_events
 	var/list/events

--- a/code/datums/observation/destroyed.dm
+++ b/code/datums/observation/destroyed.dm
@@ -5,11 +5,10 @@
 //
 //		Arguments that the called proc should expect:
 //			/datum/destroyed_instance: The instance that was destroyed.
-var/decl/observ/destroyed/destroyed_event = new()
 
 /decl/observ/destroyed
 	name = "Destroyed"
 
 /datum/Destroy()
-	destroyed_event.raise_event(src)
+	GLOB.destroyed_event.raise_event(src)
 	. = ..()

--- a/code/datums/observation/observation.dm
+++ b/code/datums/observation/observation.dm
@@ -63,7 +63,7 @@
 	var/list/global_listeners = list()  // Associative list of instances that listen to all events of this type (as opposed to events belonging to a specific source) and the proc to call.
 
 /decl/observ/New()
-	all_observable_events.events += src
+	GLOB.all_observable_events.events += src
 	. = ..()
 
 /decl/observ/proc/is_listening(var/event_source, var/datum/listener, var/proc_call)

--- a/code/datums/observation/~cleanup.dm
+++ b/code/datums/observation/~cleanup.dm
@@ -1,6 +1,6 @@
-var/list/global_listen_count = list()
-var/list/event_sources_count = list()
-var/list/event_listen_count = list()
+GLOBAL_LIST_EMPTY(global_listen_count)
+GLOBAL_LIST_EMPTY(event_sources_count)
+GLOBAL_LIST_EMPTY(event_listen_count)
 
 /decl/observ/destroyed/raise_event()
 	. = ..()
@@ -8,39 +8,39 @@ var/list/event_listen_count = list()
 		return
 	var/source = args[1]
 
-	if(global_listen_count[source])
-		cleanup_global_listener(source, global_listen_count[source])
-	if(event_sources_count[source])
-		cleanup_source_listeners(source, event_sources_count[source])
-	if(event_listen_count[source])
-		cleanup_event_listener(source, event_listen_count[source])
+	if(GLOB.global_listen_count[source])
+		cleanup_global_listener(source, GLOB.global_listen_count[source])
+	if(GLOB.event_sources_count[source])
+		cleanup_source_listeners(source, GLOB.event_sources_count[source])
+	if(GLOB.event_listen_count[source])
+		cleanup_event_listener(source, GLOB.event_listen_count[source])
 
 
 /decl/observ/register(var/datum/event_source, var/datum/listener, var/proc_call)
 	. = ..()
 	if(.)
-		event_sources_count[event_source] += 1
-		event_listen_count[listener] += 1
+		GLOB.event_sources_count[event_source] += 1
+		GLOB.event_listen_count[listener] += 1
 
 /decl/observ/unregister(var/datum/event_source, var/datum/listener, var/proc_call)
 	. = ..()
 	if(.)
-		event_sources_count[event_source] -= 1
-		event_listen_count[listener] -= 1
+		GLOB.event_sources_count[event_source] -= 1
+		GLOB.event_listen_count[listener] -= 1
 
 /decl/observ/register_global(var/datum/listener, var/proc_call)
 	. = ..()
 	if(.)
-		global_listen_count[listener] += 1
+		GLOB.global_listen_count[listener] += 1
 
 /decl/observ/unregister_global(var/datum/listener, var/proc_call)
 	. = ..()
 	if(.)
-		global_listen_count[listener] -= 1
+		GLOB.global_listen_count[listener] -= 1
 
 /decl/observ/destroyed/proc/cleanup_global_listener(listener, listen_count)
-	global_listen_count -= listener
-	for(var/entry in all_observable_events.events)
+	GLOB.global_listen_count -= listener
+	for(var/entry in GLOB.all_observable_events.events)
 		var/decl/observ/event = entry
 		if(event.unregister_global(listener))
 			log_debug("[event] - [listener] was deleted while still registered to global events.")
@@ -48,8 +48,8 @@ var/list/event_listen_count = list()
 				return
 
 /decl/observ/destroyed/proc/cleanup_source_listeners(event_source, source_listener_count)
-	event_sources_count -= event_source
-	for(var/entry in all_observable_events.events)
+	GLOB.event_sources_count -= event_source
+	for(var/entry in GLOB.all_observable_events.events)
 		var/decl/observ/event = entry
 		var/proc_owners = event.event_sources[event_source]
 		if(proc_owners)
@@ -60,8 +60,8 @@ var/list/event_listen_count = list()
 						return
 
 /decl/observ/destroyed/proc/cleanup_event_listener(listener, listener_count)
-	event_listen_count -= listener
-	for(var/entry in all_observable_events.events)
+	GLOB.event_listen_count -= listener
+	for(var/entry in GLOB.all_observable_events.events)
 		var/decl/observ/event = entry
 		for(var/event_source in event.event_sources)
 			if(event.unregister(event_source, listener))

--- a/code/game/objects/effects/decals/Cleanable/humans.dm
+++ b/code/game/objects/effects/decals/Cleanable/humans.dm
@@ -250,4 +250,4 @@ var/global/list/image/splatter_cache=list()
 /obj/effect/decal/cleanable/mucus/mapped/New()
 	..()
 	virus2 |= new /datum/disease2/disease
-	virus2.makerandom()
+	virus2[1].makerandom()

--- a/code/modules/holomap/station_holomap.dm
+++ b/code/modules/holomap/station_holomap.dm
@@ -125,7 +125,7 @@
 			watching_mob = user
 			GLOB.moved_event.register(watching_mob, src, /obj/machinery/station_map/proc/checkPosition)
 			GLOB.dir_set_event.register(watching_mob, src, /obj/machinery/station_map/proc/checkPosition)
-			destroyed_event.register(watching_mob, src, /obj/machinery/station_map/proc/stopWatching)
+			GLOB.destroyed_event.register(watching_mob, src, /obj/machinery/station_map/proc/stopWatching)
 			update_use_power(2)
 
 			if(bogus)
@@ -154,7 +154,7 @@
 				M.client.images -= holomap_datum.station_map
 		GLOB.moved_event.unregister(watching_mob, src)
 		GLOB.dir_set_event.unregister(watching_mob, src)
-		destroyed_event.unregister(watching_mob, src)
+		GLOB.destroyed_event.unregister(watching_mob, src)
 	watching_mob = null
 	update_use_power(1)
 

--- a/code/modules/integrated_electronics/subtypes/manipulation.dm
+++ b/code/modules/integrated_electronics/subtypes/manipulation.dm
@@ -188,14 +188,14 @@
 // These procs do not relocate the grenade, that's the callers responsibility
 /obj/item/integrated_circuit/manipulation/grenade/proc/attach_grenade(var/obj/item/weapon/grenade/G)
 	attached_grenade = G
-	destroyed_event.register(attached_grenade, src, /obj/item/integrated_circuit/manipulation/grenade/proc/detach_grenade)
+	GLOB.destroyed_event.register(attached_grenade, src, /obj/item/integrated_circuit/manipulation/grenade/proc/detach_grenade)
 	size += G.w_class
 	desc += " \An [attached_grenade] is attached to it!"
 
 /obj/item/integrated_circuit/manipulation/grenade/proc/detach_grenade()
 	if(!attached_grenade)
 		return
-	destroyed_event.unregister(attached_grenade, src, /obj/item/integrated_circuit/manipulation/grenade/proc/detach_grenade)
+	GLOB.destroyed_event.unregister(attached_grenade, src, /obj/item/integrated_circuit/manipulation/grenade/proc/detach_grenade)
 	attached_grenade = null
 	size = initial(size)
 	desc = initial(desc)


### PR DESCRIPTION
Error handler runtimes required stuff to be moved onto GLOB and added to GLOB's list before the things that use them. They occurred every time I started a test server on the example map prior to fixing, and not at all after implementing the fixes. I tested it once on the SC map, and found the global announcer bug and mucus bug again, so I went ahead and fixed those as well. The alarm manager controller initializes an empty list, so things can attempt to index it without runtiming (Global announcer bug).
The mucus initialized a list of viruses with a single new virus, and then attempted to call `makerandom()` on the list object, rather than the single virus within that list object.

Tested on Example map and Southern Cross map.