### PR TITLE
Drops the time between events possible duration.

### DIFF
--- a/code/modules/gamemaster/game_master.dm
+++ b/code/modules/gamemaster/game_master.dm
@@ -101,7 +101,7 @@
 	if(action.length)
 		spawn(action.length)
 			action.end()
-	next_action = world.time + rand(15 MINUTES, 30 MINUTES)
+	next_action = world.time + rand(5 MINUTES, 20 MINUTES)
 	last_department_used = action.departments[1]
 
 


### PR DESCRIPTION
Tin, due to recent meeting.

GM system will automatically choose less dangerous events if the danger level is already high.