### PR TITLE
Makes aiming more clear for the target.

### DIFF
--- a/code/modules/projectiles/targeting/targeting_overlay.dm
+++ b/code/modules/projectiles/targeting/targeting_overlay.dm
@@ -171,6 +171,7 @@ obj/aiming_overlay/proc/update_aiming_deferred()
 	if(owner.client)
 		owner.client.add_gun_icons()
 	to_chat(target, "<span class='danger'>You now have a gun pointed at you. No sudden moves!</span>")
+	to_chat(target, "<span class='critical'>If you fail to comply with your assailant, you accept the consequences of your actions.</span>")
 	aiming_with = thing
 	aiming_at = target
 	if(istype(aiming_with, /obj/item/weapon/gun))


### PR DESCRIPTION
Targets of aiming now have a second, much larger message pop up under the default to remind them of the importance of the situation.