### PR TITLE
Rewrites Atmospherics

### DIFF
--- a/code/ZAS/Atom.dm
+++ b/code/ZAS/Atom.dm
@@ -3,63 +3,32 @@
 /atom/var/pressure_resistance = ONE_ATMOSPHERE
 /atom/var/can_atmos_pass = ATMOS_PASS_YES
 
-// Used to determine if airflow/zones can pass this atom.
+// Purpose: Determines if the object can pass this atom.
+// Called by: Movement.
+// Inputs: The moving atom, target turf.
+// Outputs: Boolean if can pass.
+// Airflow and ZAS zones now uses CanZASPass() instead of this proc.
+/atom/proc/CanPass(atom/movable/mover, turf/target)
+	return !density
+
+// Purpose: Determines if airflow is allowed between T and loc.
+// Called by: Airflow.
+// Inputs: The turf the airflow is from, which may not be the same as loc. is_zone is for conditionally disallowing merging.
+// Outputs: Boolean if airflow can pass.
 /atom/proc/CanZASPass(turf/T, is_zone)
 	switch(can_atmos_pass)
-		if(ATMOS_PASS_PROC)
-			return ATMOS_PASS_YES
 		if(ATMOS_PASS_DENSITY)
 			return !density
 		else
 			return can_atmos_pass
-//	return (!density || is_zone)
-
-/*
-/atom/proc/CanAtmosPass(turf/T)
-	switch (CanAtmosPass)
-		if (ATMOS_PASS_PROC)
-			return ATMOS_PASS_YES
-		if (ATMOS_PASS_DENSITY)
-			return !density
-		else
-			return CanAtmosPass
-
-/atom/proc/CanPass(atom/movable/mover, turf/target, height=1.5, air_group = 0)
-	//Purpose: Determines if the object (or airflow) can pass this atom.
-	//Called by: Movement, airflow.
-	//Inputs: The moving atom (optional), target turf, "height" and air group
-	//Outputs: Boolean if can pass.
-
-	return (!density || !height || air_group)
-*/
-// Used to see if objects can freely move past this atom.
-// Airflow and ZAS zones now uses CanZASPass() instead.
-/atom/proc/CanPass(atom/movable/mover, turf/target, height=1.5, air_group = 0)
-	return !density
 
 /turf/can_atmos_pass = ATMOS_PASS_NO
 
-/turf/CanPass(atom/movable/mover, turf/target, height=1.5,air_group=0)
+/turf/CanPass(atom/movable/mover, turf/target)
 	if(!target) return FALSE
 
 	if(istype(mover)) // turf/Enter(...) will perform more advanced checks
 		return !density
-
-	/*
-	else // Now, doing more detailed checks for air movement and air group formation
-		if(target.blocks_air||blocks_air)
-			return 0
-
-		for(var/obj/obstacle in src)
-			if(!obstacle.CanPass(mover, target, height, air_group))
-				return 0
-		if(target != src)
-			for(var/obj/obstacle in target)
-				if(!obstacle.CanPass(mover, src, height, air_group))
-					return 0
-
-		return 1
-	*/
 
 /turf/CanZASPass(turf/T, is_zone)
 	if(T.blocks_air || src.blocks_air)
@@ -89,13 +58,6 @@
 // AIR_BLOCKED - Blocked
 // ZONE_BLOCKED - Not blocked, but zone boundaries will not cross.
 // BLOCKED - Blocked, zone boundaries will not cross even if opened.
-/*
-atom/proc/c_airblock(turf/other)
-	#ifdef ZASDBG
-	ASSERT(isturf(other))
-	#endif
-	return (AIR_BLOCKED*!CanPass(null, other, 0, 0))|(ZONE_BLOCKED*!CanPass(null, other, 1.5, 1))
-*/
 atom/proc/c_airblock(turf/other)
 	#ifdef ZASDBG
 	ASSERT(isturf(other))

--- a/code/__defines/atmos.dm
+++ b/code/__defines/atmos.dm
@@ -93,3 +93,10 @@
 #define ATMOSTANK_CO2           25000 // CO2 and PH are not critically important for station, only for toxins and alternative coolants, no need to store a lot of those.
 #define ATMOSTANK_PHORON        25000
 #define ATMOSTANK_NITROUSOXIDE  10000 // N2O doesn't have a real useful use, i guess it's on station just to allow refilling of sec's riot control canisters?
+
+// Used for quickly making certain things allow airflow or not.
+// More complicated, conditional abilities for airflow should use ATMOS_PASS_PROC and override CanZASPass().
+#define ATMOS_PASS_YES		1
+#define ATMOS_PASS_NO		0
+#define ATMOS_PASS_PROC		-1 // Asks CanZASPass()
+#define ATMOS_PASS_DENSITY	-2 // Just checks density.

--- a/code/__defines/atmos.dm
+++ b/code/__defines/atmos.dm
@@ -95,8 +95,7 @@
 #define ATMOSTANK_NITROUSOXIDE  10000 // N2O doesn't have a real useful use, i guess it's on station just to allow refilling of sec's riot control canisters?
 
 // Used for quickly making certain things allow airflow or not.
-// More complicated, conditional abilities for airflow should use ATMOS_PASS_PROC and override CanZASPass().
+// More complicated, conditional airflow should override CanZASPass().
 #define ATMOS_PASS_YES		1
 #define ATMOS_PASS_NO		0
-#define ATMOS_PASS_PROC		-1 // Asks CanZASPass()
-#define ATMOS_PASS_DENSITY	-2 // Just checks density.
+#define ATMOS_PASS_DENSITY	-1 // Just checks density.

--- a/code/game/gamemodes/meteor/meteors.dm
+++ b/code/game/gamemodes/meteor/meteors.dm
@@ -147,7 +147,7 @@
 		else
 			die(0)
 
-/obj/effect/meteor/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
+/obj/effect/meteor/CanPass(atom/movable/mover, turf/target)
 	return istype(mover, /obj/effect/meteor) ? 1 : ..()
 
 /obj/effect/meteor/proc/ram_turf(var/turf/T)

--- a/code/game/machinery/OpTable.dm
+++ b/code/game/machinery/OpTable.dm
@@ -48,13 +48,10 @@
 		qdel(src)
 	return
 
-/obj/machinery/optable/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
-	if(air_group || (height==0)) return 1
-
+/obj/machinery/optable/CanPass(atom/movable/mover, turf/target)
 	if(istype(mover) && mover.checkpass(PASSTABLE))
-		return 1
-	else
-		return 0
+		return TRUE
+	return FALSE
 
 /obj/machinery/optable/MouseDrop_T(obj/O as obj, mob/user as mob)
 

--- a/code/game/machinery/deployable.dm
+++ b/code/game/machinery/deployable.dm
@@ -128,13 +128,10 @@ for reference:
 				dismantle()
 			return
 
-/obj/structure/barricade/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)//So bullets will fly over and stuff.
-	if(air_group || (height==0))
-		return 1
+/obj/structure/barricade/CanPass(atom/movable/mover, turf/target)//So bullets will fly over and stuff.
 	if(istype(mover) && mover.checkpass(PASSTABLE))
-		return 1
-	else
-		return 0
+		return TRUE
+	return FALSE
 
 //Actual Deployable machinery stuff
 /obj/machinery/deployable
@@ -223,13 +220,10 @@ for reference:
 		anchored = !anchored
 		icon_state = "barrier[locked]"
 
-/obj/machinery/deployable/barrier/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)//So bullets will fly over and stuff.
-	if(air_group || (height==0))
-		return 1
+/obj/machinery/deployable/barrier/CanPass(atom/movable/mover, turf/target)//So bullets will fly over and stuff.
 	if(istype(mover) && mover.checkpass(PASSTABLE))
-		return 1
-	else
-		return 0
+		return TRUE
+	return FALSE
 
 /obj/machinery/deployable/barrier/proc/explode()
 

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -750,7 +750,7 @@ About the new airlock wires panel:
 			if (user)
 				src.attack_ai(user)
 
-/obj/machinery/door/airlock/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
+/obj/machinery/door/airlock/CanPass(atom/movable/mover, turf/target)
 	if (src.isElectrified())
 		if (istype(mover, /obj/item))
 			var/obj/item/i = mover

--- a/code/game/machinery/doors/blast_door.dm
+++ b/code/game/machinery/doors/blast_door.dm
@@ -259,12 +259,14 @@
 	if(stat & BROKEN)
 		stat &= ~BROKEN
 
-
-/obj/machinery/door/blast/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
-	if(air_group) return 1
+/*
+// This replicates the old functionality coded into CanPass() for this object, however it appeared to have made blast doors not airtight.
+// If for some reason this is actually needed for something important, uncomment this.
+/obj/machinery/door/blast/CanZASPass(turf/T, is_zone)
+	if(is_zone)
+		return TRUE
 	return ..()
-
-
+*/
 
 // SUBTYPE: Regular
 // Your classical blast door, found almost everywhere.

--- a/code/game/machinery/doors/blast_door.dm
+++ b/code/game/machinery/doors/blast_door.dm
@@ -264,7 +264,7 @@
 // If for some reason this is actually needed for something important, uncomment this.
 /obj/machinery/door/blast/CanZASPass(turf/T, is_zone)
 	if(is_zone)
-		return TRUE
+		return ATMOS_PASS_YES
 	return ..()
 */
 

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -140,12 +140,12 @@
 	if(istype(mover) && mover.checkpass(PASSGLASS))
 		return !opacity
 	return !density
-/*
+
 /obj/machinery/door/CanZASPass(turf/T, is_zone)
 	if(is_zone)
-		return !block_air_zones
+		return block_air_zones ? ATMOS_PASS_NO : ATMOS_PASS_YES
 	return ..()
-*/
+
 /obj/machinery/door/proc/bumpopen(mob/user as mob)
 	if(operating)	return
 	if(user.last_airflow > world.time - vsc.airflow_delay) //Fakkit

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -9,6 +9,7 @@
 	anchored = 1
 	opacity = 1
 	density = 1
+	can_atmos_pass = ATMOS_PASS_DENSITY
 	layer = DOOR_OPEN_LAYER
 	var/open_layer = DOOR_OPEN_LAYER
 	var/closed_layer = DOOR_CLOSED_LAYER
@@ -135,13 +136,16 @@
 			else
 				do_animate("deny")
 
-/obj/machinery/door/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
-	if(air_group) return !block_air_zones
+/obj/machinery/door/CanPass(atom/movable/mover, turf/target)
 	if(istype(mover) && mover.checkpass(PASSGLASS))
 		return !opacity
 	return !density
-
-
+/*
+/obj/machinery/door/CanZASPass(turf/T, is_zone)
+	if(is_zone)
+		return !block_air_zones
+	return ..()
+*/
 /obj/machinery/door/proc/bumpopen(mob/user as mob)
 	if(operating)	return
 	if(user.last_airflow > world.time - vsc.airflow_delay) //Fakkit

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -471,11 +471,10 @@
 	heat_proof = 1
 	air_properties_vary_with_direction = 1
 
-	CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
+	CanPass(atom/movable/mover, turf/target)
 		if(istype(mover) && mover.checkpass(PASSGLASS))
 			return 1
 		if(get_dir(loc, target) == dir) //Make sure looking at appropriate border
-			if(air_group) return 0
 			return !density
 		else
 			return 1

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -84,14 +84,19 @@
 		open()
 		addtimer(CALLBACK(src, .proc/close), check_access(null)? 50 : 20)
 
-/obj/machinery/door/window/CanPass(atom/movable/mover, turf/target, height, air_group)
+/obj/machinery/door/window/CanPass(atom/movable/mover, turf/target)
 	if(istype(mover) && mover.checkpass(PASSGLASS))
-		return 1
+		return TRUE
 	if(get_dir(mover, loc) == turn(dir, 180)) //Make sure looking at appropriate border
-		if(air_group) return 0
 		return !density
-	else
-		return 1
+	return TRUE
+
+/obj/machinery/door/window/CanZASPass(turf/T, is_zone)
+	if(get_dir(T, loc) == turn(dir, 180))
+		if(is_zone) // No merging allowed.
+			return ATMOS_PASS_NO
+		return ..() // Air can flow if open (density == FALSE).
+	return ATMOS_PASS_YES // Windoors don't block if not facing the right way.
 
 /obj/machinery/door/window/CheckExit(atom/movable/mover as mob|obj, turf/target as turf)
 	if(istype(mover) && mover.checkpass(PASSGLASS))

--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -180,7 +180,7 @@
 
 	to_chat(user, "<span class='notice'>[attached ? attached : "No one"] is attached.</span>")
 
-/obj/machinery/iv_drip/CanPass(atom/movable/mover, turf/target, height = 0, air_group = 0)
-	if(height && istype(mover) && mover.checkpass(PASSTABLE)) //allow bullets, beams, thrown objects, mice, drones, and the like through.
-		return 1
+/obj/machinery/iv_drip/CanPass(atom/movable/mover, turf/target)
+	if(istype(mover) && mover.checkpass(PASSTABLE)) //allow bullets, beams, thrown objects, mice, drones, and the like through.
+		return TRUE
 	return ..()

--- a/code/game/mecha/mech_sensor.dm
+++ b/code/game/mecha/mech_sensor.dm
@@ -15,14 +15,14 @@
 	var/frequency = 1379
 	var/datum/radio_frequency/radio_connection
 
-/obj/machinery/mech_sensor/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
-	if(!src.enabled()) return 1
-	if(air_group || (height==0)) return 1
+/obj/machinery/mech_sensor/CanPass(atom/movable/mover, turf/target)
+	if(!enabled())
+		return TRUE
 
-	if ((get_dir(loc, target) & dir) && src.is_blocked(mover))
+	if((get_dir(loc, target) & dir) && src.is_blocked(mover))
 		src.give_feedback(mover)
-		return 0
-	return 1
+		return FALSE
+	return TRUE
 
 /obj/machinery/mech_sensor/proc/is_blocked(O as obj)
 	if(istype(O, /obj/mecha/medical/odysseus))

--- a/code/game/objects/effects/alien/aliens.dm
+++ b/code/game/objects/effects/alien/aliens.dm
@@ -26,6 +26,7 @@
 	density = 1
 	opacity = 1
 	anchored = 1
+	can_atmos_pass = ATMOS_PASS_NO
 	var/health = 200
 	//var/mob/living/affecting = null
 
@@ -128,8 +129,7 @@
 	..()
 	return
 
-/obj/effect/alien/resin/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
-	if(air_group) return 0
+/obj/effect/alien/resin/CanPass(atom/movable/mover, turf/target)
 	if(istype(mover) && mover.checkpass(PASSGLASS))
 		return !opacity
 	return !density

--- a/code/game/objects/effects/chem/foam.dm
+++ b/code/game/objects/effects/chem/foam.dm
@@ -130,6 +130,7 @@
 	anchored = 1
 	name = "foamed metal"
 	desc = "A lightweight foamed metal wall."
+	can_atmos_pass = ATMOS_PASS_NO
 	var/metal = 1 // 1 = aluminum, 2 = iron
 
 /obj/structure/foamedmetal/New()
@@ -178,8 +179,3 @@
 		qdel(src)
 	else
 		user << "<span class='notice'>You hit the metal foam to no effect.</span>"
-
-/obj/structure/foamedmetal/CanPass(atom/movable/mover, turf/target, height=1.5, air_group = 0)
-	if(air_group)
-		return 0
-	return !density

--- a/code/game/objects/effects/spiders.dm
+++ b/code/game/objects/effects/spiders.dm
@@ -62,17 +62,16 @@
 		icon_state = "stickyweb2"
 	return ..()
 
-/obj/effect/spider/stickyweb/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
-	if(air_group || (height==0)) return 1
+/obj/effect/spider/stickyweb/CanPass(atom/movable/mover, turf/target)
 	if(istype(mover, /mob/living/simple_mob/animal/giant_spider))
-		return 1
+		return TRUE
 	else if(istype(mover, /mob/living))
 		if(prob(50))
-			mover << "<span class='warning'>You get stuck in \the [src] for a moment.</span>"
-			return 0
+			to_chat(mover, span("warning", "You get stuck in \the [src] for a moment."))
+			return FALSE
 	else if(istype(mover, /obj/item/projectile))
 		return prob(30)
-	return 1
+	return TRUE
 
 /obj/effect/spider/eggcluster
 	name = "egg cluster"

--- a/code/game/objects/effects/zone_divider.dm
+++ b/code/game/objects/effects/zone_divider.dm
@@ -8,13 +8,12 @@
 	density = 0
 	opacity = 0
 
-/obj/effect/zone_divider/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
+/obj/effect/zone_divider/CanZASPass(turf/T, is_zone)
  	// Special case to prevent us from being part of a zone during the first air master tick.
  	// We must merge ourselves into a zone on next tick.  This will cause a bit of lag on
  	// startup, but it can't really be helped you know?
 	if(air_master && air_master.current_cycle == 0)
 		spawn(1)
 			air_master.mark_for_update(get_turf(src))
-		return 0
-	return !air_group // Anything except zones can pass
-
+		return ATMOS_PASS_NO
+	return is_zone ? ATMOS_PASS_NO : ATMOS_PASS_YES // Anything except zones can pass

--- a/code/game/objects/items/weapons/policetape.dm
+++ b/code/game/objects/items/weapons/policetape.dm
@@ -286,16 +286,16 @@ var/list/tape_roll_applications = list()
 		update_icon()
 		name = "crumpled [name]"
 
-/obj/item/tape/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
+/obj/item/tape/CanPass(atom/movable/mover, turf/target)
 	if(!lifted && ismob(mover))
 		var/mob/M = mover
 		add_fingerprint(M)
-		if (!allowed(M))	//only select few learn art of not crumpling the tape
-			M << "<span class='warning'>You are not supposed to go past [src]...</span>"
+		if(!allowed(M))	//only select few learn art of not crumpling the tape
+			to_chat(M, span("warning", "You are not supposed to go past \the [src]..."))
 			if(M.a_intent == I_HELP && !(istype(M, /mob/living/simple_mob)))
-				return 0
+				return FALSE
 			crumple()
-	return ..(mover)
+	return ..()
 
 /obj/item/tape/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	breaktape(user)

--- a/code/game/objects/structures/cliff.dm
+++ b/code/game/objects/structures/cliff.dm
@@ -132,11 +132,8 @@ two tiles on initialization, and which way a cliff is facing may change during m
 
 // Movement-related code.
 
-/obj/structure/cliff/CanPass(atom/movable/mover, turf/target, height = 0, air_group = 0)
-	if(air_group || height == 0)
-		return TRUE // Airflow can always pass.
-
-	else if(isliving(mover))
+/obj/structure/cliff/CanPass(atom/movable/mover, turf/target)
+	if(isliving(mover))
 		var/mob/living/L = mover
 		if(L.hovering) // Flying mobs can always pass.
 			return TRUE

--- a/code/game/objects/structures/coathanger.dm
+++ b/code/game/objects/structures/coathanger.dm
@@ -27,7 +27,7 @@
 		user << "<span class='notice'>You cannot hang [W] on [src]</span>"
 		return ..()
 
-/obj/structure/coatrack/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
+/obj/structure/coatrack/CanPass(atom/movable/mover, turf/target)
 	var/can_hang = 0
 	for (var/T in allowed)
 		if(istype(mover,T))

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -68,7 +68,7 @@
 		else
 			to_chat(user, "It is full.")
 
-/obj/structure/closet/CanPass(atom/movable/mover, turf/target, height, air_group)
+/obj/structure/closet/CanPass(atom/movable/mover, turf/target)
 	if(wall_mounted)
 		return TRUE
 	return ..()

--- a/code/game/objects/structures/crates_lockers/closets/coffin.dm
+++ b/code/game/objects/structures/crates_lockers/closets/coffin.dm
@@ -39,7 +39,7 @@
 							"<span class='notice'>You stop climbing into \the [src.name].</span>")
 	return
 
-/obj/structure/closet/grave/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
+/obj/structure/closet/grave/CanPass(atom/movable/mover, turf/target)
 	if(opened && ismob(mover))
 		var/mob/M = mover
 		add_fingerprint(M)

--- a/code/game/objects/structures/fence.dm
+++ b/code/game/objects/structures/fence.dm
@@ -63,7 +63,7 @@
 	hole_size = LARGE_HOLE
 
 // Projectiles can pass through fences.
-/obj/structure/fence/CanPass(atom/movable/mover, turf/target, height = 0, air_group = 0)
+/obj/structure/fence/CanPass(atom/movable/mover, turf/target)
 	if(istype(mover, /obj/item/projectile))
 		return TRUE
 	return ..()

--- a/code/game/objects/structures/gravemarker.dm
+++ b/code/game/objects/structures/gravemarker.dm
@@ -38,15 +38,12 @@
 		if(epitaph)
 			to_chat(user, epitaph)
 
-/obj/structure/gravemarker/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
-	if(!mover)
-		return 1
+/obj/structure/gravemarker/CanPass(atom/movable/mover, turf/target)
 	if(istype(mover) && mover.checkpass(PASSTABLE))
-		return 1
+		return TRUE
 	if(get_dir(loc, target) & dir)
 		return !density
-	else
-		return 1
+	return TRUE
 
 /obj/structure/gravemarker/CheckExit(atom/movable/O as mob|obj, target as turf)
 	if(istype(O) && O.checkpass(PASSTABLE))

--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -49,15 +49,12 @@
 
 	attack_generic(user,damage_dealt,attack_message)
 
-/obj/structure/grille/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
-	if(air_group || (height==0)) return 1
+/obj/structure/grille/CanPass(atom/movable/mover, turf/target)
 	if(istype(mover) && mover.checkpass(PASSGRILLE))
-		return 1
-	else
-		if(istype(mover, /obj/item/projectile))
-			return prob(30)
-		else
-			return !density
+		return TRUE
+	if(istype(mover, /obj/item/projectile))
+		return prob(30)
+	return !density
 
 /obj/structure/grille/bullet_act(var/obj/item/projectile/Proj)
 	if(!Proj)	return
@@ -235,14 +232,10 @@
 
 /obj/structure/grille/cult
 	name = "cult grille"
-	desc = "A matrice built out of an unknown material, with some sort of force field blocking air around it"
+	desc = "A matrice built out of an unknown material, with some sort of force field blocking air around it."
 	icon_state = "grillecult"
-	health = 40 //Make it strong enough to avoid people breaking in too easily
-
-/obj/structure/grille/cult/CanPass(atom/movable/mover, turf/target, height = 1.5, air_group = 0)
-	if(air_group)
-		return 0 //Make sure air doesn't drain
-	..()
+	health = 40 // Make it strong enough to avoid people breaking in too easily.
+	can_atmos_pass = ATMOS_PASS_NO // Make sure air doesn't drain.
 
 /obj/structure/grille/broken/cult
 	icon_state = "grillecult-b"

--- a/code/game/objects/structures/inflatable.dm
+++ b/code/game/objects/structures/inflatable.dm
@@ -25,6 +25,7 @@
 	density = 1
 	anchored = 1
 	opacity = 0
+	can_atmos_pass = ATMOS_PASS_DENSITY
 
 	icon = 'icons/obj/inflatable.dmi'
 	icon_state = "wall"
@@ -39,9 +40,6 @@
 /obj/structure/inflatable/Destroy()
 	update_nearby_tiles()
 	return ..()
-
-/obj/structure/inflatable/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
-	return 0
 
 /obj/structure/inflatable/bullet_act(var/obj/item/projectile/Proj)
 	var/proj_damage = Proj.get_structure_damage()
@@ -168,9 +166,7 @@
 /obj/structure/inflatable/door/attack_hand(mob/user as mob)
 	return TryToSwitchState(user)
 
-/obj/structure/inflatable/door/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
-	if(air_group)
-		return state
+/obj/structure/inflatable/door/CanPass(atom/movable/mover, turf/target)
 	if(istype(mover, /obj/effect/beam))
 		return !opacity
 	return !density

--- a/code/game/objects/structures/plasticflaps.dm
+++ b/code/game/objects/structures/plasticflaps.dm
@@ -64,15 +64,4 @@
 /obj/structure/plasticflaps/mining //A specific type for mining that doesn't allow airflow because of them damn crates
 	name = "airtight plastic flaps"
 	desc = "Heavy duty, airtight, plastic flaps."
-
-/obj/structure/plasticflaps/mining/New() //set the turf below the flaps to block air
-	var/turf/T = get_turf(loc)
-	if(T)
-		T.blocks_air = 1
-	..()
-
-/obj/structure/plasticflaps/mining/Destroy() //lazy hack to set the turf to allow air to pass if it's a simulated floor
-	var/turf/T = get_turf(loc)
-	if(T && istype(T, /turf/simulated/floor))
-		T.blocks_air = 0
-	..()
+	can_atmos_pass = ATMOS_PASS_NO

--- a/code/game/objects/structures/railing.dm
+++ b/code/game/objects/structures/railing.dm
@@ -34,15 +34,12 @@
 	for(var/obj/structure/railing/R in orange(location, 1))
 		R.update_icon()
 
-/obj/structure/railing/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
-	if(!mover)
-		return 1
+/obj/structure/railing/CanPass(atom/movable/mover, turf/target)
 	if(istype(mover) && mover.checkpass(PASSTABLE))
-		return 1
-	if(get_dir(loc, target) == dir)
+		return TRUE
+	if(get_dir(mover, target) == turn(dir, 180))
 		return !density
-	else
-		return 1
+	return TRUE
 
 /obj/structure/railing/examine(mob/user)
 	. = ..()

--- a/code/game/objects/structures/simple_doors.dm
+++ b/code/game/objects/structures/simple_doors.dm
@@ -2,6 +2,7 @@
 	name = "door"
 	density = 1
 	anchored = 1
+	can_atmos_pass = ATMOS_PASS_DENSITY
 
 	icon = 'icons/obj/doors/material_doors.dmi'
 	icon_state = "metal"
@@ -63,8 +64,7 @@
 /obj/structure/simple_door/attack_hand(mob/user as mob)
 	return TryToSwitchState(user)
 
-/obj/structure/simple_door/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
-	if(air_group) return 0
+/obj/structure/simple_door/CanPass(atom/movable/mover, turf/target)
 	if(istype(mover, /obj/effect/beam))
 		return !opacity
 	return !density

--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -68,11 +68,10 @@
 		name = "[material.display_name] [initial(name)]"
 		desc += " It's made of [material.use_name]."
 
-/obj/structure/bed/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
+/obj/structure/bed/CanPass(atom/movable/mover, turf/target)
 	if(istype(mover) && mover.checkpass(PASSTABLE))
-		return 1
-	else
-		return ..()
+		return TRUE
+	return ..()
 
 /obj/structure/bed/ex_act(severity)
 	switch(severity)

--- a/code/game/objects/structures/windoor_assembly.dm
+++ b/code/game/objects/structures/windoor_assembly.dm
@@ -54,14 +54,12 @@ obj/structure/windoor_assembly/Destroy()
 /obj/structure/windoor_assembly/update_icon()
 	icon_state = "[facing]_[secure]windoor_assembly[state]"
 
-/obj/structure/windoor_assembly/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
+/obj/structure/windoor_assembly/CanPass(atom/movable/mover, turf/target)
 	if(istype(mover) && mover.checkpass(PASSGLASS))
-		return 1
+		return TRUE
 	if(get_dir(loc, target) == dir) //Make sure looking at appropriate border
-		if(air_group) return 0
 		return !density
-	else
-		return 1
+	return TRUE
 
 /obj/structure/windoor_assembly/CheckExit(atom/movable/mover as mob|obj, turf/target as turf)
 	if(istype(mover) && mover.checkpass(PASSGLASS))

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -3,6 +3,7 @@
 	desc = "A window."
 	icon = 'icons/obj/structures.dmi'
 	density = 1
+	can_atmos_pass = ATMOS_PASS_DENSITY
 	w_class = ITEMSIZE_NORMAL
 
 	layer = WINDOW_LAYER
@@ -129,7 +130,7 @@
 /obj/structure/window/blob_act()
 	take_damage(50)
 
-/obj/structure/window/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
+/obj/structure/window/CanPass(atom/movable/mover, turf/target)
 	if(istype(mover) && mover.checkpass(PASSGLASS))
 		return TRUE
 	if(is_fulltile())
@@ -138,6 +139,11 @@
 		return !density
 	else
 		return TRUE
+
+/obj/structure/window/CanZASPass(turf/T, is_zone)
+	if(is_fulltile() || get_dir(T, loc) == turn(dir, 180)) // Make sure we're handling the border correctly.
+		return anchored ? ATMOS_PASS_NO : ATMOS_PASS_YES // If it's anchored, it'll block air.
+	return ATMOS_PASS_YES // Don't stop airflow from the other sides.
 
 /obj/structure/window/CheckExit(atom/movable/O as mob|obj, target as turf)
 	if(istype(O) && O.checkpass(PASSGLASS))

--- a/code/game/objects/structures/window_spawner.dm
+++ b/code/game/objects/structures/window_spawner.dm
@@ -10,6 +10,7 @@
 	density = 1
 	anchored = 1.0
 	pressure_resistance = 4*ONE_ATMOSPHERE
+	can_atmos_pass = ATMOS_PASS_NO
 	var/win_path = /obj/structure/window/basic
 	var/activated
 
@@ -22,7 +23,7 @@
 /obj/effect/wingrille_spawn/attack_generic()
 	activate()
 
-/obj/effect/wingrille_spawn/CanPass(atom/movable/mover, turf/target, height=1.5, air_group = 0)
+/obj/effect/wingrille_spawn/CanPass(atom/movable/mover, turf/target)
 	return FALSE
 
 /obj/effect/wingrille_spawn/Initialize()

--- a/code/game/shuttle_engines.dm
+++ b/code/game/shuttle_engines.dm
@@ -9,13 +9,15 @@
 	density = 1
 	opacity = 0
 	anchored = 1
+	can_atmos_pass = ATMOS_PASS_NO
 
 	var/window_flags = 0 // Bitflags to indicate connected windows
 	var/wall_flags = 0 // Bitflags to indicate connected walls
 
-/obj/structure/shuttle/window/CanPass(atom/movable/mover, turf/target, height, air_group)
-	if(!height || air_group) return 0
-	else return ..()
+/obj/structure/shuttle/window/CanPass(atom/movable/mover, turf/target)
+	if(istype(mover) && mover.checkpass(PASSGLASS))
+		return TRUE
+	return ..()
 
 /obj/structure/shuttle/window/Initialize()
 	. = ..()

--- a/code/modules/blob/blob.dm
+++ b/code/modules/blob/blob.dm
@@ -22,10 +22,8 @@
 	update_icon()
 	return ..(loc)
 
-/obj/effect/blob/CanPass(var/atom/movable/mover, vra/turf/target, var/height = 0, var/air_group = 0)
-	if(air_group || height == 0)
-		return 1
-	return 0
+/obj/effect/blob/CanPass(var/atom/movable/mover, vra/turf/target)
+	return FALSE
 
 /obj/effect/blob/ex_act(var/severity)
 	switch(severity)
@@ -207,5 +205,5 @@
 	else
 		icon_state = "blob_damaged"
 
-/obj/effect/blob/shield/CanPass(var/atom/movable/mover, var/turf/target, var/height = 0, var/air_group = 0)
+/obj/effect/blob/shield/CanPass(var/atom/movable/mover, var/turf/target)
 	return !density

--- a/code/modules/blob2/blobs/base_blob.dm
+++ b/code/modules/blob2/blobs/base_blob.dm
@@ -46,30 +46,19 @@ var/list/blobs = list()
 		color = null
 		set_light(0)
 
-/obj/structure/blob/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
-	world << "/obj/structure/blob/CanPass(mover=[mover], target=[target], height=[height], air_group=[air_group]) called on [src]."
-	if(air_group || (height==0))
-		world << "Returned true due to being air group or having height=0"
-		return TRUE
+// Blob tiles are not actually dense so we need Special Code(tm).
+/obj/structure/blob/CanPass(atom/movable/mover, turf/target)
 	if(istype(mover) && mover.checkpass(PASSBLOB))
-		world << "Returned true due to having PASSBLOB."
 		return TRUE
 	else if(istype(mover, /mob/living))
 		var/mob/living/L = mover
 		if(L.faction == "blob")
-			world << "Returned true due to being in blob faction."
 			return TRUE
 	else if(istype(mover, /obj/item/projectile))
 		var/obj/item/projectile/P = mover
-		if(P.firer && P.firer.faction == "blob")
-			world << "Returned true due to being a projectile fired by someone in blob faction."
+		if(istype(P.firer) && P.firer.faction == "blob")
 			return TRUE
-		world << "Returned false due to being a projectile, with firer not in faction."
-		return FALSE
-	else
-		world << "Returned false."
-		return FALSE
-//	return ..()
+	return FALSE
 
 /obj/structure/blob/examine(mob/user)
 	..()
@@ -264,7 +253,7 @@ var/list/blobs = list()
 	if(!P)
 		return
 
-	if(P.firer && P.firer.faction == "blob")
+	if(istype(P.firer) && P.firer.faction == "blob")
 		return
 
 	var/damage = P.get_structure_damage() // So tasers don't hurt the blob.

--- a/code/modules/blob2/blobs/base_blob.dm
+++ b/code/modules/blob2/blobs/base_blob.dm
@@ -47,20 +47,27 @@ var/list/blobs = list()
 		set_light(0)
 
 /obj/structure/blob/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
+	world << "/obj/structure/blob/CanPass(mover=[mover], target=[target], height=[height], air_group=[air_group]) called on [src]."
 	if(air_group || (height==0))
+		world << "Returned true due to being air group or having height=0"
 		return TRUE
 	if(istype(mover) && mover.checkpass(PASSBLOB))
+		world << "Returned true due to having PASSBLOB."
 		return TRUE
 	else if(istype(mover, /mob/living))
 		var/mob/living/L = mover
 		if(L.faction == "blob")
+			world << "Returned true due to being in blob faction."
 			return TRUE
 	else if(istype(mover, /obj/item/projectile))
 		var/obj/item/projectile/P = mover
 		if(P.firer && P.firer.faction == "blob")
+			world << "Returned true due to being a projectile fired by someone in blob faction."
 			return TRUE
+		world << "Returned false due to being a projectile, with firer not in faction."
 		return FALSE
 	else
+		world << "Returned false."
 		return FALSE
 //	return ..()
 

--- a/code/modules/blob2/blobs/shield.dm
+++ b/code/modules/blob2/blobs/shield.dm
@@ -6,6 +6,7 @@
 	desc = "A solid wall of slightly twitching tendrils."
 	max_integrity = 100
 	point_return = 4
+	can_atmos_pass = ATMOS_PASS_NO
 
 /obj/structure/blob/shield/core
 	point_return = 0

--- a/code/modules/holodeck/HolodeckObjects.dm
+++ b/code/modules/holodeck/HolodeckObjects.dm
@@ -320,19 +320,18 @@
 		visible_message("<span class='notice'>[user] dunks [W] into the [src]!</span>", 3)
 		return
 
-/obj/structure/holohoop/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
+/obj/structure/holohoop/CanPass(atom/movable/mover, turf/target)
 	if (istype(mover,/obj/item) && mover.throwing)
 		var/obj/item/I = mover
 		if(istype(I, /obj/item/projectile))
-			return
+			return TRUE
 		if(prob(50))
-			I.loc = src.loc
-			visible_message("<span class='notice'>Swish! \the [I] lands in \the [src].</span>", 3)
+			I.forceMove(loc)
+			visible_message(span("notice", "Swish! \the [I] lands in \the [src]."), 3)
 		else
-			visible_message("<span class='warning'>\The [I] bounces off of \the [src]'s rim!</span>", 3)
-		return 0
-	else
-		return ..(mover, target, height, air_group)
+			visible_message(span("warning", "\The [I] bounces off of \the [src]'s rim!"), 3)
+		return FALSE
+	return ..()
 
 
 /obj/machinery/readybutton

--- a/code/modules/hydroponics/trays/tray.dm
+++ b/code/modules/hydroponics/trays/tray.dm
@@ -217,13 +217,10 @@
 
 	..()
 
-/obj/machinery/portable_atmospherics/hydroponics/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
-	if(air_group || (height==0)) return 1
-
+/obj/machinery/portable_atmospherics/hydroponics/CanPass(atom/movable/mover, turf/target)
 	if(istype(mover) && mover.checkpass(PASSTABLE))
-		return 1
-	else
-		return 0
+		return TRUE
+	return FALSE
 
 /obj/machinery/portable_atmospherics/hydroponics/proc/check_health()
 	if(seed && !dead && health <= 0)

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -143,8 +143,8 @@
 		var/mob/observer/dead/M = src
 		M.manifest(user)
 
-/mob/observer/dead/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
-	return 1
+/mob/observer/dead/CanPass(atom/movable/mover, turf/target)
+	return TRUE
 /*
 Transfer_mind is there to check if mob is being deleted/not going to have a body.
 Works together with spawning an observer, noted above.

--- a/code/modules/mob/living/living_movement.dm
+++ b/code/modules/mob/living/living_movement.dm
@@ -1,4 +1,4 @@
-/mob/CanPass(atom/movable/mover, turf/target, height, air_group)
+/mob/CanPass(atom/movable/mover, turf/target)
 	if(ismob(mover))
 		var/mob/moving_mob = mover
 		if ((other_mobs && moving_mob.other_mobs))
@@ -9,4 +9,4 @@
 	return (!mover.density || !density || lying)
 
 /mob/CanZASPass(turf/T, is_zone)
-	return TRUE
+	return ATMOS_PASS_YES

--- a/code/modules/mob/living/living_movement.dm
+++ b/code/modules/mob/living/living_movement.dm
@@ -1,7 +1,4 @@
 /mob/CanPass(atom/movable/mover, turf/target, height, air_group)
-	if(air_group || (height == 0))
-		return TRUE
-
 	if(ismob(mover))
 		var/mob/moving_mob = mover
 		if ((other_mobs && moving_mob.other_mobs))
@@ -10,3 +7,6 @@
 		var/obj/item/projectile/P = mover
 		return !P.can_hit_target(src, P.permutated, src == P.original, TRUE)
 	return (!mover.density || !density || lying)
+
+/mob/CanZASPass(turf/T, is_zone)
+	return TRUE

--- a/code/modules/power/antimatter/shielding.dm
+++ b/code/modules/power/antimatter/shielding.dm
@@ -74,9 +74,8 @@ proc/cardinalrange(var/center)
 	return
 
 
-/obj/machinery/am_shielding/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
-	if(air_group || (height==0))	return 1
-	return 0
+/obj/machinery/am_shielding/CanPass(atom/movable/mover, turf/target)
+	return FALSE
 
 
 /obj/machinery/am_shielding/process()

--- a/code/modules/power/fusion/fusion_particle_catcher.dm
+++ b/code/modules/power/fusion/fusion_particle_catcher.dm
@@ -37,7 +37,7 @@
 	update_icon()
 	return 0
 
-/obj/effect/fusion_particle_catcher/CanPass(var/atom/movable/mover, var/turf/target, var/height=0, var/air_group=0)
+/obj/effect/fusion_particle_catcher/CanPass(atom/movable/mover, turf/target)
 	if(istype(mover, /obj/effect/accelerated_particle) || istype(mover, /obj/item/projectile/beam))
 		return !density
-	return 1
+	return TRUE

--- a/code/modules/power/turbine.dm
+++ b/code/modules/power/turbine.dm
@@ -95,10 +95,8 @@
 		stat |= BROKEN
 
 // When anchored, don't let air past us.
-/obj/machinery/compressor/CanPass(atom/movable/mover, turf/target, height=1.5, air_group = 0)
-	if(!height || air_group)
-		return !anchored
-	return !density
+/obj/machinery/compressor/CanZASPass(turf/T, is_zone)
+	return anchored ? ATMOS_PASS_NO : ATMOS_PASS_YES
 
 /obj/machinery/compressor/proc/locate_machinery()
 	if(turbine)

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -467,7 +467,7 @@
 		H.vent_gas(loc)
 		qdel(H)
 
-/obj/machinery/disposal/CanPass(atom/movable/mover, turf/target, height, air_group)
+/obj/machinery/disposal/CanPass(atom/movable/mover, turf/target)
 	if(istype(mover, /obj/item/projectile))
 		return 1
 	if (istype(mover,/obj/item) && mover.throwing)
@@ -483,7 +483,7 @@
 				M.show_message("\The [I] bounces off of \the [src]'s rim!", 3)
 		return 0
 	else
-		return ..(mover, target, height, air_group)
+		return ..(mover, target)
 
 // virtual disposal object
 // travels through pipes in lieu of actual items

--- a/code/modules/shieldgen/directional_shield.dm
+++ b/code/modules/shieldgen/directional_shield.dm
@@ -53,10 +53,8 @@
 		projector = null
 	return ..()
 
-/obj/effect/directional_shield/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
-	if(air_group || (height==0))
-		return TRUE
-	else if(istype(mover, /obj/item/projectile))
+/obj/effect/directional_shield/CanPass(atom/movable/mover, turf/target)
+	if(istype(mover, /obj/item/projectile))
 		var/obj/item/projectile/P = mover
 		if(istype(P, /obj/item/projectile/test)) // Turrets need to try to kill the shield and so their test bullet needs to penetrate.
 			return TRUE
@@ -64,8 +62,6 @@
 		var/bad_arc = reverse_direction(dir) // Arc of directions from which we cannot block.
 		if(check_shield_arc(src, bad_arc, P)) // This is actually for mobs but it will work for our purposes as well.
 			return FALSE
-		else
-			return TRUE
 	return TRUE
 
 /obj/effect/directional_shield/bullet_act(var/obj/item/projectile/P)

--- a/code/modules/shieldgen/emergency_shield.dm
+++ b/code/modules/shieldgen/emergency_shield.dm
@@ -7,6 +7,7 @@
 	opacity = 0
 	anchored = 1
 	unacidable = 1
+	can_atmos_pass = ATMOS_PASS_NO
 	var/const/max_health = 200
 	var/health = max_health //The shield can only take so much beating (prevents perma-prisons)
 	var/shield_generate_power = 7500	//how much power we use when regenerating
@@ -37,10 +38,6 @@
 	density = 0
 	update_nearby_tiles()
 	..()
-
-/obj/machinery/shield/CanPass(atom/movable/mover, turf/target, height, air_group)
-	if(!height || air_group) return 0
-	else return ..()
 
 /obj/machinery/shield/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	if(!istype(W)) return

--- a/code/modules/shieldgen/energy_field.dm
+++ b/code/modules/shieldgen/energy_field.dm
@@ -18,6 +18,7 @@
 	plane = MOB_PLANE
 	layer = ABOVE_MOB_LAYER
 	density = 0
+	can_atmos_pass = ATMOS_PASS_DENSITY
 	var/obj/machinery/shield_gen/my_gen = null
 	var/strength = 0 // in Renwicks
 	var/ticks_recovering = 10
@@ -102,15 +103,6 @@
 	if(density != old_density)
 		update_icon()
 		update_nearby_tiles()
-
-/obj/effect/energy_field/CanPass(atom/movable/mover, turf/target, height=1.5, air_group = 0)
-	//Purpose: Determines if the object (or airflow) can pass this atom.
-	//Called by: Movement, airflow.
-	//Inputs: The moving atom (optional), target turf, "height" and air group
-	//Outputs: Boolean if can pass.
-
-	//return (!density || !height || air_group)
-	return !density
 
 /obj/effect/energy_field/update_icon(var/update_neightbors = 0)
 	overlays.Cut()

--- a/code/modules/shieldgen/sheldwallgen.dm
+++ b/code/modules/shieldgen/sheldwallgen.dm
@@ -317,13 +317,9 @@
 	return
 
 
-/obj/machinery/shieldwall/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
-	if(air_group || (height==0)) return 1
-
+/obj/machinery/shieldwall/CanPass(atom/movable/mover, turf/target)
 	if(istype(mover) && mover.checkpass(PASSGLASS))
 		return prob(20)
-	else
-		if (istype(mover, /obj/item/projectile))
-			return prob(10)
-		else
-			return !src.density
+	if(istype(mover, /obj/item/projectile))
+		return prob(10)
+	return !density

--- a/code/modules/tables/interactions.dm
+++ b/code/modules/tables/interactions.dm
@@ -1,21 +1,20 @@
 
-/obj/structure/table/CanPass(atom/movable/mover, turf/target, height, air_group)
-	if(air_group || (height==0)) return 1
+/obj/structure/table/CanPass(atom/movable/mover, turf/target)
 	if(istype(mover,/obj/item/projectile))
 		return (check_cover(mover,target))
 	if (flipped == 1)
 		if (get_dir(loc, target) == dir)
 			return !density
 		else
-			return 1
+			return TRUE
 	if(istype(mover) && mover.checkpass(PASSTABLE))
-		return 1
+		return TRUE
 	if(locate(/obj/structure/table/bench) in get_turf(mover))
-		return 0
+		return FALSE
 	var/obj/structure/table/table = locate(/obj/structure/table) in get_turf(mover)
 	if(table && !table.flipped)
-		return 1
-	return 0
+		return TRUE
+	return FALSE
 
 //checks if projectile 'P' from turf 'from' can hit whatever is behind the table. Returns 1 if it can, 0 if bullet stops.
 /obj/structure/table/proc/check_cover(obj/item/projectile/P, turf/from)

--- a/polaris.dme
+++ b/polaris.dme
@@ -2629,7 +2629,7 @@
 #include "code\ZAS\Zone.dm"
 #include "interface\interface.dm"
 #include "interface\skin.dmf"
-#include "maps\example\example.dm"
+#include "maps\southern_cross\southern_cross.dm"
 #include "maps\submaps\space_submaps\space.dm"
 #include "maps\submaps\surface_submaps\mountains\mountains.dm"
 #include "maps\submaps\surface_submaps\mountains\mountains_areas.dm"

--- a/polaris.dme
+++ b/polaris.dme
@@ -2629,7 +2629,7 @@
 #include "code\ZAS\Zone.dm"
 #include "interface\interface.dm"
 #include "interface\skin.dmf"
-#include "maps\southern_cross\southern_cross.dm"
+#include "maps\example\example.dm"
 #include "maps\submaps\space_submaps\space.dm"
 #include "maps\submaps\surface_submaps\mountains\mountains.dm"
 #include "maps\submaps\surface_submaps\mountains\mountains_areas.dm"


### PR DESCRIPTION
Cheeky title aside, this refactors, how ZAS knows what things air can flow through, and when zones can merge. Previously, ZAS did this in a rather strange way using ``CanPass()``, which was used both for physical objects trying to go through each other, and abstract airflows and zones. For some reason, the default arguments for this were set so that if not explicitly told that the thing trying to go through is a physical object, it would assume it was checking for if air/zones were blocked.

The projectile rewrite made it so the argument that explicitly says its not ZAS related was no longer passed, making most ``CanPass()`` checks think that people are air when moving into things like blobs, surgery tables, grilles, etc, which are not air tight.

The lazy fix would've been to put that explicit argument back in, but instead I decided to rewrite the ``CanPass()`` system by ripping out the ZAS logic from it, and making ZAS use a new proc called ``CanZASPass()``, which is explicitly for atmospherics, while ``CanPass()`` is only for physical objects.

Dev notes: To influence whether or not airflow/zones can go through an object, use ``CanZASPass()``. If you merely want to make something airtight or not, you can set ``can_atmos_pass`` to equal ``ATMOS_PASS_NO``, ``ATMOS_PASS_YES``, or ``ATMOS_PASS_DENSITY``. More complicated behavior should override ``CanZASPass()``.
I saw some strange ZAS behavior involving spawning things like airlocks or inflatables after the round starts making the debug visualizer color the room yellow instead of green, but it turns out the strangeness was already in master soooooo at least I didn't make it worse with this, and ZAS otherwise seemed to work regardless.

Fixes #5939 
Fixes #5927 
Fixes #5928 
Fixes unreported bug where you could walk through railings.
Makes airtight flaps not be superdumb in how it does its airtightness.