### PR TITLE
Fixes Whitelist Bypass Exploit

### DIFF
--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -426,7 +426,7 @@
 	dat += "<a href='byond://?src=\ref[src];hidden_jobs=1'>[show_hidden_jobs ? "Hide":"Show"] Hidden Jobs.</a><br>"
 	for(var/datum/job/job in job_master.occupations)
 		if(!IsJobAvailable(job.title))
-			return FALSE	// Prevents bypassing whitelist checks with switching characters.
+			continue	// Prevents bypassing whitelist checks with switching characters.
 	
 		if(job && IsJobAvailable(job.title))
 			// Checks for jobs with minimum age requirements

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -425,6 +425,9 @@
 	dat += "Choose from the following open/valid positions:<br>"
 	dat += "<a href='byond://?src=\ref[src];hidden_jobs=1'>[show_hidden_jobs ? "Hide":"Show"] Hidden Jobs.</a><br>"
 	for(var/datum/job/job in job_master.occupations)
+		if(!IsJobAvailable(job.title))
+			return FALSE	// Prevents bypassing whitelist checks with switching characters.
+	
 		if(job && IsJobAvailable(job.title))
 			// Checks for jobs with minimum age requirements
 			if(job.minimum_character_age && (client.prefs.age < job.minimum_character_age))


### PR DESCRIPTION
This fixes the whitelist bypass exploit.

To recreate:
1. Load a character that has the ability to join as a certain whitelisted job per age/species etc.
2. Open the select job "Join Game" menu and keep it open.
3. Load character that doesn't have that ability.
4. Click that restricted job.