### PR TITLE
Very low levels of radiation are no longer harmful

### DIFF
--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -284,7 +284,7 @@
 
 		var/damage = 0
 		radiation -= 1 * RADIATION_SPEED_COEFFICIENT
-		if(prob(25))
+		if(radiation > 2.5 && prob(25)) // Safe for a little over 2m at the recommended maximum safe dosage of 0.05Bq
 			damage = 1
 
 		if (radiation > 50)

--- a/html/changelogs/atermonera - rad_tweaks.yml
+++ b/html/changelogs/atermonera - rad_tweaks.yml
@@ -1,0 +1,5 @@
+author: Atermonera
+delete-after: True
+changes: 
+  - tweak: "Radiation has to accumulate at least a little bit before it starts to become damaging. Very low levels of radiation can be safe for a number of minutes before you are at risk of injury."
+  - bugfix: "Unless you idle for several minutes near the supermatter before it's been turned on, you should no longer be at risk of taking toxloss (Including those few spots in cargo maintenance)."


### PR DESCRIPTION
The radiation controller fires every 2 seconds, and it iterates over all living mobs, accumulating their `radiation` variable by the rads of the turf they're on.
Mob life ticks also fire every 2 seconds (afaik anymore) and will decrement the `radiation` variable by a minimum of 0.1.

Previously, if a mob had any rads whatsoever before the decrement, it had a minimum 25% chance of taking toxloss, such that standing in specific spots in maintenance outside the engine room in the instant where the radiation controller fires gives you ~0.2-0.3 radiation, which is up to 3 rolls for that 25% chance of toxloss. Hence, a lot of people started complaining about taking dangerous levels of rads in the time it takes them to put a radsuit on in the engine monitoring room.

With this change, radiation levels below 2.5 (on the mob, after the decrement) aren't hazardous. By my math, that works out to about 2 minutes at the maximum "safe" per-turf radiation level of 0.05 (proscribed by old comments in the example config, seems as good a place as any to take such a value from), and 3-4+ minutes at the levels experienced in the engine monitoring room and maintenance.