### PR TITLE
Fixes runtime in library computers

### DIFF
--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -214,8 +214,8 @@ Class Procs:
 /obj/machinery/CanUseTopic(var/mob/user)
 	if(!interact_offline && (stat & (NOPOWER | BROKEN)))
 		return STATUS_CLOSE
-
-	return ..()
+	// return ..()		// This doesn't call the parent with the correct number of arguments (causing a runtime in /code/modules/nano/interaction/base.dm), nor easily provide any indication as to what the datum/topic_state should be, so this is clearly the wrong action.
+	return STATUS_INTERACTIVE
 
 /obj/machinery/CouldUseTopic(var/mob/user)
 	..()


### PR DESCRIPTION
I couldn't actually replicate the runtime, even on the live server, but it reportedly was found when someone attempted to print a book on the librarycomp. Basically, `/obj/machinery/CanUseTopic(var/mob/user)` has a different number of parameters than `/obj/CanUseTopic(var/mob/user, var/datum/topic_state/status)`, and that second parameter is used in `/datum/proc/CanUseTopic(var/mob/user, var/datum/topic_state/status`, found in `/code/modules/nano/interaction/base`, where a proc on it is called. I.E., if you don't give it a topic_state, you implicitly give it a null, which runtimes when you try to call `null.can_use_topic()`.

Since `machinery/CanUseTopic()` doesn't provide any insight into how to actually generate a topic state that's reliably appropriate to the situation, I didn't attempt to produce one, since any calls passing through `machinery/CanUseTopic()` would destroy such information before it reached the intended destination, and therefore we cannot presently be using any other subtypes of `machinery` that actually makes important use of this proc.