### PR TITLE
Returns logs from plants

### DIFF
--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -200,7 +200,24 @@
 				qdel(src)
 				return
 			else if(seed.chems)
-				if(!isnull(seed.chems["potato"]))
+				if(W.sharp && W.edge && !isnull(seed.chems["woodpulp"]))
+					user.show_message("<span class='notice'>You make planks out of \the [src]!</span>", 1)
+					playsound(loc, 'sound/effects/woodcutting.ogg', 50, 1)
+					var/flesh_colour = seed.get_trait(TRAIT_FLESH_COLOUR)
+					if(!flesh_colour) flesh_colour = seed.get_trait(TRAIT_PRODUCT_COLOUR)
+					for(var/i=0,i<2,i++)
+						var/obj/item/stack/material/wood/NG = new (user.loc)
+						if(flesh_colour) NG.color = flesh_colour
+						for (var/obj/item/stack/material/wood/G in user.loc)
+							if(G==NG)
+								continue
+							if(G.amount>=G.max_amount)
+								continue
+							G.attackby(NG, user)
+						user << "You add the newly-formed wood to the stack. It now contains [NG.amount] planks."
+					qdel(src)
+					return
+				else if(!isnull(seed.chems["potato"]))
 					user << "You slice \the [src] into sticks."
 					new /obj/item/weapon/reagent_containers/food/snacks/rawsticks(get_turf(src))
 					qdel(src)

--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -200,24 +200,7 @@
 				qdel(src)
 				return
 			else if(seed.chems)
-				if(W.sharp && W.edge && !isnull(seed.chems["woodpulp"]))
-					user.show_message("<span class='notice'>You make planks out of \the [src]!</span>", 1)
-					playsound(loc, 'sound/effects/woodcutting.ogg', 50, 1)
-					var/flesh_colour = seed.get_trait(TRAIT_FLESH_COLOUR)
-					if(!flesh_colour) flesh_colour = seed.get_trait(TRAIT_PRODUCT_COLOUR)
-					for(var/i=0,i<2,i++)
-						var/obj/item/stack/material/wood/NG = new (user.loc)
-						if(flesh_colour) NG.color = flesh_colour
-						for (var/obj/item/stack/material/wood/G in user.loc)
-							if(G==NG)
-								continue
-							if(G.amount>=G.max_amount)
-								continue
-							G.attackby(NG, user)
-						user << "You add the newly-formed wood to the stack. It now contains [NG.amount] planks."
-					qdel(src)
-					return
-				else if(!isnull(seed.chems["potato"]))
+				if(!isnull(seed.chems["potato"]))
 					user << "You slice \the [src] into sticks."
 					new /obj/item/weapon/reagent_containers/food/snacks/rawsticks(get_turf(src))
 					qdel(src)

--- a/code/modules/hydroponics/seed_datums.dm
+++ b/code/modules/hydroponics/seed_datums.dm
@@ -459,6 +459,7 @@
 	display_name = "tower caps"
 	chems = list("woodpulp" = list(10,1))
 	mutants = null
+	has_item_product = /obj/item/stack/material/log
 
 /datum/seed/mushroom/towercap/New()
 	..()


### PR DESCRIPTION
Regular wooden logs have been unobtainable for a while due to the plantcode. Now that they can produce items, its only fair that logs come back to being available as base material.