### PR TITLE
Fixes null empty supplypack appearing in last category

### DIFF
--- a/code/controllers/Processes/supply.dm
+++ b/code/controllers/Processes/supply.dm
@@ -55,7 +55,10 @@ var/datum/controller/supply/supply_controller = new()
 
 	for(var/typepath in subtypesof(/datum/supply_pack))
 		var/datum/supply_pack/P = new typepath()
-		supply_pack[P.name] = P
+		if(P.name)
+			supply_pack[P.name] = P
+		else
+			qdel(P)
 
 /datum/controller/process/supply/setup()
 	name = "supply controller"


### PR DESCRIPTION
Nameless category supplypacks were treated same way as regular ones. Not anymore