### PR TITLE
Tweaks Daxons

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -566,6 +566,8 @@
 				H.vomit(1)
 			else if(H.nutrition > 30)
 				H.nutrition = max(0, H.nutrition - round(30 * removed))
+		else
+			H.adjustToxLoss(-10 * removed) // Carthatoline based, considering cost.
 
 /datum/reagent/hepanephrodaxon
 	name = "Hepanephrodaxon"
@@ -597,6 +599,8 @@
 				to_chat(H,"<span class='danger'>Something churns inside you.</span>")
 				H.adjustToxLoss(10 * removed)
 				H.vomit(0, 1)
+		else
+			H.adjustToxLoss(-12 * removed) // Carthatoline based, considering cost.
 
 /datum/reagent/cordradaxon
 	name = "Cordradaxon"
@@ -623,6 +627,8 @@
 				H.Confuse(2)
 		if(M.reagents.has_reagent("respirodaxon") || M.reagents.has_reagent("peridaxon"))
 			H.losebreath = CLAMP(H.losebreath + 1, 0, 10)
+		else
+			H.adjustOxyLoss(-30 * removed) // Deals with blood oxygenation.
 
 /datum/reagent/immunosuprizine
 	name = "Immunosuprizine"

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -514,6 +514,7 @@
 	taste_description = "metallic"
 	reagent_state = LIQUID
 	color = "#4444FF"
+	metabolism = REM * 1.5
 	overdose = 10
 	scannable = 1
 
@@ -527,13 +528,15 @@
 			if(I.robotic >= ORGAN_ROBOT || !(I.organ_tag in list(O_LUNGS, O_VOICE, O_GBLADDER)))
 				continue
 			if(I.damage > 0)
-				I.damage = max(I.damage - 2 * removed * repair_strength, 0)
+				I.damage = max(I.damage - 4 * removed * repair_strength, 0)
 				H.Confuse(2)
 		if(M.reagents.has_reagent("gastirodaxon") || M.reagents.has_reagent("peridaxon"))
 			if(H.losebreath >= 15 && prob(H.losebreath))
 				H.Stun(2)
 			else
 				H.losebreath = CLAMP(H.losebreath + 3, 0, 20)
+		else
+			H.losebreath = max(H.losebreath - 4, 0)
 
 /datum/reagent/gastirodaxon
 	name = "Gastirodaxon"
@@ -542,6 +545,7 @@
 	taste_description = "chalk"
 	reagent_state = LIQUID
 	color = "#8B4513"
+	metabolism = REM * 1.5
 	overdose = 10
 	scannable = 1
 
@@ -555,7 +559,7 @@
 			if(I.robotic >= ORGAN_ROBOT || !(I.organ_tag in list(O_APPENDIX, O_NUTRIENT, O_PLASMA, O_POLYP)))
 				continue
 			if(I.damage > 0)
-				I.damage = max(I.damage - 2 * removed * repair_strength, 0)
+				I.damage = max(I.damage - 4 * removed * repair_strength, 0)
 				H.Confuse(2)
 		if(M.reagents.has_reagent("hepanephrodaxon") || M.reagents.has_reagent("peridaxon"))
 			if(prob(10))
@@ -570,6 +574,7 @@
 	taste_description = "glue"
 	reagent_state = LIQUID
 	color = "#D2691E"
+	metabolism = REM * 1.5
 	overdose = 10
 	scannable = 1
 
@@ -583,7 +588,7 @@
 			if(I.robotic >= ORGAN_ROBOT || !(I.organ_tag in list(O_LIVER, O_KIDNEYS, O_APPENDIX, O_ACID, O_HIVE)))
 				continue
 			if(I.damage > 0)
-				I.damage = max(I.damage - 2 * removed * repair_strength, 0)
+				I.damage = max(I.damage - 4 * removed * repair_strength, 0)
 				H.Confuse(2)
 		if(M.reagents.has_reagent("cordradaxon") || M.reagents.has_reagent("peridaxon"))
 			if(prob(5))
@@ -600,6 +605,7 @@
 	taste_description = "rust"
 	reagent_state = LIQUID
 	color = "#FF4444"
+	metabolism = REM * 1.5
 	overdose = 10
 	scannable = 1
 
@@ -613,7 +619,7 @@
 			if(I.robotic >= ORGAN_ROBOT || !(I.organ_tag in list(O_HEART, O_RESPONSE, O_ANCHOR, O_EGG)))
 				continue
 			if(I.damage > 0)
-				I.damage = max(I.damage - 2 * removed * repair_strength, 0)
+				I.damage = max(I.damage - 4 * removed * repair_strength, 0)
 				H.Confuse(2)
 		if(M.reagents.has_reagent("respirodaxon") || M.reagents.has_reagent("peridaxon"))
 			H.losebreath = CLAMP(H.losebreath + 1, 0, 10)
@@ -681,6 +687,7 @@
 	taste_description = "mordant"
 	reagent_state = SOLID
 	color = "#84B2B0"
+	metabolism = REM * 0.75
 	overdose = 20
 	scannable = 1
 

--- a/html/changelogs/Mechoid-DAXONS.yml
+++ b/html/changelogs/Mechoid-DAXONS.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Mechoid
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Tweaked Respiro- Cordra- Gastiro- and Hepanephro- Daxons to be more effective with dealing with the side-effects of damaged organs."


### PR DESCRIPTION
After receiving feedback regarding the new chems I added previously, I've tweaked their effects / values to be more worth the cost.

Tweaks
Respiro- Cordra- Gastiro- and Hepanephro- Daxons increased in process rate from 0.2 to 0.3 per cycle.
Repair amount changed from 2 per unit to 4.

If not conflicting with other chemicals:
Respirodaxon lowers losebreath
Cordradaxon lowers oxygen damage, dealing with bloodloss
Gastirodaxon lowers toxin at 10 per unit, 2 more than carthatoline
Hepanephrodaxon lowers toxin at 12 per unit, 4 more than carthatoline

Skrell Anti-Rejection processes at 0.15 rather than 0.2.