### PR TITLE
Infinite Frame Fixy

### DIFF
--- a/code/game/machinery/exonet_node.dm
+++ b/code/game/machinery/exonet_node.dm
@@ -16,6 +16,8 @@
 
 	var/list/logs = list() // Gets written to by exonet's send_message() function.
 
+//TFF 3/6/19 - Port Cit RP fix for infinite frames
+	circuit = /obj/item/weapon/circuitboard/telecomms/exonet_node
 // Proc: New()
 // Parameters: None
 // Description: Adds components to the machine for deconstruction.
@@ -23,7 +25,6 @@
 	..()
 
 	component_parts = list()
-	component_parts += new /obj/item/weapon/circuitboard/telecomms/exonet_node(src)
 	component_parts += new /obj/item/weapon/stock_parts/subspace/ansible(src)
 	component_parts += new /obj/item/weapon/stock_parts/subspace/sub_filter(src)
 	component_parts += new /obj/item/weapon/stock_parts/manipulator(src)

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -408,6 +408,9 @@ Class Procs:
 
 /obj/machinery/proc/dismantle()
 	playsound(src.loc, 'sound/items/Crowbar.ogg', 50, 1)
+	//TFF 3/6/19 - port Cit RP fix of infinite frames. If it doesn't have a circuit board, don't create a frame. Return a smack instead. BONK!
+	if(!circuit)
+		return 0
 	var/obj/structure/frame/A = new /obj/structure/frame(src.loc)
 	var/obj/item/weapon/circuitboard/M = circuit
 	A.circuit = M
@@ -451,4 +454,4 @@ Class Procs:
 	return
 
 /datum/proc/remove_visual(mob/M)
-	return 
+	return

--- a/code/modules/hydroponics/seed_machines.dm
+++ b/code/modules/hydroponics/seed_machines.dm
@@ -94,10 +94,16 @@
 			to_chat(user, "You load [W] into [src].")
 		return
 
+//TFF 3/6/19 - fix infinite frame creation, ported from Cit RP - also allow movement of hydroponic-related machines.
 	if(default_deconstruction_screwdriver(user, W))
 		return
-	if(default_deconstruction_crowbar(user, W))
+	if(W.is_wrench())
+		playsound(src, W.usesound, 100, 1)
+		to_chat(user, "<span class='notice'>You [anchored ? "un" : ""]secure \the [src].</span>")
+		anchored = !anchored
 		return
+//	if(default_deconstruction_crowbar(user, W))	//No circuit boards to give.
+//		return
 	if(istype(W,/obj/item/weapon/disk/botany))
 		if(loaded_disk)
 			to_chat(user, "There is already a data disk loaded.")

--- a/code/modules/power/tesla/coil.dm
+++ b/code/modules/power/tesla/coil.dm
@@ -95,6 +95,7 @@
 	playsound(src.loc, 'sound/effects/lightningshock.ogg', 100, 1, extrarange = 5)
 	tesla_zap(src, 10, power/(coeff/2))
 
+//TFF 3/6/19 - Port Cit RP fix for infinite frames
 /obj/machinery/power/grounding_rod
 	name = "grounding rod"
 	desc = "Keep an area from being fried from Edison's Bane."
@@ -105,6 +106,7 @@
 
 	can_buckle = TRUE
 	buckle_lying = FALSE
+	circuit = /obj/item/weapon/circuitboard/grounding_rod
 
 /obj/machinery/power/grounding_rod/pre_mapped
 	anchored = TRUE

--- a/html/changelogs/TheFurryFeline - Infinite Frame Fixy.yml
+++ b/html/changelogs/TheFurryFeline - Infinite Frame Fixy.yml
@@ -1,0 +1,37 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: TheFurryFeline
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Fixes infinite frame production for some machinery objects such as grounding rods or exonet nodes. If there's no available circuit board to get, then don't return anything when attempting deconstruction. Ported from Cit RP. Eliminates 'Cannot read null.board_type' runtimes where they apply."
+  - tweak: "Allows hydroponic machines to be unwrenched."


### PR DESCRIPTION
On the tin: fixes production of infinite frames by porting https://github.com/Citadel-Station-13/Citadel-Station-13-RP/pull/855. This also eliminates the given runtimes of being unable to read a board type if it wasn't given for the machine object. Additionally allows machines related to Hydroponics to be unwrenched while refusing to create frames when crowbar'd, returning a whack instead. Tested and it works.