### PR TITLE
Makes gamemode player requirements be able to be overridden in the config

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -57,6 +57,8 @@ var/list/gamemode_cache = list()
 	var/list/modes = list()				// allowed modes
 	var/list/votable_modes = list()		// votable modes
 	var/list/probabilities = list()		// relative probability of each mode
+	var/list/player_requirements = list() // Overrides for how many players readied up a gamemode needs to start.
+	var/list/player_requirements_secret = list() // Same as above, but for the secret gamemode.
 	var/humans_need_surnames = 0
 	var/allow_random_events = 0			// enables random events mid-round when set to 1
 	var/allow_ai = 1					// allow ai job
@@ -248,9 +250,11 @@ var/list/gamemode_cache = list()
 			gamemode_cache[M.config_tag] = M // So we don't instantiate them repeatedly.
 			if(!(M.config_tag in modes))		// ensure each mode is added only once
 				log_misc("Adding game mode [M.name] ([M.config_tag]) to configuration.")
-				src.modes += M.config_tag
-				src.mode_names[M.config_tag] = M.name
-				src.probabilities[M.config_tag] = M.probability
+				modes += M.config_tag
+				mode_names[M.config_tag] = M.name
+				probabilities[M.config_tag] = M.probability
+				player_requirements[M.config_tag] = M.required_players
+				player_requirements_secret[M.config_tag] = M.required_players_secret
 				if (M.votable)
 					src.votable_modes += M.config_tag
 	src.votable_modes += "secret"
@@ -521,6 +525,25 @@ var/list/gamemode_cache = list()
 							log_misc("Unknown game mode probability configuration definition: [prob_name].")
 					else
 						log_misc("Incorrect probability configuration definition: [prob_name]  [prob_value].")
+
+				if ("required_players", "required_players_secret")
+					var/req_pos = findtext(value, " ")
+					var/req_name = null
+					var/req_value = null
+					var/is_secret_override = findtext(name, "required_players_secret") // Being extra sure we're not picking up an override for Secret by accident.
+
+					if(req_pos)
+						req_name = lowertext(copytext(value, 1, req_pos))
+						req_value = copytext(value, req_pos + 1)
+						if(req_name in config.modes)
+							if(is_secret_override)
+								config.player_requirements_secret[req_name] = text2num(req_value)
+							else
+								config.player_requirements[req_name] = text2num(req_value)
+						else
+							log_misc("Unknown game mode player requirement configuration definition: [req_name].")
+					else
+						log_misc("Incorrect player requirement configuration definition: [req_name]  [req_value].")
 
 				if("allow_random_events")
 					config.allow_random_events = 1

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -146,10 +146,10 @@ var/global/list/additional_antag_types = list()
 			playerC++
 
 	if(master_mode=="secret")
-		if(playerC < required_players_secret)
+		if(playerC < config.player_requirements_secret)
 			return 0
 	else
-		if(playerC < required_players)
+		if(playerC < config.player_requirements)
 			return 0
 
 	if(!(antag_templates && antag_templates.len))

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -124,6 +124,12 @@ PROBABILITY LIZARD 1
 PROBABILITY INTRIGUE 1
 PROBABILITY VISITORS 1
 
+## Overrides for required number of readied up players for a gamemode to be able to start can be defined here.
+## If it is unset, it will default to the requirement set by the gamemode datum.
+## Note that this does not control the required amount of antags for a gamemode, and so a lower number may still fail to start if not enough people want to be antags.
+## By default, this overrides the voted gamemode requirement. To override the requirement for Secret, append '_SECRET' to the end of the first word.
+## The format to use is REQUIRED_PLAYERS[_SECRET] [gamemode tag] [number of readies needed], for example, "REQUIRED_PLAYERS TRAITOR 1", or "REQUIRED_PLAYERS_SECRET MERCENARY 10".
+
 ## Hash out to disable random events during the round.
 ALLOW_RANDOM_EVENTS
 


### PR DESCRIPTION
What is says on the tin.
Hopefully a better way to achieve what #6110 was meant to do, without causing a lot of weird testing issues.
If an override number is not specified in the config, it will default to the gamemode datum's number.