### PR TITLE
Fixes newly constructed vertical pipes being invisible

### DIFF
--- a/code/modules/multiz/pipes.dm
+++ b/code/modules/multiz/pipes.dm
@@ -2,32 +2,31 @@
 // parent class for pipes //
 ////////////////////////////
 obj/machinery/atmospherics/pipe/zpipe
-		icon = 'icons/obj/structures.dmi'
-		icon_state = "up"
+	icon = 'icons/obj/structures.dmi'
+	icon_state = "up"
 
-		name = "upwards pipe"
-		desc = "A pipe segment to connect upwards."
+	name = "upwards pipe"
+	desc = "A pipe segment to connect upwards."
 
-		volume = 70
+	volume = 70
 
-		dir = SOUTH
-		initialize_directions = SOUTH
+	dir = SOUTH
+	initialize_directions = SOUTH
 
-		construction_type = /obj/item/pipe/directional
-		pipe_state = "cap"
+	construction_type = /obj/item/pipe/directional
+	pipe_state = "cap"
 
-		// node1 is the connection on the same Z
-		// node2 is the connection on the other Z
+	// node1 is the connection on the same Z
+	// node2 is the connection on the other Z
 
-		var/minimum_temperature_difference = 300
-		var/thermal_conductivity = 0 //WALL_HEAT_TRANSFER_COEFFICIENT No
+	var/minimum_temperature_difference = 300
+	var/thermal_conductivity = 0 //WALL_HEAT_TRANSFER_COEFFICIENT No
 
-		var/maximum_pressure = 70*ONE_ATMOSPHERE
-		var/fatigue_pressure = 55*ONE_ATMOSPHERE
-		alert_pressure = 55*ONE_ATMOSPHERE
+	var/maximum_pressure = 70*ONE_ATMOSPHERE
+	var/fatigue_pressure = 55*ONE_ATMOSPHERE
+	alert_pressure = 55*ONE_ATMOSPHERE
 
-
-		level = 1
+	level = 1
 
 /obj/machinery/atmospherics/pipe/zpipe/New()
 	..()
@@ -152,7 +151,7 @@ obj/machinery/atmospherics/pipe/zpipe/up/atmos_init()
 
 
 	var/turf/T = src.loc			// hide if turf is not intact
-	hide(!T.is_plating())
+	if(level == 1 && !T.is_plating()) hide(1)	// but respect level
 
 ///////////////////////
 // and the down pipe //
@@ -189,7 +188,7 @@ obj/machinery/atmospherics/pipe/zpipe/down/atmos_init()
 
 
 	var/turf/T = src.loc			// hide if turf is not intact
-	hide(!T.is_plating())
+	if(level == 1 && !T.is_plating()) hide(1)	// but respect level
 
 ///////////////////////
 // supply/scrubbers  //


### PR DESCRIPTION
or, to be exact, starting below the tile despite being constructed on top of it. Pipes constructed on plating straight away were working fine, and if you added/removed the flooring its also fine, but initially it was weird.