### PR TITLE
Fixes knocked out borgs never dying.

### DIFF
--- a/code/modules/mob/living/silicon/robot/life.dm
+++ b/code/modules/mob/living/silicon/robot/life.dm
@@ -84,6 +84,7 @@
 		Weaken(5)
 
 	if(health < config.health_threshold_dead && src.stat != 2) //die only once
+		src.stat = 2
 		death()
 
 	if (src.stat != 2) //Alive.
@@ -104,9 +105,8 @@
 
 		AdjustConfused(-1)
 
-	else //Dead.
+	else //Dead or just unconscious.
 		src.blinded = 1
-		src.stat = 2
 
 	if (src.stuttering) src.stuttering--
 

--- a/code/modules/mob/living/silicon/robot/life.dm
+++ b/code/modules/mob/living/silicon/robot/life.dm
@@ -84,7 +84,6 @@
 		Weaken(5)
 
 	if(health < config.health_threshold_dead && src.stat != 2) //die only once
-		src.stat = 2
 		death()
 
 	if (src.stat != 2) //Alive.


### PR DESCRIPTION
Fixes the borg life code making it so that a hiccup while applying any unconscious stat (1) on borgs would permanently force their stat into 2(dead), which from that point onward will just skip the death proc when it eventually would become relevant.