### PR TITLE
Fixes runtime and GPS problem with invalid Z-levels

### DIFF
--- a/code/modules/modular_computers/file_system/programs/medical/suit_sensors.dm
+++ b/code/modules/modular_computers/file_system/programs/medical/suit_sensors.dm
@@ -42,6 +42,10 @@
 	for(var/z in (data["map_levels"] | T.z))  // Always show crew from the current Z even if we can't show a map
 		data["crewmembers"] += crew_repository.health_data(z)
 
+	if(!data["map_levels"].len)
+		to_chat(user, "<span class='warning'>The crew monitor doesn't seem like it'll work here.</span>")
+		return
+
 	ui = SSnanoui.try_update_ui(user, src, ui_key, ui, data, force_open)
 	if(!ui)
 		ui = new(user, src, ui_key, "crew_monitor.tmpl", "Crew Monitoring Computer", 900, 800, state = state)

--- a/html/changelogs/mistyLuminescence - zruntime.yml
+++ b/html/changelogs/mistyLuminescence - zruntime.yml
@@ -1,0 +1,37 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: mistyLuminescence
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Fixes a runtime caused by attempting to use a crew monitor console while on an invalid Z-level."
+  - bugfix: "Fixes GPSes not detecting other GPSes while on an invalid Z-level. Transit Z is unaffected by this- no spying on other shuttles!"

--- a/maps/southern_cross/southern_cross_defines.dm
+++ b/maps/southern_cross/southern_cross_defines.dm
@@ -78,7 +78,7 @@
 	if (long_range && (srcz in map_levels))
 		return map_levels
 	else if (srcz == Z_LEVEL_TRANSIT)
-		return list() // Nothing on transit!
+		return list() // Nothing on these z-levels- sensors won't show, and GPSes won't see each other.
 	else if (srcz >= Z_LEVEL_STATION_ONE && srcz <= Z_LEVEL_STATION_THREE) // Station can see other decks.
 		return list(
 			Z_LEVEL_STATION_ONE,
@@ -90,7 +90,7 @@
 			Z_LEVEL_SURFACE_MINE,
 			Z_LEVEL_SURFACE_WILD)
 	else
-		return ..()
+		return list(srcz) //prevents runtimes when using CMC. any Z-level not defined above will be 'isolated' and only show to GPSes/CMCs on that same Z (e.g. CentCom).
 
 /datum/map/southern_cross/perform_map_generation()
 	// First, place a bunch of submaps. This comes before tunnel/forest generation as to not interfere with the submap.


### PR DESCRIPTION
Previously, if you attempted to use a crew monitor console on Centcom (or another invalid Z-level not explicitly given code under get_map_levels), it'd runtime. GPS tags would also fail to detect each other, even when adjacent.

Now, it *doesn't* runtime, GPS tags can successfully detect each other while on the same Z (but not while on different Z's, unless specifically coded under get_map_levels- e.g. Sif wilderness/plains/mine), and there's support for further Z-levels to Not Break Things if someone forgets to plug them in under get_map_levels.

TL;DR: you won't notice this ever but it's good