### PR TITLE
Event Tweaks / Fixes

### DIFF
--- a/code/modules/gamemaster/actions/action.dm
+++ b/code/modules/gamemaster/actions/action.dm
@@ -7,6 +7,7 @@
 	var/observers_used = FALSE			// Determines if the GM should check if ghosts are available before using this.
 	var/length = 0						// Determines how long the event lasts, until end() is called.
 	var/datum/game_master/gm = null
+	var/severity = 1					// The severity of the action. This is here to prevent continued future defining of this var on actions, un-used.
 
 /datum/gm_action/proc/set_up()
 	return

--- a/code/modules/gamemaster/actions/atmos_leak.dm
+++ b/code/modules/gamemaster/actions/atmos_leak.dm
@@ -13,7 +13,7 @@
 		/area/engineering/engine_room
 	)
 
-	var/severity
+	severity
 
 // Decide which area will be targeted!
 /datum/gm_action/atmos_leak/set_up()

--- a/code/modules/gamemaster/actions/blob.dm
+++ b/code/modules/gamemaster/actions/blob.dm
@@ -3,13 +3,59 @@
 	departments = list(ROLE_ENGINEERING, ROLE_SECURITY, ROLE_MEDICAL)
 	chaotic = 25
 
+	var/list/area/excluded = list(
+		/area/submap,
+		/area/shuttle,
+		/area/crew_quarters,
+		/area/holodeck,
+		/area/engineering/engine_room
+	)
+
+	var/area/target_area	// Chosen target area
+	var/turf/target_turf	// Chosen target turf in target_area
+
 	var/obj/structure/blob/core/Blob
+	var/spawn_blob_type = /obj/structure/blob/core/random_medium
+
+/datum/gm_action/blob/set_up()
+	severity = pickweight(EVENT_LEVEL_MUNDANE = 4,
+		EVENT_LEVEL_MODERATE = 2,
+		EVENT_LEVEL_MAJOR = 1
+		)
+
+	var/list/area/grand_list_of_areas = get_station_areas(excluded)
+
+	for(var/i in 1 to 10)
+		var/area/A = pick(grand_list_of_areas)
+		if(is_area_occupied(A))
+			log_debug("Blob infestation event: Rejected [A] because it is occupied.")
+			continue
+		var/list/turfs = list()
+		for(var/turf/simulated/floor/F in A)
+			if(turf_clear(F))
+				turfs += F
+		if(turfs.len == 0)
+			log_debug("Blob infestation event: Rejected [A] because it has no clear turfs.")
+			continue
+		target_area = A
+		target_turf = pick(turfs)
+
+	if(!target_area)
+		log_debug("Blob infestation event: Giving up after too many failures to pick target area")
 
 /datum/gm_action/blob/start()
 	..()
-	var/turf/T = pick(blobstart)
+	var/turf/T
 
-	Blob = new /obj/structure/blob/core/random_medium(T)
+	if(severity == EVENT_LEVEL_MUNDANE || !target_area || !target_turf)
+		T = pick(blobstart)
+	else if(severity == EVENT_LEVEL_MODERATE)
+		T = target_turf
+	else
+		T = target_turf
+		spawn_blob_type = /obj/structure/blob/core/random_hard
+
+	Blob = new spawn_blob_type(T)
 
 /datum/gm_action/blob/announce()
 	spawn(rand(600, 3000))	// 1-5 minute leeway for the blob to go un-detected.

--- a/code/modules/gamemaster/actions/camera_damage.dm
+++ b/code/modules/gamemaster/actions/camera_damage.dm
@@ -10,7 +10,7 @@
 	..()
 
 	var/severity_range = 0
-	var/severity = pickweight(EVENT_LEVEL_MUNDANE = 10,
+	severity = pickweight(EVENT_LEVEL_MUNDANE = 10,
 		EVENT_LEVEL_MODERATE = 5,
 		EVENT_LEVEL_MAJOR = 1
 		)

--- a/code/modules/gamemaster/actions/carp_migration.dm
+++ b/code/modules/gamemaster/actions/carp_migration.dm
@@ -8,14 +8,7 @@
 	length = 20 MINUTES
 
 /datum/gm_action/carp_migration/get_weight()
-	var/people_in_space = 0
-	for(var/mob/living/L in player_list)
-		if(!(L.z in using_map.station_levels))
-			continue // Not on the right z-level.
-		var/turf/T = get_turf(L)
-		if(istype(T, /turf/space) && istype(T.loc,/area/space))
-			people_in_space++
-	return 50 + (metric.count_people_in_department(ROLE_SECURITY) * 10) + (people_in_space * 20)
+	return 50 + (metric.count_people_in_department(ROLE_SECURITY) * 10) + (metric.count_all_space_mobs() * 20)
 
 /datum/gm_action/carp_migration/announce()
 	var/announcement = "Unknown biological entities have been detected near [station_name()], please stand-by."

--- a/code/modules/gamemaster/actions/electrified_door.dm
+++ b/code/modules/gamemaster/actions/electrified_door.dm
@@ -9,7 +9,6 @@
 		/area/shuttle,
 		/area/crew_quarters
 	)
-	var/severity
 
 /datum/gm_action/electrified_door/set_up()
 	var/list/area/grand_list_of_areas = get_station_areas(excluded)

--- a/code/modules/gamemaster/actions/radiation_storm.dm
+++ b/code/modules/gamemaster/actions/radiation_storm.dm
@@ -64,11 +64,4 @@
 		revoke_maint_all_access()
 
 /datum/gm_action/radiation_storm/get_weight()
-	var/people_in_space = 0
-	for(var/mob/living/L in player_list)
-		if(!(L.z in using_map.station_levels))
-			continue // Not on the right z-level.
-		var/turf/T = get_turf(L)
-		if(istype(T, /turf/space) && istype(T.loc,/area/space))
-			people_in_space++
-	return 20 + (metric.count_people_in_department(ROLE_MEDICAL) * 10) + (people_in_space * 40) + (metric.count_people_in_department(ROLE_EVERYONE) * 20)
+	return 20 + (metric.count_people_in_department(ROLE_MEDICAL) * 10) + (metric.count_all_space_mobs() * 40) + (metric.count_people_in_department(ROLE_EVERYONE) * 20)

--- a/code/modules/gamemaster/actions/rogue_drones.dm
+++ b/code/modules/gamemaster/actions/rogue_drones.dm
@@ -60,11 +60,4 @@
 		command_announcement.Announce("We're disappointed at the loss of the drones, but the survivors have been recovered.", "Rogue drone alert")
 
 /datum/gm_action/rogue_drone/get_weight()
-	var/people_in_space = 0
-	for(var/mob/living/L in player_list)
-		if(!(L.z in using_map.station_levels))
-			continue // Not on the right z-level.
-		var/turf/T = get_turf(L)
-		if(istype(T, /turf/space) && istype(T.loc,/area/space))
-			people_in_space++
-	return 20 + (metric.count_people_in_department(ROLE_SECURITY) * 10) + (people_in_space * 30)
+	return 20 + (metric.count_people_in_department(ROLE_SECURITY) * 10) + (metric.count_all_space_mobs() * 30)

--- a/code/modules/gamemaster/actions/solar_storm.dm
+++ b/code/modules/gamemaster/actions/solar_storm.dm
@@ -1,6 +1,6 @@
 /datum/gm_action/solar_storm
 	name = "solar storm"
-	var/const/rad_interval 	= 5  	//Same interval period as radiation storms.
+	var/rad_interval = 1 SECOND
 	var/base_solar_gen_rate
 	length = 3 MINUTES
 	var/duration	// Duration for the storm
@@ -21,30 +21,24 @@
 	if(isnull(base_solar_gen_rate)) base_solar_gen_rate = GLOB.solar_gen_rate
 	GLOB.solar_gen_rate = mult * base_solar_gen_rate
 
-
 /datum/gm_action/solar_storm/start()
 	..()
 	length = duration
 	command_announcement.Announce("The solar storm has reached the station. Please refain from EVA and remain inside the station until it has passed.", "Anomaly Alert")
 	adjust_solar_output(5)
 
-	while(world.time <= world.time + duration)
-		if(duration % rad_interval == 0)
-			radiate()
+	var/start_time = world.time
+
+	while(world.time <= start_time + duration)
+		sleep(rad_interval)
+		radiate()
 
 /datum/gm_action/solar_storm/get_weight()
-	var/people_in_space = 0
-	for(var/mob/living/L in player_list)
-		if(!(L.z in using_map.station_levels))
-			continue // Not on the right z-level.
-		var/turf/T = get_turf(L)
-		if(istype(T, /turf/space) && istype(T.loc,/area/space))
-			people_in_space++
-	return 20 + (metric.count_people_in_department(ROLE_ENGINEERING) * 10) + (people_in_space * 30)
+	return 20 + (metric.count_people_in_department(ROLE_ENGINEERING) * 10) + (metric.count_all_space_mobs() * 30)
 
 /datum/gm_action/solar_storm/proc/radiate()
 	// Note: Too complicated to be worth trying to use the radiation system for this.  Its only in space anyway, so we make an exception in this case.
-	for(var/mob/living/L in living_mob_list)
+	for(var/mob/living/L in player_list)
 		var/turf/T = get_turf(L)
 		if(!T)
 			continue

--- a/code/modules/gamemaster/actions/solar_storm.dm
+++ b/code/modules/gamemaster/actions/solar_storm.dm
@@ -29,9 +29,10 @@
 
 	var/start_time = world.time
 
-	while(world.time <= start_time + duration)
-		sleep(rad_interval)
-		radiate()
+	spawn()
+		while(world.time <= start_time + duration)
+			sleep(rad_interval)
+			radiate()
 
 /datum/gm_action/solar_storm/get_weight()
 	return 20 + (metric.count_people_in_department(ROLE_ENGINEERING) * 10) + (metric.count_all_space_mobs() * 30)

--- a/code/modules/gamemaster/actions/spider_infestation.dm
+++ b/code/modules/gamemaster/actions/spider_infestation.dm
@@ -3,7 +3,7 @@
 	departments = list(ROLE_SECURITY, ROLE_MEDICAL, ROLE_EVERYONE)
 	chaotic = 30
 
-	var/severity = 1
+	severity = 1
 
 	var/spawncount = 1
 

--- a/code/modules/gamemaster/actions/surprise_carp_attack.dm
+++ b/code/modules/gamemaster/actions/surprise_carp_attack.dm
@@ -8,14 +8,7 @@
 	var/mob/living/victim = null
 
 /datum/gm_action/surprise_carp_attack/get_weight()
-	var/people_in_space = 0
-	for(var/mob/living/L in player_list)
-		if(!(L.z in using_map.station_levels))
-			continue // Not on the right z-level.
-		var/turf/T = get_turf(L)
-		if(istype(T, /turf/space) && istype(T.loc,/area/space))
-			people_in_space++
-	return people_in_space * 50
+	return metric.count_all_space_mobs() * 50
 
 /datum/gm_action/surprise_carp_attack/set_up()
 	var/list/potential_victims = list()
@@ -28,7 +21,8 @@
 		var/turf/T = get_turf(L)
 		if(istype(T, /turf/space) && istype(T.loc,/area/space))
 			potential_victims.Add(L)
-	victim = pick(potential_victims)
+	if(potential_victims.len)
+		victim = pick(potential_victims)
 
 
 /datum/gm_action/surprise_carp_attack/start()

--- a/code/modules/gamemaster/actions/viral_infection.dm
+++ b/code/modules/gamemaster/actions/viral_infection.dm
@@ -5,7 +5,7 @@
 	departments = list(ROLE_MEDICAL)
 	chaotic = 5
 	var/list/viruses = list()
-	var/severity = 1
+	severity = 1
 
 /datum/gm_action/viral_infection/set_up()
 	severity = pickweight(EVENT_LEVEL_MUNDANE = 20,

--- a/code/modules/gamemaster/actions/viral_outbreak.dm
+++ b/code/modules/gamemaster/actions/viral_outbreak.dm
@@ -2,7 +2,7 @@
 	name = "viral outbreak"
 	departments = list(ROLE_MEDICAL, ROLE_EVERYONE)
 	chaotic = 30
-	var/severity = 1
+	severity = 1
 	var/list/candidates = list()
 
 /datum/gm_action/viral_outbreak/set_up()

--- a/code/modules/gamemaster/actions/wallrot.dm
+++ b/code/modules/gamemaster/actions/wallrot.dm
@@ -3,7 +3,7 @@
 	departments = list(ROLE_ENGINEERING)
 	reusable = TRUE
 	var/turf/simulated/wall/center
-	var/severity = 1
+	severity = 1
 
 /datum/gm_action/wallrot/set_up()
 	severity = rand(1,3)

--- a/code/modules/gamemaster/actions/wormholes.dm
+++ b/code/modules/gamemaster/actions/wormholes.dm
@@ -3,7 +3,7 @@
 	chaotic = 70
 	length = 12 MINUTES
 	departments = list(ROLE_EVERYONE)
-	var/severity = 1
+	severity = 1
 
 /datum/gm_action/wormholes/set_up()	// 1 out of 5 will be full-duration wormholes, meaning up to a minute long.
 	severity = pickweight(list(

--- a/code/modules/metric/count.dm
+++ b/code/modules/metric/count.dm
@@ -11,11 +11,13 @@
 				num++
 	return num
 
-/datum/metric/proc/count_all_space_mobs(var/cutoff = 75)
+/datum/metric/proc/count_all_space_mobs(var/cutoff = 75, var/respect_z = TRUE)
 	var/num = 0
 	for(var/mob/living/L in player_list)
 		var/turf/T = get_turf(L)
-		if(istype(T, /turf/space))
+		if(istype(T, /turf/space) && istype(T.loc, /area/space))
+			if(respect_z && !(L.z in using_map.station_levels))
+				continue
 			if(assess_player_activity(L) >= cutoff)
 				num++
 	return num


### PR DESCRIPTION
Fixes:
Solar Storm no longer infinite loops

Sudden Carp no longer crashes due to having no potential targets when forced.

Tweaks:
Severity is now a base var on all events, unused aside from those which previously defined it.
Blob now has a severity rating, determining where it spawns, and the lists of blobs it can choose from.