### PR TITLE
MC camera and access fixes and adjustments

### DIFF
--- a/code/__defines/machinery.dm
+++ b/code/__defines/machinery.dm
@@ -34,6 +34,7 @@ var/global/defer_powernet_rebuild = 0      // True if net rebuild will be called
 #define NETWORK_CRESCENT "Spaceport"
 // #define NETWORK_CAFE_DOCK "Cafe Dock"
 #define NETWORK_CARGO "Cargo"
+#define NETWORK_CIRCUITS "Circuits"
 #define NETWORK_CIVILIAN "Civilian"
 // #define NETWORK_CIVILIAN_EAST "Civilian East"
 // #define NETWORK_CIVILIAN_WEST "Civilian West"
@@ -109,7 +110,7 @@ var/list/restricted_camera_networks = list(NETWORK_ERT,NETWORK_MERCENARY,"Secret
 #define SUPERMATTER_WARNING 3		// Ambient temp > CRITICAL_TEMPERATURE OR integrity damaged
 #define SUPERMATTER_DANGER 4		// Integrity < 50%
 #define SUPERMATTER_EMERGENCY 5		// Integrity < 25%
-#define SUPERMATTER_DELAMINATING 6	// Pretty obvious. 
+#define SUPERMATTER_DELAMINATING 6	// Pretty obvious.
 
 //wIP - PORT ALL OF THESE TO SUBSYSTEMS AND GET RID OF THE WHOLE LIST PROCESS THING
 // Fancy-pants START/STOP_PROCESSING() macros that lets us custom define what the list is.

--- a/code/game/machinery/camera/presets.dm
+++ b/code/game/machinery/camera/presets.dm
@@ -43,6 +43,9 @@ var/global/list/engineering_networks = list(
 /obj/machinery/camera/network/civilian
 	network = list(NETWORK_CIVILIAN)
 
+/obj/machinery/camera/network/circuits
+	network = list(NETWORK_CIRCUITS)
+
 /*
 /obj/machinery/camera/network/civilian_east
 	network = list(NETWORK_CIVILIAN_EAST)

--- a/code/modules/integrated_electronics/subtypes/output.dm
+++ b/code/modules/integrated_electronics/subtypes/output.dm
@@ -244,7 +244,7 @@
 	activators = list()
 	spawn_flags = IC_SPAWN_DEFAULT|IC_SPAWN_RESEARCH
 	power_draw_idle = 5 // Raises to 80 when on.
-	var/obj/machinery/camera/network/research/camera
+	var/obj/machinery/camera/network/circuits/camera
 
 /obj/item/integrated_circuit/output/video_camera/New()
 	..()

--- a/code/modules/modular_computers/file_system/programs/command/card.dm
+++ b/code/modules/modular_computers/file_system/programs/command/card.dm
@@ -168,7 +168,7 @@
 		if("terminate")
 			if(computer && can_run(user, 1))
 				id_card.assignment = "Terminated"
-				remove_nt_access(id_card)
+				id_card.access = list()
 				callHook("terminate_employee", list(id_card))
 		if("edit")
 			if(computer && can_run(user, 1))
@@ -206,8 +206,7 @@
 
 						access = jobdatum.get_access()
 
-					remove_nt_access(id_card)
-					apply_access(id_card, access)
+					id_card.access = access
 					id_card.assignment = t1
 					id_card.rank = t1
 
@@ -225,9 +224,3 @@
 
 	SSnanoui.update_uis(NM)
 	return 1
-
-/datum/computer_file/program/card_mod/proc/remove_nt_access(var/obj/item/weapon/card/id/id_card)
-	id_card.access -= get_access_ids(ACCESS_TYPE_STATION|ACCESS_TYPE_CENTCOM)
-
-/datum/computer_file/program/card_mod/proc/apply_access(var/obj/item/weapon/card/id/id_card, var/list/accesses)
-	id_card.access |= accesses

--- a/code/modules/modular_computers/file_system/programs/generic/camera.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/camera.dm
@@ -46,13 +46,13 @@
 
 	var/list/all_networks[0]
 	for(var/network in using_map.station_networks)
-		if(can_access_network(user, get_camera_access(network)) || check_access(user, access_security) || check_access(user, access_heads))
+		if(can_access_network(user, get_camera_access(network), 1))
 			all_networks.Add(list(list(
 								"tag" = network,
 								"has_access" = 1
 								)))
 	for(var/network in using_map.secondary_networks)
-		if(can_access_network(user, get_camera_access(network)))
+		if(can_access_network(user, get_camera_access(network), 0))
 			all_networks.Add(list(list(
 								"tag" = network,
 								"has_access" = 1
@@ -79,12 +79,15 @@
 /datum/nano_module/camera_monitor/proc/modify_networks_list(var/list/networks)
 	return networks
 
-/datum/nano_module/camera_monitor/proc/can_access_network(var/mob/user, var/network_access)
+/datum/nano_module/camera_monitor/proc/can_access_network(var/mob/user, var/network_access, var/station_network = 0)
 	// No access passed, or 0 which is considered no access requirement. Allow it.
 	if(!network_access)
 		return 1
 
-	return check_access(user, network_access)
+	if(station_network)
+		return check_access(user, network_access) || check_access(user, access_security) || check_access(user, access_heads)
+	else
+		return check_access(user, network_access)
 
 /datum/nano_module/camera_monitor/Topic(href, href_list)
 	if(..())
@@ -102,7 +105,7 @@
 
 	else if(href_list["switch_network"])
 		// Either security access, or access to the specific camera network's department is required in order to access the network.
-		if(can_access_network(usr, get_camera_access(href_list["switch_network"])))
+		if(can_access_network(usr, get_camera_access(href_list["switch_network"]), (href_list["switch_network"] in using_map.station_networks)))
 			current_network = href_list["switch_network"]
 		else
 			to_chat(usr, "\The [nano_host()] shows an \"Network Access Denied\" error message.")

--- a/code/modules/modular_computers/file_system/programs/generic/camera.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/camera.dm
@@ -11,10 +11,15 @@
 			return 0
 		if(NETWORK_ENGINE,NETWORK_ALARM_ATMOS,NETWORK_ALARM_FIRE,NETWORK_ALARM_POWER)
 			return access_engine
+		if(NETWORK_CIRCUITS)
+			return access_research
 		if(NETWORK_ERT)
 			return access_cent_specops
 
-	return access_security // Default for all other networks
+	if(network in using_map.station_networks)
+		return access_security // Default for all other station networks
+	else
+		return 999	//Inaccessible if not a station network and not mentioned above
 
 /datum/computer_file/program/camera_monitor
 	filename = "cammon"
@@ -41,10 +46,17 @@
 
 	var/list/all_networks[0]
 	for(var/network in using_map.station_networks)
-		all_networks.Add(list(list(
-							"tag" = network,
-							"has_access" = can_access_network(user, get_camera_access(network))
-							)))
+		if(can_access_network(user, get_camera_access(network)) || check_access(user, access_security) || check_access(user, access_heads))
+			all_networks.Add(list(list(
+								"tag" = network,
+								"has_access" = 1
+								)))
+	for(var/network in using_map.secondary_networks)
+		if(can_access_network(user, get_camera_access(network)))
+			all_networks.Add(list(list(
+								"tag" = network,
+								"has_access" = 1
+								)))
 
 	all_networks = modify_networks_list(all_networks)
 
@@ -72,7 +84,7 @@
 	if(!network_access)
 		return 1
 
-	return check_access(user, access_security) || check_access(user, access_heads) || check_access(user, network_access)
+	return check_access(user, network_access)
 
 /datum/nano_module/camera_monitor/Topic(href, href_list)
 	if(..())

--- a/maps/northern_star/northern_star_defines.dm
+++ b/maps/northern_star/northern_star_defines.dm
@@ -53,6 +53,16 @@
 							NETWORK_INTERROGATION
 							)
 
+	secondary_networks = list(
+							NETWORK_ERT,
+							NETWORK_MERCENARY,
+							NETWORK_THUNDER,
+							NETWORK_COMMUNICATORS,
+							NETWORK_ALARM_ATMOS,
+							NETWORK_ALARM_POWER,
+							NETWORK_ALARM_FIRE
+							)
+
 	allowed_spawns = list("Arrivals Shuttle","Gateway", "Cryogenic Storage", "Cyborg Storage", "Elevator")
 
 

--- a/maps/southern_cross/southern_cross_defines.dm
+++ b/maps/southern_cross/southern_cross_defines.dm
@@ -47,6 +47,7 @@
 	// Networks that will show up as options in the camera monitor program
 	station_networks = list(
 							NETWORK_CARGO,
+							NETWORK_CIRCUITS,
 							NETWORK_CIVILIAN,
 							NETWORK_COMMAND,
 							NETWORK_ENGINE,
@@ -65,7 +66,17 @@
 							NETWORK_SECURITY,
 							NETWORK_TELECOM
 							)
-
+	// Camera networks that exist, but don't show on regular camera monitors.
+	secondary_networks = list(
+							NETWORK_ERT,
+							NETWORK_MERCENARY,
+							NETWORK_THUNDER,
+							NETWORK_COMMUNICATORS,
+							NETWORK_ALARM_ATMOS,
+							NETWORK_ALARM_POWER,
+							NETWORK_ALARM_FIRE,
+							NETWORK_SUPPLY
+							)
 	usable_email_tlds = list("freemail.nt")
 	allowed_spawns = list("Arrivals Shuttle","Gateway", "Cryogenic Storage", "Cyborg Storage")
 	unit_test_exempt_areas = list(/area/ninja_dojo, /area/ninja_dojo/firstdeck, /area/ninja_dojo/arrivals_dock)

--- a/maps/~map_system/maps.dm
+++ b/maps/~map_system/maps.dm
@@ -78,6 +78,7 @@ var/list/all_maps = list()
 	var/emergency_shuttle_recall_message
 
 	var/list/station_networks = list() 		// Camera networks that will show up on the console.
+	var/list/secondary_networks = list()	// Camera networks that exist, but don't show on regular camera monitors.
 
 	var/allowed_spawns = list("Arrivals Shuttle","Gateway", "Cryogenic Storage", "Cyborg Storage")
 


### PR DESCRIPTION
Sort of a mixed bag this one. 

- Adjusts MC camera program to only display networks you have access to and properly display networks that aren't standard map networks, but are accessible. Allows to actually see networks like Alerts and Thunderdome.

- Adds Circuits network. A station network (so appears even on regular sec consoles), and thats new network for all circuit cameras. Scientists have access to it with MCs.

- Fixes ID modification program permanently breaking Colony Director access if colony director ID is edited using MC.