### PR TITLE
POI Names

### DIFF
--- a/html/changelogs/mistyLuminescence - POInames.yml
+++ b/html/changelogs/mistyLuminescence - POInames.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: mistyLuminescence
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: Adds the "POI - " prefix to the POI location names to make it easier for ghosts to teleport to them- e.g. "POI - Rocky2" rather than just "Rocky2".

--- a/maps/submaps/space_submaps/space.dm
+++ b/maps/submaps/space_submaps/space.dm
@@ -6,7 +6,7 @@
 #endif
 
 /datum/map_template/space
-	name = "Space Content"
+	name = "POI - Space Content"
 	desc = "A map template base.  In space."
 
 // To be added: Templates for space exploration when they are made.

--- a/maps/submaps/surface_submaps/mountains/mountains_areas.dm
+++ b/maps/submaps/surface_submaps/mountains/mountains_areas.dm
@@ -4,129 +4,129 @@
 	ambience = AMBIENCE_RUINS
 
 /area/submap/cave/deadBeacon
-	name = "abandoned relay"
+	name = "POI - abandoned relay"
 	ambience = AMBIENCE_TECH_RUINS
 
 /area/submap/cave/prepper1
-	name = "Prepper Bunker"
+	name = "POI - Prepper Bunker"
 	ambience = AMBIENCE_FOREBODING
 
 /area/submap/cave/qShuttle
-	name = "Quarantined Shuttle"
+	name = "POI - Quarantined Shuttle"
 	ambience = AMBIENCE_RUINS
 
 /area/submap/cave/AMine1
-	name = "Abandoned Mine"
+	name = "POI - Abandoned Mine"
 
 /area/submap/cave/Scave1
-	name = "Spider Cave 1"
+	name = "POI - Spider Cave 1"
 	ambience = AMBIENCE_FOREBODING
 
 /area/submap/cave/crashed_ufo
-	name = "Crashed Alien Vessel"
+	name = "POI - Crashed Alien Vessel"
 	requires_power = FALSE
 	ambience = AMBIENCE_OTHERWORLDLY
 
 /area/submap/cave/crystal1
-	name = "Crystaline Cave"
+	name = "POI - Crystaline Cave"
 	ambience = AMBIENCE_SPACE
 
 /area/submap/cave/crystal2
-	name = "Crystaline Cave"
+	name = "POI - Crystaline Cave"
 	ambience = AMBIENCE_SPACE
 
 /area/submap/cave/crystal3
-	name = "Crystaline Cave"
+	name = "POI - Crystaline Cave"
 	ambience = AMBIENCE_SPACE
 
 /area/submap/cave/lost_explorer
-	name = "Final Resting Place"
+	name = "POI - Final Resting Place"
 	ambience = AMBIENCE_GHOSTLY
 
 /area/submap/Rockb1
-	name = "RockyBase1"
+	name = "POI - RockyBase1"
 	ambience = AMBIENCE_FOREBODING
 
 /area/submap/Cavelake
-	name = "Cavelake"
+	name = "POI - Cavelake"
 	ambience = AMBIENCE_SPACE
 
 /area/submap/CaveTrench
-	name = "Cave River"
+	name = "POI - Cave River"
 	ambience = AMBIENCE_FOREBODING
 
 /area/submap/CorgiRitual
-	name = "Dark Ritual"
+	name = "POI - Dark Ritual"
 	ambience = AMBIENCE_UNHOLY
 
 /area/submap/AbandonedTemple
-	name = "Abandoned Temple"
+	name = "POI - Abandoned Temple"
 	ambience = AMBIENCE_RUINS
 
 /area/submap/CrashedMedShuttle
-	name = "Crashed Med Shuttle"
+	name = "POI - Crashed Med Shuttle"
 	ambience = AMBIENCE_RUINS
 
 /area/submap/cave/digsite
-	name = "Dig Site"
+	name = "POI - Dig Site"
 	ambience = AMBIENCE_OTHERWORLDLY
 
 /area/submap/cave/vault1
-	name = "Mine Vault"
+	name = "POI - Mine Vault"
 	ambience = AMBIENCE_FOREBODING
 
 /area/submap/cave/vault2
-	name = "Mine Vault"
+	name = "POI - Mine Vault"
 	ambience = AMBIENCE_FOREBODING
 
 /area/submap/cave/vault3
-	name = "Mine Vault"
+	name = "POI - Mine Vault"
 	ambience = AMBIENCE_FOREBODING
 
 /area/submap/cave/vault4
-	name = "Mine Vault"
+	name = "POI - Mine Vault"
 	ambience = AMBIENCE_FOREBODING
 
 /area/submap/cave/vault5
-	name = "Mine Vault"
+	name = "POI - Mine Vault"
 	ambience = AMBIENCE_FOREBODING
 
 /area/submap/cave/IceCave1A
-	name = "Ice Cave 1A"
+	name = "POI - Ice Cave 1A"
 	ambience = AMBIENCE_SPACE
 
 /area/submap/cave/IceCave1B
-	name = "Ice Cave 1B"
+	name = "POI - Ice Cave 1B"
 	ambience = AMBIENCE_SPACE
 
 /area/submap/cave/IceCave1C
-	name = "Ice Cave 1C"
+	name = "POI - Ice Cave 1C"
 	ambience = AMBIENCE_SPACE
 
 /area/submap/cave/swordcave
-	name = "Cursed Sword Cave"
+	name = "POI - Cursed Sword Cave"
 	ambience = AMBIENCE_UNHOLY
 
 /area/submap/cave/SupplyDrop1
-	name = "Supply Drop 1"
+	name = "POI - Supply Drop 1"
 	ambience = AMBIENCE_TECH_RUINS
 
 /area/submap/cave/BlastMine1
-	name = "Blast Mine 1"
+	name = "POI - Blast Mine 1"
 
 /area/submap/crashedcontainmentshuttle
-	name = "Crashed Containment Shuttle"
+	name = "POI - Crashed Containment Shuttle"
 	ambience = AMBIENCE_HIGHSEC
 
 /area/submap/deadspy
-	name = "Dead Spy"
+	name = "POI - Dead Spy"
 	ambience = AMBIENCE_FOREBODING
 
 /area/submap/lava_trench
-	name = "Lava Trench"
+	name = "POI - Lava Trench"
 	ambience = AMBIENCE_LAVA
 
 /area/submap/lava_trench/outpost
-	name = "Trench Outpost"
+	name = "POI - Trench Outpost"
 	requires_power = FALSE
 	icon_state = "submap2"

--- a/maps/submaps/surface_submaps/plains/plains_areas.dm
+++ b/maps/submaps/surface_submaps/plains/plains_areas.dm
@@ -1,101 +1,101 @@
 /area/submap/farm1
-	name = "farm"
+	name = "POI - farm"
 
 /area/submap/construction1
-	name = "construction site"
+	name = "POI - construction site"
 	ambience = AMBIENCE_RUINS
 
 /area/submap/camp1
-	name = "camp site"
+	name = "POI - camp site"
 	ambience = AMBIENCE_SIF
 
 /area/submap/house1
-	name = "old explorer's home"
+	name = "POI - old explorer's home"
 
 /area/submap/beacons
-	name = "collection of marker beacons"
+	name = "POI - collection of marker beacons"
 
 /area/submap/Epod1
-	name = "Epod1"
+	name = "POI - Epod1"
 	ambience = AMBIENCE_FOREBODING
 
 /area/submap/Epod2
-	name = "Epod2"
+	name = "POI - Epod2"
 	ambience = AMBIENCE_FOREBODING
 
 /area/submap/Rocky2
-	name = "Rocky2"
+	name = "POI - Rocky2"
 
 /area/submap/Peninsula
-	name = "Peninsula"
+	name = "POI - Peninsula"
 
 /area/submap/PascalB
-	name = "PascalB"
+	name = "POI - PascalB"
 	ambience = AMBIENCE_FOREBODING
 
 /area/submap/bonfire
-	name = "abandoned bonfire"
+	name = "POI - abandoned bonfire"
 
 /area/submap/Rocky5
-	name = "Rocky5"
+	name = "POI - Rocky5"
 
 /area/submap/Shakden
-	name = "Shakden"
+	name = "POI - Shakden"
 
 /area/submap/Field1
-	name = "Field 1"
+	name = "POI - Field 1"
 
 /area/submap/Thiefc
-	name = "Thieves Cave"
+	name = "POI - Thieves' Cave"
 	ambience = AMBIENCE_FOREBODING
 
 /area/submap/smol2
-	name = "Small 2"
+	name = "POI - Small 2"
 
 /area/submap/Mechpt
-	name = "Mech Pit"
+	name = "POI - Mech Pit"
 
 /area/submap/Boathouse
-	name = "Boathouse"
+	name = "POI - Boathouse"
 
 /area/submap/Smol3
-	name = "Small 3"
+	name = "POI - Small 3"
 
 /area/submap/PooledR
-	name = "Pooled Rocks"
+	name = "POI - Pooled Rocks"
 	ambience = AMBIENCE_SIF
 
 /area/submap/Diner
-	name = "Diner"
+	name = "POI - Diner"
 	ambience = AMBIENCE_SIF
 
 /area/submap/snow1
-	name = "Snow1"
+	name = "POI - Snow1"
 	ambience = AMBIENCE_SIF
 
 /area/submap/snow2
-	name = "Snow2"
+	name = "POI - Snow2"
 	ambience = AMBIENCE_SIF
 
 /area/submap/snow3
-	name = "Snow3"
+	name = "POI - Snow3"
 	ambience = AMBIENCE_SIF
 
 /area/submap/snow4
-	name = "Snow4"
+	name = "POI - Snow4"
 	ambience = AMBIENCE_SIF
 
 /area/submap/snow5
-	name = "Snow5"
+	name = "POI - Snow5"
 	ambience = AMBIENCE_SIF
 
 /area/submap/SupplyDrop2
-	name = "Supply Drop 2"
+	name = "POI - Supply Drop 2"
 	ambience = AMBIENCE_TECH_RUINS
 
 /area/submap/RationCache
-	name = "Ration Cache"
+	name = "POI - Ration Cache"
 
 /area/submap/Oldhouse
-	name = "Oldhouse"
+	name = "POI - Oldhouse"
 	ambience = AMBIENCE_FOREBODING

--- a/maps/submaps/surface_submaps/wilderness/wilderness_areas.dm
+++ b/maps/submaps/surface_submaps/wilderness/wilderness_areas.dm
@@ -9,118 +9,118 @@
 	requires_power = FALSE
 
 /area/submap/spider1
-	name = "spider nest"
+	name = "POI - spider nest"
 	ambience = AMBIENCE_FOREBODING
 
 /area/submap/Field1
-	name = "Field 1"
+	name = "POI - Field 1"
 	ambience = AMBIENCE_SIF
 
 /area/submap/Lake1
-	name = "Lake 1"
+	name = "POI - Lake 1"
 	ambience = AMBIENCE_SIF
 
 /area/submap/MilitaryCamp1
-	name = "Military Camp 1"
+	name = "POI - Military Camp 1"
 	ambience = AMBIENCE_HIGHSEC
 
 /area/submap/Mudpit
-	name = "Mudpit"
+	name = "POI - Mudpit"
 	ambience = AMBIENCE_SIF
 
 /area/submap/Rocky1
-	name = "Rocky1"
+	name = "POI - Rocky1"
 	ambience = AMBIENCE_SIF
 
 /area/submap/Rocky2
-	name = "Rocky2"
+	name = "POI - Rocky2"
 	ambience = AMBIENCE_SIF
 
 /area/submap/Rocky3
-	name = "Rocky3"
+	name = "POI - Rocky3"
 	ambience = AMBIENCE_SIF
 
 /area/submap/Shack1
-	name = "Shack1"
+	name = "POI - Shack1"
 	ambience = AMBIENCE_RUINS
 
 /area/submap/Small1
-	name = "Small1"
+	name = "POI - Small1"
 	ambience = AMBIENCE_SIF
 
 /area/submap/SnowR1
-	name = "SnowR1"
+	name = "POI - SnowR1"
 	ambience = AMBIENCE_SIF
 
 /area/submap/BoomBase
-	name = "Boom1"
+	name = "POI - Boom1"
 	ambience = AMBIENCE_FOREBODING
 
 /area/submap/Blackshuttledown
-	name = "BSD"
+	name = "POI - BSD"
 	requires_power = FALSE
 	ambience = AMBIENCE_HIGHSEC
 
 /area/submap/Cragzone1
-	name = "Craggy1"
+	name = "POI - Craggy1"
 	ambience = AMBIENCE_SIF
 
 /area/submap/Lab1
-	name = "Lab1"
+	name = "POI - Lab1"
 	ambience = AMBIENCE_RUINS
 
 /area/submap/Rocky4
-	name = "Rocky4"
+	name = "POI - Rocky4"
 	ambience = AMBIENCE_SIF
 
 /area/submap/DJOutpost1
-	name = "DJOutpost1"
+	name = "POI - DJOutpost1"
 	ambience = AMBIENCE_TECH_RUINS
 
 /area/submap/DJOutpost2
-	name = "DJOutpost2"
+	name = "POI - DJOutpost2"
 	ambience = AMBIENCE_GHOSTLY
 
 /area/submap/MHR
-	name = "Manhack Rock"
+	name = "POI - Manhack Rock"
 	ambience = AMBIENCE_FOREBODING
 
 /area/submap/Rockybase
-	name = "Rockybase"
+	name = "POI - Rockybase"
 	ambience = AMBIENCE_HIGHSEC
 
 /area/submap/GovPatrol
-	name = "GovPatrol"
+	name = "POI - GovPatrol"
 	ambience = AMBIENCE_GHOSTLY
 
 /area/submap/DecoupledEngine
-	name = "DecoupledEngine"
+	name = "POI - DecoupledEngine"
 	ambience = AMBIENCE_FOREBODING
 
 /area/submap/DoomP
-	name = "DoomP"
+	name = "POI - DoomP"
 	ambience = AMBIENCE_HIGHSEC
 
 /area/submap/CaveS
-	name = "CaveS"
+	name = "POI - CaveS"
 	ambience = AMBIENCE_FOREBODING
 
 /area/submap/Drugd
-	name = "DrugDen"
+	name = "POI - DrugDen"
 	ambience = AMBIENCE_FOREBODING
 
 /area/submap/Manor1
-	name = "Manor1"
+	name = "POI - Manor1"
 	ambience = AMBIENCE_FOREBODING
 
 /area/submap/Epod3
-	name = "Epod3"
+	name = "POI - Epod3"
 	ambience = AMBIENCE_FOREBODING
 
 /area/submap/Epod4
-	name = "Epod4"
+	name = "POI - Epod4"
 	ambience = AMBIENCE_FOREBODING
 
 /area/submap/ButcherShack
-	name = "ButcherShack"
+	name = "POI - ButcherShack"
 	ambience = AMBIENCE_RUINS


### PR DESCRIPTION
Adds the "POI - " prefix to the POI location names to make it easier for ghosts to teleport to them- e.g. "POI - Rocky2" rather than just "Rocky2". Very simple PR, and it should make things a little easier for anyone who wants to see a huge list of POIs.

Before:
Abandoned Shuttle
Armory
Dig Site
Engineering
Medbay
PascalB

After:
Armory
Engineering
Medbay
POI - Abandoned Shuttle
POI - Dig Site
POI - PascalB

(etc)