### PR TITLE
Added two chemical spill PoIs + More Immersive PoI Names

### DIFF
--- a/code/game/objects/items/poi_items.dm
+++ b/code/game/objects/items/poi_items.dm
@@ -3,10 +3,30 @@
 	icon = 'icons/obj/objects.dmi'
 	desc = "This is definitely something cool."
 
+/datum/category_item/catalogue/information/objects/pascalb
+	name = "Object - Pascal B Steel Shaft Cap"
+	desc = "In the year 1957, the United States of America - an Earth nation - performed a series \
+	of earth nuclear weapons tests codenamed 'Operation Plumbbob', which remain the largest and \
+	longest running nuclear test series performed on the American continent. Test data included \
+	various altitude detonations, effects on several materials and structures at various \
+	distances, and the effects of radiation on military hardware and the human body. \
+	<br><br>\
+	On the 27th of August that year, in a test named 'Pascal-B' a 300t nuclear payload \
+	was buried in a shaft capped by a 900kg steel plate cap. The test was intended to \
+	verify the safety of underground detonation, but the shaft was not sufficient to \
+	contain the shockwave. According to experiment designer Robert Brownlee, the steel \
+	cap was propelled upwards at a velocity of 240,000km/h - over six times Earth's \
+	escape velocity. The cap appeared in only one frame of high-speed camera recording. \
+	<br><br>\
+	It had been theorized that the cap had exited earth's atmosphere and entered orbit. \
+	It would seem the cap traveled farther than had been possibly imagined."
+	value = CATALOGUER_REWARD_MEDIUM
+
 /obj/item/poi/pascalb
 	icon_state = "pascalb"
 	name = "misshapen manhole cover"
 	desc = "The top of this twisted chunk of metal is faintly stamped with a five pointed star. 'Property of US Army, Pascal B - 1957'."
+	catalogue_data = list(/datum/category_item/catalogue/information/objects/pascalb)
 
 /obj/item/poi/pascalb/New()
 	START_PROCESSING(SSobj, src)
@@ -19,6 +39,25 @@
 	STOP_PROCESSING(SSobj, src)
 	return ..()
 
+/datum/category_item/catalogue/information/objects/oldreactor
+	name = "Object - 24th Century Fission Reactor Rack"
+	desc = "Prior to the discovery of Phoron in 2380, and the development of the hydrophoron \
+	supermatter reactor, most spacecraft operated on nuclear fission reactors, using processed \
+	radioactive material as fuel. While the design had been near-perfected by the 24th century, \
+	with some models capable of holding hundreds of fuel rods at one time and operating almost \
+	unsupervised for weeks at a time.\
+	<br><br>\
+	However, as accidents were not uncommon due to the inherent dangers of space travel and the \
+	nature of reactor racks such as this one fully containing the unstable fuel material, many \
+	fission vessels were built capable of jettisoning their entire engine sections as it was seen \
+	as preferable to evacuating a ship's crew and potentially losing the entire craft and its cargo. \
+	<br><br>\
+	VifGov records indicate that the colony ship ICV Kauai declared a major onboard emergency in Sif orbit \
+	on the 14th April 2353, citing major systems malfunction following a fire in the engine compartment. \
+	Due to the relatively sparse population of the planet, it was deemed safe to jettison both engine \
+	blocks, and the colonists were safely towed to port with no hands lost."
+	value = CATALOGUER_REWARD_MEDIUM
+
 /obj/structure/closet/crate/oldreactor
 	name = "fission reactor rack"
 	desc = "Used in older models of nuclear reactors, essentially a cooling rack for high volumes of radioactive material."
@@ -26,6 +65,7 @@
 	icon_state = "poireactor"
 	icon_opened = "poireactor_open"
 	icon_closed = "poireactor"
+	catalogue_data = list(/datum/category_item/catalogue/information/objects/oldreactor)
 	climbable = 0
 
 	starts_with = list(
@@ -35,6 +75,7 @@
 	icon_state = "poireactor_broken"
 	name = "ruptured fission reactor rack"
 	desc = "This broken hunk of machinery looks extremely dangerous."
+	catalogue_data = list(/datum/category_item/catalogue/information/objects/oldreactor)
 
 /obj/item/poi/brokenoldreactor/New()
 	START_PROCESSING(SSobj, src)
@@ -47,3 +88,29 @@
 	STOP_PROCESSING(SSobj, src)
 	return ..()
 
+/datum/category_item/catalogue/information/objects/growthcanister
+	name = "Object - Growth Inhibitor 78-1"
+	desc = "The production of Vatborn humans is a process which involves the synthesis of over two hundred \
+	distinct chemical compounds. While most Vatborn are 'produced' as infants and merely genetically modified \
+	to encourage rapid early maturation, the specific development of the controversial 'Expedited' Vatborn calls for \
+	a far more intensive process.\
+	<br><br>\
+	Growth Inhibitor Type 78-1 is used in the rapid artificial maturation process to prevent the 'overdevelopment' of\
+	particular cell structures in the Vatborn's body, halting the otherwise inevitable development of aggressive cancerous\
+	growths which would be detrimental or lethal to the subject. Exposure to the compound in its pure form can cause\
+	devastating damage to living tissue, ceasing all regenerative activity in an organism's cells. While immediate effects\
+	can be halted by recent medical innovations, exposure can severely shorten a sapient's life expectancy.\
+	<br><br>\
+	In early 2564, the NanoTrasen corporation was implicated in the accidental spillage of over a dozen full cargo containers\
+	of Growth Inhibitor 78-1 in the Ullran Expanse of Sif, and were charged by the Sif Environmental Agency with extreme \
+	environmental damage and neglect."
+	value = CATALOGUER_REWARD_MEDIUM
+
+/obj/structure/prop/poicanister
+	name = "Ruptured Chemical Canister"
+	desc = "A cracked open chemical canister labelled 'Growth Inhibitor 78-1'"
+	icon = 'icons/obj/atmos.dmi'
+	icon_state = "yellow-1"
+	catalogue_data = list(/datum/category_item/catalogue/information/objects/growthcanister)
+	anchored = 0
+	density = 1

--- a/code/game/turfs/simulated/water.dm
+++ b/code/game/turfs/simulated/water.dm
@@ -168,10 +168,10 @@ var/list/shoreline_icon_cache = list()
 
 turf/simulated/floor/water/contaminated/Entered(atom/movable/AM, atom/oldloc)
 	..()
-	var/mob/living/L = AM
-	if(L.isSynthetic())
-		return
-	poisonlevel *= 1 - L.get_water_protection()
-	if(poisonlevel > 0)
-		L.adjustToxLoss(poisonlevel)
-
+	if(istype(AM, /mob/living))
+		var/mob/living/L = AM
+		if(L.isSynthetic())
+			return
+		poisonlevel *= 1 - L.get_water_protection()
+		if(poisonlevel > 0)
+			L.adjustToxLoss(poisonlevel)

--- a/code/game/turfs/simulated/water.dm
+++ b/code/game/turfs/simulated/water.dm
@@ -161,3 +161,17 @@ var/list/shoreline_icon_cache = list()
 	if(L.get_water_protection() < 1)
 		return FALSE
 	return ..()
+
+/turf/simulated/floor/water/contaminated
+	desc = "This water smells pretty acrid."
+	var poisonlevel = 10
+
+turf/simulated/floor/water/contaminated/Entered(atom/movable/AM, atom/oldloc)
+	..()
+	var/mob/living/L = AM
+	if(L.isSynthetic())
+		return
+	poisonlevel *= 1 - L.get_water_protection()
+	if(poisonlevel > 0)
+		L.adjustToxLoss(poisonlevel)
+

--- a/html/changelogs/Cerebulon - ChemPoIs.yml
+++ b/html/changelogs/Cerebulon - ChemPoIs.yml
@@ -1,0 +1,38 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Cerebulon
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Added two chemical-spill themed PoIs."
+  - rscadd: "Added cataloguer info for the radioactive manhole cover and decoupled engine PoIs"
+  - tweak: "Renamed several PoIs to have more descriptive/immersive names"

--- a/maps/submaps/surface_submaps/plains/chemspill1.dmm
+++ b/maps/submaps/surface_submaps/plains/chemspill1.dmm
@@ -1,0 +1,29 @@
+"a" = (/turf/template_noop,/area/template_noop)
+"b" = (/turf/simulated/floor/outdoors/snow/sif,/area/template_noop)
+"e" = (/turf/simulated/floor/outdoors/snow/sif,/area/submap/ChemSpill1)
+"f" = (/obj/effect/decal/remains/deer,/turf/simulated/floor/outdoors/dirt/sif,/area/submap/ChemSpill1)
+"g" = (/turf/simulated/floor/outdoors/dirt/sif,/area/submap/ChemSpill1)
+"h" = (/turf/simulated/floor/outdoors/mud,/area/submap/ChemSpill1)
+"i" = (/turf/simulated/floor/water/contaminated,/area/submap/ChemSpill1)
+"j" = (/obj/structure/prop/poicanister,/turf/simulated/floor/water/contaminated,/area/submap/ChemSpill1)
+"k" = (/obj/effect/decal/remains/mouse,/turf/simulated/floor/water/contaminated,/area/submap/ChemSpill1)
+"l" = (/turf/simulated/floor/outdoors/rocks,/area/submap/ChemSpill1)
+"m" = (/obj/effect/decal/remains/ribcage,/turf/simulated/floor/outdoors/dirt/sif,/area/submap/ChemSpill1)
+"n" = (/obj/effect/decal/remains/lizard,/turf/simulated/floor/outdoors/dirt/sif,/area/submap/ChemSpill1)
+
+(1,1,1) = {"
+aaaaaaaaaaaaaa
+aaeaaaaaegeaaa
+agggeeegeggeee
+agggggggggggee
+aegfgggeggggga
+eeggllggggegga
+gggggihhggeeea
+aggghhihhggeaa
+aeeghijiihllaa
+aeelghikhgglaa
+aeellhhihmleaa
+aeeglghhheeaab
+aagngggeggggga
+aalgeegeeaggaa
+"}

--- a/maps/submaps/surface_submaps/plains/plains.dm
+++ b/maps/submaps/surface_submaps/plains/plains.dm
@@ -84,7 +84,7 @@
 	cost = 5
 
 /datum/map_template/surface/plains/normal/Rocky2
-	name =  "Rocky2"
+	name =  "Rocky 2"
 	desc = "More rocks."
 	mappath = 'maps/submaps/surface_submaps/wilderness/Rocky2.dmm'
 	allow_duplicates = TRUE
@@ -109,7 +109,7 @@
 	cost = 5
 
 /datum/map_template/surface/plains/Shakden
-	name = "Shakden"
+	name = "Shantak Den"
 	desc = "Not to be confused with Shaq Den"
 	mappath = 'maps/submaps/surface_submaps/plains/Shakden.dmm'
 	cost = 10
@@ -163,31 +163,31 @@
 	cost = 25
 
 /datum/map_template/surface/plains/snow1
-	name = "Snow1"
+	name = "Snow 1"
 	desc = "Snow"
 	mappath = 'maps/submaps/surface_submaps/plains/snow1.dmm'
 	cost = 5
 
 /datum/map_template/surface/plains/snow2
-	name = "Snow2"
+	name = "Snow 2"
 	desc = "More snow"
 	mappath = 'maps/submaps/surface_submaps/plains/snow2.dmm'
 	cost = 5
 
 /datum/map_template/surface/plains/snow3
-	name = "Snow3"
+	name = "Snow 3"
 	desc = "Snow Snow Snow"
 	mappath = 'maps/submaps/surface_submaps/plains/snow3.dmm'
 	cost = 5
 
 /datum/map_template/surface/plains/snow4
-	name = "Snow4"
+	name = "Snow 4"
 	desc = "Too much snow"
 	mappath = 'maps/submaps/surface_submaps/plains/snow4.dmm'
 	cost = 5
 
 /datum/map_template/surface/plains/snow5
-	name = "Snow5"
+	name = "Snow 5"
 	desc = "Please stop the snow"
 	mappath = 'maps/submaps/surface_submaps/plains/snow5.dmm'
 	cost = 5
@@ -199,13 +199,19 @@
 	cost = 5
 
 /datum/map_template/surface/plains/SupplyDrop2
-	name = "Supply Drop 2"
+	name = "Old Supply Drop"
 	desc = "A drop pod that's clearly been here a while, most of the things inside are rusted and worthless."
 	mappath = 'maps/submaps/surface_submaps/plains/SupplyDrop2.dmm'
 	cost = 8
 
 /datum/map_template/surface/plains/Oldhouse
-	name = "Oldhouse"
+	name = "Old House"
 	desc = "Someones old library it seems.."
 	mappath = 'maps/submaps/surface_submaps/plains/Oldhouse.dmm'
 	cost = 15
+
+/datum/map_template/surface/plains/ChemSpill1
+	name = "Ruptured Canister"
+	desc = "A dumped chemical canister. Looks dangerous."
+	mappath = 'maps/submaps/surface_submaps/plains/chemspill1.dmm'
+	cost = 10

--- a/maps/submaps/surface_submaps/plains/plains_areas.dm
+++ b/maps/submaps/surface_submaps/plains/plains_areas.dm
@@ -1,30 +1,30 @@
 /area/submap/farm1
-	name = "POI - farm"
+	name = "POI - Farm"
 
 /area/submap/construction1
-	name = "POI - construction site"
+	name = "POI - Construction Site"
 	ambience = AMBIENCE_RUINS
 
 /area/submap/camp1
-	name = "POI - camp site"
+	name = "POI - Camp Site"
 	ambience = AMBIENCE_SIF
 
 /area/submap/house1
-	name = "POI - old explorer's home"
+	name = "POI - Empty Explorer's Home"
 
 /area/submap/beacons
-	name = "POI - collection of marker beacons"
+	name = "POI - Lost Beacons"
 
 /area/submap/Epod1
-	name = "POI - Epod1"
+	name = "POI - Crashed Escape Pod"
 	ambience = AMBIENCE_FOREBODING
 
 /area/submap/Epod2
-	name = "POI - Epod2"
+	name = "POI - Wrecked Escape Pod"
 	ambience = AMBIENCE_FOREBODING
 
 /area/submap/Rocky2
-	name = "POI - Rocky2"
+	name = "POI - Horseshoe Rock"
 
 /area/submap/Peninsula
 	name = "POI - Peninsula"
@@ -34,13 +34,13 @@
 	ambience = AMBIENCE_FOREBODING
 
 /area/submap/bonfire
-	name = "POI - abandoned bonfire"
+	name = "POI - Abandoned Bonfire"
 
 /area/submap/Rocky5
-	name = "POI - Rocky5"
+	name = "POI - Rocky Outcrop"
 
 /area/submap/Shakden
-	name = "POI - Shakden"
+	name = "POI - Shantak den"
 
 /area/submap/Field1
 	name = "POI - Field 1"
@@ -50,7 +50,7 @@
 	ambience = AMBIENCE_FOREBODING
 
 /area/submap/smol2
-	name = "POI - Small 2"
+	name = "POI - Broken Lean-to"
 
 /area/submap/Mechpt
 	name = "POI - Mech Pit"
@@ -59,7 +59,7 @@
 	name = "POI - Boathouse"
 
 /area/submap/Smol3
-	name = "POI - Small 3"
+	name = "POI - Merchant's Stand"
 
 /area/submap/PooledR
 	name = "POI - Pooled Rocks"
@@ -70,32 +70,36 @@
 	ambience = AMBIENCE_SIF
 
 /area/submap/snow1
-	name = "POI - Snow1"
+	name = "Snow"
 	ambience = AMBIENCE_SIF
 
 /area/submap/snow2
-	name = "POI - Snow2"
+	name = "Snow Spot"
 	ambience = AMBIENCE_SIF
 
 /area/submap/snow3
-	name = "POI - Snow3"
+	name = "Snow Patch"
 	ambience = AMBIENCE_SIF
 
 /area/submap/snow4
-	name = "POI - Snow4"
+	name = "Snow Drift"
 	ambience = AMBIENCE_SIF
 
 /area/submap/snow5
-	name = "POI - Snow5"
+	name = "Snowy Patch"
 	ambience = AMBIENCE_SIF
 
 /area/submap/SupplyDrop2
-	name = "POI - Supply Drop 2"
+	name = "POI - Old Supply Drop"
 	ambience = AMBIENCE_TECH_RUINS
 
 /area/submap/RationCache
 	name = "POI - Ration Cache"
 
 /area/submap/Oldhouse
-	name = "POI - Oldhouse"
+	name = "POI - Old House"
 	ambience = AMBIENCE_FOREBODING
+
+/area/submap/ChemSpill1
+	name = "POI - Ruptured Canister"
+	ambience = AMBIENCE_TECH_RUINS

--- a/maps/submaps/surface_submaps/wilderness/chemspill2.dmm
+++ b/maps/submaps/surface_submaps/wilderness/chemspill2.dmm
@@ -1,0 +1,57 @@
+"a" = (/turf/template_noop,/area/template_noop)
+"b" = (/turf/simulated/floor/outdoors/dirt/sif,/area/submap/ChemSpill2)
+"c" = (/turf/simulated/floor/snow,/area/submap/ChemSpill2)
+"d" = (/turf/simulated/floor/outdoors/mud,/area/submap/ChemSpill2)
+"e" = (/turf/simulated/floor/outdoors/ice,/area/submap/ChemSpill2)
+"f" = (/turf/simulated/floor/water/contaminated,/area/submap/ChemSpill2)
+"g" = (/turf/template_noop,/area/submap/ChemSpill2)
+"h" = (/turf/simulated/floor/outdoors/rocks,/area/submap/ChemSpill1)
+"i" = (/obj/structure/prop/poicanister,/turf/simulated/floor/water/contaminated,/area/submap/ChemSpill2)
+"j" = (/turf/simulated/floor/outdoors/rocks,/area/submap/ChemSpill2)
+"k" = (/obj/random/trash,/turf/simulated/floor/outdoors/rocks,/area/submap/ChemSpill2)
+"l" = (/obj/effect/decal/remains/deer,/turf/simulated/floor/outdoors/dirt/sif,/area/submap/ChemSpill2)
+"m" = (/obj/structure/prop/poicanister,/turf/simulated/floor/outdoors/mud,/area/submap/ChemSpill2)
+"n" = (/obj/effect/decal/remains/ribcage,/turf/simulated/floor/water/contaminated,/area/submap/ChemSpill2)
+"o" = (/obj/item/stack/rods,/turf/simulated/floor/water/contaminated,/area/submap/ChemSpill2)
+"p" = (/obj/random/firstaid,/turf/simulated/floor/outdoors/dirt/sif,/area/submap/ChemSpill2)
+"q" = (/obj/random/tech_supply,/obj/random/energy,/turf/simulated/floor/outdoors/dirt/sif,/area/submap/ChemSpill2)
+"r" = (/obj/random/humanoidremains,/obj/random/rigsuit,/turf/simulated/floor/outdoors/dirt/sif,/area/submap/ChemSpill2)
+"s" = (/obj/effect/decal/remains/lizard,/turf/simulated/floor/outdoors/mud,/area/submap/ChemSpill2)
+"t" = (/obj/item/weapon/storage/mre/random,/turf/simulated/floor/outdoors/dirt/sif,/area/submap/ChemSpill2)
+"u" = (/obj/effect/decal/remains/mouse,/turf/simulated/floor/outdoors/mud,/area/submap/ChemSpill2)
+"v" = (/obj/effect/decal/cleanable/blood/oil,/turf/simulated/floor/outdoors/rocks,/area/submap/ChemSpill2)
+"w" = (/obj/effect/decal/remains/xeno,/turf/simulated/floor/outdoors/mud,/area/submap/ChemSpill2)
+"x" = (/obj/effect/decal/cleanable/blood/oil,/turf/simulated/floor/outdoors/ice,/area/submap/ChemSpill2)
+
+(1,1,1) = {"
+aaaaaaaaaaabbaaaaaaaaaaaaaaaaa
+aaaaaaaabbbbbbbbaabbbcdddbbaaa
+aaaabbbbbcddbbbbbbbccdefddbgaa
+aaaabbddddffdbddddccdefifjbgaa
+aaaabbdfffffdfdfffddddfffjbbaa
+aabbbdeffffffffffffjjkddjjbbaa
+aabbbdffffffffffffffffjdbbbbaa
+aalbcdeffdmfffffffnffjddbbbbaa
+aabbcdeffdddfffffffffjddbbbbaa
+aaaadeeefffffffffffffjjdbblbaa
+aaaddeefffffffffffffffedbbbbaa
+aabcdefffffffeefffffffedbbbbaa
+aabcddffffofbbbeebbffffdljbbaa
+abbbcdefffbbbbbbbbbbffddbbbbaa
+aabbcddfffecbbbbbbbfffdcbbbbaa
+aaaacddfffeecpbbbbbffddcbbaaaa
+aaaacdefffccbqrbbbbffsdcbaaaaa
+aaacbdffffbbbbbtbbeffddbaaaaaa
+aaacjjjfffbbbbbbbbfffddbbbaaaa
+aaabujjfffibbebbbffffddbbbaaaa
+aaabbdjfffffffbffffffdsbbbaaaa
+aaaabdvefffffffffffffddbjjaaaa
+aaaabddeeffffffffffffddjjjbaaa
+aaaabdjjjefffffffffffedbbjbaaa
+aaabbccjjddkjfffffffffdccjbaaa
+aaabbbbddccjjjwjfffddfejccbaaa
+aaaabbbbbbbbddcdddieeexjbbbaaa
+aaaablbaaabbbaaacdddddjjhaaaaa
+aaaaaaaaaaaaaaaaabccbaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+"}

--- a/maps/submaps/surface_submaps/wilderness/wilderness.dm
+++ b/maps/submaps/surface_submaps/wilderness/wilderness.dm
@@ -79,86 +79,86 @@
 	cost = 5
 
 /datum/map_template/surface/wilderness/normal/Rocky1
-	name = "Rocky1"
+	name = "Rocky 1"
 	desc = "DununanununanununuNAnana"
 	mappath = 'maps/submaps/surface_submaps/wilderness/Rocky1.dmm'
 	allow_duplicates = TRUE
 	cost = 5
 
 /datum/map_template/surface/wilderness/normal/Rocky2
-	name =  "Rocky2"
+	name =  "Rocky 2"
 	desc = "More rocks."
 	mappath = 'maps/submaps/surface_submaps/wilderness/Rocky2.dmm'
 	allow_duplicates = TRUE
 	cost = 5
 
 /datum/map_template/surface/wilderness/normal/Rocky3
-	name = "Rocky3"
+	name = "Rocky 3"
 	desc = "More and more and more rocks."
 	mappath = 'maps/submaps/surface_submaps/wilderness/Rocky3.dmm'
 	desc = "DununanununanununuNAnana"
 	cost = 5
 
 /datum/map_template/surface/wilderness/normal/Shack1
-	name = "Shack1"
+	name = "Shack 1"
 	desc = "A small shack in the middle of nowhere, Your halloween murder happens here"
 	mappath = 'maps/submaps/surface_submaps/wilderness/Shack1.dmm'
 	cost = 5
 
 /datum/map_template/surface/wilderness/normal/Smol1
-	name = "Smol1"
+	name = "Smol 1"
 	desc = "A tiny grove of trees, The Nemesis of thicc"
 	mappath = 'maps/submaps/surface_submaps/wilderness/Smol1.dmm'
 	cost = 5
 
 /datum/map_template/surface/wilderness/normal/Snowrock1
-	name = "Snowrock1"
+	name = "Snowrock 1"
 	desc = "A rocky snow covered area"
 	mappath = 'maps/submaps/surface_submaps/wilderness/Snowrock1.dmm'
 	cost = 5
 
 /datum/map_template/surface/wilderness/normal/Cragzone1
-	name = "Cragzone1"
+	name = "Cragzone 1"
 	desc = "Rocks and more rocks."
 	mappath = 'maps/submaps/surface_submaps/wilderness/Cragzone1.dmm'
 	cost = 5
 	allow_duplicates = TRUE
 
 /datum/map_template/surface/wilderness/normal/Lab1
-	name = "Lab1"
+	name = "Lab 1"
 	desc = "An isolated small robotics lab."
 	mappath = 'maps/submaps/surface_submaps/wilderness/Lab1.dmm'
 	cost = 5
 
 /datum/map_template/surface/wilderness/normal/Rocky4
-	name = "Rocky4"
+	name = "Rocky 4"
 	desc = "An interesting geographic formation."
 	mappath = 'maps/submaps/surface_submaps/wilderness/Rocky4.dmm'
 	cost = 5
 
 /datum/map_template/surface/wilderness/deep/DJOutpost1
-	name = "DJOutpost1"
+	name = "DJOutpost 1"
 	desc = "Home of Sif Free Radio, the best - and only - radio station for miles around."
 	mappath = 'maps/submaps/surface_submaps/wilderness/DJOutpost1.dmm'
 	template_group = "Sif Free Radio"
 	cost = 5
 
 /datum/map_template/surface/wilderness/deep/DJOutpost2
-	name = "DJOutpost2"
+	name = "DJOutpost 2"
 	desc = "The cratered remains of Sif Free Radio, the best - and only - radio station for miles around."
 	mappath = 'maps/submaps/surface_submaps/wilderness/DJOutpost2.dmm'
 	template_group = "Sif Free Radio"
 	cost = 5
 
 /datum/map_template/surface/wilderness/deep/DJOutpost3
-	name = "DJOutpost3"
+	name = "DJOutpost 3"
 	desc = "The surprisingly high-tech home of Sif Free Radio, the best - and only - radio station for miles around."
 	mappath = 'maps/submaps/surface_submaps/wilderness/DJOutpost3.dmm'
 	template_group = "Sif Free Radio"
 	cost = 10
 
 /datum/map_template/surface/wilderness/deep/DJOutpost4
-	name = "DJOutpost4"
+	name = "DJOutpost 4"
 	desc = "The surprisingly high-tech home of Sif Free Radio, the only radio station run by mindless clones."
 	mappath = 'maps/submaps/surface_submaps/wilderness/DJOutpost4.dmm'
 	template_group = "Sif Free Radio"
@@ -221,7 +221,7 @@
 	cost = 20
 
 /datum/map_template/surface/wilderness/normal/Drugden
-	name = "Drugden"
+	name = "Drug Den"
 	desc = "The remains of ill thought out whims."
 	mappath = 'maps/submaps/surface_submaps/wilderness/Drugden.dmm'
 	cost = 20
@@ -233,7 +233,7 @@
 	cost = 10
 
 /datum/map_template/surface/wilderness/deep/Manor1
-	name = "Manor1"
+	name = "Manor 1"
 	desc = "Whodunit"
 	mappath = 'maps/submaps/surface_submaps/wilderness/Manor1.dmm'
 	cost = 20
@@ -257,13 +257,19 @@
 	cost = 5
 
 /datum/map_template/surface/wilderness/deep/Chapel1
-	name = "Chapel1"
+	name = "Chapel 1"
 	desc = "The chapel of lights and a robot."
 	mappath = 'maps/submaps/surface_submaps/wilderness/Chapel.dmm'
 	cost = 20
 
 /datum/map_template/surface/wilderness/normal/Shelter1
-	name = "Shelter1"
+	name = "Shelter 1"
 	desc = "The remains of a resourceful, but prideful explorer."
 	mappath = 'maps/submaps/surface_submaps/wilderness/Shelter.dmm'
+	cost = 10
+
+/datum/map_template/surface/wilderness/normal/ChemSpill2
+	name = "Acrid Lake"
+	desc = "A pool of water contaminated with highly dangerous chemicals."
+	mappath = 'maps/submaps/surface_submaps/wilderness/chemspill2.dmm'
 	cost = 10

--- a/maps/submaps/surface_submaps/wilderness/wilderness_areas.dm
+++ b/maps/submaps/surface_submaps/wilderness/wilderness_areas.dm
@@ -9,19 +9,19 @@
 	requires_power = FALSE
 
 /area/submap/spider1
-	name = "POI - spider nest"
+	name = "POI - Spider Nest"
 	ambience = AMBIENCE_FOREBODING
 
 /area/submap/Field1
-	name = "POI - Field 1"
+	name = "POI - Field"
 	ambience = AMBIENCE_SIF
 
 /area/submap/Lake1
-	name = "POI - Lake 1"
+	name = "POI - Lake"
 	ambience = AMBIENCE_SIF
 
 /area/submap/MilitaryCamp1
-	name = "POI - Military Camp 1"
+	name = "POI - Military Camp"
 	ambience = AMBIENCE_HIGHSEC
 
 /area/submap/Mudpit
@@ -29,56 +29,56 @@
 	ambience = AMBIENCE_SIF
 
 /area/submap/Rocky1
-	name = "POI - Rocky1"
+	name = "POI - Rocky Demise"
 	ambience = AMBIENCE_SIF
 
 /area/submap/Rocky2
-	name = "POI - Rocky2"
+	name = "Rocky Crevice"
 	ambience = AMBIENCE_SIF
 
 /area/submap/Rocky3
-	name = "POI - Rocky3"
+	name = "Rocky Valley"
 	ambience = AMBIENCE_SIF
 
 /area/submap/Shack1
-	name = "POI - Shack1"
+	name = "POI - Shack"
 	ambience = AMBIENCE_RUINS
 
 /area/submap/Small1
-	name = "POI - Small1"
+	name = "Snowy Thicket"
 	ambience = AMBIENCE_SIF
 
 /area/submap/SnowR1
-	name = "POI - SnowR1"
+	name = "POI - Rocky Overhang"
 	ambience = AMBIENCE_SIF
 
 /area/submap/BoomBase
-	name = "POI - Boom1"
+	name = "POI - Lab Crater"
 	ambience = AMBIENCE_FOREBODING
 
 /area/submap/Blackshuttledown
-	name = "POI - BSD"
+	name = "POI - Black-Operative Shuttle"
 	requires_power = FALSE
 	ambience = AMBIENCE_HIGHSEC
 
 /area/submap/Cragzone1
-	name = "POI - Craggy1"
+	name = "Craggy Area"
 	ambience = AMBIENCE_SIF
 
 /area/submap/Lab1
-	name = "POI - Lab1"
+	name = "POI - Remote Lab"
 	ambience = AMBIENCE_RUINS
 
 /area/submap/Rocky4
-	name = "POI - Rocky4"
+	name = "Rocky Pond"
 	ambience = AMBIENCE_SIF
 
 /area/submap/DJOutpost1
-	name = "POI - DJOutpost1"
+	name = "POI - Radio Outpost"
 	ambience = AMBIENCE_TECH_RUINS
 
 /area/submap/DJOutpost2
-	name = "POI - DJOutpost2"
+	name = "POI - Abandoned Radio Outpost"
 	ambience = AMBIENCE_GHOSTLY
 
 /area/submap/MHR
@@ -86,43 +86,43 @@
 	ambience = AMBIENCE_FOREBODING
 
 /area/submap/Rockybase
-	name = "POI - Rockybase"
+	name = "POI - Rocky Base"
 	ambience = AMBIENCE_HIGHSEC
 
 /area/submap/GovPatrol
-	name = "POI - GovPatrol"
+	name = "POI - Lost Government Patrol"
 	ambience = AMBIENCE_GHOSTLY
 
 /area/submap/DecoupledEngine
-	name = "POI - DecoupledEngine"
+	name = "POI - Decoupled Engine"
 	ambience = AMBIENCE_FOREBODING
 
 /area/submap/DoomP
-	name = "POI - DoomP"
+	name = "POI - Fortified Base"
 	ambience = AMBIENCE_HIGHSEC
 
 /area/submap/CaveS
-	name = "POI - CaveS"
+	name = "POI - Spider Cave"
 	ambience = AMBIENCE_FOREBODING
 
 /area/submap/Drugd
-	name = "POI - DrugDen"
+	name = "POI - Drug Den"
 	ambience = AMBIENCE_FOREBODING
 
 /area/submap/Manor1
-	name = "POI - Manor1"
+	name = "POI - Manor House"
 	ambience = AMBIENCE_FOREBODING
 
 /area/submap/Epod3
-	name = "POI - Epod3"
+	name = "POI - Infested Escape Pod"
 	ambience = AMBIENCE_FOREBODING
 
 /area/submap/Epod4
-	name = "POI - Epod4"
+	name = "POI - Flooded Escape Pod"
 	ambience = AMBIENCE_FOREBODING
 
 /area/submap/ButcherShack
-	name = "POI - ButcherShack"
+	name = "POI - Butcher's Shack"
 	ambience = AMBIENCE_RUINS
 
 /area/submap/Chapel1
@@ -132,3 +132,7 @@
 /area/submap/Shelter1
 	name = "POI - Raided Shelter"
 	ambience = AMBIENCE_GHOSTLY
+
+/area/submap/ChemSpill2
+	name = "POI - Acrid Lake"
+	ambience = AMBIENCE_FOREBODING


### PR DESCRIPTION
Added two PoIs based on the recent chemical spill events:

Ruptured Canister
- Plains
- No loot
- Can be scanned for cataloguer points
- Mildly dangerous

Acrid Lake
- Wilderness
- Contains several canisters
- Random medkit, energy weapon and rigsuit
- Moderately dangerous

Also:
- Added cataloguer info for the Pascal-b and Decoupled Engine PoIs
- Renamed the 'front facing' names of many PoIs to be more descriptive, or at least not be numbered (e.g. "PoI - Epod1" is now "PoI - Crashed Escape Pod").
- Filler PoIs like snow patches with no notable features are no longer listed as "PoI - X" because they're literally nothing.