### PR TITLE
RCD Updates

### DIFF
--- a/code/datums/autolathe/autolathe.dm
+++ b/code/datums/autolathe/autolathe.dm
@@ -6,7 +6,8 @@ var/datum/category_collection/autolathe/autolathe_recipes
 	if(I.matter && !resources)
 		resources = list()
 		for(var/material in I.matter)
-			resources[material] = I.matter[material]*1.25 // More expensive to produce than they are to recycle.
+			var/coeff = (no_scale ? 1 : 1.25) //most objects are more expensive to produce than to recycle
+			resources[material] = I.matter[material]*coeff // but if it's a sheet or RCD cartridge, it's 1:1
 	if(is_stack && istype(I, /obj/item/stack))
 		var/obj/item/stack/IS = I
 		max_stack = IS.max_amount
@@ -66,6 +67,7 @@ var/datum/category_collection/autolathe/autolathe_recipes
 	var/power_use = 0
 	var/is_stack
 	var/max_stack
+	var/no_scale
 
 /datum/category_item/autolathe/dd_SortValue()
 	return name

--- a/code/datums/autolathe/engineering.dm
+++ b/code/datums/autolathe/engineering.dm
@@ -91,8 +91,14 @@
 	path =/obj/item/weapon/stock_parts/spring
 
 /datum/category_item/autolathe/engineering/rcd_ammo
-	name = "matter cartridge"
+	name = "compressed matter cartridge"
 	path =/obj/item/weapon/rcd_ammo
+	no_scale = 1
+
+/datum/category_item/autolathe/engineering/rcd_ammo_large
+	name = "high-capacity matter cartridge"
+	path =/obj/item/weapon/rcd_ammo
+	no_scale = 1
 
 /datum/category_item/autolathe/engineering/rcd
 	name = "rapid construction device"

--- a/code/datums/autolathe/general.dm
+++ b/code/datums/autolathe/general.dm
@@ -74,21 +74,25 @@
 	name = "steel sheets"
 	path =/obj/item/stack/material/steel
 	is_stack = 1
+	no_scale = 1
 
 /datum/category_item/autolathe/general/glass
 	name = "glass sheets"
 	path =/obj/item/stack/material/glass
 	is_stack = 1
+	no_scale = 1
 
 /datum/category_item/autolathe/general/rglass
 	name = "reinforced glass sheets"
 	path =/obj/item/stack/material/glass/reinforced
 	is_stack = 1
+	no_scale = 1
 
 /datum/category_item/autolathe/general/rods
 	name = "metal rods"
 	path =/obj/item/stack/rods
 	is_stack = 1
+	no_scale = 1
 
 /datum/category_item/autolathe/general/knife
 	name = "kitchen knife"

--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -83,16 +83,17 @@
 			else
 				//Make sure it's buildable and list requires resources.
 				for(var/material in R.resources)
-					var/sheets = round(stored_material[material]/round(R.resources[material]*mat_efficiency))
+					var/coeff = (R.no_scale ? 1 : mat_efficiency) //stacks are unaffected by production coefficient
+					var/sheets = round(stored_material[material]/round(R.resources[material]*coeff))
 					if(isnull(max_sheets) || max_sheets > sheets)
 						max_sheets = sheets
-					if(!isnull(stored_material[material]) && stored_material[material] < round(R.resources[material]*mat_efficiency))
+					if(!isnull(stored_material[material]) && stored_material[material] < round(R.resources[material]*coeff))
 						can_make = 0
 					if(!comma)
 						comma = 1
 					else
 						material_string += ", "
-					material_string += "[round(R.resources[material] * mat_efficiency)] [material]"
+					material_string += "[round(R.resources[material] * coeff)] [material]"
 				material_string += ".<br></td>"
 				//Build list of multipliers for sheets.
 				if(R.is_stack)
@@ -250,16 +251,17 @@
 		busy = 1
 		update_use_power(2)
 
+		var/coeff = (making.no_scale ? 1 : mat_efficiency) //stacks are unaffected by production coefficient
 		//Check if we still have the materials.
 		for(var/material in making.resources)
 			if(!isnull(stored_material[material]))
-				if(stored_material[material] < round(making.resources[material] * mat_efficiency) * multiplier)
+				if(stored_material[material] < round(making.resources[material] * coeff) * multiplier)
 					return
 
 		//Consume materials.
 		for(var/material in making.resources)
 			if(!isnull(stored_material[material]))
-				stored_material[material] = max(0, stored_material[material] - round(making.resources[material] * mat_efficiency) * multiplier)
+				stored_material[material] = max(0, stored_material[material] - round(making.resources[material] * coeff) * multiplier)
 
 		update_icon() // So lid closes
 

--- a/code/modules/research/designs/misc.dm
+++ b/code/modules/research/designs/misc.dm
@@ -169,6 +169,15 @@ datum/design/item/laserpointer
 	build_path = /obj/item/device/t_scanner/advanced
 	sort_string = "VASSB"
 
+/datum/design/item/device/rcd_adv
+	name = "Advanced Rapid Construction Device"
+	desc = "An advanced version of the rapid construction device, capable of (de-)constructing walls, airlocks, grilles and windows at range."
+	id = "advancedtscanner"
+	req_tech = list(TECH_MAGNET = 6, TECH_ENGINEERING = 8, TECH_MATERIAL = 6, TECH_BLUESPACE = 4)
+	materials = list(DEFAULT_WALL_MATERIAL = 12500, "glass" = 10000, "uranium" = 3500, MAT_VERDANTIUM = 1250)
+	build_path = /obj/item/weapon/rcd/advanced
+	sort_string = "VASSC"
+
 /datum/design/item/translator
 	name = "handheld translator"
 	id = "translator"

--- a/code/modules/research/designs/misc.dm
+++ b/code/modules/research/designs/misc.dm
@@ -172,7 +172,7 @@ datum/design/item/laserpointer
 /datum/design/item/device/rcd_adv
 	name = "Advanced Rapid Construction Device"
 	desc = "An advanced version of the rapid construction device, capable of (de-)constructing walls, airlocks, grilles and windows at range."
-	id = "advancedtscanner"
+	id = "advancedrcd"
 	req_tech = list(TECH_MAGNET = 6, TECH_ENGINEERING = 8, TECH_MATERIAL = 6, TECH_BLUESPACE = 4)
 	materials = list(DEFAULT_WALL_MATERIAL = 12500, "glass" = 10000, "uranium" = 3500, MAT_VERDANTIUM = 1250)
 	build_path = /obj/item/weapon/rcd/advanced

--- a/html/changelogs/mistyLuminescence - RCDs.yml
+++ b/html/changelogs/mistyLuminescence - RCDs.yml
@@ -1,0 +1,39 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: mistyLuminescence
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: The advanced RCD can now be created in R&D, requiring high electromagnetic, engineering, material and bluespace research, as well as uranium and verdantium.
+  - tweak: RCDs can now be filled directly by using metal, glass or reinforced glass on them.
+  - rscadd: High-capacity matter cartridges can now be printed in autolathes.
+  - bugfix: Fixes a material duplication exploit.


### PR DESCRIPTION
* The advanced RCD can now be created in R&D, requiring high electromagnetic, engineering, material and bluespace research, as well as uranium and verdantium.
* RCDs can now be filled directly by using metal, glass or reinforced glass on them.
* High-capacity matter cartridges can now be printed in autolathes.
* Fixes a material duplication exploit. 