### PR TITLE
Fixes export reports not mentioning crates' cost

### DIFF
--- a/code/controllers/Processes/supply.dm
+++ b/code/controllers/Processes/supply.dm
@@ -100,6 +100,7 @@ var/datum/controller/supply/supply_controller = new()
 		EC.name = "\proper[MA.name]"
 		EC.value = 0
 		EC.contents = list()
+		var/base_value = 0
 
 		// Must be in a crate!
 		if(istype(MA,/obj/structure/closet/crate))
@@ -107,6 +108,8 @@ var/datum/controller/supply/supply_controller = new()
 			callHook("sell_crate", list(CR, area_shuttle))
 
 			points += CR.points_per_crate
+			if(CR.points_per_crate)
+				base_value = CR.points_per_crate
 			var/find_slip = 1
 
 			for(var/atom/A in CR)
@@ -151,6 +154,7 @@ var/datum/controller/supply/supply_controller = new()
 
 		exported_crates += EC
 		points += EC.value
+		EC.value += base_value
 
 		// Duplicate the receipt for the admin-side log
 		var/datum/exported_crate/adm = new()


### PR DESCRIPTION
Now the total cost tally up will include cost of crates in which stuff was sent.