### PR TITLE
Fixes communicator newsfeed app.

### DIFF
--- a/code/game/machinery/newscaster.dm
+++ b/code/game/machinery/newscaster.dm
@@ -15,6 +15,7 @@
 	var/backup_author = ""
 	var/icon/backup_img = null
 	var/icon/backup_caption = ""
+	var/post_time = 0
 
 /datum/feed_channel
 	var/channel_name=""
@@ -78,6 +79,7 @@
 	newMsg.body = msg
 	newMsg.time_stamp = "[stationtime2text()]"
 	newMsg.is_admin_message = adminMessage
+	newMsg.post_time = round_duration_in_ticks // Should be almost universally unique
 	if(message_type)
 		newMsg.message_type = message_type
 	if(photo)

--- a/code/game/objects/items/devices/communicator/UI.dm
+++ b/code/game/objects/items/devices/communicator/UI.dm
@@ -122,6 +122,8 @@
 	data["manifest"] = PDA_Manifest
 	data["feeds"] = compile_news()
 	data["latest_news"] = get_recent_news()
+	if(newsfeed_channel)
+		data["target_feed"] = data["feeds"][newsfeed_channel]
 	if(cartridge) // If there's a cartridge, we need to grab the information from it
 		data["cart_devices"] = cartridge.get_device_status()
 		data["cart_templates"] = cartridge.ui_templates
@@ -279,6 +281,10 @@
 	if(href_list["toggle_device"])
 		var/obj/O = cartridge.internal_devices[text2num(href_list["toggle_device"])]
 		cartridge.active_devices ^= list(O) // Exclusive or, will toggle its presence
+
+	if(href_list["newsfeed"])
+		world << "newsfeed [href_list["newsfeed"]]"
+		newsfeed_channel = text2num(href_list["newsfeed"])
 
 	if(href_list["cartridge_topic"] && cartridge) // Has to have a cartridge to perform these functions
 		cartridge.Topic(href, href_list)

--- a/code/game/objects/items/devices/communicator/UI.dm
+++ b/code/game/objects/items/devices/communicator/UI.dm
@@ -283,7 +283,6 @@
 		cartridge.active_devices ^= list(O) // Exclusive or, will toggle its presence
 
 	if(href_list["newsfeed"])
-		world << "newsfeed [href_list["newsfeed"]]"
 		newsfeed_channel = text2num(href_list["newsfeed"])
 
 	if(href_list["cartridge_topic"] && cartridge) // Has to have a cartridge to perform these functions

--- a/code/game/objects/items/devices/communicator/communicator.dm
+++ b/code/game/objects/items/devices/communicator/communicator.dm
@@ -72,6 +72,7 @@ var/global/list/obj/item/device/communicator/all_communicators = list()
 	var/datum/exonet_protocol/exonet = null
 	var/list/communicating = list()
 	var/update_ticks = 0
+	var/newsfeed_channel = 0
 
 // Proc: New()
 // Parameters: None

--- a/code/game/objects/items/devices/communicator/helper.dm
+++ b/code/game/objects/items/devices/communicator/helper.dm
@@ -46,23 +46,24 @@
 				index++
 				if(FM.img)
 					usr << browse_rsc(FM.img, "pda_news_tmp_photo_[feeds["channel"]]_[index].png")
-					// News stories are HTML-stripped but require newline replacement to be properly displayed in NanoUI
-					var/body = replacetext(FM.body, "\n", "<br>")
-					messages[++messages.len] = list(
-								"author" = FM.author,
-								"body" = body,
-								"message_type" = FM.message_type,
-								"time_stamp" = FM.time_stamp,
-								"has_image" = (FM.img != null),
-								"caption" = FM.caption,
-								"index" = index
-								)
+				// News stories are HTML-stripped but require newline replacement to be properly displayed in NanoUI
+				var/body = replacetext(FM.body, "\n", "<br>")
+				messages[++messages.len] = list(
+						"author" = FM.author,
+						"body" = body,
+						"message_type" = FM.message_type,
+						"time_stamp" = FM.time_stamp,
+						"has_image" = (FM.img != null),
+						"caption" = FM.caption,
+						"index" = index
+					)
 
 		feeds[++feeds.len] = list(
 					"name" = channel.channel_name,
 					"censored" = channel.censored,
 					"author" = channel.author,
-					"messages" = messages
+					"messages" = messages,
+					"index" = feeds.len + 1 // actually align them, since I guess the population of the list doesn't occur until after the evaluation of the new entry's contents
 					)
 	return feeds
 
@@ -85,14 +86,14 @@
 							"time_stamp" = FM.time_stamp,
 							"has_image" = (FM.img != null),
 							"caption" = FM.caption,
+							"time" = FM.post_time
 							)
 
 	// Cut out all but the youngest three
-	while(news.len > 3)
-		var/oldest = min(news[1]["time_stamp"], news[2]["time_stamp"], news[3]["time_stamp"], news[4]["time_stamp"])
-		for(var/i = 1, i <= 4, i++)
-			if(news[i]["time_stamp"] == oldest)
-				news.Remove(news[i])
+	if(news.len > 3)
+		sortByKey(news, "time")
+		news.Cut(1, news.len - 2) // Last three have largest timestamps, youngest posts
+		news.Swap(1, 3) // List is sorted in ascending order of timestamp, we want descending
 
 	return news
 

--- a/nano/templates/communicator.tmpl
+++ b/nano/templates/communicator.tmpl
@@ -195,37 +195,61 @@ Used In File(s): code\game\objects\items\devices\communicator\communicator.dm
 	<h3>News</h3>
 	<HR>
 	
-	{{if data.feeds.length}}	
-		<!--Most recent three posts -->
-		<h4>Recent News</h4>
-		<div class="statusDisplay" style="height: 250px; overflow: auto;">
-		{{for data.latest_news}}
-			<h6>{{:value.channel}}</h6>
-			-{{:value.body}}<br>
-			{{if value.has_image}}
-				<img src='pda_news_tmp_photo_{{:data.feed.channel}}_{{:value.index}}.png' width = '180'><br>
-				{{if value.caption}}
-					<span class="caption">{{:value.caption}}</span><br>
-				{{/if}}
-			{{/if}}
-			<span class="footer">
-				{{:helper.link('Go to', 'arrow', {'newsfeed' : value.channel})}}
-				[{{:value.message_type}} by <span class="average">{{:value.author}}</span> - {{:value.time_stamp}}]</span>
-			<br>
-		{{empty}}
-		{{/for}}
-		</div>
-		<HR>
-
-		<!--List all newsfeeds -->		
-		<h4>News Feeds</h4>
-		<div>
-		{{for data.feeds}}
-			<div class='itemContent'>
-				{{:helper.link(value.name, 'arrow',  {'newsfeed' : value.name})}}
+	{{if data.feeds.length}}
+		{{if data.target_feed}}
+			{{:helper.link('Back', 'arrow', {'newsfeed' : 0})}}
+			<h4>{{:data.target_feed.name}}</h4>
+			<h5>By: {{:data.target_feed.author}}</h5>
+			<div class="statusDisplay" style="overflow: auto;">
+				{{for data.target_feed.messages}}
+					-{{:value.body}}<br>
+					{{if value.has_image}}
+						<img src='pda_news_tmp_photo_{{:data.feed.channel}}_{{:value.index}}.png' width = '180'><br>
+						{{if value.caption}}
+							<span class="caption">{{:value.caption}}</span><br>
+						{{/if}}
+					{{/if}}
+					<span class="footer">
+						[{{:value.message_type}} by <span class="average">{{:value.author}}</span> - {{:value.time_stamp}}]
+					</span>
+					<br>
+				{{empty}}
+				{{/for}}
 			</div>
-		{{/for}}
-		</div>
+
+		{{else}}
+			<!--Most recent three posts -->
+			<h4>Recent News</h4>
+			<div class="statusDisplay" style="height: 250px; overflow: auto;">
+				{{for data.latest_news}}
+					<h6>{{:value.channel}}</h6>
+					-{{:value.body}}<br>
+					{{if value.has_image}}
+						<img src='pda_news_tmp_photo_{{:data.feed.channel}}_{{:value.index}}.png' width = '180'><br>
+						{{if value.caption}}
+							<span class="caption">{{:value.caption}}</span><br>
+						{{/if}}
+					{{/if}}
+					<span class="footer">
+						{{:helper.link('Go to', 'arrow', {'newsfeed' : value.channel})}}
+						[{{:value.message_type}} by <span class="average">{{:value.author}}</span> - {{:value.time_stamp}}]
+					</span>
+					<br>
+				{{empty}}
+				{{/for}}
+			</div>
+			<HR>
+
+			<!--List all newsfeeds -->		
+			<h4>News Feeds</h4>
+			<div>
+				{{for data.feeds}}
+					<div class='itemContent'>
+						{{:helper.link(value.name, 'arrow',  {'newsfeed' : value.index})}}
+					</div>
+				{{/for}}
+			</div>
+		{{/if}}
 	{{else}}
 	<!--No news feeds -->
 		<div class="item">
@@ -233,7 +257,7 @@ Used In File(s): code\game\objects\items\devices\communicator\communicator.dm
 				Error
 			</div>
 			<div class="itemContent">
-				No weather reports available. Please try again later.
+				No newsfeeds available. Please try again later.
 			</div>
 		</div>
 	{{/if}}


### PR DESCRIPTION
Fixes non-terminal while loop in get_latest_news(), helper.dm
Newscaster posts now have a world.time-esque timestamp number, so they can be (almost) uniquely identified

[Tested](https://puu.sh/Fcwj6/f3cf2edd08.mp4) (.mp4)

"Latest news" posts are now sorted, in a sensible manner that most certainly does NOT use a while loop that doesn't terminate, murdering the entire server the moment a fourth news post is made from ANY system. And the post timestamps are from the first function I found in time.dm that seemed like a good fit, because there's so many of them at this point it's basically a matter of "I choose... _this_ one."

And since the fix that caused the server-crash was reverted, this isn't really a high priority, and speaking of which, I actually need to update this branch because I pulled from master before the revert so I could verify the issue.