### PR TITLE
Changes Space Helmet Cameras to a Verb

### DIFF
--- a/code/modules/clothing/spacesuits/spacesuits.dm
+++ b/code/modules/clothing/spacesuits/spacesuits.dm
@@ -30,23 +30,36 @@
 	brightness_on = 4
 	on = 0
 
-/obj/item/clothing/head/helmet/space/attack_self(mob/user)
+/obj/item/clothing/head/helmet/space/verb/toggle_camera()
+	set name = "Toggle Helmet Camera"
+	set desc = "Turn your helmet's camera on or off."
+	set category = "IC"
+	set src in usr
+	if(usr.stat || usr.restrained() || usr.incapacitated())
+		return
 
-	if(!camera && camera_networks)
+	if(camera_networks)
+		if(!camera)
+			camera = new /obj/machinery/camera(src)
+			camera.replace_networks(camera_networks)
+			camera.set_status(FALSE) //So the camera will activate in the following check.
 
-		camera = new /obj/machinery/camera(src)
-		camera.replace_networks(camera_networks)
-		camera.c_tag = user.name
-		user << "<font color='blue'>User scanned as [camera.c_tag]. Camera activated.</font>"
-		user.update_action_buttons()
-		return 1
+		if(camera.status == TRUE)
+			camera.set_status(FALSE)
+			to_chat(usr, "<font color='blue'>Camera deactivated.</font>")
+		else
+			camera.set_status(TRUE)
+			camera.c_tag = usr.name
+			to_chat(usr, "<font color='blue'>User scanned as [camera.c_tag]. Camera activated.</font>")
 
-	..()
+	else
+		to_chat(usr, "This helmet does not have a built-in camera.")
+		return
 
 /obj/item/clothing/head/helmet/space/examine()
 	..()
 	if(camera_networks && get_dist(usr,src) <= 1)
-		usr << "This helmet has a built-in camera. It's [camera ? "" : "in"]active."
+		to_chat(usr, "This helmet has a built-in camera. It's [camera ? "" : "in"]active.")
 
 /obj/item/clothing/suit/space
 	name = "Space suit"
@@ -95,18 +108,18 @@
 	if(user.wear_suit == src)
 		for(var/obj/item/organ/external/E in user.bad_external_organs)
 			if(E.is_broken() && E.apply_splint(src))
-				user << "You feel [src] constrict about your [E.name], supporting it."
+				to_chat(user, "You feel [src] constrict about your [E.name], supporting it.")
 				supporting_limbs |= E
 	else
 		// Otherwise, remove the splints.
 		for(var/obj/item/organ/external/E in supporting_limbs)
 			if(E.splinted == src && E.remove_splint(src))
-				user << "\The [src] stops supporting your [E.name]."
+				to_chat(user, "\The [src] stops supporting your [E.name].")
 		supporting_limbs.Cut()
 
 /obj/item/clothing/suit/space/proc/handle_fracture(var/mob/living/carbon/human/user, var/obj/item/organ/external/E)
 	if(!istype(user) || isnull(supporting_limbs))
 		return
 	if(E.is_broken() && E.apply_splint(src))
-		user << "You feel [src] constrict about your [E.name], supporting it."
+		to_chat(user, "You feel [src] constrict about your [E.name], supporting it.")
 		supporting_limbs |= E

--- a/code/modules/clothing/spacesuits/spacesuits.dm
+++ b/code/modules/clothing/spacesuits/spacesuits.dm
@@ -33,7 +33,7 @@
 /obj/item/clothing/head/helmet/space/verb/toggle_camera()
 	set name = "Toggle Helmet Camera"
 	set desc = "Turn your helmet's camera on or off."
-	set category = "IC"
+	set category = "Object"
 	set src in usr
 	if(usr.stat || usr.restrained() || usr.incapacitated())
 		return

--- a/html/changelogs/Nalarac - Helmet Cameras.yml
+++ b/html/changelogs/Nalarac - Helmet Cameras.yml
@@ -1,0 +1,37 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Nalarac
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Changes space helmet cameras to be a verb instead of on toggling lights."
+  - rscadd: "Toggling helmet camera resets user upon activation (so you can have a new user)."


### PR DESCRIPTION
You no longer enable the helmet camera when toggling helmet lights.

The verb is located in the <strike>IC</strike> **Object** tab.
The camera can be deactivated and reactivated with the verb after initial activation.
The user is set each time the camera is activated, so a new user can be scanned to the suit's camera.

Changes some lines to use to_chat