### PR TITLE
Removes Resident from the Southern Cross

### DIFF
--- a/code/datums/outfits/jobs/civilian.dm
+++ b/code/datums/outfits/jobs/civilian.dm
@@ -7,11 +7,6 @@
 	id_pda_assignment = "Visitor"
 	uniform = /obj/item/clothing/under/assistantformal
 
-/decl/hierarchy/outfit/job/assistant/resident
-	name = OUTFIT_JOB_NAME("Resident")
-	id_pda_assignment = "Resident"
-	uniform = /obj/item/clothing/under/color/white
-
 /decl/hierarchy/outfit/job/service
 	l_ear = /obj/item/device/radio/headset/headset_service
 	hierarchy_type = /decl/hierarchy/outfit/job/service

--- a/code/game/jobs/job/assistant.dm
+++ b/code/game/jobs/job/assistant.dm
@@ -12,9 +12,12 @@
 	access = list()			//See /datum/job/assistant/get_access()
 	minimal_access = list()	//See /datum/job/assistant/get_access()
 	outfit_type = /decl/hierarchy/outfit/job/assistant
-	alt_titles = list("Technical Assistant","Medical Intern","Research Assistant",
-					"Visitor" = /decl/hierarchy/outfit/job/assistant/visitor,
-					"Resident" = /decl/hierarchy/outfit/job/assistant/resident)
+	alt_titles = list(
+		"Technical Assistant",
+		"Medical Intern",
+		"Research Assistant",
+		"Visitor" = /decl/hierarchy/outfit/job/assistant/visitor
+	)
 
 /datum/job/assistant/get_access()
 	if(config.assistant_maint)

--- a/maps/northern_star/job/outfits.dm
+++ b/maps/northern_star/job/outfits.dm
@@ -1,0 +1,6 @@
+//Job Outfits
+
+/decl/hierarchy/outfit/job/assistant/resident
+	name = OUTFIT_JOB_NAME("Resident")
+	id_pda_assignment = "Resident"
+	uniform = /obj/item/clothing/under/color/white

--- a/maps/northern_star/northern_star.dm
+++ b/maps/northern_star/northern_star.dm
@@ -9,6 +9,8 @@
 	#include "northern_star_defines.dm"
 	#include "northern_star_areas.dm"
 	#include "northern_star_shuttles.dm"
+	#include "northern_star_jobs.dm"
+	#include "job/outfits.dm"
 
 	#define USING_MAP_DATUM /datum/map/northern_star
 

--- a/maps/northern_star/northern_star_defines.dm
+++ b/maps/northern_star/northern_star_defines.dm
@@ -27,7 +27,7 @@
 
 	shuttle_docked_message = "The scheduled shuttle to the %dock_name% has docked with the station at docks one and two. It will depart in approximately %ETD%."
 	shuttle_leaving_dock = "The Crew Transfer Shuttle has left the station. Estimate %ETA% until the shuttle docks at %dock_name%."
-	shuttle_called_message = "A crew transfer to %Dock_name% has been scheduled. The shuttle has been called. Those leaving should proceed to docks one and two in approximately %ETA%."
+	shuttle_called_message = "A crew transfer to %dock_name% has been scheduled. The shuttle has been called. Those leaving should proceed to docks one and two in approximately %ETA%."
 	shuttle_recall_message = "The scheduled crew transfer has been cancelled."
 	emergency_shuttle_docked_message = "The Emergency Shuttle has docked with the station at docks one and two. You have approximately %ETD% to board the Emergency Shuttle."
 	emergency_shuttle_leaving_dock = "The Emergency Shuttle has left the station. Estimate %ETA% until the shuttle docks at %dock_name%."

--- a/maps/northern_star/northern_star_jobs.dm
+++ b/maps/northern_star/northern_star_jobs.dm
@@ -1,0 +1,9 @@
+// Overrides the alt titles.
+/datum/job/assistant
+	alt_titles = list(
+		"Technical Assistant",
+		"Medical Intern",
+		"Research Assistant",
+		"Visitor" = /decl/hierarchy/outfit/job/assistant/visitor,
+		"Resident" = /decl/hierarchy/outfit/job/assistant/resident
+	)

--- a/maps/southern_cross/southern_cross_defines.dm
+++ b/maps/southern_cross/southern_cross_defines.dm
@@ -37,7 +37,7 @@
 
 	shuttle_docked_message = "The scheduled shuttle to the %dock_name% has docked with the station at docks one and two. It will depart in approximately %ETD%."
 	shuttle_leaving_dock = "The Crew Transfer Shuttle has left the station. Estimate %ETA% until the shuttle docks at %dock_name%."
-	shuttle_called_message = "A crew transfer to %Dock_name% has been scheduled. The shuttle has been called. Those leaving should proceed to docks one and two in approximately %ETA%."
+	shuttle_called_message = "A crew transfer to %dock_name% has been scheduled. The shuttle has been called. Those leaving should proceed to docks one and two in approximately %ETA%."
 	shuttle_recall_message = "The scheduled crew transfer has been cancelled."
 	emergency_shuttle_docked_message = "The Emergency Shuttle has docked with the station at docks one and two. You have approximately %ETD% to board the Emergency Shuttle."
 	emergency_shuttle_leaving_dock = "The Emergency Shuttle has left the station. Estimate %ETA% until the shuttle docks at %dock_name%."


### PR DESCRIPTION
This was planned to happen a very long time ago but nobody ever got around to it.
Still available for the Northern Star map, if anyone still uses that.
Also cleans up a thing in the shuttle called message.