### PR TITLE
Big Bugfix Bonanza

### DIFF
--- a/code/game/machinery/computer/camera.dm
+++ b/code/game/machinery/computer/camera.dm
@@ -248,7 +248,7 @@
 	icon_state = "television"
 	icon_keyboard = null
 	icon_screen = "detective_tv"
-	circuit = null
+	circuit = /obj/item/weapon/circuitboard/security/tv
 	light_color = "#3848B3"
 	light_power_on = 0.5
 

--- a/code/game/machinery/computer/medical.dm
+++ b/code/game/machinery/computer/medical.dm
@@ -553,4 +553,5 @@
 	icon_state = "laptop"
 	icon_keyboard = "laptop_key"
 	icon_screen = "medlaptop"
+	circuit = /obj/item/weapon/circuitboard/med_data/laptop
 	density = 0

--- a/code/game/machinery/recharger.dm
+++ b/code/game/machinery/recharger.dm
@@ -7,6 +7,7 @@ obj/machinery/recharger
 	use_power = 1
 	idle_power_usage = 4
 	active_power_usage = 40000	//40 kW
+	var/efficiency = 40000 //will provide the modified power rate when upgraded
 	var/obj/item/charging = null
 	var/list/allowed_devices = list(/obj/item/weapon/gun/energy, /obj/item/weapon/melee/baton, /obj/item/modular_computer, /obj/item/weapon/computer_hardware/battery_module, /obj/item/weapon/cell, /obj/item/device/flashlight, /obj/item/device/electronic_assembly, /obj/item/weapon/weldingtool/electric, /obj/item/ammo_magazine/smart, /obj/item/device/flash)
 	var/icon_state_charged = "recharger2"
@@ -68,6 +69,8 @@ obj/machinery/recharger
 		return
 	else if(default_deconstruction_crowbar(user, G))
 		return
+	else if(default_part_replacement(user, G))
+		return
 
 /obj/machinery/recharger/attack_hand(mob/user as mob)
 	if(istype(user,/mob/living/silicon))
@@ -95,7 +98,7 @@ obj/machinery/recharger
 			var/obj/item/modular_computer/C = charging
 			if(!C.battery_module.battery.fully_charged())
 				icon_state = icon_state_charging
-				C.battery_module.battery.give(active_power_usage*CELLRATE)
+				C.battery_module.battery.give(CELLRATE*efficiency)
 				update_use_power(2)
 			else
 				icon_state = icon_state_charged
@@ -105,7 +108,7 @@ obj/machinery/recharger
 			var/obj/item/weapon/computer_hardware/battery_module/BM = charging
 			if(!BM.battery.fully_charged())
 				icon_state = icon_state_charging
-				BM.battery.give(active_power_usage*CELLRATE)
+				BM.battery.give(CELLRATE*efficiency)
 				update_use_power(2)
 			else
 				icon_state = icon_state_charged
@@ -116,7 +119,7 @@ obj/machinery/recharger
 		if(istype(C))
 			if(!C.fully_charged())
 				icon_state = icon_state_charging
-				C.give(active_power_usage*CELLRATE)
+				C.give(CELLRATE*efficiency)
 				update_use_power(2)
 			else
 				icon_state = icon_state_charged
@@ -140,13 +143,20 @@ obj/machinery/recharger
 	else
 		icon_state = icon_state_idle
 
+/obj/machinery/recharger/RefreshParts()
+	var/E = 0
+	for(var/obj/item/weapon/stock_parts/capacitor/C in component_parts)
+		E += C.rating
+	efficiency = active_power_usage * (1+ (E - 1)*0.5)
+
 /obj/machinery/recharger/wallcharger
 	name = "wall recharger"
 	icon = 'icons/obj/stationobjs.dmi'
 	icon_state = "wrecharger0"
 	plane = TURF_PLANE
 	layer = ABOVE_TURF_LAYER
-	active_power_usage = 25000	//25 kW , It's more specialized than the standalone recharger (guns, batons, and flashlights only) so make it more powerful
+	active_power_usage = 60000	//50 kW , It's more specialized than the standalone recharger (guns, batons, and flashlights only) so make it more powerful
+	efficiency = 60000
 	allowed_devices = list(/obj/item/weapon/gun/energy, /obj/item/weapon/gun/magnetic, /obj/item/weapon/melee/baton, /obj/item/device/flashlight, /obj/item/weapon/cell/device)
 	icon_state_charged = "wrecharger2"
 	icon_state_charging = "wrecharger1"

--- a/code/game/machinery/recharger.dm
+++ b/code/game/machinery/recharger.dm
@@ -155,7 +155,7 @@ obj/machinery/recharger
 	icon_state = "wrecharger0"
 	plane = TURF_PLANE
 	layer = ABOVE_TURF_LAYER
-	active_power_usage = 60000	//50 kW , It's more specialized than the standalone recharger (guns, batons, and flashlights only) so make it more powerful
+	active_power_usage = 60000	//60 kW , It's more specialized than the standalone recharger (guns, batons, and flashlights only) so make it more powerful
 	efficiency = 60000
 	allowed_devices = list(/obj/item/weapon/gun/energy, /obj/item/weapon/gun/magnetic, /obj/item/weapon/melee/baton, /obj/item/device/flashlight, /obj/item/weapon/cell/device)
 	icon_state_charged = "wrecharger2"

--- a/code/game/mecha/equipment/tools/medical_tools.dm
+++ b/code/game/mecha/equipment/tools/medical_tools.dm
@@ -469,7 +469,8 @@
 				if(M)
 					S.icon_state = initial(S.icon_state)
 					S.icon = initial(S.icon)
-					S.reagents.trans_to_mob(M, S.reagents.total_volume, CHEM_BLOOD)
+					if(M.can_inject())
+						S.reagents.trans_to_mob(M, S.reagents.total_volume, CHEM_BLOOD)
 					M.take_organ_damage(2)
 					S.visible_message("<span class=\"attack\"> [M] was hit by the syringe!</span>")
 					break
@@ -619,7 +620,7 @@
 		if(R.reagent_state == 2 && add_known_reagent(R.id,R.name))
 			occupant_message("Reagent analyzed, identified as [R.name] and added to database.")
 			send_byjax(chassis.occupant,"msyringegun.browser","reagents_form",get_reagents_form())
-	occupant_message("Analyzis complete.")
+	occupant_message("Analysis complete.")
 	return 1
 
 /obj/item/mecha_parts/mecha_equipment/tool/syringe_gun/proc/add_known_reagent(r_id,r_name)

--- a/code/game/objects/items/weapons/circuitboards/computer/camera_monitor.dm
+++ b/code/game/objects/items/weapons/circuitboards/computer/camera_monitor.dm
@@ -14,6 +14,10 @@
 	..()
 	network = using_map.station_networks
 
+/obj/item/weapon/circuitboard/security/tv
+	name = T_BOARD("security camera monitor - television")
+	build_path = /obj/machinery/computer/security/wooden_tv
+
 /obj/item/weapon/circuitboard/security/engineering
 	name = T_BOARD("engineering camera monitor")
 	build_path = /obj/machinery/computer/security/engineering

--- a/code/game/objects/items/weapons/circuitboards/computer/computer.dm
+++ b/code/game/objects/items/weapons/circuitboards/computer/computer.dm
@@ -21,6 +21,10 @@
 	name = T_BOARD("medical records console")
 	build_path = /obj/machinery/computer/med_data
 
+/obj/item/weapon/circuitboard/med_data/laptop
+	name = T_BOARD("medical records laptop")
+	build_path = /obj/machinery/computer/med_data/laptop
+
 /obj/item/weapon/circuitboard/scan_consolenew
 	name = T_BOARD("DNA machine")
 	build_path = /obj/machinery/computer/scan_consolenew

--- a/code/modules/client/preferences_factions.dm
+++ b/code/modules/client/preferences_factions.dm
@@ -74,6 +74,7 @@ var/global/list/religion_choices = list(
 	"Singulitarian Worship",
 	"Xilar Qall",
 	"Tajr-kii Rarkajar",
+	"The Unity",
 	"Agnosticism",
 	"Deism"
 	)

--- a/code/modules/client/preferences_factions.dm
+++ b/code/modules/client/preferences_factions.dm
@@ -74,7 +74,6 @@ var/global/list/religion_choices = list(
 	"Singulitarian Worship",
 	"Xilar Qall",
 	"Tajr-kii Rarkajar",
-	"The Unity",
 	"Agnosticism",
 	"Deism"
 	)

--- a/code/modules/clothing/spacesuits/miscellaneous.dm
+++ b/code/modules/clothing/spacesuits/miscellaneous.dm
@@ -17,7 +17,7 @@
 	gas_transfer_coefficient = 0.01
 	permeability_coefficient = 0.02
 	item_flags = 0
-	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|FEET|ARMS
+	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|FEET|ARMS|HANDS
 	allowed = list(/obj/item/weapon/tank/emergency/oxygen, /obj/item/device/flashlight,/obj/item/weapon/gun/energy, /obj/item/weapon/gun/projectile, /obj/item/ammo_magazine, /obj/item/ammo_casing, /obj/item/weapon/melee/baton,/obj/item/weapon/handcuffs)
 	slowdown = 1.5
 	armor = list(melee = 65, bullet = 50, laser = 50, energy = 25, bomb = 50, bio = 100, rad = 50)

--- a/code/modules/clothing/spacesuits/void/zaddat.dm
+++ b/code/modules/clothing/spacesuits/void/zaddat.dm
@@ -42,6 +42,7 @@
 	switch(suit_style)
 		if("Engineer")
 			name = "\improper Engineer's Guild Shroud"
+			base_name = "\improper Engineer's Guild Shroud"
 			desc = "This rugged Shroud was created by the Xozi Engineering Guild."
 			icon_state = "zaddat_engie"
 			item_state = "zaddat_engie"
@@ -52,6 +53,7 @@
 				helmet.item_state = "zaddat_engie"
 		if("Spacer")
 			name = "\improper Spacer's Guild Shroud"
+			base_name = "\improper Spacer's Guild Shroud"
 			desc = "The blue plastic Shroud worn by members of the Zaddat Spacer's Guild."
 			icon_state = "zaddat_spacer"
 			item_state = "zaddat_spacer"
@@ -62,6 +64,7 @@
 				helmet.item_state = "zaddat_spacer"
 		if("Knight")
 			name = "\improper Knight's Shroud"
+			base_name = "\improper Knight's Shroud"
 			desc = "This distinctive steel-plated Shroud was popularized by the Noble Guild."
 			icon_state = "zaddat_knight"
 			item_state = "zaddat_knight"
@@ -72,6 +75,7 @@
 				helmet.item_state = "zaddat_knight"
 		if("Fashion")
 			name = "\improper Avazi House Shroud"
+			base_name = "\improper Avazi House Shroud"
 			desc = "The designers of the Avazi Fashion House are among the most renowned in Zaddat society, and their Shroud designs second to none."
 			icon_state = "zaddat_fashion"
 			item_state = "zaddat_fashion"
@@ -82,6 +86,7 @@
 				helmet.item_state = "zaddat_fashion"
 		if("Bishop")
 			name = "\improper Bishop-patterned Shroud"
+			base_name = "\improper Bishop-patterned Shroud"
 			desc = "The bold designers of the Dzaz Fashion House chose to make this Bishop-themed Shroud design as a commentary on the symbiotic nature of Vanax and human culture. Allegedly."
 			icon_state = "zaddat_bishop"
 			item_state = "zaddat_bishop"
@@ -92,6 +97,7 @@
 				helmet.item_state = "zaddat_bishop"
 		if("Rugged")
 			name = "rugged Shroud"
+			base_name = "rugged Shroud"
 			desc = "This Shroud was patterned after from First Contact era human voidsuits."
 			icon_state = "zaddat_rugged"
 			item_state = "zaddat_rugged"

--- a/code/modules/mob/living/bot/secbot.dm
+++ b/code/modules/mob/living/bot/secbot.dm
@@ -128,7 +128,7 @@
 /mob/living/bot/secbot/attackby(var/obj/item/O, var/mob/user)
 	var/curhealth = health
 	. = ..()
-	if(health < curhealth)
+	if(health < curhealth && on == 1)
 		react_to_attack(user)
 
 /mob/living/bot/secbot/bullet_act(var/obj/item/projectile/P)

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -18,6 +18,8 @@
 		if(!temp || !temp.is_usable())
 			H << "<font color='red'>You can't use your hand.</font>"
 			return
+	if(H.lying)
+		return
 	M.break_cloak()
 
 	..()
@@ -91,7 +93,7 @@
 				spawn(30)
 					cpr_time = 1
 
-				H.visible_message("<span class='danger'>\The [H] is trying perform CPR on \the [src]!</span>")
+				H.visible_message("<span class='danger'>\The [H] is trying to perform CPR on \the [src]!</span>")
 
 				if(!do_after(H, 30))
 					return
@@ -121,6 +123,7 @@
 			var/obj/item/weapon/grab/G = new /obj/item/weapon/grab(M, src)
 			if(buckled)
 				M << "<span class='notice'>You cannot grab [src], [TT.he] is buckled in!</span>"
+				return
 			if(!G)	//the grab will delete itself in New if affecting is anchored
 				return
 			M.put_in_active_hand(G)

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -936,6 +936,13 @@ Note that amputating the affected organ does in fact remove the infection from t
 
 			qdel(src)
 
+	if(victim.l_hand)
+		if(istype(victim.l_hand,/obj/item/weapon/material/twohanded)) //if they're holding a two-handed weapon, drop it now they've lost a hand
+			victim.l_hand.update_held_icon()
+	if(victim.r_hand)
+		if(istype(victim.r_hand,/obj/item/weapon/material/twohanded))
+			victim.r_hand.update_held_icon()
+
 /****************************************************
 			   HELPERS
 ****************************************************/

--- a/html/changelogs/mistyLuminescence - bugfix.yml
+++ b/html/changelogs/mistyLuminescence - bugfix.yml
@@ -40,4 +40,3 @@ changes:
   - rscfix: Rechargers now correctly benefit from upgraded capacitors.
   - rscfix: Medical record laptops and detective TV camera consoles no longer turn into regular consoles when de- and re-constructed.
   - rscfix: Zaddat Shrouds now retain their base name when damaged, if the shroud has been customized.
-  - rscfix: The Unity has been added to the religion list.

--- a/html/changelogs/mistyLuminescence - bugfix.yml
+++ b/html/changelogs/mistyLuminescence - bugfix.yml
@@ -1,0 +1,43 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: mistyLuminescence
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscfix: Prone people can no longer interact with an empty hand.
+  - rscfix: Two-handed items are now correctly unwielded when the user's offhand is severed.
+  - rscfix: Mecha syringe guns now respect pierceproof clothing.
+  - rscfix: Securitrons now correctly ignore attacks when disabled.
+  - rscfix: Rechargers now correctly benefit from upgraded capacitors.
+  - rscfix: Medical record laptops and detective TV camera consoles no longer turn into regular consoles when de- and re-constructed.
+  - rscfix: Zaddat Shrouds now retain their base name when damaged, if the shroud has been customized.
+  - rscfix: The Unity has been added to the religion list.

--- a/html/changelogs/mistyLuminescence - bugfix.yml
+++ b/html/changelogs/mistyLuminescence - bugfix.yml
@@ -33,10 +33,10 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes: 
-  - rscfix: Prone people can no longer interact with an empty hand.
-  - rscfix: Two-handed items are now correctly unwielded when the user's offhand is severed.
-  - rscfix: Mecha syringe guns now respect pierceproof clothing.
-  - rscfix: Securitrons now correctly ignore attacks when disabled.
-  - rscfix: Rechargers now correctly benefit from upgraded capacitors.
-  - rscfix: Medical record laptops and detective TV camera consoles no longer turn into regular consoles when de- and re-constructed.
-  - rscfix: Zaddat Shrouds now retain their base name when damaged, if the shroud has been customized.
+  - bugfix: Prone people can no longer interact with an empty hand.
+  - bugfix: Two-handed items are now correctly unwielded when the user's offhand is severed.
+  - bugfix: Mecha syringe guns now respect pierceproof clothing.
+  - bugfix: Securitrons now correctly ignore attacks when disabled.
+  - bugfix: Rechargers now correctly benefit from upgraded capacitors.
+  - bugfix: Medical record laptops and detective TV camera consoles no longer turn into regular consoles when de- and re-constructed.
+  - bugfix: Zaddat Shrouds now retain their base name when damaged, if the shroud has been customized.


### PR DESCRIPTION
Been a while since I've been here! Have some bugfixes (and bug closes!).

Fixes #380 - prone people can no longer interact with an empty hand.
Fixes #658 - now checks for two-handed items on limb loss.
Fixes #1048 - mecha syringe guns now respect pierceproof clothing.
Fixes #3318 - securitrons will only react to being attacked when active.
Fixes #3386 - rechargers now benefit from upgraded capacitors.
Fixes #5434 - adds a subtype of medical records (and detective TV) computers.
Fixes #5948 - shrouds now retain their base name when damaged.

Closes #896 - unable to reproduce.
Closes #1065 - unable to reproduce.
Closes #1370 - unable to reproduce.
Closes #1754 - unable to reproduce.
Closes #1829 - fixed a while back, but never closed. Whoops.
Closes #2027 - unable to reproduce.
Closes #6015 - unable to reproduce.
Closes #6062 - intentional (see Cerebulon's comment below).