### PR TITLE
Fixes some kitchen screwery

### DIFF
--- a/code/modules/food/recipes_microwave.dm
+++ b/code/modules/food/recipes_microwave.dm
@@ -90,13 +90,6 @@ I said no!
 	)
 	result = /obj/item/weapon/reagent_containers/food/snacks/monkeyburger
 
-/datum/recipe/syntiburger
-	items = list(
-		/obj/item/weapon/reagent_containers/food/snacks/bun,
-		/obj/item/weapon/reagent_containers/food/snacks/meat/syntiflesh
-	)
-	result = /obj/item/weapon/reagent_containers/food/snacks/monkeyburger
-
 /datum/recipe/brainburger
 	items = list(
 		/obj/item/weapon/reagent_containers/food/snacks/bun,
@@ -208,20 +201,6 @@ I said no!
 		/obj/item/weapon/reagent_containers/food/snacks/meat,
 		/obj/item/weapon/reagent_containers/food/snacks/meat,
 		/obj/item/weapon/reagent_containers/food/snacks/meat,
-		/obj/item/weapon/reagent_containers/food/snacks/cheesewedge,
-		/obj/item/weapon/reagent_containers/food/snacks/cheesewedge,
-		/obj/item/weapon/reagent_containers/food/snacks/cheesewedge,
-	)
-	result = /obj/item/weapon/reagent_containers/food/snacks/sliceable/meatbread
-
-/datum/recipe/syntibread
-	items = list(
-		/obj/item/weapon/reagent_containers/food/snacks/dough,
-		/obj/item/weapon/reagent_containers/food/snacks/dough,
-		/obj/item/weapon/reagent_containers/food/snacks/dough,
-		/obj/item/weapon/reagent_containers/food/snacks/meat/syntiflesh,
-		/obj/item/weapon/reagent_containers/food/snacks/meat/syntiflesh,
-		/obj/item/weapon/reagent_containers/food/snacks/meat/syntiflesh,
 		/obj/item/weapon/reagent_containers/food/snacks/cheesewedge,
 		/obj/item/weapon/reagent_containers/food/snacks/cheesewedge,
 		/obj/item/weapon/reagent_containers/food/snacks/cheesewedge,
@@ -353,19 +332,11 @@ I said no!
 	)
 	result = /obj/item/weapon/reagent_containers/food/snacks/human/kabob
 
-/datum/recipe/monkeykabob
+/datum/recipe/kabob	//Do not put before humankabob
 	items = list(
 		/obj/item/stack/rods,
-		/obj/item/weapon/reagent_containers/food/snacks/meat/monkey,
-		/obj/item/weapon/reagent_containers/food/snacks/meat/monkey,
-	)
-	result = /obj/item/weapon/reagent_containers/food/snacks/monkeykabob
-
-/datum/recipe/syntikabob
-	items = list(
-		/obj/item/stack/rods,
-		/obj/item/weapon/reagent_containers/food/snacks/meat/syntiflesh,
-		/obj/item/weapon/reagent_containers/food/snacks/meat/syntiflesh,
+		/obj/item/weapon/reagent_containers/food/snacks/meat,
+		/obj/item/weapon/reagent_containers/food/snacks/meat,
 	)
 	result = /obj/item/weapon/reagent_containers/food/snacks/monkeykabob
 
@@ -477,11 +448,6 @@ I said no!
 	items = list(/obj/item/weapon/reagent_containers/food/snacks/meat)
 	result = /obj/item/weapon/reagent_containers/food/snacks/meatsteak
 
-/datum/recipe/syntisteak
-	reagents = list("sodiumchloride" = 1, "blackpepper" = 1)
-	items = list(/obj/item/weapon/reagent_containers/food/snacks/meat/syntiflesh)
-	result = /obj/item/weapon/reagent_containers/food/snacks/meatsteak
-
 /datum/recipe/pizzamargherita
 	fruit = list("tomato" = 1)
 	items = list(
@@ -509,17 +475,6 @@ I said no!
 		/obj/item/weapon/reagent_containers/food/snacks/meat,
 		/obj/item/weapon/reagent_containers/food/snacks/meat,
 		/obj/item/weapon/reagent_containers/food/snacks/meat,
-		/obj/item/weapon/reagent_containers/food/snacks/cheesewedge
-	)
-	result = /obj/item/weapon/reagent_containers/food/snacks/sliceable/pizza/meatpizza
-
-/datum/recipe/syntipizza
-	fruit = list("tomato" = 1)
-	items = list(
-		/obj/item/weapon/reagent_containers/food/snacks/sliceable/flatdough,
-		/obj/item/weapon/reagent_containers/food/snacks/meat/syntiflesh,
-		/obj/item/weapon/reagent_containers/food/snacks/meat/syntiflesh,
-		/obj/item/weapon/reagent_containers/food/snacks/meat/syntiflesh,
 		/obj/item/weapon/reagent_containers/food/snacks/cheesewedge
 	)
 	result = /obj/item/weapon/reagent_containers/food/snacks/sliceable/pizza/meatpizza

--- a/code/modules/hydroponics/seed_datums.dm
+++ b/code/modules/hydroponics/seed_datums.dm
@@ -3,9 +3,9 @@
 	name = "chili"
 	seed_name = "chili"
 	display_name = "chili plants"
+	kitchen_tag = "chili"
 	chems = list("capsaicin" = list(3,5), "nutriment" = list(1,25))
 	mutants = list("icechili")
-	kitchen_tag = "chili"
 
 /datum/seed/chili/New()
 	..()
@@ -24,9 +24,9 @@
 	name = "icechili"
 	seed_name = "ice pepper"
 	display_name = "ice-pepper plants"
+	kitchen_tag = "icechili"
 	mutants = null
 	chems = list("frostoil" = list(3,5), "nutriment" = list(1,50))
-	kitchen_tag = "icechili"
 
 /datum/seed/chili/ice/New()
 	..()
@@ -39,9 +39,9 @@
 	name = "berries"
 	seed_name = "berry"
 	display_name = "berry bush"
+	kitchen_tag = "berries"
 	mutants = list("glowberries","poisonberries")
 	chems = list("nutriment" = list(1,10), "berryjuice" = list(10,10))
-	kitchen_tag = "berries"
 
 /datum/seed/berry/New()
 	..()
@@ -129,9 +129,9 @@
 	name = "deathnettle"
 	seed_name = "death nettle"
 	display_name = "death nettles"
+	kitchen_tag = "deathnettle"
 	mutants = null
 	chems = list("nutriment" = list(1,50), "pacid" = list(0,1))
-	kitchen_tag = "deathnettle"
 
 /datum/seed/nettle/death/New()
 	..()
@@ -221,9 +221,9 @@
 	name = "eggplant"
 	seed_name = "eggplant"
 	display_name = "eggplants"
+	kitchen_tag = "eggplant"
 	mutants = list("egg-plant")
 	chems = list("nutriment" = list(1,10))
-	kitchen_tag = "eggplant"
 
 /datum/seed/eggplant/New()
 	..()
@@ -243,9 +243,9 @@
 	name = "egg-plant"
 	seed_name = "egg-plant"
 	display_name = "egg-plants"
+	kitchen_tag = "egg-plant"
 	mutants = null
 	chems = list("nutriment" = list(1,5), "egg" = list(3,12))
-	kitchen_tag = "egg-plant"
 	has_item_product = /obj/item/weapon/reagent_containers/food/snacks/egg/purple
 
 //Apples/varieties.
@@ -253,9 +253,9 @@
 	name = "apple"
 	seed_name = "apple"
 	display_name = "apple tree"
+	kitchen_tag = "apple"
 	mutants = list("poisonapple","goldapple")
 	chems = list("nutriment" = list(1,10),"applejuice" = list(10,20))
-	kitchen_tag = "apple"
 
 /datum/seed/apple/New()
 	..()
@@ -279,9 +279,9 @@
 	name = "goldapple"
 	seed_name = "golden apple"
 	display_name = "gold apple tree"
+	kitchen_tag = "goldapple"
 	mutants = null
 	chems = list("nutriment" = list(1,10), "gold" = list(1,5))
-	kitchen_tag = "goldapple"
 
 /datum/seed/apple/gold/New()
 	..()
@@ -296,9 +296,9 @@
 	name = "ambrosia"
 	seed_name = "ambrosia vulgaris"
 	display_name = "ambrosia vulgaris"
+	kitchen_tag = "ambrosia"
 	mutants = list("ambrosiadeus")
 	chems = list("nutriment" = list(1), "space_drugs" = list(1,8), "kelotane" = list(1,8,1), "bicaridine" = list(1,10,1), "toxin" = list(1,10))
-	kitchen_tag = "ambrosia"
 
 /datum/seed/ambrosia/New()
 	..()
@@ -316,9 +316,9 @@
 	name = "ambrosiadeus"
 	seed_name = "ambrosia deus"
 	display_name = "ambrosia deus"
+	kitchen_tag = "ambrosiadeus"
 	mutants = null
 	chems = list("nutriment" = list(1), "bicaridine" = list(1,8), "synaptizine" = list(1,8,1), "hyperzine" = list(1,10,1), "space_drugs" = list(1,10))
-	kitchen_tag = "ambrosiadeus"
 
 /datum/seed/ambrosia/deus/New()
 	..()
@@ -512,8 +512,8 @@
 	name = "harebells"
 	seed_name = "harebell"
 	display_name = "harebells"
-	chems = list("nutriment" = list(1,20))
 	kitchen_tag = "harebell"
+	chems = list("nutriment" = list(1,20))
 
 /datum/seed/flower/New()
 	..()
@@ -530,8 +530,8 @@
 	name = "poppies"
 	seed_name = "poppy"
 	display_name = "poppies"
-	chems = list("nutriment" = list(1,20), "bicaridine" = list(1,10))
 	kitchen_tag = "poppy"
+	chems = list("nutriment" = list(1,20), "bicaridine" = list(1,10))
 
 /datum/seed/flower/poppy/New()
 	..()
@@ -621,6 +621,7 @@
 	name = "grapes"
 	seed_name = "grape"
 	display_name = "grapevines"
+	kitchen_tag = "grapes"
 	mutants = list("greengrapes")
 	chems = list("nutriment" = list(1,10), "sugar" = list(1,5), "grapejuice" = list(10,10))
 
@@ -654,8 +655,8 @@
 	name = "lettuce"
 	seed_name = "lettuce"
 	display_name = "lettuce"
-	chems = list("nutriment" = list(1,15))
 	kitchen_tag = "cabbage"
+	chems = list("nutriment" = list(1,15))
 
 /datum/seed/lettuce/New()
 	..()
@@ -676,8 +677,8 @@
 	name = "siflettuce"
 	seed_name = "glacial lettuce"
 	display_name = "glacial lettuce"
-	chems = list("nutriment" = list(1,5), "paracetamol" = list(0,2))
 	kitchen_tag = "icelettuce"
+	chems = list("nutriment" = list(1,5), "paracetamol" = list(0,2))
 
 /datum/seed/lettuce/ice/New()
 	..()
@@ -744,8 +745,8 @@
 	name = "peanut"
 	seed_name = "peanut"
 	display_name = "peanut vines"
-	chems = list("nutriment" = list(1,10), "peanutoil" = list(1,3))
 	kitchen_tag = "peanut"
+	chems = list("nutriment" = list(1,10), "peanutoil" = list(1,3))
 
 /datum/seed/peanuts/New()
 	..()
@@ -763,6 +764,7 @@
 	name = "vanilla"
 	seed_name = "vanilla"
 	display_name = "vanilla"
+	kitchen_tag = "vanilla"
 	chems = list("nutriment" = list(1,10), "vanilla" = list(0,3), "sugar" = list(0, 1))
 
 /datum/seed/vanilla/New()
@@ -782,8 +784,8 @@
 	name = "cabbage"
 	seed_name = "cabbage"
 	display_name = "cabbages"
-	chems = list("nutriment" = list(1,10))
 	kitchen_tag = "cabbage"
+	chems = list("nutriment" = list(1,10))
 
 /datum/seed/cabbage/New()
 	..()
@@ -804,9 +806,9 @@
 	name = "banana"
 	seed_name = "banana"
 	display_name = "banana tree"
+	kitchen_tag = "banana"
 	chems = list("banana" = list(10,10))
 	trash_type = /obj/item/weapon/bananapeel
-	kitchen_tag = "banana"
 
 /datum/seed/banana/New()
 	..()
@@ -826,8 +828,8 @@
 	name = "corn"
 	seed_name = "corn"
 	display_name = "ears of corn"
-	chems = list("nutriment" = list(1,10), "cornoil" = list(1,10))
 	kitchen_tag = "corn"
+	chems = list("nutriment" = list(1,10), "cornoil" = list(1,10))
 	trash_type = /obj/item/weapon/corncob
 
 /datum/seed/corn/New()
@@ -848,8 +850,8 @@
 	name = "potato"
 	seed_name = "potato"
 	display_name = "potatoes"
-	chems = list("nutriment" = list(1,10), "potatojuice" = list(10,10))
 	kitchen_tag = "potato"
+	chems = list("nutriment" = list(1,10), "potatojuice" = list(10,10))
 
 /datum/seed/potato/New()
 	..()
@@ -867,8 +869,8 @@
 	name = "onion"
 	seed_name = "onion"
 	display_name = "onions"
-	chems = list("nutriment" = list(1,10))
 	kitchen_tag = "onion"
+	chems = list("nutriment" = list(1,10))
 
 /datum/seed/onion/New()
 	..()
@@ -885,8 +887,8 @@
 	name = "soybean"
 	seed_name = "soybean"
 	display_name = "soybeans"
-	chems = list("nutriment" = list(1,20), "soymilk" = list(10,20))
 	kitchen_tag = "soybeans"
+	chems = list("nutriment" = list(1,20), "soymilk" = list(10,20))
 
 /datum/seed/soybean/New()
 	..()
@@ -903,8 +905,8 @@
 	name = "wheat"
 	seed_name = "wheat"
 	display_name = "wheat stalks"
-	chems = list("nutriment" = list(1,25), "flour" = list(15,15))
 	kitchen_tag = "wheat"
+	chems = list("nutriment" = list(1,25), "flour" = list(15,15))
 
 /datum/seed/wheat/New()
 	..()
@@ -923,8 +925,8 @@
 	name = "rice"
 	seed_name = "rice"
 	display_name = "rice stalks"
-	chems = list("nutriment" = list(1,25), "rice" = list(10,15))
 	kitchen_tag = "rice"
+	chems = list("nutriment" = list(1,25), "rice" = list(10,15))
 
 /datum/seed/rice/New()
 	..()
@@ -943,8 +945,8 @@
 	name = "carrot"
 	seed_name = "carrot"
 	display_name = "carrots"
-	chems = list("nutriment" = list(1,20), "imidazoline" = list(3,5), "carrotjuice" = list(10,20))
 	kitchen_tag = "carrot"
+	chems = list("nutriment" = list(1,20), "imidazoline" = list(3,5), "carrotjuice" = list(10,20))
 
 /datum/seed/carrots/New()
 	..()
@@ -978,8 +980,8 @@
 	name = "whitebeet"
 	seed_name = "white-beet"
 	display_name = "white-beets"
-	chems = list("nutriment" = list(0,20), "sugar" = list(1,5))
 	kitchen_tag = "whitebeet"
+	chems = list("nutriment" = list(0,20), "sugar" = list(1,5))
 
 /datum/seed/whitebeets/New()
 	..()
@@ -997,6 +999,7 @@
 	name = "sugarcane"
 	seed_name = "sugarcane"
 	display_name = "sugarcanes"
+	kitchen_tag = "sugarcanes"
 	chems = list("sugar" = list(4,5))
 
 /datum/seed/sugarcane/New()
@@ -1016,8 +1019,8 @@
 	name = "rhubarb"
 	seed_name = "rhubarb"
 	display_name = "rhubarb"
-	chems = list("nutriment" = list(1,15))
 	kitchen_tag = "rhubarb"
+	chems = list("nutriment" = list(1,15))
 
 /datum/seed/rhubarb/New()
 	..()
@@ -1034,8 +1037,8 @@
 	name = "celery"
 	seed_name = "celery"
 	display_name = "celery"
-	chems = list("nutriment" = list(5,20))
 	kitchen_tag = "celery"
+	chems = list("nutriment" = list(5,20))
 
 /datum/seed/celery/New()
 	..()
@@ -1052,8 +1055,8 @@
 	name = "spineapple"
 	seed_name = "spineapple"
 	display_name = "spineapple"
-	chems = list("nutriment" = list(1,5), "enzyme" = list(1,5), "pineapplejuice" = list(1, 20))
 	kitchen_tag = "pineapple"
+	chems = list("nutriment" = list(1,5), "enzyme" = list(1,5), "pineapplejuice" = list(1, 20))
 
 /datum/seed/spineapple/New()
 	..()
@@ -1076,8 +1079,8 @@
 	seed_name = "durian"
 	seed_noun = "pits"
 	display_name = "durian"
-	chems = list("nutriment" = list(1,5), "durianpaste" = list(1, 20))
 	kitchen_tag = "durian"
+	chems = list("nutriment" = list(1,5), "durianpaste" = list(1, 20))
 
 /datum/seed/durian/New()
 	..()
@@ -1097,8 +1100,8 @@
 	name = "watermelon"
 	seed_name = "watermelon"
 	display_name = "watermelon vine"
-	chems = list("nutriment" = list(1,6), "watermelonjuice" = list(10,6))
 	kitchen_tag = "watermelon"
+	chems = list("nutriment" = list(1,6), "watermelonjuice" = list(10,6))
 
 /datum/seed/watermelon/New()
 	..()
@@ -1121,8 +1124,8 @@
 	name = "pumpkin"
 	seed_name = "pumpkin"
 	display_name = "pumpkin vine"
-	chems = list("nutriment" = list(1,6))
 	kitchen_tag = "pumpkin"
+	chems = list("nutriment" = list(1,6))
 
 /datum/seed/pumpkin/New()
 	..()
@@ -1141,8 +1144,8 @@
 	name = "lime"
 	seed_name = "lime"
 	display_name = "lime trees"
-	chems = list("nutriment" = list(1,20), "limejuice" = list(10,20))
 	kitchen_tag = "lime"
+	chems = list("nutriment" = list(1,20), "limejuice" = list(10,20))
 
 /datum/seed/citrus/New()
 	..()
@@ -1161,8 +1164,8 @@
 	name = "lemon"
 	seed_name = "lemon"
 	display_name = "lemon trees"
-	chems = list("nutriment" = list(1,20), "lemonjuice" = list(10,20))
 	kitchen_tag = "lemon"
+	chems = list("nutriment" = list(1,20), "lemonjuice" = list(10,20))
 
 /datum/seed/citrus/lemon/New()
 	..()
@@ -1188,8 +1191,8 @@
 	name = "grass"
 	seed_name = "grass"
 	display_name = "grass"
-	chems = list("nutriment" = list(1,20))
 	kitchen_tag = "grass"
+	chems = list("nutriment" = list(1,20))
 
 /datum/seed/grass/New()
 	..()
@@ -1208,6 +1211,7 @@
 	name = "cocoa"
 	seed_name = "cacao"
 	display_name = "cacao tree"
+	kitchen_tag = "cocoa"
 	chems = list("nutriment" = list(1,10), "coco" = list(4,5))
 
 /datum/seed/cocoa/New()
@@ -1228,8 +1232,8 @@
 	seed_name = "cherry"
 	seed_noun = "pits"
 	display_name = "cherry tree"
-	chems = list("nutriment" = list(1,15), "sugar" = list(1,15), "cherryjelly" = list(10,15))
 	kitchen_tag = "cherries"
+	chems = list("nutriment" = list(1,15), "sugar" = list(1,15), "cherryjelly" = list(10,15))
 
 /datum/seed/cherries/New()
 	..()
@@ -1248,8 +1252,8 @@
 	name = "kudzu"
 	seed_name = "kudzu"
 	display_name = "kudzu vines"
-	chems = list("nutriment" = list(1,50), "anti_toxin" = list(1,25))
 	kitchen_tag = "kudzu"
+	chems = list("nutriment" = list(1,50), "anti_toxin" = list(1,25))
 
 /datum/seed/kudzu/New()
 	..()
@@ -1290,8 +1294,8 @@
 	name = "shand"
 	seed_name = "Selem's hand"
 	display_name = "Selem's hand leaves"
-	chems = list("bicaridine" = list(0,10))
 	kitchen_tag = "shand"
+	chems = list("bicaridine" = list(0,10))
 
 /datum/seed/shand/New()
 	..()
@@ -1310,8 +1314,8 @@
 	name = "mtear"
 	seed_name = "Malani's tear"
 	display_name = "Malani's tear leaves"
-	chems = list("honey" = list(1,10), "kelotane" = list(3,5))
 	kitchen_tag = "mtear"
+	chems = list("honey" = list(1,10), "kelotane" = list(3,5))
 
 /datum/seed/mtear/New()
 	..()
@@ -1330,6 +1334,7 @@
 	name = "telriis"
 	seed_name = "telriis"
 	display_name = "telriis grass"
+	kitchen_tag = "telriis"
 	chems = list("pwine" = list(1,5), "nutriment" = list(1,6))
 
 /datum/seed/telriis/New()
@@ -1346,6 +1351,7 @@
 	name = "thaadra"
 	seed_name = "thaa'dra"
 	display_name = "thaa'dra lichen"
+	kitchen_tag = "thaadra"
 	chems = list("frostoil" = list(1,5),"nutriment" = list(1,5))
 
 /datum/seed/thaadra/New()
@@ -1362,6 +1368,7 @@
 	name = "jurlmah"
 	seed_name = "jurl'mah"
 	display_name = "jurl'mah reeds"
+	kitchen_tag = "jurlmah"
 	chems = list("serotrotium" = list(1,5),"nutriment" = list(1,5))
 
 /datum/seed/jurlmah/New()
@@ -1377,6 +1384,7 @@
 	name = "amauri"
 	seed_name = "amauri"
 	display_name = "amauri plant"
+	kitchen_tag = "amauri"
 	chems = list("zombiepowder" = list(1,10),"condensedcapsaicin" = list(1,5),"nutriment" = list(1,5))
 
 /datum/seed/amauri/New()
@@ -1392,6 +1400,7 @@
 	name = "gelthi"
 	seed_name = "gelthi"
 	display_name = "gelthi plant"
+	kitchen_tag = "gelthi"
 	chems = list("stoxin" = list(1,5),"capsaicin" = list(1,5),"nutriment" = list(1,5))
 
 /datum/seed/gelthi/New()
@@ -1407,6 +1416,7 @@
 	name = "vale"
 	seed_name = "vale"
 	display_name = "vale bush"
+	kitchen_tag = "vale"
 	chems = list("paracetamol" = list(1,5),"dexalin" = list(1,2),"nutriment"= list(1,5))
 
 /datum/seed/vale/New()
@@ -1422,6 +1432,7 @@
 	name = "surik"
 	seed_name = "surik"
 	display_name = "surik vine"
+	kitchen_tag = "surik"
 	chems = list("impedrezene" = list(1,3),"synaptizine" = list(1,2),"nutriment" = list(1,5))
 
 /datum/seed/surik/New()


### PR DESCRIPTION
- Removes redundant syntiflesh recipies from the list.

- Allows kabobs to be made with any meat, not exclusively human, synti and monkey (similar to other meat dishes in that sense now)

- Fixes Fruit Salad recipe by adding kitchen tag to grapes (greengrapes share it and are interchangable with regular for it)

- Adds a bunch of kitchen tags to some other plants that had none, to prevent another grapes situation