### PR TITLE
Fixes Bagel Poppy Recipe

### DIFF
--- a/code/modules/food/recipes_microwave.dm
+++ b/code/modules/food/recipes_microwave.dm
@@ -1301,7 +1301,7 @@ I said no!
 	items = list(
 		/obj/item/weapon/reagent_containers/food/snacks/bun
 	)
-	result = /obj/item/weapon/reagent_containers/food/snacks/bagelraisin
+	result = /obj/item/weapon/reagent_containers/food/snacks/bagelpoppy
 
 /datum/recipe/microwave/bageleverything
 	reagents = list("water" = 5)


### PR DESCRIPTION
Such that crafting it using a microwave actually spawns a poppy bagel, instead of a raisin bagel.