### PR TITLE
QoL improvements for broken components

### DIFF
--- a/code/game/objects/structures/loot_piles.dm
+++ b/code/game/objects/structures/loot_piles.dm
@@ -340,7 +340,7 @@ Loot piles can be depleted, if loot_depleted is turned on.  Note that players wh
 		/obj/item/weapon/stock_parts/subspace/transmitter,
 		/obj/item/weapon/stock_parts/subspace/treatment,
 		/obj/item/frame,
-		/obj/item/broken_device,
+		/obj/item/broken_device/random,
 		/obj/item/borg/upgrade/restart,
 		/obj/item/weapon/cell,
 		/obj/item/weapon/cell/high,

--- a/code/modules/mob/living/silicon/robot/component.dm
+++ b/code/modules/mob/living/silicon/robot/component.dm
@@ -208,6 +208,18 @@
 	name = "broken component"
 	icon = 'icons/obj/robot_component.dmi'
 	icon_state = "broken"
+	matter = list(DEFAULT_WALL_MATERIAL = 1000)
+
+/obj/item/broken_device/random
+	var/list/possible_icons = list("binradio_broken",
+									"motor_broken",
+									"armor_broken",
+									"camera_broken",
+									"analyser_broken",
+									"radio_broken")
+
+/obj/item/broken_device/random/Initialize()
+	icon_state = pick(possible_icons)
 
 /obj/item/robot_parts/robot_component
 	icon = 'icons/obj/robot_component.dmi'

--- a/html/changelogs/Heroman3003 - Broken Components.yml
+++ b/html/changelogs/Heroman3003 - Broken Components.yml
@@ -1,0 +1,37 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Heroman3003
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Broken components now have matter worth of 1000 steel units (half a sheet)."
+  - tweak: "Components dropped from loot piles will now use random proper sprite instead of default placeholder."


### PR DESCRIPTION
- Adds matter cost to broken components, making them recyclable in autolathes. Yields 1000 steel (half a sheet).

- Adds 'random' broken components that use random sprite, instead of placeholder default. Loot pile in PoI now drops those instead of the default.