### PR TITLE
[READY] Fixes chemistry/nanoui

### DIFF
--- a/code/controllers/subsystems/nanoui.dm
+++ b/code/controllers/subsystems/nanoui.dm
@@ -1,6 +1,6 @@
 SUBSYSTEM_DEF(nanoui)
 	name = "NanoUI"
-	wait = 20
+	wait = 5
 	// a list of current open /nanoui UIs, grouped by src_object and ui_key
 	var/list/open_uis = list()
 	// a list of current open /nanoui UIs, not grouped, for use in processing

--- a/code/controllers/subsystems/nanoui.dm
+++ b/code/controllers/subsystems/nanoui.dm
@@ -24,7 +24,7 @@ SUBSYSTEM_DEF(nanoui)
 				if(fexists(path + filename))
 					asset_files.Add(fcopy_rsc(path + filename)) // add this file to asset_files for sending to clients when they connect
 	for(var/i in GLOB.clients)
-		addtimer(src, CALLBACK(send_resources, i), 10)
+		addtimer(CALLBACK(src, .proc/send_resources, i), 10)
 	return ..()
 
 /datum/controller/subsystem/nanoui/Recover()
@@ -45,7 +45,7 @@ SUBSYSTEM_DEF(nanoui)
 
 //Sends asset files to a client, called on client/New()
 /datum/controller/subsystem/nanoui/proc/send_resources(client)
-	if(!initialized)
+	if(!subsystem_initialized)
 		return
 	for(var/file in asset_files)
 		client << browse_rsc(file)	// send the file to the client

--- a/code/controllers/subsystems/nanoui.dm
+++ b/code/controllers/subsystems/nanoui.dm
@@ -23,6 +23,8 @@ SUBSYSTEM_DEF(nanoui)
 			if(copytext(filename, length(filename)) != "/") // filenames which end in "/" are actually directories, which we want to ignore
 				if(fexists(path + filename))
 					asset_files.Add(fcopy_rsc(path + filename)) // add this file to asset_files for sending to clients when they connect
+	for(var/i in GLOB.clients)
+		addtimer(src, CALLBACK(send_resources, i), 10)
 	return ..()
 
 /datum/controller/subsystem/nanoui/Recover()
@@ -40,3 +42,10 @@ SUBSYSTEM_DEF(nanoui)
 	for(var/thing in processing_uis)
 		var/datum/nanoui/UI = thing
 		UI.process()
+
+//Sends asset files to a client, called on client/New()
+/datum/controller/subsystem/nanoui/proc/send_resources(client)
+	if(!initialized)
+		return
+	for(var/file in asset_files)
+		client << browse_rsc(file)	// send the file to the client

--- a/code/controllers/subsystems/processing/chemistry.dm
+++ b/code/controllers/subsystems/processing/chemistry.dm
@@ -4,6 +4,7 @@ PROCESSING_SUBSYSTEM_DEF(chemistry)
 	flags = SS_BACKGROUND|SS_POST_FIRE_TIMING
 	init_order = INIT_ORDER_CHEMISTRY
 	var/list/chemical_reactions = list()
+	var/list/chemical_reactions_by_reagent = list()
 	var/list/chemical_reagents = list()
 
 /datum/controller/subsystem/processing/chemistry/Recover()
@@ -22,15 +23,16 @@ PROCESSING_SUBSYSTEM_DEF(chemistry)
 // more than one chemical it will still only appear in only one of the sublists.
 /datum/controller/subsystem/processing/chemistry/proc/initialize_chemical_reactions()
 	var/paths = typesof(/datum/chemical_reaction) - /datum/chemical_reaction
-	SSchemistry.chemical_reactions = list()
+	chemical_reactions = list()
+	chemical_reactions_by_reagent = list()
 
 	for(var/path in paths)
-		var/datum/chemical_reaction/D = new path()
+		var/datum/chemical_reaction/D = new path
+		chemical_reactions += D
 		if(D.required_reagents && D.required_reagents.len)
 			var/reagent_id = D.required_reagents[1]
-			if(!chemical_reactions[reagent_id])
-				chemical_reactions[reagent_id] = list()
-			chemical_reactions[reagent_id] += D
+			LAZYINITLIST(chemical_reactions_by_reagent[reagent_id])
+			chemical_reactions_by_reagent[reagent_id] += D
 
 //Chemical Reagents - Initialises all /datum/reagent into a list indexed by reagent id
 /datum/controller/subsystem/processing/chemistry/proc/initialize_chemical_reagents()

--- a/code/modules/nano/nanomanager.dm
+++ b/code/modules/nano/nanomanager.dm
@@ -222,17 +222,3 @@
 	oldMob.open_uis.Cut()
 
 	return 1 // success
-
- /**
-  * Sends all nano assets to the client
-  * This is called on user login
-  *
-  * @param client /client The user's client
-  *
-  * @return nothing
-  */
-
-/datum/controller/subsystem/nanoui/proc/send_resources(client)
-	for(var/file in asset_files)
-		client << browse_rsc(file)	// send the file to the client
-

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -77,42 +77,30 @@
 	return
 
 /datum/reagents/proc/handle_reactions()
-	START_PROCESSING(SSchemistry, src)
-	process()
-
-//returns 1 if the holder should continue reactiong, 0 otherwise.
-/datum/reagents/process()
-	if(QDELETED(my_atom))		//No container, no reaction.
-		return PROCESS_KILL
-	if(my_atom.flags & NOREACT) // No reactions here
-		return PROCESS_KILL
-
-	var/reaction_occured
-	var/list/effect_reactions = list()
+	if(QDELETED(my_atom))
+		return FALSE
+	if(my_atom.flags & NOREACT)
+		return FALSE
+	var/reaction_occurred
 	var/list/eligible_reactions = list()
-	for(var/i in 1 to PROCESS_REACTION_ITER)
-		reaction_occured = 0
+	var/list/effect_reactions = list()
+	do
+		reaction_occurred = FALSE
+		for(var/i in reagent_list)
+			var/datum/reagent/R = i
+			eligible_reactions |= SSchemistry.chemical_reactions_by_reagent[R.id]
 
-		//need to rebuild this to account for chain reactions
-		for(var/datum/reagent/R in reagent_list)
-			eligible_reactions |= SSchemistry.chemical_reactions[R.id]
-
-		for(var/datum/chemical_reaction/C in eligible_reactions)
+		for(var/i in eligible_reactions)
+			var/datum/chemical_reaction/C = i
 			if(C.can_happen(src) && C.process(src))
 				effect_reactions |= C
-				reaction_occured = 1
-
-		eligible_reactions.Cut()
-
-		if(!reaction_occured)
-			break
-
-	for(var/datum/chemical_reaction/C in effect_reactions)
+				reaction_occurred = TRUE
+		eligible_reactions.len = 0
+	while(reaction_occurred)
+	for(var/i in effect_reactions)
+		var/datum/chemical_reaction/C = i
 		C.post_reaction(src)
-
 	update_total()
-	if(!reaction_occured)
-		return PROCESS_KILL
 
 /* Holder-to-chemical */
 

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -78,6 +78,7 @@
 
 /datum/reagents/proc/handle_reactions()
 	START_PROCESSING(SSchemistry, src)
+	process()
 
 //returns 1 if the holder should continue reactiong, 0 otherwise.
 /datum/reagents/process()


### PR DESCRIPTION
Chemistry processes instantly again
Nanoui sends stuff even after client connect

WIP because I need to test if NanoUI is still lagging/not ticking fast enough, and because I want to get rid of chemistry processing entirely (to make ALL reactions happen instantly, including subreactions from the first reaction's products, like on TGchemistry, unless people want it to be limited to 5 reactions per tick per container for whatever reason.)