### PR TITLE
Replaces needless runtime spam with a sanity check

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -68,7 +68,7 @@
 	if(QDELETED(src))
 		crash_with("GC: -- [type] had initialize() called after qdel() --")
 	if(initialized)
-		crash_with("Warning: [src]([type]) initialized multiple times!")
+		return
 	initialized = TRUE
 	return INITIALIZE_HINT_NORMAL
 


### PR DESCRIPTION
Replaces the multiple atom initialization runtime crash report with a simple sanity check.

The report in the runtime log is not really worth the trouble of choking the runtime logs with a 5 digit number of runtime errors in a matter of seconds every time someone loads up an area when just a simple sanity check can take care of the problem itself just fine.