### PR TITLE
Allows synthetic names to start with a number

### DIFF
--- a/code/_helpers/text.dm
+++ b/code/_helpers/text.dm
@@ -84,7 +84,6 @@
 
 			// 0  .. 9
 			if(48 to 57)			//Numbers
-				if(!last_char_group)		continue	//suppress at start of string
 				if(!allow_numbers)			continue	// If allow_numbers is 0, then don't do this.
 				output += ascii2text(ascii_char)
 				number_of_alphanumeric++


### PR DESCRIPTION
Because, really, why not? Special symbols (like +, -, etc) are all still forbidden at start of the names.