### PR TITLE
Fixes Naming ED-209 and ED-CLN

### DIFF
--- a/code/modules/mob/living/bot/ed209bot.dm
+++ b/code/modules/mob/living/bot/ed209bot.dm
@@ -203,7 +203,8 @@
 				build_step++
 				to_chat(user, "<span class='notice'>You complete the ED-209.</span>")
 				var/turf/T = get_turf(src)
-				new /mob/living/bot/secbot/ed209(T,created_name,lasercolor)
+				var/mob/living/bot/secbot/ed209/S = new /mob/living/bot/secbot/ed209(T)
+				S.name = created_name
 				user.drop_item()
 				qdel(W)
 				user.drop_from_inventory(src)

--- a/code/modules/mob/living/bot/edCLNbot.dm
+++ b/code/modules/mob/living/bot/edCLNbot.dm
@@ -3,7 +3,7 @@
 	desc = "A large cleaning robot. It looks rather efficient."
 	icon_state = "edCLN0"
 	req_one_access = list(access_robotics, access_janitor)
-	botcard_access = list(access_janitor, access_maint_tunnels)
+	botcard_access = list(access_janitor)
 
 	locked = 0 // Start unlocked so roboticist can set them to patrol.
 	wait_if_pulled = 0 // One big boi.
@@ -229,7 +229,8 @@
 				build_step++
 				to_chat(user, "<span class='notice'>You complete the ED-CLN.</span>")
 				var/turf/T = get_turf(src)
-				new /mob/living/bot/cleanbot/edCLN(T,created_name)
+				var/mob/living/bot/cleanbot/edCLN/S = new /mob/living/bot/cleanbot/edCLN(T)
+				S.name = created_name
 				user.drop_item()
 				qdel(W)
 				user.drop_from_inventory(src)

--- a/html/changelogs/Nalarac - ED209.yml
+++ b/html/changelogs/Nalarac - ED209.yml
@@ -1,0 +1,37 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Nalarac
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "ED-209 and ED-CLN now properly accept names given with a pen."
+  - tweak: "Removed maintenance access from ED-CLN to prevent maintenance wandering."


### PR DESCRIPTION
Naming the ED-209 and ED-CLN will now result in the bot keeping its assigned name.

Also removes maintenance access from ED-CLN (like the cleanbot previously) so it doesn't get stuck in maintenance.