### PR TITLE
[Bugfix?] Bat Attack Spelling Fixy

### DIFF
--- a/code/modules/mob/living/simple_mob/subtypes/animal/space/bats.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/space/bats.dm
@@ -13,7 +13,7 @@
 	maxHealth = 20
 	health = 20
 
-	attacktext = list("bites")
+	attacktext = list("bitten")
 	attack_sound = 'sound/weapons/bite.ogg'
 
 	response_help = "pets the"


### PR DESCRIPTION
Bruh, how long had this been overlooked? Silly bats, your grammar sucks. Time to bite properly.

Changelog Notes: 

- Fixes spelling for attacktext. "Has bites" to "Has bitten"