### PR TITLE
Energy-Swords and Changeling Melee Weapons Can Deflect Projectiles

### DIFF
--- a/code/game/gamemodes/changeling/powers/armblade.dm
+++ b/code/game/gamemodes/changeling/powers/armblade.dm
@@ -32,7 +32,7 @@
 	genomecost = 1
 	verbpath = /mob/proc/changeling_claw
 
-//Grows a scary, and powerful arm blade.
+//Grows a scary, and powerful claw.
 /mob/proc/changeling_claw()
 	set category = "Changeling"
 	set name = "Claw (15)"
@@ -61,6 +61,9 @@
 	var/mob/living/creator //This is just like ninja swords, needed to make sure dumb shit that removes the sword doesn't make it stay around.
 	var/weapType = "weapon"
 	var/weapLocation = "arm"
+
+	var/defend_chance = 30	// The base chance for the weapon to parry.
+	var/projectile_parry_chance = 15	// The base chance for a projectile to be deflected.
 
 /obj/item/weapon/melee/changeling/New(location)
 	..()
@@ -107,6 +110,28 @@
 			if(src)
 				qdel(src)
 
+/obj/item/weapon/melee/changeling/handle_shield(mob/user, var/damage, atom/damage_source = null, mob/attacker = null, var/def_zone = null, var/attack_text = "the attack")
+	if(default_parry_check(user, attacker, damage_source) && prob(defend_chance))
+		user.visible_message("<span class='danger'>\The [user] parries [attack_text] with \the [src]!</span>")
+		playsound(user.loc, 'sound/weapons/slash.ogg', 50, 1)
+		return 1
+	if(unique_parry_check(user, attacker, damage_source) && prob(projectile_parry_chance))
+		user.visible_message("<span class='danger'>\The [user] deflects [attack_text] with \the [src]!</span>")
+		playsound(user.loc, 'sound/weapons/slash.ogg', 50, 1)
+		return 1
+
+	return 0
+
+/obj/item/weapon/melee/changeling/unique_parry_check(mob/user, mob/attacker, atom/damage_source)
+	if(user.incapacitated() || !istype(damage_source, /obj/item/projectile))
+		return 0
+
+	var/bad_arc = reverse_direction(user.dir)
+	if(!check_shield_arc(user, bad_arc, damage_source, attacker))
+		return 0
+
+	return 1
+
 /obj/item/weapon/melee/changeling/arm_blade
 	name = "arm blade"
 	desc = "A grotesque blade made out of bone and flesh that cleaves through people as a hot knife through butter."
@@ -117,11 +142,15 @@
 	edge = 1
 	pry = 1
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
+	defend_chance = 60
+	projectile_parry_chance = 45
 
 /obj/item/weapon/melee/changeling/arm_blade/greater
 	name = "arm greatblade"
 	desc = "A grotesque blade made out of bone and flesh that cleaves through people and armor as a hot knife through butter."
 	armor_penetration = 30
+	defend_chance = 70
+	projectile_parry_chance = 60
 
 /obj/item/weapon/melee/changeling/claw
 	name = "hand claw"
@@ -131,9 +160,13 @@
 	sharp = 1
 	edge = 1
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
+	defend_chance = 50
+	projectile_parry_chance = 30
 
 /obj/item/weapon/melee/changeling/claw/greater
 	name = "hand greatclaw"
 	force = 20
 	armor_penetration = 20
 	pry = 1
+	defend_chance = 60
+	projectile_parry_chance = 50

--- a/code/game/objects/items/weapons/material/swords.dm
+++ b/code/game/objects/items/weapons/material/swords.dm
@@ -11,8 +11,7 @@
 	hitsound = 'sound/weapons/bladeslice.ogg'
 
 /obj/item/weapon/material/sword/handle_shield(mob/user, var/damage, atom/damage_source = null, mob/attacker = null, var/def_zone = null, var/attack_text = "the attack")
-	
-	if(default_parry_check(user, attacker, damage_source) && prob(50))
+	if(unique_parry_check(user, attacker, damage_source) && prob(50))
 		user.visible_message("<span class='danger'>\The [user] parries [attack_text] with \the [src]!</span>")
 		playsound(user.loc, 'sound/weapons/punchmiss.ogg', 50, 1)
 		return 1

--- a/code/game/objects/items/weapons/melee/energy.dm
+++ b/code/game/objects/items/weapons/melee/energy.dm
@@ -127,6 +127,8 @@
 	var/random_color = TRUE
 	var/active_state = "sword"
 
+	var/projectile_parry_chance = 65
+
 /obj/item/weapon/melee/energy/sword/dropped(var/mob/user)
 	..()
 	if(!istype(loc,/mob))
@@ -173,7 +175,7 @@
 	icon_state = initial(icon_state)
 
 /obj/item/weapon/melee/energy/sword/handle_shield(mob/user, var/damage, atom/damage_source = null, mob/attacker = null, var/def_zone = null, var/attack_text = "the attack")
-	if(active && default_parry_check(user, attacker, damage_source) && prob(50))
+	if(active && default_parry_check(user, attacker, damage_source) && prob(60))
 		user.visible_message("<span class='danger'>\The [user] parries [attack_text] with \the [src]!</span>")
 
 		var/datum/effect/effect/system/spark_spread/spark_system = new /datum/effect/effect/system/spark_spread()
@@ -181,7 +183,26 @@
 		spark_system.start()
 		playsound(user.loc, 'sound/weapons/blade1.ogg', 50, 1)
 		return 1
+	if(active && unique_parry_check(user, attacker, damage_source) && prob(projectile_parry_chance))
+		user.visible_message("<span class='danger'>\The [user] deflects [attack_text] with \the [src]!</span>")
+
+		var/datum/effect/effect/system/spark_spread/spark_system = new /datum/effect/effect/system/spark_spread()
+		spark_system.set_up(5, 0, user.loc)
+		spark_system.start()
+		playsound(user.loc, 'sound/weapons/blade1.ogg', 50, 1)
+		return 1
+
 	return 0
+
+/obj/item/weapon/melee/energy/sword/unique_parry_check(mob/user, mob/attacker, atom/damage_source)
+	if(user.incapacitated() || !istype(damage_source, /obj/item/projectile/))
+		return 0
+
+	var/bad_arc = reverse_direction(user.dir)
+	if(!check_shield_arc(user, bad_arc, damage_source, attacker))
+		return 0
+
+	return 1
 
 /obj/item/weapon/melee/energy/sword/pirate
 	name = "energy cutlass"
@@ -215,6 +236,7 @@
 	lpower = 2
 	lcolor = "#0000FF"
 	active_state = "ionic_rapier"
+	projectile_parry_chance = 30	// It's not specifically designed for cutting and slashing, but it can still, maybe, save your life.
 
 /obj/item/weapon/melee/energy/sword/ionic_rapier/afterattack(var/atom/movable/AM, var/mob/living/user, var/proximity)
 	if(istype(AM, /obj) && proximity && active)
@@ -250,6 +272,7 @@
 	origin_tech = list(TECH_COMBAT = 5, TECH_MAGNET = 3, TECH_ILLEGAL = 4)
 	active_force = 25
 	armor_penetration = 25
+	projectile_parry_chance = 40
 
 	var/hitcost = 75
 	var/obj/item/weapon/cell/bcell = null
@@ -336,6 +359,7 @@
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
 	var/mob/living/creator
 	var/datum/effect/effect/system/spark_spread/spark_system
+	var/projectile_parry_chance = 60
 	lcolor = "#00FF00"
 
 /obj/item/weapon/melee/energy/blade/New()
@@ -372,6 +396,37 @@
 			host.embedded -= src
 			host.drop_from_inventory(src)
 		spawn(1) if(src) qdel(src)
+
+/obj/item/weapon/melee/energy/blade/handle_shield(mob/user, var/damage, atom/damage_source = null, mob/attacker = null, var/def_zone = null, var/attack_text = "the attack")
+	if(default_parry_check(user, attacker, damage_source) && prob(60))
+		user.visible_message("<span class='danger'>\The [user] parries [attack_text] with \the [src]!</span>")
+
+		var/datum/effect/effect/system/spark_spread/spark_system = new /datum/effect/effect/system/spark_spread()
+		spark_system.set_up(5, 0, user.loc)
+		spark_system.start()
+		playsound(user.loc, 'sound/weapons/blade1.ogg', 50, 1)
+		return 1
+	if(unique_parry_check(user, attacker, damage_source) && prob(projectile_parry_chance))
+		user.visible_message("<span class='danger'>\The [user] deflects [attack_text] with \the [src]!</span>")
+
+		var/datum/effect/effect/system/spark_spread/spark_system = new /datum/effect/effect/system/spark_spread()
+		spark_system.set_up(5, 0, user.loc)
+		spark_system.start()
+		playsound(user.loc, 'sound/weapons/blade1.ogg', 50, 1)
+		return 1
+
+	return 0
+
+/obj/item/weapon/melee/energy/blade/unique_parry_check(mob/user, mob/attacker, atom/damage_source)
+
+	if(user.incapacitated() || !istype(damage_source, /obj/item/projectile/))
+		return 0
+
+	var/bad_arc = reverse_direction(user.dir)
+	if(!check_shield_arc(user, bad_arc, damage_source, attacker))
+		return 0
+
+	return 1
 
 /*
  *Energy Spear

--- a/code/game/objects/items/weapons/shields.dm
+++ b/code/game/objects/items/weapons/shields.dm
@@ -29,6 +29,9 @@
 
 	return 1
 
+/obj/item/proc/unique_parry_check(mob/user, mob/attacker, atom/damage_source)	// An overrideable version of the above proc.
+	return default_parry_check(user, attacker, damage_source)
+
 /obj/item/weapon/shield
 	name = "shield"
 	var/base_block_chance = 50

--- a/html/changelogs/Mechoid - Melee2RevengeoftheDeflect.yml
+++ b/html/changelogs/Mechoid - Melee2RevengeoftheDeflect.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Mechoid
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Changeling arm-weapons and E-swords can now block projectiles (again)."


### PR DESCRIPTION
On the tin.

Energy swords, changeling claws / blades, and ninja swords can now deflect projectiles (in some cases, again).

Recursively-Enhanced changeling melee weapons have greater blocking capability, both for melee and projectiles. Claws are, generally, inferior to arm-blades due to size.

Adds an over-rideable proc for parrying.

Also I fucked up again and committed to my master. God. Damnit.