### PR TITLE
SMESs no longer turn off when out of power

### DIFF
--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -144,11 +144,6 @@
 		charge -= output_used*SMESRATE		// reduce the storage (may be recovered in /restore() if excessive)
 
 		add_avail(output_used)				// add output to powernet (smes side)
-
-		if(output_used < 0.0001)			// either from no charge or set to 0
-			outputting(0)
-			investigate_log("lost power and turned <font color='red'>off</font>","singulo")
-			log_game("SMES([x],[y],[z]) Power depleted.")
 	else if(output_attempt && output_level > 0)
 		outputting = 1
 	else


### PR DESCRIPTION
Basically, this stops an SMES unit from setting output to zero when it runs out of power, allowing an SMES unit to still output power so long as it is getting input. Especially useful for Solars.

Ported from Baystation PR #11973