### PR TITLE
Unregulated passive regulators don't limit flow

### DIFF
--- a/html/changelogs/atermonera - unregulatorinator.yml
+++ b/html/changelogs/atermonera - unregulatorinator.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Atermonera
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Unregulated pressure regulators (Regulation set to OFF) no longer limit flow rate, and instead act as one-way opened valves. For best results, place away from other pumps."


### PR DESCRIPTION
If pressure regulation is set to `off`, then they're more or less one-way opened valves.
I can't make them _actual_ valves in this case because that defeats the original purpose of breaking the distro line into multiple networks so all the shutoff valves don't close at once.
Presently, they only transfer gases between the singular pipes immediately to their left and right (or top and bottom). This is particularly annoying on the central loops, which are broken up to facilitate the automated shutoff valves, because each pipe holds only a very small fraction of the total gas in the network, which means that moving gases from atmospherics to cargo (far end of the clockwise loop) takes literally forever. It also limits flow rate, but because of the pressures involved, that's usually less of an issue.
This makes the transfer consider the volume of connected networks, when present, and does not consider the flow rate (if you don't regulate the pressure, the machinery that's controlling flow to try and achieve a particular pressure isn't being used), such that the transfer is near instantaneous, as though it were a 1-way valve.
This increase in flow rate doesn't work when the regulator is connected directly to a non-simple pipe, on either end, as such things lack the `parent` var that has the gas_mixture datum. That is to say, if it's attached to a shutoff valve, it doesn't actually speed things up (This was the original intent, and I am now working on the original correct solution of making the shutoff valves smarter).

This has been [tested](https://puu.sh/F4Mb5/9e8ee6a048.mp4) (.mp4), and also in the case described above where it's next to a valve, though I didn't record that.

Open to discussion as to whether or not this is desired, since it didn't fulfill the original goal of not making distro take ages to fill, I'm not very attached to it.