### PR TITLE
Fixes elevator doors opening in passing

### DIFF
--- a/code/modules/turbolift/turbolift_console.dm
+++ b/code/modules/turbolift/turbolift_console.dm
@@ -71,7 +71,7 @@
 		return
 	light_up()
 	pressed(user)
-	if(floor == lift.current_floor)
+	if(floor == lift.current_floor && !(lift.target_floor))	//Make sure we're not going anywhere before opening doors
 		lift.open_doors()
 		spawn(3)
 			reset()


### PR DESCRIPTION
That happened if you pressed the button as elevator passed by your current floor but not to it. It left doors open until elevator stopped at your floor next time.