### PR TITLE
Fixes runtimes from organizations catalogue

### DIFF
--- a/code/datums/observation/destroyed.dm
+++ b/code/datums/observation/destroyed.dm
@@ -10,5 +10,6 @@
 	name = "Destroyed"
 
 /datum/Destroy()
-	GLOB.destroyed_event.raise_event(src)
+	if(GLOB.destroyed_event)
+		GLOB.destroyed_event.raise_event(src)
 	. = ..()


### PR DESCRIPTION
It works, it seems. Generally prevents datum deleting from runtiming if it happens too early.