### PR TITLE
Drop the number of shots of normal and sec-xeno tasers back down to 5.

### DIFF
--- a/code/modules/projectiles/guns/energy/stun.dm
+++ b/code/modules/projectiles/guns/energy/stun.dm
@@ -4,6 +4,7 @@
 	icon_state = "taser"
 	item_state = null	//so the human update icon uses the icon_state instead.
 	projectile_type = /obj/item/projectile/beam/stun
+	charge_cost = 480
 
 /obj/item/weapon/gun/energy/taser/mounted
 	name = "mounted taser gun"

--- a/code/modules/xenobio/items/weapons.dm
+++ b/code/modules/xenobio/items/weapons.dm
@@ -74,7 +74,7 @@
 	icon_state = "taserblue"
 	item_state = "taser"
 	projectile_type = /obj/item/projectile/beam/stun/xeno/weak
-	charge_cost = 240
+	charge_cost = 480
 	accuracy = 0 //Same accuracy as a normal Sec taser.
 	description_fluff = "An NT Mk30 NL retrofitted after the events that occurred aboard the NRS Prometheus."
 

--- a/html/changelogs/Mechoid-Tasers.yml
+++ b/html/changelogs/Mechoid-Tasers.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Mechoid
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Security taser shot count dropped from 10 to 5."


### PR DESCRIPTION
On the tin.
Tweaks:
- Taser shot count dropped to 5 from 10.
- Security-Issued xeno taser shot count dropped to 5 from 10.

This means that targets have a higher likelihood of escape should the officer(s) pursuing them miss, as they must either change weapons or reload their tasers.