### PR TITLE
Prevents amber slime feeding from healing slimes

### DIFF
--- a/code/modules/mob/living/simple_mob/subtypes/slime/xenobio/consumption.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/slime/xenobio/consumption.dm
@@ -1,7 +1,7 @@
 // Handles hunger, starvation, growth, and eatting humans.
 
 // Might be best to make this a /mob/living proc and override.
-/mob/living/simple_mob/slime/xenobio/proc/adjust_nutrition(input)
+/mob/living/simple_mob/slime/xenobio/proc/adjust_nutrition(input, var/heal = 1)
 	nutrition = between(0, nutrition + input, get_max_nutrition())
 
 	if(input > 0)
@@ -12,11 +12,12 @@
 				adjustToxLoss(-10)
 
 		// Heal 1 point of damage per 5 nutrition coming in.
-		adjustBruteLoss(-input * 0.2)
-		adjustFireLoss(-input * 0.2)
-		adjustToxLoss(-input * 0.2)
-		adjustOxyLoss(-input * 0.2)
-		adjustCloneLoss(-input * 0.2)
+		if(heal)
+			adjustBruteLoss(-input * 0.2)
+			adjustFireLoss(-input * 0.2)
+			adjustToxLoss(-input * 0.2)
+			adjustOxyLoss(-input * 0.2)
+			adjustCloneLoss(-input * 0.2)
 
 
 /mob/living/simple_mob/slime/xenobio/proc/get_max_nutrition() // Can't go above it

--- a/code/modules/mob/living/simple_mob/subtypes/slime/xenobio/subtypes.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/slime/xenobio/subtypes.dm
@@ -450,7 +450,7 @@
 			continue
 		if(istype(L, /mob/living/simple_mob/slime/xenobio))
 			var/mob/living/simple_mob/slime/xenobio/X = L
-			X.adjust_nutrition(rand(15, 25))
+			X.adjust_nutrition(rand(15, 25), 0)
 		if(ishuman(L))
 			var/mob/living/carbon/human/H = L
 			if(H.isSynthetic())


### PR DESCRIPTION
What it says. Any form of feeding heals slimes.. But when ambers overload, dealing with them becomes nearly impossible as they can outheal anything that is not instakill if they occupy big enough area, simply with sheer numbers.

This basically makes Amber effect more fair and balanced.