### PR TITLE
Printers print Fields correctly now.

### DIFF
--- a/code/modules/modular_computers/hardware/nano_printer.dm
+++ b/code/modules/modular_computers/hardware/nano_printer.dm
@@ -31,9 +31,23 @@
 	if(paper_title)
 		P.name = paper_title
 	P.update_icon()
+	P.fields = count_fields(P.info, P.fields)
+	P.updateinfolinks()
 
 	stored_paper--
 	return 1
+
+/obj/item/weapon/computer_hardware/nano_printer/proc/count_fields(var/info, var/fields)
+//Count the fields. This is taken directly from paper.dm, /obj/item/weapon/paper/proc/parsepencode(). -Hawk_v3
+	var/t = info
+	var/laststart = 1
+	while(1)
+		var/i = findtext(t, "<span class=\"paper_field\">", laststart)	//</span>
+		if(i==0)
+			break
+		laststart = i+1
+		fields++
+	return fields
 
 /obj/item/weapon/computer_hardware/nano_printer/attackby(obj/item/W as obj, mob/user as mob)
 	if(istype(W, /obj/item/weapon/paper))

--- a/code/modules/modular_computers/hardware/nano_printer.dm
+++ b/code/modules/modular_computers/hardware/nano_printer.dm
@@ -31,14 +31,15 @@
 	if(paper_title)
 		P.name = paper_title
 	P.update_icon()
-	P.fields = count_fields(P.info, P.fields)
+	P.fields = count_fields(P.info)
 	P.updateinfolinks()
 
 	stored_paper--
 	return 1
 
-/obj/item/weapon/computer_hardware/nano_printer/proc/count_fields(var/info, var/fields)
+/obj/item/weapon/computer_hardware/nano_printer/proc/count_fields(var/info)
 //Count the fields. This is taken directly from paper.dm, /obj/item/weapon/paper/proc/parsepencode(). -Hawk_v3
+	var/fields = 0
 	var/t = info
 	var/laststart = 1
 	while(1)


### PR DESCRIPTION
This counts up all the mentions of [field] (expanded out into HTML) in the paper and sets the paper's fields var to it, allowing the updateinfolinks proc to work correctly as intended.
