### PR TITLE
Fixes some Precursotech oversights.

### DIFF
--- a/code/game/objects/random/misc.dm
+++ b/code/game/objects/random/misc.dm
@@ -520,3 +520,12 @@
 				/obj/item/weapon/cigbutt,
 				/obj/item/weapon/cigbutt/cigarbutt,
 				/obj/effect/decal/remains/mouse)
+
+/obj/random/janusmodule
+	name = "random janus circuit"
+	desc = "A random (possibly broken) Janus module."
+	icon = 'icons/obj/abductor.dmi'
+	icon_state = "circuit_damaged"
+
+/obj/random/janusmodule/item_to_spawn()
+	return pick(subtypesof(/obj/item/weapon/circuitboard/mecha/imperion))

--- a/code/modules/materials/material_sheets.dm
+++ b/code/modules/materials/material_sheets.dm
@@ -275,6 +275,8 @@
 	return
 
 /obj/item/stack/material/supermatter/attack_hand(mob/user)
+	. = ..()
+
 	update_mass()
 	radiation_repository.radiate(src, 5 + amount)
 	var/mob/living/M = user

--- a/code/modules/research/designs/precursor.dm
+++ b/code/modules/research/designs/precursor.dm
@@ -58,6 +58,15 @@
 	build_path = /obj/item/weapon/weldingtool/experimental/hybrid
 	sort_string = "PATCW"
 
+/datum/design/item/precursor/janusmodule
+	name = "Blackbox Circuit Datamass"
+	desc = "A design that seems to be in a constantly shifting superposition."
+	id = "janus_module"
+	materials = list(MAT_DURASTEEL = 3000, MAT_MORPHIUM = 2000, MAT_METALHYDROGEN = 6000, MAT_URANIUM = 6000, MAT_VERDANTIUM = 1500)
+	req_tech = list(TECH_MATERIAL = 7, TECH_BLUESPACE = 5, TECH_MAGNET = 6, TECH_PHORON = 3, TECH_ARCANE = 1, TECH_PRECURSOR = 2)
+	build_path = /obj/random/janusmodule
+	sort_string = "PAJAA"
+
 /datum/design/item/anomaly/AssembleDesignName()
 	..()
 	name = "Anomalous prototype ([item_name])"


### PR DESCRIPTION
- Janus modules can now be built, though due to Q U A N T U M   B U L L S H I T  E X P L O I T A T I O N, you can't guarantee which one you'll build. These machines aren't made for inherent 4th dimensions.

- Supermatter chunks can be picked up.