### PR TITLE
Protolathe Power Cells Tweak

### DIFF
--- a/code/modules/power/cells/power_cells.dm
+++ b/code/modules/power/cells/power_cells.dm
@@ -18,6 +18,7 @@
 /obj/item/weapon/cell/secborg/empty/New()
 	..()
 	charge = 0
+	update_icon()
 
 /obj/item/weapon/cell/apc
 	name = "heavy-duty power cell"
@@ -35,6 +36,7 @@
 /obj/item/weapon/cell/high/empty/New()
 	..()
 	charge = 0
+	update_icon()
 
 /obj/item/weapon/cell/super
 	name = "super-capacity power cell"
@@ -46,6 +48,7 @@
 /obj/item/weapon/cell/super/empty/New()
 	..()
 	charge = 0
+	update_icon()
 
 /obj/item/weapon/cell/hyper
 	name = "hyper-capacity power cell"
@@ -57,6 +60,7 @@
 /obj/item/weapon/cell/hyper/empty/New()
 	..()
 	charge = 0
+	update_icon()
 
 /obj/item/weapon/cell/infinite
 	name = "infinite-capacity power cell!"

--- a/code/modules/research/designs.dm
+++ b/code/modules/research/designs.dm
@@ -62,3 +62,12 @@ other types of metals and chemistry for reagents).
 
 /datum/design/item
 	build_type = PROTOLATHE
+
+//Make sure items don't get free power
+/datum/design/item/Fabricate()
+	var/obj/item/I = ..()
+	var/obj/item/weapon/cell/C = I.get_cell()
+	if(C)
+		C.charge = 0
+		I.update_icon()
+	return I

--- a/code/modules/research/designs/power_cells.dm
+++ b/code/modules/research/designs/power_cells.dm
@@ -12,6 +12,7 @@
 /datum/design/item/powercell/Fabricate()
 	var/obj/item/weapon/cell/C = ..()
 	C.charge = 0 //shouldn't produce power out of thin air.
+	C.update_icon()
 	return C
 
 /datum/design/item/powercell/basic

--- a/html/changelogs/Nalarac - Protolathe.yml
+++ b/html/changelogs/Nalarac - Protolathe.yml
@@ -1,0 +1,37 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Nalarac
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Power cells and device cells both properly show as empty when printed from the protolathe and mech fabricator."
+  - tweak: "Items with cells printed from the protolathe now start empty (e.g. phoron pistol)."


### PR DESCRIPTION
Fixes power cells and device cells not having the empty-charge icon when made.

Tweaks the protolathe so all items that come with power cells start empty (such as energy weapons)