### PR TITLE
Fixes blast door issue, and slimesky being considered unjustified.

### DIFF
--- a/code/game/machinery/doors/blast_door.dm
+++ b/code/game/machinery/doors/blast_door.dm
@@ -63,6 +63,10 @@
 /obj/machinery/door/blast/emag_act()
 	return -1
 
+// Blast doors are triggered remotely, so nobody is allowed to physically influence it.
+/obj/machinery/door/blast/allowed(mob/M)
+	return FALSE
+
 // Proc: force_open()
 // Parameters: None
 // Description: Opens the door. No checks are done inside this proc.
@@ -207,9 +211,10 @@
 // Proc: attack_generic()
 // Parameters: Attacking simple mob, incoming damage.
 // Description: Checks the power or integrity of the blast door, if either have failed, chekcs the damage to determine if the creature would be able to open the door by force. Otherwise, super.
-/obj/machinery/door/blast/attack_generic(var/mob/user, var/damage)
+/obj/machinery/door/blast/attack_generic(mob/living/user, damage)
 	if(stat & (BROKEN|NOPOWER))
-		if(damage >= 10)
+		if(damage >= STRUCTURE_MIN_DAMAGE_THRESHOLD)
+			user.set_AI_busy(TRUE) // If the mob doesn't have an AI attached, this won't do anything.
 			if(src.density)
 				visible_message("<span class='danger'>\The [user] starts forcing \the [src] open!</span>")
 				if(do_after(user, 5 SECONDS, src))
@@ -220,6 +225,7 @@
 				if(do_after(user, 2 SECONDS, src))
 					visible_message("<span class='danger'>\The [user] forces \the [src] closed!</span>")
 					force_close(1)
+			user.set_AI_busy(FALSE)
 		else
 			visible_message("<span class='notice'>\The [user] strains fruitlessly to force \the [src] [density ? "open" : "closed"].</span>")
 		return

--- a/code/modules/ai/aI_holder_subtypes/slime_xenobio_ai.dm
+++ b/code/modules/ai/aI_holder_subtypes/slime_xenobio_ai.dm
@@ -34,16 +34,22 @@
 
 // Checks if disciplining the slime would be 'justified' right now.
 /datum/ai_holder/simple_mob/xenobio_slime/proc/is_justified_to_discipline()
+	ai_log("xenobio_slime/is_justified_to_discipline() : Entered.", AI_LOG_TRACE)
 	if(!can_act())
+		ai_log("xenobio_slime/is_justified_to_discipline() : Judged to be unjustified because we cannot act. Exiting.", AI_LOG_DEBUG)
 		return FALSE // The slime considers it abuse if they get stunned while already stunned.
 	if(rabid)
+		ai_log("xenobio_slime/is_justified_to_discipline() : Judged to be justified because we're rabid. Exiting.", AI_LOG_TRACE)
 		return TRUE
 	if(target && can_attack(target))
 		if(ishuman(target))
 			var/mob/living/carbon/human/H = target
 			if(istype(H.species, /datum/species/monkey))
+				ai_log("xenobio_slime/is_justified_to_discipline() : Judged to be unjustified because we're targeting a monkey. Exiting.", AI_LOG_DEBUG)
 				return FALSE // Attacking monkeys is okay.
+		ai_log("xenobio_slime/is_justified_to_discipline() : Judged to be justified because we are targeting a non-monkey. Exiting.", AI_LOG_TRACE)
 		return TRUE // Otherwise attacking other things is bad.
+	ai_log("xenobio_slime/is_justified_to_discipline() : Judged to be unjustified because we are not targeting anything. Exiting.", AI_LOG_DEBUG)
 	return FALSE // Not attacking anything.
 
 /datum/ai_holder/simple_mob/xenobio_slime/proc/can_command(mob/living/commander)
@@ -64,7 +70,7 @@
 	if(amount > 0)
 		if(rabid)
 			return
-		var/justified = is_justified_to_discipline()
+		var/justified = my_slime.is_justified_to_discipline() // This will also consider the AI-side of that proc.
 		lost_target() // Stop attacking.
 
 		if(justified)

--- a/code/modules/mob/living/bot/secbot.dm
+++ b/code/modules/mob/living/bot/secbot.dm
@@ -24,8 +24,7 @@
 	var/awaiting_surrender = 0
 	var/can_next_insult = 0			// Uses world.time
 	var/stun_strength = 60			// For humans.
-	var/xeno_stun_strength = 0		// For simple mobs.
-	var/xeno_harm_strength = 15 	// Ditto.
+	var/xeno_harm_strength = 15 	// How hard to hit simple_mobs.
 	var/baton_glow = "#FF6A00"
 
 	var/used_weapon	= /obj/item/weapon/melee/baton	//Weapon used by the bot
@@ -44,12 +43,13 @@
 	desc = "A little security robot, with a slime baton subsituted for the regular one."
 	default_icon_state = "slimesecbot"
 	stun_strength = 10 // Slimebatons aren't meant for humans.
-	xeno_stun_strength = 5
-	xeno_harm_strength = 9
+
+	xeno_harm_strength = 9 // Weaker than regular slimesky but they can stun.
 	baton_glow = "#33CCFF"
 	req_one_access = list(access_research, access_robotics)
 	botcard_access = list(access_research, access_robotics, access_xenobiology, access_xenoarch, access_tox, access_tox_storage, access_maint_tunnels)
 	used_weapon = /obj/item/weapon/melee/baton/slime
+	var/xeno_stun_strength = 5 // How hard to slimebatoned()'d naughty slimes. 5 works out to 2 discipline and 5 weaken.
 
 /mob/living/bot/secbot/slime/slimesky
 	name = "Doctor Slimesky"
@@ -262,7 +262,6 @@
 			busy = 0
 	else if(istype(M, /mob/living/simple_mob))
 		var/mob/living/simple_mob/S = M
-		S.Weaken(xeno_stun_strength)
 		S.adjustBruteLoss(xeno_harm_strength)
 		do_attack_animation(M)
 		playsound(loc, "swing_hit", 50, 1, -1)
@@ -279,7 +278,7 @@
 
 	if(istype(L, /mob/living/simple_mob/slime/xenobio))
 		var/mob/living/simple_mob/slime/xenobio/S = L
-		S.adjust_discipline(2)
+		S.slimebatoned(src, xeno_stun_strength)
 
 
 


### PR DESCRIPTION
Fixes #5964. Simplemobs now need to bust down the blast door before being able to pry them open, like airlocks.
Fixes yet-to-be-reported bug of slimesky discipline being always unjustified due to out-of-order stun/discipline.