### PR TITLE
Pilot consoles require pilot access

### DIFF
--- a/html/changelogs/Anewbe - Pilots.yml
+++ b/html/changelogs/Anewbe - Pilots.yml
@@ -1,0 +1,4 @@
+author: Anewbe
+delete-after: True
+changes
+  - tweak: "Pilot consoles now require pilot access to use."

--- a/maps/southern_cross/shuttles/crew_shuttles.dm
+++ b/maps/southern_cross/shuttles/crew_shuttles.dm
@@ -3,6 +3,7 @@
 /obj/machinery/computer/shuttle_control/web/shuttle1
 	name = "shuttle control console"
 	shuttle_tag = "Shuttle 1"
+	req_access = list(access_pilot)
 
 /datum/shuttle/web_shuttle/shuttle1
 	name = "Shuttle 1"
@@ -45,6 +46,7 @@
 /obj/machinery/computer/shuttle_control/web/shuttle2
 	name = "shuttle control console"
 	shuttle_tag = "Shuttle 2"
+	req_access = list(access_pilot)
 
 /datum/shuttle/web_shuttle/shuttle2
 	name = "Shuttle 2"


### PR DESCRIPTION
The pilot ships being faster when driven was supposed to be a reason to play Pilot, not a reason to break into the cockpit.

Staff Request:   Mangled/(Mangled)(JMP): legit say I said "I cant be bothered yelling at people breaking into the cockpit anymore, ID lock that shit but make it emaggable" Screenshot this, right now and post it in the git thingie.