### PR TITLE
Fixes some AI bugs.

### DIFF
--- a/code/modules/ai/aI_holder_subtypes/slime_xenobio_ai.dm
+++ b/code/modules/ai/aI_holder_subtypes/slime_xenobio_ai.dm
@@ -38,7 +38,7 @@
 		return FALSE // The slime considers it abuse if they get stunned while already stunned.
 	if(rabid)
 		return TRUE
-	if(target)
+	if(target && can_attack(target))
 		if(ishuman(target))
 			var/mob/living/carbon/human/H = target
 			if(istype(H.species, /datum/species/monkey))

--- a/code/modules/ai/aI_holder_subtypes/slime_xenobio_ai.dm
+++ b/code/modules/ai/aI_holder_subtypes/slime_xenobio_ai.dm
@@ -5,6 +5,7 @@
 	hostile = TRUE
 	cooperative = TRUE
 	firing_lanes = TRUE
+	mauling = TRUE // They need it to get the most out of monkeys.
 	var/rabid = FALSE	// Will attack regardless of discipline.
 	var/discipline = 0	// Beating slimes makes them less likely to lash out.  In theory.
 	var/resentment = 0	// 'Unjustified' beatings make this go up, and makes it more likely for abused slimes to go rabid.
@@ -33,6 +34,8 @@
 
 // Checks if disciplining the slime would be 'justified' right now.
 /datum/ai_holder/simple_mob/xenobio_slime/proc/is_justified_to_discipline()
+	if(!can_act())
+		return FALSE // The slime considers it abuse if they get stunned while already stunned.
 	if(rabid)
 		return TRUE
 	if(target)

--- a/code/modules/ai/ai_holder_combat.dm
+++ b/code/modules/ai/ai_holder_combat.dm
@@ -70,8 +70,10 @@
 		on_engagement(target)
 		if(firing_lanes && !test_projectile_safety(target))
 			// Nudge them a bit, maybe they can shoot next time.
-			step_rand(holder)
-			holder.face_atom(target)
+			var/turf/T = get_step(holder, pick(cardinal))
+			if(T)
+				holder.IMove(T) // IMove() will respect movement cooldown.
+				holder.face_atom(target)
 			ai_log("engage_target() : Could not safely fire at target. Exiting.", AI_LOG_DEBUG)
 			return
 
@@ -130,6 +132,9 @@
 
 // Used to make sure projectiles will probably hit the target and not the wall or a friend.
 /datum/ai_holder/proc/test_projectile_safety(atom/movable/AM)
+	if(holder.Adjacent(AM)) // If they're right next to us then lets just say yes. check_trajectory() tends to spaz out otherwise.
+		return TRUE
+
 	var/mob/living/L = check_trajectory(AM, holder) // This isn't always reliable but its better than the previous method.
 //	world << "Checked trajectory, would hit [L]."
 

--- a/code/modules/ai/ai_holder_targeting.dm
+++ b/code/modules/ai/ai_holder_targeting.dm
@@ -105,7 +105,7 @@
 	if(isliving(the_target))
 		var/mob/living/L = the_target
 		if(ishuman(L) || issilicon(L))
-			if(!L.client)	// SSD players get a pass
+			if(L.key && !L.client)	// SSD players get a pass
 				return FALSE
 		if(L.stat)
 			if(L.stat == DEAD) // Leave dead things alone

--- a/code/modules/mob/living/simple_mob/subtypes/slime/xenobio/defense.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/slime/xenobio/defense.dm
@@ -50,5 +50,5 @@
 
 // Getting slimebatoned/xenotased.
 /mob/living/simple_mob/slime/xenobio/slimebatoned(mob/living/user, amount)
-	Weaken(amount)
 	adjust_discipline(round(amount/2))
+	Weaken(amount) // This needs to come afterwards or else it will always be considered abuse to the slime.


### PR DESCRIPTION
Fixes #5805 
Fixes #5833 
Fixes unreported bug of xenobio slimes going vegan and not eating monkeys.
Fixes unreported bug/exploit where spam-tasing xenobio slimes disciplines them faster than intended, before they even tried to eat you again.
Slime AI is now allowed to attack unconscious mobs again, to not reduce nutritional intake from monkeys.