### PR TITLE
Tweaks to Sword Cave PoI

### DIFF
--- a/maps/submaps/surface_submaps/mountains/SwordCave.dmm
+++ b/maps/submaps/surface_submaps/mountains/SwordCave.dmm
@@ -6,9 +6,10 @@
 "f" = (/turf/simulated/floor/water/deep,/area/submap/cave/swordcave)
 "g" = (/obj/structure/ghost_pod/manual/cursedblade,/turf/simulated/mineral/floor/ignore_mapgen,/area/submap/cave/swordcave)
 "h" = (/mob/living/simple_mob/faithless/cult,/turf/simulated/mineral/floor/ignore_mapgen,/area/submap/cave/swordcave)
-"i" = (/obj/item/device/gps/explorer,/turf/simulated/mineral/floor/ignore_mapgen,/area/submap/cave/swordcave)
+"i" = (/obj/item/device/gps/explorer/on,/turf/simulated/mineral/floor/ignore_mapgen,/area/submap/cave/swordcave)
 "j" = (/obj/structure/loot_pile/surface/bones,/turf/simulated/mineral/floor/ignore_mapgen,/area/submap/cave/swordcave)
 "k" = (/mob/living/simple_mob/animal/space/bats,/turf/simulated/mineral/floor/ignore_mapgen,/area/submap/cave/swordcave)
+"l" = (/mob/living/simple_mob/animal/space/bats/cult,/turf/simulated/mineral/floor/ignore_mapgen,/area/submap/cave/swordcave)
 
 (1,1,1) = {"
 aaaaaaaabbbbbbbbbbbbbbbbbbbbbbbbbbbaaaaaa
@@ -26,26 +27,26 @@ aabbbcccdeeffeeccijcdccccceefeeccdcbbbaaa
 abbbccccceefffeeeccccccceeefeeccccccbbaaa
 abbbcccccceefffeeeccccceeeffeeccccccbbbaa
 abbbcdccccceefffeeeeeeeeffffeeccccccbbbaa
-abbcccckcccceeffffeeeeefffffeeccccccbbbaa
+abbcccclcccceeffffeeeeefffffeeccccccbbbaa
 abbcccccccccceeffffffffffffeeccccdccbbbaa
 abbccccccccccceeffeeeeeefffeecccccccbbbaa
 abbbccccdcccccceefeeeeeeeeeeckccccccbbbaa
 abbbcccccccccccceeecccdceeecccccccccbbaaa
-abbbcccccccccccccecccccccceccccdckccbbaaa
-abbbcccccccccckcccccccccccccccccccccbbaaa
-abbbbcccccckccccccccccccccckccccccccbbaaa
-abbbbbcccccccccccccccckccccccccckcccbbaaa
+abbbcccccccccccccecccccccceccccdclccbbaaa
+abbbcccccccccclcccccccccccccccccccccbbaaa
+abbbbcccccclccccccccccccccclccccccccbbaaa
+abbbbbcccccccccccccccclccccccccclcccbbaaa
 aabbbbbccccccccccccccccccccccccccccbbbaaa
 aabbbbbccccccccccccdccccccccccccccbbbbaaa
 aabbbbbcccccdccccccccccccccccccccbbbbbaaa
-aabbbbbccccccccccckccccccccdcccccbbbbaaaa
+aabbbbbccccccccccclccccccccdcccccbbbbaaaa
 aabbbbbbbccccccccccccccccccccccccbbbbaaaa
 aaabbbbbbbcccccccccccccccdccccccbbbbaaaaa
-aaaabbbbbbcckcccccdcccccccccccccbbbbaaaaa
+aaaabbbbbbcclcccccdcccccccccccccbbbbaaaaa
 aaaaabbbbbcccccccccccccccccccccbbbbbaaaaa
 aaaaabbbbbccccccccccccccccccccbbbbbaaaaaa
 aaaaaabbbbbcccdccccccccccccccbbbbbaaaaaaa
-aaaaaaabbbbbcccccccckccccckcbbbbbbaaaaaaa
+aaaaaaabbbbbcccccccclccccclcbbbbbbaaaaaaa
 aaaaaaabbbbbbcccccccccccccccbbbbbaaaaaaaa
 aaaaaaabbbbbbbbbbbbccccccccccbbbaaaaaaaaa
 aaaaaaaaabbbbbbbbbbbccccccccccbaaaaaaaaaa


### PR DESCRIPTION
Replaces explorer GPS with an enabled explorer GPS, as to make PoI actually detectable to the exlorers, and replaces all bats with bats/cult to prevent them from killing faithless/cult before the round even starts.