### PR TITLE
Audible emotes can be used again

### DIFF
--- a/code/modules/mob/language/generic.dm
+++ b/code/modules/mob/language/generic.dm
@@ -18,6 +18,9 @@
 	// if you make a loud noise (screams etc), you'll be heard from 4 tiles over instead of two
 	return (copytext(message, length(message)) == "!") ? 4 : 2
 
+/datum/language/noise/can_speak_special(var/mob/speaker)
+	return TRUE	//Audible emotes
+
 // 'basic' language; spoken by default.
 /datum/language/common
 	name = LANGUAGE_GALCOM

--- a/code/modules/mob/language/language.dm
+++ b/code/modules/mob/language/language.dm
@@ -134,14 +134,15 @@
 
 /datum/language/proc/can_speak_special(var/mob/speaker)
 	. = TRUE
-	if(ishuman(speaker))
-		var/mob/living/carbon/human/H = speaker
-		if(src.name in H.species.assisted_langs)
-			. = FALSE
-			var/obj/item/organ/internal/voicebox/vox = locate() in H.internal_organs	// Only voiceboxes for now. Maybe someday it'll include other organs, but I'm not that clever
-			if(vox)
-				if(!vox.is_broken() && (src in vox.assists_languages))
-					. = TRUE
+	if(name != "Noise")	// Audible Emotes
+		if(ishuman(speaker))
+			var/mob/living/carbon/human/H = speaker
+			if(src.name in H.species.assisted_langs)
+				. = FALSE
+				var/obj/item/organ/internal/voicebox/vox = locate() in H.internal_organs	// Only voiceboxes for now. Maybe someday it'll include other organs, but I'm not that clever
+				if(vox)
+					if(!vox.is_broken() && (src in vox.assists_languages))
+						. = TRUE
 
 // Language handling.
 /mob/proc/add_language(var/language)
@@ -171,6 +172,9 @@
 	if(!speaking)
 		log_debug("[src] attempted to speak a null language.")
 		return 0
+
+	if(speaking == all_languages["Noise"])
+		return 1
 
 	if (only_species_language && speaking != all_languages[species_language])
 		return 0


### PR DESCRIPTION
Fixitfixitfixitfixit

So the gibberish code didn't recognize "Noise" as a language anyone can speak, OR "!" as valid start to a sentence, OR something. I don't know. This fixes it.