### PR TITLE
Copy character slots

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -217,7 +217,8 @@ datum/preferences
 		dat += "<a href='?src=\ref[src];load=1'>Load slot</a> - "
 		dat += "<a href='?src=\ref[src];save=1'>Save slot</a> - "
 		dat += "<a href='?src=\ref[src];reload=1'>Reload slot</a> - "
-		dat += "<a href='?src=\ref[src];resetslot=1'>Reset slot</a>"
+		dat += "<a href='?src=\ref[src];resetslot=1'>Reset slot</a> - "
+		dat += "<a href='?src=\ref[src];copy=1'>Copy slot</a>"
 
 	else
 		dat += "Please create an account to save your preferences."
@@ -271,6 +272,14 @@ datum/preferences
 			return 0
 		load_character(SAVE_RESET)
 		sanitize_preferences()
+	else if(href_list["copy"])
+		if(!IsGuestKey(usr.key))
+			open_copy_dialog(usr)
+			return 1
+	else if(href_list["overwrite"])
+		overwrite_character(text2num(href_list["overwrite"]))
+		sanitize_preferences()
+		close_load_dialog(usr)
 	else
 		return 0
 
@@ -327,3 +336,26 @@ datum/preferences
 /datum/preferences/proc/close_load_dialog(mob/user)
 	//user << browse(null, "window=saves")
 	panel.close()
+
+/datum/preferences/proc/open_copy_dialog(mob/user)
+	var/dat = "<body>"
+	dat += "<tt><center>"
+
+	var/savefile/S = new /savefile(path)
+	if(S)
+		dat += "<b>Select a character slot to overwrite</b><br>"
+		dat += "<b>You will then need to save to confirm</b><hr>"
+		var/name
+		for(var/i=1, i<= config.character_slots, i++)
+			S.cd = "/character[i]"
+			S["real_name"] >> name
+			if(!name)	name = "Character[i]"
+			if(i==default_slot)
+				name = "<b>[name]</b>"
+			dat += "<a href='?src=\ref[src];overwrite=[i]'>[name]</a><br>"
+
+	dat += "<hr>"
+	dat += "</center></tt>"
+	panel = new(user, "Character Slots", "Character Slots", 300, 390, src)
+	panel.set_content(dat)
+	panel.open()

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -94,6 +94,22 @@
 	player_setup.save_character(S)
 	return 1
 
+/datum/preferences/proc/overwrite_character(slot)
+	if(!path)				return 0
+	if(!fexists(path))		return 0
+	var/savefile/S = new /savefile(path)
+	if(!S)					return 0
+	if(!slot)	slot = default_slot
+	if(slot != SAVE_RESET)
+		slot = sanitize_integer(slot, 1, config.character_slots, initial(default_slot))
+		if(slot != default_slot)
+			default_slot = slot
+			S["default_slot"] << slot
+	else
+		S["default_slot"] << default_slot
+
+	return 1
+
 /datum/preferences/proc/sanitize_preferences()
 	player_setup.sanitize_setup()
 	return 1

--- a/html/changelogs/PrismaticGynoid - charactercopy.yml
+++ b/html/changelogs/PrismaticGynoid - charactercopy.yml
@@ -1,0 +1,6 @@
+author: PrismaticGynoid
+
+delete-after: True
+
+changes: 
+  - rscadd: "Adds the ability to copy a character slot onto another one, allowing for easier rearranging of characters, or wiping characters by copying empty slots."


### PR DESCRIPTION
Adds a button to the setup menu that can be used to copy a character over another slot, allowing for easier duplicating, rearranging, and wiping of character slots. After you copy a character to another slot, you must then save to overwrite what's already on that slot - or don't, if you've changed your mind.

Essentially what it does behind the scenes is load a character slot without loading the preferences for that character slot, instead leaving the preferences of the previous slot open for you to overwrite the loaded slot with. Tested a bunch and it doesn't seem to break anything/ mess up the save files any.