### PR TITLE
Removes A Few Alternate Tool Options For 2 Surgical Operations

### DIFF
--- a/code/modules/surgery/external_repair.dm
+++ b/code/modules/surgery/external_repair.dm
@@ -34,7 +34,6 @@
 /datum/surgery_step/repairflesh/scan_injury
 	allowed_tools = list(
 	/obj/item/weapon/autopsy_scanner = 100,
-	/obj/item/device/healthanalyzer = 80,
 	/obj/item/device/analyzer = 10
 	)
 
@@ -85,8 +84,6 @@
 /datum/surgery_step/repairflesh/repair_burns
 	allowed_tools = list(
 	/obj/item/stack/medical/advanced/ointment = 100,
-	/obj/item/weapon/surgical/FixOVein = 100,
-	/obj/item/weapon/surgical/hemostat = 60,
 	/obj/item/stack/medical/ointment = 50,
 	/obj/item/weapon/tape_roll = 30,
 	/obj/item/taperoll = 10
@@ -153,8 +150,6 @@
 /datum/surgery_step/repairflesh/repair_brute
 	allowed_tools = list(
 	/obj/item/stack/medical/advanced/bruise_pack = 100,
-	/obj/item/weapon/surgical/cautery = 100,
-	/obj/item/weapon/surgical/bonesetter = 60,
 	/obj/item/stack/medical/bruise_pack = 50,
 	/obj/item/weapon/tape_roll = 40,
 	/obj/item/taperoll = 10

--- a/code/modules/surgery/neck.dm
+++ b/code/modules/surgery/neck.dm
@@ -24,7 +24,6 @@
 	priority = 1
 	allowed_tools = list(
 		/obj/item/weapon/surgical/FixOVein = 100,
-		/obj/item/stack/nanopaste = 50,
 		/obj/item/stack/cable_coil = 40,
 		/obj/item/device/assembly/mousetrap = 5)
 


### PR DESCRIPTION
TLDR:
- Fixovein, Cautery, Bone-setter and hemostat, were removed as 'trauma/burn-kit' alternates, as both burn and brute heal operations had a non-kit 100% success rate tool that you could use instead of kits. Now, you have to use kits, or attempt gauze/ointment with a lower success-rate than the kits.

- Health analyzer was removed as an alternative to biopsy scanner for the first step in brute/burn healing operations to prevent conflicts with analyzing patients vitals mid-surgery. 

- Nanopaste was removed as an alternative to fixovein for the first step in head-reattachment, as it conflicted with mending prosthetics in the skull.
----------------------

For the brute/burn healing surgeries, the idea behind it was to use advanced trauma kits and burn kits applied directly to the damaged area to heal a greater amount than you would by just putting them on externally. It was possible to simply ignore that entirely and use other surgical tools, like the bone-setter, hemostat, fixovein, and cautery, as 100% success-rate options without having to actually USE supplies. Instead of using kits, you could just...not, and it'd always work. You could also use a health-analyzer for the initial step instead of the biopsy scanner, which at times resulted in conflicts where someone would be trying to analyze the patient's vitals and it kept attempting a surgical step, so that was removed to prevent conflicts.

For the head-reattachment-surgery, nanopaste was removed as an alternative tool for the initial step of 'mending the blood vessels in the brainstem', as it conflicted with mechanical eye mending. The chance to fail meant that you could actually end up really screwing a patient up and you HAD to succeed in that step before you could continue on to heal their damaged optical-sensors, so you had no real choice other than to keep trying until you succeeded. 

