### PR TITLE
Changeling & Straight Jacket modifications.

### DIFF
--- a/code/game/gamemodes/changeling/powers/escape_restraints.dm
+++ b/code/game/gamemodes/changeling/powers/escape_restraints.dm
@@ -37,25 +37,23 @@
 		C.update_inv_handcuffed()
 		if (C.client)
 			C.client.screen -= W
+		W.forceMove(C.loc)
+		W.dropped(C)
 		if(W)
-			W.loc = C.loc
-			W.dropped(C)
-			if(W)
-				W.layer = initial(W.layer)
+			W.layer = initial(W.layer)
 	if(C.legcuffed)
 		var/obj/item/weapon/W = C.legcuffed
 		C.legcuffed = null
 		C.update_inv_legcuffed()
 		if(C.client)
 			C.client.screen -= W
+		W.forceMove(C.loc)
+		W.dropped(C)
 		if(W)
-			W.loc = C.loc
-			W.dropped(C)
-			if(W)
-				W.layer = initial(W.layer)
-	if(C.wear_suit && istype(C.wear_suit, /obj/item/clothing/suit/straight_jacket))
+			W.layer = initial(W.layer)
+	if(istype(C.wear_suit, /obj/item/clothing/suit/straight_jacket))
 		var/obj/item/clothing/suit/straight_jacket/SJ = C.wear_suit
-		SJ.loc = C.loc
+		SJ.forceMove(C.loc)
 		SJ.dropped(C)
 		C.wear_suit = null
 		escape_cooldown *= 1.5	// Straight jackets are tedious compared to cuffs.

--- a/code/game/gamemodes/changeling/powers/escape_restraints.dm
+++ b/code/game/gamemodes/changeling/powers/escape_restraints.dm
@@ -21,7 +21,7 @@
 	if(world.time < changeling.next_escape)
 		to_chat(src, "<span class='warning'>We are still recovering from our last escape...</span>")
 		return 0
-	if(!(C.handcuffed || C.legcuffed))	// No need to waste chems if there's nothing to break out of
+	if(!(C.handcuffed || C.legcuffed || istype(C.wear_suit,/obj/item/clothing/suit/straight_jacket)))	// No need to waste chems if there's nothing to break out of
 		to_chat(C, "<span class='warning'>We are are not restrained in a way we can escape...</span>")
 		return 0
 
@@ -53,6 +53,12 @@
 			W.dropped(C)
 			if(W)
 				W.layer = initial(W.layer)
+	if(C.wear_suit && istype(C.wear_suit, /obj/item/clothing/suit/straight_jacket))
+		var/obj/item/clothing/suit/straight_jacket/SJ = C.wear_suit
+		SJ.loc = C.loc
+		SJ.dropped(C)
+		C.wear_suit = null
+		escape_cooldown *= 1.5	// Straight jackets are tedious compared to cuffs.
 
 	if(src.mind.changeling.recursive_enhancement)
 		escape_cooldown *= 0.5

--- a/code/game/gamemodes/changeling/powers/revive.dm
+++ b/code/game/gamemodes/changeling/powers/revive.dm
@@ -53,25 +53,23 @@
 			H.update_inv_handcuffed()
 			if (H.client)
 				H.client.screen -= W
+			W.forceMove(H.loc)
+			W.dropped(H)
 			if(W)
-				W.loc = H.loc
-				W.dropped(H)
-				if(W)
-					W.layer = initial(W.layer)
+				W.layer = initial(W.layer)
 		if(H.legcuffed)
 			var/obj/item/weapon/W = H.legcuffed
 			H.legcuffed = null
 			H.update_inv_legcuffed()
 			if(H.client)
 				H.client.screen -= W
+			W.forceMove(H.loc)
+			W.dropped(H)
 			if(W)
-				W.loc = H.loc
-				W.dropped(H)
-				if(W)
-					W.layer = initial(W.layer)
-		if(H.wear_suit && istype(H.wear_suit, /obj/item/clothing/suit/straight_jacket))
+				W.layer = initial(W.layer)
+		if(istype(H.wear_suit, /obj/item/clothing/suit/straight_jacket))
 			var/obj/item/clothing/suit/straight_jacket/SJ = H.wear_suit
-			SJ.loc = H.loc
+			SJ.forceMove(H.loc)
 			SJ.dropped(H)
 			H.wear_suit = null
 

--- a/code/game/gamemodes/changeling/powers/revive.dm
+++ b/code/game/gamemodes/changeling/powers/revive.dm
@@ -45,6 +45,36 @@
 		BITSET(H.hud_updateflag, STATUS_HUD)
 		BITSET(H.hud_updateflag, LIFE_HUD)
 
+		if(H.handcuffed)
+			var/obj/item/weapon/W = H.handcuffed
+			H.handcuffed = null
+			if(H.buckled && H.buckled.buckle_require_restraints)
+				H.buckled.unbuckle_mob()
+			H.update_inv_handcuffed()
+			if (H.client)
+				H.client.screen -= W
+			if(W)
+				W.loc = H.loc
+				W.dropped(H)
+				if(W)
+					W.layer = initial(W.layer)
+		if(H.legcuffed)
+			var/obj/item/weapon/W = H.legcuffed
+			H.legcuffed = null
+			H.update_inv_legcuffed()
+			if(H.client)
+				H.client.screen -= W
+			if(W)
+				W.loc = H.loc
+				W.dropped(H)
+				if(W)
+					W.layer = initial(W.layer)
+		if(H.wear_suit && istype(H.wear_suit, /obj/item/clothing/suit/straight_jacket))
+			var/obj/item/clothing/suit/straight_jacket/SJ = H.wear_suit
+			SJ.loc = H.loc
+			SJ.dropped(H)
+			H.wear_suit = null
+
 	C.halloss = 0
 	C.shock_stage = 0 //Pain
 	C << "<span class='notice'>We have regenerated.</span>"

--- a/code/modules/clothing/suits/miscellaneous.dm
+++ b/code/modules/clothing/suits/miscellaneous.dm
@@ -224,6 +224,8 @@
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|FEET|ARMS|HANDS
 	flags_inv = HIDEGLOVES|HIDESHOES|HIDEJUMPSUIT|HIDETAIL|HIDETIE|HIDEHOLSTER
 
+	var/resist_time = 4800	// Eight minutes.
+
 /obj/item/clothing/suit/straight_jacket/attack_hand(mob/living/user as mob)
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user

--- a/code/modules/mob/living/carbon/human/human_resist.dm
+++ b/code/modules/mob/living/carbon/human/human_resist.dm
@@ -1,0 +1,112 @@
+/mob/living/carbon/human/process_resist()
+	//drop && roll
+	if(on_fire && !buckled)
+		adjust_fire_stacks(-1.2)
+		Weaken(3)
+		spin(32,2)
+		visible_message(
+			"<span class='danger'>[src] rolls on the floor, trying to put themselves out!</span>",
+			"<span class='notice'>You stop, drop, and roll!</span>"
+			)
+		sleep(30)
+		if(fire_stacks <= 0)
+			visible_message(
+				"<span class='danger'>[src] has successfully extinguished themselves!</span>",
+				"<span class='notice'>You extinguish yourself.</span>"
+				)
+			ExtinguishMob()
+		return TRUE
+
+	if(handcuffed)
+		spawn() escape_handcuffs()
+	else if(legcuffed)
+		spawn() escape_legcuffs()
+	else if(wear_suit && istype(wear_suit, /obj/item/clothing/suit/straight_jacket))
+		spawn() escape_straight_jacket()
+	else
+		..()
+
+/mob/living/carbon/human/proc/escape_straight_jacket()
+	setClickCooldown(100)
+
+	if(can_break_straight_jacket())
+		break_straight_jacket()
+		return
+
+	var/mob/living/carbon/human/H = src
+	var/obj/item/clothing/suit/straight_jacket/SJ = H.wear_suit
+
+	var/breakouttime = SJ.resist_time	// Configurable per-jacket!
+
+	var/attack_type = 0
+
+	if(H.gloves && istype(H.gloves,/obj/item/clothing/gloves/gauntlets/rig))
+		breakouttime /= 2	// Pneumatic force goes a long way.
+	else if(H.species.unarmed_types)
+		for(var/datum/unarmed_attack/U in H.species.unarmed_types)
+			if(istype(U, /datum/unarmed_attack/claws))
+				breakouttime /= 1.5
+				attack_type = 1
+				break
+			else if(istype(U, /datum/unarmed_attack/bite/sharp))
+				breakouttime /= 1.25
+				attack_type = 2
+				break
+
+	switch(attack_type)
+		if(0)
+			visible_message(
+			"<span class='danger'>\The [src] struggles to remove \the [SJ]!</span>",
+			"<span class='warning'>You struggle to remove \the [SJ]. (This will take around [round(breakouttime / 600)] minutes and you need to stand still.)</span>"
+			)
+		if(1)
+			visible_message(
+			"<span class='danger'>\The [src] starts clawing at \the [SJ]!</span>",
+			"<span class='warning'>You claw at \the [SJ]. (This will take around [round(breakouttime / 600)] minutes and you need to stand still.)</span>"
+			)
+		if(2)
+			visible_message(
+			"<span class='danger'>\The [src] starts gnawing on \the [SJ]!</span>",
+			"<span class='warning'>You gnaw on \the [SJ]. (This will take around [round(breakouttime / 600)] minutes and you need to stand still.)</span>"
+			)
+
+	if(do_after(src, breakouttime, incapacitation_flags = INCAPACITATION_DISABLED & INCAPACITATION_KNOCKDOWN))
+		if(!wear_suit)
+			return
+		visible_message(
+			"<span class='danger'>\The [src] manages to remove \the [wear_suit]!</span>",
+			"<span class='notice'>You successfully remove \the [wear_suit].</span>"
+			)
+		drop_from_inventory(wear_suit)
+
+/mob/living/carbon/human/proc/can_break_straight_jacket()
+	if((HULK in mutations) || species.can_shred(src,1))
+		return 1
+	return ..()
+
+/mob/living/carbon/human/proc/break_straight_jacket()
+	visible_message(
+		"<span class='danger'>[src] is trying to rip \the [wear_suit]!</span>",
+		"<span class='warning'>You attempt to rip your [wear_suit.name] apart. (This will take around 5 seconds and you need to stand still)</span>"
+		)
+
+	if(do_after(src, 20 SECONDS, incapacitation_flags = INCAPACITATION_DEFAULT & ~INCAPACITATION_RESTRAINED))	// Same scaling as breaking cuffs, 5 seconds to 120 seconds, 20 seconds to 480 seconds.
+		if(!wear_suit || buckled)
+			return
+
+		visible_message(
+			"<span class='danger'>[src] manages to rip \the [wear_suit]!</span>",
+			"<span class='warning'>You successfully rip your [wear_suit.name].</span>"
+			)
+
+		say(pick(";RAAAAAAAARGH!", ";HNNNNNNNNNGGGGGGH!", ";GWAAAAAAAARRRHHH!", "NNNNNNNNGGGGGGGGHH!", ";AAAAAAARRRGH!", "RAAAAAAAARGH!", "HNNNNNNNNNGGGGGGH!", "GWAAAAAAAARRRHHH!", "AAAAAAARRRGH!" ))
+
+		qdel(wear_suit)
+		wear_suit = null
+		if(buckled && buckled.buckle_require_restraints)
+			buckled.unbuckle_mob()
+
+/mob/living/carbon/human/can_break_cuffs()
+	if(species.can_shred(src,1))
+		return 1
+	return ..()

--- a/code/modules/mob/living/carbon/human/human_resist.dm
+++ b/code/modules/mob/living/carbon/human/human_resist.dm
@@ -26,6 +26,10 @@
 	else
 		..()
 
+#define RESIST_ATTACK_DEFAULT	0
+#define RESIST_ATTACK_CLAWS		1
+#define RESIST_ATTACK_BITE		2
+
 /mob/living/carbon/human/proc/escape_straight_jacket()
 	setClickCooldown(100)
 
@@ -38,7 +42,7 @@
 
 	var/breakouttime = SJ.resist_time	// Configurable per-jacket!
 
-	var/attack_type = 0
+	var/attack_type = RESIST_ATTACK_DEFAULT
 
 	if(H.gloves && istype(H.gloves,/obj/item/clothing/gloves/gauntlets/rig))
 		breakouttime /= 2	// Pneumatic force goes a long way.
@@ -46,25 +50,25 @@
 		for(var/datum/unarmed_attack/U in H.species.unarmed_types)
 			if(istype(U, /datum/unarmed_attack/claws))
 				breakouttime /= 1.5
-				attack_type = 1
+				attack_type = RESIST_ATTACK_CLAWS
 				break
 			else if(istype(U, /datum/unarmed_attack/bite/sharp))
 				breakouttime /= 1.25
-				attack_type = 2
+				attack_type = RESIST_ATTACK_BITE
 				break
 
 	switch(attack_type)
-		if(0)
+		if(RESIST_ATTACK_DEFAULT)
 			visible_message(
 			"<span class='danger'>\The [src] struggles to remove \the [SJ]!</span>",
 			"<span class='warning'>You struggle to remove \the [SJ]. (This will take around [round(breakouttime / 600)] minutes and you need to stand still.)</span>"
 			)
-		if(1)
+		if(RESIST_ATTACK_CLAWS)
 			visible_message(
 			"<span class='danger'>\The [src] starts clawing at \the [SJ]!</span>",
 			"<span class='warning'>You claw at \the [SJ]. (This will take around [round(breakouttime / 600)] minutes and you need to stand still.)</span>"
 			)
-		if(2)
+		if(RESIST_ATTACK_BITE)
 			visible_message(
 			"<span class='danger'>\The [src] starts gnawing on \the [SJ]!</span>",
 			"<span class='warning'>You gnaw on \the [SJ]. (This will take around [round(breakouttime / 600)] minutes and you need to stand still.)</span>"
@@ -78,6 +82,10 @@
 			"<span class='notice'>You successfully remove \the [wear_suit].</span>"
 			)
 		drop_from_inventory(wear_suit)
+
+#undef RESIST_ATTACK_DEFAULT
+#undef RESIST_ATTACK_CLAWS
+#undef RESIST_ATTACK_BITE
 
 /mob/living/carbon/human/proc/can_break_straight_jacket()
 	if((HULK in mutations) || species.can_shred(src,1))

--- a/code/modules/mob/living/carbon/resist.dm
+++ b/code/modules/mob/living/carbon/resist.dm
@@ -153,11 +153,6 @@
 		legcuffed = null
 		update_inv_legcuffed()
 
-/mob/living/carbon/human/can_break_cuffs()
-	if(species.can_shred(src,1))
-		return 1
-	return ..()
-
 /mob/living/carbon/escape_buckle()
 	if(!buckled) return
 

--- a/html/changelogs/Mechoid - LingJacket.yml
+++ b/html/changelogs/Mechoid - LingJacket.yml
@@ -1,0 +1,37 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Mechoid
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Oversight regarding Changeling revive not removing restraints fixed."
+  - tweak: "Straight Jackets can now be resisted out of in 8 minutes, or as low as 5 depending on species attacks. Shredding or hulked humans will break out in 20 seconds, destroying the jacket."

--- a/polaris.dme
+++ b/polaris.dme
@@ -1906,6 +1906,7 @@
 #include "code\modules\mob\living\carbon\human\human_movement.dm"
 #include "code\modules\mob\living\carbon\human\human_organs.dm"
 #include "code\modules\mob\living\carbon\human\human_powers.dm"
+#include "code\modules\mob\living\carbon\human\human_resist.dm"
 #include "code\modules\mob\living\carbon\human\human_species.dm"
 #include "code\modules\mob\living\carbon\human\inventory.dm"
 #include "code\modules\mob\living\carbon\human\life.dm"


### PR DESCRIPTION
Fixes:
- Changeling revive's de-restraint was missed in the re-making of Changeling. As it was brought up after a round of changeling, this behavior was expected to exist in the new version, **as it did previously**.

Tweaks:
- Straight jackets now can be resisted out of. No longer an IC tool for OOC issues, or an 'I win tool'.
- Takes approximately 8 minutes default, 5.5 minutes with claws, or 6-7 minutes with sharp bite attacks. Shredding and hulk reduce this time to 20 seconds.

Code shifting:
- Human-specific resist code moved to its own file in **mob/living/carbon/human** .