### PR TITLE
Unpicks some mining spaghetti

### DIFF
--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -56,7 +56,6 @@
 	origin_tech = list(TECH_MATERIAL = 3, TECH_POWER = 2, TECH_ENGINEERING = 2)
 	desc = "Cracks rocks with sonic blasts, perfect for killing cave lizards."
 	drill_verb = "hammering"
-	destroy_artefacts = TRUE
 
 /obj/item/weapon/pickaxe/gold
 	name = "golden pickaxe"

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -47,7 +47,6 @@
 	origin_tech = list(TECH_MATERIAL = 2, TECH_POWER = 3, TECH_ENGINEERING = 2)
 	desc = "Yours is the drill that will pierce through the rock walls."
 	drill_verb = "drilling"
-	destroy_artefacts = TRUE
 
 /obj/item/weapon/pickaxe/jackhammer
 	name = "sonic jackhammer"
@@ -99,7 +98,6 @@
 	origin_tech = list(TECH_MATERIAL = 6, TECH_POWER = 4, TECH_ENGINEERING = 5)
 	desc = "Yours is the drill that will pierce the heavens!"
 	drill_verb = "drilling"
-	destroy_artefacts = TRUE
 
 /obj/item/weapon/pickaxe/borgdrill
 	name = "enhanced sonic jackhammer"
@@ -108,7 +106,6 @@
 	digspeed = 15
 	desc = "Cracks rocks with sonic blasts. This one seems like an improved design."
 	drill_verb = "hammering"
-	destroy_artefacts = TRUE
 
 /*****************************Shovel********************************/
 

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -29,7 +29,7 @@
 	sharp = 1
 
 	var/excavation_amount = 200
-	var/destroy_artefacts = FALSE // some mining tools will just trash artefacts completely. At least you won't get assblasted by rads.
+	var/destroy_artefacts = FALSE // some mining tools will destroy artefacts completely while avoiding side-effects.
 
 /obj/item/weapon/pickaxe/silver
 	name = "silver pickaxe"

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -29,6 +29,7 @@
 	sharp = 1
 
 	var/excavation_amount = 200
+	var/destroy_artefacts = FALSE // some mining tools will just trash artefacts completely. At least you won't get assblasted by rads.
 
 /obj/item/weapon/pickaxe/silver
 	name = "silver pickaxe"
@@ -46,6 +47,7 @@
 	origin_tech = list(TECH_MATERIAL = 2, TECH_POWER = 3, TECH_ENGINEERING = 2)
 	desc = "Yours is the drill that will pierce through the rock walls."
 	drill_verb = "drilling"
+	destroy_artefacts = TRUE
 
 /obj/item/weapon/pickaxe/jackhammer
 	name = "sonic jackhammer"
@@ -55,6 +57,7 @@
 	origin_tech = list(TECH_MATERIAL = 3, TECH_POWER = 2, TECH_ENGINEERING = 2)
 	desc = "Cracks rocks with sonic blasts, perfect for killing cave lizards."
 	drill_verb = "hammering"
+	destroy_artefacts = TRUE
 
 /obj/item/weapon/pickaxe/gold
 	name = "golden pickaxe"
@@ -96,6 +99,7 @@
 	origin_tech = list(TECH_MATERIAL = 6, TECH_POWER = 4, TECH_ENGINEERING = 5)
 	desc = "Yours is the drill that will pierce the heavens!"
 	drill_verb = "drilling"
+	destroy_artefacts = TRUE
 
 /obj/item/weapon/pickaxe/borgdrill
 	name = "enhanced sonic jackhammer"
@@ -104,6 +108,7 @@
 	digspeed = 15
 	desc = "Cracks rocks with sonic blasts. This one seems like an improved design."
 	drill_verb = "hammering"
+	destroy_artefacts = TRUE
 
 /*****************************Shovel********************************/
 

--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -24,7 +24,6 @@ var/list/mining_overlay_cache = list()
 	var/sand_dug
 	var/mined_ore = 0
 	var/last_act = 0
-	var/emitter_blasts_taken = 0 // EMITTER MINING! Muhehe.
 	var/overlay_detail
 
 	var/datum/geosample/geologic_data
@@ -208,14 +207,22 @@ var/list/mining_overlay_cache = list()
 					new oretype(src)
 				resources[ore] = 0
 
-/turf/simulated/mineral/bullet_act(var/obj/item/projectile/Proj)
+/turf/simulated/mineral/bullet_act(var/obj/item/projectile/Proj) // only emitters for now
+	if(Proj.excavation_amount)
+		var/newDepth = excavation_level + Proj.excavation_amount // Used commonly below
+		if(newDepth >= 200) // first, if the turf is completely drilled then don't bother checking for finds and just drill it
+			GetDrilled(0)
 
-	// Emitter blasts
-	if(istype(Proj, /obj/item/projectile/beam/emitter) || istype(Proj, /obj/item/projectile/beam/heavylaser/fakeemitter))
-		emitter_blasts_taken++
-		if(emitter_blasts_taken > 2) // 3 blasts per tile
-			mined_ore = 1
-			GetDrilled()
+		//destroy any archaeological finds
+		if(finds && finds.len)
+			var/datum/find/F = finds[1]
+			if(newDepth > F.excavation_required) // Digging too deep with something as clumsy or random as a blaster will destroy artefacts
+				finds.Remove(finds[1])
+				if(prob(50))
+					artifact_debris()
+
+		excavation_level += Proj.excavation_amount
+		update_archeo_overlays(Proj.excavation_amount)
 
 /turf/simulated/mineral/Bumped(AM)
 
@@ -383,16 +390,8 @@ var/list/mining_overlay_cache = list()
 				var/datum/find/F = finds[1]
 				if(newDepth > F.excavation_required) // Digging too deep can break the item. At least you won't summon a Balrog (probably)
 					fail_message = ". <b>[pick("There is a crunching noise","[W] collides with some different rock","Part of the rock face crumbles away","Something breaks under [W]")]</b>"
-
+				wreckfinds(P.destroy_artefacts)
 			to_chat(user, "<span class='notice'>You start [P.drill_verb][fail_message].</span>")
-
-			if(fail_message && prob(90))
-				if(prob(25))
-					excavate_find(prob(5), finds[1])
-				else if(prob(50))
-					finds.Remove(finds[1])
-					if(prob(50))
-						artifact_debris()
 
 			if(do_after(user,P.digspeed))
 
@@ -406,63 +405,14 @@ var/list/mining_overlay_cache = list()
 				to_chat(user, "<span class='notice'>You finish [P.drill_verb] \the [src].</span>")
 
 				if(newDepth >= 200) // This means the rock is mined out fully
-					var/obj/structure/boulder/B
-					if(artifact_find)
-						if( excavation_level > 0 || prob(15) )
-							//boulder with an artifact inside
-							B = new(src)
-							if(artifact_find)
-								B.artifact_find = artifact_find
-						else
-							artifact_debris(1)
-					else if(prob(5))
-						//empty boulder
-						B = new(src)
-
-					if(B)
+					if(P.destroy_artefacts)
 						GetDrilled(0)
 					else
-						GetDrilled(1)
+						excavate_turf()
 					return
 
 				excavation_level += P.excavation_amount
-				var/updateIcon = 0
-
-				//archaeo overlays
-				if(!archaeo_overlay && finds && finds.len)
-					var/datum/find/F = finds[1]
-					if(F.excavation_required <= excavation_level + F.view_range)
-						cut_overlay(archaeo_overlay)
-						archaeo_overlay = "overlay_archaeo[rand(1,3)]"
-						add_overlay(archaeo_overlay)
-
-				else if(archaeo_overlay && (!finds || !finds.len))
-					cut_overlay(archaeo_overlay)
-					archaeo_overlay = null
-
-				//there's got to be a better way to do this
-				var/update_excav_overlay = 0
-				if(excavation_level >= 150)
-					if(excavation_level - P.excavation_amount < 150)
-						update_excav_overlay = 1
-				else if(excavation_level >= 100)
-					if(excavation_level - P.excavation_amount < 100)
-						update_excav_overlay = 1
-				else if(excavation_level >= 50)
-					if(excavation_level - P.excavation_amount < 50)
-						update_excav_overlay = 1
-
-				//update overlays displaying excavation level
-				if( !(excav_overlay && excavation_level > 0) || update_excav_overlay )
-					var/excav_quadrant = round(excavation_level / 25) + 1
-					if(excav_quadrant > 5)
-						excav_quadrant = 5
-					cut_overlay(excav_overlay)
-					excav_overlay = "overlay_excv[excav_quadrant]_[rand(1,3)]"
-					add_overlay(excav_overlay)
-
-				if(updateIcon)
-					update_icon()
+				update_archeo_overlays(P.excavation_amount)
 
 				//drop some rocks
 				next_rock += P.excavation_amount
@@ -474,6 +424,54 @@ var/list/mining_overlay_cache = list()
 			return
 
 	return attack_hand(user)
+
+/turf/simulated/mineral/proc/wreckfinds(var/destroy = FALSE)
+	if(!destroy && prob(90)) //nondestructive methods have a chance of letting you step away to not trash things
+		if(prob(25))
+			excavate_find(prob(5), finds[1])
+	else if(prob(50) || destroy) //destructive methods will always destroy finds, no bowls menacing with spikes for you
+		finds.Remove(finds[1])
+		if(prob(50))
+			artifact_debris()
+
+/turf/simulated/mineral/proc/update_archeo_overlays(var/excavation_amount = 0)
+	var/updateIcon = 0
+
+	//archaeo overlays
+	if(!archaeo_overlay && finds && finds.len)
+		var/datum/find/F = finds[1]
+		if(F.excavation_required <= excavation_level + F.view_range)
+			cut_overlay(archaeo_overlay)
+			archaeo_overlay = "overlay_archaeo[rand(1,3)]"
+			add_overlay(archaeo_overlay)
+
+	else if(archaeo_overlay && (!finds || !finds.len))
+		cut_overlay(archaeo_overlay)
+		archaeo_overlay = null
+
+	//there's got to be a better way to do this
+	var/update_excav_overlay = 0
+	if(excavation_level >= 150)
+		if(excavation_level - excavation_amount < 150)
+			update_excav_overlay = 1
+	else if(excavation_level >= 100)
+		if(excavation_level - excavation_amount < 100)
+			update_excav_overlay = 1
+	else if(excavation_level >= 50)
+		if(excavation_level - excavation_amount < 50)
+			update_excav_overlay = 1
+
+	//update overlays displaying excavation level
+	if( !(excav_overlay && excavation_level > 0) || update_excav_overlay )
+		var/excav_quadrant = round(excavation_level / 25) + 1
+		if(excav_quadrant > 5)
+			excav_quadrant = 5
+		cut_overlay(excav_overlay)
+		excav_overlay = "overlay_excv[excav_quadrant]_[rand(1,3)]"
+		add_overlay(excav_overlay)
+
+	if(updateIcon)
+		update_icon()
 
 /turf/simulated/mineral/proc/clear_ore_effects()
 	for(var/obj/effect/mineral/M in contents)
@@ -488,6 +486,26 @@ var/list/mining_overlay_cache = list()
 		geologic_data.UpdateNearbyArtifactInfo(src)
 		O.geologic_data = geologic_data
 	return O
+
+/turf/simulated/mineral/proc/excavate_turf()
+	var/obj/structure/boulder/B
+	if(artifact_find)
+		if( excavation_level > 0 || prob(15) )
+			//boulder with an artifact inside
+			B = new(src)
+			if(artifact_find)
+				B.artifact_find = artifact_find
+		else
+			artifact_debris(1)
+	else if(prob(5))
+		//empty boulder
+		B = new(src)
+
+	if(B)
+		GetDrilled(0)
+	else
+		GetDrilled(1)
+	return
 
 /turf/simulated/mineral/proc/GetDrilled(var/artifact_fail = 0)
 

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -108,6 +108,7 @@
 	var/reflected = 0 // This should be set to 1 if reflected by any means, to prevent infinite reflections.
 	var/modifier_type_to_apply = null // If set, will apply a modifier to mobs that are hit by this projectile.
 	var/modifier_duration = null // How long the above modifier should last for. Leave null to be permanent.
+	var/excavation_amount = 0 // How much, if anything, it drills from a mineral turf.
 
 	embed_chance = 0	//Base chance for a projectile to embed
 

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -63,6 +63,7 @@
 	icon_state = "emitter"
 	fire_sound = 'sound/weapons/emitter.ogg'
 	light_color = "#00CC33"
+	excavation_amount = 70 // 3 shots to mine a turf
 
 	muzzle_type = /obj/effect/projectile/muzzle/emitter
 	tracer_type = /obj/effect/projectile/tracer/emitter
@@ -118,6 +119,7 @@
 	fire_sound = 'sound/weapons/emitter.ogg'
 	damage = 0 // The actual damage is computed in /code/modules/power/singularity/emitter.dm
 	light_color = "#00CC33"
+	excavation_amount = 70 // 3 shots to mine a turf
 
 	muzzle_type = /obj/effect/projectile/muzzle/emitter
 	tracer_type = /obj/effect/projectile/tracer/emitter


### PR DESCRIPTION
Something of an attempt to disentangle the spaghetticode surrounding mineral turfs.

Moved a bunch of the junk from the horrible nested if statement in attackby() into separate procs. With any luck these can be unpicked further.

Replaced the snowflaked emitter-beam code with a generic projectile-mining effect that uses the same "mining depth" as pickaxes - allows for the addition of generic ranged mining tools if someone wants to do that. Emitters are given a mining depth of 70 so it'll take 3 shots to mine a turf as before.

Gives some mining tools (namely, advanced and diamond drills and the sonic jackhammer) a "destroy artefacts" property. Guaranteed destruction of any artefact finds, but at least you don't have to deal with rocky debris or getting assblasted with rads completely at random provided you geared up with an appropriate tool. (same as a ripley drill basically, it just drills and doesn't care what it's drilling)