### PR TITLE
Fix SLED infinite looping.

### DIFF
--- a/code/modules/mob/living/bot/SLed209bot.dm
+++ b/code/modules/mob/living/bot/SLed209bot.dm
@@ -21,7 +21,6 @@
 	xeno_harm_strength = 9
 	req_one_access = list(access_research, access_robotics)
 	botcard_access = list(access_research, access_robotics, access_xenobiology, access_xenoarch, access_tox, access_tox_storage, access_maint_tunnels)
-	used_weapon = /obj/item/weapon/melee/baton/slime
 	var/xeno_stun_strength = 6
 
 /mob/living/bot/secbot/ed209/slime/update_icons()


### PR DESCRIPTION
Why am I like this.

Fixes SLED explode() infinite loop due to a second definition of used_weapon.