### PR TITLE
Fixes a bug with holographic projectors.

### DIFF
--- a/code/modules/integrated_electronics/subtypes/output.dm
+++ b/code/modules/integrated_electronics/subtypes/output.dm
@@ -300,7 +300,7 @@
 		text_output += "\an [name]"
 	else
 		text_output += "\an ["\improper[initial_name]"] labeled '[name]'"
-	text_output += " which is currently [get_pin_data(IC_INPUT, 1) ? "lit <font color=[led_color]>¤</font>" : "unlit."]"
+	text_output += " which is currently [get_pin_data(IC_INPUT, 1) ? "lit <font color=[led_color]>Â¤</font>" : "unlit."]"
 	to_chat(user,jointext(text_output,null))
 
 /obj/item/integrated_circuit/output/led/red
@@ -462,7 +462,7 @@
 
 
 /obj/item/integrated_circuit/output/holographic_projector/proc/destroy_hologram()
-	hologram.forceMove(src)
+	hologram = null
 	qdel(hologram)
 
 //	holo_beam.End()


### PR DESCRIPTION
Would not properly null out the variable, meaning it just waits to be garbage collected. Bad. Very bad.

The other change is because the Github web editor wanted to convert it to UTF-8. As you see, there is no visible change, though I may need to fix that if it causes display issues in-game. (I believe it doesn't work anyway.)