### PR TITLE
Allows restriction of z-levels from spawning xenoarch finds

### DIFF
--- a/code/__defines/map.dm
+++ b/code/__defines/map.dm
@@ -6,6 +6,7 @@
 #define MAP_LEVEL_SEALED		0x010 // Z-levels that don't allow random transit at edge
 #define MAP_LEVEL_EMPTY			0x020 // Empty Z-levels that may be used for various things (currently used by bluespace jump)
 #define MAP_LEVEL_CONSOLES		0x040 // Z-levels available to various consoles, such as the crew monitor (when that gets coded in). Defaults to station_levels if unset.
+#define MAP_LEVEL_XENOARCH_EXEMPT 0x080	// Z-levels exempt from xenoarch digsite generation.
 
 // Misc map defines.
 #define SUBMAP_MAP_EDGE_PAD 15 // Automatically created submaps are forbidden from being this close to the main map's edge.

--- a/code/controllers/subsystems/xenoarch.dm
+++ b/code/controllers/subsystems/xenoarch.dm
@@ -31,7 +31,7 @@ SUBSYSTEM_DEF(xenoarch)
 
 /datum/controller/subsystem/xenoarch/proc/SetupXenoarch()
 	for(var/turf/simulated/mineral/M in turfs)
-		if(!M.density)
+		if(!M.density || M.z in using_map.xenoarch_exempt_levels)
 			continue
 
 		if(isnull(M.geologic_data))

--- a/maps/~map_system/maps.dm
+++ b/maps/~map_system/maps.dm
@@ -30,6 +30,7 @@ var/list/all_maps = list()
 	var/list/contact_levels = list() // Z-levels that can be contacted from the station, for eg announcements
 	var/list/player_levels = list()  // Z-levels a character can typically reach
 	var/list/sealed_levels = list()  // Z-levels that don't allow random transit at edge
+	var/list/xenoarch_exempt_levels = list()	//Z-levels exempt from xenoarch finds and digsites spawning.
 	var/list/empty_levels = null     // Empty Z-levels that may be used for various things (currently used by bluespace jump)
 
 	var/list/map_levels              // Z-levels available to various consoles, such as the crew monitor (when that gets coded in). Defaults to station_levels if unset.
@@ -178,6 +179,7 @@ var/list/all_maps = list()
 	if(flags & MAP_LEVEL_CONTACT) map.contact_levels += z
 	if(flags & MAP_LEVEL_PLAYER) map.player_levels += z
 	if(flags & MAP_LEVEL_SEALED) map.sealed_levels += z
+	if(flags & MAP_LEVEL_XENOARCH_EXEMPT) map.xenoarch_exempt_levels += z
 	if(flags & MAP_LEVEL_EMPTY)
 		if(!map.empty_levels) map.empty_levels = list()
 		map.empty_levels += z


### PR DESCRIPTION
I admittedly have no idea whether any of the Polaris maps have it as an issue, but xenoarch is handled entirely separately from mining spawning and a mechanism to prevent spawning on specific z-levels that still have rock tiles wouldn't be unwelcome, I believe. As of initial posting, no level is actually restricted.