### PR TITLE
Makes airtight plastic flaps less of a free pass

### DIFF
--- a/code/game/objects/structures/plasticflaps.dm
+++ b/code/game/objects/structures/plasticflaps.dm
@@ -67,8 +67,11 @@
 	can_atmos_pass = ATMOS_PASS_NO
 
 /obj/structure/plasticflaps/mining/CanPass(atom/A, turf/T)
-	for(var/mob_type in mobs_can_pass)
-		if(istype(A, mob_type))
-			return ..()
-
-	return 0
+	var/mob/living/M = A
+	if(istype(M))
+		for(var/mob_type in mobs_can_pass)
+			if(istype(A, mob_type))
+				return ..()
+		return 0
+	else
+		return ..()

--- a/code/game/objects/structures/plasticflaps.dm
+++ b/code/game/objects/structures/plasticflaps.dm
@@ -8,6 +8,7 @@
 	layer = MOB_LAYER
 	plane = MOB_PLANE
 	explosion_resistance = 5
+	var/can_pass_lying = 1
 	var/list/mobs_can_pass = list(
 		/mob/living/bot,
 		/mob/living/simple_mob/slime/xenobio,
@@ -18,9 +19,9 @@
 /obj/structure/plasticflaps/attackby(obj/item/P, mob/user)
 	if(P.is_wirecutter())
 		playsound(src, P.usesound, 50, 1)
-		user << "<span class='notice'>You start to cut the plastic flaps.</span>"
+		to_chat(user, "<span class='notice'>You start to cut the plastic flaps.</span>")
 		if(do_after(user, 10 * P.toolspeed))
-			user << "<span class='notice'>You cut the plastic flaps.</span>"
+			to_chat(user, "<span class='notice'>You cut the plastic flaps.</span>")
 			var/obj/item/stack/material/plastic/A = new /obj/item/stack/material/plastic( src.loc )
 			A.amount = 4
 			qdel(src)
@@ -41,7 +42,7 @@
 
 	var/mob/living/M = A
 	if(istype(M))
-		if(M.lying)
+		if(M.lying && can_pass_lying)
 			return ..()
 		for(var/mob_type in mobs_can_pass)
 			if(istype(A, mob_type))
@@ -63,15 +64,6 @@
 
 /obj/structure/plasticflaps/mining //A specific type for mining that doesn't allow airflow because of them damn crates
 	name = "airtight plastic flaps"
-	desc = "Heavy duty, airtight, plastic flaps."
+	desc = "Heavy duty, airtight, plastic flaps. Have extra safety installed, preventing passage of living beings."
 	can_atmos_pass = ATMOS_PASS_NO
-
-/obj/structure/plasticflaps/mining/CanPass(atom/A, turf/T)
-	var/mob/living/M = A
-	if(istype(M))
-		for(var/mob_type in mobs_can_pass)
-			if(istype(A, mob_type))
-				return ..()
-		return 0
-	else
-		return ..()
+	can_pass_lying = 0

--- a/code/game/objects/structures/plasticflaps.dm
+++ b/code/game/objects/structures/plasticflaps.dm
@@ -65,3 +65,10 @@
 	name = "airtight plastic flaps"
 	desc = "Heavy duty, airtight, plastic flaps."
 	can_atmos_pass = ATMOS_PASS_NO
+
+/obj/structure/plasticflaps/mining/CanPass(atom/A, turf/T)
+	for(var/mob_type in mobs_can_pass)
+		if(istype(A, mob_type))
+			return ..()
+
+	return 0


### PR DESCRIPTION
Those free one-tile no wait magical airlocks are a bit nonsensical. Especially if someone were to use them as exactly that. Prevents passage of mobs that wouldn't be able to pass through normal flaps standing entirely.