### PR TITLE
GameMaster Tuning

### DIFF
--- a/code/game/objects/structures/props/swarm.dm
+++ b/code/game/objects/structures/props/swarm.dm
@@ -98,7 +98,7 @@
 			active_beams |= Beam(S,icon='icons/effects/beam.dmi',icon_state="holo_beam",time=3 SECONDS,maxdistance=3,beam_type = /obj/effect/ebeam,beam_sleep_time=2)
 
 		if(S.cell)
-			S.cell.give(rand(5, 30))
+			S.cell.give(rand(30, 120))
 
 		. = TRUE
 

--- a/code/modules/gamemaster/actions/swarmboarder.dm
+++ b/code/modules/gamemaster/actions/swarmboarder.dm
@@ -1,7 +1,7 @@
 /datum/gm_action/swarm_boarder
 	name = "swarmer shell"
 	departments = list(ROLE_EVERYONE, ROLE_SECURITY, ROLE_ENGINEERING)
-	chaotic = 30
+	chaotic = 60
 	observers_used = TRUE
 	var/area/target_area	// Chosen target area
 	var/area/target_turf	// Chosen target turf in target_area
@@ -67,7 +67,7 @@
 	new swarmertype(target_turf)
 
 /datum/gm_action/swarm_boarder/get_weight()
-	return -60 + (metric.count_people_in_department(ROLE_SECURITY) * 20 + metric.count_people_in_department(ROLE_SYNTHETIC) * 5 + metric.count_people_in_department(ROLE_EVERYONE) * 1)
+	return max(0, -60 + (metric.count_people_in_department(ROLE_SECURITY) * 10 + metric.count_people_in_department(ROLE_SYNTHETIC) * 5))
 
 /datum/gm_action/swarm_boarder/announce()
 	spawn(rand(5 MINUTES, 15 MINUTES))

--- a/code/modules/gamemaster/game_master.dm
+++ b/code/modules/gamemaster/game_master.dm
@@ -28,6 +28,7 @@
 				config_setup_delay = FALSE
 				if(config.enable_game_master)
 					suspended = FALSE
+					next_action = world.time + rand(15 MINUTES, 25 MINUTES)
 			else
 				sleep(30 SECONDS)
 
@@ -56,6 +57,9 @@
 		return FALSE
 	if(ignore_time_restrictions)
 		return TRUE
+	if(world.time < next_action) // Sanity.
+		log_debug("Game Master unable to start event: Time until next action is approximately [round((next_action - world.time) / (1 MINUTE))] minute(s)")
+		return FALSE
 	// Last minute antagging is bad for humans to do, so the GM will respect the start and end of the round.
 	var/mills = round_duration_in_ticks
 	var/mins = round((mills % 36000) / 600)

--- a/code/modules/mob/holder.dm
+++ b/code/modules/mob/holder.dm
@@ -95,6 +95,9 @@ var/list/holder_mob_icon_cache = list()
 /obj/item/weapon/holder/drone
 	origin_tech = list(TECH_MAGNET = 3, TECH_ENGINEERING = 5)
 
+/obj/item/weapon/holder/drone/swarm
+	origin_tech = list(TECH_MAGNET = 6, TECH_ENGINEERING = 7, TECH_PRECURSOR = 2, TECH_ARCANE = 1)
+
 /obj/item/weapon/holder/pai
 	origin_tech = list(TECH_DATA = 2)
 

--- a/code/modules/mob/living/silicon/robot/drone/swarm.dm
+++ b/code/modules/mob/living/silicon/robot/drone/swarm.dm
@@ -3,9 +3,10 @@
 	real_name = "drone"
 	icon = 'icons/mob/swarmbot.dmi'
 	icon_state = "swarmer"
+	item_state = "repairbot"
 	faction = "swarmer"
-	maxHealth = 75
-	health = 75
+	maxHealth = 35
+	health = 35
 	cell_emp_mult = 0.5
 	universal_speak = 0
 	universal_understand = 1
@@ -25,6 +26,8 @@
 		/obj)
 
 	mob_always_swap = 1
+
+	speed = 3
 
 	softfall = TRUE
 
@@ -46,6 +49,8 @@
 	var/spell_setup = list(
 		/spell/aoe_turf/conjure/swarmer,
 		/spell/aoe_turf/conjure/forcewall/swarm,
+		/spell/aoe_turf/conjure/zeropointwell,
+		/spell/aoe_turf/conjure/zeropointbarricade,
 		/spell/aoe_turf/blink/swarm,
 		/spell/aoe_turf/conjure/swarmer/gunner,
 		/spell/aoe_turf/conjure/swarmer/melee
@@ -71,6 +76,11 @@
 	icon_state = "swarmer_ranged"
 	faction = "swarmer"
 
+	maxHealth = 50
+	health = 50
+
+	speed = 4
+
 	law_type = /datum/ai_laws/swarm_drone/soldier
 	module_type = /obj/item/weapon/robot_module/drone/swarm/ranged
 
@@ -86,6 +96,11 @@
 	icon = 'icons/mob/swarmbot.dmi'
 	icon_state = "swarmer_melee"
 	faction = "swarmer"
+
+	maxHealth = 70
+	health = 70
+
+	speed = 2
 
 	law_type = /datum/ai_laws/swarm_drone/soldier
 	module_type = /obj/item/weapon/robot_module/drone/swarm/melee

--- a/code/modules/mob/living/silicon/robot/drone/swarm_abilities.dm
+++ b/code/modules/mob/living/silicon/robot/drone/swarm_abilities.dm
@@ -4,7 +4,7 @@
 	desc = "This ability constructs a standard swarmer shell that may activate at some point."
 
 	school = "conjuration"
-	charge_max = 120 SECONDS
+	charge_max = 5 MINUTES
 	spell_flags = 0
 	invocation = "none"
 	invocation_type = SpI_NONE

--- a/code/modules/mob/living/silicon/robot/drone/swarm_items.dm
+++ b/code/modules/mob/living/silicon/robot/drone/swarm_items.dm
@@ -130,7 +130,7 @@
 /obj/effect/temporary_effect/pulse/disintegrate/on_pulse()
 	var/turf/T = get_turf(src)
 	if(istype(T,/turf/simulated/wall))
-		explosion(get_turf(src), -1, -1, 1, 3, adminlog = 0)
+		T.take_damage(rand(20, 50))
 	else
 		qdel(src)
 

--- a/code/modules/projectiles/guns/energy/stun.dm
+++ b/code/modules/projectiles/guns/energy/stun.dm
@@ -26,7 +26,7 @@
 	name = "disabler"
 	desc = "An archaic device which attacks the target's nervous-system or control circuits."
 	projectile_type = /obj/item/projectile/beam/stun/disabler
-	charge_cost = 200
+	charge_cost = 800
 	recharge_time = 0.5 SECONDS
 
 /obj/item/weapon/gun/energy/stunrevolver


### PR DESCRIPTION
Tweaks the Game Master's intialization to properly handle setup.

Could not reproduce noted GM issues of event spam after applying a sanity check, which was already done on a previous step, not labeling it a bugfix due to this uncertainty.

Tweaks Swarmers after data from recent Calamity.

CEREBUL WHY IS THAT THERE.