### PR TITLE
Fixes Diona and Promethean prosthetics.

### DIFF
--- a/code/modules/organs/robolimbs.dm
+++ b/code/modules/organs/robolimbs.dm
@@ -42,7 +42,7 @@ var/const/standard_monitor_styles = "blank=ipc_blank;\
 	var/lifelike										 // If set, appears organic.
 	var/skin_tone										 // If set, applies skin tone rather than part color
 	var/blood_color = "#030303"
-	var/list/species_cannot_use = list(SPECIES_TESHARI)
+	var/list/species_cannot_use = list(SPECIES_TESHARI, SPECIES_PROMETHEAN, SPECIES_DIONA)
 	var/list/monitor_styles			 		 			 //If empty, the model of limbs offers a head compatible with monitors.
 	var/parts = BP_ALL						 			 //Defines what parts said brand can replace on a body.
 	var/health_hud_intensity = 1						 // Intensity modifier for the health GUI indicator.


### PR DESCRIPTION
Dionaea and Prometheans can no longer have Prosthetics attached to them, in loadout or in-round. This includes FBPs.

Promethean cores can still be MMI'd and placed into an FBP in round, as that is a 'human' FBP, not a Promethean-based one.