### PR TITLE
Allows Set Transfer Amounts of 250 and 500 for Reagent Cartridges

### DIFF
--- a/code/modules/reagents/dispenser/cartridge.dm
+++ b/code/modules/reagents/dispenser/cartridge.dm
@@ -8,7 +8,7 @@
 	volume = CARTRIDGE_VOLUME_LARGE
 	amount_per_transfer_from_this = 50
 	// Large, but inaccurate. Use a chem dispenser or beaker for accuracy.
-	possible_transfer_amounts = list(50, 100)
+	possible_transfer_amounts = list(50, 100, 250, 500)
 	unacidable = 1
 
 	var/spawn_reagent = null


### PR DESCRIPTION
This honestly probably won't result in anything other than a small QOL for like... one or two people who actually sometimes take the reagent cartridges out to mix high volumes of things. I know, it says "large, inaccurate, if you want accuracy then use a chem dispenser", but I figure that if you can reliably and accurately pour out 1/5th and 1/10th, you can _probably_ do 1/2 and if you have a big enough container, the whole cartridge. 



