### PR TITLE
Adds holding pen check + alert

### DIFF
--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -397,15 +397,20 @@
 			usr << "<span class='info'>There isn't enough space left on \the [src] to write anything.</span>"
 			return
 
-		var/t =  sanitize(input("Enter what you want to write:", "Write", null, null) as message, free_space, extra = 0)
+		var/t =  sanitize(input("Enter what you want to write:", "Write", null, null) as message, extra = 0)
 
 		if(!t)
 			return
 
+		if(t > free_space)
+			var/textalert = "[copytext(t, free_space-5, free_space)] ..."
+			alert(usr, "You've gone over the allowed amount of text! Here's where you're about to be cut off: [textalert]", "", "Okay!")
+			t = sanitize(input("Enter what you want to write:", "Write", null, textalert) as message, extra = 0)
+
 		var/obj/item/i = usr.get_active_hand() // Check to see if he still got that darn pen, also check if he's using a crayon or pen.
 		var/iscrayon = 0
 		if(!istype(i, /obj/item/weapon/pen))
-			alert(usr, "You aren't holding a pen anymore! If you want to keep your work, grab one.", "Confirm Continuation", "Okay")
+			alert(usr, "You aren't holding a pen anymore! If you want to keep your work, grab one.", "", "Okay")
 			i = usr.get_active_hand()
 
 		if(!istype(i, /obj/item/weapon/pen))

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -405,6 +405,10 @@
 		var/obj/item/i = usr.get_active_hand() // Check to see if he still got that darn pen, also check if he's using a crayon or pen.
 		var/iscrayon = 0
 		if(!istype(i, /obj/item/weapon/pen))
+			alert(usr, "You aren't holding a pen anymore! If you want to keep your work, grab one.", "Confirm Continuation", "Okay")
+			i = usr.get_active_hand()
+
+		if(!istype(i, /obj/item/weapon/pen))
 			var/mob/living/M = usr
 			if(istype(M) && M.back && istype(M.back,/obj/item/weapon/rig))
 				var/obj/item/weapon/rig/r = M.back


### PR DESCRIPTION
If you start writing on a paper, but then switch hands/drop your writing utensil/get rid of it, it will alert you to give the chance to pick one up/switch back.

Fixes #6292.

If you've got a suggestion for the message/alert title, feel free to give them.