### PR TITLE
Prevents people from joining with the same character

### DIFF
--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -163,6 +163,13 @@
 		ViewManifest()
 
 	if(href_list["SelectedJob"])
+	
+		//Prevents people rejoining as same character.
+		for (var/mob/living/carbon/human/C in mob_list)
+			var/char_name = client.prefs.real_name
+			if(char_name == C.real_name)
+				usr << "<span class='notice'>There is a character that already exists with the same name - <b>[C.real_name]</b>, please join with a different one.</span>"
+				return
 
 		if(!config.enter_allowed)
 			usr << "<span class='notice'>There is an administrative lock on entering the game!</span>"


### PR DESCRIPTION
Just a check on late spawn to prevent people from rejoining constantly as the same char.

![image](https://user-images.githubusercontent.com/12565163/52837331-30bfd380-30e6-11e9-88e5-78fe99aae4fb.png)
