### PR TITLE
Allows to interact with turf itself in Turf tab

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -721,7 +721,7 @@
 				listed_turf = null
 			else
 				if(statpanel("Turf"))
-					stat("\icon[listed_turf]", listed_turf.name)
+					stat(listed_turf)
 					for(var/atom/A in listed_turf)
 						if(!A.mouse_opacity)
 							continue


### PR DESCRIPTION
The one that appears when you alt-click. You could interact with every object on the turf, but not turf itself, so if it was obstructed visually you couldn't like remove tiles or clean the dirt. Now you can.