### PR TITLE
Can now construct NTNet relays

### DIFF
--- a/code/game/objects/items/weapons/circuitboards/machinery/research.dm
+++ b/code/game/objects/items/weapons/circuitboards/machinery/research.dm
@@ -87,10 +87,10 @@ obj/item/weapon/circuitboard/rdserver/attackby(obj/item/I as obj, mob/user as mo
 							/obj/item/weapon/stock_parts/micro_laser = 1,
 							/obj/item/weapon/stock_parts/console_screen = 1)
 
-obj/item/weapon/circuitboard/ntnet_relay
+/obj/item/weapon/circuitboard/ntnet_relay
 	name = "Circuit board (NTNet Quantum Relay)"
-	build_path = "/obj/machinery/ntnet_relay"
-	board_type = "machine"
+	build_path = /obj/machinery/ntnet_relay
+	board_type = new /datum/frame/frame_types/machine
 	origin_tech = list(TECH_DATA = 4)
 	req_components = list(
-							"/obj/item/stack/cable_coil" = 15)
+							/obj/item/stack/cable_coil = 15)


### PR DESCRIPTION
NTNet relays couldn't be constructed due to Old Code:tm:?
Now they can.