### PR TITLE
Phase Weaponry - Energy-->Beam

### DIFF
--- a/code/game/mecha/equipment/weapons/weapons.dm
+++ b/code/game/mecha/equipment/weapons/weapons.dm
@@ -161,7 +161,7 @@
 	description_fluff = "Essentially an Orion mounted inside a modified Gaia case."
 	icon_state = "mecha_phase"
 	energy_drain = 25
-	projectile = /obj/item/projectile/energy/phase/heavy
+	projectile = /obj/item/projectile/beam/phase/heavy
 	fire_sound = 'sound/weapons/Taser.ogg'
 
 	equip_type = EQUIP_UTILITY

--- a/code/modules/projectiles/guns/energy/phase.dm
+++ b/code/modules/projectiles/guns/energy/phase.dm
@@ -8,7 +8,7 @@
 	wielded_item_state = "phasecarbine-wielded"
 	slot_flags = SLOT_BACK|SLOT_BELT
 	charge_cost = 240
-	projectile_type = /obj/item/projectile/energy/phase
+	projectile_type = /obj/item/projectile/beam/phase
 	one_handed_penalty = 15
 
 /obj/item/weapon/gun/energy/phasegun/pistol
@@ -19,7 +19,7 @@
 	w_class = ITEMSIZE_NORMAL
 	slot_flags = SLOT_BELT|SLOT_HOLSTER
 	charge_cost = 300
-	projectile_type = /obj/item/projectile/energy/phase/light
+	projectile_type = /obj/item/projectile/beam/phase/light
 	one_handed_penalty = 0
 
 /obj/item/weapon/gun/energy/phasegun/pistol/mounted
@@ -40,7 +40,7 @@ obj/item/weapon/gun/energy/phasegun/rifle
 	w_class = ITEMSIZE_LARGE
 	slot_flags = SLOT_BACK
 	charge_cost = 150
-	projectile_type = /obj/item/projectile/energy/phase/heavy
+	projectile_type = /obj/item/projectile/beam/phase/heavy
 	accuracy = 15
 	one_handed_penalty = 30
 
@@ -53,6 +53,6 @@ obj/item/weapon/gun/energy/phasegun/rifle
 	w_class = ITEMSIZE_HUGE		// This thing is big.
 	slot_flags = SLOT_BACK
 	charge_cost = 100
-	projectile_type = /obj/item/projectile/energy/phase/heavy/cannon
+	projectile_type = /obj/item/projectile/beam/phase/heavy/cannon
 	accuracy = 15
 	one_handed_penalty = 65

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -223,3 +223,28 @@
 	name = "stun beam"
 	icon_state = "stun"
 	agony = 30
+
+/obj/item/projectile/beam/phase
+	name = "phase wave"
+	icon_state = "gauss"
+	fire_sound = 'sound/weapons/Taser.ogg'
+	damage = 5
+	SA_bonus_damage = 45	// 50 total on animals
+	SA_vulnerability = SA_ANIMAL
+	light_color = "#FFFFFF"
+
+	combustion = FALSE
+
+	muzzle_type = /obj/effect/projectile/muzzle/stun
+	tracer_type = /obj/effect/projectile/tracer/stun
+	impact_type = /obj/effect/projectile/impact/stun
+
+/obj/item/projectile/beam/phase/light
+	SA_bonus_damage = 35	// 40 total on animals
+
+/obj/item/projectile/beam/phase/heavy
+	SA_bonus_damage = 55	// 60 total on animals
+
+/obj/item/projectile/beam/phase/heavy/cannon
+	damage = 15
+	SA_bonus_damage = 60	// 75 total on animals

--- a/code/modules/projectiles/projectile/energy.dm
+++ b/code/modules/projectiles/projectile/energy.dm
@@ -213,24 +213,3 @@
 
 	embed_chance = 0
 	muzzle_type = /obj/effect/projectile/muzzle/pulse
-
-/obj/item/projectile/energy/phase
-	name = "phase wave"
-	icon_state = "phase"
-	range = 6
-	damage = 5
-	SA_bonus_damage = 45	// 50 total on animals
-	SA_vulnerability = SA_ANIMAL
-
-/obj/item/projectile/energy/phase/light
-	range = 4
-	SA_bonus_damage = 35	// 40 total on animals
-
-/obj/item/projectile/energy/phase/heavy
-	range = 8
-	SA_bonus_damage = 55	// 60 total on animals
-
-/obj/item/projectile/energy/phase/heavy/cannon
-	range = 10
-	damage = 15
-	SA_bonus_damage = 60	// 75 total on animals

--- a/html/changelogs/mistyLuminescence - phaserlasers.yml
+++ b/html/changelogs/mistyLuminescence - phaserlasers.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: mistyLuminescence
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rsctweak: "Due to recent advances in phase technology, all NT-issued phase weapons now fire a beam of energy rather than a single projectile."


### PR DESCRIPTION
Previously: phase weaponry fired energy projectiles, similar to that of the stun revolver, which would impact against windows.
Now: phase weaponry fires beam projectiles, similar to that of the taser, which passes through windows and leaves a visible trail.

You wanna use windows tactically to Not Die on Sif? Go for it.
You wanna not have to break into the Armory every time there's space carp and no Warden/HoS? Sure.
You wanna know where your explorer buddy is shooting so you can join in? Absolutely.
You wanna get your ass handed to you by the Sif wildlife because it won't save you in the slightest? Yep.

The biggest implication of this change is that, like tasers, phasers can now be fired through windows. This means more tactical and engaging explorer gameplay (hey, you can now use windows as cover!), the ability to take out space carp when there's nobody with Armory access, and probably Ian being shot a little more by antags. Sorry, Ian, it's for the greater good.

That's really all there is to it! Minor change, but a welcome one, I think. (You'll still get shredded by spiders, though.)