### PR TITLE
Fixes gamemode checking list itself, instead of entries

### DIFF
--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -146,10 +146,10 @@ var/global/list/additional_antag_types = list()
 			playerC++
 
 	if(master_mode=="secret")
-		if(playerC < config.player_requirements_secret)
+		if(playerC < config.player_requirements_secret[config_tag])
 			return 0
 	else
-		if(playerC < config.player_requirements)
+		if(playerC < config.player_requirements[config_tag])
 			return 0
 
 	if(!(antag_templates && antag_templates.len))

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -99,7 +99,7 @@ var/global/datum/controller/gameticker/ticker
 	job_master.DivideOccupations() // Apparently important for new antagonist system to register specific job antags properly.
 
 	if(!src.mode.can_start())
-		world << "<B>Unable to start [mode.name].</B> Not enough players readied, [mode.required_players] players needed. Reverting to pregame lobby."
+		world << "<B>Unable to start [mode.name].</B> Not enough players readied, [config.player_requirements[mode.config_tag]] players needed. Reverting to pregame lobby."
 		current_state = GAME_STATE_PREGAME
 		Master.SetRunLevel(RUNLEVEL_LOBBY)
 		mode.fail_setup()


### PR DESCRIPTION
When checking for required player amount. Im not sure why behaviour on when to start/not start the game was so inconsistant, but I presume its jankyness involved in comparing a list to a number, rather than number to a number.