### PR TITLE
Rig helmets are now airtight when they should be, rather than when they shouldn't

### DIFF
--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -213,11 +213,11 @@
 	if(seal == 1)
 		min_pressure_protection = rigsuit_min_pressure
 		max_pressure_protection = rigsuit_max_pressure
-		piece.item_flags &= ~AIRTIGHT
+		piece.item_flags |= AIRTIGHT
 	else
 		min_pressure_protection = null
 		max_pressure_protection = null
-		piece.item_flags |= AIRTIGHT
+		piece.item_flags &= ~AIRTIGHT
 	return
 
 


### PR DESCRIPTION
'tis a case of the backwards.
Fixes #5891 