### PR TITLE
Fix Multitool Modes

### DIFF
--- a/code/game/objects/items/devices/multitool.dm
+++ b/code/game/objects/items/devices/multitool.dm
@@ -51,10 +51,10 @@
 	return ..()
 
 /obj/item/device/multitool/proc/mode_switch(mob/living/user)
-	if(++mode_index > modes.len) mode_index = 1
+	if(mode_index + 1 > modes.len) mode_index = 1
 
 	else
-		mode_index++
+		mode_index += 1
 
 	toolmode = modes[mode_index]
 	to_chat(user,"<span class='notice'>\The [src] is now set to [toolmode].</span>")


### PR DESCRIPTION
So apparently, I'm still an idiot. Fixes a bug I was confused about for a fucking year since I didn't understand the documentation for some asinine reason.

Multitools can properly store refs.