### PR TITLE
Adds Nock/robe items to loadout

### DIFF
--- a/code/modules/client/preference_setup/loadout/loadout_head.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_head.dm
@@ -387,4 +387,3 @@
 /datum/gear/head/cowlwhite
 	display_name = "cowl, white"
 	path = /obj/item/clothing/head/cowlw
-

--- a/code/modules/client/preference_setup/loadout/loadout_head.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_head.dm
@@ -380,3 +380,11 @@
 	display_name = "jingasa"
 	path = /obj/item/clothing/head/jingasa
 
+/datum/gear/head/cowlblack
+	display_name = "cowl, black"
+	path = /obj/item/clothing/head/cowlb
+
+/datum/gear/head/cowlwhite
+	display_name = "cowl, white"
+	path = /obj/item/clothing/head/cowlw
+

--- a/code/modules/client/preference_setup/loadout/loadout_mask.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_mask.dm
@@ -21,3 +21,19 @@
 	display_name = "sterile mask"
 	path = /obj/item/clothing/mask/surgical
 	cost = 2
+
+/datum/gear/mask/nockscarab
+	display_name = "nock mask (blue, scarab)"
+	path = /obj/item/clothing/mask/nock_scarab
+
+/datum/gear/mask/nocklife
+	display_name = "nock mask (green, life)"
+	path = /obj/item/clothing/mask/nock_life
+
+/datum/gear/mask/nockdemon
+	display_name = "nock mask (purple, demon)"
+	path = /obj/item/clothing/mask/nock_demon
+
+/datum/gear/mask/nockornate
+	display_name = "nock mask (red, ornate)
+	path = /obj/item/clothing/mask/nock_ornate

--- a/code/modules/client/preference_setup/loadout/loadout_mask.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_mask.dm
@@ -35,5 +35,5 @@
 	path = /obj/item/clothing/mask/nock_demon
 
 /datum/gear/mask/nockornate
-	display_name = "nock mask (red, ornate)
+	display_name = "nock mask (red, ornate)"
 	path = /obj/item/clothing/mask/nock_ornate

--- a/code/modules/client/preference_setup/loadout/loadout_uniform.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_uniform.dm
@@ -494,7 +494,7 @@
 
 /datum/gear/uniform/blackgoldrobe
 	display_name = "Robe, black-gold"
-	path = /obj/item/clothing/under/goldrobe
+	path = /obj/item/clothing/under/blackgoldrobe
 
 /datum/gear/uniform/whitegoldrobe
 	display_name = "Robe, white-gold"

--- a/code/modules/client/preference_setup/loadout/loadout_uniform.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_uniform.dm
@@ -484,3 +484,18 @@
 	display_name = "plain ascetic garb"
 	path = /obj/item/clothing/under/ascetic
 
+/datum/gear/uniform/blackrobe
+	display_name = "Robe, black"
+	path = /obj/item/clothing/under/blackrobe
+
+/datum/gear/uniform/whiterobe
+	display_name = "Robe, white"
+	path = /obj/item/clothing/under/whiterobe
+
+/datum/gear/uniform/blackgoldrobe
+	display_name = "Robe, black-gold"
+	path = /obj/item/clothing/under/goldrobe
+
+/datum/gear/uniform/whitegoldrobe
+	display_name = "Robe, white-gold"
+	path = /obj/item/clothing/under/whitegoldrobe

--- a/code/modules/clothing/head/misc.dm
+++ b/code/modules/clothing/head/misc.dm
@@ -427,15 +427,13 @@
 	icon_state = "jingasa"
 	body_parts_covered = 0
 	item_state_slots = list(slot_r_hand_str = "taq", slot_l_hand_str = "taq")
-	
-/obj/item/clothing/head/cowl
+
+/obj/item/clothing/head/cowlb
 	name = "black cowl"
 	desc = "A gold-lined black cowl. It gives off uncomfortable cult vibes, but fancy."
 	icon_state = "cowl"
-	body_parts_covered = 0
 
-/obj/item/clothing/head/cowl
+/obj/item/clothing/head/cowlw
 	name = "white cowl"
 	desc = "A gold-lined white cowl. It gives off uncomfortable cult vibes, but fancy."
 	icon_state = "whitecowl"
-	body_parts_covered = 0

--- a/code/modules/clothing/masks/miscellaneous.dm
+++ b/code/modules/clothing/masks/miscellaneous.dm
@@ -169,30 +169,30 @@
 	body_parts_covered = HEAD|FACE|EYES
 	w_class = ITEMSIZE_SMALL
 	siemens_coefficient = 0.9
-	
+
 /obj/item/clothing/mask/nock_scarab
-	name = "nock mask (blue, scarab)"
+	name = "nock scarab mask"
 	desc = "To Nock followers, masks symbolize rebirth and a new persona. Damaging the wearer's mask is generally considered an attack on their person itself."
 	icon_state = "nock_scarab"
 	w_class = ITEMSIZE_SMALL
 	body_parts_covered = HEAD|FACE
 
 /obj/item/clothing/mask/nock_demon
-	name = "nock mask (purple, demon)"
+	name = "nock demon mask"
 	desc = "To Nock followers, masks symbolize rebirth and a new persona. Damaging the wearer's mask is generally considered an attack on their person itself."
 	icon_state = "nock_demon"
 	w_class = ITEMSIZE_SMALL
 	body_parts_covered = HEAD|FACE
 
 /obj/item/clothing/mask/nock_life
-	name = "nock mask (green, life)"
+	name = "nock life mask"
 	desc = "To Nock followers, masks symbolize rebirth and a new persona. Damaging the wearer's mask is generally considered an attack on their person itself."
 	icon_state = "nock_life"
 	w_class = ITEMSIZE_SMALL
 	body_parts_covered = HEAD|FACE
 
 /obj/item/clothing/mask/nock_ornate
-	name = "nock mask (red, ornate)"
+	name = "nock ornate mask"
 	desc = "To Nock followers, masks symbolize rebirth and a new persona. Damaging the wearer's mask is generally considered an attack on their person itself."
 	icon_state = "nock_ornate"
 	w_class = ITEMSIZE_SMALL

--- a/code/modules/clothing/under/miscellaneous.dm
+++ b/code/modules/clothing/under/miscellaneous.dm
@@ -303,22 +303,22 @@
 
 /obj/item/clothing/under/robe
 	name = "black robe"
-	desc = "A black robe. It gives off uncomfortable cult vibes."
+	desc = "A black robe. Nothing sinister going on here."
 	icon_state = "robe"
 
 /obj/item/clothing/under/whiterobe
 	name = "white robe"
-	desc = "A white robe. It gives off uncomfortable cult vibes."
+	desc = "A white robe. Nothing sinister going on here."
 	icon_state = "whiterobe"
 
 /obj/item/clothing/under/goldrobe
 	name = "black gold-lined robe"
-	desc = "A gold-lined black robe. It gives off uncomfortable cult vibes, but fancy."
+	desc = "A gold-lined black robe. Fancy, yet intimidating."
 	icon_state = "goldrobe"
 
 /obj/item/clothing/under/whitegoldrobe
 	name = "white gold-lined robe"
-	desc = "A gold-lined white robe. It gives off uncomfortable cult vibes, but fancy."
+	desc = "A gold-lined white robe. Fancy, yet intimidating."
 	icon_state = "whitegoldrobe"
 
 /*

--- a/code/modules/clothing/under/miscellaneous.dm
+++ b/code/modules/clothing/under/miscellaneous.dm
@@ -301,7 +301,7 @@
 	icon_state = "ascetic"
 	item_state_slots = list(slot_r_hand_str = "white", slot_l_hand_str = "white")
 
-/obj/item/clothing/under/robe
+/obj/item/clothing/under/blackrobe
 	name = "black robe"
 	desc = "A black robe. Nothing sinister going on here."
 	icon_state = "robe"
@@ -311,7 +311,7 @@
 	desc = "A white robe. Nothing sinister going on here."
 	icon_state = "whiterobe"
 
-/obj/item/clothing/under/goldrobe
+/obj/item/clothing/under/blackgoldrobe
 	name = "black gold-lined robe"
 	desc = "A gold-lined black robe. Fancy, yet intimidating."
 	icon_state = "goldrobe"


### PR DESCRIPTION
Adds items from #5956 to loadout so chaplains can use them.
Fixes cowls having the same path.
Cowls now cover your hair description etc.
Removes direct references to cultiness from not-culty robes (Mechoid plans on adding actual culty ones)