### PR TITLE
Fixes way elevator handles deleting z-shadows

### DIFF
--- a/code/modules/multiz/zshadow.dm
+++ b/code/modules/multiz/zshadow.dm
@@ -24,6 +24,7 @@
 	sync_icon(L)
 
 /mob/zshadow/Destroy()
+	owner.shadow = null
 	owner = null
 	..() //But we don't return because the hint is wrong
 	return QDEL_HINT_QUEUE

--- a/code/modules/turbolift/turbolift.dm
+++ b/code/modules/turbolift/turbolift.dm
@@ -97,6 +97,8 @@
 			if(istype(AM, /mob/living))
 				var/mob/living/M = AM
 				M.gib()
+			else if(istype(AM, /mob/zshadow))
+				AM.Destroy()		//prevent deleting shadow without deleting shadow's shadows
 			else if(AM.simulated && !(istype(AM, /mob/observer)))
 				qdel(AM)
 


### PR DESCRIPTION
Should stop the bug where going from first to third floor on elevator would leave a HUD icon behind in place.

Problem was caused by the fact that shadow 'stack' was not deleted properly.