### PR TITLE
Fixes technical cameras being affected by random event

### DIFF
--- a/code/modules/events/camera_damage.dm
+++ b/code/modules/events/camera_damage.dm
@@ -33,6 +33,6 @@
 	return acquire_random_camera(remaining_attempts--)
 
 /datum/event/camera_damage/proc/is_valid_camera(var/obj/machinery/camera/C)
-	// Only return a functional camera, not installed in a silicon, and that exists somewhere players have access
+	// Only return a functional camera, not installed in a silicon/hardsuit/circuit/etc, and that exists somewhere players have access
 	var/turf/T = get_turf(C)
-	return T && C.can_use() && !istype(C.loc, /mob/living/silicon) && (T.z in using_map.player_levels)
+	return T && C.can_use() && istype(C.loc, /turf) && (T.z in using_map.player_levels)

--- a/code/modules/gamemaster/actions/camera_damage.dm
+++ b/code/modules/gamemaster/actions/camera_damage.dm
@@ -44,9 +44,9 @@
 	return acquire_random_camera(remaining_attempts--)
 
 /datum/gm_action/camera_damage/proc/is_valid_camera(var/obj/machinery/camera/C)
-	// Only return a functional camera, not installed in a silicon, and that exists somewhere players have access
+	// Only return a functional camera, not installed in a silicon/hardsuit/circuit/etc, and that exists somewhere players have access
 	var/turf/T = get_turf(C)
-	return T && C.can_use() && !istype(C.loc, /mob/living/silicon) && (T.z in using_map.player_levels)
+	return T && C.can_use() && istype(C.loc, /turf) && (T.z in using_map.player_levels)
 
 /datum/gm_action/camera_damage/get_weight()
 	return 40 + (metric.count_people_in_department(ROLE_ENGINEERING) * 20) + (metric.count_people_in_department(ROLE_SYNTHETIC) * 40)


### PR DESCRIPTION
Silicon cameras were already excluded, but hardsuit cameras were not and thats pretty bad. Most technical cameras are inaccessible and all are irrepairable, so they should all be skipped when looking for target for event.