### PR TITLE
fixes communicator weather app's air reading

### DIFF
--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -577,31 +577,7 @@ var/global/list/obj/item/device/pda/PDAs = list()
 
 
 	if(mode==3)
-		var/turf/T = get_turf(user.loc)
-		if(!isnull(T))
-			var/datum/gas_mixture/environment = T.return_air()
-
-			var/pressure = environment.return_pressure()
-			var/total_moles = environment.total_moles
-
-			if (total_moles)
-				var/o2_level = environment.gas["oxygen"]/total_moles
-				var/n2_level = environment.gas["nitrogen"]/total_moles
-				var/co2_level = environment.gas["carbon_dioxide"]/total_moles
-				var/phoron_level = environment.gas["phoron"]/total_moles
-				var/unknown_level =  1-(o2_level+n2_level+co2_level+phoron_level)
-				data["aircontents"] = list(\
-					"pressure" = "[round(pressure,0.1)]",\
-					"nitrogen" = "[round(n2_level*100,0.1)]",\
-					"oxygen" = "[round(o2_level*100,0.1)]",\
-					"carbon_dioxide" = "[round(co2_level*100,0.1)]",\
-					"phoron" = "[round(phoron_level*100,0.01)]",\
-					"other" = "[round(unknown_level, 0.01)]",\
-					"temp" = "[round(environment.temperature-T0C,0.1)]",\
-					"reading" = 1\
-					)
-		if(isnull(data["aircontents"]))
-			data["aircontents"] = list("reading" = 0)
+		data["aircontents"] = src.analyze_air()
 	if(mode==6)
 		if(has_reception)
 			feeds.Cut()
@@ -1544,3 +1520,37 @@ var/global/list/obj/item/device/pda/PDAs = list()
 /obj/item/device/pda/emp_act(severity)
 	for(var/atom/A in src)
 		A.emp_act(severity)
+
+/obj/item/device/pda/proc/analyze_air()
+	var/list/results = list()
+	var/turf/T = get_turf(src.loc)
+	if(!isnull(T))
+		var/datum/gas_mixture/environment = T.return_air()
+		var/pressure = environment.return_pressure()
+		var/total_moles = environment.total_moles
+		if (total_moles)
+			var/o2_level = environment.gas["oxygen"]/total_moles
+			var/n2_level = environment.gas["nitrogen"]/total_moles
+			var/co2_level = environment.gas["carbon_dioxide"]/total_moles
+			var/phoron_level = environment.gas["phoron"]/total_moles
+			var/unknown_level =  1-(o2_level+n2_level+co2_level+phoron_level)
+
+			// Label is what the entry is describing
+			// Type identifies which unit or other special characters to use
+			// Val is the information reported
+			// Bad_high/_low are the values outside of which the entry reports as dangerous
+			// Poor_high/_low are the values outside of which the entry reports as unideal
+			// Values were extracted from the template itself
+			results = list(
+						list("entry" = "Pressure", "type" = "pressure", "val" = "[round(pressure,0.1)]", "bad_high" = 120, "poor_high" = 110, "poor_low" = 95, "bad_low" = 80),
+						list("entry" = "Temperature", "type" = "temp", "val" = "[round(environment.temperature-T0C,0.1)]", "bad_high" = 35, "poor_high" = 25, "poor_low" = 15, "bad_low" = 5),
+						list("entry" = "Oxygen", "type" = "pressure", "val" = "[round(o2_level*100,0.1)]", "bad_high" = 140, "poor_high" = 135, "poor_low" = 19, "bad_low" = 17),
+						list("entry" = "Nitrogen", "type" = "pressure", "val" = "[round(n2_level*100,0.1)]", "bad_high" = 105, "poor_high" = 85, "poor_low" = 50, "bad_low" = 40),
+						list("entry" = "Carbon Dioxide", "type" = "pressure", "val" = "[round(co2_level*100,0.1)]", "bad_high" = 10, "poor_high" = 5, "poor_low" = 0, "bad_low" = 0),
+						list("entry" = "Phoron", "type" = "pressure", "val" = "[round(phoron_level*100,0.01)]", "bad_high" = 0.5, "poor_high" = 0, "poor_low" = 0, "bad_low" = 0),
+						list("entry" = "Other", "type" = "pressure", "val" = "[round(unknown_level, 0.01)]", "bad_high" = 1, "poor_high" = 0.5, "poor_low" = 0, "bad_low" = 0)
+						)
+
+	if(isnull(results))
+		results = list(list("entry" = "pressure", "val" = "0"))
+	return results

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -1535,22 +1535,22 @@ var/global/list/obj/item/device/pda/PDAs = list()
 			var/phoron_level = environment.gas["phoron"]/total_moles
 			var/unknown_level =  1-(o2_level+n2_level+co2_level+phoron_level)
 
-			// Label is what the entry is describing
+			// entry is what the element is describing
 			// Type identifies which unit or other special characters to use
 			// Val is the information reported
 			// Bad_high/_low are the values outside of which the entry reports as dangerous
 			// Poor_high/_low are the values outside of which the entry reports as unideal
 			// Values were extracted from the template itself
 			results = list(
-						list("entry" = "Pressure", "type" = "pressure", "val" = "[round(pressure,0.1)]", "bad_high" = 120, "poor_high" = 110, "poor_low" = 95, "bad_low" = 80),
-						list("entry" = "Temperature", "type" = "temp", "val" = "[round(environment.temperature-T0C,0.1)]", "bad_high" = 35, "poor_high" = 25, "poor_low" = 15, "bad_low" = 5),
-						list("entry" = "Oxygen", "type" = "pressure", "val" = "[round(o2_level*100,0.1)]", "bad_high" = 140, "poor_high" = 135, "poor_low" = 19, "bad_low" = 17),
-						list("entry" = "Nitrogen", "type" = "pressure", "val" = "[round(n2_level*100,0.1)]", "bad_high" = 105, "poor_high" = 85, "poor_low" = 50, "bad_low" = 40),
-						list("entry" = "Carbon Dioxide", "type" = "pressure", "val" = "[round(co2_level*100,0.1)]", "bad_high" = 10, "poor_high" = 5, "poor_low" = 0, "bad_low" = 0),
-						list("entry" = "Phoron", "type" = "pressure", "val" = "[round(phoron_level*100,0.01)]", "bad_high" = 0.5, "poor_high" = 0, "poor_low" = 0, "bad_low" = 0),
-						list("entry" = "Other", "type" = "pressure", "val" = "[round(unknown_level, 0.01)]", "bad_high" = 1, "poor_high" = 0.5, "poor_low" = 0, "bad_low" = 0)
+						list("entry" = "Pressure", "units" = "kPa", "val" = "[round(pressure,0.1)]", "bad_high" = 120, "poor_high" = 110, "poor_low" = 95, "bad_low" = 80),
+						list("entry" = "Temperature", "units" = "&degC", "val" = "[round(environment.temperature-T0C,0.1)]", "bad_high" = 35, "poor_high" = 25, "poor_low" = 15, "bad_low" = 5),
+						list("entry" = "Oxygen", "units" = "kPa", "val" = "[round(o2_level*100,0.1)]", "bad_high" = 140, "poor_high" = 135, "poor_low" = 19, "bad_low" = 17),
+						list("entry" = "Nitrogen", "units" = "kPa", "val" = "[round(n2_level*100,0.1)]", "bad_high" = 105, "poor_high" = 85, "poor_low" = 50, "bad_low" = 40),
+						list("entry" = "Carbon Dioxide", "units" = "kPa", "val" = "[round(co2_level*100,0.1)]", "bad_high" = 10, "poor_high" = 5, "poor_low" = 0, "bad_low" = 0),
+						list("entry" = "Phoron", "units" = "kPa", "val" = "[round(phoron_level*100,0.01)]", "bad_high" = 0.5, "poor_high" = 0, "poor_low" = 0, "bad_low" = 0),
+						list("entry" = "Other", "units" = "kPa", "val" = "[round(unknown_level, 0.01)]", "bad_high" = 1, "poor_high" = 0.5, "poor_low" = 0, "bad_low" = 0)
 						)
 
 	if(isnull(results))
-		results = list(list("entry" = "pressure", "val" = "0"))
+		results = list(list("entry" = "pressure", "units" = "kPa", "val" = "0", "bad_high" = 120, "poor_high" = 110, "poor_low" = 95, "bad_low" = 80))
 	return results

--- a/code/game/objects/items/devices/communicator/helper.dm
+++ b/code/game/objects/items/devices/communicator/helper.dm
@@ -19,17 +19,17 @@
 			// Poor_high/_low are the values outside of which the entry reports as unideal
 			// Values were extracted from the template itself
 			results = list(
-						list("entry" = "Pressure", "type" = "pressure", "val" = "[round(pressure,0.1)]", "bad_high" = 120, "poor_high" = 110, "poor_low" = 95, "bad_low" = 80),
-						list("entry" = "Temperature", "type" = "temp", "val" = "[round(environment.temperature-T0C,0.1)]", "bad_high" = 35, "poor_high" = 25, "poor_low" = 15, "bad_low" = 5),
-						list("entry" = "Oxygen", "type" = "pressure", "val" = "[round(o2_level*100,0.1)]", "bad_high" = 140, "poor_high" = 135, "poor_low" = 19, "bad_low" = 17),
-						list("entry" = "Nitrogen", "type" = "pressure", "val" = "[round(n2_level*100,0.1)]", "bad_high" = 105, "poor_high" = 85, "poor_low" = 50, "bad_low" = 40),
-						list("entry" = "Carbon Dioxide", "type" = "pressure", "val" = "[round(co2_level*100,0.1)]", "bad_high" = 10, "poor_high" = 5, "poor_low" = 0, "bad_low" = 0),
-						list("entry" = "Phoron", "type" = "pressure", "val" = "[round(phoron_level*100,0.01)]", "bad_high" = 0.5, "poor_high" = 0, "poor_low" = 0, "bad_low" = 0),
-						list("entry" = "Other", "type" = "pressure", "val" = "[round(unknown_level, 0.01)]", "bad_high" = 1, "poor_high" = 0.5, "poor_low" = 0, "bad_low" = 0)
+						list("entry" = "Pressure", "units" = "kPa", "val" = "[round(pressure,0.1)]", "bad_high" = 120, "poor_high" = 110, "poor_low" = 95, "bad_low" = 80),
+						list("entry" = "Temperature", "units" = "&degC", "val" = "[round(environment.temperature-T0C,0.1)]", "bad_high" = 35, "poor_high" = 25, "poor_low" = 15, "bad_low" = 5),
+						list("entry" = "Oxygen", "units" = "kPa", "val" = "[round(o2_level*100,0.1)]", "bad_high" = 140, "poor_high" = 135, "poor_low" = 19, "bad_low" = 17),
+						list("entry" = "Nitrogen", "units" = "kPa", "val" = "[round(n2_level*100,0.1)]", "bad_high" = 105, "poor_high" = 85, "poor_low" = 50, "bad_low" = 40),
+						list("entry" = "Carbon Dioxide", "units" = "kPa", "val" = "[round(co2_level*100,0.1)]", "bad_high" = 10, "poor_high" = 5, "poor_low" = 0, "bad_low" = 0),
+						list("entry" = "Phoron", "units" = "kPa", "val" = "[round(phoron_level*100,0.01)]", "bad_high" = 0.5, "poor_high" = 0, "poor_low" = 0, "bad_low" = 0),
+						list("entry" = "Other", "units" = "kPa", "val" = "[round(unknown_level, 0.01)]", "bad_high" = 1, "poor_high" = 0.5, "poor_low" = 0, "bad_low" = 0)
 						)
 
 	if(isnull(results))
-		results = list(list("entry" = "pressure", "val" = "0"))
+		results = list(list("entry" = "pressure", "units" = "kPa", "val" = "0", "bad_high" = 120, "poor_high" = 110, "poor_low" = 95, "bad_low" = 80))
 	return results
 
 

--- a/nano/templates/atmospheric_scan.tmpl
+++ b/nano/templates/atmospheric_scan.tmpl
@@ -6,7 +6,7 @@
 					{{:value.entry}}:
 				</div>
 				<div class="itemContent">
-					{{:helper.string('<span class="{0}">{1}{2}</span>', value.val < value.bad_low || value.val > value.bad_high ? 'bad' : value.val < value.poor_low || value.val > value.poor_high ? 'average' : 'good' , value.val, value.type == 'pressure' ? 'kPa' : '&degC')}}
+					{{:helper.string('<span class="{0}">{1}{2}</span>', value.val < value.bad_low || value.val > value.bad_high ? 'bad' : value.val < value.poor_low || value.val > value.poor_high ? 'average' : 'good' , value.val, value.units)}}
 				</div>
 			</div>
 		{{/if}}

--- a/nano/templates/atmospheric_scan.tmpl
+++ b/nano/templates/atmospheric_scan.tmpl
@@ -1,57 +1,14 @@
-<div class="item">
-    {{if data.aircontents.reading == 1}}
-		<div class="itemLabel">
-			Pressure:
-		</div>
-		<div class = "itemContent">
-			{{:helper.string('<span class="{0}">{1} kPa</span>', data.aircontents.pressure < 80 || data.aircontents.pressure > 120 ? 'bad' : data.aircontents.pressure < 95 || data.aircontents.pressure > 110 ? 'average' : 'good' , data.aircontents.pressure)}}
-		</div>
-		<div class="itemLabel">
-			Temperature:
-		</div>
-		<div class = "itemContent">
-			{{:helper.string('<span class="{0}">{1} &deg;C</span>', data.aircontents.temp < 5 || data.aircontents.temp > 35 ? 'bad' : data.aircontents.temp < 15 || data.aircontents.temp > 25 ? 'average' : 'good' , data.aircontents.temp)}}
-		</div>
-		<br>
-		<div class="itemLabel">
-			Oxygen:
-		</div>
-		<div class = "itemContent">
-			{{:helper.string('<span class="{0}">{1}%</span>', data.aircontents.oxygen < 17 ? 'bad' : data.aircontents.oxygen < 19 ? 'average' : 'good' , data.aircontents.oxygen)}}
-		</div>
-		<div class="itemLabel">
-			Nitrogen:
-		</div>
-		<div class = "itemContent">
-			{{:helper.string('<span class="{0}">{1}%</span>', data.aircontents.nitrogen > 82 ? 'bad' : data.aircontents.nitrogen > 80 ? 'average' : 'good' , data.aircontents.nitrogen)}}
-		</div>
-		{{if data.aircontents.carbon_dioxide > 0}}				
-		<div class="itemLabel">
-			Carbon Dioxide:
-		</div>
-		<div class = "itemContent">
-			{{:helper.string('<span class="{0}">{1}%</span>', data.aircontents.carbon_dioxide > 5 ? 'bad' : 'good' , data.aircontents.carbon_dioxide)}}
-		</div>
-		{{/if}}
-		{{if data.aircontents.phoron > 0}}
-		<div class="itemLabel">
-			Phoron:
-		</div>
-		<div class = "itemContent">
-			{{:helper.string('<span class="{0}">{1}%</span>', data.aircontents.phoron  > 0 ? 'bad' : 'good' , data.aircontents.phoron)}}
-		</div>
-		{{/if}}
-		{{if data.aircontents.other > 0}}
-			<div class="itemLabel">
-				Unknown:
-			</div>
-			<div class = "itemContent">
-				<span class="bad">{{:data.aircontents.other}}%</span>
+<div class="statusDisplay" style="height: 250px; overflow: auto;">
+	{{for data.aircontents}}
+		{{if value.val != 0 || value.entry == "pressure" || value.entry == "temperature"}}
+			<div class="item">
+				<div class="itemLabel">
+					{{:value.entry}}:
+				</div>
+				<div class="itemContent">
+					{{:helper.string('<span class="{0}">{1}{2}</span>', value.val < value.bad_low || value.val > value.bad_high ? 'bad' : value.val < value.poor_low || value.val > value.poor_high ? 'average' : 'good' , value.val, value.type == 'pressure' ? 'kPa' : '&degC')}}
+				</div>
 			</div>
 		{{/if}}
-	{{else}}
-		<div class="itemContent" style="width: 100%;">
-			<span class="average"><b>Unable to get air reading</b></span>
-		</div>
-	{{/if}}
+	{{/for}}
 </div>

--- a/nano/templates/pda.tmpl
+++ b/nano/templates/pda.tmpl
@@ -300,10 +300,7 @@ Used In File(s): \code\game\objects\items\devices\PDA\PDA.dm
 
 	{{else data.mode == 3}}
         <H2>Atmospheric Scan</H2>
-        <div class="statusDisplay" style="height: 250px; overflow: auto;">
-            {{#def.atmosphericScan}}
-        </div>
-
+        {{#def.atmosphericScan}}
 
 	{{else data.mode == 40}} <!-- Cartridge: Signaler -->
         <H2>Remote Signaling System</H2>


### PR DESCRIPTION
Because it has come to ater's attention that the currently used template isn't actually designed to accommodate the supplied data format. This should never have been the case, but cursory investigation indicates that it has always been the case. Ater blames tortoisegit not grabbing all the files it was supposed to grab at some point in the indiscriminate past. Also updates PDAs to use the same format, such that they can continue to use the same template. Tested on that too.
Before/After:
![before](https://puu.sh/DQuPE/666093c935.png)
![after](https://puu.sh/DQuPY/d9986b691d.png)