### PR TITLE
Fixes Repairing Bots

### DIFF
--- a/code/modules/mob/living/bot/bot.dm
+++ b/code/modules/mob/living/bot/bot.dm
@@ -111,7 +111,15 @@
 	else if(istype(O, /obj/item/weapon/weldingtool))
 		if(health < getMaxHealth())
 			if(open)
-				health = min(getMaxHealth(), health + 10)
+				if(getBruteLoss() < 10)
+					bruteloss = 0
+				else
+					bruteloss = bruteloss - 10
+				if(getFireLoss() < 10)
+					fireloss = 0
+				else
+					fireloss = fireloss - 10
+				updatehealth()
 				user.visible_message("<span class='notice'>[user] repairs [src].</span>","<span class='notice'>You repair [src].</span>")
 				playsound(src, O.usesound, 50, 1)
 			else

--- a/code/modules/mob/living/bot/bot.dm
+++ b/code/modules/mob/living/bot/bot.dm
@@ -88,13 +88,13 @@
 
 /mob/living/bot/attackby(var/obj/item/O, var/mob/user)
 	if(O.GetID())
-		if(access_scanner.allowed(user) && !open && !emagged)
+		if(access_scanner.allowed(user) && !open)
 			locked = !locked
 			to_chat(user, "<span class='notice'>Controls are now [locked ? "locked." : "unlocked."]</span>")
 			attack_hand(user)
-		else
 			if(emagged)
-				to_chat(user, "<span class='warning'>ERROR</span>")
+				to_chat(user, "<span class='warning'>ERROR! SYSTEMS COMPROMISED!</span>")
+		else
 			if(open)
 				to_chat(user, "<span class='warning'>Please close the access panel before locking it.</span>")
 			else
@@ -127,6 +127,13 @@
 		else
 			to_chat(user, "<span class='notice'>[src] does not need a repair.</span>")
 		return
+	else if(istype(O, /obj/item/device/assembly/prox_sensor) && emagged)
+		if(open)
+			to_chat(user, "<span class='notice'>You repair the bot's systems.</span>")
+			emagged = 0
+			qdel(O)
+		else
+			to_chat(user, "<span class='notice'>Unable to repair with the maintenance panel closed.</span>")
 	else
 		..()
 

--- a/html/changelogs/Nalarac - Bot Repairing.yml
+++ b/html/changelogs/Nalarac - Bot Repairing.yml
@@ -34,3 +34,4 @@ delete-after: True
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes: 
   - bugfix: "Repairing bots (like Beepsky) works now."
+  - rcsadd: "Emagged bots can be repaired with proximity sensors."

--- a/html/changelogs/Nalarac - Bot Repairing.yml
+++ b/html/changelogs/Nalarac - Bot Repairing.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Nalarac
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Repairing bots (like Beepsky) works now."

--- a/html/changelogs/Nalarac - Bot Repairing.yml
+++ b/html/changelogs/Nalarac - Bot Repairing.yml
@@ -34,4 +34,4 @@ delete-after: True
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes: 
   - bugfix: "Repairing bots (like Beepsky) works now."
-  - rcsadd: "Emagged bots can be repaired with proximity sensors."
+  - rscadd: "Emagged bots can be repaired with proximity sensors."


### PR DESCRIPTION
You can now repair beepsky, slime securitrons, and other bots if they get damaged.
Emagged bots can be repaired with a proximity sensor when the maintenance panel is open.