### PR TITLE
Pauses event processing while doing event actions

### DIFF
--- a/code/controllers/subsystems/events.dm
+++ b/code/controllers/subsystems/events.dm
@@ -21,7 +21,8 @@ SUBSYSTEM_DEF(events)
 
 /datum/controller/subsystem/events/fire(resumed)
 	for(var/datum/event/E in active_events)
-		E.process()
+		if(E.processing_active)
+			E.process()
 
 	for(var/i = EVENT_LEVEL_MUNDANE to EVENT_LEVEL_MAJOR)
 		var/list/datum/event_container/EC = event_containers[i]

--- a/code/modules/events/event.dm
+++ b/code/modules/events/event.dm
@@ -40,15 +40,16 @@
 	return total_weight
 
 /datum/event	//NOTE: Times are measured in master controller ticks!
-	var/startWhen		= 0	//When in the lifetime to call start().
-	var/announceWhen	= 0	//When in the lifetime to call announce().
-	var/endWhen			= 0	//When in the lifetime the event should end.
+	var/startWhen			= 0	//When in the lifetime to call start().
+	var/announceWhen		= 0	//When in the lifetime to call announce().
+	var/endWhen				= 0	//When in the lifetime the event should end.
 
-	var/severity		= 0 //Severity. Lower means less severe, higher means more severe. Does not have to be supported. Is set on New().
-	var/activeFor		= 0	//How long the event has existed. You don't need to change this.
-	var/isRunning		= 1 //If this event is currently running. You should not change this.
-	var/startedAt		= 0 //When this event started.
-	var/endedAt			= 0 //When this event ended.
+	var/severity			= 0 //Severity. Lower means less severe, higher means more severe. Does not have to be supported. Is set on New().
+	var/activeFor			= 0	//How long the event has existed. You don't need to change this.
+	var/isRunning			= TRUE //If this event is currently running. You should not change this.
+	var/startedAt			= 0 //When this event started.
+	var/endedAt				= 0 //When this event ended.
+	var/processing_active 	= TRUE
 	var/datum/event_meta/event_meta = null
 
 /datum/event/nothing
@@ -96,18 +97,26 @@
 //This proc will handle the calls to the appropiate procs.
 /datum/event/process()
 	if(activeFor > startWhen && activeFor < endWhen)
+		processing_active = FALSE
 		tick()
+		processing_active = TRUE
 
 	if(activeFor == startWhen)
-		isRunning = 1
+		isRunning = TRUE
+		processing_active = FALSE
 		start()
+		processing_active = TRUE
 
 	if(activeFor == announceWhen)
+		processing_active = FALSE
 		announce()
+		processing_active = TRUE
 
 	if(activeFor == endWhen)
-		isRunning = 0
+		isRunning = FALSE
+		processing_active = FALSE
 		end()
+		processing_active = TRUE
 
 	// Everything is done, let's clean up.
 	if(activeFor >= lastProcessAt())


### PR DESCRIPTION
Should have no practical effect on any current events but if any event is ever added where it requires some sort of player prompt (like choosing a willing ghost for a spawned mob), this will come in handy to prevent the event still processing while choosing is happening and going haywire.