### PR TITLE
Teleporter Construction

### DIFF
--- a/code/game/machinery/teleporter.dm
+++ b/code/game/machinery/teleporter.dm
@@ -87,8 +87,6 @@
 	attack_hand()
 
 /obj/machinery/computer/teleporter/attack_hand(user as mob)
-	if(..()) return
-
 	/* Ghosts can't use this one because it's a direct selection */
 	if(istype(user, /mob/observer/dead)) return
 
@@ -184,15 +182,20 @@
 
 	component_parts = list()
 	component_parts += new /obj/item/weapon/stock_parts/scanning_module(src)
-	component_parts += new /obj/item/weapon/stock_parts/scanning_module(src)
-	component_parts += new /obj/item/weapon/stock_parts/scanning_module(src)
-	component_parts += new /obj/item/weapon/stock_parts/scanning_module(src)
 	component_parts += new /obj/item/weapon/stock_parts/micro_laser(src)
-	component_parts += new /obj/item/weapon/stock_parts/micro_laser(src)
-	component_parts += new /obj/item/weapon/stock_parts/micro_laser(src)
-	component_parts += new /obj/item/weapon/stock_parts/micro_laser(src)
+	component_parts += new /obj/item/weapon/stock_parts/subspace/treatment(src)
 	component_parts += new /obj/item/stack/cable_coil(src, 10)
 	RefreshParts()
+
+/obj/machinery/teleport/hub/attackby(obj/item/weapon/W as obj, mob/user as mob)
+	if(default_deconstruction_screwdriver(user, W))
+		return
+	else if(default_deconstruction_crowbar(user, W))
+		return
+	else if(default_part_replacement(user, W))
+		return
+	else
+		..()
 
 /obj/machinery/teleport/hub/Bumped(M as mob|obj)
 	spawn()
@@ -332,13 +335,20 @@
 
 	component_parts = list()
 	component_parts += new /obj/item/weapon/stock_parts/console_screen(src)
-	component_parts += new /obj/item/weapon/stock_parts/capacitor(src)
-	component_parts += new /obj/item/weapon/stock_parts/capacitor(src)
+	component_parts += new /obj/item/weapon/stock_parts/subspace/sub_filter(src)
+	component_parts += new /obj/item/weapon/stock_parts/subspace/ansible(src)
 	component_parts += new /obj/item/stack/cable_coil(src, 10)
 	RefreshParts()
 
-/obj/machinery/teleport/station/attackby(var/obj/item/weapon/W)
-	attack_hand()
+/obj/machinery/teleport/station/attackby(obj/item/weapon/W as obj, mob/user as mob)
+	if(default_deconstruction_screwdriver(user, W))
+		return
+	else if(default_deconstruction_crowbar(user, W))
+		return
+	else if(default_part_replacement(user, W))
+		return
+	else
+		attack_hand()
 
 /obj/machinery/teleport/station/attack_ai()
 	attack_hand()

--- a/code/game/machinery/teleporter.dm
+++ b/code/game/machinery/teleporter.dm
@@ -87,6 +87,8 @@
 	attack_hand()
 
 /obj/machinery/computer/teleporter/attack_hand(user as mob)
+	if(..()) return
+
 	/* Ghosts can't use this one because it's a direct selection */
 	if(istype(user, /mob/observer/dead)) return
 

--- a/code/game/objects/items/weapons/circuitboards/frame.dm
+++ b/code/game/objects/items/weapons/circuitboards/frame.dm
@@ -165,21 +165,23 @@
 /obj/item/weapon/circuitboard/teleporter_hub
 	name = T_BOARD("teleporter hub")
 	build_path = /obj/machinery/teleport/hub
-	board_type = "teleporter_hub"
-//	origin_tech = list(TECH_DATA = 2, TECH_BLUESPACE = 4)
+	board_type = new /datum/frame/frame_types/machine
+	origin_tech = list(TECH_DATA = 2, TECH_BLUESPACE = 5)
 	req_components = list(
-							/obj/item/weapon/stock_parts/scanning_module = 4,
-							/obj/item/weapon/stock_parts/micro_laser = 4,
+							/obj/item/weapon/stock_parts/scanning_module = 1,
+							/obj/item/weapon/stock_parts/micro_laser = 1,
+							/obj/item/weapon/stock_parts/subspace/treatment = 1,
 							/obj/item/stack/cable_coil = 10)
 
 /obj/item/weapon/circuitboard/teleporter_station
 	name = T_BOARD("teleporter station")
 	build_path = /obj/machinery/teleport/station
-	board_type = "teleporter_station"
-//	origin_tech = list(TECH_DATA = 2, TECH_BLUESPACE = 3)
+	board_type = new /datum/frame/frame_types/machine
+	origin_tech = list(TECH_DATA = 2, TECH_BLUESPACE = 4)
 	req_components = list(
 							/obj/item/weapon/stock_parts/console_screen = 1,
-							/obj/item/weapon/stock_parts/capacitor = 2,
+							/obj/item/weapon/stock_parts/subspace/sub_filter = 1,
+							/obj/item/weapon/stock_parts/subspace/ansible = 1,
 							/obj/item/stack/cable_coil = 10)
 
 /obj/item/weapon/circuitboard/body_scanner

--- a/code/modules/research/designs/circuits.dm
+++ b/code/modules/research/designs/circuits.dm
@@ -116,6 +116,20 @@ CIRCUITS BELOW
 	build_path = /obj/item/weapon/circuitboard/teleporter
 	sort_string = "HAAAA"
 
+/datum/design/circuit/telestation
+	name = "teleporter station"
+	id = "telestation"
+	req_tech = list(TECH_DATA = 4, TECH_BLUESPACE = 4)
+	build_path = /obj/item/weapon/circuitboard/teleporter_station
+	sort_string = "HAAAG"
+
+/datum/design/circuit/telehub
+	name = "teleporter hub"
+	id = "telehub"
+	req_tech = list(TECH_DATA = 5, TECH_BLUESPACE = 5)
+	build_path = /obj/item/weapon/circuitboard/teleporter_hub
+	sort_string = "HAAAH"
+
 /datum/design/circuit/robocontrol
 	name = "robotics control console"
 	id = "robocontrol"

--- a/html/changelogs/mistyLuminescence - Teleporters.yml
+++ b/html/changelogs/mistyLuminescence - Teleporters.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: mistyLuminescence
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: You can now construct and deconstruct teleporters. You'll need certain subspace parts from telecomms storage or R&D, as well as high bluespace levels for the circuits.


### PR DESCRIPTION
Teleporters can now be constructed and deconstructed. Intended as a companion PR to the teleporter changes introduced in #6209 , but works standalone if 6209's changes are reverted.

Teleporter hub requires Bluespace and Data 5, and a scanning module, microlaser, subspace treatment disk and 10 cable coils.
Teleporter station requires Bluespace and Data 4, and a console screen, subspace filter, ansible and 10 cable coils.

(And if you want to stop people escaping the station as antag? Sabotage the teleporters and shuttles.)