### PR TITLE
Port weight/body types to traits

### DIFF
--- a/code/modules/client/preference_setup/traits/trait_defines.dm
+++ b/code/modules/client/preference_setup/traits/trait_defines.dm
@@ -72,25 +72,45 @@
 	Regardless, you find it quite difficult to land shots where you wanted them to go."
 	modifier_type = /datum/modifier/trait/inaccurate
 
-/datum/trait/modifier/physical/smaller
-	name = "Smaller"
-	modifier_type = /datum/modifier/trait/smaller
-	mutually_exclusive = list(/datum/trait/modifier/physical/small, /datum/trait/modifier/physical/large, /datum/trait/modifier/physical/larger)
+/datum/trait/modifier/physical/shorter
+	name = "Shorter"
+	modifier_type = /datum/modifier/trait/shorter
+	mutually_exclusive = list(/datum/trait/modifier/physical/short, /datum/trait/modifier/physical/tall, /datum/trait/modifier/physical/taller)
 
-/datum/trait/modifier/physical/small
-	name = "Small"
-	modifier_type = /datum/modifier/trait/small
-	mutually_exclusive = list(/datum/trait/modifier/physical/smaller, /datum/trait/modifier/physical/large, /datum/trait/modifier/physical/larger)
+/datum/trait/modifier/physical/short
+	name = "Short"
+	modifier_type = /datum/modifier/trait/short
+	mutually_exclusive = list(/datum/trait/modifier/physical/shorter, /datum/trait/modifier/physical/tall, /datum/trait/modifier/physical/taller)
 
-/datum/trait/modifier/physical/large
-	name = "Large"
-	modifier_type = /datum/modifier/trait/large
-	mutually_exclusive = list(/datum/trait/modifier/physical/smaller, /datum/trait/modifier/physical/small, /datum/trait/modifier/physical/larger)
+/datum/trait/modifier/physical/tall
+	name = "Tall"
+	modifier_type = /datum/modifier/trait/tall
+	mutually_exclusive = list(/datum/trait/modifier/physical/shorter, /datum/trait/modifier/physical/short, /datum/trait/modifier/physical/taller)
 
-/datum/trait/modifier/physical/larger
-	name = "Larger"
-	modifier_type = /datum/modifier/trait/larger
-	mutually_exclusive = list(/datum/trait/modifier/physical/smaller, /datum/trait/modifier/physical/small, /datum/trait/modifier/physical/large)
+/datum/trait/modifier/physical/taller
+	name = "Taller"
+	modifier_type = /datum/modifier/trait/taller
+	mutually_exclusive = list(/datum/trait/modifier/physical/shorter, /datum/trait/modifier/physical/short, /datum/trait/modifier/physical/tall)
+
+/datum/trait/modifier/physical/thin
+	name = "Thin"
+	modifier_type = /datum/modifier/trait/thin
+	mutually_exclusive = list(/datum/trait/modifier/physical/fat, /datum/trait/modifier/physical/obese, /datum/trait/modifier/physical/thinner)
+
+/datum/trait/modifier/physical/thinner
+	name = "Rail Thin"
+	modifier_type = /datum/modifier/trait/thinner
+	mutually_exclusive = list(/datum/trait/modifier/physical/fat, /datum/trait/modifier/physical/obese, /datum/trait/modifier/physical/thin)
+
+/datum/trait/modifier/physical/fat
+	name = "Broad-Shouldered"
+	modifier_type = /datum/modifier/trait/fat
+	mutually_exclusive = list(/datum/trait/modifier/physical/thin, /datum/trait/modifier/physical/obese, /datum/trait/modifier/physical/thinner)
+
+/datum/trait/modifier/physical/obese
+	name = "Heavily Built"
+	modifier_type = /datum/modifier/trait/obese
+	mutually_exclusive = list(/datum/trait/modifier/physical/fat, /datum/trait/modifier/physical/thinner, /datum/trait/modifier/physical/thin)
 
 /datum/trait/modifier/physical/colorblind_protanopia
 	name = "Protanopia"

--- a/code/modules/mob/_modifiers/traits.dm
+++ b/code/modules/mob/_modifiers/traits.dm
@@ -60,33 +60,67 @@
 	metabolism_percent = 0.5
 	incoming_healing_percent = 0.6
 
-/datum/modifier/trait/larger
-	name = "Larger"
-	desc = "Your body is larger than average."
+/datum/modifier/trait/taller
+	name = "Taller"
+	desc = "Your body is taller than average."
+	icon_scale_x_percent = 1
+	icon_scale_y_percent = 1.09
 
-	icon_scale_x_percent = 1.1
-	icon_scale_y_percent = 1.1
-
-/datum/modifier/trait/large
-	name = "Large"
-	desc = "Your body is a bit larger than average."
-
-	icon_scale_x_percent = 1.05
+/datum/modifier/trait/tall
+	name = "Tall"
+	desc = "Your body is a bit taller than average."
+	icon_scale_x_percent = 1
 	icon_scale_y_percent = 1.05
 
-/datum/modifier/trait/small
-	name = "Small"
-	desc = "Your body is a bit smaller than average."
-
-	icon_scale_x_percent = 0.95
+/datum/modifier/trait/short
+	name = "Short"
+	desc = "Your body is a bit shorter than average."
+	icon_scale_x_percent = 1
 	icon_scale_y_percent = 0.95
 
-/datum/modifier/trait/smaller
-	name = "Smaller"
-	desc = "Your body is smaller than average."
 
-	icon_scale_x_percent = 0.9
-	icon_scale_y_percent = 0.9
+/datum/modifier/trait/shorter
+	name = "Shorter"
+	desc = "You are shorter than average."
+	icon_scale_x_percent = 1
+	icon_scale_y_percent = 0.915
+
+/datum/modifier/trait/fat
+	name = "Overweight"
+	desc = "You are heavier than average."
+
+	metabolism_percent = 1.2
+	icon_scale_x_percent = 1.054
+	icon_scale_y_percent = 1
+	slowdown = 1.1
+	max_health_percent = 1.05
+
+/datum/modifier/trait/obese
+	name = "Obese"
+	desc = "You are much heavier than average."
+	metabolism_percent = 1.4
+	icon_scale_x_percent = 1.095
+	icon_scale_y_percent = 1
+	slowdown = 1.2
+	max_health_percent = 1.10
+
+/datum/modifier/trait/thin
+	name = "Thin"
+	desc = "You are skinnier than average."
+	metabolism_percent = 0.8
+	icon_scale_x_percent = 0.945
+	icon_scale_y_percent = 1
+	max_health_percent = 0.95
+	outgoing_melee_damage_percent = 0.95
+
+/datum/modifier/trait/thinner
+	name = "Very Thin"
+	desc = "You are much skinnier than average."
+	metabolism_percent = 0.6
+	icon_scale_x_percent = 0.905
+	icon_scale_y_percent = 1
+	max_health_percent = 0.90
+	outgoing_melee_damage_percent = 0.9
 
 /datum/modifier/trait/colorblind_protanopia
 	name = "Protanopia"

--- a/html/changelogs/woodrat - mobsizeport.yml
+++ b/html/changelogs/woodrat - mobsizeport.yml
@@ -1,0 +1,37 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Woodrat
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscdel: "Removed the old size modifier traits for mobs."
+  - rscadd: "Port and tweak of the size modifiers from World Server for mobs."


### PR DESCRIPTION
Port and tweak from World Server of their weight and body type system

Removed the current size trait system for player mobs.
Replaced with the weight and size system from world server.
Mobs with heavier body types will be slower but have a higher metabolism.
Mobs with thinner body types will have a slower metabolism and are more fragile.
Being tall or short has no effect aside from the sprite.

[Example Pic](https://i.imgur.com/fwkk6nS.png)

Couple weird quirks (sprites are a lot more fuzzy compared to world server, and lying down sprites can look slightly off) but overhaul seems usable.