### PR TITLE
Improve analyzers and gas mixers

### DIFF
--- a/code/ATMOSPHERICS/components/trinary_devices/mixer.dm
+++ b/code/ATMOSPHERICS/components/trinary_devices/mixer.dm
@@ -85,20 +85,21 @@
 		to_chat(user, "<span class='warning'>Access denied.</span>")
 		return
 	usr.set_machine(src)
+	var/list/node_connects = get_node_connect_dirs()
 	var/dat = {"<b>Power: </b><a href='?src=\ref[src];power=1'>[use_power?"On":"Off"]</a><br>
 				<b>Set Flow Rate Limit: </b>
 				[set_flow_rate]L/s | <a href='?src=\ref[src];set_press=1'>Change</a>
 				<br>
 				<b>Flow Rate: </b>[round(last_flow_rate, 0.1)]L/s
 				<br><hr>
-				<b>Node 1 Concentration:</b>
+				<b>Node 1 ([dir_name(node_connects[1],TRUE)]) Concentration:</b>
 				<a href='?src=\ref[src];node1_c=-0.1'><b>-</b></a>
 				<a href='?src=\ref[src];node1_c=-0.01'>-</a>
 				[mixing_inputs[air1]]([mixing_inputs[air1]*100]%)
 				<a href='?src=\ref[src];node1_c=0.01'><b>+</b></a>
 				<a href='?src=\ref[src];node1_c=0.1'>+</a>
 				<br>
-				<b>Node 2 Concentration:</b>
+				<b>Node 2 ([dir_name(node_connects[2],TRUE)]) Concentration:</b>
 				<a href='?src=\ref[src];node2_c=-0.1'><b>-</b></a>
 				<a href='?src=\ref[src];node2_c=-0.01'>-</a>
 				[mixing_inputs[air2]]([mixing_inputs[air2]*100]%)

--- a/code/_helpers/atmospherics.dm
+++ b/code/_helpers/atmospherics.dm
@@ -14,11 +14,11 @@
 	return 0
 
 /proc/atmosanalyzer_scan(var/obj/target, var/datum/gas_mixture/mixture, var/mob/user)
-	var/pressure = mixture.return_pressure()
-	var/total_moles = mixture.total_moles
-
 	var/list/results = list()
-	if (total_moles>0)
+
+	if (mixture && mixture.total_moles > 0)
+		var/pressure = mixture.return_pressure()
+		var/total_moles = mixture.total_moles
 		results += "<span class='notice'>Pressure: [round(pressure,0.1)] kPa</span>"
 		for(var/mix in mixture.gas)
 			results += "<span class='notice'>[gas_data.name[mix]]: [round((mixture.gas[mix] / total_moles) * 100)]%</span>"
@@ -27,6 +27,9 @@
 		results += "<span class='notice'>\The [target] is empty!</span>"
 
 	return results
+
+/turf/proc/atmosanalyze(var/mob/user)
+	return atmosanalyzer_scan(src, src.air, user)
 
 /obj/proc/atmosanalyze(var/mob/user)
 	return
@@ -39,6 +42,33 @@
 
 /obj/machinery/atmospherics/pipe/atmosanalyze(var/mob/user)
 	return atmosanalyzer_scan(src, src.parent.air, user)
+
+/obj/machinery/atmospherics/portables_connector/atmosanalyze(var/mob/user)
+	return atmosanalyzer_scan(src, src.network.gases, user)
+
+/obj/machinery/atmospherics/unary/atmosanalyze(var/mob/user)
+	return atmosanalyzer_scan(src, src.air_contents, user)
+
+/obj/machinery/atmospherics/binary/atmosanalyze(var/mob/user)
+	return atmosanalyzer_scan(src, src.air1, user)
+
+/obj/machinery/atmospherics/trinary/atmos_filter/atmosanalyze(var/mob/user)
+	return atmosanalyzer_scan(src, src.air1, user)
+	
+/obj/machinery/atmospherics/trinary/mixer/atmosanalyze(var/mob/user)
+	return atmosanalyzer_scan(src, src.air3, user)
+	
+/obj/machinery/atmospherics/omni/atmos_filter/atmosanalyze(var/mob/user)
+	return atmosanalyzer_scan(src, src.input.air, user)
+	
+/obj/machinery/atmospherics/omni/mixer/atmosanalyze(var/mob/user)
+	return atmosanalyzer_scan(src, src.output.air, user)
+	
+/obj/machinery/meter/atmosanalyze(var/mob/user)
+	var/datum/gas_mixture/mixture = null
+	if(src.target)
+		mixture = src.target.parent.air
+	return atmosanalyzer_scan(src, mixture, user)
 
 /obj/machinery/power/rad_collector/atmosanalyze(var/mob/user)
 	if(P)	return atmosanalyzer_scan(src, src.P.air_contents, user)

--- a/code/_helpers/atmospherics.dm
+++ b/code/_helpers/atmospherics.dm
@@ -1,4 +1,4 @@
-/obj/proc/analyze_gases(var/obj/A, var/mob/user)
+/obj/proc/analyze_gases(var/atom/A, var/mob/user)
 	if(src != A)
 		user.visible_message("<span class='notice'>\The [user] has used \an [src] on \the [A]</span>")
 
@@ -13,7 +13,7 @@
 	user << "<span class='warning'>Your [src] flashes a red light as it fails to analyze \the [A].</span>"
 	return 0
 
-/proc/atmosanalyzer_scan(var/obj/target, var/datum/gas_mixture/mixture, var/mob/user)
+/proc/atmosanalyzer_scan(var/atom/target, var/datum/gas_mixture/mixture, var/mob/user)
 	var/list/results = list()
 
 	if (mixture && mixture.total_moles > 0)
@@ -28,10 +28,10 @@
 
 	return results
 
-/turf/proc/atmosanalyze(var/mob/user)
+/turf/atmosanalyze(var/mob/user)
 	return atmosanalyzer_scan(src, src.air, user)
 
-/obj/proc/atmosanalyze(var/mob/user)
+/atom/proc/atmosanalyze(var/mob/user)
 	return
 
 /obj/item/weapon/tank/atmosanalyze(var/mob/user)


### PR DESCRIPTION
Analyzers can now analyze more things:
-Turfs (also stops runtimes from people trying to analyze turfs)
-Meters (gives results for whatever the meter's attached to)
-All atmos components except valves (gives results for the input, except on mixers.  Gives results for the output on mixers)
Gas mixers now show what direction each input is in the menu where you adjust the concentrations of the input nodes.