### PR TITLE
Implements blacklist for specific plant sprites for random seeds

### DIFF
--- a/code/modules/hydroponics/_hydro_setup.dm
+++ b/code/modules/hydroponics/_hydro_setup.dm
@@ -107,8 +107,8 @@ GLOBAL_LIST_INIT(plant_item_products, list(
 
 GLOBAL_LIST_INIT(forbidden_plant_growth_sprites, list(
 	"gnomes"
-	)
+	))
 
 GLOBAL_LIST_INIT(forbidden_plant_product_sprites, list(
 	"gnomes"
-	)
+	))

--- a/code/modules/hydroponics/_hydro_setup.dm
+++ b/code/modules/hydroponics/_hydro_setup.dm
@@ -104,3 +104,11 @@ GLOBAL_LIST_INIT(plant_item_products, list(
 	/obj/item/weapon/spacecash/c1 = 3,
 	/obj/item/weapon/spacecash/c10 = 1
 	))
+
+GLOBAL_LIST_INIT(forbidden_plant_growth_sprites, list(
+	"gnomes"
+	)
+
+GLOBAL_LIST_INIT(forbidden_plant_product_sprites, list(
+	"gnomes"
+	)

--- a/code/modules/hydroponics/seed.dm
+++ b/code/modules/hydroponics/seed.dm
@@ -408,8 +408,8 @@
 	seed_noun = pick("spores","nodes","cuttings","seeds")
 
 	set_trait(TRAIT_POTENCY,rand(5,30),200,0)
-	set_trait(TRAIT_PRODUCT_ICON,pick(plant_controller.plant_product_sprites))
-	set_trait(TRAIT_PLANT_ICON,pick(plant_controller.plant_sprites))
+	set_trait(TRAIT_PRODUCT_ICON,pick(plant_controller.accessible_product_sprites))
+	set_trait(TRAIT_PLANT_ICON,pick(plant_controller.accessible_plant_sprites))
 	set_trait(TRAIT_PLANT_COLOUR,"#[get_random_colour(0,75,190)]")
 	set_trait(TRAIT_PRODUCT_COLOUR,"#[get_random_colour(0,75,190)]")
 	update_growth_stages()
@@ -454,6 +454,7 @@
 
 		var/list/banned_chems = list(
 			"adminordrazine",
+			"magicdust",
 			"nutriment"
 			)
 

--- a/code/modules/hydroponics/seed_controller.dm
+++ b/code/modules/hydroponics/seed_controller.dm
@@ -68,7 +68,7 @@ var/global/datum/controller/plants/plant_controller // Set in New().
 
 		if(!(plant_sprites[base]) || (plant_sprites[base]<ikey))
 			plant_sprites[base] = ikey
-			if(!(base in forbidden_plant_growth_sprites))
+			if(!(base in GLOB.forbidden_plant_growth_sprites))
 				accessible_plant_sprites[base] = ikey
 
 	for(var/icostate in icon_states('icons/obj/hydroponics_products.dmi'))
@@ -76,7 +76,7 @@ var/global/datum/controller/plants/plant_controller // Set in New().
 		var/base = copytext(icostate,1,split)
 		if(split)
 			plant_product_sprites |= base
-			if(!(base in forbidden_plant_product_sprites))
+			if(!(base in GLOB.forbidden_plant_product_sprites))
 				accessible_product_sprites |= base
 
 	// Populate the global seed datum list.

--- a/code/modules/hydroponics/seed_controller.dm
+++ b/code/modules/hydroponics/seed_controller.dm
@@ -25,16 +25,18 @@ var/global/datum/controller/plants/plant_controller // Set in New().
 
 	var/plants_per_tick = PLANTS_PER_TICK
 	var/plant_tick_time = PLANT_TICK_TIME
-	var/list/product_descs = list()         // Stores generated fruit descs.
-	var/list/plant_queue = list()           // All queued plants.
-	var/list/seeds = list()                 // All seed data stored here.
-	var/list/gene_tag_masks = list()        // Gene obfuscation for delicious trial and error goodness.
-	var/list/plant_icon_cache = list()      // Stores images of growth, fruits and seeds.
-	var/list/plant_sprites = list()         // List of all harvested product sprites.
-	var/list/plant_product_sprites = list() // List of all growth sprites plus number of growth stages.
-	var/processing = 0                      // Off/on.
-	var/list/gene_masked_list = list()		// Stored gene masked list, rather than recreating it when needed.
-	var/list/plant_gene_datums = list()		// Stored datum versions of the gene masked list.
+	var/list/product_descs = list()					// Stores generated fruit descs.
+	var/list/plant_queue = list()					// All queued plants.
+	var/list/seeds = list()							// All seed data stored here.
+	var/list/gene_tag_masks = list()				// Gene obfuscation for delicious trial and error goodness.
+	var/list/plant_icon_cache = list()				// Stores images of growth, fruits and seeds.
+	var/list/plant_sprites = list()					// List of all growth sprites plus number of growth stages.
+	var/list/accessible_plant_sprites = list()		// List of all plant sprites allowed to appear in random generation.
+	var/list/plant_product_sprites = list()			// List of all harvested product sprites.
+	var/list/accessible_product_sprites = list()	// List of all product sprites allowed to appear in random generation.
+	var/processing = 0                     			// Off/on.
+	var/list/gene_masked_list = list()				// Stored gene masked list, rather than recreating it when needed.
+	var/list/plant_gene_datums = list()				// Stored datum versions of the gene masked list.
 
 /datum/controller/plants/New()
 	if(plant_controller && plant_controller != src)
@@ -66,11 +68,16 @@ var/global/datum/controller/plants/plant_controller // Set in New().
 
 		if(!(plant_sprites[base]) || (plant_sprites[base]<ikey))
 			plant_sprites[base] = ikey
+			if(!(base in forbidden_plant_growth_sprites))
+				accessible_plant_sprites[base] = ikey
 
 	for(var/icostate in icon_states('icons/obj/hydroponics_products.dmi'))
 		var/split = findtext(icostate,"-")
+		var/base = copytext(icostate,1,split)
 		if(split)
-			plant_product_sprites |= copytext(icostate,1,split)
+			plant_product_sprites |= base
+			if(!(base in forbidden_plant_product_sprites))
+				accessible_product_sprites |= base
 
 	// Populate the global seed datum list.
 	for(var/type in typesof(/datum/seed)-/datum/seed)


### PR DESCRIPTION
For now just gnomes there, not being a plant at all.

Also makes gnome reagent, magic dust, excluded from the random seeds for 'adminspawn only' reason.