### PR TITLE
Belt-Worn RIGs

### DIFF
--- a/code/modules/clothing/spacesuits/rig/modules/modules.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/modules.dm
@@ -233,6 +233,10 @@
 		var/obj/item/weapon/rig/R = back
 		SetupStat(R)
 
+	else if(. && istype(belt,/obj/item/weapon/rig))
+		var/obj/item/weapon/rig/R = belt
+		SetupStat(R)
+
 /mob/proc/SetupStat(var/obj/item/weapon/rig/R)
 	if(R && !R.canremove && R.installed_modules.len && statpanel("Hardsuit Modules"))
 		var/cell_status = R.cell ? "[R.cell.charge]/[R.cell.maxcharge]" : "ERROR"

--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -185,7 +185,7 @@
 	return ..()
 
 /obj/item/weapon/rig/get_worn_icon_file(var/body_type,var/slot_name,var/default_icon,var/inhands)
-	if(!inhands && slot_name == slot_back_str)
+	if(!inhands && (slot_name == slot_back_str || slot_name == slot_belt_str))
 		if(icon_override)
 			return icon_override
 		else if(mob_icon)
@@ -194,7 +194,7 @@
 	return ..()
 
 /obj/item/weapon/rig/proc/suit_is_deployed()
-	if(!istype(wearer) || src.loc != wearer || wearer.back != src)
+	if(!istype(wearer) || src.loc != wearer || (wearer.back != src && wearer.belt != src))
 		return 0
 	if(helm_type && !(helmet && wearer.head == helmet))
 		return 0
@@ -288,7 +288,7 @@
 					failed_to_seal = 1
 					break
 
-				if(!failed_to_seal && M.back == src && piece == compare_piece)
+				if(!failed_to_seal && (M.back == src || M.belt == src) && piece == compare_piece)
 
 					if(seal_delay && !instant && !do_after(M,seal_delay,needhand=0))
 						failed_to_seal = 1
@@ -319,7 +319,7 @@
 				else
 					failed_to_seal = 1
 
-		if((M && !(istype(M) && M.back == src) && !istype(M,/mob/living/silicon)) || (!seal_target && !suit_is_deployed()))
+		if((M && !(istype(M) && (M.back == src || M.belt == src)) && !istype(M,/mob/living/silicon)) || (!seal_target && !suit_is_deployed()))
 			failed_to_seal = 1
 
 	sealing = null
@@ -412,13 +412,13 @@
 
 	return environment.temperature
 
-/obj/item/weapon/rig/proc/attached_to_back(mob/M)
+/obj/item/weapon/rig/proc/attached_to_user(mob/M)
 	if (!ishuman(M))
 		return 0
 
 	var/mob/living/carbon/human/H = M
 
-	if (!H.wear_suit || H.back != src)
+	if (!H.wear_suit || (H.back != src && H.belt != src))
 		return 0
 
 	return 1
@@ -430,7 +430,7 @@
 	if (!ismob(loc))
 		return
 
-	if (!attached_to_back(loc))		//make sure the rig's not just in their hands
+	if (!attached_to_user(loc))		//make sure the rig's not just in their hands
 		return
 
 	if (!suit_is_deployed())		//inbuilt systems only work on the suit they're designed to work on
@@ -468,7 +468,7 @@
 	// Run through cooling
 	coolingProcess()
 
-	if(!istype(wearer) || loc != wearer || wearer.back != src || canremove || !cell || cell.charge <= 0)
+	if(!istype(wearer) || loc != wearer || (wearer.back != src && wearer.belt != src) || canremove || !cell || cell.charge <= 0)
 		if(!cell || cell.charge <= 0)
 			if(electrified > 0)
 				electrified = 0
@@ -521,7 +521,7 @@
 
 	if(!user_is_ai)
 		var/mob/living/carbon/human/H = user
-		if(istype(H) && H.back != src)
+		if(istype(H) && (H.back != src && H.belt != src))
 			fail_msg = "<span class='warning'>You must be wearing \the [src] to do this.</span>"
 		else if(user.incorporeal_move)
 			fail_msg = "<span class='warning'>You must be solid to do this.</span>"
@@ -657,7 +657,7 @@
 			return 1
 		if(malfunction_check(user))
 			return 0
-		if(user.back != src)
+		if(user.back != src && user.belt != src)
 			return 0
 		else if(!src.allowed(user))
 			user << "<span class='danger'>Unauthorized user. Access denied.</span>"
@@ -716,16 +716,24 @@
 /obj/item/weapon/rig/equipped(mob/living/carbon/human/M)
 	..()
 
-	if(seal_delay > 0 && istype(M) && M.back == src)
+	if(istype(M.back, /obj/item/weapon/rig) && istype(M.belt, /obj/item/weapon/rig))
+		to_chat(M, "<span class='notice'>You try to put on the [src], but it won't fit.</span>")
+		if(M && (M.back == src || M.belt == src))
+			if(!M.unEquip(src))
+				return
+		src.forceMove(get_turf(src))
+		return
+
+	if(seal_delay > 0 && istype(M) && (M.back == src || M.belt == src))
 		M.visible_message("<font color='blue'>[M] starts putting on \the [src]...</font>", "<font color='blue'>You start putting on \the [src]...</font>")
 		if(!do_after(M,seal_delay))
-			if(M && M.back == src)
+			if(M && (M.back == src || M.belt == src))
 				if(!M.unEquip(src))
 					return
 			src.forceMove(get_turf(src))
 			return
 
-	if(istype(M) && M.back == src)
+	if(istype(M) && (M.back == src || M.belt == src))
 		M.visible_message("<font color='blue'><b>[M] struggles into \the [src].</b></font>", "<font color='blue'><b>You struggle into \the [src].</b></font>")
 		wearer = M
 		wearer.wearing_rig = src
@@ -736,7 +744,7 @@
 	if(sealing || !cell || !cell.charge)
 		return
 
-	if(!istype(wearer) || !wearer.back == src)
+	if(!istype(wearer) || (!wearer.back == src && !wearer.belt == src))
 		return
 
 	if(usr == wearer && (usr.stat||usr.paralysis||usr.stunned)) // If the usr isn't wearing the suit it's probably an AI.
@@ -805,7 +813,7 @@
 
 	if(!H || !istype(H)) return
 
-	if(H.back != src)
+	if(H.back != src && H.belt != src)
 		return
 
 	if(sealed)
@@ -949,7 +957,7 @@
 	if(offline || !cell || !cell.charge || locked_down)
 		if(user) user << "<span class='warning'>Your host rig is unpowered and unresponsive.</span>"
 		return 0
-	if(!wearer || wearer.back != src)
+	if(!wearer || (wearer.back != src && wearer.belt != src))
 		if(user) user << "<span class='warning'>Your host rig is not being worn.</span>"
 		return 0
 	if(!wearer.stat && !control_overridden && !ai_override_enabled)
@@ -1050,7 +1058,12 @@
 	return src
 
 /mob/living/carbon/human/get_rig()
-	return back
+	if(istype(back, /obj/item/weapon/rig))
+		return back
+	else if(istype(belt, /obj/item/weapon/rig))
+		return belt
+	else
+		return null
 
 //Boot animation screen objects
 /obj/screen/rig_booting

--- a/code/modules/clothing/spacesuits/rig/rig_attackby.dm
+++ b/code/modules/clothing/spacesuits/rig/rig_attackby.dm
@@ -66,7 +66,7 @@
 		else if(istype(W,/obj/item/rig_module))
 			if(istype(src.loc,/mob/living/carbon/human))
 				var/mob/living/carbon/human/H = src.loc
-				if(H.back == src)
+				if(H.back == src || H.belt == src)
 					to_chat(user, "<span class='danger'>You can't install a hardsuit module while the suit is being worn.</span>")
 					return 1
 
@@ -128,7 +128,7 @@
 
 			if(istype(src.loc,/mob/living/carbon/human) && to_remove != "cell")
 				var/mob/living/carbon/human/H = src.loc
-				if(H.back == src)
+				if(H.back == src || H.belt == src)
 					to_chat(user, "You can't remove an installed device while the hardsuit is being worn.")
 					return
 

--- a/code/modules/clothing/spacesuits/rig/rig_pieces.dm
+++ b/code/modules/clothing/spacesuits/rig/rig_pieces.dm
@@ -97,7 +97,7 @@
 		return 0
 
 	var/mob/living/carbon/human/H = loc
-	if(!istype(H) || !H.back)
+	if(!istype(H) || (!H.back && !H.belt))
 		return 0
 
 	var/obj/item/weapon/rig/suit = H.back

--- a/code/modules/clothing/spacesuits/rig/rig_verbs.dm
+++ b/code/modules/clothing/spacesuits/rig/rig_verbs.dm
@@ -6,7 +6,7 @@
 	set category = "Hardsuit"
 	set src = usr.contents
 
-	if(wearer)
+	if(wearer && (wearer.back == src || wearer.belt == src))
 		ui_interact(usr)
 
 /obj/item/weapon/rig/verb/toggle_vision()

--- a/code/modules/clothing/spacesuits/rig/rig_verbs.dm
+++ b/code/modules/clothing/spacesuits/rig/rig_verbs.dm
@@ -16,7 +16,7 @@
 	set category = "Hardsuit"
 	set src = usr.contents
 
-	if(!istype(wearer))
+	if(!istype(wearer) || (!wearer.back == src && !wearer.belt == src))
 		usr << "<span class='warning'>The hardsuit is not being worn.</span>"
 		return
 
@@ -46,7 +46,7 @@
 	set category = "Hardsuit"
 	set src = usr.contents
 
-	if(!istype(wearer))
+	if(!istype(wearer) || (!wearer.back == src && !wearer.belt == src))
 		usr << "<span class='warning'>The hardsuit is not being worn.</span>"
 		return
 
@@ -74,7 +74,7 @@
 	set category = "Hardsuit"
 	set src = usr.contents
 
-	if(!istype(wearer))
+	if(!istype(wearer) || (!wearer.back == src && !wearer.belt == src))
 		usr << "<span class='warning'>The hardsuit is not being worn.</span>"
 		return
 
@@ -90,7 +90,7 @@
 	set category = "Hardsuit"
 	set src = usr.contents
 
-	if(!istype(wearer))
+	if(!istype(wearer) || (!wearer.back == src && !wearer.belt == src))
 		usr << "<span class='warning'>The hardsuit is not being worn.</span>"
 		return
 
@@ -106,7 +106,7 @@
 	set category = "Hardsuit"
 	set src = usr.contents
 
-	if(!istype(wearer))
+	if(!istype(wearer) || (!wearer.back == src && !wearer.belt == src))
 		usr << "<span class='warning'>The hardsuit is not being worn.</span>"
 		return
 
@@ -125,7 +125,7 @@
 	set category = "Hardsuit"
 	set src = usr.contents
 
-	if(!istype(wearer))
+	if(!istype(wearer) || (!wearer.back == src && !wearer.belt == src))
 		usr << "<span class='warning'>The hardsuit is not being worn.</span>"
 		return
 
@@ -178,7 +178,7 @@
 		usr << "<span class='warning'>The suit is not active.</span>"
 		return
 
-	if(!istype(wearer))
+	if(!istype(wearer) || (!wearer.back == src && !wearer.belt == src))
 		usr << "<span class='warning'>The hardsuit is not being worn.</span>"
 		return
 
@@ -205,7 +205,7 @@
 		usr << "<span class='warning'>The suit is not active.</span>"
 		return
 
-	if(!istype(wearer))
+	if(!istype(wearer) || (!wearer.back == src && !wearer.belt == src))
 		usr << "<span class='warning'>The hardsuit is not being worn.</span>"
 		return
 
@@ -241,7 +241,7 @@
 		usr << "<span class='warning'>The suit is not active.</span>"
 		return
 
-	if(!istype(wearer))
+	if(!istype(wearer) || (!wearer.back == src && !wearer.belt == src))
 		usr << "<span class='warning'>The hardsuit is not being worn.</span>"
 		return
 
@@ -276,7 +276,7 @@
 		usr << "<span class='warning'>The suit is not active.</span>"
 		return
 
-	if(!istype(wearer))
+	if(!istype(wearer) || (!wearer.back == src && !wearer.belt == src))
 		usr << "<span class='warning'>The hardsuit is not being worn.</span>"
 		return
 

--- a/code/modules/clothing/spacesuits/rig/rig_verbs.dm
+++ b/code/modules/clothing/spacesuits/rig/rig_verbs.dm
@@ -6,7 +6,7 @@
 	set category = "Hardsuit"
 	set src = usr.contents
 
-	if(wearer && wearer.back == src)
+	if(wearer)
 		ui_interact(usr)
 
 /obj/item/weapon/rig/verb/toggle_vision()
@@ -16,7 +16,7 @@
 	set category = "Hardsuit"
 	set src = usr.contents
 
-	if(!istype(wearer) || !wearer.back == src)
+	if(!istype(wearer))
 		usr << "<span class='warning'>The hardsuit is not being worn.</span>"
 		return
 
@@ -46,7 +46,7 @@
 	set category = "Hardsuit"
 	set src = usr.contents
 
-	if(!istype(wearer) || !wearer.back == src)
+	if(!istype(wearer))
 		usr << "<span class='warning'>The hardsuit is not being worn.</span>"
 		return
 
@@ -74,7 +74,7 @@
 	set category = "Hardsuit"
 	set src = usr.contents
 
-	if(!istype(wearer) || !wearer.back == src)
+	if(!istype(wearer))
 		usr << "<span class='warning'>The hardsuit is not being worn.</span>"
 		return
 
@@ -90,7 +90,7 @@
 	set category = "Hardsuit"
 	set src = usr.contents
 
-	if(!istype(wearer) || !wearer.back == src)
+	if(!istype(wearer))
 		usr << "<span class='warning'>The hardsuit is not being worn.</span>"
 		return
 
@@ -106,7 +106,7 @@
 	set category = "Hardsuit"
 	set src = usr.contents
 
-	if(!istype(wearer) || !wearer.back == src)
+	if(!istype(wearer))
 		usr << "<span class='warning'>The hardsuit is not being worn.</span>"
 		return
 
@@ -125,7 +125,7 @@
 	set category = "Hardsuit"
 	set src = usr.contents
 
-	if(!istype(wearer) || !wearer.back == src)
+	if(!istype(wearer))
 		usr << "<span class='warning'>The hardsuit is not being worn.</span>"
 		return
 
@@ -178,7 +178,7 @@
 		usr << "<span class='warning'>The suit is not active.</span>"
 		return
 
-	if(!istype(wearer) || !wearer.back == src)
+	if(!istype(wearer))
 		usr << "<span class='warning'>The hardsuit is not being worn.</span>"
 		return
 
@@ -197,7 +197,7 @@
 
 	if(malfunction_check(usr))
 		return
-	
+
 	if(!check_power_cost(usr, 0, 0, 0, 0))
 		return
 
@@ -205,7 +205,7 @@
 		usr << "<span class='warning'>The suit is not active.</span>"
 		return
 
-	if(!istype(wearer) || !wearer.back == src)
+	if(!istype(wearer))
 		usr << "<span class='warning'>The hardsuit is not being worn.</span>"
 		return
 
@@ -241,7 +241,7 @@
 		usr << "<span class='warning'>The suit is not active.</span>"
 		return
 
-	if(!istype(wearer) || !wearer.back == src)
+	if(!istype(wearer))
 		usr << "<span class='warning'>The hardsuit is not being worn.</span>"
 		return
 
@@ -276,7 +276,7 @@
 		usr << "<span class='warning'>The suit is not active.</span>"
 		return
 
-	if(!istype(wearer) || !wearer.back == src)
+	if(!istype(wearer))
 		usr << "<span class='warning'>The hardsuit is not being worn.</span>"
 		return
 

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -82,6 +82,8 @@ This saves us from having to call add_fingerprint() any time something is put in
 		if(slot_tie)
 			return 1
 
+/obj/item/var/suitlink = 1 //makes belt items require a jumpsuit- set individual items to suitlink = 0 to allow wearing on belt slot without suit
+
 /mob/living/carbon/human/u_equip(obj/W as obj)
 	if(!W)	return 0
 
@@ -98,7 +100,7 @@ This saves us from having to call add_fingerprint() any time something is put in
 			drop_from_inventory(l_store)
 		if (wear_id)
 			drop_from_inventory(wear_id)
-		if (belt)
+		if (belt && belt.suitlink == 1)
 			worn_clothing -= belt
 			drop_from_inventory(belt)
 		worn_clothing -= w_uniform

--- a/code/modules/surgery/other.dm
+++ b/code/modules/surgery/other.dm
@@ -201,21 +201,28 @@
 		var/obj/item/weapon/weldingtool/welder = tool
 		if(!welder.isOn() || !welder.remove_fuel(1,user))
 			return 0
-	return (target_zone == BP_TORSO) && istype(target.back, /obj/item/weapon/rig) && !(target.back.canremove)
+	return (target_zone == BP_TORSO) && ((istype(target.back, /obj/item/weapon/rig) && !(target.back.canremove)) || (istype(target.belt, /obj/item/weapon/rig) && !(target.belt.canremove)))
 
 /datum/surgery_step/hardsuit/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
-	user.visible_message("[user] starts cutting through the support systems of [target]'s [target.back] with \the [tool]." , \
-	"You start cutting through the support systems of [target]'s [target.back] with \the [tool].")
+	var/obj/item/weapon/rig/rig = target.back
+	if(!istype(rig))
+		rig = target.belt
+		if(!istype(rig))
+			return
+	user.visible_message("[user] starts cutting through the support systems of \the [rig] on [target] with \the [tool]." , \
+	"You start cutting through the support systems of \the [rig] on [target] with \the [tool].")
 	..()
 
 /datum/surgery_step/hardsuit/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/weapon/rig/rig = target.back
 	if(!istype(rig))
-		return
+		rig = target.belt
+		if(!istype(rig))
+			return
 	rig.reset()
-	user.visible_message("<span class='notice'>[user] has cut through the support systems of [target]'s [rig] with \the [tool].</span>", \
-		"<span class='notice'>You have cut through the support systems of [target]'s [rig] with \the [tool].</span>")
+	user.visible_message("<span class='notice'>[user] has cut through the support systems of \the [rig] on [target] with \the [tool].</span>", \
+		"<span class='notice'>You have cut through the support systems of \the [rig] on [target] with \the [tool].</span>")
 
 /datum/surgery_step/hardsuit/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	user.visible_message("<span class='danger'>[user]'s [tool] can't quite seem to get through the metal...</span>", \
-	"<span class='danger'>Your [tool] can't quite seem to get through the metal. It's weakening, though - try again.</span>")
+	"<span class='danger'>\The [tool] can't quite seem to get through the metal. It's weakening, though - try again.</span>")

--- a/html/changelogs/mistyLuminescence - beltrigs.yml
+++ b/html/changelogs/mistyLuminescence - beltrigs.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: mistyLuminescence
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Lays the foundation for RIGs to be worn on the belt slot. Doesn't apply to any RIGs currently, unless VV'd, but stay tuned!"


### PR DESCRIPTION
Lays the foundation for RIGs to be worn on the belt slot instead of the back slot. Also, lets certain items (none yet, but the functionality now exists) be worn on the belt slot without a jumpsuit.

* Modules are fully functional.
* Deployment works as intended.
* Can be surgically removed as usual.
* Two RIGs cannot be worn at once- it just won't fit.
* MMIs, AIs and pAIs can be installed as usual, and operate as usual.

When making a RIG available from the belt, just add SLOT_BELT as usual. When making an item fit in the belt slot without a jumpsuit, set 'suitlink' to 0 (default = 1). Highly recommended for belt-RIGs to avoid bugs.

Again, this doesn't actually change anything for players, so you're not going to notice the difference unless someone VV's a RIG (which is encouraged for testing purposes!). I've tested it as much as I can on my end, but it could use a once-over.

Possible PRs if this gets merged:
* Add this functionality to the offstation (vox, merc, ninja, ERT) rigs?
* Allow actual belts (e.g. toolbelt, sec-belt) to be worn without jumpsuits?