### PR TITLE
Stops initialization from grinding to a halt when loading maps

### DIFF
--- a/code/__defines/subsystems.dm
+++ b/code/__defines/subsystems.dm
@@ -52,6 +52,7 @@ var/global/list/runlevel_flags = list(RUNLEVEL_LOBBY, RUNLEVEL_SETUP, RUNLEVEL_G
 // Subsystem init_order, from highest priority to lowest priority
 // Subsystems shutdown in the reverse of the order they initialize in
 // The numbers just define the ordering, they are meaningless otherwise.
+#define INIT_ORDER_MAPPING		17
 #define INIT_ORDER_DECALS		16
 #define INIT_ORDER_ATOMS		15
 #define INIT_ORDER_MACHINES		10

--- a/code/controllers/subsystem.dm
+++ b/code/controllers/subsystem.dm
@@ -6,6 +6,7 @@
 	var/priority = FIRE_PRIORITY_DEFAULT	//When mutiple subsystems need to run in the same tick, higher priority subsystems will run first and be given a higher share of the tick before MC_TICK_CHECK triggers a sleep
 
 	var/flags = 0			//see MC.dm in __DEFINES Most flags must be set on world start to take full effect. (You can also restart the mc to force them to process again)
+	var/subsystem_initialized = FALSE	//set to TRUE after it has been initialized, will obviously never be set if the subsystem doesn't initialize
 	var/runlevels = RUNLEVELS_DEFAULT	//points of the game at which the SS can fire
 
 	//set to 0 to prevent fire() calls, mostly for admin use or subsystems that may be resumed later
@@ -154,6 +155,7 @@
 
 //used to initialize the subsystem AFTER the map has loaded
 /datum/controller/subsystem/Initialize(start_timeofday)
+	subsystem_initialized = TRUE
 	var/time = (REALTIMEOFDAY - start_timeofday) / 10
 	var/msg = "Initialized [name] subsystem within [time] second[time == 1 ? "" : "s"]!"
 	to_chat(world, "<span class='boldannounce'>[msg]</span>")

--- a/code/controllers/subsystems/mapping.dm
+++ b/code/controllers/subsystems/mapping.dm
@@ -1,0 +1,29 @@
+// Handles map-related tasks, mostly here to ensure it does so after the MC initializes.
+SUBSYSTEM_DEF(mapping)
+	name = "Mapping"
+	init_order = INIT_ORDER_MAPPING
+	flags = SS_NO_FIRE
+
+	var/list/map_templates = list()
+	var/dmm_suite/maploader = null
+
+/datum/controller/subsystem/mapping/Initialize(timeofday)
+	if(subsystem_initialized)
+		return
+	maploader = new()
+	load_map_templates()
+
+	if(config.generate_map)
+		// Map-gen is still very specific to the map, however putting it here should ensure it loads in the correct order.
+		if(using_map.perform_map_generation())
+			using_map.refresh_mining_turfs()
+
+
+/datum/controller/subsystem/mapping/proc/load_map_templates()
+	for(var/T in subtypesof(/datum/map_template))
+		var/datum/map_template/template = T
+		if(!(initial(template.mappath))) // If it's missing the actual path its probably a base type or being used for inheritence.
+			continue
+		template = new T()
+		map_templates[template.name] = template
+	return TRUE

--- a/code/modules/admin/verbs/map_template_loadverb.dm
+++ b/code/modules/admin/verbs/map_template_loadverb.dm
@@ -5,10 +5,10 @@
 	var/datum/map_template/template
 
 
-	var/map = input(usr, "Choose a Map Template to place at your CURRENT LOCATION","Place Map Template") as null|anything in map_templates
+	var/map = input(usr, "Choose a Map Template to place at your CURRENT LOCATION","Place Map Template") as null|anything in SSmapping.map_templates
 	if(!map)
 		return
-	template = map_templates[map]
+	template = SSmapping.map_templates[map]
 
 	var/orientation = text2dir(input(usr, "Choose an orientation for this Map Template.", "Orientation") as null|anything in list("North", "South", "East", "West"))
 	if(!orientation)
@@ -41,10 +41,10 @@
 
 	var/datum/map_template/template
 
-	var/map = input(usr, "Choose a Map Template to place on a new Z-level.","Place Map Template") as null|anything in map_templates
+	var/map = input(usr, "Choose a Map Template to place on a new Z-level.","Place Map Template") as null|anything in SSmapping.map_templates
 	if(!map)
 		return
-	template = map_templates[map]
+	template = SSmapping.map_templates[map]
 
 	var/orientation = text2dir(input(usr, "Choose an orientation for this Map Template.", "Orientation") as null|anything in list("North", "South", "East", "West"))
 	if(!orientation)
@@ -76,7 +76,7 @@
 	var/datum/map_template/M = new(map, "[map]")
 	if(M.preload_size(map))
 		to_chat(usr, "Map template '[map]' ready to place ([M.width]x[M.height])")
-		map_templates[M.name] = M
+		SSmapping.map_templates[M.name] = M
 		message_admins("<span class='adminnotice'>[key_name_admin(usr)] has uploaded a map template ([map])</span>")
 	else
 		to_chat(usr, "Map template '[map]' failed to load properly")

--- a/code/modules/maps/tg/map_template.dm
+++ b/code/modules/maps/tg/map_template.dm
@@ -1,15 +1,3 @@
-var/list/global/map_templates = list()
-
-// Called when the world starts, in world.dm
-/proc/load_map_templates()
-	for(var/T in subtypesof(/datum/map_template))
-		var/datum/map_template/template = T
-		if(!(initial(template.mappath))) // If it's missing the actual path its probably a base type or being used for inheritence.
-			continue
-		template = new T()
-		map_templates[template.name] = template
-	return TRUE
-
 /datum/map_template
 	var/name = "Default Template Name"
 	var/desc = "Some text should go here. Maybe."
@@ -27,8 +15,6 @@ var/list/global/map_templates = list()
 	var/allow_duplicates = FALSE // If false, only one map template will be spawned by the game. Doesn't affect admins spawning then manually.
 	var/discard_prob = 0 // If non-zero, there is a chance that the map seeding algorithm will skip this template when selecting potential templates to use.
 
-	var/static/dmm_suite/maploader = new
-
 /datum/map_template/New(path = null, rename = null)
 	if(path)
 		mappath = path
@@ -39,7 +25,7 @@ var/list/global/map_templates = list()
 		name = rename
 
 /datum/map_template/proc/preload_size(path, orientation = SOUTH)
-	var/bounds = maploader.load_map(file(path), 1, 1, 1, cropMap=FALSE, measureOnly=TRUE, orientation=orientation)
+	var/bounds = SSmapping.maploader.load_map(file(path), 1, 1, 1, cropMap=FALSE, measureOnly=TRUE, orientation=orientation)
 	if(bounds)
 		width = bounds[MAP_MAXX] // Assumes all templates are rectangular, have a single Z level, and begin at 1,1,1
 		height = bounds[MAP_MAXY]
@@ -91,7 +77,7 @@ var/list/global/map_templates = list()
 		x = round((world.maxx - width)/2)
 		y = round((world.maxy - height)/2)
 
-	var/list/bounds = maploader.load_map(file(mappath), x, y, no_changeturf = TRUE, orientation=orientation)
+	var/list/bounds = SSmapping.maploader.load_map(file(mappath), x, y, no_changeturf = TRUE, orientation=orientation)
 	if(!bounds)
 		return FALSE
 
@@ -116,7 +102,7 @@ var/list/global/map_templates = list()
 	if(annihilate)
 		annihilate_bounds(old_T, centered, orientation)
 
-	var/list/bounds = maploader.load_map(file(mappath), T.x, T.y, T.z, cropMap=TRUE, orientation = orientation)
+	var/list/bounds = SSmapping.maploader.load_map(file(mappath), T.x, T.y, T.z, cropMap=TRUE, orientation = orientation)
 	if(!bounds)
 		return
 
@@ -175,8 +161,8 @@ var/list/global/map_templates = list()
 	var/list/priority_submaps = list() // Submaps that will always be placed.
 
 	// Lets go find some submaps to make.
-	for(var/map in map_templates)
-		var/datum/map_template/MT = map_templates[map]
+	for(var/map in SSmapping.map_templates)
+		var/datum/map_template/MT = SSmapping.map_templates[map]
 		if(!MT.allow_duplicates && MT.loaded > 0) // This probably won't be an issue but we might as well.
 			continue
 		if(!istype(MT, desired_map_template_type)) // Not the type wanted.
@@ -188,7 +174,7 @@ var/list/global/map_templates = list()
 		else
 			potential_submaps += MT
 
-	CHECK_TICK
+//	CHECK_TICK
 
 	var/list/loaded_submap_names = list()
 	var/list/template_groups_used = list() // Used to avoid spawning three seperate versions of the same PoI.
@@ -208,7 +194,7 @@ var/list/global/map_templates = list()
 			admin_notice("Submap loader had no submaps to pick from with [budget] left to spend.", R_DEBUG)
 			break
 
-		CHECK_TICK
+//		CHECK_TICK
 
 		// Can we afford it?
 		if(chosen_template.cost > budget)
@@ -246,9 +232,9 @@ var/list/global/map_templates = list()
 					valid = FALSE // Probably overlapping something important.
 			//		world << "Invalid due to overlapping with area [new_area.type] at ([check.x], [check.y], [check.z]), when attempting to place at ([T.x], [T.y], [T.z])."
 					break
-				CHECK_TICK
+//				CHECK_TICK
 
-			CHECK_TICK
+//			CHECK_TICK
 
 			if(!valid)
 				continue
@@ -258,7 +244,7 @@ var/list/global/map_templates = list()
 			// Do loading here.
 			chosen_template.load(T, centered = TRUE, orientation=orientation) // This is run before the main map's initialization routine, so that can initilize our submaps for us instead.
 
-			CHECK_TICK
+//			CHECK_TICK
 
 			// For pretty maploading statistics.
 			if(loaded_submap_names[chosen_template.name])

--- a/code/modules/maps/tg/map_template.dm
+++ b/code/modules/maps/tg/map_template.dm
@@ -174,7 +174,7 @@
 		else
 			potential_submaps += MT
 
-//	CHECK_TICK
+	CHECK_TICK
 
 	var/list/loaded_submap_names = list()
 	var/list/template_groups_used = list() // Used to avoid spawning three seperate versions of the same PoI.
@@ -194,7 +194,7 @@
 			admin_notice("Submap loader had no submaps to pick from with [budget] left to spend.", R_DEBUG)
 			break
 
-//		CHECK_TICK
+		CHECK_TICK
 
 		// Can we afford it?
 		if(chosen_template.cost > budget)
@@ -232,9 +232,9 @@
 					valid = FALSE // Probably overlapping something important.
 			//		world << "Invalid due to overlapping with area [new_area.type] at ([check.x], [check.y], [check.z]), when attempting to place at ([T.x], [T.y], [T.z])."
 					break
-//				CHECK_TICK
+				CHECK_TICK
 
-//			CHECK_TICK
+			CHECK_TICK
 
 			if(!valid)
 				continue
@@ -244,7 +244,7 @@
 			// Do loading here.
 			chosen_template.load(T, centered = TRUE, orientation=orientation) // This is run before the main map's initialization routine, so that can initilize our submaps for us instead.
 
-//			CHECK_TICK
+			CHECK_TICK
 
 			// For pretty maploading statistics.
 			if(loaded_submap_names[chosen_template.name])

--- a/code/world.dm
+++ b/code/world.dm
@@ -84,13 +84,6 @@ var/global/datum/global_init/init = new ()
 	// This is kinda important. Set up details of what the hell things are made of.
 	populate_material_list()
 
-	// Loads all the pre-made submap templates.
-	load_map_templates()
-
-	if(config.generate_map)
-		if(using_map.perform_map_generation())
-			using_map.refresh_mining_turfs()
-
 	// Create frame types.
 	populate_frame_types()
 
@@ -428,7 +421,7 @@ var/world_topic_spam_protect_time = world.timeofday
 			log_admin("[key_name(usr)] Has requested an immediate world restart via client side debugging tools")
 			message_admins("[key_name_admin(usr)] Has requested an immediate world restart via client side debugging tools")
 			world << "<span class='boldannounce'>[key_name_admin(usr)] has requested an immediate world restart via client side debugging tools</span>"
-			
+
 		else
 			world << "<span class='boldannounce'>Rebooting world immediately due to host request</span>"
 	else

--- a/polaris.dme
+++ b/polaris.dme
@@ -198,6 +198,7 @@
 #include "code\controllers\subsystems\inactivity.dm"
 #include "code\controllers\subsystems\lighting.dm"
 #include "code\controllers\subsystems\machines.dm"
+#include "code\controllers\subsystems\mapping.dm"
 #include "code\controllers\subsystems\orbits.dm"
 #include "code\controllers\subsystems\overlays.dm"
 #include "code\controllers\subsystems\planets.dm"


### PR DESCRIPTION
Now the game can be played again without forcing someone to proc-call ``Recover()`` on the MC.
Now the maploading will load after the MC and not before it.