### PR TITLE
glove attack refactor

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -293,6 +293,17 @@
 	punch_force = initial(punch_force)
 	wearer = null
 
+/obj/item/clothing/gloves
+	var/datum/unarmed_attack/special_attack = null //do the gloves have a special unarmed attack?
+	var/special_attack_type = null
+
+/obj/item/clothing/gloves/New()
+	..()
+	if(special_attack_type && ispath(special_attack_type))
+		special_attack = new special_attack_type
+
+
+
 /////////////////////////////////////////////////////////////////////
 //Rings
 

--- a/code/modules/holodeck/HolodeckObjects.dm
+++ b/code/modules/holodeck/HolodeckObjects.dm
@@ -137,7 +137,7 @@ datum/unarmed_attack/holopugilism/unarmed_override(var/mob/living/carbon/human/u
 	if(!damage)
 		playsound(target.loc, 'sound/weapons/punchmiss.ogg', 25, 1, -1)
 		target.visible_message("<font color='red'><B>[user] has attempted to punch [target]!</B></font>")
-		return 1
+		return TRUE
 	var/obj/item/organ/external/affecting = target.get_organ(ran_zone(user.zone_sel.selecting))
 	var/armor_block = target.run_armor_check(affecting, "melee")
 	var/armor_soak = target.get_armor_soak(affecting, "melee")
@@ -150,14 +150,14 @@ datum/unarmed_attack/holopugilism/unarmed_override(var/mob/living/carbon/human/u
 	target.visible_message("<font color='red'><B>[user] has punched [target]!</B></font>")
 
 	if(armor_soak >= damage)
-		return
+		return TRUE
 
 	target.apply_damage(damage, HALLOSS, affecting, armor_block, armor_soak)
 	if(damage >= 9)
 		target.visible_message("<font color='red'><B>[user] has weakened [target]!</B></font>")
 		target.apply_effect(4, WEAKEN, armor_block)
 
-	return 1
+	return TRUE
 
 /obj/structure/window/reinforced/holowindow/attackby(obj/item/W as obj, mob/user as mob)
 	if(!istype(W))
@@ -289,8 +289,8 @@ datum/unarmed_attack/holopugilism/unarmed_override(var/mob/living/carbon/human/u
 		spark_system.set_up(5, 0, user.loc)
 		spark_system.start()
 		playsound(user.loc, 'sound/weapons/blade1.ogg', 50, 1)
-		return 1
-	return 0
+		return TRUE
+	return FALSE
 
 /obj/item/weapon/holo/esword/New()
 	item_color = pick("red","blue","green","purple")

--- a/code/modules/holodeck/HolodeckObjects.dm
+++ b/code/modules/holodeck/HolodeckObjects.dm
@@ -126,6 +126,38 @@
 			slot_r_hand_str = 'icons/mob/items/righthand_gloves.dmi',
 			)
 	item_state = "boxing"
+	special_attack_type = /datum/unarmed_attack/holopugilism
+
+datum/unarmed_attack/holopugilism
+	sparring_variant_type = /datum/unarmed_attack/holopugilism
+
+datum/unarmed_attack/holopugilism/unarmed_override(var/mob/living/carbon/human/user,var/mob/living/carbon/human/target,var/zone)
+	user.do_attack_animation(src)
+	var/damage = rand(0, 9)
+	if(!damage)
+		playsound(target.loc, 'sound/weapons/punchmiss.ogg', 25, 1, -1)
+		target.visible_message("<font color='red'><B>[user] has attempted to punch [target]!</B></font>")
+		return 1
+	var/obj/item/organ/external/affecting = target.get_organ(ran_zone(user.zone_sel.selecting))
+	var/armor_block = target.run_armor_check(affecting, "melee")
+	var/armor_soak = target.get_armor_soak(affecting, "melee")
+
+	if(HULK in user.mutations)
+		damage += 5
+
+	playsound(target.loc, "punch", 25, 1, -1)
+
+	target.visible_message("<font color='red'><B>[user] has punched [target]!</B></font>")
+
+	if(armor_soak >= damage)
+		return
+
+	target.apply_damage(damage, HALLOSS, affecting, armor_block, armor_soak)
+	if(damage >= 9)
+		target.visible_message("<font color='red'><B>[user] has weakened [target]!</B></font>")
+		target.apply_effect(4, WEAKEN, armor_block)
+
+	return 1
 
 /obj/structure/window/reinforced/holowindow/attackby(obj/item/W as obj, mob/user as mob)
 	if(!istype(W))

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -1,7 +1,7 @@
 /mob/living/carbon/human/proc/get_unarmed_attack(var/mob/living/carbon/human/target, var/hit_zone)
 	if(src.gloves)
 		var/obj/item/clothing/gloves/G = src.gloves
-		if(G.special_attack && G.special_attack.is_usable(src, target, hit_zone))
+		if(istype(G) && G.special_attack && G.special_attack.is_usable(src, target, hit_zone))
 			if(pulling_punches)
 				var/datum/unarmed_attack/soft_type = G.special_attack.get_sparring_variant()
 				if(soft_type)

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -235,7 +235,7 @@
 					var/obj/item/clothing/gloves/G = H.gloves
 					real_damage += G.punch_force
 					hit_dam_type = G.punch_damtype
-					if(H.pulling_punches && !attack.sharp && !attack.edge)	//SO IT IS DECREED: PULLING PUNCHES WILL PREVENT THE ACTUAL DAMAGE FROM RINGS AND KNUCKLES, BUT NOT THE ADDED PAIN, BUT YOU CAN'T "PULL" A FUCKING KNIFE
+					if(H.pulling_punches && !attack.sharp && !attack.edge)	//SO IT IS DECREED: PULLING PUNCHES WILL PREVENT THE ACTUAL DAMAGE FROM RINGS AND KNUCKLES, BUT NOT THE ADDED PAIN, BUT YOU CAN'T "PULL" A KNIFE
 						hit_dam_type = AGONY
 			real_damage *= damage_multiplier
 			rand_damage *= damage_multiplier

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -40,11 +40,11 @@
 				H.do_attack_animation(src)
 				playsound(loc, 'sound/weapons/punchmiss.ogg', 25, 1, -1)
 				visible_message("<font color='red'><B>[H] reaches for [src], but misses!</B></font>")
-				return 0
+				return FALSE
 
 		if(H != src && check_shields(0, null, H, H.zone_sel.selecting, H.name))
 			H.do_attack_animation(src)
-			return 0
+			return FALSE
 
 	if(istype(M,/mob/living/carbon))
 		var/mob/living/carbon/C = M
@@ -88,7 +88,7 @@
 
 			else if(!(M == src && apply_pressure(M, M.zone_sel.selecting)))
 				help_shake_act(M)
-			return 1
+			return TRUE
 
 		if(I_GRAB)
 			if(M == src || anchored)
@@ -113,7 +113,7 @@
 			H.do_attack_animation(src)
 			playsound(loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
 			visible_message("<span class='warning'>[M] has grabbed [src] passively!</span>")
-			return 1
+			return TRUE
 
 		if(I_HURT)
 
@@ -139,7 +139,7 @@
 
 			if(!affecting || affecting.is_stump())
 				M << "<span class='danger'>They are missing that limb!</span>"
-				return 1
+				return TRUE
 
 			switch(src.a_intent)
 				if(I_HELP)
@@ -209,10 +209,10 @@
 			// See what attack they use
 			var/datum/unarmed_attack/attack = H.get_unarmed_attack(src, hit_zone)
 			if(!attack)
-				return 0
+				return FALSE
 
 			if(attack.unarmed_override(H, src, hit_zone))
-				return 0
+				return FALSE
 
 			H.do_attack_animation(src)
 			if(!attack_message)
@@ -225,7 +225,7 @@
 			add_attack_logs(H,src,"Melee attacked with fists (miss/block)")
 
 			if(miss_type)
-				return 0
+				return FALSE
 
 			var/real_damage = rand_damage
 			var/hit_dam_type = attack.damage_type
@@ -326,7 +326,7 @@
 	var/armor_soak = get_armor_soak(affecting, armor_type, armor_pen)
 	apply_damage(damage, BRUTE, affecting, armor_block, armor_soak, sharp = a_sharp, edge = a_edge)
 	updatehealth()
-	return 1
+	return TRUE
 
 //Used to attack a joint through grabbing
 /mob/living/carbon/human/proc/grab_joint(var/mob/living/user, var/def_zone)
@@ -337,43 +337,43 @@
 			break
 
 	if(!has_grab)
-		return 0
+		return FALSE
 
 	if(!def_zone) def_zone = user.zone_sel.selecting
 	var/target_zone = check_zone(def_zone)
 	if(!target_zone)
-		return 0
+		return FALSE
 	var/obj/item/organ/external/organ = get_organ(check_zone(target_zone))
 	if(!organ || organ.dislocated > 0 || organ.dislocated == -1) //don't use is_dislocated() here, that checks parent
-		return 0
+		return FALSE
 
 	user.visible_message("<span class='warning'>[user] begins to dislocate [src]'s [organ.joint]!</span>")
 	if(do_after(user, 100))
 		organ.dislocate(1)
 		src.visible_message("<span class='danger'>[src]'s [organ.joint] [pick("gives way","caves in","crumbles","collapses")]!</span>")
-		return 1
-	return 0
+		return TRUE
+	return FALSE
 
 //Breaks all grips and pulls that the mob currently has.
 /mob/living/carbon/human/proc/break_all_grabs(mob/living/carbon/user)
-	var/success = 0
+	var/success = FALSE
 	if(pulling)
 		visible_message("<span class='danger'>[user] has broken [src]'s grip on [pulling]!</span>")
-		success = 1
+		success = TRUE
 		stop_pulling()
 
 	if(istype(l_hand, /obj/item/weapon/grab))
 		var/obj/item/weapon/grab/lgrab = l_hand
 		if(lgrab.affecting)
 			visible_message("<span class='danger'>[user] has broken [src]'s grip on [lgrab.affecting]!</span>")
-			success = 1
+			success = TRUE
 		spawn(1)
 			qdel(lgrab)
 	if(istype(r_hand, /obj/item/weapon/grab))
 		var/obj/item/weapon/grab/rgrab = r_hand
 		if(rgrab.affecting)
 			visible_message("<span class='danger'>[user] has broken [src]'s grip on [rgrab.affecting]!</span>")
-			success = 1
+			success = TRUE
 		spawn(1)
 			qdel(rgrab)
 	return success
@@ -388,11 +388,11 @@
 /mob/living/carbon/human/proc/apply_pressure(mob/living/user, var/target_zone)
 	var/obj/item/organ/external/organ = get_organ(target_zone)
 	if(!organ || !(organ.status & ORGAN_BLEEDING) || (organ.robotic >= ORGAN_ROBOT))
-		return 0
+		return FALSE
 
 	if(organ.applied_pressure)
 		user << "<span class='warning'>Someone is already applying pressure to [user == src? "your [organ.name]" : "[src]'s [organ.name]"].</span>"
-		return 0
+		return FALSE
 
 	var/datum/gender/TU = gender_datums[user.get_visible_gender()]
 
@@ -413,4 +413,4 @@
 		else
 			user.visible_message("\The [user] stops applying pressure to [src]'s [organ.name]!", "You stop applying pressure to [src]'s [organ.name]!")
 
-	return 1
+	return TRUE

--- a/code/modules/mob/living/carbon/human/unarmed_attack.dm
+++ b/code/modules/mob/living/carbon/human/unarmed_attack.dm
@@ -105,6 +105,9 @@ var/global/list/sparring_attack_cache = list()
 		return
 	user.visible_message("<span class='danger'>[user] attempts to press [TU.his] [eye_attack_text] into [target]'s eyes, but [TT.he] [TT.does]n't have any!</span>")
 
+/datum/unarmed_attack/proc/unarmed_override(var/mob/living/carbon/human/user,var/mob/living/carbon/human/target,var/zone)
+	return 0 //return true if the unarmed override prevents further attacks
+
 /datum/unarmed_attack/bite
 	attack_verb = list("bit")
 	attack_sound = 'sound/weapons/bite.ogg'

--- a/code/modules/mob/living/carbon/human/unarmed_attack.dm
+++ b/code/modules/mob/living/carbon/human/unarmed_attack.dm
@@ -25,18 +25,18 @@ var/global/list/sparring_attack_cache = list()
 
 /datum/unarmed_attack/proc/is_usable(var/mob/living/carbon/human/user, var/mob/living/carbon/human/target, var/zone)
 	if(user.restrained())
-		return 0
+		return FALSE
 
 	// Check if they have a functioning hand.
 	var/obj/item/organ/external/E = user.organs_by_name["l_hand"]
 	if(E && !E.is_stump())
-		return 1
+		return TRUE
 
 	E = user.organs_by_name["r_hand"]
 	if(E && !E.is_stump())
-		return 1
+		return TRUE
 
-	return 0
+	return FALSE
 
 /datum/unarmed_attack/proc/get_unarmed_damage()
 	return damage
@@ -106,7 +106,7 @@ var/global/list/sparring_attack_cache = list()
 	user.visible_message("<span class='danger'>[user] attempts to press [TU.his] [eye_attack_text] into [target]'s eyes, but [TT.he] [TT.does]n't have any!</span>")
 
 /datum/unarmed_attack/proc/unarmed_override(var/mob/living/carbon/human/user,var/mob/living/carbon/human/target,var/zone)
-	return 0 //return true if the unarmed override prevents further attacks
+	return FALSE //return true if the unarmed override prevents further attacks
 
 /datum/unarmed_attack/bite
 	attack_verb = list("bit")
@@ -124,7 +124,7 @@ var/global/list/sparring_attack_cache = list()
 		return 0
 	if (user == target && (zone == BP_HEAD || zone == O_EYES || zone == O_MOUTH))
 		return 0
-	return 1
+	return TRUE
 
 /datum/unarmed_attack/punch
 	attack_verb = list("punched")
@@ -190,20 +190,20 @@ var/global/list/sparring_attack_cache = list()
 
 /datum/unarmed_attack/kick/is_usable(var/mob/living/carbon/human/user, var/mob/living/carbon/human/target, var/zone)
 	if (user.legcuffed)
-		return 0
+		return FALSE
 
 	if(!(zone in list("l_leg", "r_leg", "l_foot", "r_foot", BP_GROIN)))
-		return 0
+		return FALSE
 
 	var/obj/item/organ/external/E = user.organs_by_name["l_foot"]
 	if(E && !E.is_stump())
-		return 1
+		return TRUE
 
 	E = user.organs_by_name["r_foot"]
 	if(E && !E.is_stump())
-		return 1
+		return TRUE
 
-	return 0
+	return FALSE
 
 /datum/unarmed_attack/kick/get_unarmed_damage(var/mob/living/carbon/human/user)
 	var/obj/item/clothing/shoes = user.shoes
@@ -234,23 +234,23 @@ var/global/list/sparring_attack_cache = list()
 /datum/unarmed_attack/stomp/is_usable(var/mob/living/carbon/human/user, var/mob/living/carbon/human/target, var/zone)
 
 	if (user.legcuffed)
-		return 0
+		return FALSE
 
 	if(!istype(target))
-		return 0
+		return FALSE
 
 	if (!user.lying && (target.lying || (zone in list("l_foot", "r_foot"))))
 		if(target.grabbed_by == user && target.lying)
-			return 0
+			return FALSE
 		var/obj/item/organ/external/E = user.organs_by_name["l_foot"]
 		if(E && !E.is_stump())
-			return 1
+			return TRUE
 
 		E = user.organs_by_name["r_foot"]
 		if(E && !E.is_stump())
-			return 1
+			return TRUE
 
-		return 0
+		return FALSE
 
 /datum/unarmed_attack/stomp/get_unarmed_damage(var/mob/living/carbon/human/user)
 	var/obj/item/clothing/shoes = user.shoes


### PR DESCRIPTION
In practical terms, the only change this PR makes for the player experience is that you have to use harm intent to punch people with the holographic boxing gloves now.

Removes a chunk from human attack_hand() that was performing an istype check to look for holographic boxing gloves every time a human was clicked on by another human (which overrode _everything_, even contact disease spreading and the like)

Adds the ability to associate a special unarmed_attack with a set of gloves so if people want they can make spiked knuckle dusters or power fists or taser gloves or whatever and keep the code for those things with the item instead of having to add code into attack_hand().

Adds the ability for unarmed attacks to override the normal attack sequence and perform some other proc instead.

Puts all the boxing glove stuff that was removed from attack_hand() into the above two places.

Slight change to the way attacks handle the existing glove damagetype - it no longer forces the damagetype to painloss for pulled punches where the attack is sharp or edge. Sharp stuff will cut you either way.