### PR TITLE
Fixes Mech Cable Layer

### DIFF
--- a/code/game/mecha/equipment/mecha_equipment.dm
+++ b/code/game/mecha/equipment/mecha_equipment.dm
@@ -241,3 +241,6 @@
 	if(chassis)
 		chassis.log_message("<i>[src]:</i> [message]")
 	return
+
+/obj/item/mecha_parts/mecha_equipment/proc/MoveAction() //Allows mech equipment to do an action upon the mech moving
+	return

--- a/code/game/mecha/equipment/tools/medical_tools.dm
+++ b/code/game/mecha/equipment/tools/medical_tools.dm
@@ -10,7 +10,7 @@
 	var/mob/living/carbon/human/occupant = null
 	var/datum/global_iterator/pr_mech_sleeper
 	var/inject_amount = 5
-	required_type = /obj/mecha/medical
+	required_type = list(/obj/mecha/medical)
 	salvageable = 0
 	allow_duplicate = TRUE
 
@@ -247,144 +247,6 @@
 	return
 
 
-/obj/item/mecha_parts/mecha_equipment/tool/cable_layer
-	name = "Cable Layer"
-	icon_state = "mecha_wire"
-	var/datum/event/event
-	var/turf/old_turf
-	var/obj/structure/cable/last_piece
-	var/obj/item/stack/cable_coil/cable
-	var/max_cable = 1000
-	required_type = /obj/mecha/working
-
-/obj/item/mecha_parts/mecha_equipment/tool/cable_layer/New()
-	cable = new(src)
-	cable.amount = 0
-	..()
-
-/obj/item/mecha_parts/mecha_equipment/tool/cable_layer/attach()
-	..()
-	event = chassis.events.addEvent("onMove",src,"layCable")
-	return
-
-/obj/item/mecha_parts/mecha_equipment/tool/cable_layer/detach()
-	chassis.events.clearEvent("onMove",event)
-	return ..()
-
-/obj/item/mecha_parts/mecha_equipment/tool/cable_layer/destroy()
-	chassis.events.clearEvent("onMove",event)
-	return ..()
-
-/obj/item/mecha_parts/mecha_equipment/tool/cable_layer/action(var/obj/item/stack/cable_coil/target)
-	if(!action_checks(target))
-		return
-	var/result = load_cable(target)
-	var/message
-	if(isnull(result))
-		message = "<font color='red'>Unable to load [target] - no cable found.</font>"
-	else if(!result)
-		message = "Reel is full."
-	else
-		message = "[result] meters of cable successfully loaded."
-		send_byjax(chassis.occupant,"exosuit.browser","\ref[src]",src.get_equip_info())
-	occupant_message(message)
-	return
-
-/obj/item/mecha_parts/mecha_equipment/tool/cable_layer/Topic(href,href_list)
-	..()
-	if(href_list["toggle"])
-		set_ready_state(!equip_ready)
-		occupant_message("[src] [equip_ready?"dea":"a"]ctivated.")
-		log_message("[equip_ready?"Dea":"A"]ctivated.")
-		return
-	if(href_list["cut"])
-		if(cable && cable.amount)
-			var/m = round(input(chassis.occupant,"Please specify the length of cable to cut","Cut cable",min(cable.amount,30)) as num, 1)
-			m = min(m, cable.amount)
-			if(m)
-				use_cable(m)
-				var/obj/item/stack/cable_coil/CC = new (get_turf(chassis))
-				CC.amount = m
-		else
-			occupant_message("There's no more cable on the reel.")
-	return
-
-/obj/item/mecha_parts/mecha_equipment/tool/cable_layer/get_equip_info()
-	var/output = ..()
-	if(output)
-		return "[output] \[Cable: [cable ? cable.amount : 0] m\][(cable && cable.amount) ? "- <a href='?src=\ref[src];toggle=1'>[!equip_ready?"Dea":"A"]ctivate</a>|<a href='?src=\ref[src];cut=1'>Cut</a>" : null]"
-	return
-
-/obj/item/mecha_parts/mecha_equipment/tool/cable_layer/proc/load_cable(var/obj/item/stack/cable_coil/CC)
-	if(istype(CC) && CC.amount)
-		var/cur_amount = cable? cable.amount : 0
-		var/to_load = max(max_cable - cur_amount,0)
-		if(to_load)
-			to_load = min(CC.amount, to_load)
-			if(!cable)
-				cable = new(src)
-				cable.amount = 0
-			cable.amount += to_load
-			CC.use(to_load)
-			return to_load
-		else
-			return 0
-	return
-
-/obj/item/mecha_parts/mecha_equipment/tool/cable_layer/proc/use_cable(amount)
-	if(!cable || cable.amount<1)
-		set_ready_state(1)
-		occupant_message("Cable depleted, [src] deactivated.")
-		log_message("Cable depleted, [src] deactivated.")
-		return
-	if(cable.amount < amount)
-		occupant_message("No enough cable to finish the task.")
-		return
-	cable.use(amount)
-	update_equip_info()
-	return 1
-
-/obj/item/mecha_parts/mecha_equipment/tool/cable_layer/proc/reset()
-	last_piece = null
-
-/obj/item/mecha_parts/mecha_equipment/tool/cable_layer/proc/dismantleFloor(var/turf/new_turf)
-	if(istype(new_turf, /turf/simulated/floor))
-		var/turf/simulated/floor/T = new_turf
-		if(!T.is_plating())
-			T.make_plating(!(T.broken || T.burnt))
-	return new_turf.is_plating()
-
-/obj/item/mecha_parts/mecha_equipment/tool/cable_layer/proc/layCable(var/turf/new_turf)
-	if(equip_ready || !istype(new_turf) || !dismantleFloor(new_turf))
-		return reset()
-	var/fdirn = turn(chassis.dir,180)
-	for(var/obj/structure/cable/LC in new_turf)		// check to make sure there's not a cable there already
-		if(LC.d1 == fdirn || LC.d2 == fdirn)
-			return reset()
-	if(!use_cable(1))
-		return reset()
-	var/obj/structure/cable/NC = new(new_turf)
-	NC.cableColor("red")
-	NC.d1 = 0
-	NC.d2 = fdirn
-	NC.update_icon()
-
-	var/datum/powernet/PN
-	if(last_piece && last_piece.d2 != chassis.dir)
-		last_piece.d1 = min(last_piece.d2, chassis.dir)
-		last_piece.d2 = max(last_piece.d2, chassis.dir)
-		last_piece.update_icon()
-		PN = last_piece.powernet
-
-	if(!PN)
-		PN = new()
-	PN.add_cable(NC)
-	NC.mergeConnectedNetworks(NC.d2)
-
-	//NC.mergeConnectedNetworksOnTurf()
-	last_piece = NC
-	return 1
-
 /obj/item/mecha_parts/mecha_equipment/tool/syringe_gun
 	name = "syringe gun"
 	desc = "Exosuit-mounted chem synthesizer with syringe gun. Reagents inside are held in stasis, so no reactions will occur. (Can be attached to: Medical Exosuits)"
@@ -402,7 +264,7 @@
 	range = MELEE|RANGED
 	equip_cooldown = 10
 	origin_tech = list(TECH_MATERIAL = 3, TECH_BIO = 4, TECH_MAGNET = 4, TECH_DATA = 3)
-	required_type = /obj/mecha/medical
+	required_type = list(/obj/mecha/medical)
 
 /obj/item/mecha_parts/mecha_equipment/tool/syringe_gun/New()
 	..()

--- a/code/game/mecha/equipment/tools/tools.dm
+++ b/code/game/mecha/equipment/tools/tools.dm
@@ -1537,3 +1537,132 @@
 	chassis.step_in = initial(chassis.step_in)
 	..()
 	return
+
+/obj/item/mecha_parts/mecha_equipment/tool/cable_layer
+	name = "Cable Layer"
+	icon_state = "mecha_wire"
+	var/turf/old_turf
+	var/obj/structure/cable/last_piece
+	var/obj/item/stack/cable_coil/cable
+	var/max_cable = 1000
+	required_type = list(/obj/mecha/working)
+
+/obj/item/mecha_parts/mecha_equipment/tool/cable_layer/New()
+	cable = new(src)
+	cable.amount = 0
+	..()
+
+/obj/item/mecha_parts/mecha_equipment/tool/cable_layer/MoveAction()
+	layCable()
+
+/obj/item/mecha_parts/mecha_equipment/tool/cable_layer/action(var/obj/item/stack/cable_coil/target)
+	if(!action_checks(target))
+		return
+	var/result = load_cable(target)
+	var/message
+	if(isnull(result))
+		message = "<font color='red'>Unable to load [target] - no cable found.</font>"
+	else if(!result)
+		message = "Reel is full."
+	else
+		message = "[result] meters of cable successfully loaded."
+		send_byjax(chassis.occupant,"exosuit.browser","\ref[src]",src.get_equip_info())
+	occupant_message(message)
+	return
+
+/obj/item/mecha_parts/mecha_equipment/tool/cable_layer/Topic(href,href_list)
+	..()
+	if(href_list["toggle"])
+		set_ready_state(!equip_ready)
+		occupant_message("[src] [equip_ready?"dea":"a"]ctivated.")
+		log_message("[equip_ready?"Dea":"A"]ctivated.")
+		return
+	if(href_list["cut"])
+		if(cable && cable.amount)
+			var/m = round(input(chassis.occupant,"Please specify the length of cable to cut","Cut cable",min(cable.amount,30)) as num, 1)
+			m = min(m, cable.amount)
+			if(m)
+				use_cable(m)
+				var/obj/item/stack/cable_coil/CC = new (get_turf(chassis))
+				CC.amount = m
+		else
+			occupant_message("There's no more cable on the reel.")
+	return
+
+/obj/item/mecha_parts/mecha_equipment/tool/cable_layer/get_equip_info()
+	var/output = ..()
+	if(output)
+		return "[output] \[Cable: [cable ? cable.amount : 0] m\][(cable && cable.amount) ? "- <a href='?src=\ref[src];toggle=1'>[!equip_ready?"Dea":"A"]ctivate</a>|<a href='?src=\ref[src];cut=1'>Cut</a>" : null]"
+	return
+
+/obj/item/mecha_parts/mecha_equipment/tool/cable_layer/proc/load_cable(var/obj/item/stack/cable_coil/CC)
+	if(istype(CC) && CC.amount)
+		var/cur_amount = cable? cable.amount : 0
+		var/to_load = max(max_cable - cur_amount,0)
+		if(to_load)
+			to_load = min(CC.amount, to_load)
+			if(!cable)
+				cable = new(src)
+				cable.amount = 0
+			cable.amount += to_load
+			CC.use(to_load)
+			return to_load
+		else
+			return 0
+	return
+
+/obj/item/mecha_parts/mecha_equipment/tool/cable_layer/proc/use_cable(amount)
+	if(!cable || cable.amount<1)
+		set_ready_state(1)
+		occupant_message("Cable depleted, [src] deactivated.")
+		log_message("Cable depleted, [src] deactivated.")
+		return
+	if(cable.amount < amount)
+		occupant_message("No enough cable to finish the task.")
+		return
+	cable.use(amount)
+	update_equip_info()
+	return 1
+
+/obj/item/mecha_parts/mecha_equipment/tool/cable_layer/proc/reset()
+	last_piece = null
+
+/obj/item/mecha_parts/mecha_equipment/tool/cable_layer/proc/dismantleFloor(var/turf/new_turf)
+	new_turf = get_turf(chassis)
+	if(istype(new_turf, /turf/simulated/floor))
+		var/turf/simulated/floor/T = new_turf
+		if(!T.is_plating())
+			T.make_plating(!(T.broken || T.burnt))
+	return new_turf.is_plating()
+
+/obj/item/mecha_parts/mecha_equipment/tool/cable_layer/proc/layCable(var/turf/new_turf)
+	new_turf = get_turf(chassis)
+	if(equip_ready || !istype(new_turf, /turf/simulated/floor) || !dismantleFloor(new_turf))
+		return reset()
+	var/fdirn = turn(chassis.dir,180)
+	for(var/obj/structure/cable/LC in new_turf)		// check to make sure there's not a cable there already
+		if(LC.d1 == fdirn || LC.d2 == fdirn)
+			return reset()
+	if(!use_cable(1))
+		return reset()
+	var/obj/structure/cable/NC = new(new_turf)
+	NC.cableColor("red")
+	NC.d1 = 0
+	NC.d2 = fdirn
+	NC.update_icon()
+
+	var/datum/powernet/PN
+	if(last_piece && last_piece.d2 != chassis.dir)
+		last_piece.d1 = min(last_piece.d2, chassis.dir)
+		last_piece.d2 = max(last_piece.d2, chassis.dir)
+		last_piece.update_icon()
+		PN = last_piece.powernet
+
+	if(!PN)
+		PN = new()
+	PN.add_cable(NC)
+	NC.mergeConnectedNetworks(NC.d2)
+
+	//NC.mergeConnectedNetworksOnTurf()
+	last_piece = NC
+	return 1

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -384,8 +384,15 @@
 /obj/mecha/Move()
 	. = ..()
 	if(.)
-		events.fireEvent("onMove",get_turf(src))
+		MoveAction()
 	return
+
+/obj/mecha/proc/MoveAction() //Allows mech equipment to do an action once the mech moves
+	if(!equipment.len)
+		return
+
+	for(var/obj/item/mecha_parts/mecha_equipment/ME in equipment)
+		ME.MoveAction()
 
 /obj/mecha/relaymove(mob/user,direction)
 	if(user != src.occupant) //While not "realistic", this piece is player friendly.

--- a/html/changelogs/Nalarac - Cable Layer.yml
+++ b/html/changelogs/Nalarac - Cable Layer.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Nalarac
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Mech cable layer works again."


### PR DESCRIPTION
Fixes #3515 

The mech cable layer will now properly lay down cables over the tiles it walks over.
Replaces the cable layer using the event system to work with procs instead.

Moved the cable layer from medical tools to just tools. To illustrate what was actually changed because of this, the changes before moving files are shown below:
![image](https://user-images.githubusercontent.com/8042031/62432066-0c3ad080-b6f3-11e9-9b8b-fb0d38f2fa19.png)
![image](https://user-images.githubusercontent.com/8042031/62432090-41dfb980-b6f3-11e9-95db-f18e71fc8474.png)
