### PR TITLE
Fixed the vendor machines zapping twice

### DIFF
--- a/code/datums/wires/seedstorage.dm
+++ b/code/datums/wires/seedstorage.dm
@@ -10,10 +10,6 @@
 
 /datum/wires/seedstorage/CanUse(var/mob/living/L)
 	var/obj/machinery/seed_storage/V = holder
-	if(!istype(L, /mob/living/silicon))
-		if(V.seconds_electrified)
-			if(V.shock(L, 100))
-				return 0
 	if(V.panel_open)
 		return 1
 	return 0

--- a/code/datums/wires/smartfridge.dm
+++ b/code/datums/wires/smartfridge.dm
@@ -12,10 +12,6 @@ var/const/SMARTFRIDGE_WIRE_IDSCAN		= 4
 
 /datum/wires/smartfridge/CanUse(var/mob/living/L)
 	var/obj/machinery/smartfridge/S = holder
-	if(!istype(L, /mob/living/silicon))
-		if(S.seconds_electrified)
-			if(S.shock(L, 100))
-				return 0
 	if(S.panel_open)
 		return 1
 	return 0

--- a/code/datums/wires/vending.dm
+++ b/code/datums/wires/vending.dm
@@ -9,10 +9,6 @@ var/const/VENDING_WIRE_IDSCAN = 8
 
 /datum/wires/vending/CanUse(var/mob/living/L)
 	var/obj/machinery/vending/V = holder
-	if(!istype(L, /mob/living/silicon))
-		if(V.seconds_electrified)
-			if(V.shock(L, 100))
-				return 0
 	if(V.panel_open)
 		return 1
 	return 0
@@ -43,7 +39,7 @@ var/const/VENDING_WIRE_IDSCAN = 8
 		if(VENDING_WIRE_THROW)
 			V.shoot_inventory = !mended
 		if(VENDING_WIRE_CONTRABAND)
-			V.categories &= ~CAT_HIDDEN  
+			V.categories &= ~CAT_HIDDEN
 		if(VENDING_WIRE_ELECTRIFY)
 			if(mended)
 				V.seconds_electrified = 0


### PR DESCRIPTION
If it was electrified, it would deliver the electrical shock twice per any interaction. Fixed

To specify, this applies to Vendomats, Seed dispensers and SmartFridges.