### PR TITLE
Clean up dead code obsoleted by outfit system

### DIFF
--- a/code/datums/outfits/jobs/cargo.dm
+++ b/code/datums/outfits/jobs/cargo.dm
@@ -14,7 +14,7 @@
 /decl/hierarchy/outfit/job/cargo/cargo_tech
 	name = OUTFIT_JOB_NAME("Cargo technician")
 	uniform = /obj/item/clothing/under/rank/cargotech
-	id_type = /obj/item/weapon/card/id/cargo/cargo_tech
+	id_type = /obj/item/weapon/card/id/cargo
 	pda_type = /obj/item/device/pda/cargo
 
 /decl/hierarchy/outfit/job/cargo/mining
@@ -23,7 +23,7 @@
 	l_ear = /obj/item/device/radio/headset/headset_mine
 	backpack = /obj/item/weapon/storage/backpack/industrial
 	satchel_one  = /obj/item/weapon/storage/backpack/satchel/eng
-	id_type = /obj/item/weapon/card/id/cargo/mining
+	id_type = /obj/item/weapon/card/id/cargo
 	pda_type = /obj/item/device/pda/shaftminer
 	backpack_contents = list(/obj/item/weapon/tool/crowbar = 1, /obj/item/weapon/storage/bag/ore = 1)
 	flags = OUTFIT_HAS_BACKPACK|OUTFIT_EXTENDED_SURVIVAL

--- a/code/datums/outfits/jobs/civilian.dm
+++ b/code/datums/outfits/jobs/civilian.dm
@@ -14,7 +14,7 @@
 /decl/hierarchy/outfit/job/service/bartender
 	name = OUTFIT_JOB_NAME("Bartender")
 	uniform = /obj/item/clothing/under/rank/bartender
-	id_type = /obj/item/weapon/card/id/civilian/bartender
+	id_type = /obj/item/weapon/card/id/civilian
 	pda_type = /obj/item/device/pda/bar
 	backpack_contents = list(/obj/item/clothing/accessory/permit/gun/bar = 1)
 
@@ -33,7 +33,7 @@
 	uniform = /obj/item/clothing/under/rank/chef
 	suit = /obj/item/clothing/suit/chef
 	head = /obj/item/clothing/head/chefhat
-	id_type = /obj/item/weapon/card/id/civilian/chef
+	id_type = /obj/item/weapon/card/id/civilian
 	pda_type = /obj/item/device/pda/chef
 
 /decl/hierarchy/outfit/job/service/chef/cook
@@ -49,20 +49,20 @@
 	backpack = /obj/item/weapon/storage/backpack/hydroponics
 	satchel_one = /obj/item/weapon/storage/backpack/satchel/hyd
 	messenger_bag = /obj/item/weapon/storage/backpack/messenger/hyd
-	id_type = /obj/item/weapon/card/id/civilian/botanist
+	id_type = /obj/item/weapon/card/id/civilian
 	pda_type = /obj/item/device/pda/botanist
 
 /decl/hierarchy/outfit/job/service/janitor
 	name = OUTFIT_JOB_NAME("Janitor")
 	uniform = /obj/item/clothing/under/rank/janitor
-	id_type = /obj/item/weapon/card/id/civilian/janitor
+	id_type = /obj/item/weapon/card/id/civilian
 	pda_type = /obj/item/device/pda/janitor
 
 /decl/hierarchy/outfit/job/librarian
 	name = OUTFIT_JOB_NAME("Librarian")
 	uniform = /obj/item/clothing/under/suit_jacket/red
 	l_hand = /obj/item/weapon/barcodescanner
-	id_type = /obj/item/weapon/card/id/civilian/librarian
+	id_type = /obj/item/weapon/card/id/civilian
 	pda_type = /obj/item/device/pda/librarian
 
 /decl/hierarchy/outfit/job/internal_affairs_agent
@@ -73,14 +73,14 @@
 	shoes = /obj/item/clothing/shoes/brown
 	glasses = /obj/item/clothing/glasses/sunglasses/big
 	l_hand = /obj/item/weapon/clipboard
-	id_type = /obj/item/weapon/card/id/civilian/internal_affairs_agent
+	id_type = /obj/item/weapon/card/id/civilian
 	pda_type = /obj/item/device/pda/lawyer
 
 /decl/hierarchy/outfit/job/chaplain
 	name = OUTFIT_JOB_NAME("Chaplain")
 	uniform = /obj/item/clothing/under/rank/chaplain
 	l_hand = /obj/item/weapon/storage/bible
-	id_type = /obj/item/weapon/card/id/civilian/chaplain
+	id_type = /obj/item/weapon/card/id/civilian
 	pda_type = /obj/item/device/pda/chaplain
 
 /decl/hierarchy/outfit/job/explorer

--- a/code/datums/outfits/jobs/command.dm
+++ b/code/datums/outfits/jobs/command.dm
@@ -7,7 +7,7 @@
 	backpack = /obj/item/weapon/storage/backpack/captain
 	satchel_one = /obj/item/weapon/storage/backpack/satchel/cap
 	messenger_bag = /obj/item/weapon/storage/backpack/messenger/com
-	id_type = /obj/item/weapon/card/id/gold/captain
+	id_type = /obj/item/weapon/card/id/gold
 	pda_type = /obj/item/device/pda/captain
 
 /decl/hierarchy/outfit/job/captain/post_equip(var/mob/living/carbon/human/H)
@@ -28,14 +28,14 @@
 	uniform = /obj/item/clothing/under/rank/head_of_personnel
 	l_ear = /obj/item/device/radio/headset/heads/hop
 	shoes = /obj/item/clothing/shoes/brown
-	id_type = /obj/item/weapon/card/id/silver/hop
+	id_type = /obj/item/weapon/card/id/silver
 	pda_type = /obj/item/device/pda/heads/hop
 
 /decl/hierarchy/outfit/job/secretary
 	name = OUTFIT_JOB_NAME("Command Secretary")
 	l_ear = /obj/item/device/radio/headset/headset_com
 	shoes = /obj/item/clothing/shoes/brown
-	id_type = /obj/item/weapon/card/id/silver/secretary
+	id_type = /obj/item/weapon/card/id/silver
 	pda_type = /obj/item/device/pda/heads
 	r_hand = /obj/item/weapon/clipboard
 

--- a/code/datums/outfits/jobs/engineering.dm
+++ b/code/datums/outfits/jobs/engineering.dm
@@ -23,12 +23,12 @@
 	name = OUTFIT_JOB_NAME("Engineer")
 	head = /obj/item/clothing/head/hardhat
 	uniform = /obj/item/clothing/under/rank/engineer
-	id_type = /obj/item/weapon/card/id/engineering/engineer
+	id_type = /obj/item/weapon/card/id/engineering
 	pda_type = /obj/item/device/pda/engineering
 
 /decl/hierarchy/outfit/job/engineering/atmos
 	name = OUTFIT_JOB_NAME("Atmospheric technician")
 	uniform = /obj/item/clothing/under/rank/atmospheric_technician
 	belt = /obj/item/weapon/storage/belt/utility/atmostech
-	id_type = /obj/item/weapon/card/id/engineering/atmos
+	id_type = /obj/item/weapon/card/id/engineering
 	pda_type = /obj/item/device/pda/atmos

--- a/code/datums/outfits/jobs/job.dm
+++ b/code/datums/outfits/jobs/job.dm
@@ -13,8 +13,11 @@
 
 	flags = OUTFIT_HAS_BACKPACK
 
-/decl/hierarchy/outfit/job/equip_id(mob/living/carbon/human/H)
+/decl/hierarchy/outfit/job/equip_id(mob/living/carbon/human/H, rank, assignment)
 	var/obj/item/weapon/card/id/C = ..()
+	var/datum/job/J = job_master.GetJob(rank)
+	if(J)
+		C.access = J.get_access()
 	if(H.mind)
 		var/datum/mind/M = H.mind
 		if(M.initial_account)

--- a/code/datums/outfits/jobs/medical.dm
+++ b/code/datums/outfits/jobs/medical.dm
@@ -25,7 +25,7 @@
 	suit = /obj/item/clothing/suit/storage/toggle/labcoat
 	l_hand = /obj/item/weapon/storage/firstaid/regular
 	r_pocket = /obj/item/device/flashlight/pen
-	id_type = /obj/item/weapon/card/id/medical/doctor
+	id_type = /obj/item/weapon/card/id/medical
 
 /decl/hierarchy/outfit/job/medical/doctor/emergency_physician
 	name = OUTFIT_JOB_NAME("Emergency Physician")
@@ -65,7 +65,7 @@
 	suit = /obj/item/clothing/suit/storage/toggle/labcoat/chemist
 	backpack = /obj/item/weapon/storage/backpack/chemistry
 	satchel_one = /obj/item/weapon/storage/backpack/satchel/chem
-	id_type = /obj/item/weapon/card/id/medical/chemist
+	id_type = /obj/item/weapon/card/id/medical
 	pda_type = /obj/item/device/pda/chemist
 
 /decl/hierarchy/outfit/job/medical/geneticist
@@ -75,7 +75,7 @@
 	backpack = /obj/item/weapon/storage/backpack/genetics
 	r_pocket = /obj/item/device/flashlight/pen
 	satchel_one = /obj/item/weapon/storage/backpack/satchel/gen
-	id_type = /obj/item/weapon/card/id/medical/geneticist
+	id_type = /obj/item/weapon/card/id/medical
 	pda_type = /obj/item/device/pda/geneticist
 
 /decl/hierarchy/outfit/job/medical/psychiatrist
@@ -83,7 +83,7 @@
 	uniform = /obj/item/clothing/under/rank/psych
 	suit = /obj/item/clothing/suit/storage/toggle/labcoat
 	shoes = /obj/item/clothing/shoes/laceup
-	id_type = /obj/item/weapon/card/id/medical/psychiatrist
+	id_type = /obj/item/weapon/card/id/medical
 
 /decl/hierarchy/outfit/job/medical/psychiatrist/psychologist
 	name = OUTFIT_JOB_NAME("Psychologist")
@@ -97,7 +97,7 @@
 	l_hand = /obj/item/weapon/storage/firstaid/regular
 	belt = /obj/item/weapon/storage/belt/medical/emt
 	pda_slot = slot_l_store
-	id_type = /obj/item/weapon/card/id/medical/paramedic
+	id_type = /obj/item/weapon/card/id/medical
 	flags = OUTFIT_HAS_BACKPACK|OUTFIT_EXTENDED_SURVIVAL
 
 /decl/hierarchy/outfit/job/medical/paramedic/emt

--- a/code/datums/outfits/jobs/science.dm
+++ b/code/datums/outfits/jobs/science.dm
@@ -20,13 +20,13 @@
 /decl/hierarchy/outfit/job/science/scientist
 	name = OUTFIT_JOB_NAME("Scientist")
 	uniform = /obj/item/clothing/under/rank/scientist
-	id_type = /obj/item/weapon/card/id/science/scientist
+	id_type = /obj/item/weapon/card/id/science
 	suit = /obj/item/clothing/suit/storage/toggle/labcoat/science
 
 /decl/hierarchy/outfit/job/science/xenobiologist
 	name = OUTFIT_JOB_NAME("Xenobiologist")
 	uniform = /obj/item/clothing/under/rank/scientist
-	id_type = /obj/item/weapon/card/id/science/xenobiologist
+	id_type = /obj/item/weapon/card/id/science
 	suit = /obj/item/clothing/suit/storage/toggle/labcoat/science
 
 /decl/hierarchy/outfit/job/science/roboticist
@@ -34,7 +34,7 @@
 	uniform = /obj/item/clothing/under/rank/roboticist
 	shoes = /obj/item/clothing/shoes/black
 	belt = /obj/item/weapon/storage/belt/utility/full
-	id_type = /obj/item/weapon/card/id/science/roboticist
+	id_type = /obj/item/weapon/card/id/science
 	pda_slot = slot_r_store
 	pda_type = /obj/item/device/pda/roboticist
 	backpack = /obj/item/weapon/storage/backpack

--- a/code/datums/outfits/jobs/security.dm
+++ b/code/datums/outfits/jobs/security.dm
@@ -20,7 +20,7 @@
 	name = OUTFIT_JOB_NAME("Warden")
 	uniform = /obj/item/clothing/under/rank/warden
 	l_pocket = /obj/item/device/flash
-	id_type = /obj/item/weapon/card/id/security/warden
+	id_type = /obj/item/weapon/card/id/security
 	pda_type = /obj/item/device/pda/warden
 
 /decl/hierarchy/outfit/job/security/detective
@@ -31,7 +31,7 @@
 	l_pocket = /obj/item/weapon/flame/lighter/zippo
 	shoes = /obj/item/clothing/shoes/laceup
 	r_hand = /obj/item/weapon/storage/briefcase/crimekit
-	id_type = /obj/item/weapon/card/id/security/detective
+	id_type = /obj/item/weapon/card/id/security
 	pda_type = /obj/item/device/pda/detective
 	backpack = /obj/item/weapon/storage/backpack
 	satchel_one = /obj/item/weapon/storage/backpack/satchel/norm
@@ -46,5 +46,5 @@
 	name = OUTFIT_JOB_NAME("Security Officer")
 	uniform = /obj/item/clothing/under/rank/security
 	l_pocket = /obj/item/device/flash
-	id_type = /obj/item/weapon/card/id/security/officer
+	id_type = /obj/item/weapon/card/id/security
 	pda_type = /obj/item/device/pda/security

--- a/code/game/jobs/job/captain.dm
+++ b/code/game/jobs/job/captain.dm
@@ -11,7 +11,6 @@ var/datum/announcement/minor/captain_announcement = new(do_newscast = 1)
 	spawn_positions = 1
 	supervisors = "company officials and Corporate Regulations"
 	selection_color = "#1D1D4F"
-	idtype = /obj/item/weapon/card/id/gold
 	req_admin_notify = 1
 	access = list() 			//See get_access()
 	minimal_access = list() 	//See get_access()
@@ -44,7 +43,6 @@ var/datum/announcement/minor/captain_announcement = new(do_newscast = 1)
 	spawn_positions = 1
 	supervisors = "the Colony Director"
 	selection_color = "#2F2F7F"
-	idtype = /obj/item/weapon/card/id/silver/hop
 	req_admin_notify = 1
 	minimal_player_age = 10
 	economic_modifier = 10
@@ -79,7 +77,6 @@ var/datum/announcement/minor/captain_announcement = new(do_newscast = 1)
 	spawn_positions = 2
 	supervisors = "command staff"
 	selection_color = "#2F2F7F"
-	idtype = /obj/item/weapon/card/id/silver/secretary
 	minimal_player_age = 5
 	economic_modifier = 7
 

--- a/code/game/jobs/job/civilian.dm
+++ b/code/game/jobs/job/civilian.dm
@@ -9,7 +9,6 @@
 	spawn_positions = 2
 	supervisors = "the head of personnel"
 	selection_color = "#515151"
-	idtype = /obj/item/weapon/card/id/civilian/bartender
 	access = list(access_hydroponics, access_bar, access_kitchen)
 	minimal_access = list(access_bar)
 
@@ -27,7 +26,6 @@
 	spawn_positions = 2
 	supervisors = "the head of personnel"
 	selection_color = "#515151"
-	idtype = /obj/item/weapon/card/id/civilian/chef
 	access = list(access_hydroponics, access_bar, access_kitchen)
 	minimal_access = list(access_kitchen)
 
@@ -44,7 +42,6 @@
 	spawn_positions = 1
 	supervisors = "the head of personnel"
 	selection_color = "#515151"
-	idtype = /obj/item/weapon/card/id/civilian/botanist
 	access = list(access_hydroponics, access_bar, access_kitchen)
 	minimal_access = list(access_hydroponics)
 
@@ -63,7 +60,6 @@
 	spawn_positions = 1
 	supervisors = "the head of personnel"
 	selection_color = "#7a4f33"
-	idtype = /obj/item/weapon/card/id/cargo/head
 	economic_modifier = 5
 	access = list(access_maint_tunnels, access_mailsorting, access_cargo, access_cargo_bot, access_qm, access_mining, access_mining_station)
 	minimal_access = list(access_maint_tunnels, access_mailsorting, access_cargo, access_cargo_bot, access_qm, access_mining, access_mining_station)
@@ -83,7 +79,6 @@
 	spawn_positions = 2
 	supervisors = "the quartermaster and the head of personnel"
 	selection_color = "#9b633e"
-	idtype = /obj/item/weapon/card/id/cargo/cargo_tech
 	access = list(access_maint_tunnels, access_mailsorting, access_cargo, access_cargo_bot, access_mining, access_mining_station)
 	minimal_access = list(access_maint_tunnels, access_cargo, access_cargo_bot, access_mailsorting)
 
@@ -99,7 +94,6 @@
 	spawn_positions = 3
 	supervisors = "the quartermaster and the head of personnel"
 	selection_color = "#9b633e"
-	idtype = /obj/item/weapon/card/id/cargo/mining
 	economic_modifier = 5
 	access = list(access_maint_tunnels, access_mailsorting, access_cargo, access_cargo_bot, access_mining, access_mining_station)
 	minimal_access = list(access_mining, access_mining_station, access_mailsorting)
@@ -118,7 +112,6 @@
 	spawn_positions = 2
 	supervisors = "the head of personnel"
 	selection_color = "#515151"
-	idtype = /obj/item/weapon/card/id/civilian/janitor
 	access = list(access_janitor, access_maint_tunnels)
 	minimal_access = list(access_janitor, access_maint_tunnels)
 
@@ -136,7 +129,6 @@
 	spawn_positions = 1
 	supervisors = "the head of personnel"
 	selection_color = "#515151"
-	idtype = /obj/item/weapon/card/id/civilian/librarian
 	access = list(access_library, access_maint_tunnels)
 	minimal_access = list(access_library)
 
@@ -154,7 +146,6 @@
 	spawn_positions = 2
 	supervisors = "company officials and Corporate Regulations"
 	selection_color = "#515151"
-	idtype = /obj/item/weapon/card/id/civilian/internal_affairs_agent
 	economic_modifier = 7
 	access = list(access_lawyer, access_sec_doors, access_maint_tunnels, access_heads)
 	minimal_access = list(access_lawyer, access_sec_doors, access_heads)

--- a/code/game/jobs/job/civilian_chaplain.dm
+++ b/code/game/jobs/job/civilian_chaplain.dm
@@ -9,7 +9,6 @@
 	spawn_positions = 1
 	supervisors = "the head of personnel"
 	selection_color = "#515151"
-	idtype = /obj/item/weapon/card/id/civilian/chaplain
 	access = list(access_morgue, access_chapel_office, access_crematorium, access_maint_tunnels)
 	minimal_access = list(access_chapel_office, access_crematorium)
 	alt_titles = list("Counselor")

--- a/code/game/jobs/job/engineering.dm
+++ b/code/game/jobs/job/engineering.dm
@@ -9,7 +9,6 @@
 	spawn_positions = 1
 	supervisors = "the Colony Director"
 	selection_color = "#7F6E2C"
-	idtype = /obj/item/weapon/card/id/engineering/head
 	req_admin_notify = 1
 	economic_modifier = 10
 
@@ -39,7 +38,6 @@
 	spawn_positions = 5
 	supervisors = "the chief engineer"
 	selection_color = "#5B4D20"
-	idtype = /obj/item/weapon/card/id/engineering/engineer
 	economic_modifier = 5
 	access = list(access_eva, access_engine, access_engine_equip, access_tech_storage, access_maint_tunnels, access_external_airlocks, access_construction, access_atmospherics)
 	minimal_access = list(access_eva, access_engine, access_engine_equip, access_tech_storage, access_maint_tunnels, access_external_airlocks, access_construction)
@@ -59,7 +57,6 @@
 	spawn_positions = 2
 	supervisors = "the chief engineer"
 	selection_color = "#5B4D20"
-	idtype = /obj/item/weapon/card/id/engineering/atmos
 	economic_modifier = 5
 	access = list(access_eva, access_engine, access_engine_equip, access_tech_storage, access_maint_tunnels, access_external_airlocks, access_construction, access_atmospherics, access_external_airlocks)
 	minimal_access = list(access_eva, access_engine, access_atmospherics, access_maint_tunnels, access_emergency_storage, access_construction, access_external_airlocks)

--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -13,7 +13,6 @@
 	var/current_positions = 0             // How many players have this job
 	var/supervisors = null                // Supervisors, who this person answers to directly
 	var/selection_color = "#ffffff"       // Selection screen color
-	var/idtype = /obj/item/weapon/card/id // The type of the ID the player will have
 	var/list/alt_titles                   // List of alternate titles, if any
 	var/req_admin_notify                  // If this is set to 1, a text is printed to the player when jobs are assigned, telling him that he should let admins know that he has to disconnect.
 	var/minimal_player_age = 0            // If you have use_age_restriction_for_jobs config option enabled and the database set up, this option will add a requirement for players to be at least minimal_player_age days old. (meaning they first signed in at least that many days before.)
@@ -21,6 +20,7 @@
 	var/head_position = 0                 // Is this position Command?
 	var/minimum_character_age = 0
 	var/ideal_character_age = 30
+	var/has_headset = TRUE                //Do people with this job need to be given headsets and told how to use them?  E.g. Cyborgs don't.
 
 	var/account_allowed = 1				  // Does this job type come with a station account?
 	var/economic_modifier = 2			  // With how much does this job modify the initial account amount?
@@ -39,13 +39,6 @@
 		. = alt_titles[alt_title]
 	. = . || outfit_type
 	. = outfit_by_type(.)
-
-/datum/job/proc/equip_backpack(var/mob/living/carbon/human/H)
-	switch(H.backbag)
-		if(2) H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack(H), slot_back)
-		if(3) H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/satchel/norm(H), slot_back)
-		if(4) H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/satchel(H), slot_back)
-		if(5) H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/messenger(H), slot_back)
 
 /datum/job/proc/setup_account(var/mob/living/carbon/human/H)
 	if(!account_allowed || (H.mind && H.mind.initial_account))

--- a/code/game/jobs/job/medical.dm
+++ b/code/game/jobs/job/medical.dm
@@ -9,7 +9,6 @@
 	spawn_positions = 1
 	supervisors = "the Colony Director"
 	selection_color = "#026865"
-	idtype = /obj/item/weapon/card/id/medical/head
 	req_admin_notify = 1
 	economic_modifier = 10
 	access = list(access_medical, access_medical_equip, access_morgue, access_genetics, access_heads,
@@ -35,7 +34,6 @@
 	spawn_positions = 3
 	supervisors = "the chief medical officer"
 	selection_color = "#013D3B"
-	idtype = /obj/item/weapon/card/id/medical/doctor
 	economic_modifier = 7
 	access = list(access_medical, access_medical_equip, access_morgue, access_surgery, access_chemistry, access_virology, access_genetics, access_eva)
 	minimal_access = list(access_medical, access_medical_equip, access_morgue, access_surgery, access_virology, access_eva)
@@ -57,7 +55,6 @@
 	spawn_positions = 2
 	supervisors = "the chief medical officer"
 	selection_color = "#013D3B"
-	idtype = /obj/item/weapon/card/id/medical/chemist
 	economic_modifier = 5
 	access = list(access_medical, access_medical_equip, access_morgue, access_surgery, access_chemistry, access_virology, access_genetics)
 	minimal_access = list(access_medical, access_medical_equip, access_chemistry)
@@ -78,7 +75,6 @@
 	spawn_positions = 0
 	supervisors = "the chief medical officer and research director"
 	selection_color = "#013D3B"
-	idtype = /obj/item/weapon/card/id/medical/geneticist
 	economic_modifier = 7
 	access = list(access_medical, access_morgue, access_surgery, access_chemistry, access_virology, access_genetics, access_research)
 	minimal_access = list(access_medical, access_morgue, access_genetics, access_research)
@@ -97,7 +93,6 @@
 	economic_modifier = 5
 	supervisors = "the chief medical officer"
 	selection_color = "#013D3B"
-	idtype = /obj/item/weapon/card/id/medical/psychiatrist
 	access = list(access_medical, access_medical_equip, access_morgue, access_psychiatrist)
 	minimal_access = list(access_medical, access_medical_equip, access_psychiatrist)
 	outfit_type = /decl/hierarchy/outfit/job/medical/psychiatrist
@@ -113,7 +108,6 @@
 	spawn_positions = 2
 	supervisors = "the chief medical officer"
 	selection_color = "#013D3B"
-	idtype = /obj/item/weapon/card/id/medical/paramedic
 	economic_modifier = 4
 	access = list(access_medical, access_medical_equip, access_morgue, access_surgery, access_chemistry, access_virology, access_eva, access_maint_tunnels, access_external_airlocks, access_psychiatrist)
 	minimal_access = list(access_medical, access_medical_equip, access_morgue, access_eva, access_maint_tunnels, access_external_airlocks)

--- a/code/game/jobs/job/science.dm
+++ b/code/game/jobs/job/science.dm
@@ -9,7 +9,6 @@
 	spawn_positions = 1
 	supervisors = "the Colony Director"
 	selection_color = "#AD6BAD"
-	idtype = /obj/item/weapon/card/id/science/head
 	req_admin_notify = 1
 	economic_modifier = 15
 	access = list(access_rd, access_heads, access_tox, access_genetics, access_morgue,
@@ -38,7 +37,6 @@
 	spawn_positions = 3
 	supervisors = "the research director"
 	selection_color = "#633D63"
-	idtype = /obj/item/weapon/card/id/science/scientist
 	economic_modifier = 7
 	access = list(access_robotics, access_tox, access_tox_storage, access_research, access_xenobiology, access_xenoarch)
 	minimal_access = list(access_tox, access_tox_storage, access_research, access_xenoarch)
@@ -58,7 +56,6 @@
 	spawn_positions = 2
 	supervisors = "the research director"
 	selection_color = "#633D63"
-	idtype = /obj/item/weapon/card/id/science/xenobiologist
 	economic_modifier = 7
 	access = list(access_robotics, access_tox, access_tox_storage, access_research, access_xenobiology, access_hydroponics)
 	minimal_access = list(access_research, access_xenobiology, access_hydroponics, access_tox_storage)
@@ -78,7 +75,6 @@
 	spawn_positions = 2
 	supervisors = "research director"
 	selection_color = "#633D63"
-	idtype = /obj/item/weapon/card/id/science/roboticist
 	economic_modifier = 5
 	access = list(access_robotics, access_tox, access_tox_storage, access_tech_storage, access_morgue, access_research) //As a job that handles so many corpses, it makes sense for them to have morgue access.
 	minimal_access = list(access_robotics, access_tech_storage, access_morgue, access_research) //As a job that handles so many corpses, it makes sense for them to have morgue access.

--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -9,7 +9,6 @@
 	spawn_positions = 1
 	supervisors = "the Colony Director"
 	selection_color = "#8E2929"
-	idtype = /obj/item/weapon/card/id/security/head
 	req_admin_notify = 1
 	economic_modifier = 10
 	access = list(access_security, access_eva, access_sec_doors, access_brig, access_armory,
@@ -36,7 +35,6 @@
 	spawn_positions = 1
 	supervisors = "the head of security"
 	selection_color = "#601C1C"
-	idtype = /obj/item/weapon/card/id/security/warden
 	economic_modifier = 5
 	access = list(access_security, access_eva, access_sec_doors, access_brig, access_armory, access_maint_tunnels, access_morgue, access_external_airlocks)
 	minimal_access = list(access_security, access_eva, access_sec_doors, access_brig, access_armory, access_maint_tunnels, access_external_airlocks)
@@ -53,7 +51,6 @@
 	spawn_positions = 2
 	supervisors = "the head of security"
 	selection_color = "#601C1C"
-	idtype = /obj/item/weapon/card/id/security/detective
 	access = list(access_security, access_sec_doors, access_forensics_lockers, access_morgue, access_maint_tunnels, access_eva, access_external_airlocks)
 	minimal_access = list(access_security, access_sec_doors, access_forensics_lockers, access_morgue, access_maint_tunnels, access_eva, access_external_airlocks)
 	economic_modifier = 5
@@ -71,7 +68,6 @@
 	spawn_positions = 4
 	supervisors = "the head of security"
 	selection_color = "#601C1C"
-	idtype = /obj/item/weapon/card/id/security/officer
 	economic_modifier = 4
 	access = list(access_security, access_eva, access_sec_doors, access_brig, access_maint_tunnels, access_morgue, access_external_airlocks)
 	minimal_access = list(access_security, access_eva, access_sec_doors, access_brig, access_maint_tunnels, access_external_airlocks)

--- a/code/game/jobs/job/silicon.dm
+++ b/code/game/jobs/job/silicon.dm
@@ -11,16 +11,9 @@
 	minimal_player_age = 7
 	account_allowed = 0
 	economic_modifier = 0
+	has_headset = FALSE
 
 /datum/job/ai/equip(var/mob/living/carbon/human/H)
-	if(!H)	return 0
-	return 1
-/*
-/datum/job/ai/equip_survival(var/mob/living/carbon/human/H)
-	if(!H)	return 0
-	return 1
-*/
-/datum/job/ai/equip_backpack(var/mob/living/carbon/human/H)
 	if(!H)	return 0
 	return 1
 
@@ -45,18 +38,10 @@
 	alt_titles = list("Robot", "Drone")
 	account_allowed = 0
 	economic_modifier = 0
+	has_headset = FALSE
 
 /datum/job/cyborg/equip(var/mob/living/carbon/human/H)
 	if(!H)	return 0
-	return 1
-/*
-/datum/job/cyborg/equip_survival(var/mob/living/carbon/human/H)
-	if(!H)	return 0
-	return 1
-*/
-/datum/job/cyborg/equip_backpack(var/mob/living/carbon/human/H)
-	if(!H)	return 0
-	return 1
 	return 1
 
 /datum/job/cyborg/equip_preview(mob/living/carbon/human/H)

--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -398,8 +398,6 @@ var/global/datum/controller/occupations/job_master
 			//Equip job items.
 			job.setup_account(H)
 			job.equip(H, H.mind ? H.mind.role_alt_title : "")
-			job.equip_backpack(H)
-//			job.equip_survival(H)
 			job.apply_fingerprints(H)
 			if(job.title != "Cyborg" && job.title != "AI")
 				H.equip_post_job()
@@ -485,9 +483,7 @@ var/global/datum/controller/occupations/job_master
 
 		if(job.supervisors)
 			H << "<b>As the [alt_title ? alt_title : rank] you answer directly to [job.supervisors]. Special circumstances may change this.</b>"
-
-		if(job.idtype)
-			spawnId(H, rank, alt_title)
+		if(job.has_headset)
 			H.equip_to_slot_or_del(new /obj/item/device/radio/headset(H), slot_l_ear)
 			H << "<b>To speak on your department's radio channel use :h. For the use of other channels, examine your headset.</b>"
 
@@ -528,48 +524,6 @@ var/global/datum/controller/occupations/job_master
 		BITSET(H.hud_updateflag, IMPLOYAL_HUD)
 		BITSET(H.hud_updateflag, SPECIALROLE_HUD)
 		return H
-
-
-	proc/spawnId(var/mob/living/carbon/human/H, rank, title)
-		if(!H)	return 0
-		var/obj/item/weapon/card/id/C = H.get_equipped_item(slot_wear_id)
-		if(istype(C))  return 0
-
-		var/datum/job/job = null
-		for(var/datum/job/J in occupations)
-			if(J.title == rank)
-				job = J
-				break
-
-		if(job)
-			if(job.title == "Cyborg")
-				return
-			else
-				C = new job.idtype(H)
-				C.access = job.get_access()
-		else
-			C = new /obj/item/weapon/card/id(H)
-		if(C)
-			C.rank = rank
-			C.assignment = title ? title : rank
-			H.set_id_info(C)
-
-			//put the player's account number onto the ID
-			if(H.mind && H.mind.initial_account)
-				C.associated_account_number = H.mind.initial_account.account_number
-
-			H.equip_to_slot_or_del(C, slot_wear_id)
-
-//		H.equip_to_slot_or_del(new /obj/item/device/pda(H), slot_belt)
-		if(locate(/obj/item/device/pda,H))
-			var/obj/item/device/pda/pda = locate(/obj/item/device/pda,H)
-			pda.owner = H.real_name
-			pda.ownjob = C.assignment
-			pda.ownrank = C.rank
-			pda.name = "PDA-[H.real_name] ([pda.ownjob])"
-
-		return 1
-
 
 	proc/LoadJobs(jobsfile) //ran during round setup, reads info from jobs.txt -- Urist
 		if(!config.load_jobs_from_txt)

--- a/code/game/objects/items/weapons/id cards/station_ids.dm
+++ b/code/game/objects/items/weapons/id cards/station_ids.dm
@@ -23,8 +23,6 @@
 	var/primary_color = rgb(0,0,0) // Obtained by eyedroppering the stripe in the middle of the card
 	var/secondary_color = rgb(0,0,0) // Likewise for the oval in the top-left corner
 
-	var/datum/job/job_access_type = /datum/job/assistant    // Job type to acquire access rights from, if any
-
 	//alt titles are handled a bit weirdly in order to unobtrusively integrate into existing ID system
 	var/assignment = null	//can be alt title or the actual job
 	var/rank = null			//actual job
@@ -134,16 +132,6 @@
 	icon_state = "silver"
 	item_state = "silver_id"
 
-/obj/item/weapon/card/id/silver/secretary
-	assignment = "Command Secretary"
-	rank = "Command Secretary"
-	job_access_type = /datum/job/secretary
-
-/obj/item/weapon/card/id/silver/hop
-	assignment = "Head of Personnel"
-	rank = "Head of Personnel"
-	job_access_type = /datum/job/hop
-
 /obj/item/weapon/card/id/gold
 	name = "identification card"
 	desc = "A golden card which shows power and might."
@@ -154,13 +142,11 @@
 /obj/item/weapon/card/id/gold/captain
 	assignment = "Colony Director"
 	rank = "Colony Director"
-	job_access_type = /datum/job/captain
 
 /obj/item/weapon/card/id/gold/captain/spare
 	name = "\improper Colony Director's spare ID"
 	desc = "The spare ID of the High Lord himself."
 	registered_name = "Colony Director"
-	job_access_type = /datum/job/captain
 
 /obj/item/weapon/card/id/synthetic
 	name = "\improper Synthetic ID"
@@ -205,31 +191,6 @@
 	primary_color = rgb(189,237,237)
 	secondary_color = rgb(223,255,255)
 
-/obj/item/weapon/card/id/medical/doctor
-	assignment = "Medical Doctor"
-	rank = "Medical Doctor"
-	job_access_type = /datum/job/doctor
-
-/obj/item/weapon/card/id/medical/chemist
-	assignment = "Chemist"
-	rank = "Chemist"
-	job_access_type = /datum/job/chemist
-
-/obj/item/weapon/card/id/medical/geneticist
-	assignment = "Geneticist"
-	rank = "Geneticist"
-	job_access_type = /datum/job/doctor	//geneticist
-
-/obj/item/weapon/card/id/medical/psychiatrist
-	assignment = "Psychiatrist"
-	rank = "Psychiatrist"
-	job_access_type = /datum/job/psychiatrist
-
-/obj/item/weapon/card/id/medical/paramedic
-	assignment = "Paramedic"
-	rank = "Paramedic"
-	job_access_type = /datum/job/paramedic
-
 /obj/item/weapon/card/id/medical/head
 	name = "identification card"
 	desc = "A card which represents care and compassion."
@@ -238,7 +199,6 @@
 	secondary_color = rgb(255,223,127)
 	assignment = "Chief Medical Officer"
 	rank = "Chief Medical Officer"
-	job_access_type = /datum/job/cmo
 
 /obj/item/weapon/card/id/security
 	name = "identification card"
@@ -246,21 +206,6 @@
 	icon_state = "sec"
 	primary_color = rgb(189,47,0)
 	secondary_color = rgb(223,127,95)
-
-/obj/item/weapon/card/id/security/officer
-	assignment = "Security Officer"
-	rank = "Security Officer"
-	job_access_type = /datum/job/officer
-
-/obj/item/weapon/card/id/security/detective
-	assignment = "Detective"
-	rank = "Detective"
-	job_access_type = /datum/job/detective
-
-/obj/item/weapon/card/id/security/warden
-	assignment = "Warden"
-	rank = "Warden"
-	job_access_type = /datum/job/warden
 
 /obj/item/weapon/card/id/security/head
 	name = "identification card"
@@ -270,7 +215,6 @@
 	secondary_color = rgb(255,223,127)
 	assignment = "Head of Security"
 	rank = "Head of Security"
-	job_access_type = /datum/job/hos
 
 /obj/item/weapon/card/id/engineering
 	name = "identification card"
@@ -278,16 +222,6 @@
 	icon_state = "eng"
 	primary_color = rgb(189,94,0)
 	secondary_color = rgb(223,159,95)
-
-/obj/item/weapon/card/id/engineering/engineer
-	assignment = "Station Engineer"
-	rank = "Station Engineer"
-	job_access_type = /datum/job/engineer
-
-/obj/item/weapon/card/id/engineering/atmos
-	assignment = "Atmospheric Technician"
-	rank = "Atmospheric Technician"
-	job_access_type = /datum/job/atmos
 
 /obj/item/weapon/card/id/engineering/head
 	name = "identification card"
@@ -297,7 +231,6 @@
 	secondary_color = rgb(255,223,127)
 	assignment = "Chief Engineer"
 	rank = "Chief Engineer"
-	job_access_type = /datum/job/chief_engineer
 
 /obj/item/weapon/card/id/science
 	name = "identification card"
@@ -305,21 +238,6 @@
 	icon_state = "sci"
 	primary_color = rgb(142,47,142)
 	secondary_color = rgb(191,127,191)
-
-/obj/item/weapon/card/id/science/scientist
-	assignment = "Scientist"
-	rank = "Scientist"
-	job_access_type = /datum/job/scientist
-
-/obj/item/weapon/card/id/science/xenobiologist
-	assignment = "Xenobiologist"
-	rank = "Xenobiologist"
-	job_access_type = /datum/job/xenobiologist
-
-/obj/item/weapon/card/id/science/roboticist
-	assignment = "Roboticist"
-	rank = "Roboticist"
-	job_access_type = /datum/job/roboticist
 
 /obj/item/weapon/card/id/science/head
 	name = "identification card"
@@ -329,7 +247,6 @@
 	secondary_color = rgb(255,223,127)
 	assignment = "Research Director"
 	rank = "Research Director"
-	job_access_type = /datum/job/rd
 
 /obj/item/weapon/card/id/cargo
 	name = "identification card"
@@ -337,16 +254,6 @@
 	icon_state = "cargo"
 	primary_color = rgb(142,94,0)
 	secondary_color = rgb(191,159,95)
-
-/obj/item/weapon/card/id/cargo/cargo_tech
-	assignment = "Cargo Technician"
-	rank = "Cargo Technician"
-	job_access_type = /datum/job/cargo_tech
-
-/obj/item/weapon/card/id/cargo/mining
-	assignment = "Shaft Miner"
-	rank = "Shaft Miner"
-	job_access_type = /datum/job/mining
 
 /obj/item/weapon/card/id/cargo/head
 	name = "identification card"
@@ -356,12 +263,10 @@
 	secondary_color = rgb(255,223,127)
 	assignment = "Quartermaster"
 	rank = "Quartermaster"
-	job_access_type = /datum/job/qm
 
 /obj/item/weapon/card/id/assistant
 	assignment = "Assistant"
 	rank = "Assistant"
-	job_access_type = /datum/job/assistant
 
 /obj/item/weapon/card/id/civilian
 	name = "identification card"
@@ -371,42 +276,6 @@
 	secondary_color = rgb(95,159,191)
 	assignment = "Civilian"
 	rank = "Assistant"
-	job_access_type = /datum/job/assistant
-
-/obj/item/weapon/card/id/civilian/bartender
-	assignment = "Bartender"
-	rank = "Bartender"
-	job_access_type = /datum/job/bartender
-
-/obj/item/weapon/card/id/civilian/botanist
-	assignment = "Botanist"
-	rank = "Botanist"
-	job_access_type = /datum/job/hydro
-
-/obj/item/weapon/card/id/civilian/chaplain
-	assignment = "Chaplain"
-	rank = "Chaplain"
-	job_access_type = /datum/job/chaplain
-
-/obj/item/weapon/card/id/civilian/chef
-	assignment = "Chef"
-	rank = "Chef"
-	job_access_type = /datum/job/chef
-
-/obj/item/weapon/card/id/civilian/internal_affairs_agent
-	assignment = "Internal Affairs Agent"
-	rank = "Internal Affairs Agent"
-	job_access_type = /datum/job/lawyer
-
-/obj/item/weapon/card/id/civilian/janitor
-	assignment = "Janitor"
-	rank = "Janitor"
-	job_access_type = /datum/job/janitor
-
-/obj/item/weapon/card/id/civilian/librarian
-	assignment = "Librarian"
-	rank = "Librarian"
-	job_access_type = /datum/job/librarian
 
 /obj/item/weapon/card/id/civilian/head //This is not the HoP. There's no position that uses this right now.
 	name = "identification card"

--- a/maps/southern_cross/job/outfits.dm
+++ b/maps/southern_cross/job/outfits.dm
@@ -14,7 +14,7 @@ Keep outfits simple. Spawn with basic uniforms and minimal gear. Gear instead go
 	id_slot = slot_wear_id
 	pda_slot = slot_l_store
 	pda_type = /obj/item/device/pda/cargo // Brown looks more rugged
-	id_type = /obj/item/weapon/card/id/civilian/explorer
+	id_type = /obj/item/weapon/card/id/civilian
 	id_pda_assignment = "Explorer"
 	flags = OUTFIT_HAS_BACKPACK|OUTFIT_COMPREHENSIVE_SURVIVAL
 	backpack_contents = list(/obj/item/clothing/accessory/permit/gun/planetside = 1)
@@ -47,7 +47,7 @@ Keep outfits simple. Spawn with basic uniforms and minimal gear. Gear instead go
 	id_slot = slot_wear_id
 	pda_slot = slot_belt
 	pda_type = /obj/item/device/pda/cargo // Brown looks more rugged
-	id_type = /obj/item/weapon/card/id/civilian/pilot
+	id_type = /obj/item/weapon/card/id/civilian
 	id_pda_assignment = "Pilot"
 	flags = OUTFIT_HAS_BACKPACK|OUTFIT_COMPREHENSIVE_SURVIVAL
 
@@ -60,6 +60,6 @@ Keep outfits simple. Spawn with basic uniforms and minimal gear. Gear instead go
 	l_hand = /obj/item/weapon/storage/firstaid/regular
 	belt = /obj/item/weapon/storage/belt/medical/emt
 	pda_slot = slot_l_store
-	id_type = /obj/item/weapon/card/id/medical/sar
+	id_type = /obj/item/weapon/card/id/medical
 	id_pda_assignment = "Search and Rescue"
 	flags = OUTFIT_HAS_BACKPACK|OUTFIT_EXTENDED_SURVIVAL|OUTFIT_COMPREHENSIVE_SURVIVAL

--- a/maps/southern_cross/southern_cross_jobs.dm
+++ b/maps/southern_cross/southern_cross_jobs.dm
@@ -17,23 +17,6 @@ var/const/access_explorer = 43
 	desc = "Explorer"
 	region = ACCESS_REGION_GENERAL
 
-//SC IDs
-
-/obj/item/weapon/card/id/medical/sar
-	assignment = "Search and Rescue"
-	rank = "Search and Rescue"
-	job_access_type = /datum/job/sar
-
-/obj/item/weapon/card/id/civilian/pilot
-	assignment = "Pilot"
-	rank = "Pilot"
-	job_access_type = /datum/job/pilot
-
-/obj/item/weapon/card/id/civilian/explorer
-	assignment = "Explorer"
-	rank = "Explorer"
-	job_access_type = /datum/job/explorer
-
 //SC Jobs
 
 /*
@@ -51,7 +34,6 @@ var/const/access_explorer = 43
 	spawn_positions = 1
 	supervisors = "company officials and Corporate Regulations"
 	selection_color = "#1D1D4F"
-	idtype = /obj/item/weapon/card/id/gold
 	req_admin_notify = 1
 	access = list() 			//See get_access()
 	minimal_access = list() 	//See get_access()
@@ -78,7 +60,6 @@ var/const/access_explorer = 43
 	spawn_positions = 2
 	supervisors = "the head of personnel"
 	selection_color = "#515151"
-	idtype = /obj/item/weapon/card/id/civilian/pilot
 	economic_modifier = 4
 	access = list(access_pilot, access_cargo, access_mining, access_mining_station)
 	minimal_access = list(access_pilot, access_cargo, access_mining, access_mining_station)
@@ -94,7 +75,6 @@ var/const/access_explorer = 43
 	spawn_positions = 4
 	supervisors = "the explorer leader and the head of personnel"
 	selection_color = "#515151"
-	idtype = /obj/item/weapon/card/id/civilian/explorer
 	economic_modifier = 4
 	access = list(access_explorer)
 	minimal_access = list(access_explorer)
@@ -115,7 +95,6 @@ var/const/access_explorer = 43
 	spawn_positions = 2
 	supervisors = "the chief medical officer"
 	selection_color = "#515151"
-	idtype = /obj/item/weapon/card/id/medical
 	economic_modifier = 4
 	access = list(access_medical, access_medical_equip, access_morgue, access_surgery, access_chemistry, access_virology, access_eva, access_maint_tunnels, access_external_airlocks, access_psychiatrist, access_explorer)
 	minimal_access = list(access_medical, access_medical_equip, access_morgue, access_explorer)


### PR DESCRIPTION
- job_access_type on ids is used literally nowhere.  Removed.
- spawnId is only called on people who already have ids, and does nothing because of it.  Removed.
- idtype is defined both for jobs and outfits, and for jobs it's only used in spawnid and to not give ais and cyborgs headsets.  Replaced with new has_headset variable
- equip_backpack and equip_survival on jobs are also useless, since outfits handle that.  Removed.
- spawnId put access on ids, but equip_id doesn't.  Made equip_id for job outfits put access on ids.
- With equip_id putting access on ids we don't need all the different subtypes of id.  Removed a lot of them.