### PR TITLE
Fixes some items having item_flag PHORONGUARD

### DIFF
--- a/code/modules/clothing/spacesuits/rig/suits/alien.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/alien.dm
@@ -47,7 +47,8 @@
 	suit_type = "alien"
 	icon_state = "vox_rig"
 	armor = list(melee = 60, bullet = 50, laser = 40, energy = 15, bomb = 30, bio = 100, rad = 50)
-	item_flags = THICKMATERIAL|PHORONGUARD
+	flags = PHORONGUARD
+	item_flags = THICKMATERIAL
 	siemens_coefficient = 0.2
 	offline_slowdown = 5
 	allowed = list(/obj/item/weapon/gun,/obj/item/device/flashlight,/obj/item/weapon/tank,/obj/item/device/suit_cooling_unit)

--- a/code/modules/clothing/spacesuits/spacesuits.dm
+++ b/code/modules/clothing/spacesuits/spacesuits.dm
@@ -58,7 +58,7 @@
 	gas_transfer_coefficient = 0.01
 	permeability_coefficient = 0.02
 	flags = PHORONGUARD
-	item_flags = THICKMATERIAL | PHORONGUARD
+	item_flags = THICKMATERIAL
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|FEET|ARMS|HANDS
 	allowed = list(/obj/item/device/flashlight,/obj/item/weapon/tank/emergency/oxygen,/obj/item/device/suit_cooling_unit)
 	slowdown = 3

--- a/code/modules/clothing/suits/bio.dm
+++ b/code/modules/clothing/suits/bio.dm
@@ -8,7 +8,8 @@
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|BLOCKHAIR
 	body_parts_covered = HEAD|FACE|EYES
 	siemens_coefficient = 0.9
-	item_flags = THICKMATERIAL | PHORONGUARD
+	flags = PHORONGUARD
+	item_flags = THICKMATERIAL
 
 /obj/item/clothing/suit/bio_suit
 	name = "bio suit"
@@ -23,7 +24,8 @@
 	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 100, rad = 20)
 	flags_inv = HIDEGLOVES|HIDESHOES|HIDEJUMPSUIT|HIDETAIL|HIDETIE|HIDEHOLSTER
 	siemens_coefficient = 0.9
-	item_flags = THICKMATERIAL | PHORONGUARD
+	flags = PHORONGUARD
+	item_flags = THICKMATERIAL
 
 //Standard biosuit, orange stripe
 /obj/item/clothing/head/bio_hood/general


### PR DESCRIPTION
Its meant to be used as regular flag, not item_flag. Those that had it duplicated in two, just cleared it out. Those that had it only in item_flags moved into regular flags.