### PR TITLE
Sterilizine Hurts Slimes

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -966,6 +966,14 @@
 	for(var/obj/effect/decal/cleanable/blood/B in T)
 		qdel(B)
 
+/datum/reagent/sterilizine/touch_mob(var/mob/living/L, var/amount)
+	if(istype(L))
+		if(istype(L, /mob/living/simple_mob/slime))
+			var/mob/living/simple_mob/slime/S = L
+			S.adjustToxLoss(rand(15, 25) * amount)	// Does more damage than water.
+			S.visible_message("<span class='warning'>[S]'s flesh sizzles where the fluid touches it!</span>", "<span class='danger'>Your flesh burns in the fluid!</span>")
+		remove_self(amount)
+
 /datum/reagent/leporazine
 	name = "Leporazine"
 	id = "leporazine"

--- a/html/changelogs/Mechoid - Sterilizine.yml
+++ b/html/changelogs/Mechoid - Sterilizine.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Mechoid
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Sterilizine now hurts slimes, similar to water."


### PR DESCRIPTION
Sterilizine will now hurt slimes by a random amount, ranging from equivalent to water (15) to 25, mirroring how both chemicals injure Prometheans.