### PR TITLE
Makes airtight plastic flaps unmakeable

### DIFF
--- a/code/game/objects/structures/plasticflaps.dm
+++ b/code/game/objects/structures/plasticflaps.dm
@@ -8,7 +8,6 @@
 	layer = MOB_LAYER
 	plane = MOB_PLANE
 	explosion_resistance = 5
-	var/can_pass_lying = 1
 	var/list/mobs_can_pass = list(
 		/mob/living/bot,
 		/mob/living/simple_mob/slime/xenobio,
@@ -37,12 +36,12 @@
 	if (istype(A, /obj/structure/bed) && B.has_buckled_mobs())//if it's a bed/chair and someone is buckled, it will not pass
 		return 0
 
-	if(istype(A, /obj/vehicle)) //no vehicles
+	if(istype(A, /obj/vehicle) || istype (A, /obj/mecha)) //no vehicles
 		return 0
 
 	var/mob/living/M = A
 	if(istype(M))
-		if(M.lying && can_pass_lying)
+		if(M.lying)
 			return ..()
 		for(var/mob_type in mobs_can_pass)
 			if(istype(A, mob_type))
@@ -64,6 +63,5 @@
 
 /obj/structure/plasticflaps/mining //A specific type for mining that doesn't allow airflow because of them damn crates
 	name = "airtight plastic flaps"
-	desc = "Heavy duty, airtight, plastic flaps. Have extra safety installed, preventing passage of living beings."
+	desc = "Heavy duty, airtight, plastic flaps."
 	can_atmos_pass = ATMOS_PASS_NO
-	can_pass_lying = 0

--- a/code/game/objects/structures/plasticflaps.dm
+++ b/code/game/objects/structures/plasticflaps.dm
@@ -8,6 +8,7 @@
 	layer = MOB_LAYER
 	plane = MOB_PLANE
 	explosion_resistance = 5
+	var/can_pass_lying = TRUE
 	var/list/mobs_can_pass = list(
 		/mob/living/bot,
 		/mob/living/simple_mob/slime/xenobio,
@@ -41,7 +42,7 @@
 
 	var/mob/living/M = A
 	if(istype(M))
-		if(M.lying)
+		if(M.lying && can_pass_lying)
 			return ..()
 		for(var/mob_type in mobs_can_pass)
 			if(istype(A, mob_type))
@@ -63,5 +64,6 @@
 
 /obj/structure/plasticflaps/mining //A specific type for mining that doesn't allow airflow because of them damn crates
 	name = "airtight plastic flaps"
-	desc = "Heavy duty, airtight, plastic flaps."
+	desc = "Heavy duty, airtight, plastic flaps. Have extra safety installed, preventing passage of living beings."
 	can_atmos_pass = ATMOS_PASS_NO
+	can_pass_lying = FALSE

--- a/code/modules/materials/material_recipes.dm
+++ b/code/modules/materials/material_recipes.dm
@@ -127,7 +127,6 @@
 	recipes += new/datum/stack_recipe("freezer floor tile", /obj/item/stack/tile/floor/freezer, 1, 4, 20)
 	recipes += new/datum/stack_recipe("shower curtain", /obj/structure/curtain, 4, time = 15, one_per_turf = 1, on_floor = 1)
 	recipes += new/datum/stack_recipe("plastic flaps", /obj/structure/plasticflaps, 4, time = 25, one_per_turf = 1, on_floor = 1)
-	recipes += new/datum/stack_recipe("airtight plastic flaps", /obj/structure/plasticflaps/mining, 5, time = 25, one_per_turf = 1, on_floor = 1)
 	recipes += new/datum/stack_recipe("water-cooler", /obj/structure/reagent_dispensers/water_cooler, 4, time = 10, one_per_turf = 1, on_floor = 1)
 	recipes += new/datum/stack_recipe("lampshade", /obj/item/weapon/lampshade, 1, time = 1)
 	recipes += new/datum/stack_recipe("plastic net", /obj/item/weapon/material/fishing_net, 25, time = 1 MINUTE)


### PR DESCRIPTION
On dev request changed contents of PR. Now just removed the flaps recipe from the game.

Original PR descripton:
Can once again pass all living movs if they are resting.
Can no longer pass active mechs.
Are no longer constructible (map-in/spawn only). Original PR that restricted them was mostly aimed to address the ease of making what basically amounts to perfect airlock literally anywhere by using those, but this is a much better and smoother solution to that.