### PR TITLE
Light Replacer QOL

### DIFF
--- a/html/changelogs/TheFurryFeline - Bulbs_Recycling.yml
+++ b/html/changelogs/TheFurryFeline - Bulbs_Recycling.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: TheFurryFeline
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Changes light replacers to allow you to automatically transfer used bulbs into the item and get a new one every 4 bulbs replaced. Additionally, this allows you to both use the replacer on a box of bulbs to get the bulbs added as well as clicking the item with a box of bulbs to put them inside it."


### PR DESCRIPTION
Tweaks light replacers to allow automatic replacing of broken bulbs in a light fixture. Also lets you shove bulbs into said objects. Ported from Yogastation with code used from https://github.com/CHOMPstation/CHOMPstation/pull/517. If there's a better way to code this, do tell me. It works, however.

Changelog notes:

- Light replacer now uses broken lights instead of dropping them
- Every 4 broken lights switched refills the light replacer with 1 new bulb
- You can now also use a box of lights on the light replacer to refill it (the old method of using the light replacer on the box still works)