### PR TITLE
Makeover Kit

### DIFF
--- a/code/datums/supplypacks/contraband.dm
+++ b/code/datums/supplypacks/contraband.dm
@@ -88,7 +88,8 @@
 					/obj/item/weapon/storage/box/syndie_kit/chameleon,
 					/obj/item/device/encryptionkey/syndicate,
 					/obj/item/weapon/card/id/syndicate,
-					/obj/item/clothing/mask/gas/voice
+					/obj/item/clothing/mask/gas/voice,
+					/obj/item/weapon/makeover
 					),
 			list( //the professional,
 					/obj/item/weapon/gun/projectile/silenced,

--- a/code/datums/uplink/stealth_items.dm
+++ b/code/datums/uplink/stealth_items.dm
@@ -33,3 +33,8 @@
 	name = "Voice Changer"
 	item_cost = 15
 	path = /obj/item/clothing/mask/gas/voice
+
+/datum/uplink_item/item/stealth_items/makeover
+	name = "Makeover Kit"
+	item_cost = 5
+	path = /obj/item/weapon/makeover

--- a/code/game/objects/items/weapons/cosmetics.dm
+++ b/code/game/objects/items/weapons/cosmetics.dm
@@ -88,3 +88,25 @@
 			if(FEMALE)
 				text = "lady"
 	user.visible_message("<span class='notice'>[user] uses [src] to comb their hair with incredible style and sophistication. What a [text].</span>")
+
+/obj/item/weapon/makeover
+	name = "makeover kit"
+	desc = "A tiny case containing a mirror and some contact lenses."
+	w_class = ITEMSIZE_TINY
+	icon = 'icons/obj/items.dmi'
+	icon_state = "trinketbox"
+	var/list/ui_users = list()
+
+/obj/item/weapon/makeover/attack_self(mob/living/carbon/user as mob)
+	if(ishuman(user))
+		to_chat(user, "<span class='notice'>You flip open \the [src] and begin to adjust your appearance.</span>")
+		var/datum/nano_module/appearance_changer/AC = ui_users[user]
+		if(!AC)
+			AC = new(src, user)
+			AC.name = "SalonPro Porta-Makeover Deluxe&trade;"
+			ui_users[user] = AC
+		AC.ui_interact(user)
+		var/mob/living/carbon/human/H = user
+		var/obj/item/organ/internal/eyes/E = H.internal_organs_by_name[O_EYES]
+		if(istype(E))
+			E.change_eye_color()

--- a/code/game/objects/items/weapons/storage/wallets.dm
+++ b/code/game/objects/items/weapons/storage/wallets.dm
@@ -35,7 +35,8 @@
 		/obj/item/weapon/tool/screwdriver,
 		/obj/item/weapon/stamp,
 		/obj/item/clothing/accessory/permit,
-		/obj/item/clothing/accessory/badge
+		/obj/item/clothing/accessory/badge,
+		/obj/item/weapon/makeover
 		)
 	cant_hold = list(/obj/item/weapon/tool/screwdriver/power)
 	slot_flags = SLOT_ID

--- a/code/modules/client/preference_setup/loadout/loadout_cosmetics.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_cosmetics.dm
@@ -1,7 +1,3 @@
-/datum/gear/cosmetic/makeover
-	display_name = "makeover kit"
-	path = /obj/item/weapon/makeover
-
 /datum/gear/cosmetic/lipstick/black
 	display_name = "lipstick, black"
 	path = /obj/item/weapon/lipstick/black

--- a/code/modules/client/preference_setup/loadout/loadout_cosmetics.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_cosmetics.dm
@@ -1,3 +1,7 @@
+/datum/gear/cosmetic/makeover
+	display_name = "makeover kit"
+	path = /obj/item/weapon/makeover
+
 /datum/gear/cosmetic/lipstick/black
 	display_name = "lipstick, black"
 	path = /obj/item/weapon/lipstick/black

--- a/html/changelogs/mistyLuminescence - makeover.yml
+++ b/html/changelogs/mistyLuminescence - makeover.yml
@@ -33,4 +33,4 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes: 
-  - rscadd: "Adds the makeover kit to the loadout for 1 point. Makeover kits can be used to change the user's hair style and color, and eye color."
+  - rscadd: "Adds the makeover kit to the traitor uplink for 5 TC, also available in the Infiltrator bundle null crate in Cargo. Makeover kits can be used to change the user's hair style and color, and eye color."

--- a/html/changelogs/mistyLuminescence - makeover.yml
+++ b/html/changelogs/mistyLuminescence - makeover.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: mistyLuminescence
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Adds the makeover kit to the loadout for 1 point. Makeover kits can be used to change the user's hair style and color, and eye color."


### PR DESCRIPTION
Adds the makeover kit to the traitor uplink (5 TC) and infiltrator null crate bundle. It's a tiny box with a mirror and some contact lenses inside, for styling your hair and changing your eye color. Pretty good for disguises too, if you can duck into a side room and give yourself a magenta floor-length braid and bright red eyes before Security catches you.

Does *not* change fur or scales color for nonhuman races- it's just the hair and eyes.