### PR TITLE
Allows supplypacks with req_one_access to exist

### DIFF
--- a/code/controllers/Processes/supply.dm
+++ b/code/controllers/Processes/supply.dm
@@ -224,8 +224,12 @@ var/datum/controller/supply/supply_controller = new()
 		if(SP.access)
 			if(isnum(SP.access))
 				A.req_access = list(SP.access)
-			else if(islist(SP.access))
+			else if(islist(SP.access) && SP.one_access)
 				var/list/L = SP.access // access var is a plain var, we need a list
+				A.req_one_access = L.Copy()
+				A.req_access.Cut()
+			else if(islist(SP.access) && !SP.one_access)
+				var/list/L = SP.access
 				A.req_access = L.Copy()
 			else
 				log_debug("<span class='danger'>Supply pack with invalid access restriction [SP.access] encountered!</span>")

--- a/code/datums/supplypacks/supplypacks.dm
+++ b/code/datums/supplypacks/supplypacks.dm
@@ -33,6 +33,7 @@ var/list/all_supply_groups = list("Atmospherics",
 	var/containertype = null
 	var/containername = null
 	var/access = null
+	var/one_access = FALSE
 	var/contraband = 0
 	var/num_contained = 0		//number of items picked to be contained in a /randomised crate
 	var/group = "Miscellaneous"


### PR DESCRIPTION
Basically adds an option for supplypacks to use req_one_access instead of just req_access if the access defined is a list. Unused for now, but good to have to leave options open for the future (or downstreams)