### PR TITLE
Nerfs NTNet Relay power usage

### DIFF
--- a/code/modules/modular_computers/NTNet/NTNet_relay.dm
+++ b/code/modules/modular_computers/NTNet/NTNet_relay.dm
@@ -3,7 +3,7 @@
 	name = "NTNet Quantum Relay"
 	desc = "A very complex router and transmitter capable of connecting electronic devices together. Looks fragile."
 	use_power = 2
-	active_power_usage = 1600
+	active_power_usage = 2000 //20kW, apropriate for machine that keeps massive cross-Zlevel wireless network operational.
 	idle_power_usage = 100
 	icon_state = "bus"
 	anchored = 1

--- a/code/modules/modular_computers/NTNet/NTNet_relay.dm
+++ b/code/modules/modular_computers/NTNet/NTNet_relay.dm
@@ -3,7 +3,7 @@
 	name = "NTNet Quantum Relay"
 	desc = "A very complex router and transmitter capable of connecting electronic devices together. Looks fragile."
 	use_power = 2
-	active_power_usage = 20000 //20kW, apropriate for machine that keeps massive cross-Zlevel wireless network operational.
+	active_power_usage = 1600
 	idle_power_usage = 100
 	icon_state = "bus"
 	anchored = 1


### PR DESCRIPTION
...It probably should not be drawing as much power as the rest of telecommunications combined. 1600 puts it as equivalent of the Telecommunications hub, which is, IIRC, the most power-intensive machinery in telecomms.