### PR TITLE
Lowers cost of ponchos and cloaks in loadout

### DIFF
--- a/code/modules/client/preference_setup/loadout/loadout_suit.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_suit.dm
@@ -186,6 +186,11 @@ datum/gear/suit/duster
 		ponchos[initial(poncho.name)] = poncho
 	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(ponchos))
 
+/datum/gear/suit/roles/poncho
+	display_name = "poncho, cargo"
+	path = /obj/item/clothing/accessory/poncho/roles/cargo
+	cost = 1
+
 /datum/gear/suit/roles/poncho/security
 	display_name = "poncho, security"
 	path = /obj/item/clothing/accessory/poncho/roles/security
@@ -201,10 +206,6 @@ datum/gear/suit/duster
 /datum/gear/suit/roles/poncho/science
 	display_name = "poncho, science"
 	path = /obj/item/clothing/accessory/poncho/roles/science
-
-/datum/gear/suit/roles/poncho/cargo
-	display_name = "poncho, cargo"
-	path = /obj/item/clothing/accessory/poncho/roles/cargo
 
 /datum/gear/suit/roles/poncho/cloak/hos
 	display_name = "cloak, head of security"


### PR DESCRIPTION
Lowers cost of ponchos and cloaks in loadout from 2 to 1, mostly to match price of generic poncho selection. Most of those do not have any department restriction (other than heads') and no special stats of any form either, so I don't think they should cost more just for not being part of the selection dropdown.