### PR TITLE
Fixes calculation of wall rad resistance

### DIFF
--- a/code/modules/radiation/radiation.dm
+++ b/code/modules/radiation/radiation.dm
@@ -45,7 +45,7 @@
 
 /turf/simulated/wall/calc_rad_resistance()
 	SSradiation.resistance_cache[src] = (length(contents) + 1)
-	cached_rad_resistance = (density ? material.weight / config.radiation_material_resistance_divisor : 0)
+	cached_rad_resistance = (density ? (material.weight + material.radiation_resistance) / config.radiation_material_resistance_divisor : 0)
 	return
 
 /obj


### PR DESCRIPTION
For some reason walls did not at all take into account the rad resistance of their material. Probably a missed var during rad refactor?