### PR TITLE
Inaccuracy Rebalance (NPC)

### DIFF
--- a/code/modules/mob/living/simple_mob/simple_mob.dm
+++ b/code/modules/mob/living/simple_mob/simple_mob.dm
@@ -106,7 +106,7 @@
 	var/attack_sharp = FALSE			// Is the attack sharp?
 	var/attack_edge = FALSE				// Does the attack have an edge?
 
-	var/melee_attack_delay = null			// If set, the mob will do a windup animation and can miss if the target moves out of the way.
+	var/melee_attack_delay = 2			// If set, the mob will do a windup animation and can miss if the target moves out of the way.
 	var/ranged_attack_delay = null
 	var/special_attack_delay = null
 

--- a/code/modules/mob/living/simple_mob/subtypes/animal/giant_spider/webslinger.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/giant_spider/webslinger.dm
@@ -24,6 +24,10 @@
 	icon_dead = "webslinger_dead"
 	maxHealth = 90
 	health = 90
+
+	projectile_dispersion = 12
+	projectile_accuracy = -25
+
 	projectilesound = 'sound/weapons/thudswoosh.ogg'
 	projectiletype = /obj/item/projectile/webball
 	base_attack_cooldown = 10

--- a/code/modules/mob/living/simple_mob/subtypes/humanoid/mercs/mercs.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/humanoid/mercs/mercs.dm
@@ -159,6 +159,8 @@
 
 	loot_list = list(/obj/item/weapon/gun/projectile/automatic/c20r = 100)
 
+	projectile_dispersion = 7
+	projectile_accuracy = -20
 	base_attack_cooldown = 5 // Two attacks a second or so.
 	reload_max = 20
 
@@ -181,6 +183,8 @@
 
 	loot_list = list(/obj/item/weapon/gun/energy/laser = 100)
 
+	projectile_dispersion = 5
+	projectile_accuracy = -20
 	reload_max = 10
 
 // Ion Rifle
@@ -206,6 +210,8 @@
 	reload_max = 4
 	reload_time = 1.5 SECONDS	// It's a shotgun, it takes a moment
 
+	projectile_dispersion = 8
+	projectile_accuracy = -40
 	special_attack_charges = 5
 
 
@@ -255,6 +261,9 @@
 	min_n2 = 0
 	max_n2 = 0
 	minbodytemp = 0
+
+	projectile_dispersion = 7
+	projectile_accuracy = -20
 
 	corpse = /obj/effect/landmark/mobcorpse/syndicatecommando
 

--- a/code/modules/mob/living/simple_mob/subtypes/mechanical/hivebot/ranged_damage.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/mechanical/hivebot/ranged_damage.dm
@@ -9,7 +9,8 @@
 /mob/living/simple_mob/mechanical/hivebot/ranged_damage/basic
 	name = "ranged hivebot"
 	desc = "A robot with a makeshift integrated ballistic weapon."
-
+	projectile_dispersion = 10
+	projectile_accuracy = -20
 
 // This one shoots quickly, and is considerably more dangerous.
 /mob/living/simple_mob/mechanical/hivebot/ranged_damage/rapid
@@ -17,7 +18,8 @@
 	desc = "A robot with a crude but deadly integrated rifle."
 	base_attack_cooldown = 5 // Two attacks a second or so.
 	player_msg = "You have a <b>rapid fire attack</b>."
-
+	projectile_dispersion = 7
+	projectile_accuracy = -10
 
 // Shoots deadly lasers.
 /mob/living/simple_mob/mechanical/hivebot/ranged_damage/laser
@@ -26,7 +28,8 @@
 	projectiletype = /obj/item/projectile/beam/blue
 	projectilesound = 'sound/weapons/Laser.ogg'
 	player_msg = "You have a <b>laser attack</b>."
-
+	projectile_dispersion = 7
+	projectile_accuracy = -20
 
 // Shoots EMPs, to screw over other robots.
 /mob/living/simple_mob/mechanical/hivebot/ranged_damage/ion
@@ -48,6 +51,8 @@
 	health = 4 LASERS_TO_KILL
 	melee_damage_lower = 15
 	melee_damage_upper = 15
+	projectile_dispersion = 5
+	projectile_accuracy = -15
 
 // Also beefy, but tries to stay at their 'home', ideal for base defense.
 /mob/living/simple_mob/mechanical/hivebot/ranged_damage/strong/guard

--- a/code/modules/mob/living/simple_mob/subtypes/mechanical/mecha/durand.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/mechanical/mecha/durand.dm
@@ -38,6 +38,8 @@
 	melee_damage_upper = 40
 	base_attack_cooldown = 2 SECONDS
 	projectiletype = /obj/item/projectile/beam/heavylaser
+	projectile_dispersion = 10
+	projectile_accuracy = -30
 
 	var/defense_mode = FALSE
 	var/defense_deflect = 35
@@ -45,6 +47,7 @@
 /mob/living/simple_mob/mechanical/mecha/combat/durand/proc/set_defense_mode(new_mode)
 	defense_mode = new_mode
 	deflect_chance = defense_mode ? defense_deflect : initial(deflect_chance)
+	projectile_accuracy = defense_mode ? -10 : initial(projectile_accuracy)
 	to_chat(src, span("notice", "You [defense_mode ? "en" : "dis"]able defense mode."))
 
 /mob/living/simple_mob/mechanical/mecha/combat/durand/SelfMove(turf/n, direct)

--- a/code/modules/mob/living/simple_mob/subtypes/mechanical/mecha/gygax.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/mechanical/mecha/gygax.dm
@@ -31,6 +31,7 @@
 				"rad"		= 100
 				)
 
+	projectile_dispersion = 8
 	projectiletype = /obj/item/projectile/beam/midlaser
 
 	ai_holder_type = /datum/ai_holder/simple_mob/intentional/adv_dark_gygax
@@ -80,3 +81,4 @@
 	icon_state = "medgax"
 	wreckage = /obj/structure/loot_pile/mecha/gygax/medgax
 
+	projectile_dispersion = 8

--- a/code/modules/mob/living/simple_mob/subtypes/mechanical/mecha/hoverpod.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/mechanical/mecha/hoverpod.dm
@@ -23,6 +23,8 @@
 	maxHealth = 150
 	hovering = TRUE // Can fly.
 
+	projectile_dispersion = 10
+	projectile_accuracy = -30
 	projectiletype = /obj/item/projectile/beam
 	base_attack_cooldown = 2 SECONDS
 

--- a/code/modules/mob/living/simple_mob/subtypes/mechanical/viscerator.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/mechanical/viscerator.dm
@@ -36,6 +36,7 @@
 	mob_swap_flags = 0
 	mob_push_flags = 0
 
+	melee_attack_delay = null // No attack delay, as their movement is functionally an attack.
 	melee_damage_lower = 4 // Approx 8 DPS.
 	melee_damage_upper = 4
 	base_attack_cooldown = 5 // Two attacks a second or so.


### PR DESCRIPTION
Most mobs have a slight attack delay, and ranged mobs tend to have inaccuracy similar to a player. Automatic-firing enemies tend to have higher inaccuracy than single-fire, and mechanical tend to have higher accuracy than organic.

Base melee attack delay for simple mobs is now 2 ticks. 1 second is roughly 10 ticks. Viscerators have no delay, as their movement is inherently an attack.