### PR TITLE
Adds hardhats to engineering lockers

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
@@ -96,6 +96,7 @@
 		/obj/item/clothing/glasses/meson,
 		/obj/item/weapon/cartridge/engineering,
 		/obj/item/taperoll/engineering,
+		/obj/item/clothing/head/hardhat,
 		/obj/item/clothing/suit/storage/hooded/wintercoat/engineering,
 		/obj/item/clothing/shoes/boots/winter/engineering,
 		/obj/item/weapon/tank/emergency/oxygen/engi)
@@ -123,6 +124,7 @@
 	starts_with = list(
 		/obj/item/clothing/accessory/storage/brown_vest,
 		/obj/item/clothing/suit/fire/firefighter,
+		/obj/item/clothing/head/hardhat/red,
 		/obj/item/device/flashlight,
 		/obj/item/weapon/extinguisher,
 		/obj/item/clamp,


### PR DESCRIPTION
Because those aren't just wardrobe items, but also technically safety equipment, they should probably go into the personal lockers too. Plus atmostech locker on its own lacked head covering to pair up with firesuit that it has.

Adds regular hardhat to engineer locker and red one to atmostech.