### PR TITLE
Update and document GLOB macros

### DIFF
--- a/code/__datastructures/globals.dm
+++ b/code/__datastructures/globals.dm
@@ -1,11 +1,15 @@
-//See controllers/globals.dm
+// See also controllers/globals.dm
+
+// Creates a global initializer with a given InitValue expression, do not use outside this file
 #define GLOBAL_MANAGED(X, InitValue)\
 /datum/controller/global_vars/proc/InitGlobal##X(){\
 	##X = ##InitValue;\
 	gvars_datum_init_order += #X;\
 }
+// Creates an empty global initializer, do not use outside this file
 #define GLOBAL_UNMANAGED(X) /datum/controller/global_vars/proc/InitGlobal##X() { return; }
 
+// Prevents a given global from being VV'd
 #ifndef TESTING
 #define GLOBAL_PROTECT(X)\
 /datum/controller/global_vars/InitGlobal##X(){\
@@ -16,24 +20,42 @@
 #define GLOBAL_PROTECT(X)
 #endif
 
+// Standard BYOND global, do not use outside this file
 #define GLOBAL_REAL_VAR(X) var/global/##X
+
+// Standard typed BYOND global, do not use outside this file
 #define GLOBAL_REAL(X, Typepath) var/global##Typepath/##X
 
+// Defines a global var on the controller, do not use outside this file.
 #define GLOBAL_RAW(X) /datum/controller/global_vars/var/global##X
 
+// Create an untyped global with an initializer expression
 #define GLOBAL_VAR_INIT(X, InitValue) GLOBAL_RAW(/##X); GLOBAL_MANAGED(X, InitValue)
 
+// Create a global const var, do not use
 #define GLOBAL_VAR_CONST(X, InitValue) GLOBAL_RAW(/const/##X) = InitValue; GLOBAL_UNMANAGED(X)
 
+// Create a list global with an initializer expression
 #define GLOBAL_LIST_INIT(X, InitValue) GLOBAL_RAW(/list/##X); GLOBAL_MANAGED(X, InitValue)
 
+// Create a list global that is initialized as an empty list
 #define GLOBAL_LIST_EMPTY(X) GLOBAL_LIST_INIT(X, list())
 
+// Create a typed list global with an initializer expression
+#define GLOBAL_LIST_INIT_TYPED(X, Typepath, InitValue) GLOBAL_RAW(/list##Typepath/X); GLOBAL_MANAGED(X, InitValue)
+
+// Create a typed list global that is initialized as an empty list
+#define GLOBAL_LIST_EMPTY_TYPED(X, Typepath) GLOBAL_LIST_INIT_TYPED(X, Typepath, list())
+
+// Create a typed global with an initializer expression
 #define GLOBAL_DATUM_INIT(X, Typepath, InitValue) GLOBAL_RAW(Typepath/##X); GLOBAL_MANAGED(X, InitValue)
 
+// Create an untyped null global
 #define GLOBAL_VAR(X) GLOBAL_RAW(/##X); GLOBAL_UNMANAGED(X)
 
+// Create a null global list
 #define GLOBAL_LIST(X) GLOBAL_RAW(/list/##X); GLOBAL_UNMANAGED(X)
 
+// Create a typed null global
 #define GLOBAL_DATUM(X, Typepath) GLOBAL_RAW(Typepath/##X); GLOBAL_UNMANAGED(X)
 

--- a/code/__datastructures/globals.dm
+++ b/code/__datastructures/globals.dm
@@ -4,7 +4,7 @@
 	##X = ##InitValue;\
 	gvars_datum_init_order += #X;\
 }
-#define GLOBAL_UNMANAGED(X, InitValue) /datum/controller/global_vars/proc/InitGlobal##X()
+#define GLOBAL_UNMANAGED(X) /datum/controller/global_vars/proc/InitGlobal##X() { return; }
 
 #ifndef TESTING
 #define GLOBAL_PROTECT(X)\
@@ -23,7 +23,7 @@
 
 #define GLOBAL_VAR_INIT(X, InitValue) GLOBAL_RAW(/##X); GLOBAL_MANAGED(X, InitValue)
 
-#define GLOBAL_VAR_CONST(X, InitValue) GLOBAL_RAW(/const/##X) = InitValue; GLOBAL_UNMANAGED(X, InitValue)
+#define GLOBAL_VAR_CONST(X, InitValue) GLOBAL_RAW(/const/##X) = InitValue; GLOBAL_UNMANAGED(X)
 
 #define GLOBAL_LIST_INIT(X, InitValue) GLOBAL_RAW(/list/##X); GLOBAL_MANAGED(X, InitValue)
 
@@ -31,9 +31,9 @@
 
 #define GLOBAL_DATUM_INIT(X, Typepath, InitValue) GLOBAL_RAW(Typepath/##X); GLOBAL_MANAGED(X, InitValue)
 
-#define GLOBAL_VAR(X) GLOBAL_RAW(/##X); GLOBAL_MANAGED(X, null)
+#define GLOBAL_VAR(X) GLOBAL_RAW(/##X); GLOBAL_UNMANAGED(X)
 
-#define GLOBAL_LIST(X) GLOBAL_RAW(/list/##X); GLOBAL_MANAGED(X, null)
+#define GLOBAL_LIST(X) GLOBAL_RAW(/list/##X); GLOBAL_UNMANAGED(X)
 
-#define GLOBAL_DATUM(X, Typepath) GLOBAL_RAW(Typepath/##X); GLOBAL_MANAGED(X, null)
+#define GLOBAL_DATUM(X, Typepath) GLOBAL_RAW(Typepath/##X); GLOBAL_UNMANAGED(X)
 


### PR DESCRIPTION
Adds comments and global typed lists to GLOB macros
 * Credit to tgstation/tgstation#38893 and tgstation/tgstation#44825
 * Document what the global var declaration macros do.
 * Add macros to declare typed global lists.

Ports avoiding overwriting raw globals with null during global init.
 * From tgstation/tgstation#31882
 * Previously globals declared without an initial value would get set to null when globals are initialized.  This might be fine, but typically if  a global isn't given an initial value at declaration its because other  (probably legacy) code intends to initialize it.  That code might run  before global variable initialization, and thus be overwritten with null  when global variables initialize.

*Summary*: Only one of the changed macros is actually used anywhere.  This PR is to fix things up and add documentation in preparation for starting to really use GLOB style globals.