### PR TITLE
Suit coolers don't overheat in vacuum

### DIFF
--- a/code/game/objects/items/devices/suit_cooling.dm
+++ b/code/game/objects/items/devices/suit_cooling.dm
@@ -46,7 +46,9 @@
 
 	var/mob/living/carbon/human/H = loc
 
-	var/efficiency = 1 - H.get_pressure_weakness()			// You need to have a good seal for effective cooling
+	var/turf/T = get_turf(src)
+	var/datum/gas_mixture/environment = T.return_air()
+	var/efficiency = 1 - H.get_pressure_weakness(environment.return_pressure())	// You need to have a good seal for effective cooling
 	var/temp_adj = 0										// How much the unit cools you. Adjusted later on.
 	var/env_temp = get_environment_temperature()			// This won't save you from a fire
 	var/thermal_protection = H.get_heat_protection(env_temp)	// ... unless you've got a good suit.

--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -434,8 +434,10 @@
 
 	var/mob/living/carbon/human/H = loc
 
-	var/efficiency = 1 - H.get_pressure_weakness()		//you need to have a good seal for effective cooling
-	var/env_temp = get_environment_temperature()		//wont save you from a fire
+	var/turf/T = get_turf(src)
+	var/datum/gas_mixture/environment = T.return_air()
+	var/efficiency = 1 - H.get_pressure_weakness(environment.return_pressure())	// You need to have a good seal for effective cooling
+	var/env_temp = get_environment_temperature()						//wont save you from a fire
 	var/temp_adj = min(H.bodytemperature - max(thermostat, env_temp), max_cooling)
 
 	if (temp_adj < 0.5)	//only cools, doesn't heat, also we don't need extreme precision

--- a/html/changelogs/atermonera_suit_cooling.yml
+++ b/html/changelogs/atermonera_suit_cooling.yml
@@ -1,0 +1,4 @@
+author: atermonera
+delete-after: True
+changes: 
+  - bugfix: "Suit coolers and rigsuit coolers now protect FBPs against vacuum again."


### PR DESCRIPTION
Rigsuit coolers are still confusingly only accessible via the hud element sharing the rigsuit's appearance, rather than looking like a suit cooler or being operable by more than mouse *obstinate grumbling*
fixes #5854