### PR TITLE
Adds pressure protection bounds to clothing.

### DIFF
--- a/code/__defines/items_clothing.dm
+++ b/code/__defines/items_clothing.dm
@@ -53,11 +53,10 @@
 
 //Flags for items (equipment) - Used in /obj/item/var/item_flags
 #define THICKMATERIAL          0x1  // Prevents syringes, parapens and hyposprays if equipped to slot_suit or slot_head.
-#define STOPPRESSUREDAMAGE     0x2  // Counts towards pressure protection. Note that like temperature protection, body_parts_covered is considered here as well.
-#define AIRTIGHT               0x4  // Functions with internals.
-#define NOSLIP                 0x8  // Prevents from slipping on wet floors, in space, etc.
-#define BLOCK_GAS_SMOKE_EFFECT 0x10 // Blocks the effect that chemical clouds would have on a mob -- glasses, mask and helmets ONLY! (NOTE: flag shared with ONESIZEFITSALL)
-#define FLEXIBLEMATERIAL       0x20 // At the moment, masks with this flag will not prevent eating even if they are covering your face.
+#define AIRTIGHT               0x2  // Functions with internals.
+#define NOSLIP                 0x4  // Prevents from slipping on wet floors, in space, etc.
+#define BLOCK_GAS_SMOKE_EFFECT 0x8  // Blocks the effect that chemical clouds would have on a mob -- glasses, mask and helmets ONLY! (NOTE: flag shared with ONESIZEFITSALL)
+#define FLEXIBLEMATERIAL       0x10 // At the moment, masks with this flag will not prevent eating even if they are covering your face.
 
 // Flags for pass_flags. - Used in /atom/var/pass_flags
 #define PASSTABLE  0x1

--- a/code/game/gamemodes/changeling/powers/armor.dm
+++ b/code/game/gamemodes/changeling/powers/armor.dm
@@ -35,8 +35,8 @@
 	name = "flesh mass"
 	icon_state = "lingspacesuit"
 	desc = "A huge, bulky mass of pressure and temperature-resistant organic tissue, evolved to facilitate space travel."
-	flags = STOPPRESSUREDAMAGE			 //Not THICKMATERIAL because it's organic tissue, so if somebody tries to inject something into it,
-										//it still ends up in your blood. (also balance but muh fluff)
+	flags = 0	//Not THICKMATERIAL because it's organic tissue, so if somebody tries to inject something into it,
+				//it still ends up in your blood. (also balance but muh fluff)
 	allowed = list(/obj/item/device/flashlight, /obj/item/weapon/tank/emergency/oxygen, /obj/item/weapon/tank/oxygen)
 	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 0, rad = 0) //No armor at all.
 	canremove = 0
@@ -55,7 +55,7 @@
 	name = "flesh mass"
 	icon_state = "lingspacehelmet"
 	desc = "A covering of pressure and temperature-resistant organic tissue with a glass-like chitin front."
-	flags = BLOCKHAIR | STOPPRESSUREDAMAGE //Again, no THICKMATERIAL.
+	flags = BLOCKHAIR //Again, no THICKMATERIAL.
 	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 0, rad = 0)
 	body_parts_covered = HEAD|FACE|EYES
 	canremove = 0

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -27,6 +27,10 @@
 	var/max_heat_protection_temperature //Set this variable to determine up to which temperature (IN KELVIN) the item protects against heat damage. Keep at null to disable protection. Only protects areas set by heat_protection flags
 	var/min_cold_protection_temperature //Set this variable to determine down to which temperature (IN KELVIN) the item protects against cold damage. 0 is NOT an acceptable number due to if(varname) tests!! Keep at null to disable protection. Only protects areas set by cold_protection flags
 
+	var/max_pressure_protection // Set this variable if the item protects its wearer against high pressures below an upper bound. Keep at null to disable protection.
+	var/min_pressure_protection // Set this variable if the item protects its wearer against low pressures above a lower bound. Keep at null to disable protection. 0 represents protection against hard vacuum.
+
+
 	var/datum/action/item_action/action = null
 	var/action_button_name //It is also the text which gets displayed on the action button. If not set it defaults to 'Use [name]'. If it's not set, there'll be no button.
 	var/action_button_is_hands_free = 0 //If 1, bypass the restrained, lying, and stunned checks action buttons normally test for

--- a/code/modules/clothing/head/hardhat.dm
+++ b/code/modules/clothing/head/hardhat.dm
@@ -18,16 +18,19 @@
 /obj/item/clothing/head/hardhat/red
 	icon_state = "hardhat0_red"
 	name = "firefighter helmet"
-	item_flags = STOPPRESSUREDAMAGE
 	heat_protection = HEAD
 	max_heat_protection_temperature = FIRE_HELMET_MAX_HEAT_PROTECTION_TEMPERATURE
+	min_pressure_protection = 0.8* ONE_ATMOSPHERE
+	max_pressure_protection = 50 * ONE_ATMOSPHERE
+
 
 /obj/item/clothing/head/hardhat/white
 	icon_state = "hardhat0_white"
 	name = "sleek hard hat"
-	item_flags = STOPPRESSUREDAMAGE
 	heat_protection = HEAD
 	max_heat_protection_temperature = FIRE_HELMET_MAX_HEAT_PROTECTION_TEMPERATURE
+	min_pressure_protection = 0.8* ONE_ATMOSPHERE
+	max_pressure_protection = 50 * ONE_ATMOSPHERE
 
 /obj/item/clothing/head/hardhat/dblue
 	name = "blue hard hat"

--- a/code/modules/clothing/spacesuits/alien.dm
+++ b/code/modules/clothing/spacesuits/alien.dm
@@ -32,7 +32,7 @@
 /obj/item/clothing/suit/space/vox
 	w_class = ITEMSIZE_NORMAL
 	flags = PHORONGUARD
-	item_flags = STOPPRESSUREDAMAGE | THICKMATERIAL
+	item_flags = THICKMATERIAL
 	allowed = list(/obj/item/weapon/gun,/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/weapon/melee/baton,/obj/item/weapon/melee/energy/sword,/obj/item/weapon/handcuffs,/obj/item/weapon/tank)
 	armor = list(melee = 60, bullet = 50, laser = 40,energy = 15, bomb = 30, bio = 100, rad = 50)
 	siemens_coefficient = 0.2
@@ -44,7 +44,7 @@
 	armor = list(melee = 60, bullet = 50, laser = 40, energy = 15, bomb = 30, bio = 100, rad = 50)
 	siemens_coefficient = 0.2
 	flags = PHORONGUARD
-	item_flags = STOPPRESSUREDAMAGE | THICKMATERIAL | AIRTIGHT
+	item_flags = THICKMATERIAL | AIRTIGHT
 	flags_inv = 0
 	species_restricted = list(SPECIES_VOX)
 

--- a/code/modules/clothing/spacesuits/miscellaneous.dm
+++ b/code/modules/clothing/spacesuits/miscellaneous.dm
@@ -3,7 +3,7 @@
 	name = "space helmet"
 	icon_state = "capspace"
 	desc = "A special helmet designed for work in a hazardous, low-pressure environment. Only for the most fashionable of military figureheads."
-	item_flags = STOPPRESSUREDAMAGE
+	item_flags = 0
 	flags_inv = HIDEFACE|BLOCKHAIR
 	permeability_coefficient = 0.01
 	armor = list(melee = 65, bullet = 50, laser = 50,energy = 25, bomb = 50, bio = 100, rad = 50)
@@ -16,7 +16,7 @@
 	w_class = ITEMSIZE_HUGE
 	gas_transfer_coefficient = 0.01
 	permeability_coefficient = 0.02
-	item_flags = STOPPRESSUREDAMAGE
+	item_flags = 0
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|FEET|ARMS
 	allowed = list(/obj/item/weapon/tank/emergency/oxygen, /obj/item/device/flashlight,/obj/item/weapon/gun/energy, /obj/item/weapon/gun/projectile, /obj/item/ammo_magazine, /obj/item/ammo_casing, /obj/item/weapon/melee/baton,/obj/item/weapon/handcuffs)
 	slowdown = 1.5
@@ -33,7 +33,7 @@
 	icon_state = "deathsquad"
 	item_state_slots = list(slot_r_hand_str = "syndicate-helm-black-red", slot_l_hand_str = "syndicate-helm-black-red")
 	armor = list(melee = 65, bullet = 55, laser = 35,energy = 20, bomb = 30, bio = 100, rad = 60)
-	item_flags = STOPPRESSUREDAMAGE | THICKMATERIAL
+	item_flags = THICKMATERIAL
 	flags_inv = BLOCKHAIR
 	siemens_coefficient = 0.6
 
@@ -44,7 +44,7 @@
 	icon_state = "beret_badge"
 	item_state_slots = list(slot_r_hand_str = "beret", slot_l_hand_str = "beret")
 	armor = list(melee = 65, bullet = 55, laser = 35,energy = 20, bomb = 30, bio = 30, rad = 30)
-	item_flags = STOPPRESSUREDAMAGE
+	item_flags = 0
 	flags_inv = BLOCKHAIR
 	siemens_coefficient = 0.9
 
@@ -53,7 +53,7 @@
 	name = "Santa's hat"
 	desc = "Ho ho ho. Merrry X-mas!"
 	icon_state = "santahat"
-	item_flags = STOPPRESSUREDAMAGE
+	item_flags = 0
 	flags_inv = BLOCKHAIR
 	body_parts_covered = HEAD
 
@@ -62,7 +62,7 @@
 	desc = "Festive!"
 	icon_state = "santa"
 	slowdown = 0
-	item_flags = STOPPRESSUREDAMAGE
+	item_flags = 0
 	allowed = list(/obj/item) //for stuffing exta special presents
 
 //Space pirate outfit
@@ -71,7 +71,7 @@
 	desc = "Yarr."
 	icon_state = "pirate"
 	armor = list(melee = 60, bullet = 50, laser = 30,energy = 15, bomb = 30, bio = 30, rad = 30)
-	item_flags = STOPPRESSUREDAMAGE
+	item_flags = 0
 	flags_inv = BLOCKHAIR
 	body_parts_covered = 0
 	siemens_coefficient = 0.9

--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -83,7 +83,9 @@
 	var/offline_slowdown = 3                                  // If the suit is deployed and unpowered, it sets slowdown to this.
 	var/vision_restriction
 	var/offline_vision_restriction = 1                        // 0 - none, 1 - welder vision, 2 - blind. Maybe move this to helmets.
-	var/airtight = 1 //If set, will adjust AIRTIGHT and STOPPRESSUREDAMAGE flags on components. Otherwise it should leave them untouched.
+	var/airtight = 1 //If set, will adjust AIRTIGHT flag and pressure protections on components. Otherwise it should leave them untouched.
+	var/rigsuit_max_pressure = 20 * ONE_ATMOSPHERE			  // Max pressure the rig protects against when sealed
+	var/rigsuit_min_pressure = 0							  // Min pressure the rig protects against when sealed
 
 	var/emp_protection = 0
 
@@ -204,6 +206,21 @@
 		return 0
 	return 1
 
+// Updates pressure protection
+// Seal = 1 sets protection
+// Seal = 0 unsets protection
+/obj/item/weapon/rig/proc/update_airtight(var/obj/item/piece, var/seal = 0)
+	if(seal == 1)
+		min_pressure_protection = rigsuit_min_pressure
+		max_pressure_protection = rigsuit_max_pressure
+		piece.item_flags &= ~AIRTIGHT
+	else
+		min_pressure_protection = null
+		max_pressure_protection = null
+		piece.item_flags |= AIRTIGHT
+	return
+
+
 /obj/item/weapon/rig/proc/reset()
 	offline = 2
 	canremove = 1
@@ -211,7 +228,7 @@
 		if(!piece) continue
 		piece.icon_state = "[suit_state]"
 		if(airtight)
-			piece.item_flags &= ~(STOPPRESSUREDAMAGE|AIRTIGHT)
+			update_airtight(piece, 0) // Unseal
 	update_icon(1)
 
 /obj/item/weapon/rig/proc/toggle_seals(var/mob/living/carbon/human/M,var/instant)
@@ -339,9 +356,9 @@
 /obj/item/weapon/rig/proc/update_component_sealed()
 	for(var/obj/item/piece in list(helmet,boots,gloves,chest))
 		if(canremove)
-			piece.item_flags &= ~(STOPPRESSUREDAMAGE|AIRTIGHT)
+			update_airtight(piece, 0) // Unseal
 		else
-			piece.item_flags |=  (STOPPRESSUREDAMAGE|AIRTIGHT)
+			update_airtight(piece, 1) // Seal
 
 /obj/item/weapon/rig/ui_action_click()
 	toggle_cooling(usr)

--- a/code/modules/clothing/spacesuits/rig/rig_pieces.dm
+++ b/code/modules/clothing/spacesuits/rig/rig_pieces.dm
@@ -40,10 +40,10 @@
 	name = "chestpiece"
 	allowed = list(/obj/item/device/flashlight,/obj/item/weapon/tank,/obj/item/device/suit_cooling_unit)
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
-	heat_protection =    UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
-	cold_protection =    UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
-	flags_inv =          HIDEJUMPSUIT|HIDETAIL
-	item_flags =              STOPPRESSUREDAMAGE | THICKMATERIAL | AIRTIGHT
+	heat_protection =	 UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
+	cold_protection =	 UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
+	flags_inv =			 HIDEJUMPSUIT|HIDETAIL
+	item_flags =		 THICKMATERIAL | AIRTIGHT
 	slowdown = 0
 	//will reach 10 breach damage after 25 laser carbine blasts, 3 revolver hits, or ~1 PTR hit. Completely immune to smg or sts hits.
 	breach_threshold = 38

--- a/code/modules/clothing/spacesuits/rig/suits/light.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/light.dm
@@ -8,7 +8,7 @@
 	armor = list(melee = 50, bullet = 15, laser = 50, energy = 10, bomb = 25, bio = 0, rad = 0)
 	emp_protection = 10
 	slowdown = 0
-	item_flags = STOPPRESSUREDAMAGE | THICKMATERIAL
+	item_flags = THICKMATERIAL
 	offline_slowdown = 0
 	offline_vision_restriction = 0
 

--- a/code/modules/clothing/spacesuits/rig/suits/station.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/station.dm
@@ -155,6 +155,7 @@
 	offline_slowdown = 0
 	offline_vision_restriction = 0
 	siemens_coefficient= 0.75
+	rigsuit_max_pressure = 100 * ONE_ATMOSPHERE // Comparable to atmos suit
 
 	helm_type = /obj/item/clothing/head/helmet/space/rig/ce
 	glove_type = /obj/item/clothing/gloves/gauntlets/rig/ce

--- a/code/modules/clothing/spacesuits/spacesuits.dm
+++ b/code/modules/clothing/spacesuits/spacesuits.dm
@@ -7,13 +7,15 @@
 	icon_state = "space"
 	desc = "A special helmet designed for work in a hazardous, low-pressure environment."
 	flags = PHORONGUARD
-	item_flags = STOPPRESSUREDAMAGE | THICKMATERIAL | AIRTIGHT
+	item_flags = THICKMATERIAL | AIRTIGHT
 	permeability_coefficient = 0.01
 	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 100, rad = 50)
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|BLOCKHAIR
 	body_parts_covered = HEAD|FACE|EYES
 	cold_protection = HEAD
 	min_cold_protection_temperature = SPACE_HELMET_MIN_COLD_PROTECTION_TEMPERATURE
+	min_pressure_protection = 0 * ONE_ATMOSPHERE
+	max_pressure_protection = 20* ONE_ATMOSPHERE
 	siemens_coefficient = 0.9
 	species_restricted = list("exclude",SPECIES_DIONA)
 	preserve_item = 1
@@ -56,7 +58,7 @@
 	gas_transfer_coefficient = 0.01
 	permeability_coefficient = 0.02
 	flags = PHORONGUARD
-	item_flags = STOPPRESSUREDAMAGE | THICKMATERIAL | PHORONGUARD
+	item_flags = THICKMATERIAL | PHORONGUARD
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|FEET|ARMS|HANDS
 	allowed = list(/obj/item/device/flashlight,/obj/item/weapon/tank/emergency/oxygen,/obj/item/device/suit_cooling_unit)
 	slowdown = 3
@@ -64,6 +66,8 @@
 	flags_inv = HIDEGLOVES|HIDESHOES|HIDEJUMPSUIT|HIDETAIL|HIDETIE|HIDEHOLSTER
 	cold_protection = UPPER_TORSO | LOWER_TORSO | LEGS | FEET | ARMS | HANDS
 	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
+	min_pressure_protection = 0 * ONE_ATMOSPHERE
+	max_pressure_protection = 20* ONE_ATMOSPHERE
 	siemens_coefficient = 0.9
 	species_restricted = list("exclude",SPECIES_DIONA)
 	preserve_item = 1

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -126,7 +126,7 @@
 	item_state_slots = list(slot_r_hand_str = "swat", slot_l_hand_str = "swat")
 	gas_transfer_coefficient = 0.01
 	permeability_coefficient = 0.01
-	item_flags = STOPPRESSUREDAMAGE | THICKMATERIAL
+	item_flags = THICKMATERIAL
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|FEET|ARMS
 	allowed = list(/obj/item/weapon/gun,/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/weapon/melee/baton,/obj/item/weapon/handcuffs,/obj/item/weapon/tank/emergency/oxygen,/obj/item/clothing/head/helmet)
 	slowdown = 1
@@ -135,6 +135,8 @@
 	flags_inv = HIDEGLOVES|HIDESHOES|HIDEJUMPSUIT|HIDETIE|HIDEHOLSTER
 	cold_protection = UPPER_TORSO | LOWER_TORSO | LEGS | FEET | ARMS | HANDS
 	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
+	min_pressure_protection = 0 * ONE_ATMOSPHERE
+	max_pressure_protection = 20* ONE_ATMOSPHERE
 	siemens_coefficient = 0.6
 
 

--- a/code/modules/clothing/suits/utility.dm
+++ b/code/modules/clothing/suits/utility.dm
@@ -20,10 +20,13 @@
 	allowed = list(/obj/item/device/flashlight,/obj/item/weapon/tank/emergency/oxygen,/obj/item/weapon/extinguisher)
 	slowdown = 1.0
 	flags_inv = HIDEGLOVES|HIDESHOES|HIDEJUMPSUIT|HIDETAIL|HIDETIE|HIDEHOLSTER
-	item_flags = STOPPRESSUREDAMAGE
+	item_flags = 0
 	heat_protection = UPPER_TORSO|LOWER_TORSO|LEGS|FEET|ARMS|HANDS
 	max_heat_protection_temperature = FIRESUIT_MAX_HEAT_PROTECTION_TEMPERATURE
 	cold_protection = UPPER_TORSO | LOWER_TORSO | LEGS | FEET | ARMS | HANDS
+	min_pressure_protection = 0.8 * ONE_ATMOSPHERE
+	max_pressure_protection = 50  * ONE_ATMOSPHERE
+
 
 /obj/item/clothing/suit/fire/firefighter
 	icon_state = "firesuit"

--- a/code/modules/examine/descriptions/armor.dm
+++ b/code/modules/examine/descriptions/armor.dm
@@ -46,8 +46,13 @@
 	if(flags & AIRTIGHT)
 		armor_stats += "It is airtight. \n"
 
-	if(flags & STOPPRESSUREDAMAGE)
+	if(min_pressure_protection == 0)
 		armor_stats += "Wearing this will protect you from the vacuum of space. \n"
+	else if(min_pressure_protection != null)
+		armor_stats += "Wearing this will protect you from low pressures, but not the vacuum of space. \n"
+
+	if(max_pressure_protection != null)
+		armor_stats += "Wearing this will protect you from high pressures. \n"
 
 	if(flags & THICKMATERIAL)
 		armor_stats += "The material is exceptionally thick. \n"

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -69,7 +69,7 @@
 	var/damage_mod = 1
 	//presumably, if they are wearing a helmet that stops pressure effects, then it probably covers the throat as well
 	var/obj/item/clothing/head/helmet = get_equipped_item(slot_head)
-	if(istype(helmet) && (helmet.body_parts_covered & HEAD) && (helmet.flags & STOPPRESSUREDAMAGE))
+	if(istype(helmet) && (helmet.body_parts_covered & HEAD) && (helmet.min_pressure_protection != null)) // Both min- and max_pressure_protection must be set for it to function at all, so we can just check that one is set.
 		//we don't do an armor_check here because this is not an impact effect like a weapon swung with momentum, that either penetrates or glances off.
 		damage_mod = 1.0 - (helmet.armor["melee"]/100)
 

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -151,7 +151,6 @@
 		pressure_adjustment_coefficient = 1
 
 	pressure_adjustment_coefficient = min(pressure_adjustment_coefficient, 1)
-	world << "pressure coefficient at pressure [pressure] kPa -- [pressure_adjustment_coefficient]"
 	return pressure_adjustment_coefficient
 
 // Calculate how much of the enviroment pressure-difference affects the human.
@@ -172,8 +171,6 @@
 		// Otherwise calculate how much of that absolute pressure difference affects us, can be 0 to 1 (equals 0% to 100%).
 		// This is our relative difference.
 		pressure_difference *= get_pressure_weakness(pressure)
-
-	world << "pressure_difference at [pressure]kPa: [pressure_difference]"
 
 	// The difference is always positive to avoid extra calculations.
 	// Apply the relative difference on a standard atmosphere to get the final result.

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -103,15 +103,27 @@
 	if(!inStasisNow())
 		..()
 
-// Calculate how vulnerable the human is to under- and overpressure.
-// Returns 0 (equals 0 %) if sealed in an undamaged suit, 1 if unprotected (equals 100%).
+// Calculate how vulnerable the human is to the current pressure.
+// Returns 0 (equals 0 %) if sealed in an undamaged suit that's rated for the pressure, 1 if unprotected (equals 100%).
 // Suitdamage can modifiy this in 10% steps.
-/mob/living/carbon/human/proc/get_pressure_weakness()
+// Protection scales down from 100% at the boundary to 0% at 10% in excess of the boundary
+/mob/living/carbon/human/proc/get_pressure_weakness(pressure)
+	if(pressure == null)
+		return 1 // No protection if someone forgot to give a pressure
 
 	var/pressure_adjustment_coefficient = 1 // Assume no protection at first.
 
-	if(wear_suit && (wear_suit.item_flags & STOPPRESSUREDAMAGE) && head && (head.item_flags & STOPPRESSUREDAMAGE)) // Complete set of pressure-proof suit worn, assume fully sealed.
+	// Check suit
+	if(wear_suit && wear_suit.max_pressure_protection != null && wear_suit.min_pressure_protection != null)
 		pressure_adjustment_coefficient = 0
+		// Pressure is too high
+		if(wear_suit.max_pressure_protection < pressure)
+			// Protection scales down from 100% at the boundary to 0% at 10% in excess of the boundary
+			pressure_adjustment_coefficient += round((pressure - wear_suit.max_pressure_protection) / (wear_suit.max_pressure_protection/10))
+
+		// Pressure is too low
+		if(wear_suit.min_pressure_protection > pressure)
+			pressure_adjustment_coefficient += round((wear_suit.min_pressure_protection - pressure) / (wear_suit.min_pressure_protection/10))
 
 		// Handles breaches in your space suit. 10 suit damage equals a 100% loss of pressure protection.
 		if(istype(wear_suit,/obj/item/clothing/suit/space))
@@ -119,8 +131,27 @@
 			if(S.can_breach && S.damage)
 				pressure_adjustment_coefficient += S.damage * 0.1
 
-	pressure_adjustment_coefficient = min(1,max(pressure_adjustment_coefficient,0)) // So it isn't less than 0 or larger than 1.
+	else
+		// Missing key protection
+		pressure_adjustment_coefficient = 1
 
+	// Check hat
+	if(head && head.max_pressure_protection != null && head.min_pressure_protection != null)
+		// Pressure is too high
+		if(head.max_pressure_protection < pressure)
+			// Protection scales down from 100% at the boundary to 0% at 10% in excess of the boundary
+			pressure_adjustment_coefficient += round((pressure - head.max_pressure_protection) / (head.max_pressure_protection/10))
+
+		// Pressure is too low
+		if(head.min_pressure_protection > pressure)
+			pressure_adjustment_coefficient += round((head.min_pressure_protection - pressure) / (head.min_pressure_protection/10))
+
+	else
+		// Missing key protection
+		pressure_adjustment_coefficient = 1
+
+	pressure_adjustment_coefficient = min(pressure_adjustment_coefficient, 1)
+	world << "pressure coefficient at pressure [pressure] kPa -- [pressure_adjustment_coefficient]"
 	return pressure_adjustment_coefficient
 
 // Calculate how much of the enviroment pressure-difference affects the human.
@@ -140,7 +171,9 @@
 	else
 		// Otherwise calculate how much of that absolute pressure difference affects us, can be 0 to 1 (equals 0% to 100%).
 		// This is our relative difference.
-		pressure_difference *= get_pressure_weakness()
+		pressure_difference *= get_pressure_weakness(pressure)
+
+	world << "pressure_difference at [pressure]kPa: [pressure_difference]"
 
 	// The difference is always positive to avoid extra calculations.
 	// Apply the relative difference on a standard atmosphere to get the final result.
@@ -674,7 +707,8 @@
 
 	// Account for massive pressure differences.  Done by Polymorph
 	// Made it possible to actually have something that can protect against high pressure... Done by Errorage. Polymorph now has an axe sticking from his head for his previous hardcoded nonsense!
-	if(status_flags & GODMODE)	return 1	//godmode
+	if(status_flags & GODMODE)
+		return 1	//godmode
 
 	if(adjusted_pressure >= species.hazard_high_pressure)
 		var/pressure_damage = min( ( (adjusted_pressure / species.hazard_high_pressure) -1 )*PRESSURE_DAMAGE_COEFFICIENT , MAX_HIGH_PRESSURE_DAMAGE)

--- a/code/modules/xenoarcheaology/tools/equipment.dm
+++ b/code/modules/xenoarcheaology/tools/equipment.dm
@@ -6,6 +6,8 @@
 	item_state = "engspace_suit"
 	update_icon_define = "icons/mob/spacesuit.dmi"
 	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 100, rad = 100)
+	max_pressure_protection = 5   * ONE_ATMOSPHERE // Not very good protection, but if an anomaly starts doing gas stuff you're not screwed
+	min_pressure_protection = 0.7 * ONE_ATMOSPHERE
 
 /obj/item/clothing/head/bio_hood/anomaly
 	name = "Anomaly hood"
@@ -13,6 +15,8 @@
 	icon_state = "engspace_helmet"
 	item_state = "engspace_helmet"
 	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 100, rad = 100)
+	max_pressure_protection = 5   * ONE_ATMOSPHERE // Not very good protection, but if an anomaly starts doing gas stuff you're not screwed
+	min_pressure_protection = 0.7 * ONE_ATMOSPHERE
 
 /obj/item/clothing/suit/space/anomaly
 	name = "Excavation suit"
@@ -22,6 +26,7 @@
 	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 100, rad = 100)
 	allowed = list(/obj/item/device/flashlight,/obj/item/weapon/tank,/obj/item/device/suit_cooling_unit)
 	slowdown = 1
+	// Pressure protection inherited from space suits
 
 /obj/item/clothing/head/helmet/space/anomaly
 	name = "Excavation hood"

--- a/html/changelogs/Atermonera-pressure_protection.yml
+++ b/html/changelogs/Atermonera-pressure_protection.yml
@@ -1,0 +1,8 @@
+author: Atermonera
+delete-after: True
+changes: 
+  - rscadd: "Clothing now has pressure protection variables, that set lower and upper pressure bounds within which they will protect you from pressure-based harm."
+  - rscadd: "Protection falls off when exceeding the pressure limits from 100% protection at the boundary to 0% at 10% in excess (above the max or below the min) boundary."
+  - tweak: "Currently, only hat and suit slots are checked for this protection (No change)."
+  - tweak: "Anomaly suits (The orange ones) now offer limited pressure protection in case anomalies start making or draining air."
+  - bugfix: "Firesuits are no longer spaceproof, but still offer protection against the high pressures of fire."


### PR DESCRIPTION
Protection falls off when exceeding the pressure limits from 100% protection at the boundary to 0% at 10% in excess (above the max or below the min) boundary. Currently, only hat and suit slots are checked for this protection (No change from prior behaviour). In order for the protection to work, both the max and min pressure variables must be non-null.
Anomaly suits (The orange ones) now offer limited pressure protection in case anomalies start making or draining air. Firesuits are no longer spaceproof, but still offer protection against the high pressures of fire.
Tested.
Fixes #5739 