### PR TITLE
Adds Setting for Turrets to Shoot Downed People

### DIFF
--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -441,7 +441,7 @@
 		settings[++settings.len] = list("category" = "Check Access Authorization", "setting" = "check_access", "value" = check_access)
 		settings[++settings.len] = list("category" = "Check misc. Lifeforms", "setting" = "check_anomalies", "value" = check_anomalies)
 		settings[++settings.len] = list("category" = "Neutralize All Entities", "setting" = "check_all", "value" = check_all)
-		settings[++settings.len] = list("category" = "Neutralize Downed Entities on Lethal", "setting" = "check_down", "value" = check_down)
+		settings[++settings.len] = list("category" = "Neutralize Downed Entities", "setting" = "check_down", "value" = check_down)
 		data["settings"] = settings
 
 	ui = SSnanoui.try_update_ui(user, src, ui_key, ui, data, force_open)
@@ -738,9 +738,8 @@
 	if(!emagged && issilicon(L) && check_all == FALSE)	// Don't target silica, unless told to neutralize everything.
 		return TURRET_NOT_TARGET
 
-	if(L.stat && !emagged)					//if the target is dead/dying, check to see if we can continue shooting.
-		if(L.stat == DEAD || !check_down)	//if the target is dead or we're not allowed to shoot downed targets, don't fire.
-			return TURRET_NOT_TARGET		//move onto next potential victim!
+	if(L.stat == DEAD && !emagged)		//if the perp is dead, no need to bother really
+		return TURRET_NOT_TARGET	//move onto next potential victim!
 
 	if(get_dist(src, L) > 7)	//if it's too far away, why bother?
 		return TURRET_NOT_TARGET
@@ -756,7 +755,7 @@
 
 	if(check_synth || check_all)	//If it's set to attack all non-silicons or everything, target them!
 		if(L.lying)
-			return lethal ? TURRET_SECONDARY_TARGET : TURRET_NOT_TARGET
+			return check_down ? TURRET_SECONDARY_TARGET : TURRET_NOT_TARGET
 		return TURRET_PRIORITY_TARGET
 
 	if(iscuffed(L)) // If the target is handcuffed, leave it alone
@@ -773,7 +772,7 @@
 			return TURRET_NOT_TARGET	//if threat level < 4, keep going
 
 	if(L.lying)		//if the perp is lying down, it's still a target but a less-important target
-		return lethal ? TURRET_SECONDARY_TARGET : TURRET_NOT_TARGET
+		return check_down ? TURRET_SECONDARY_TARGET : TURRET_NOT_TARGET
 
 	return TURRET_PRIORITY_TARGET	//if the perp has passed all previous tests, congrats, it is now a "shoot-me!" nominee
 

--- a/html/changelogs/Nalarac - Turret Shooting Downed People.yml
+++ b/html/changelogs/Nalarac - Turret Shooting Downed People.yml
@@ -33,4 +33,4 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes: 
-  - rscadd: "Added setting for turrets to fire upon downed targets when on lethal setting."
+  - rscadd: "Added setting for turrets to fire upon downed/laying targets."

--- a/html/changelogs/Nalarac - Turret Shooting Downed People.yml
+++ b/html/changelogs/Nalarac - Turret Shooting Downed People.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Nalarac
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Added setting for turrets to fire upon downed targets when on lethal setting."


### PR DESCRIPTION
The turret will only shoot downed individuals (including laying down) with this setting enabled <strike>**AND** set to lethal.</strike>

This was the compromise decided upon in the last staff meeting for:
Fixes #6318 