### PR TITLE
 Fixes editing colony director IDs editing global 'station access' list 

### DIFF
--- a/code/game/antagonist/station/highlander.dm
+++ b/code/game/antagonist/station/highlander.dm
@@ -47,8 +47,8 @@ var/datum/antagonist/highlander/highlanders
 	var/obj/item/weapon/card/id/W = new(player)
 	W.name = "[player.real_name]'s ID Card"
 	W.icon_state = "centcom"
-	W.access = get_all_station_access()
-	W.access += get_all_centcom_access()
+	W.access = get_all_station_access().Copy
+	W.access |= get_all_centcom_access()
 	W.assignment = "Highlander"
 	W.registered_name = player.real_name
 	player.equip_to_slot_or_del(W, slot_wear_id)

--- a/code/game/jobs/job/captain.dm
+++ b/code/game/jobs/job/captain.dm
@@ -31,7 +31,7 @@ var/datum/announcement/minor/captain_announcement = new(do_newscast = 1)
 		H.implant_loyalty(src)
 */
 /datum/job/captain/get_access()
-	return get_all_station_access()
+	return get_all_station_access().Copy()
 
 /datum/job/hop
 	title = "Head of Personnel"

--- a/code/game/objects/items/weapons/id cards/station_ids.dm
+++ b/code/game/objects/items/weapons/id cards/station_ids.dm
@@ -171,7 +171,7 @@
 
 /obj/item/weapon/card/id/synthetic/Initialize()
 	. = ..()
-	access = get_all_station_access() + access_synth
+	access = get_all_station_access().Copy() + access_synth
 
 /obj/item/weapon/card/id/centcom
 	name = "\improper CentCom. ID"
@@ -182,7 +182,7 @@
 
 /obj/item/weapon/card/id/centcom/Initialize()
 	. = ..()
-	access = get_all_centcom_access()
+	access = get_all_centcom_access().Copy()
 
 /obj/item/weapon/card/id/centcom/station/Initialize()
 	. = ..()

--- a/code/game/objects/items/weapons/id cards/syndicate_ids.dm
+++ b/code/game/objects/items/weapons/id cards/syndicate_ids.dm
@@ -12,7 +12,7 @@
 
 /obj/item/weapon/card/id/syndicate/station_access/Initialize()
 	. = ..() // Same as the normal Syndicate id, only already has all station access
-	access |= get_all_station_access()
+	access |= get_all_station_access().Copy()
 
 /obj/item/weapon/card/id/syndicate/Destroy()
 	unset_registered_user(registered_user)

--- a/code/game/objects/items/weapons/id cards/syndicate_ids.dm
+++ b/code/game/objects/items/weapons/id cards/syndicate_ids.dm
@@ -12,7 +12,7 @@
 
 /obj/item/weapon/card/id/syndicate/station_access/Initialize()
 	. = ..() // Same as the normal Syndicate id, only already has all station access
-	access |= get_all_station_access().Copy()
+	access |= get_all_station_access()
 
 /obj/item/weapon/card/id/syndicate/Destroy()
 	unset_registered_user(registered_user)

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -282,11 +282,11 @@
 				var/obj/item/device/pda/pda = H.wear_id
 				id = pda.id
 			id.icon_state = "gold"
-			id.access = get_all_accesses()
+			id.access = get_all_accesses().Copy()
 		else
 			var/obj/item/weapon/card/id/id = new/obj/item/weapon/card/id(M);
 			id.icon_state = "gold"
-			id.access = get_all_accesses()
+			id.access = get_all_accesses().Copy()
 			id.registered_name = H.real_name
 			id.assignment = "Colony Director"
 			id.name = "[id.registered_name]'s ID Card ([id.assignment])"


### PR DESCRIPTION
Also same thing for centcomm access IDs and 'centcom access list'.