### PR TITLE
Makes rigpieces phoron immune

### DIFF
--- a/code/modules/clothing/shoes/magboots.dm
+++ b/code/modules/clothing/shoes/magboots.dm
@@ -2,6 +2,7 @@
 	desc = "Magnetic boots, often used during extravehicular activity to ensure the user remains safely attached to the vehicle. They're large enough to be worn over other footwear."
 	name = "magboots"
 	icon_state = "magboots0"
+	item_flags = PHORONGUARD
 	item_state_slots = list(slot_r_hand_str = "magboots", slot_l_hand_str = "magboots")
 	species_restricted = null
 	force = 3

--- a/code/modules/clothing/spacesuits/rig/rig_pieces.dm
+++ b/code/modules/clothing/spacesuits/rig/rig_pieces.dm
@@ -23,7 +23,7 @@
 
 /obj/item/clothing/gloves/gauntlets/rig
 	name = "gauntlets"
-	item_flags = THICKMATERIAL
+	item_flags = THICKMATERIAL|PHORONGUARD
 	body_parts_covered = HANDS
 	heat_protection =    HANDS
 	cold_protection =    HANDS


### PR DESCRIPTION
Specifically. Rigsuit gloves and all magbootsl. Because really, those things aren't cloth and none of rig pieces can actually be cleaned properly of phoron contamination.