### PR TITLE
APCs/Air Alarms can be (un)locked via altclick

### DIFF
--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -766,17 +766,24 @@
 		return
 
 	if(istype(W, /obj/item/weapon/card/id) || istype(W, /obj/item/device/pda))// trying to unlock the interface with an ID card
-		if(stat & (NOPOWER|BROKEN))
-			user << "It does nothing"
-			return
-		else
-			if(allowed(usr) && !wires.IsIndexCut(AALARM_WIRE_IDSCAN))
-				locked = !locked
-				user << "<span class='notice'>You [ locked ? "lock" : "unlock"] the Air Alarm interface.</span>"
-			else
-				user << "<span class='warning'>Access denied.</span>"
-			return
+		togglelock()
 	return ..()
+
+/obj/machinery/alarm/verb/togglelock(mob/user as mob)
+	if(stat & (NOPOWER|BROKEN))
+		to_chat(user, "It does nothing.")
+		return
+	else
+		if(allowed(usr) && !wires.IsIndexCut(AALARM_WIRE_IDSCAN))
+			locked = !locked
+			to_chat(user, "<span class='notice'>You [locked ? "lock" : "unlock"] the Air Alarm interface.</span>")
+		else
+			to_chat(user, "<span class='warning'>Access denied.</span>")
+		return
+
+/obj/machinery/alarm/AltClick()
+	..()
+	togglelock()
 
 /obj/machinery/alarm/power_change()
 	..()

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -534,23 +534,8 @@
 			update_icon()
 
 	else if (istype(W, /obj/item/weapon/card/id)||istype(W, /obj/item/device/pda))			// trying to unlock the interface with an ID card
-		if(emagged)
-			to_chat(user,"The panel is unresponsive.")
-		else if(opened)
-			to_chat(user,"You must close the cover to swipe an ID card.")
-		else if(wiresexposed)
-			to_chat(user,"You must close the wire panel.")
-		else if(stat & (BROKEN|MAINT))
-			to_chat(user,"Nothing happens.")
-		else if(hacker)
-			to_chat(user,"<span class='warning'>Access denied.</span>")
-		else
-			if(src.allowed(usr) && !isWireCut(APC_WIRE_IDSCAN))
-				locked = !locked
-				to_chat(user,"You [ locked ? "lock" : "unlock"] the APC interface.")
-				update_icon()
-			else
-				to_chat(user,"<span class='warning'>Access denied.</span>")
+		togglelock()
+		
 	else if (istype(W, /obj/item/stack/cable_coil) && !terminal && opened && has_electronics!=2)
 		var/turf/T = loc
 		if(istype(T) && !T.is_plating())
@@ -685,6 +670,29 @@
 			to_chat(user,"<span class='notice'>The [src.name] looks too sturdy to bash open with \the [W.name].</span>")
 
 // attack with hand - remove cell (if cover open) or interact with the APC
+
+/obj/machinery/power/apc/verb/togglelock(mob/user as mob)
+	if(emagged)
+		to_chat(user,"The panel is unresponsive.")
+	else if(opened)
+		to_chat(user,"You must close the cover to swipe an ID card.")
+	else if(wiresexposed)
+		to_chat(user,"You must close the wire panel.")
+	else if(stat & (BROKEN|MAINT))
+		to_chat(user,"Nothing happens.")
+	else if(hacker)
+		to_chat(user,"<span class='warning'>Access denied.</span>")
+	else
+		if(src.allowed(usr) && !isWireCut(APC_WIRE_IDSCAN))
+			locked = !locked
+			to_chat(user,"You [ locked ? "lock" : "unlock"] the APC interface.")
+			update_icon()
+		else
+			to_chat(user,"<span class='warning'>Access denied.</span>")
+
+/obj/machinery/power/apc/AltClick(mob/user)
+	..()
+	togglelock()
 
 /obj/machinery/power/apc/emag_act(var/remaining_charges, var/mob/user)
 	if (!(emagged || hacker))		// trying to unlock with an emag card


### PR DESCRIPTION
Has been tested on a downstream (https://github.com/Yawn-Wider/YWPolarisVore/pull/372) and works there.

Only (un)locks if you have The Access:tm:.