### PR TITLE
Nerfs Simple Doors

### DIFF
--- a/code/game/objects/structures/simple_doors.dm
+++ b/code/game/objects/structures/simple_doors.dm
@@ -131,7 +131,7 @@
 			user << "You finished digging."
 			Dismantle()
 	else if(istype(W,/obj/item/weapon)) //not sure, can't not just weapons get passed to this proc?
-		hardness -= W.force/100
+		hardness -= W.force/10
 		user << "You hit the [name] with your [W.name]!"
 		CheckHardness()
 	else if(istype(W,/obj/item/weapon/weldingtool))
@@ -141,6 +141,10 @@
 	else
 		attack_hand(user)
 	return
+
+/obj/structure/simple_door/bullet_act(var/obj/item/projectile/Proj)
+	hardness -= W.force/10
+	CheckHardness()
 
 /obj/structure/simple_door/proc/CheckHardness()
 	if(hardness <= 0)

--- a/code/game/objects/structures/simple_doors.dm
+++ b/code/game/objects/structures/simple_doors.dm
@@ -143,7 +143,7 @@
 	return
 
 /obj/structure/simple_door/bullet_act(var/obj/item/projectile/Proj)
-	hardness -= W.force/10
+	hardness -= Proj.force/10
 	CheckHardness()
 
 /obj/structure/simple_door/proc/CheckHardness()


### PR DESCRIPTION
Simple doors would take the integrity of the material (150 for steel AND resin), divide it by 10, and use that hardness as health. Damage taken by the door would have its force divided by 100. This meant that in order to do 15 damage to a steel door with a baton, you'd need to hit the door 100 times. Now you only need to hit the door 10 times.

Also makes it so bullets/lasers work against the doors

Summation: Resin doors take 10 baton hits to break. (Resin walls take 14.)