### PR TITLE
Implements is_cable_coil() in cable coils.

### DIFF
--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -154,6 +154,10 @@ var/list/possible_cable_coil_colours = list(
 // General procedures
 ///////////////////////////////////
 
+//Finally implements is_cable_coil():
+/obj/item/stack/cable_coil/is_cable_coil()
+	return TRUE
+
 //If underfloor, hide the cable
 /obj/structure/cable/hide(var/i)
 	if(istype(loc, /turf))


### PR DESCRIPTION
One of the holdouts from the conversion of turning tool status into procs. This being missing breaks some downstream stuff, and breaks part of constructable_frame.dm too.