### PR TITLE
Allows Multiple Light Printing in Autolathe

### DIFF
--- a/code/datums/autolathe/autolathe.dm
+++ b/code/datums/autolathe/autolathe.dm
@@ -8,9 +8,12 @@ var/datum/category_collection/autolathe/autolathe_recipes
 		for(var/material in I.matter)
 			var/coeff = (no_scale ? 1 : 1.25) //most objects are more expensive to produce than to recycle
 			resources[material] = I.matter[material]*coeff // but if it's a sheet or RCD cartridge, it's 1:1
-	if(is_stack && istype(I, /obj/item/stack))
-		var/obj/item/stack/IS = I
-		max_stack = IS.max_amount
+	if(is_stack)
+		if(istype(I, /obj/item/stack))
+			var/obj/item/stack/IS = I
+			max_stack = IS.max_amount
+		else
+			max_stack = 10
 	qdel(I)
 
 /****************************
@@ -65,7 +68,7 @@ var/datum/category_collection/autolathe/autolathe_recipes
 	var/list/resources
 	var/hidden
 	var/power_use = 0
-	var/is_stack
+	var/is_stack // Creates multiple of an item if applied to non-stack items
 	var/max_stack
 	var/no_scale
 

--- a/code/datums/autolathe/general.dm
+++ b/code/datums/autolathe/general.dm
@@ -105,10 +105,12 @@
 /datum/category_item/autolathe/general/tube
 	name = "light tube"
 	path =/obj/item/weapon/light/tube
+	is_stack = TRUE
 
 /datum/category_item/autolathe/general/bulb
 	name = "light bulb"
 	path =/obj/item/weapon/light/bulb
+	is_stack = TRUE
 
 /datum/category_item/autolathe/general/ashtray_glass
 	name = "glass ashtray"

--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -276,9 +276,13 @@
 
 		//Create the desired item.
 		var/obj/item/I = new making.path(src.loc)
-		if(multiplier > 1 && istype(I, /obj/item/stack))
-			var/obj/item/stack/S = I
-			S.amount = multiplier
+		if(multiplier > 1)
+			if(istype(I, /obj/item/stack))
+				var/obj/item/stack/S = I
+				S.amount = multiplier
+			else
+				for(multiplier; multiplier > 1; --multiplier) // Create multiple items if it's not a stack.
+					new making.path(src.loc)
 
 	updateUsrDialog()
 


### PR DESCRIPTION
Allows light tubes and light bulbs to be printed 5 or 10 at a time.

Changes the is_stack var to be more general. Non-stack items with it will be able to produce 5 or 10 of said item at a time. This means it can be applied to other items if desired.