### PR TITLE
Fixes non-black/white paint buckets not actually having paint in them

### DIFF
--- a/code/game/objects/items/weapons/paint.dm
+++ b/code/game/objects/items/weapons/paint.dm
@@ -37,7 +37,7 @@ var/global/list/cached_icons = list()
 		else if (paint_type == "black")
 			reagents.add_reagent("carbon", volume/5)
 		else
-			reagents.add_reagent("crayon_dust_[paint_type]", volume/5)
+			reagents.add_reagent("marker_ink_[paint_type]", volume/5)
 		reagents.handle_reactions()
 
 	red


### PR DESCRIPTION
Recipe for paint was changed at some point to use marker ink instead of crayon dust. Buckets rather than having paint in them directly, just had all ingridients for said paint (why tho? either way, out of scope), so red, yellow, green,  blue and purple paint buckets came without paint, but just ingridients for old recipe.