### PR TITLE
Sex On The Beach recipe fix

### DIFF
--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -2461,13 +2461,13 @@
 	id = "virginsexonthebeach"
 	result = "virginsexonthebeach"
 	required_reagents = list("orangejuice" = 3, "grenadine" = 2)
-	result_amount = 4
+	result_amount = 5
 
 /datum/chemical_reaction/drinks/sexonthebeach
 	name = "Sex On The Beach"
 	id = "sexonthebeach"
 	result = "sexonthebeach"
-	required_reagents = list("orangejuice" = 3, "grenadine" = 2, "vodka" = 1)
+	required_reagents = list("virginsexonthebeach" = 5, "vodka" = 1)
 	result_amount = 6
 
 /datum/chemical_reaction/drinks/eggnog


### PR DESCRIPTION
Fixes the Sex On The Beach drink being unable to be made by slightly altering the recipe - it's now made using the virgin version of the drink first, to prevent it from being interfered with by the Screwdriver recipe. 
Also slightly alters the result amount of the virgin drink to avoid matter destruction/creation.