### PR TITLE
Lowers Bot Emag Chance from Ion Storm

### DIFF
--- a/code/modules/events/ion_storm.dm
+++ b/code/modules/events/ion_storm.dm
@@ -1,7 +1,7 @@
 //This file was auto-corrected by findeclaration.exe on 29/05/2012 15:03:04
 
 /datum/event/ionstorm
-	var/botEmagChance = 0.5
+	var/botEmagChance = 0.05
 	var/list/players = list()
 
 /datum/event/ionstorm/announce()
@@ -14,8 +14,8 @@
 
 	for (var/mob/living/silicon/ai/target in silicon_mob_list)
 		var/law = target.generate_ion_law()
-		target << "<font color='red'><b>You have detected a change in your laws information:</b></font>"
-		target << law
+		to_chat(target, "<font color='red'><b>You have detected a change in your laws information:</b></font>")
+		to_chat(target, law)
 		target.add_ion_law(law)
 		target.show_laws()
 

--- a/html/changelogs/Nalarac - Bot Ion Storm.yml
+++ b/html/changelogs/Nalarac - Bot Ion Storm.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Nalarac
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Lowered Chance of bots being emagged during ion storm."


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/8042031/62428749-ae928e00-b6ca-11e9-9377-da9e713d195b.png)

Changes the value of the bot Emag Chance from **0.5** to **0.05** in the ion storm event. The effect of this change are shown in the table above with 8.3 minutes being the minimum event time and 25 minutes being the max.

fixes #6371 