### PR TITLE
Prescription Pills

### DIFF
--- a/code/game/objects/items/weapons/storage/firstaid.dm
+++ b/code/game/objects/items/weapons/storage/firstaid.dm
@@ -271,3 +271,8 @@
 	name = "bottle of Iron pills"
 	desc = "Contains pills used to aid in blood regeneration."
 	starts_with = list(/obj/item/weapon/reagent_containers/pill/iron = 7)
+
+/obj/item/weapon/storage/pill_bottle/rx
+	name = "bottle of prescription medicine pills"
+	desc = "Contains pills used to treat... something. The label doesn't say what."
+	starts_with = list(/obj/item/weapon/reagent_containers/pill/rx = 7)

--- a/code/modules/client/preference_setup/loadout/loadout_general.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_general.dm
@@ -99,3 +99,8 @@
 	display_name = "Cards Against The Galaxy (black deck)"
 	path = /obj/item/weapon/deck/cah/black
 	description = "The ever-popular Cards Against The Galaxy word game. Warning: may include traces of broken fourth wall. This is the black deck."
+
+/datum/gear/rxpills
+	display_name = "bottle of prescription medicine pills"
+	path = /obj/item/weapon/storage/pill_bottle/rx
+	description = "What kind of medicine is this? What does it treat? Why are all the pills unlabelled? Who knows."

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -304,3 +304,12 @@
 /obj/item/weapon/reagent_containers/pill/diet/Initialize()
 	. = ..()
 	reagents.add_reagent("lipozine", 2)
+
+/obj/item/weapon/reagent_containers/pill/rx
+	name = "prescription medicine pill"
+	desc = "This pill isn't actually labelled with anything, but you're pretty sure it's some kind of prescription medicine."
+	icon_state = "pill19"
+
+/obj/item/weapon/reagent_containers/pill/rx/Initialize()
+	. = ..()
+	reagents.add_reagent("banana", 2) //medicine tastes like bananas in space

--- a/html/changelogs/mistyLuminescence - rxloadout.yml
+++ b/html/changelogs/mistyLuminescence - rxloadout.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: TheFurryFeline
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: Adds a bottle of prescription medicine pills to the loadout. The medicine does absolutely nothing (except taste of banana), but it could be nice for RP purposes.


### PR DESCRIPTION
Adds a bottle of prescription medicine to the loadout for 1 point. It does absolutely nothing, but if you want to pop some pills for RP value, you can. If you want *actual medicine* that has mechanical effects, go see the chemist- these just taste faintly of banana.

Will conflict with #6199 - if that gets merged first, I'll update this to match.