### PR TITLE
Changeling Item Name/Desc Fixy

### DIFF
--- a/code/game/gamemodes/changeling/powers/armor.dm
+++ b/code/game/gamemodes/changeling/powers/armor.dm
@@ -134,8 +134,8 @@
 	siemens_coefficient = 0
 
 /obj/item/clothing/shoes/boots/combat/changeling //Noslips
-	desc = "chitinous boots"
-	name = "Footwear made out of a hard, black chitinous material.  The bottoms of these appear to have spikes that can protrude or extract itself into and out \
+	name = "chitinous boots"
+	desc = "Footwear made out of a hard, black chitinous material.  The bottoms of these appear to have spikes that can protrude or extract itself into and out \
 	of the floor at will, granting the wearer stability."
 	icon_state = "lingboots"
 	armor = list(melee = 75, bullet = 60, laser = 70,energy = 60, bomb = 60, bio = 0, rad = 0)


### PR DESCRIPTION
Minor var fixes for the changeling combat boots variation. Apparently name and desc were flipped around, resulting in abnormal name output when removed from a dead Beta Replicant.