### PR TITLE
Makes transfer always occur if nobody is playing.

### DIFF
--- a/code/controllers/subsystems/vote.dm
+++ b/code/controllers/subsystems/vote.dm
@@ -31,6 +31,24 @@ SUBSYSTEM_DEF(vote)
 			reset()
 
 /datum/controller/subsystem/vote/proc/autotransfer()
+	// Before doing the vote, see if anyone is playing.
+	// If not, just do the transfer.
+	var/players_are_in_round = FALSE
+	for(var/a in player_list) // Mobs with clients attached.
+		var/mob/living/L = a
+		if(!istype(L)) // Exclude ghosts and other weird things.
+			continue
+		if(L.stat == DEAD) // Dead mobs aren't playing.
+			continue
+		// Everything else is, however.
+		players_are_in_round = TRUE
+		break
+
+	if(!players_are_in_round)
+		log_debug("The crew transfer shuttle was automatically called at vote time due to no players being present.")
+		init_shift_change(null, 1)
+		return
+
 	initiate_vote(VOTE_CREW_TRANSFER, "the server", 1)
 	log_debug("The server has called a crew transfer vote.")
 


### PR DESCRIPTION
What it says on the tin.
This will hopefully help empty overnight rounds come to a close, so that people won't join to a de-powered, broken station filled with holes due to running for 8 hours continuously.