### PR TITLE
Adds Material Scanner to Protolathe

### DIFF
--- a/code/modules/research/designs/misc.dm
+++ b/code/modules/research/designs/misc.dm
@@ -29,13 +29,18 @@
 	sort_string = "GAAAB"
 
 /datum/design/item/hud/mesons
-	name = "Optical meson scanners design"
-	desc = "Using the meson-scanning technology those glasses allow you to see through walls, floor or anything else."
+	name = "optical meson scanner"
 	id = "mesons"
 	req_tech = list(TECH_MAGNET = 2, TECH_ENGINEERING = 2)
-	materials = list(DEFAULT_WALL_MATERIAL = 50, "glass" = 50)
 	build_path = /obj/item/clothing/glasses/meson
 	sort_string = "GAAAC"
+
+/datum/design/item/hud/material
+	name = "optical material scanner"
+	id = "material"
+	req_tech = list(TECH_MAGNET = 3, TECH_ENGINEERING = 3)
+	build_path = /obj/item/clothing/glasses/material
+	sort_string = "GAAAD"
 
 /datum/design/item/device/ano_scanner
 	name = "Alden-Saraspova counter"

--- a/code/modules/research/designs/misc.dm
+++ b/code/modules/research/designs/misc.dm
@@ -19,28 +19,28 @@
 	id = "health_hud"
 	req_tech = list(TECH_BIO = 2, TECH_MAGNET = 3)
 	build_path = /obj/item/clothing/glasses/hud/health
-	sort_string = "GAAAA"
+	sort_string = "GBAAA"
 
 /datum/design/item/hud/security
 	name = "security records"
 	id = "security_hud"
 	req_tech = list(TECH_MAGNET = 3, TECH_COMBAT = 2)
 	build_path = /obj/item/clothing/glasses/hud/security
-	sort_string = "GAAAB"
+	sort_string = "GBAAB"
 
 /datum/design/item/hud/mesons
 	name = "optical meson scanner"
 	id = "mesons"
 	req_tech = list(TECH_MAGNET = 2, TECH_ENGINEERING = 2)
 	build_path = /obj/item/clothing/glasses/meson
-	sort_string = "GAAAC"
+	sort_string = "GBAAC"
 
 /datum/design/item/hud/material
 	name = "optical material scanner"
 	id = "material"
 	req_tech = list(TECH_MAGNET = 3, TECH_ENGINEERING = 3)
 	build_path = /obj/item/clothing/glasses/material
-	sort_string = "GAAAD"
+	sort_string = "GBAAD"
 
 /datum/design/item/device/ano_scanner
 	name = "Alden-Saraspova counter"


### PR DESCRIPTION
Adds the optical material scanner to the protolathe (the ones miners get).
Costs 50 steel and 50 glass (same as all the other HUDs)
Required tech is 3 magnet and 3 engineering (same as on the HUD)

Also adjusts the meson design so it actually uses its parent code like the other HUDs

EDIT: Changed sorting string of the HUDs to GBAA- from GAAA- so they don't use the same sorting string as the design storage disk and technology data storage disk