### PR TITLE
Fixes custom table placement

### DIFF
--- a/code/modules/tables/interactions.dm
+++ b/code/modules/tables/interactions.dm
@@ -66,13 +66,11 @@
 		return ..()
 	if(isrobot(user))
 		return
-	user.drop_item()
-	if (O.loc != src.loc)
-		step(O, get_dir(O, src))
+	user.unEquip(O, 0, src.loc)
 	return
 
 
-/obj/structure/table/attackby(obj/item/W as obj, mob/user as mob, var/click_parameters)
+/obj/structure/table/attackby(obj/item/W as obj, mob/user as mob, var/hit_modifier, var/click_parameters)
 	if (!W) return
 
 	// Handle harm intent grabbing/tabling.


### PR DESCRIPTION
Because if you're going to add a new parameter to a widely-used existing proc, you'd best be sure you're using it correctly. And not trying to stuff your new data into the wrong argument.

Also modernizes mouse-drop onto table because I noticed the code was ugly.

![tested](https://puu.sh/FdJAE/9a8c585beb.png)
Wrenches remain bound to the middle until someone adds the click_parameters stuff to mousedrop