### PR TITLE
Prettifies closet contents list with (newly added) countable variant of english_list

### DIFF
--- a/code/_helpers/_lists.dm
+++ b/code/_helpers/_lists.dm
@@ -25,8 +25,8 @@
 		if(2) return "[input[1]][and_text][input[2]]"
 		else  return "[jointext(input, comma_text, 1, -1)][final_comma_text][and_text][input[input.len]]"
 
-//Returns a list that counts equal-ish items, outputting count and item names, optionally with icons and specific determiners
-/proc/counting_english_list(var/list/input, output_icons = TRUE, determiners = DET_NONE, nothing_text = "nothing", and_text = " and ", comma_text = ", ", final_comma_text = "")
+//Returns a newline-separated list that counts equal-ish items, outputting count and item names, optionally with icons and specific determiners
+/proc/counting_english_list(var/list/input, output_icons = TRUE, determiners = DET_NONE, nothing_text = "nothing", line_prefix = "\t", first_item_prefix = "\n", last_item_suffix = "\n", and_text = "\n", comma_text = "\n", final_comma_text = "")
 	var/list/counts = list() // counted input items
 	var/list/items = list() // actual objects for later reference (for icons and formatting)
 
@@ -41,10 +41,11 @@
 
 	// assemble the output list
 	var/list/out = list()
+	var/i = 0
 	for(var/item in items)
 		var/name = "[item]"
 		var/count = counts[name]
-		var/item_str = ""
+		var/item_str = line_prefix
 		if(count > 1)
 			item_str += "[count]x&nbsp;"
 
@@ -61,10 +62,21 @@
 		else
 			// non-atoms use plain string conversion
 			item_str += name
+
+		if(i == 0)
+			item_str = first_item_prefix + item_str
+		if(i == items.len - 1)
+			item_str = item_str + last_item_suffix
+
 		out.Add(item_str)
+		i++
 
 	// finally return the list using regular english_list builder
 	return english_list(out, nothing_text, and_text, comma_text, final_comma_text)
+
+//A "preset" for counting_english_list that displays the list "inline" (comma separated)
+/proc/inline_counting_english_list(var/list/input, output_icons = TRUE, determiners = DET_NONE, nothing_text = "nothing", and_text = " and ", comma_text = ", ", final_comma_text = "", line_prefix = "", first_item_prefix = "", last_item_suffix = "")
+	return counting_english_list(input, output_icons, determiners, nothing_text, and_text, comma_text, final_comma_text)
 
 //Returns list element or null. Should prevent "index out of bounds" error.
 proc/listgetindex(var/list/list,index)

--- a/code/_helpers/_lists.dm
+++ b/code/_helpers/_lists.dm
@@ -60,7 +60,7 @@
 				else item_str += name
 		else
 			// non-atoms use plain string conversion
-			item_str = name
+			item_str += name
 		out.Add(item_str)
 
 	// finally return the list using regular english_list builder

--- a/code/_helpers/_lists.dm
+++ b/code/_helpers/_lists.dm
@@ -15,20 +15,21 @@
  * Misc
  */
 
-//Returns a list in plain english as a string, optionally counting the elements, displaying icons, etc. (icons, determiners work only with counting)
-/proc/english_list(var/list/input, nothing_text = "nothing", and_text = " and ", comma_text = ", ", final_comma_text = "", output_counts = FALSE, output_icons = TRUE, determiners = DET_NONE)
-	// non-countable lists MUST use legacy code to maintain compatibility
-	// with shoddy usage of english_list for code logic
-	// and because it preserves order of inputs
-	if (!output_counts)
-		switch(input.len)
-			if(0) return nothing_text
-			if(1) return "[input[1]]"
-			if(2) return "[input[1]][and_text][input[2]]"
-			else  return "[jointext(input, comma_text, 1, -1)][final_comma_text][and_text][input[input.len]]"
+//Returns a list in plain english as a string
+/proc/english_list(var/list/input, nothing_text = "nothing", and_text = " and ", comma_text = ", ", final_comma_text = "")
+	// this proc cannot be merged with counting_english_list to maintain compatibility
+	// with shoddy use of this proc for code logic and for cases that require original order
+	switch(input.len)
+		if(0) return nothing_text
+		if(1) return "[input[1]]"
+		if(2) return "[input[1]][and_text][input[2]]"
+		else  return "[jointext(input, comma_text, 1, -1)][final_comma_text][and_text][input[input.len]]"
 
+//Returns a list that counts equal-ish items, outputting count and item names, optionally with icons and specific determiners
+/proc/counting_english_list(var/list/input, output_icons = TRUE, determiners = DET_NONE, nothing_text = "nothing", and_text = " and ", comma_text = ", ", final_comma_text = "")
 	var/list/counts = list() // counted input items
 	var/list/items = list() // actual objects for later reference (for icons and formatting)
+
 	// count items
 	for(var/item in input)
 		var/name = "[item]" // index items by name; usually works fairly well for loose equality
@@ -62,11 +63,8 @@
 			item_str = name
 		out.Add(item_str)
 
-	switch(out.len)
-		if(0) return nothing_text
-		if(1) return "[out[1]]"
-		if(2) return "[out[1]][and_text][out[2]]"
-		else return "[jointext(out, comma_text, 1, -1)][final_comma_text][and_text][out[out.len]]"
+	// finally return the list using regular english_list builder
+	return english_list(out, nothing_text, and_text, comma_text, final_comma_text)
 
 //Returns list element or null. Should prevent "index out of bounds" error.
 proc/listgetindex(var/list/list,index)

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -74,7 +74,7 @@
 			to_chat(user, "It is full.")
 
 	if(!src.opened && isobserver(user))
-		to_chat(user, "It contains: [english_list(contents, output_counts = TRUE)].")
+		to_chat(user, "It contains: [counting_english_list(contents)].")
 
 /obj/structure/closet/CanPass(atom/movable/mover, turf/target)
 	if(wall_mounted)

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -74,7 +74,7 @@
 			to_chat(user, "It is full.")
 
 	if(!src.opened && isobserver(user))
-		to_chat(user, "It contains: [counting_english_list(contents)].")
+		to_chat(user, "It contains: [counting_english_list(contents)]")
 
 /obj/structure/closet/CanPass(atom/movable/mover, turf/target)
 	if(wall_mounted)

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -57,7 +57,7 @@
 	update_icon()
 
 /obj/structure/closet/examine(mob/user)
-	if(..(user, 1) && !opened)
+	if(!src.opened && (..(user, 1) || isobserver(user)))
 		var/content_size = 0
 		for(var/obj/item/I in src.contents)
 			if(!I.anchored)
@@ -72,6 +72,9 @@
 			to_chat(user, "There is still some free space.")
 		else
 			to_chat(user, "It is full.")
+
+	if(!src.opened && isobserver(user))
+		to_chat(user, "It contains: [english_list(contents, output_counts = TRUE)].")
 
 /obj/structure/closet/CanPass(atom/movable/mover, turf/target)
 	if(wall_mounted)
@@ -358,12 +361,6 @@
 	src.add_fingerprint(user)
 	if(!src.toggle())
 		to_chat(usr, "<span class='notice'>It won't budge!</span>")
-
-/obj/structure/closet/attack_ghost(mob/ghost)
-	if(ghost.client && ghost.client.inquisitive_ghost)
-		ghost.examinate(src)
-		if (!src.opened)
-			to_chat(ghost, "It contains: [english_list(contents)].")
 
 /obj/structure/closet/verb/verb_toggleopen()
 	set src in oview(1)


### PR DESCRIPTION
## Summary
Contents of closets (as viewed by ghosts) are now less ugly and easier to read.

## Screenshots
Before (`english_list`):
![dreamseeker_2020-01-29_00-42-46](https://user-images.githubusercontent.com/781546/73316338-e40bd480-4232-11ea-9756-7ece6414ffcf.png)

After (`counting_english_list`):
![dreamseeker_2020-01-30_01-22-38](https://user-images.githubusercontent.com/781546/73409604-0fa8c080-4300-11ea-96d3-92e29d3355b4.png)

Third option (`inline_counting_english_list`):
![dreamseeker_2020-01-29_00-35-23](https://user-images.githubusercontent.com/781546/73316342-e53d0180-4232-11ea-8006-e9eea5997200.png)

## Changes
- Adds a proc similar to `english_list` that counts items in lists and outputs the contents in actual (newline-separated) lists while also (optionally) displaying icons or specific determiners.
- Moves the ghost examine code of closets to `proc/examine` where it belongs.
- Ghosts now also see empty/full messages like characters standing
close do.
- The contents list for closets now shows number of items (if multiple)
and their icons (wherever possible), displaying it in a newline-separated list.
- The list no longer shows unnecessary determiners ("the" before every
single item).
- After some revisions, `english_list` remains untouched. Many places that use it would not support the new features anyway - some use it improperly/unnecessarily but others need to keep the list ordered, which the countable one cannot do.
- Also adds proc `inline_counting_english_list`, which is a "preset" for `counting_english_list` that is inline and looks more like `english_list`, but it supports icons and other features. It is not used anywhere yet.

## Additional notes
I tried really hard to make the new code work for the old use cases, but there were odd edge cases with some usages of `english_list` that broke logic (as, unexpectedly, this view proc is used for some code logic in cameras, weather and other places). Might revisit this later, fix those edge cases and make the new code used exclusively.

I might also look at other lists that would benefit from this; namely some stats/views where icons and/or counts would be helpful, or perhaps lists that use their own code but could use either of the newly added procs.

I also encourage people to use these procs in the future; they are highly configurable for (hopefully) any desired output imaginable, and it could still be expanded if need be. Please use named arguments to configure it though.

I would also like to discourage people from using these procs (including `english_list`) for stuff where native `jointext` would suffice - especially if it's for code logic and not for pretty printing.

Lastly, 🎉! Having fun after ~4 years.