### PR TITLE
Fixes Nurse Spider Feeding

### DIFF
--- a/code/modules/ai/ai_holder_targeting.dm
+++ b/code/modules/ai/ai_holder_targeting.dm
@@ -4,6 +4,7 @@
 	var/hostile = FALSE						// Do we try to hurt others?
 	var/retaliate = FALSE					// Attacks whatever struck it first. Mobs will still attack back if this is false but hostile is true.
 	var/mauling = FALSE						// Attacks unconscious mobs
+	var/handle_corpse = FALSE					// Allows AI to acknowledge corpses (e.g. nurse spiders)
 
 	var/atom/movable/target = null			// The thing (mob or object) we're trying to kill.
 	var/atom/movable/preferred_target = null// If set, and if given the chance, we will always prefer to target this over other options.

--- a/code/modules/ai/ai_holder_targeting.dm
+++ b/code/modules/ai/ai_holder_targeting.dm
@@ -122,7 +122,7 @@
 			if(L.key && !L.client)	// SSD players get a pass
 				return FALSE
 		if(L.stat)
-			if(L.stat == DEAD) // Leave dead things alone
+			if(L.stat == DEAD && !handle_corpse) // Leave dead things alone
 				return FALSE
 			if(L.stat == UNCONSCIOUS)	// Do we have mauling? Yes? Then maul people who are sleeping but not SSD
 				if(mauling)

--- a/code/modules/mob/living/simple_mob/subtypes/animal/giant_spider/nurse.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/giant_spider/nurse.dm
@@ -51,6 +51,9 @@
 	var/egg_type = /obj/effect/spider/eggcluster/small
 	var/web_type = /obj/effect/spider/stickyweb/dark
 
+/datum/ai_holder/simple_mob/melee/nurse_spider
+	mauling = TRUE		// The nurse puts mobs into webs by attacking, so it needs to attack in crit
+	handle_corpse = TRUE	// Lets the nurse wrap dead things
 
 /mob/living/simple_mob/animal/giant_spider/nurse/inject_poison(mob/living/L, target_zone)
 	..() // Inject the stoxin here.


### PR DESCRIPTION
Gives nurse spider _mauling_ so they can attack in crit to wrap the mob in webs and the newly made _handle_corpse_ so they can wrap dead mobs