### PR TITLE
Minor PDA cartridge tweaks

### DIFF
--- a/code/datums/outfits/jobs/command.dm
+++ b/code/datums/outfits/jobs/command.dm
@@ -36,7 +36,7 @@
 	l_ear = /obj/item/device/radio/headset/headset_com
 	shoes = /obj/item/clothing/shoes/brown
 	id_type = /obj/item/weapon/card/id/silver/secretary
-	pda_type = /obj/item/device/pda/heads/hop
+	pda_type = /obj/item/device/pda/heads
 	r_hand = /obj/item/weapon/clipboard
 
 /decl/hierarchy/outfit/job/secretary/pre_equip(mob/living/carbon/human/H)

--- a/code/game/objects/items/devices/PDA/cart.dm
+++ b/code/game/objects/items/devices/PDA/cart.dm
@@ -4,6 +4,7 @@ var/list/command_cartridges = list(
 	/obj/item/weapon/cartridge/hos,
 	/obj/item/weapon/cartridge/ce,
 	/obj/item/weapon/cartridge/rd,
+	/obj/item/weapon/cartridge/cmo,
 	/obj/item/weapon/cartridge/head,
 	/obj/item/weapon/cartridge/lawyer // Internal Affaris,
 	)

--- a/code/game/objects/items/devices/PDA/cart.dm
+++ b/code/game/objects/items/devices/PDA/cart.dm
@@ -150,7 +150,7 @@ var/list/civilian_cartridges = list(
 */
 
 /obj/item/weapon/cartridge/service
-	name = "\improper Serv-U Pro"
+	name = "\improper Serv-U Pro cartridge"
 	desc = "A data cartridge designed to serve YOU!"
 
 /obj/item/weapon/cartridge/signal
@@ -176,12 +176,12 @@ var/list/civilian_cartridges = list(
 	access_quartermaster = 1
 
 /obj/item/weapon/cartridge/miner
-	name = "\improper Drill-Jockey 4.5"
+	name = "\improper Drill-Jockey 4.5 cartridge"
 	desc = "It's covered in some sort of sand."
 	icon_state = "cart-q"
 
 /obj/item/weapon/cartridge/head
-	name = "\improper Easy-Record DELUXE"
+	name = "\improper Easy-Record DELUXE cartridge"
 	icon_state = "cart-h"
 	access_status_display = 1
 
@@ -194,7 +194,7 @@ var/list/civilian_cartridges = list(
 	access_security = 1
 
 /obj/item/weapon/cartridge/hos
-	name = "\improper R.O.B.U.S.T. DELUXE"
+	name = "\improper R.O.B.U.S.T. DELUXE cartridge"
 	icon_state = "cart-hos"
 	access_status_display = 1
 	access_security = 1
@@ -204,21 +204,21 @@ var/list/civilian_cartridges = list(
 	. = ..()
 
 /obj/item/weapon/cartridge/ce
-	name = "\improper Power-On DELUXE"
+	name = "\improper Power-On DELUXE cartridge"
 	icon_state = "cart-ce"
 	access_status_display = 1
 	access_engine = 1
 	access_atmos = 1
 
 /obj/item/weapon/cartridge/cmo
-	name = "\improper Med-U DELUXE"
+	name = "\improper Med-U DELUXE cartridge"
 	icon_state = "cart-cmo"
 	access_status_display = 1
 	access_reagent_scanner = 1
 	access_medical = 1
 
 /obj/item/weapon/cartridge/rd
-	name = "\improper Signal Ace DELUXE"
+	name = "\improper Signal Ace DELUXE cartridge"
 	icon_state = "cart-rd"
 	access_status_display = 1
 	access_reagent_scanner = 1

--- a/code/modules/research/designs/pdas.dm
+++ b/code/modules/research/designs/pdas.dm
@@ -62,7 +62,7 @@
 	sort_string = "VBAAI"
 
 /datum/design/item/pda_cartridge/head
-	id = "cart_hop"
+	id = "cart_head"
 	build_path = /obj/item/weapon/cartridge/head
 	sort_string = "VBAAJ"
 

--- a/code/modules/research/designs/pdas.dm
+++ b/code/modules/research/designs/pdas.dm
@@ -61,6 +61,11 @@
 	build_path = /obj/item/weapon/cartridge/quartermaster
 	sort_string = "VBAAI"
 
+/datum/design/item/pda_cartridge/head
+	id = "cart_hop"
+	build_path = /obj/item/weapon/cartridge/head
+	sort_string = "VBAAJ"
+
 /datum/design/item/pda_cartridge/hop
 	id = "cart_hop"
 	build_path = /obj/item/weapon/cartridge/hop

--- a/code/modules/research/designs/pdas.dm
+++ b/code/modules/research/designs/pdas.dm
@@ -69,29 +69,29 @@
 /datum/design/item/pda_cartridge/hop
 	id = "cart_hop"
 	build_path = /obj/item/weapon/cartridge/hop
-	sort_string = "VBAAJ"
+	sort_string = "VBAAK"
 
 /datum/design/item/pda_cartridge/hos
 	id = "cart_hos"
 	build_path = /obj/item/weapon/cartridge/hos
-	sort_string = "VBAAK"
+	sort_string = "VBAAL"
 
 /datum/design/item/pda_cartridge/ce
 	id = "cart_ce"
 	build_path = /obj/item/weapon/cartridge/ce
-	sort_string = "VBAAL"
+	sort_string = "VBAAM"
 
 /datum/design/item/pda_cartridge/cmo
 	id = "cart_cmo"
 	build_path = /obj/item/weapon/cartridge/cmo
-	sort_string = "VBAAM"
+	sort_string = "VBAAN"
 
 /datum/design/item/pda_cartridge/rd
 	id = "cart_rd"
 	build_path = /obj/item/weapon/cartridge/rd
-	sort_string = "VBAAN"
+	sort_string = "VBAAO"
 
 /datum/design/item/pda_cartridge/captain
 	id = "cart_captain"
 	build_path = /obj/item/weapon/cartridge/captain
-	sort_string = "VBAAO"
+	sort_string = "VBAAP"


### PR DESCRIPTION
Adds CMO cartridge to list of Command PDA cartridges (for purposes of relay)

Secretaries now start with Easy-Record DELUXE instead of HumanResources9001 cartridge

Easy-Record DELUXE is now makeable in RnD

Adjusted names of some cartridges to have word 'cartridge' in their name