### PR TITLE
Bots don't speak gibberish

### DIFF
--- a/code/modules/mob/language/language.dm
+++ b/code/modules/mob/language/language.dm
@@ -175,7 +175,14 @@
 	if (only_species_language && speaking != all_languages[species_language])
 		return 0
 
-	return (speaking.can_speak_special(src) && (universal_speak || (speaking && (speaking.flags & INNATE)) || speaking in src.languages))
+	if(speaking.can_speak_special(src))
+		if(universal_speak)
+			return 1
+		if(speaking && (speaking.flags & INNATE))
+			return 1
+		if(speaking in src.languages)
+			return 1
+	return 0
 
 /mob/proc/get_language_prefix()
 	if(client && client.prefs.language_prefixes && client.prefs.language_prefixes.len)

--- a/code/modules/mob/living/bot/bot.dm
+++ b/code/modules/mob/living/bot/bot.dm
@@ -44,6 +44,8 @@
 	..()
 	update_icons()
 
+	default_language = all_languages[LANGUAGE_GALCOM]
+
 	botcard = new /obj/item/weapon/card/id(src)
 	botcard.access = botcard_access.Copy()
 

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -138,7 +138,7 @@ proc/get_radio_key_from_channel(var/channel)
 		if(message)
 			client.handle_spam_prevention(MUTE_IC)
 			if((client.prefs.muted & MUTE_IC) || say_disabled)
-				src << "<span class='warning'>You cannot speak in IC (Muted).</span>"
+				to_chat(src, "<span class='warning'>You cannot speak in IC (Muted).</span>")
 				return
 
 	//Redirect to say_dead if talker is dead
@@ -196,7 +196,7 @@ proc/get_radio_key_from_channel(var/channel)
 
 	//Self explanatory.
 	if(is_muzzled() && !(speaking && (speaking.flags & SIGNLANG)))
-		src << "<span class='danger'>You're muzzled and cannot speak!</span>"
+		to_chat(src, "<span class='danger'>You're muzzled and cannot speak!</span>")
 		return
 
 	//Clean up any remaining junk on the left like spaces.

--- a/html/changelogs/ater_botspeak.yml
+++ b/html/changelogs/ater_botspeak.yml
@@ -1,0 +1,4 @@
+author: Atermonera
+delete-after: True
+changes: 
+  - bugfix: "Robot sound files have been decrypted following a bizarre ransomware attack by Boiling Point remnants."


### PR DESCRIPTION
I only had to discover an order-of-operations quirck of byond that's been in this code since it was first written.
`(speaking.can_speak_special(src) || speaking in src.languages)` evaluates as `((speaking.can_speak_special(src) || speaking) in src.languages)` but `(speaking.can_speak_special(src) && speaking in src.languages)` evaluates as `(speaking.can_speak_special(src) && (speaking in src.languages))`
Which caused the original expression in `can_speak()` to fail a product of sums equation but pass a sum-of-products equation, due to insufficient use of parentheses. The if blocks circumvent that issue entirely.

This has been tested: ![test](https://puu.sh/Czsl9/a343635138.png), debug prints were removed following the test. Borgs and humans both correctly default to GalCom as of testing, which was branched from Polaris/Master as of earlier today.
