### PR TITLE
Makes ahelping on existing ticket give proper feedback

### DIFF
--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -490,6 +490,7 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 		if(alert(usr, "You already have a ticket open. Is this for the same issue?",,"Yes","No") != "No")
 			if(current_ticket)
 				current_ticket.MessageNoRecipient(msg)
+				to_chat(usr, "<span class='adminnotice'>PM to-<b>Admins</b>: [msg]</span>")
 				return
 			else
 				to_chat(usr, "<span class='warning'>Ticket not found, creating new one...</span>")


### PR DESCRIPTION
As of live, if you ahelp something on an 'already open ticket', the game will give you no indication of message being sent. Fixes that aspect.