### PR TITLE
Blob factories now properly remove their listings from mobs when destroyed.

### DIFF
--- a/code/modules/blob2/blobs/factory.dm
+++ b/code/modules/blob2/blobs/factory.dm
@@ -15,7 +15,8 @@
 	var/spore_cooldown = 8 SECONDS
 
 /obj/structure/blob/factory/Destroy()
-	for(var/mob/living/simple_mob/blob/spore/spore in spores)
+	for(var/mob/living/L in spores)
+		var/mob/living/simple_mob/blob/spore/spore = L
 		if(istype(spore) && spore.factory == src)
 			spore.factory = null
 		else


### PR DESCRIPTION
On the tin.