### PR TITLE
EPv2 x Communicator fix.

### DIFF
--- a/code/game/objects/items/devices/communicator/UI.dm
+++ b/code/game/objects/items/devices/communicator/UI.dm
@@ -63,6 +63,11 @@
 		if(ghost.exonet)
 			im_contacts_ui[++im_contacts_ui.len] = list("name" = sanitize(ghost.name), "address" = ghost.exonet.address, "ref" = "\ref[ghost]")
 
+	for(var/obj/item/integrated_circuit/input/EPv2/CIRC in im_contacts)
+		if(CIRC.exonet && CIRC.assembly)
+			im_contacts_ui[++im_contacts_ui.len] = list("name" = sanitize(CIRC.assembly.name), "address" = CIRC.exonet.address, "ref" = "\ref[CIRC]")
+
+
 	//Actual messages.
 	for(var/I in im_list)
 		im_list_ui[++im_list_ui.len] = list("address" = I["address"], "to_address" = I["to_address"], "im" = I["im"])

--- a/code/game/objects/items/devices/communicator/messaging.dm
+++ b/code/game/objects/items/devices/communicator/messaging.dm
@@ -64,6 +64,10 @@
 		who = comm.owner
 		comm.im_contacts |= src
 		im_list += list(list("address" = origin_address, "to_address" = exonet.address, "im" = text))
+	else if(istype(candidate, /obj/item/integrated_circuit))
+		var/obj/item/integrated_circuit/CIRC = candidate
+		who = CIRC
+		im_list += list(list("address" = origin_address, "to_address" = exonet.address, "im" = text))
 	else return
 
 	im_contacts |= candidate

--- a/code/modules/integrated_electronics/subtypes/input.dm
+++ b/code/modules/integrated_electronics/subtypes/input.dm
@@ -423,7 +423,9 @@
 	desc = "Enables the sending and receiving of messages on the Exonet with the EPv2 protocol."
 	extended_desc = "An EPv2 address is a string with the format of XXXX:XXXX:XXXX:XXXX.  Data can be send or received using the \
 	second pin on each side, with additonal data reserved for the third pin.  When a message is received, the second activaiton pin \
-	will pulse whatever's connected to it.  Pulsing the first activation pin will send a message."
+	will pulse whatever's connected to it.  Pulsing the first activation pin will send a message.\
+	\
+	When messaging Communicators, you must set data to send to the string `text` to avoid errors in reception."
 	icon_state = "signal"
 	complexity = 4
 	inputs = list(


### PR DESCRIPTION
EPv2 circuits can now properly send 'text' data type messages to communicators, and initiate 'conversations'.