### PR TITLE
Unidentified Auto Tweak 2: Electric Boogaloo

### DIFF
--- a/code/modules/reagents/Chemistry-Machinery.dm
+++ b/code/modules/reagents/Chemistry-Machinery.dm
@@ -602,6 +602,11 @@
 					continue
 				to_chat(user, span("notice", "Contains [R.volume]u of <b>[R.name]</b>.<br>[R.description]<br>"))
 
+		// Last, unseal it if it's an autoinjector.
+		if(istype(I,/obj/item/weapon/reagent_containers/hypospray/autoinjector/biginjector) && !(I.flags & OPENCONTAINER))
+			I.flags |= OPENCONTAINER
+			to_chat(user, span("notice", "Sample container unsealed.<br>"))
+
 		to_chat(user, span("notice", "Scanning of \the [I] complete."))
 		analyzing = FALSE
 		update_icon()

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -184,7 +184,6 @@
 	volume = 15
 	origin_tech = list(TECH_BIO = 4)
 	filled_reagents = list("inaprovaline" = 15)
-	flags = 0 // Removed OPENCONTAINER so you can't extract things to cheese the identification system in unidentified versions.
 
 /obj/item/weapon/reagent_containers/hypospray/autoinjector/biginjector/brute
 	name = "trauma hypo"

--- a/code/modules/reagents/reagent_containers/unidentified_hypospray.dm
+++ b/code/modules/reagents/reagent_containers/unidentified_hypospray.dm
@@ -7,74 +7,98 @@
 // The good.
 /obj/item/weapon/reagent_containers/hypospray/autoinjector/biginjector/brute/unidentified
 	init_hide_identity = TRUE
+	flags = 0
 
 /obj/item/weapon/reagent_containers/hypospray/autoinjector/biginjector/burn/unidentified
 	init_hide_identity = TRUE
+	flags = 0
 
 /obj/item/weapon/reagent_containers/hypospray/autoinjector/biginjector/toxin/unidentified
 	init_hide_identity = TRUE
+	flags = 0
 
 /obj/item/weapon/reagent_containers/hypospray/autoinjector/biginjector/oxy/unidentified
 	init_hide_identity = TRUE
+	flags = 0
 
 /obj/item/weapon/reagent_containers/hypospray/autoinjector/biginjector/purity/unidentified
 	init_hide_identity = TRUE
+	flags = 0
 
 /obj/item/weapon/reagent_containers/hypospray/autoinjector/biginjector/pain/unidentified
 	init_hide_identity = TRUE
+	flags = 0
 
 /obj/item/weapon/reagent_containers/hypospray/autoinjector/biginjector/organ/unidentified
 	init_hide_identity = TRUE
+	flags = 0
 
 /obj/item/weapon/reagent_containers/hypospray/autoinjector/biginjector/clotting/unidentified
 	init_hide_identity = TRUE
+	flags = 0
 
 /obj/item/weapon/reagent_containers/hypospray/autoinjector/biginjector/bonemed/unidentified
 	init_hide_identity = TRUE
+	flags = 0
 
 /obj/item/weapon/reagent_containers/hypospray/autoinjector/biginjector/combat/unidentified
 	init_hide_identity = TRUE
+	flags = 0
 
 /obj/item/weapon/reagent_containers/hypospray/autoinjector/biginjector/healing_nanites/unidentified
 	init_hide_identity = TRUE
+	flags = 0
 
 // The somewhat bad.
 /obj/item/weapon/reagent_containers/hypospray/autoinjector/biginjector/stimm/unidentified
 	init_hide_identity = TRUE
+	flags = 0
 
 /obj/item/weapon/reagent_containers/hypospray/autoinjector/biginjector/space_drugs/unidentified
 	init_hide_identity = TRUE
+	flags = 0
 
 /obj/item/weapon/reagent_containers/hypospray/autoinjector/biginjector/expired/unidentified
 	init_hide_identity = TRUE
+	flags = 0
 
 /obj/item/weapon/reagent_containers/hypospray/autoinjector/biginjector/serotrotium/unidentified
 	init_hide_identity = TRUE
+	flags = 0
 
 /obj/item/weapon/reagent_containers/hypospray/autoinjector/biginjector/cryptobiolin/unidentified
 	init_hide_identity = TRUE
+	flags = 0
 
 /obj/item/weapon/reagent_containers/hypospray/autoinjector/biginjector/mindbreaker/unidentified
 	init_hide_identity = TRUE
+	flags = 0
 
 /obj/item/weapon/reagent_containers/hypospray/autoinjector/biginjector/psilocybin/unidentified
 	init_hide_identity = TRUE
+	flags = 0
 
 /obj/item/weapon/reagent_containers/hypospray/autoinjector/biginjector/soporific/unidentified
 	init_hide_identity = TRUE
+	flags = 0
 
 // The very bad.
 /obj/item/weapon/reagent_containers/hypospray/autoinjector/biginjector/cyanide/unidentified
 	init_hide_identity = TRUE
+	flags = 0
 
 /obj/item/weapon/reagent_containers/hypospray/autoinjector/biginjector/impedrezene/unidentified
 	init_hide_identity = TRUE
+	flags = 0
 
 /obj/item/weapon/reagent_containers/hypospray/autoinjector/biginjector/mutagen/unidentified
 	init_hide_identity = TRUE
+	flags = 0
 
 /obj/item/weapon/reagent_containers/hypospray/autoinjector/biginjector/defective_nanites/unidentified
 	init_hide_identity = TRUE
+	flags = 0
 
 /obj/item/weapon/reagent_containers/hypospray/autoinjector/biginjector/contaminated/unidentified
 	init_hide_identity = TRUE
+	flags = 0

--- a/html/changelogs/mistyLuminescence - biginjector2.yml
+++ b/html/changelogs/mistyLuminescence - biginjector2.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: mistyLuminescence
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Large autoinjectors are now scannable and syringeable again, just like they used to be. Unidentified autoinjectors still aren't, unless you ID them first."


### PR DESCRIPTION
Remakes #5983 by @Anewbe 's request. It's basically the same PR except this time without the R&D scanner thing.

In very simple words delivered in the form of space-rap and interpretive dance, here's how it works:
*Listen up, explorers, to the Research Director,*  
*But remember, you're the one with an autoinjector!*  
*What's that, you didn't get it identified?*  
*How are you gonna know what chems are inside?!*  
*That pen is nasty, ain't safe to use!*  
*You can't even scan it! That gives me the blues!*  
*Now, Chem has a machine that can fix your probs,*  
*But only Chem can do it, so respect those jobs!*  
*Before the rework, you could syringe all day,*  
*Replace it with chloral to make your enemies pay!*  
*But now you can't do that in case it's P-O-I,*  
*Doesn't that just make you... wanna cry?*  
*So here's the deal, the biznit, the rap-*  
*We're tweaking a bit, and this PR ain't crap!*  
*Now it's like before, with syringes ahoy,*  
*And scanners too, for girl, NB or boy!*  
*You can do what you want, to an autoinjector,*  
*But only ID'd ones, says the Research Director.*  
*If it's from Sif, some neat loot from the plains,*  
*It's still unID'd so the old system remains!*  
*Does that make sense? It's the same as before!*  
*Except if you want to scan an auto, just count to four!*  
*One! Is it identified?*  
*Yes? You can scan it and syringe it alright!*  
*Two! Take it to Chemistry!*  
*They'll scan it and prod it and put it in their machine!*  
*Three! Get your autoinjector back!*  
*Or maybe Chem keeps it, that'd be quite the hack!*  
*And FOUR! Your injector is safe to use!*  
*And you can syringe it! Scan it! Even fill it with booze!*  
*Did you get all that? The autoinjector rap?*  
*Now take it from me, this PR ain't crap.*  

Or, in slightly longer but less fun words:
**How it used to work**: any autoinjector was scannable and syringeable.
**What the rework was supposed to do**: make unidentified autoinjectors unscannable/unsyringeable.
**What the rework actually did**: make *any* biginjector unscannable/unsyringeable.
**What this PR does**: makes unidentified autoinjectors unscannable/unsyringeable until identified.

Yes, I've tested it, and it works perfectly.