### PR TITLE
Fixes to Modular Computers and NTNet Relays

### DIFF
--- a/code/game/objects/items/weapons/circuitboards/machinery/research.dm
+++ b/code/game/objects/items/weapons/circuitboards/machinery/research.dm
@@ -87,10 +87,10 @@ obj/item/weapon/circuitboard/rdserver/attackby(obj/item/I as obj, mob/user as mo
 							/obj/item/weapon/stock_parts/micro_laser = 1,
 							/obj/item/weapon/stock_parts/console_screen = 1)
 
-obj/item/weapon/circuitboard/ntnet_relay
+/obj/item/weapon/circuitboard/ntnet_relay
 	name = "Circuit board (NTNet Quantum Relay)"
-	build_path = "/obj/machinery/ntnet_relay"
-	board_type = "machine"
+	build_path = /obj/machinery/ntnet_relay
+	board_type = new /datum/frame/frame_types/machine
 	origin_tech = list(TECH_DATA = 4)
 	req_components = list(
-							"/obj/item/stack/cable_coil" = 15)
+							/obj/item/stack/cable_coil = 15)

--- a/code/modules/modular_computers/NTNet/NTNet.dm
+++ b/code/modules/modular_computers/NTNet/NTNet.dm
@@ -31,9 +31,10 @@ var/global/datum/ntnet/ntnet_global = new()
 /datum/ntnet/New()
 	if(ntnet_global && (ntnet_global != src))
 		ntnet_global = src // There can be only one.
-	for(var/obj/machinery/ntnet_relay/R in machines)
-		relays.Add(R)
-		R.NTNet = src
+	if (SSatoms && SSatoms.initialized > INITIALIZATION_INSSATOMS)
+		for(var/obj/machinery/ntnet_relay/R in machines)
+			relays.Add(R)
+			R.NTNet = src
 	build_software_lists()
 	build_news_list()
 	build_emails_list()

--- a/code/modules/modular_computers/NTNet/NTNet_relay.dm
+++ b/code/modules/modular_computers/NTNet/NTNet_relay.dm
@@ -113,7 +113,7 @@
 	for(var/datum/computer_file/program/ntnet_dos/D in dos_sources)
 		D.target = null
 		D.error = "Connection to quantum relay severed"
-	..()
+	. = ..()
 
 /obj/machinery/ntnet_relay/attackby(var/obj/item/weapon/W as obj, var/mob/user as mob)
 	if(W.is_screwdriver())

--- a/code/modules/modular_computers/NTNet/NTNet_relay.dm
+++ b/code/modules/modular_computers/NTNet/NTNet_relay.dm
@@ -8,6 +8,7 @@
 	icon_state = "bus"
 	anchored = 1
 	density = 1
+	circuit = /obj/item/weapon/circuitboard/ntnet_relay
 	var/datum/ntnet/NTNet = null // This is mostly for backwards reference and to allow varedit modifications from ingame.
 	var/enabled = 1				// Set to 0 if the relay was turned off
 	var/dos_failure = 0			// Set to 1 if the relay failed due to (D)DoS attack
@@ -93,17 +94,16 @@
 		return 1
 
 /obj/machinery/ntnet_relay/New()
-	uid = gl_uid
-	gl_uid++
-	component_parts = list()
-	component_parts += new /obj/item/stack/cable_coil(src,15)
-	component_parts += new /obj/item/weapon/circuitboard/ntnet_relay(src)
+	..()
+	assign_uid()
+	default_apply_parts()
 
+/obj/machinery/ntnet_relay/Initialize()
+	. = ..()
 	if(ntnet_global)
 		ntnet_global.relays.Add(src)
 		NTNet = ntnet_global
 		ntnet_global.add_log("New quantum relay activated. Current amount of linked relays: [NTNet.relays.len]")
-	..()
 
 /obj/machinery/ntnet_relay/Destroy()
 	if(ntnet_global)
@@ -115,22 +115,9 @@
 		D.error = "Connection to quantum relay severed"
 	. = ..()
 
-/obj/machinery/ntnet_relay/attackby(var/obj/item/weapon/W as obj, var/mob/user as mob)
-	if(W.is_screwdriver())
-		playsound(src.loc, 'sound/items/Screwdriver.ogg', 50, 1)
-		panel_open = !panel_open
-		to_chat(user, "You [panel_open ? "open" : "close"] the maintenance hatch")
+/obj/machinery/ntnet_relay/attackby(var/obj/item/W as obj, var/mob/user as mob)
+	if(default_deconstruction_screwdriver(user, W))
 		return
-	if(W.is_crowbar())
-		if(!panel_open)
-			to_chat(user, "Open the maintenance panel first.")
-			return
-		playsound(src.loc, 'sound/items/Crowbar.ogg', 50, 1)
-		to_chat(user, "You disassemble \the [src]!")
-
-		for(var/atom/movable/A in component_parts)
-			A.forceMove(src.loc)
-		new /obj/structure/frame(src.loc)
-		qdel(src)
+	if(default_deconstruction_crowbar(user, W))
 		return
 	..()

--- a/code/modules/modular_computers/computers/modular_computer/core.dm
+++ b/code/modules/modular_computers/computers/modular_computer/core.dm
@@ -41,14 +41,14 @@
 /obj/item/modular_computer/proc/install_default_programs()
 	return 1
 
-/obj/item/modular_computer/New()
+/obj/item/modular_computer/Initialize()
 	START_PROCESSING(SSobj, src)
 	install_default_hardware()
 	if(hard_drive)
 		install_default_programs()
 	update_icon()
 	update_verbs()
-	..()
+	. = ..()
 
 /obj/item/modular_computer/Destroy()
 	kill_program(1)

--- a/code/modules/modular_computers/file_system/computer_file.dm
+++ b/code/modules/modular_computers/file_system/computer_file.dm
@@ -23,7 +23,7 @@ var/global/file_uid = 0
 	if(holder.holder2 && holder.holder2.active_program == src)
 		holder.holder2.kill_program(1)
 	holder = null
-	..()
+	return ..()
 
 // Returns independent copy of this file.
 /datum/computer_file/proc/clone(var/rename = 0)

--- a/code/modules/modular_computers/hardware/_hardware.dm
+++ b/code/modules/modular_computers/hardware/_hardware.dm
@@ -47,6 +47,7 @@
 	to_chat(user, "Hardware Integrity Test... (Corruption: [damage]/[max_damage]) [damage > damage_failure ? "FAIL" : damage > damage_malfunction ? "WARN" : "PASS"]")
 
 /obj/item/weapon/computer_hardware/New(var/obj/L)
+	..()
 	w_class = hardware_size
 	if(istype(L, /obj/item/modular_computer))
 		holder2 = L

--- a/code/modules/modular_computers/hardware/network_card.dm
+++ b/code/modules/modular_computers/hardware/network_card.dm
@@ -97,4 +97,4 @@ var/global/ntnet_card_uid = 1
 /obj/item/weapon/computer_hardware/network_card/Destroy()
 	if(holder2 && (holder2.network_card == src))
 		holder2.network_card = null
-	..()
+	return ..()

--- a/html/changelogs/leshana - vplk-ntnet-fixer.yml
+++ b/html/changelogs/leshana - vplk-ntnet-fixer.yml
@@ -1,0 +1,5 @@
+author: leshana
+delete-after: True
+changes: 
+  - bugfix: "NTNet Quantum Relay can be constructed/deconstructed without runtimes."
+  - bugfix: "Missing qdel hints or calls to parent in New/Initialize for NTNet items."


### PR DESCRIPTION
#### Fix NTNet Relays to be constructible/de-constructible
- Circuit boards should use type paths not strings.
- Use standard default component creation pattern.
- Fix race condition between /datum/ntnet/New and NTNet relay Initialize()
#### Fix issues with New and Destroy in NTNet
- New() on atoms needs to call parent.
- Destroy() needs to return a qdel hint.
- Only add yourself to processing in Initialize() to make sure globals are instantiated.
