### PR TITLE
Makes unsimulated walls properly block air

### DIFF
--- a/code/game/turfs/unsimulated/walls.dm
+++ b/code/game/turfs/unsimulated/walls.dm
@@ -4,6 +4,7 @@
 	icon_state = "riveted"
 	opacity = 1
 	density = 1
+	blocks_air = TRUE
 
 /turf/unsimulated/wall/fakeglass
 	name = "window"


### PR DESCRIPTION
Lack of this var made them generate connection edges when they, as wall, should have none.