### PR TITLE
Fixes antagonist options not appearing in preferences

### DIFF
--- a/code/__defines/gamemode.dm
+++ b/code/__defines/gamemode.dm
@@ -45,8 +45,6 @@ var/list/be_special_flags = list(
 	"pAI"              = BE_PAI
 )
 
-#define IS_MODE_COMPILED(MODE) (ispath(text2path("/datum/game_mode/"+(MODE))))
-
 
 // Antagonist datum flags.
 #define ANTAG_OVERRIDE_JOB        0x1 // Assigned job is set to MODE when spawning.

--- a/code/modules/client/preference_setup/antagonism/02_candidacy.dm
+++ b/code/modules/client/preference_setup/antagonism/02_candidacy.dm
@@ -1,21 +1,21 @@
 var/global/list/special_roles = list( //keep synced with the defines BE_* in setup.dm --rastaf
 //some autodetection here.
-// TODO: Update to new antagonist system.
-	"traitor" = IS_MODE_COMPILED("traitor"),             // 0
-	"operative" = IS_MODE_COMPILED("nuclear"),           // 1
-	"changeling" = IS_MODE_COMPILED("changeling"),       // 2
-	"wizard" = IS_MODE_COMPILED("wizard"),               // 3
-	"malf AI" = IS_MODE_COMPILED("malfunction"),         // 4
-	"revolutionary" = IS_MODE_COMPILED("revolution"),    // 5
-	"alien candidate" = 1, //always show                 // 6
-	"positronic brain" = 1,                              // 7
-	"cultist" = IS_MODE_COMPILED("cult"),                // 8
-	"renegade" = 1,                                      // 9
-	"ninja" = "true",                                    // 10
-	"raider" = IS_MODE_COMPILED("heist"),                // 11
-	"diona" = 1,                                         // 12
-	"loyalist" = IS_MODE_COMPILED("revolution"),         // 13
-	"pAI candidate" = 1, // -- TLE                       // 14
+// Change these to 0 if the equivalent mode is disabled for whatever reason!
+	"traitor" = 1,										// 0
+	"operative" = 1,									// 1
+	"changeling" = 1,									// 2
+	"wizard" = 1,										// 3
+	"malf AI" = 1,								        // 4
+	"revolutionary" = 1,								// 5
+	"alien candidate" = 1,								// 6
+	"positronic brain" = 1,								// 7
+	"cultist" = 1,										// 8
+	"renegade" = 1,                                     // 9
+	"ninja" = 1,	                                  	// 10
+	"raider" = 1,										// 11
+	"diona" = 1,                                        // 12
+	"loyalist" = 1,										// 13
+	"pAI candidate" = 1, // -- TLE                      // 14
 )
 
 /datum/category_item/player_setup_item/antagonism/candidacy


### PR DESCRIPTION
Removed a broken and redundant gamemode compile check that was preventing antagonist options from appearing in character preferences.
(Neerti said so.)
(TODO was from 2015 and absolutely mysterious)