### PR TITLE
Properly splits security and engineering alarms

### DIFF
--- a/code/modules/modular_computers/file_system/programs/engineering/alarm_monitor.dm
+++ b/code/modules/modular_computers/file_system/programs/engineering/alarm_monitor.dm
@@ -1,12 +1,12 @@
 /datum/computer_file/program/alarm_monitor
-	filename = "alarmmonitor"
-	filedesc = "Alarm Monitoring"
+	filename = "alarmmonitoreng"
+	filedesc = "Alarm Monitoring (Engineering)"
 	nanomodule_path = /datum/nano_module/alarm_monitor/engineering
 	ui_header = "alarm_green.gif"
 	program_icon_state = "alert-green"
 	program_key_state = "atmos_key"
 	program_menu_icon = "alert"
-	extended_desc = "This program provides visual interface for the alarm system."
+	extended_desc = "This program provides visual interface for the engineering alarm system."
 	required_access = access_engine
 	requires_ntnet = 1
 	network_destination = "alarm monitoring network"
@@ -46,7 +46,7 @@
 
 /datum/nano_module/alarm_monitor/engineering/New()
 	..()
-	alarm_handlers = list(atmosphere_alarm, camera_alarm, fire_alarm, power_alarm)
+	alarm_handlers = list(atmosphere_alarm, fire_alarm, power_alarm)
 
 /datum/nano_module/alarm_monitor/security/New()
 	..()

--- a/code/modules/modular_computers/file_system/programs/security/alarm_monitor.dm
+++ b/code/modules/modular_computers/file_system/programs/security/alarm_monitor.dm
@@ -1,0 +1,6 @@
+/datum/computer_file/program/alarm_monitor/security			//Subtype of engineering alarm monitor, look at /engineering/alarm_monitor for details
+	filename = "alarmmonitorsec"
+	filedesc = "Alarm Monitoring (Security)"
+	extended_desc = "This program provides visual interface for the security alarm system."
+	nanomodule_path = /datum/nano_module/alarm_monitor/security
+	required_access = access_security

--- a/polaris.dme
+++ b/polaris.dme
@@ -2191,6 +2191,7 @@
 #include "code\modules\modular_computers\file_system\programs\medical\suit_sensors.dm"
 #include "code\modules\modular_computers\file_system\programs\research\email_administration.dm"
 #include "code\modules\modular_computers\file_system\programs\research\ntmonitor.dm"
+#include "code\modules\modular_computers\file_system\programs\security\alarm_monitor.dm"
 #include "code\modules\modular_computers\file_system\programs\security\digitalwarrant.dm"
 #include "code\modules\modular_computers\hardware\_hardware.dm"
 #include "code\modules\modular_computers\hardware\battery_module.dm"


### PR DESCRIPTION
Added new MC program: Alarm Monitor (Security) - monitors camera and motion alarms, security access.

Alarm Monitor renamed to Alarm Monitor (Engineering).

Engineering alarm consoles and Alarm Monitor (Engineering) program no longer monitor camera alarms (was part of MC changes).