### PR TITLE
Fixes adding verbs to mobs in varedit.

### DIFF
--- a/code/modules/admin/view_variables/topic.dm
+++ b/code/modules/admin/view_variables/topic.dm
@@ -366,7 +366,7 @@
 		if(istype(H,/mob/living/silicon/ai))
 			possibleverbs += typesof(/mob/living/silicon/proc,/mob/living/silicon/ai/proc,/mob/living/silicon/ai/verb)
 		if(istype(H,/mob/living/simple_mob))
-			possibleverbs += typesof(/mob/living/simple_mob/proc,/mob/living/simple_mob/verb)
+			possibleverbs += typesof(/mob/living/simple_mob/proc)
 		possibleverbs -= H.verbs
 		possibleverbs += "Cancel" 								// ...And one for the bottom
 

--- a/code/modules/admin/view_variables/topic.dm
+++ b/code/modules/admin/view_variables/topic.dm
@@ -359,13 +359,14 @@
 		var/list/possibleverbs = list()
 		possibleverbs += "Cancel" 								// One for the top...
 		possibleverbs += typesof(/mob/proc,/mob/verb,/mob/living/proc,/mob/living/verb)
-		switch(H.type)
-			if(/mob/living/carbon/human)
-				possibleverbs += typesof(/mob/living/carbon/proc,/mob/living/carbon/verb,/mob/living/carbon/human/verb,/mob/living/carbon/human/proc)
-			if(/mob/living/silicon/robot)
-				possibleverbs += typesof(/mob/living/silicon/proc,/mob/living/silicon/robot/proc,/mob/living/silicon/robot/verb)
-			if(/mob/living/silicon/ai)
-				possibleverbs += typesof(/mob/living/silicon/proc,/mob/living/silicon/ai/proc,/mob/living/silicon/ai/verb)
+		if(istype(H,/mob/living/carbon/human))
+			possibleverbs += typesof(/mob/living/carbon/proc,/mob/living/carbon/verb,/mob/living/carbon/human/verb,/mob/living/carbon/human/proc)
+		if(istype(H,/mob/living/silicon/robot))
+			possibleverbs += typesof(/mob/living/silicon/proc,/mob/living/silicon/robot/proc,/mob/living/silicon/robot/verb)
+		if(istype(H,/mob/living/silicon/ai))
+			possibleverbs += typesof(/mob/living/silicon/proc,/mob/living/silicon/ai/proc,/mob/living/silicon/ai/verb)
+		if(istype(H,/mob/living/simple_mob))
+			possibleverbs += typesof(/mob/living/simple_mob/proc,/mob/living/simple_mob/verb)
 		possibleverbs -= H.verbs
 		possibleverbs += "Cancel" 								// ...And one for the bottom
 


### PR DESCRIPTION
Previously only _**strictly**_ human, robot, and ai types would get any additional verbs that weren't _**strictly**_ /mob or /mob/living procs or verbs.
This means that unless your mob was _**strictly**_ the base type of human or robot or AI, it would be impossible to add any procs or verbs that are made for anything that is not _**strictly**_ /mob or /mob/living. Strictly meaning that _any and all_ subtypes would be excluded.

Now humans _and_ human subtypes can get carbon and human verbs, robots _and_ robot subtypes can get silicon and robot verbs, AI _and_ AI subtypes can get silicon and AI verbs, and now also simplemobs _and_ simplemob subtypes can get simplemob verbs.