### PR TITLE
Buffs radiation so it isn't defeated by a thin sheet of lead.

### DIFF
--- a/code/__defines/misc.dm
+++ b/code/__defines/misc.dm
@@ -352,7 +352,9 @@ var/global/list/##LIST_NAME = list();\
 #define RAD_LEVEL_HIGH 25
 #define RAD_LEVEL_VERY_HIGH 75
 
-#define RADIATION_THRESHOLD_CUTOFF 0.1	// Radiation will not affect a tile when below this value.
+// Calculation modes for effective radiation
+#define RAD_RESIST_CALC_DIV 0 // Each turf absorbs some fraction of the working radiation level
+#define RAD_RESIST_CALC_SUB 1 // Each turf absorbs a fixed amount of radiation
 
 //https://secure.byond.com/docs/ref/info.html#/atom/var/mouse_opacity
 #define MOUSE_OPACITY_TRANSPARENT 0

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -235,8 +235,10 @@ var/list/gamemode_cache = list()
 
 	var/show_human_death_message = 1
 
+	var/radiation_resistance_calc_mode = RAD_RESIST_CALC_SUB // 0:1 subtraction:division for computing effective radiation on a turf
 	var/radiation_decay_rate = 1 //How much radiation is reduced by each tick
 	var/radiation_resistance_multiplier = 6.5
+	var/radiation_material_resistance_divisor = 1
 	var/radiation_lower_limit = 0.35 //If the radiation level for a turf would be below this, ignore it.
 
 	var/random_submap_orientation = FALSE // If true, submaps loaded automatically can be rotated.
@@ -783,6 +785,21 @@ var/list/gamemode_cache = list()
 				if("radiation_lower_limit")
 					radiation_lower_limit = text2num(value)
 
+				if("radiation_resistance_calc_divide")
+					radiation_resistance_calc_mode = RAD_RESIST_CALC_DIV
+
+				if("radiation_resistance_calc_subtract")
+					radiation_resistance_calc_mode = RAD_RESIST_CALC_SUB
+
+				if("radiation_resistance_multiplier")
+					radiation_resistance_multiplier = text2num(value)
+
+				if("radiation_material_resistance_divisor")
+					radiation_material_resistance_divisor = text2num(value)
+
+				if("radiation_decay_rate")
+					radiation_decay_rate = text2num(value)
+
 				if ("panic_bunker")
 					config.panic_bunker = 1
 
@@ -794,6 +811,8 @@ var/list/gamemode_cache = list()
 
 				if("autostart_solars")
 					config.autostart_solars = TRUE
+
+
 
 				else
 					log_misc("Unknown setting in configuration: '[name]'")

--- a/code/modules/radiation/radiation.dm
+++ b/code/modules/radiation/radiation.dm
@@ -24,6 +24,7 @@
 		rad_power = new_power
 		if(!flat)
 			range = min(round(sqrt(rad_power / config.radiation_lower_limit)), 31)  // R = rad_power / dist**2 - Solve for dist
+	return
 
 /turf
 	var/cached_rad_resistance = 0
@@ -37,13 +38,15 @@
 		else if(O.density) //So open doors don't get counted
 			var/material/M = O.get_material()
 			if(!M)	continue
-			cached_rad_resistance += M.weight + M.radiation_resistance
+			cached_rad_resistance += (M.weight + M.radiation_resistance) / config.radiation_material_resistance_divisor
 	// Looks like storing the contents length is meant to be a basic check if the cache is stale due to items enter/exiting.  Better than nothing so I'm leaving it as is. ~Leshana
 	SSradiation.resistance_cache[src] = (length(contents) + 1)
+	return
 
 /turf/simulated/wall/calc_rad_resistance()
 	SSradiation.resistance_cache[src] = (length(contents) + 1)
-	cached_rad_resistance = (density ? material.weight + material.radiation_resistance : 0)
+	cached_rad_resistance = (density ? material.weight / config.radiation_material_resistance_divisor : 0)
+	return
 
 /obj
 	var/rad_resistance = 0  // Allow overriding rad resistance
@@ -57,3 +60,4 @@
 		src.apply_effect(severity, IRRADIATE, src.getarmor(null, "rad"))
 		for(var/atom/I in src)
 			I.rad_act(severity)
+	return

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -433,3 +433,21 @@ STARLIGHT 0
 ## Uncomment to allow specific solar control computers to set themselves up.
 ## This requires solar controller computers in the map to be set up to use it, with the auto_start variable.
 # AUTOSTART_SOLARS
+
+## Rate of radiation decay (how much it's reduced by) per life tick
+RADIATION_DECAY_RATE 1
+
+## Lower limit on radiation for actually irradiating things on a turf
+RADIATION_LOWER_LIMIT 0.01
+
+## Multiplier for radiation resistances when tracing a ray from source to destination to compute radiation on a turf
+RADIATION_RESISTANCE_MULTIPLIER 2.1
+
+## Divisor for material weights when computing radiation resistance of a material object (walls)
+RADIATION_MATERIAL_RESISTANCE_DIVISOR 16
+
+
+## Mode of computing radiation resistance into effective radiation on a turf
+## One and only one of the following options must be uncommented
+RADIATION_RESISTANCE_CALC_DIVIDE
+# RADIATION_RESISTANCE_CALC_SUBTRACT

--- a/html/changelogs/atermonera - rad_buff.yml
+++ b/html/changelogs/atermonera - rad_buff.yml
@@ -1,0 +1,4 @@
+author: Atermonera
+delete-after: True
+changes: 
+  - bugfix: "Radiation has been made more potent and is no longer defeated by a thin sheet of lead."


### PR DESCRIPTION
Fixes #6488 
Makes radiation config options actually controlled by config.
Adds config options to switch between the old (subtractive) and new (divisive) methods for computing effective radiation at a turf from a source. I made the default the old system, because that's what our numbers were originally balanced around, so the new calculation system is _theoretically_ opt-in. Unless you've already changed config numbers.
Also makes radiation accumulate the effective radiation of all sources within reasonable range (contributing at least the config-defined lower limit). Because standing in a cafe where the walls floor, tables, chairs, and diningware are all made of uranium is significantly more radioactive than just sitting in an uranium chair.

To use the config options, I'll just paste them here so you don't have to go fishing through the diff, since they're fairly straightforward:
>\#\# Rate of radiation decay (how much it's reduced by) per life tick
> RADIATION_DECAY_RATE 1
> 
> \#\# Lower limit on radiation for actually irradiating things on a turf
> RADIATION_LOWER_LIMIT 0.01
> 
> \#\# Multiplier for radiation resistances when tracing a ray from source to destination to compute radiation on a turf
> RADIATION_RESISTANCE_MULTIPLIER 2.1
> 
> \#\# Divisor for material weights when computing radiation resistance of a material object (walls)
> RADIATION_MATERIAL_RESISTANCE_DIVISOR 16
> 
> \#\# Mode of computing radiation resistance into effective radiation on a turf
> \#\# One and only one of the following options must be uncommented
> RADIATION_RESISTANCE_CALC_DIVIDE
> \# RADIATION_RESISTANCE_CALC_SUBTRACT