### PR TITLE
Fixes antibiotic resistance

### DIFF
--- a/code/modules/virus2/disease2.dm
+++ b/code/modules/virus2/disease2.dm
@@ -165,6 +165,7 @@
 	disease.stageprob = stageprob
 	disease.antigen   = antigen
 	disease.uniqueID = uniqueID
+	disease.resistance = resistance
 	disease.affected_species = affected_species.Copy()
 	for(var/datum/disease2/effectholder/holder in effects)
 		var/datum/disease2/effectholder/newholder = new /datum/disease2/effectholder


### PR DESCRIPTION
Fixes antibiotic resistance being reset when copied to new datum instance because certain machines make careful copies instead of directly copying the datum! Who knew!