### PR TITLE
Fixes taperolls not being usable on tiles with directional windows

### DIFF
--- a/code/game/objects/items/weapons/policetape.dm
+++ b/code/game/objects/items/weapons/policetape.dm
@@ -140,14 +140,14 @@ var/list/tape_roll_applications = list()
 /obj/item/taperoll/attack_self(mob/user as mob)
 	if(!start)
 		start = get_turf(src)
-		usr << "<span class='notice'>You place the first end of \the [src].</span>"
+		to_chat(user, "<span class='notice'>You place the first end of \the [src].</span>")
 		update_icon()
 	else
 		end = get_turf(src)
 		if(start.y != end.y && start.x != end.x || start.z != end.z)
 			start = null
 			update_icon()
-			usr << "<span class='notice'>\The [src] can only be laid horizontally or vertically.</span>"
+			to_chat(user, "<span class='notice'>\The [src] can only be laid horizontally or vertically.</span>")
 			return
 
 		if(start == end)
@@ -162,10 +162,13 @@ var/list/tape_roll_applications = list()
 					for(var/obj/structure/window/W in T)
 						if(W.is_fulltile() || W.dir == reverse_dir[dir])
 							possible_dirs += dir
+			for(var/obj/structure/window/window in start)
+				if(istype(window) && !window.is_fulltile())
+					possible_dirs += window.dir
 			if(!possible_dirs)
 				start = null
 				update_icon()
-				usr << "<span class='notice'>You can't place \the [src] here.</span>"
+				to_chat(user, "<span class='notice'>You can't place \the [src] here.</span>")
 				return
 			if(possible_dirs & (NORTH|SOUTH))
 				var/obj/item/tape/TP = new tape_type(start)
@@ -181,7 +184,7 @@ var/list/tape_roll_applications = list()
 				TP.update_icon()
 			start = null
 			update_icon()
-			usr << "<span class='notice'>You finish placing \the [src].</span>"
+			to_chat(user, "<span class='notice'>You finish placing \the [src].</span>")
 			return
 
 		var/turf/cur = start
@@ -199,6 +202,28 @@ var/list/tape_roll_applications = list()
 				can_place = 0
 			else
 				for(var/obj/O in cur)
+					if(istype(O, /obj/structure/window))
+						var/obj/structure/window/window = O
+						if(window.is_fulltile())
+							can_place = 0
+							break
+						if(cur == start)
+							if(window.dir == orientation)
+								can_place = 0
+								break
+							else
+								continue
+						else if(cur == end)
+							if(window.dir == reverse_dir[orientation])
+								can_place = 0
+								break
+							else
+								continue
+						else if (window.dir == reverse_dir[orientation] || window.dir == orientation)
+							can_place = 0
+							break
+						else
+							continue
 					if(O.density)
 						can_place = 0
 						break
@@ -208,7 +233,7 @@ var/list/tape_roll_applications = list()
 		if (!can_place)
 			start = null
 			update_icon()
-			usr << "<span class='warning'>You can't run \the [src] through that!</span>"
+			to_chat(user, "<span class='warning'>You can't run \the [src] through that!</span>")
 			return
 
 		cur = start
@@ -224,6 +249,9 @@ var/list/tape_roll_applications = list()
 					for(var/obj/structure/window/W in T)
 						if(W.is_fulltile() || W.dir == orientation)
 							tape_dir = dir
+				for(var/obj/structure/window/window in cur)
+					if(istype(window) && !window.is_fulltile() && window.dir == reverse_dir[orientation])
+						tape_dir = dir
 			else if(cur == end)
 				var/turf/T = get_step(end, orientation)
 				if(T && !T.density)
@@ -231,6 +259,9 @@ var/list/tape_roll_applications = list()
 					for(var/obj/structure/window/W in T)
 						if(W.is_fulltile() || W.dir == reverse_dir[orientation])
 							tape_dir = dir
+				for(var/obj/structure/window/window in cur)
+					if(istype(window) && !window.is_fulltile() && window.dir == orientation)
+						tape_dir = dir
 			for(var/obj/item/tape/T in cur)
 				if((T.tape_dir == tape_dir) && (T.icon_base == icon_base))
 					tapetest = 1
@@ -246,7 +277,7 @@ var/list/tape_roll_applications = list()
 			cur = get_step_towards(cur,end)
 		start = null
 		update_icon()
-		usr << "<span class='notice'>You finish placing \the [src].</span>"
+		to_chat(user, "<span class='notice'>You finish placing \the [src].</span>")
 		return
 
 /obj/item/taperoll/afterattack(var/atom/A, mob/user as mob, proximity)
@@ -256,12 +287,12 @@ var/list/tape_roll_applications = list()
 	if (istype(A, /obj/machinery/door))
 		var/turf/T = get_turf(A)
 		if(locate(/obj/item/tape, A.loc))
-			user << "There's already tape over that door!"
+			to_chat(user, "There's already tape over that door!")
 		else
 			var/obj/item/tape/P = new tape_type(T)
 			P.update_icon()
 			P.layer = WINDOW_LAYER
-			user << "<span class='notice'>You finish placing \the [src].</span>"
+			to_chat(user, "<span class='notice'>You finish placing \the [src].</span>")
 
 	if (istype(A, /turf/simulated/floor) ||istype(A, /turf/unsimulated/floor))
 		var/turf/F = A

--- a/code/game/objects/items/weapons/policetape.dm
+++ b/code/game/objects/items/weapons/policetape.dm
@@ -157,14 +157,14 @@ var/list/tape_roll_applications = list()
 			for(var/dir in cardinal)
 				T = get_step(start, dir)
 				if(T && T.density)
-					possible_dirs += dir
+					possible_dirs |= dir
 				else
 					for(var/obj/structure/window/W in T)
 						if(W.is_fulltile() || W.dir == reverse_dir[dir])
-							possible_dirs += dir
+							possible_dirs |= dir
 			for(var/obj/structure/window/window in start)
 				if(istype(window) && !window.is_fulltile())
-					possible_dirs += window.dir
+					possible_dirs |= window.dir
 			if(!possible_dirs)
 				start = null
 				update_icon()

--- a/html/changelogs/Heroman3003 - windowtapes.yml
+++ b/html/changelogs/Heroman3003 - windowtapes.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Heroman3003
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Tape rolls can now be used on tiles with directional windows as long as they don't directly obstruct them."


### PR DESCRIPTION
To clarify, if window is directly blocking path of tape, it will still be unusuable. But if you can freely go in direction parallel to tape on same tile, you can now put tape onto it with no problem.