### PR TITLE
[CRITICAL] Non-prometheans no longer die to water

### DIFF
--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -142,7 +142,7 @@
 		"Your skin prickles in the heat."
 		)
 
-	var/water_resistance = 0.1								// How wet the species gets from being splashed. Only really useful for Prometheans.
+	var/water_resistance = 1								// How wet the species gets from being splashed. Only really useful for Prometheans.
 
 	var/passive_temp_gain = 0								// Species will gain this much temperature every second
 	var/hazard_high_pressure = HAZARD_HIGH_PRESSURE			// Dangerously high pressure.


### PR DESCRIPTION
Closes #6646

the `water_resistance` var is used in this code chunk:
```
/mob/living/proc/inflict_water_damage(amount)
	amount *= 1 - get_water_protection()
	if(amount > 0)
		adjustToxLoss(amount)
```
which is called by 
```
/mob/living/water_act(amount)
	adjust_fire_stacks(-amount * 5)
	for(var/atom/movable/AM in contents)
		AM.water_act(amount)
	remove_modifiers_of_type(/datum/modifier/fire)
	inflict_water_damage(20 * amount) // Only things vulnerable to water will actually be harmed (slimes/prommies).
```