### PR TITLE
Fixes lift and shuttle moves not updating lighting

### DIFF
--- a/code/_helpers/unsorted.dm
+++ b/code/_helpers/unsorted.dm
@@ -831,6 +831,7 @@ proc/GaussRandRound(var/sigma,var/roundto)
 					//Move the objects. Not forceMove because the object isn't "moving" really, it's supposed to be on the "same" turf.
 					for(var/obj/O in T)
 						O.loc = X
+						O.update_light()
 
 					//Move the mobs unless it's an AI eye or other eye type.
 					for(var/mob/M in T)


### PR DESCRIPTION
The light sources in elevators and shuttles no longer leave their lighting permanently stuck at the initial location.