### PR TITLE
Subspace Jammer now blocks signalers, suit sensors, lasts longer

### DIFF
--- a/code/datums/repositories/crew.dm
+++ b/code/datums/repositories/crew.dm
@@ -24,7 +24,7 @@ var/global/datum/repository/crew/crew_repository = new()
 	var/tracked = scan()
 	for(var/obj/item/clothing/under/C in tracked)
 		var/turf/pos = get_turf(C)
-		if((C) && (C.has_sensor) && (pos) && (pos.z == zLevel) && (C.sensor_mode != SUIT_SENSOR_OFF))
+		if((C) && (C.has_sensor) && (pos) && (pos.z == zLevel) && (C.sensor_mode != SUIT_SENSOR_OFF) && !(is_jammed(C)))
 			if(istype(C.loc, /mob/living/carbon/human))
 				var/mob/living/carbon/human/H = C.loc
 				if(H.w_uniform != C)

--- a/code/datums/uplink/tools.dm
+++ b/code/datums/uplink/tools.dm
@@ -84,7 +84,7 @@
 	item_cost = 25
 	path = /obj/item/device/radio_jammer
 	desc = "A device which is capable of disrupting subspace communications, preventing the use of headsets, PDAs, and communicators within \
-	a radius of seven meters.  It runs off weapon cells, which can be replaced as needed.  One cell will last for approximately a minute."
+	a radius of seven meters.  It runs off weapon cells, which can be replaced as needed.  One cell will last for approximately ten minutes."
 
 /datum/uplink_item/item/tools/emag
 	name = "Cryptographic Sequencer"

--- a/code/game/objects/items/devices/PDA/cart.dm
+++ b/code/game/objects/items/devices/PDA/cart.dm
@@ -572,6 +572,8 @@ var/list/civilian_cartridges = list(
 				active3 = S
 
 		if("Send Signal")
+			if(is_jammed(src))
+				return
 			spawn( 0 )
 				radio:send_signal("ACTIVATE")
 				return

--- a/code/game/objects/items/devices/radio/jammer.dm
+++ b/code/game/objects/items/devices/radio/jammer.dm
@@ -15,7 +15,7 @@ var/global/list/active_radio_jammers = list()
 
 /obj/item/device/radio_jammer
 	name = "subspace jammer"
-	desc = "Primarily for blocking subspace communications, preventing the use of headsets, PDAs, and communicators."
+	desc = "Primarily for blocking subspace communications, preventing the use of headsets, PDAs, and communicators. Also masks suit sensors."	// Added suit sensor jamming
 	icon = 'icons/obj/device.dmi'
 	icon_state = "jammer0"
 	var/active_state = "jammer1"
@@ -24,7 +24,7 @@ var/global/list/active_radio_jammers = list()
 	var/on = 0
 	var/jam_range = 7
 	var/obj/item/weapon/cell/device/weapon/power_source
-	var/tick_cost = 80 // Will last for roughly one minute, as process() ticks every 2 seconds.
+	var/tick_cost = 8 // Will last for roughly ten minutes, as process() ticks every 2 seconds.
 
 	origin_tech = list(TECH_ILLEGAL = 7, TECH_BLUESPACE = 5) //Such technology! Subspace jamming!
 

--- a/code/modules/assembly/signaler.dm
+++ b/code/modules/assembly/signaler.dm
@@ -7,7 +7,7 @@
 	matter = list(DEFAULT_WALL_MATERIAL = 1000, "glass" = 200, "waste" = 100)
 	wires = WIRE_RECEIVE | WIRE_PULSE | WIRE_RADIO_PULSE | WIRE_RADIO_RECEIVE
 
-	secured = 1
+	secured = TRUE
 
 	var/code = 30
 	var/frequency = 1457
@@ -15,7 +15,7 @@
 	var/airlock_wire = null
 	var/datum/wires/connected = null
 	var/datum/radio_frequency/radio_connection
-	var/deadman = 0
+	var/deadman = FALSE
 
 /obj/item/device/assembly/signaler/New()
 	..()
@@ -25,13 +25,13 @@
 
 
 /obj/item/device/assembly/signaler/activate()
-	if(cooldown > 0)	return 0
+	if(cooldown > 0)	return FALSE
 	cooldown = 2
 	spawn(10)
 		process_cooldown()
 
 	signal()
-	return 1
+	return TRUE
 
 /obj/item/device/assembly/signaler/update_icon()
 	if(holder)
@@ -70,7 +70,8 @@ Code:
 
 
 /obj/item/device/assembly/signaler/Topic(href, href_list, state = deep_inventory_state)
-	if(..()) return 1
+	if(..())
+		return TRUE
 
 	if(!usr.canmove || usr.stat || usr.restrained() || !in_range(loc, usr))
 		usr << browse(null, "window=radio")
@@ -109,7 +110,10 @@ Code:
 		..()
 
 /obj/item/device/assembly/signaler/proc/signal()
-	if(!radio_connection) return
+	if(!radio_connection)
+		return
+	if(is_jammed(src))
+		return
 
 	var/datum/signal/signal = new
 	signal.source = src
@@ -120,19 +124,26 @@ Code:
 
 
 /obj/item/device/assembly/signaler/pulse(var/radio = 0)
+	if(is_jammed(src))
+		return FALSE
 	if(src.connected && src.wires)
 		connected.Pulse(src)
 	else if(holder)
 		holder.process_activation(src, 1, 0)
 	else
 		..(radio)
-	return 1
+	return TRUE
 
 
 /obj/item/device/assembly/signaler/receive_signal(datum/signal/signal)
-	if(!signal)	return 0
-	if(signal.encryption != code)	return 0
-	if(!(src.wires & WIRE_RADIO_RECEIVE))	return 0
+	if(!signal)
+		return FALSE
+	if(signal.encryption != code)
+		return FALSE
+	if(!(src.wires & WIRE_RADIO_RECEIVE))
+		return FALSE
+	if(is_jammed(src))
+		return FALSE
 	pulse(1)
 
 	if(!holder)
@@ -161,7 +172,7 @@ Code:
 	if(!M || !ismob(M))
 		if(prob(5))
 			signal()
-		deadman = 0
+		deadman = FALSE
 		STOP_PROCESSING(SSobj, src)
 	else if(prob(5))
 		M.visible_message("[M]'s finger twitches a bit over [src]'s signal button!")
@@ -171,7 +182,7 @@ Code:
 	set src in usr
 	set name = "Threaten to push the button!"
 	set desc = "BOOOOM!"
-	deadman = 1
+	deadman = TRUE
 	START_PROCESSING(SSobj, src)
 	log_and_message_admins("is threatening to trigger a signaler deadman's switch")
 	usr.visible_message("<font color='red'>[usr] moves their finger over [src]'s signal button...</font>")

--- a/html/changelogs/Anewbe - Jamming.yml
+++ b/html/changelogs/Anewbe - Jamming.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Anewbe
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "The Subspace Jammer traitor item now lasts about 10 minutes. It now blocks signalers from sending or receiving, and also obscures suit sensors around it."


### PR DESCRIPTION
Buffs the Subspace Jammer traitor item, so hopefully it'll be used occasionally.
- Signalers can't send or receive while in range.
- Suit Sensors don't show up on the console if they're in jamming range.
- Battery now lasts 10 minutes.