### PR TITLE
Fixes Ripley Speedboost Being Uncreatable

### DIFF
--- a/code/modules/research/mechfab_designs.dm
+++ b/code/modules/research/mechfab_designs.dm
@@ -667,6 +667,7 @@
 /datum/design/item/mecha/speedboost_ripley
 	name = "Ripley Leg Actuator Overdrive"
 	desc = "System enhancements and overdrives to make a mech's legs move faster."
+	id = "mech_speedboost_ripley"
 	req_tech = list( TECH_POWER = 5, TECH_MATERIAL = 4, TECH_ENGINEERING = 4)
 	materials = list(DEFAULT_WALL_MATERIAL = 10000, "silver" = 1000, "gold" = 1000)
 	build_path = /obj/item/mecha_parts/mecha_equipment/speedboost


### PR DESCRIPTION
I am dumb and didn't notice I didn't put an ID in the datum.

Fixes the ripley speedboost being uncreatable in the exosuit fabricator.