### PR TITLE
Adds custom DNA hash source - optional whitelist/character setup version

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -95,6 +95,7 @@ var/list/gamemode_cache = list()
 	var/uneducated_mice = 0 //Set to 1 to prevent newly-spawned mice from understanding human speech
 
 	var/usealienwhitelist = 0
+	var/usednawhitelist = 0
 	var/limitalienplayers = 0
 	var/alien_to_human_ratio = 0.5
 	var/allow_extra_antags = 0
@@ -645,6 +646,9 @@ var/list/gamemode_cache = list()
 
 				if("usealienwhitelist")
 					usealienwhitelist = 1
+
+				if ("usednawhitelist")
+					config.usednawhitelist = 1
 
 				if("alien_player_ratio")
 					limitalienplayers = 1

--- a/code/game/dna/dna2.dm
+++ b/code/game/dna/dna2.dm
@@ -358,7 +358,11 @@ var/global/list/datum/dna/gene/dna_genes[0]
 			ResetSE()
 
 		if(length(unique_enzymes) != 32)
-			unique_enzymes = md5(character.real_name)
+			if (character.use_custom_dna)
+				unique_enzymes = md5("customdna:" + character.custom_dna_hash)	//Prefix to hash to prevent DNA duplication of unwilling target
+			else
+				unique_enzymes = md5(character.real_name)
+
 	else
 		if(length(uni_identity) != 3*DNA_UI_LENGTH)
 			uni_identity = "00600200A00E0110148FC01300B0095BD7FD3F4"
@@ -371,6 +375,8 @@ var/global/list/datum/dna/gene/dna_genes[0]
 	ResetUIFrom(character)
 
 	ResetSE()
-
-	unique_enzymes = md5(character.real_name)
+	if (character.use_custom_dna)
+		unique_enzymes = md5("customdna:" + character.custom_dna_hash)	//Prefix to hash to prevent DNA duplication of unwilling target
+	else
+		unique_enzymes = md5(character.real_name)
 	reg_dna[unique_enzymes] = character.real_name

--- a/code/game/jobs/whitelist.dm
+++ b/code/game/jobs/whitelist.dm
@@ -19,7 +19,7 @@ var/list/whitelist = list()
 /var/list/alien_whitelist = list()
 
 /hook/startup/proc/loadAlienWhitelist()
-	if(config.usealienwhitelist)
+	if(config.usealienwhitelist || config.usednawhitelist)
 		load_alienwhitelist()
 	return 1
 
@@ -72,8 +72,31 @@ var/list/whitelist = list()
 			if(findtext(s,"[M.ckey] - All"))
 				return 1
 
+/proc/is_dna_whitelisted(mob/M)
+	//They are admin or the DNA whitelist isn't in use
+	if(dna_whitelist_overrides(M))
+		return 1
+
+	//You did something wrong
+	if(!M)
+		return 0
+
+	//If we have a loaded file, search it
+	if(alien_whitelist)
+		for (var/s in alien_whitelist)
+			if(findtext(s,"[M.ckey] - DNA"))
+				return 1
+
 /proc/whitelist_overrides(mob/M)
 	if(!config.usealienwhitelist)
+		return 1
+	if(check_rights(R_ADMIN, 0, M))
+		return 1
+
+	return 0
+
+/proc/dna_whitelist_overrides(mob/M)
+	if(!config.usednawhitelist)
 		return 1
 	if(check_rights(R_ADMIN, 0, M))
 		return 1

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -61,6 +61,11 @@ datum/preferences
 	var/g_synth							//Same as above
 	var/b_synth							//Same as above
 	var/synth_markings = 0				//Enable/disable markings on synth parts.
+	
+	//Custom DNA preferences
+	var/use_custom_dna = 0				//Override standard DNA generation string
+	var/custom_dna_hash					//string to hash off of
+	
 
 		//Some faction information.
 	var/home_system = "Unset"           //System of birth.

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -80,6 +80,8 @@
 	var/gen_record = ""
 	var/exploit_record = ""
 	var/exploit_addons = list()		//Assorted things that show up at the end of the exploit_record list
+	var/use_custom_dna = 0			//Override standard DNA generation string
+	var/custom_dna_hash				//string to hash off of
 	var/blinded = null
 	var/bhunger = 0			//Carbon
 	var/ajourn = 0

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -277,6 +277,9 @@ GATEWAY_DELAY 18000
 ## Uncomment to restrict non-admins from using humanoid alien races
 USEALIENWHITELIST
 
+## Uncomment to restrict non-admins from setting custom DNA hashing
+USEDNAWHITELIST
+
 ## Comment this to unrestrict the number of alien players allowed in the round. The number represents the number of alien players for every human player.
 #ALIEN_PLAYER_RATIO 0.2
 ##Remove the # to let ghosts spin chairs


### PR DESCRIPTION
Custom DNA hashes for players, via whitelist and character setup, with config/config.txt option to allow without whitelist. Useful for characters such as identical twins, to allow characters that should have matching DNA to actually have it.

Option for enabling and setting hash seed strings added to _Character Setup > General_ on per character basis. Like alien and language whitelist items, option is available to administrators regardless of whitelist entries.

whitelist requirement enabled via **/config/config.txt**
`## Uncomment to restrict non-admins from setting custom DNA hashing`
`USEDNAWHITELIST`

whitelist entries are added to **/config/alienwhitelist.txt**
`ckey - DNA`
Hashing not included in the '- ALL' option of alienwhitelist.

Hashes are generated off the user defined strings, with fixed prefix 'customdna:' to prevent duplication of non-custom hashes. Strings that match will yield identical DNA hashes _(Useful for twins, possibly other uses.)_

[https://i.gyazo.com/b7ed858b5665953a582ef7ea8347dc5b.png](https://i.gyazo.com/b7ed858b5665953a582ef7ea8347dc5b.png)

[https://i.gyazo.com/76f84747f16c761a5c92c62cc4879e1b.png](https://i.gyazo.com/76f84747f16c761a5c92c62cc4879e1b.png)

Tested and working.

I understand this one is likely to receive the same tags as the other, and that there's a good possibility of it not being used, but going back and doing it in a more reasonable and convenient way seemed like a good idea.