### PR TITLE
Ctrl+Click now removes pens from PDAs

### DIFF
--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -74,6 +74,8 @@ var/global/list/obj/item/device/pda/PDAs = list()
 	
 	if(can_use(usr))
 		remove_pen()
+		return
+	..()
 
 /obj/item/device/pda/AltClick()
 	if(issilicon(usr))

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -68,6 +68,12 @@ var/global/list/obj/item/device/pda/PDAs = list()
 	if(..(user, 1))
 		to_chat(user, "The time [stationtime2text()] is displayed in the corner of the screen.")
 
+/obj/item/device/pda/CtrlClick()
+	if(issilicon(usr))
+		return
+	
+	if(can_use(usr))
+		remove_pen()
 
 /obj/item/device/pda/AltClick()
 	if(issilicon(usr))
@@ -1043,6 +1049,19 @@ var/global/list/obj/item/device/pda/PDAs = list()
 			id.loc = get_turf(src)
 		id = null
 
+/obj/item/device/pda/proc/remove_pen()
+	var/obj/item/weapon/pen/O = locate() in src
+	if(O)
+		if(istype(loc, /mob))
+			var/mob/M = loc
+			if(M.get_active_hand() == null)
+				M.put_in_hands(O)
+				to_chat(usr, "<span class='notice'>You remove \the [O] from \the [src].</span>")
+				return
+		O.loc = get_turf(src)
+	else
+		to_chat(usr, "<span class='notice'>This PDA does not have a pen in it.</span>")
+
 /obj/item/device/pda/proc/create_message(var/mob/living/U = usr, var/obj/item/device/pda/P, var/tap = 1)
 	if(tap)
 		U.visible_message("<span class='notice'>\The [U] taps on their PDA's screen.</span>")
@@ -1203,17 +1222,7 @@ var/global/list/obj/item/device/pda/PDAs = list()
 		return
 
 	if ( can_use(usr) )
-		var/obj/item/weapon/pen/O = locate() in src
-		if(O)
-			if (istype(loc, /mob))
-				var/mob/M = loc
-				if(M.get_active_hand() == null)
-					M.put_in_hands(O)
-					to_chat(usr, "<span class='notice'>You remove \the [O] from \the [src].</span>")
-					return
-			O.loc = get_turf(src)
-		else
-			to_chat(usr, "<span class='notice'>This PDA does not have a pen in it.</span>")
+		remove_pen()
 	else
 		to_chat(usr, "<span class='notice'>You cannot do this while restrained.</span>")
 


### PR DESCRIPTION
As per title. Tested and works.
Ctrl+Clicking on it to drag the PDA whilst it's on the ground will function as it would with anything else.