### PR TITLE
Melee Mobs Can Attack with Pointblank

### DIFF
--- a/code/modules/ai/ai_holder_combat.dm
+++ b/code/modules/ai/ai_holder_combat.dm
@@ -65,6 +65,11 @@
 		on_engagement(target)
 		melee_attack(target)
 
+	else if(distance <= 1 && !holder.ICheckRangedAttack(target)) // Doesn't have projectile, but is pointblank
+		ai_log("engage_target() : Attempting a melee attack.", AI_LOG_TRACE)
+		on_engagement(target)
+		melee_attack(target)
+
 	// Shoot them.
 	else if(holder.ICheckRangedAttack(target) && (distance <= max_range(target)) )
 		on_engagement(target)


### PR DESCRIPTION
Fixes #6174 
Fixes #5934 

If a mob has pointblank, but isn't ranged, it can now attack again. This fixes hivebots not attacking people.