### PR TITLE
Changes DBCore connection procs to check for config value SQL_ENABLED instead of ENABLE_STAT_TRACKING

### DIFF
--- a/code/defines/procs/dbcore.dm
+++ b/code/defines/procs/dbcore.dm
@@ -56,7 +56,7 @@ DBConnection/New(dbi_handler,username,password_handler,cursor_handler)
 	_db_con = _dm_db_new_con()
 
 DBConnection/proc/Connect(dbi_handler=src.dbi,user_handler=src.user,password_handler=src.password,cursor_handler)
-	if(!sqllogging)
+	if(!config.sql_enabled)
 		return 0
 	if(!src) return 0
 	cursor_handler = src.default_cursor
@@ -66,7 +66,7 @@ DBConnection/proc/Connect(dbi_handler=src.dbi,user_handler=src.user,password_han
 DBConnection/proc/Disconnect() return _dm_db_close(_db_con)
 
 DBConnection/proc/IsConnected()
-	if(!sqllogging) return 0
+	if(!config.sql_enabled) return 0
 	var/success = _dm_db_is_connected(_db_con)
 	return success
 


### PR DESCRIPTION
Changes DBCore connection procs to check for existing config value SQL_ENABLED instead of ENABLE_STAT_TRACKING.  I think it makes a bit more sense to be able to control the old /tg/ stat logging system independently of being able to connect to the DB altogether.

(I haven't tested this locally because I am bad and have not set up a local MariaDB instance but it SHOULD work!  Maybe testing the PR directly in the dead of early morning...)