### PR TITLE
Refactors strangerocks not to be ore

### DIFF
--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -591,9 +591,9 @@ turf/simulated/mineral/floor/light_corner
 	if(is_clean)
 		X = new /obj/item/weapon/archaeological_find(src, new_item_type = F.find_type)
 	else
-		X = new /obj/item/weapon/ore/strangerock(src, inside_item_type = F.find_type)
+		X = new /obj/item/weapon/strangerock(src, inside_item_type = F.find_type)
 		geologic_data.UpdateNearbyArtifactInfo(src)
-		var/obj/item/weapon/ore/strangerock/SR = X
+		var/obj/item/weapon/strangerock/SR = X
 		SR.geologic_data = geologic_data
 
 	//some find types delete the /obj/item/weapon/archaeological_find and replace it with something else, this handles when that happens

--- a/code/modules/mob/living/simple_mob/subtypes/animal/space/worm.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/space/worm.dm
@@ -411,7 +411,7 @@
 		/obj/random/bomb_supply = 7,
 		/obj/random/contraband = 3,
 		/obj/random/unidentified_medicine/old_medicine = 7,
-		/obj/item/weapon/ore/strangerock = 3,
+		/obj/item/weapon/strangerock = 3,
 		/obj/item/weapon/ore/phoron = 7,
 		/obj/random/handgun = 1,
 		/obj/random/toolbox = 4,

--- a/code/modules/xenoarcheaology/finds/finds.dm
+++ b/code/modules/xenoarcheaology/finds/finds.dm
@@ -14,20 +14,22 @@
 	clearance_range = rand(4, 12)
 	dissonance_spread = rand(1500, 2500) / 100
 
-/obj/item/weapon/ore/strangerock
+/obj/item/weapon/strangerock
 	name = "Strange rock"
 	desc = "Seems to have some unusal strata evident throughout it."
 	icon = 'icons/obj/xenoarchaeology.dmi'
 	icon_state = "strange"
+	var/datum/geosample/geologic_data
 	origin_tech = list(TECH_MATERIAL = 5)
 
-/obj/item/weapon/ore/strangerock/New(loc, var/inside_item_type = 0)
-	..(loc)
+/obj/item/weapon/strangerock/New(loc, var/inside_item_type = 0)
+	pixel_x = rand(0,16)-8
+	pixel_y = rand(0,8)-8
 
 	if(inside_item_type)
 		new /obj/item/weapon/archaeological_find(src, new_item_type = inside_item_type)
 
-/obj/item/weapon/ore/strangerock/attackby(var/obj/item/I, var/mob/user)
+/obj/item/weapon/strangerock/attackby(var/obj/item/I, var/mob/user)
 	if(istype(I, /obj/item/weapon/pickaxe/brush))
 		var/obj/item/inside = locate() in src
 		if(inside)


### PR DESCRIPTION
For purpoes of such thing as ore crates and ore bags not collecting them because they just get destroyed in the long run.