### PR TITLE
Sanity check for orphaned ai_holder runtimes

### DIFF
--- a/code/modules/ai/ai_holder_disabled.dm
+++ b/code/modules/ai/ai_holder_disabled.dm
@@ -5,6 +5,9 @@
 
 // If our holder is able to do anything.
 /datum/ai_holder/proc/can_act()
+	if(!holder) // Holder missing.
+		SSai.processing -= src
+		return FALSE
 	if(holder.stat) // Dead or unconscious.
 		ai_log("can_act() : Stat was non-zero ([holder.stat]).", AI_LOG_TRACE)
 		return FALSE


### PR DESCRIPTION
Seems like ai_holder datums take their own sweet time deleting themselves after losing their parent mobs, causing a ton of null holder runtimes during that time window. Now they should be able to sense that their holder mob is gone and avoid that.