### PR TITLE
Changes way syringes interact with containers

### DIFF
--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -171,7 +171,9 @@
 					return
 
 			var/cycle_time = injtime*0.33 //33% of the time slept between 5u doses
-			var/warmup_time = cycle_time //If the target is another mob, this gets overwritten
+			var/warmup_time = 0	//0 for containers
+			if(ismob(target))
+				warmup_time = cycle_time //If the target is another mob, this gets overwritten
 
 			if(ismob(target) && target != user)
 				warmup_time = injtime*0.66 // Otherwise 66% of the time is warmup
@@ -200,14 +202,14 @@
 
 			var/trans = 0
 			var/contained = reagentlist()
-			while(reagents.total_volume)
-				if(ismob(target))
+			if(ismob(target))
+				while(reagents.total_volume)
 					trans += reagents.trans_to_mob(target, amount_per_transfer_from_this, CHEM_BLOOD)
-				else
-					trans += reagents.trans_to_obj(target, amount_per_transfer_from_this)
-				update_icon()
-				if(!reagents.total_volume || !do_after(user,cycle_time,target))
-					break
+					update_icon()
+					if(!reagents.total_volume || !do_after(user,cycle_time,target))
+						break
+			else
+				trans += reagents.trans_to_obj(target, amount_per_transfer_from_this)
 
 			if (reagents.total_volume <= 0 && mode == SYRINGE_INJECT)
 				mode = SYRINGE_DRAW

--- a/html/changelogs/Heroman3003 - syringetweak.yml
+++ b/html/changelogs/Heroman3003 - syringetweak.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Heroman3003
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Syringes will now inject 5 units per injection and immedeately when injecting into reagent containers. Does not chage way injecting mobs work"


### PR DESCRIPTION
Only applies to non-mob containers like beakers, food, slime extracts, etc.

Makes it only inject 5u per click.
Makes injection immedeate.

Way mob injections, self or other, are unaffected.