### PR TITLE
Fixes solar panel assembly dupe

### DIFF
--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -253,6 +253,7 @@ GLOBAL_LIST_EMPTY(solars_list)
 					new /obj/machinery/power/tracker(get_turf(src), src)
 				else
 					new /obj/machinery/power/solar(get_turf(src), src)
+				qdel(src)
 			else
 				to_chat(user, "<span class='warning'>You need two sheets of glass to put them into a solar panel.</span>")
 				return


### PR DESCRIPTION
Every time you build a solar panel, assembly frame is still there under the newly built panel. Fix.