### PR TITLE
Reverts some real spacebrain gas

### DIFF
--- a/code/game/turfs/turf_changing.dm
+++ b/code/game/turfs/turf_changing.dm
@@ -28,7 +28,7 @@
 
 	if(N == /turf/space)
 		var/turf/below = GetBelow(src)
-		if(istype(below) && !istype(below,/turf/space))
+		if(istype(below) && (air_master.has_valid_zone(below) || air_master.has_valid_zone(src)))
 			N = /turf/simulated/open
 
 	var/obj/fire/old_fire = fire


### PR DESCRIPTION
I'm not gonna ask what made it look like a good idea to change this from "do not force intentional space turfs to open space if the area below has no atmos simulation" to "forcibly turn intentional space turfs to open space on literally everything that doesn't exclusively have space turf below". Base turf types defined for areas/z-levels are a thing.

Was a real doozy on a multi-z map with engine rotation at space side.