### PR TITLE
Fixes ghost jump-to-mob

### DIFF
--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -384,11 +384,12 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 
 	return (T && T.holy) && (is_manifest || (mind in cult.current_antagonists))
 
-/mob/observer/dead/verb/jumptomob(target in getmobs()) //Moves the ghost instead of just changing the ghosts's eye -Nodrak
+/mob/observer/dead/verb/jumptomob(input in getmobs()) //Moves the ghost instead of just changing the ghosts's eye -Nodrak
 	set category = "Ghost"
 	set name = "Jump to Mob"
 	set desc = "Teleport to a mob"
 
+	var/target = getmobs()[input]
 	if(istype(usr, /mob/observer/dead)) //Make sure they're an observer!
 
 		if (!target)//Make sure we actually have a target

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -389,9 +389,8 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	set name = "Jump to Mob"
 	set desc = "Teleport to a mob"
 
-	var/target = getmobs()[input]
 	if(istype(usr, /mob/observer/dead)) //Make sure they're an observer!
-
+		var/target = getmobs()[input]
 		if (!target)//Make sure we actually have a target
 			return
 		else


### PR DESCRIPTION
Admin version works just fine still.

Whatever broke it backend originally got fixed, which invalidated the current state of it. Its sort of a revert of original fix, but I honestly have no idea what caused the issue in the first place so here it is. Hopefully weird list bugs won't come up again.