### PR TITLE
Fixes being unable to pull items down stairs

### DIFF
--- a/code/modules/multiz/movement.dm
+++ b/code/modules/multiz/movement.dm
@@ -280,6 +280,10 @@
 
 	// Detect if we made a silent landing.
 	if(locate(/obj/structure/stairs) in landing)
+		if(isliving(src))
+			var/mob/living/L = src
+			if(L.pulling)
+				L.pulling.forceMove(landing)
 		return 1
 	else
 		var/atom/A = find_fall_target(oldloc, landing)


### PR DESCRIPTION
You could pull them when you were moving upstairs, but moving downstairs caused item to just get lost behind. This should fix that.