### PR TITLE
Teshari Poncho Fix

### DIFF
--- a/code/modules/clothing/under/accessories/clothing.dm
+++ b/code/modules/clothing/under/accessories/clothing.dm
@@ -62,6 +62,19 @@
 		"Teshari" = 'icons/mob/species/seromi/suit.dmi'
 		)
 
+/obj/item/clothing/accessory/poncho/equipped() //Solution for race-specific sprites for an accessory which is also a suit. Suit icons break if you don't use icon override which then also overrides race-specific sprites.
+	..()
+	var/mob/living/carbon/human/H = loc
+	if(istype(H) && H.wear_suit == src)
+		if(H.species.name == "Teshari")
+			icon_override = 'icons/mob/species/seromi/suit.dmi'
+		else
+			icon_override = 'icons/mob/ties.dmi'
+		update_clothing_icon()
+
+/obj/item/clothing/accessory/poncho/dropped() //Resets the override to prevent the wrong .dmi from being used because equipped only triggers when wearing ponchos as suits.
+	icon_override = null
+
 /obj/item/clothing/accessory/poncho/green
 	name = "green poncho"
 	desc = "A simple, comfortable cloak without sleeves. This one is green."


### PR DESCRIPTION
Did you know several poncho sprites exist for teshari? This fix will allow ponchos to properly use teshari sprites when worn by teshari instead of human base sprites. This fix can additionally be extended to other species if for some reason somebody wants to make other species sprites for ponchos.

Technical details: Ponchos are an accessory and draw icons from ties.dmi as an accessory but suits.dmi worn as a suit. This is avoided by using icon_override to always draw from ties.dmi but this unfortunately overrides species-specific sprites. Now icon_override will be set to seromi/suits.dmi when worn by teshari and ties.dmi when worn by anything else.

Potential downsides: Ponchos without teshari sprites will now be invisible on teshari. This will also apply to children of ponchos, namely department cloaks.