### PR TITLE
Fix and tweak station Railguns.

### DIFF
--- a/code/datums/supplypacks/munitions.dm
+++ b/code/datums/supplypacks/munitions.dm
@@ -168,6 +168,14 @@
 	containername = "Magnetic weapon crate"
 	access = access_security
 
+/datum/supply_pack/munitions/mshells
+	name = "Weapons - Magnetic Shells"
+	contains = list(/obj/item/weapon/magnetic_ammo = 3)
+	cost = 100
+	containertype = /obj/structure/closet/crate/secure/weapon
+	containername = "Magnetic ammunition crate"
+	access = access_security
+
 /datum/supply_pack/munitions/shotgunammo
 	name = "Ammunition - Shotgun shells"
 	contains = list(

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -160,6 +160,7 @@
 		/obj/item/weapon/melee/baton,
 		/obj/item/weapon/gun/energy/taser,
 		/obj/item/weapon/gun/energy/stunrevolver,
+		/obj/item/weapon/gun/magnetic/railgun/heater/pistol,
 		/obj/item/weapon/gun/energy/gun,
 		/obj/item/weapon/flame/lighter,
 		/obj/item/device/flashlight,

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -110,6 +110,7 @@
 		/obj/item/device/flash,
 		/obj/item/weapon/melee/baton/loaded,
 		/obj/item/weapon/gun/magnetic/railgun/heater/pistol/hos,
+		/obj/item/weapon/rcd_ammo/large,
 		/obj/item/weapon/cell/device/weapon,
 		/obj/item/clothing/accessory/holster/waist,
 		/obj/item/weapon/melee/telebaton,

--- a/code/modules/projectiles/guns/magnetic/magnetic_railgun.dm
+++ b/code/modules/projectiles/guns/magnetic/magnetic_railgun.dm
@@ -119,7 +119,7 @@
 
 	removable_components = TRUE
 
-	initial_cell_type = /obj/item/weapon/cell/high
+	initial_cell_type = /obj/item/weapon/cell/device/weapon
 	initial_capacitor_type = /obj/item/weapon/stock_parts/capacitor
 
 	fire_delay = 8
@@ -127,7 +127,7 @@
 	slot_flags = SLOT_BACK
 
 	slowdown = 0
-	slowdown_held = 0
+	slowdown_held = 0.3
 	slowdown_worn = 0
 
 	power_cost = 400
@@ -150,14 +150,16 @@
 
 	w_class = ITEMSIZE_NORMAL
 
-	initial_cell_type = /obj/item/weapon/cell/high
+	slowdown_held = 0
+
+	initial_cell_type = /obj/item/weapon/cell/device/weapon
 	initial_capacitor_type = /obj/item/weapon/stock_parts/capacitor
 
 	slot_flags = SLOT_BELT|SLOT_HOLSTER
 
 	firemodes = list(
-		list(mode_name="lethal", power_cost = 2000, projectile_type = /obj/item/projectile/bullet/magnetic/heated, burst=1, fire_delay=8, move_delay=null, one_handed_penalty=0),
-		list(mode_name="stun", power_cost = 1500, projectile_type = /obj/item/projectile/energy/electrode/stunshot, burst=1, fire_delay=5, move_delay=null, one_handed_penalty=0),
+		list(mode_name="lethal", power_cost = 500, projectile_type = /obj/item/projectile/bullet/magnetic/heated, burst=1, fire_delay=10, move_delay=null, one_handed_penalty=0),
+		list(mode_name="stun", power_cost = 350, projectile_type = /obj/item/projectile/energy/electrode/stunshot, burst=1, fire_delay=7, move_delay=null, one_handed_penalty=0),
 		)
 
 /obj/item/weapon/gun/magnetic/railgun/heater/pistol/hos
@@ -168,8 +170,8 @@
 	description_antag = "This weapon starts with a DNA locking chip attached. Using an EMAG on the weapon will disarm it, and allow you to use the chip as your own."
 
 	firemodes = list(
-		list(mode_name="lethal", power_cost = 1500, projectile_type = /obj/item/projectile/bullet/magnetic/heated, burst=1, fire_delay=8, move_delay=null, one_handed_penalty=0),
-		list(mode_name="stun", power_cost = 1200, projectile_type = /obj/item/projectile/energy/electrode/stunshot, burst=1, fire_delay=5, move_delay=null, one_handed_penalty=0),
+		list(mode_name="lethal", power_cost = 400, projectile_type = /obj/item/projectile/bullet/magnetic/heated, burst=1, fire_delay=8, move_delay=null, one_handed_penalty=0),
+		list(mode_name="stun", power_cost = 300, projectile_type = /obj/item/projectile/energy/electrode/stunshot, burst=1, fire_delay=5, move_delay=null, one_handed_penalty=0),
 		)
 
 /obj/item/weapon/gun/magnetic/railgun/flechette/sif
@@ -184,9 +186,9 @@
 
 	slot_flags = SLOT_BACK
 
-	slowdown = 0.3
+	slowdown_held = 0.3
 
-	power_cost = 200
+	power_cost = 300
 	projectile_type = /obj/item/projectile/bullet/magnetic/flechette/hunting
 	empty_sound = 'sound/weapons/smg_empty_alarm.ogg'
 

--- a/code/modules/research/designs/weapons.dm
+++ b/code/modules/research/designs/weapons.dm
@@ -204,6 +204,13 @@
 	build_path = /obj/item/ammo_casing/chemdart
 	sort_string = "MADBD"
 
+/datum/design/item/weapon/ammo/flechette
+	id = "magnetic_ammo"
+	req_tech = list(TECH_COMBAT = 4, TECH_MATERIAL = 4, TECH_MAGNET = 4)
+	materials = list(DEFAULT_WALL_MATERIAL = 500, "gold" = 300, "glass" = 150, MAT_PHORON = 100)
+	build_path = /obj/item/weapon/magnetic_ammo
+	sort_string = "MADBE"
+
 // Melee weapons
 
 /datum/design/item/weapon/melee/AssembleDesignName()


### PR DESCRIPTION
Makes railguns actually a viable option, and the HoS able to use their shiny pistol.

Heater pistols now fit in security belts, like their energy cousins.

Flechette ammo can now be ordered, and produced from R&D.

Certain railguns use held slowdown instead of worn slowdown again, so it's easier to carry them when they are stowed.