### PR TITLE
Fixes promethean mice lunchboxes

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/prometheans.dm
+++ b/code/modules/mob/living/carbon/human/species/station/prometheans.dm
@@ -113,10 +113,18 @@ var/datum/species/shapeshifter/promethean/prometheans
 	prometheans = src
 
 /datum/species/shapeshifter/promethean/equip_survival_gear(var/mob/living/carbon/human/H)
-	var/boxtype = pick(typesof(/obj/item/weapon/storage/toolbox/lunchbox))
+	var/boxtype = pick(list(/obj/item/weapon/storage/toolbox/lunchbox,
+							/obj/item/weapon/storage/toolbox/lunchbox/heart,
+							/obj/item/weapon/storage/toolbox/lunchbox/cat,
+							/obj/item/weapon/storage/toolbox/lunchbox/nt,
+							/obj/item/weapon/storage/toolbox/lunchbox/mars,
+							/obj/item/weapon/storage/toolbox/lunchbox/cti,
+							/obj/item/weapon/storage/toolbox/lunchbox/nymph,
+							/obj/item/weapon/storage/toolbox/lunchbox/syndicate))	//Only pick the empty types
 	var/obj/item/weapon/storage/toolbox/lunchbox/L = new boxtype(get_turf(H))
 	var/mob/living/simple_mob/animal/passive/mouse/mouse = new (L)
 	var/obj/item/weapon/holder/holder = new (L)
+	holder.held_mob = mouse
 	mouse.forceMove(holder)
 	holder.sync(mouse)
 	if(H.backbag == 1)


### PR DESCRIPTION
Fixes mice spawning under the promethean and runtiming a bunch

Fixes lunchboxes having a 50% chance to have a bunch of food in them in addition to mouse (now just mouse and never anything else)