### PR TITLE
Fix Sundry Runtime Errors

### DIFF
--- a/code/ATMOSPHERICS/components/omni_devices/filter.dm
+++ b/code/ATMOSPHERICS/components/omni_devices/filter.dm
@@ -88,7 +88,7 @@
 	return 1
 
 /obj/machinery/atmospherics/omni/atmos_filter/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1)
-	usr.set_machine(src)
+	user.set_machine(src)
 
 	var/list/data = new()
 

--- a/code/datums/wires/wires.dm
+++ b/code/datums/wires/wires.dm
@@ -117,7 +117,7 @@ var/list/wireColours = list("red", "blue", "green", "darkred", "orange", "brown"
 			var/obj/item/I = L.get_active_hand()
 			holder.add_hiddenprint(L)
 			if(href_list["cut"]) // Toggles the cut/mend status
-				if(I.is_wirecutter())
+				if(I?.is_wirecutter())
 					var/colour = href_list["cut"]
 					CutWireColour(colour)
 					playsound(holder, I.usesound, 20, 1)

--- a/code/modules/client/preference_setup/loadout/loadout.dm
+++ b/code/modules/client/preference_setup/loadout/loadout.dm
@@ -257,12 +257,12 @@ var/list/gear_datums = list()
 
 /datum/gear/proc/spawn_item(var/location, var/metadata)
 	var/datum/gear_data/gd = new(path, location)
-	for(var/datum/gear_tweak/gt in gear_tweaks)
-		if(gear_tweaks.len)
+	if(length(gear_tweaks) && metadata)
+		for(var/datum/gear_tweak/gt in gear_tweaks)
 			gt.tweak_gear_data(metadata["[gt]"], gd)
 	var/item = new gd.path(gd.location)
-	for(var/datum/gear_tweak/gt in gear_tweaks)
-		if(gear_tweaks.len)
+	if(length(gear_tweaks) && metadata)
+		for(var/datum/gear_tweak/gt in gear_tweaks)
 			gt.tweak_item(item, metadata["[gt]"])
 	var/mob/M = location
 	if(istype(M) && exploitable) //Update exploitable info records for the mob without creating a duplicate object at their feet.

--- a/code/modules/hydroponics/seed.dm
+++ b/code/modules/hydroponics/seed.dm
@@ -98,7 +98,7 @@
 		return
 
 	var/datum/reagents/R = new/datum/reagents(100)
-	if(chems.len)
+	if(chems && chems.len)
 		for(var/rid in chems)
 			var/injecting = min(5,max(1,get_trait(TRAIT_POTENCY)/3))
 			R.add_reagent(rid,injecting)
@@ -192,7 +192,7 @@
 			if(!flesh_colour) flesh_colour = get_trait(TRAIT_PRODUCT_COLOUR)
 			if(flesh_colour) splat.color = get_trait(TRAIT_PRODUCT_COLOUR)
 
-	if(chems)
+	if(chems && chems.len)
 		for(var/mob/living/M in T.contents)
 			if(!M.reagents)
 				continue

--- a/code/modules/xenoarcheaology/finds/find_spawning.dm
+++ b/code/modules/xenoarcheaology/finds/find_spawning.dm
@@ -36,7 +36,7 @@
 			item_type = "bowl"
 			if(prob(33))
 				new_item = new /obj/item/weapon/reagent_containers/glass/replenishing(src.loc)
-				new_item.origin_tech[TECH_ARCANE] = 1
+				LAZYSET(new_item.origin_tech, TECH_ARCANE, 1)
 			else
 				new_item = new /obj/item/weapon/reagent_containers/glass/beaker(src.loc)
 			new_item.icon = 'icons/obj/xenoarchaeology.dmi'
@@ -50,7 +50,7 @@
 			item_type = "urn"
 			if(prob(33))
 				new_item = new /obj/item/weapon/reagent_containers/glass/replenishing(src.loc)
-				new_item.origin_tech[TECH_ARCANE] = 1
+				LAZYSET(new_item.origin_tech, TECH_ARCANE, 1)
 			else
 				new_item = new /obj/item/weapon/reagent_containers/glass/beaker(src.loc)
 			new_item.icon = 'icons/obj/xenoarchaeology.dmi'
@@ -67,7 +67,7 @@
 			else
 				new_item = new /obj/item/weapon/material/kitchen/utensil/spoon(src.loc)
 			if(prob(60))
-				new_item.origin_tech[TECH_ARCANE] = 1
+				LAZYSET(new_item.origin_tech, TECH_ARCANE, 1)
 			additional_desc = "[pick("It's like no [item_type] you've ever seen before",\
 			"It's a mystery how anyone is supposed to eat with this",\
 			"You wonder what the creator's mouth was shaped like")]."
@@ -81,7 +81,7 @@
 			[pick("performing unspeakable acts","posing heroically","in a fetal position","cheering","sobbing","making a plaintive gesture","making a rude gesture")]."
 			if(prob(25))
 				new_item = new /obj/item/weapon/vampiric(src.loc)
-				new_item.origin_tech[TECH_ARCANE] = 1
+				LAZYSET(new_item.origin_tech, TECH_ARCANE, 1)
 		if(5)
 			name = "instrument"
 			icon = 'icons/obj/xenoarchaeology.dmi'
@@ -141,7 +141,7 @@
 			var/storage_amount = 2**(new_box.max_w_class-1)
 			new_box.max_storage_space = rand(storage_amount, storage_amount * 10)
 			if(prob(30))
-				new_item.origin_tech[TECH_ARCANE] = 1
+				LAZYSET(new_item.origin_tech, TECH_ARCANE, 1)
 				apply_image_decorations = 1
 		if(12)
 			item_type = "[pick("cylinder","tank","chamber")]"
@@ -192,7 +192,7 @@
 			if(prob(30))
 				icon = 'icons/obj/xenoarchaeology.dmi'
 				icon_state = "pen1"
-				new_item.origin_tech[TECH_ARCANE] = 1
+				LAZYSET(new_item.origin_tech, TECH_ARCANE, 1)
 				apply_image_decorations = 1
 		if(16)
 			apply_prefix = 0
@@ -217,7 +217,7 @@
 				new_item = new /obj/item/device/soulstone(src.loc)
 				new_item.icon = 'icons/obj/xenoarchaeology.dmi'
 				new_item.icon_state = icon_state
-				new_item.origin_tech[TECH_ARCANE] = 2
+				LAZYSET(new_item.origin_tech, TECH_ARCANE, 2)
 		if(17)
 			//cultblade
 			apply_prefix = 0
@@ -248,14 +248,14 @@
 
 			var/new_type = pick(possible_spawns)
 			new_item = new new_type(src.loc)
-			new_item.origin_tech[TECH_ARCANE] = 1
+			LAZYSET(new_item.origin_tech, TECH_ARCANE, 1)
 		if(21)
 			//soulstone
 			apply_prefix = 0
 			new_item = new /obj/item/device/soulstone(src.loc)
 			item_type = new_item.name
 			apply_material_decorations = 0
-			new_item.origin_tech[TECH_ARCANE] = 2
+			LAZYSET(new_item.origin_tech, TECH_ARCANE, 2)
 		if(22)
 			if(prob(50))
 				new_item = new /obj/item/weapon/material/shard(src.loc)
@@ -303,10 +303,10 @@
 					new_gun.power_supply.rigged = 1
 				if(prob(10))
 					new_gun.power_supply.maxcharge = 0
-					new_gun.origin_tech[TECH_ARCANE] = rand(0, 1)
+					LAZYSET(new_gun.origin_tech, TECH_ARCANE, rand(0, 1))
 				if(prob(15))
 					new_gun.power_supply.charge = rand(0, new_gun.power_supply.maxcharge)
-					new_gun.origin_tech[TECH_ARCANE] = 1
+					LAZYSET(new_gun.origin_tech, TECH_ARCANE, 1)
 				else
 					new_gun.power_supply.charge = 0
 
@@ -431,7 +431,7 @@
 			//gas mask
 			if(prob(25))
 				new_item = new /obj/item/clothing/mask/gas/poltergeist(src.loc)
-				new_item.origin_tech[TECH_ARCANE] = 1
+				LAZYSET(new_item.origin_tech, TECH_ARCANE, 1)
 			else
 				new_item = new /obj/item/clothing/mask/gas(src.loc)
 			if(prob(40))
@@ -465,14 +465,14 @@
 
 			var/new_type = pick(alien_stuff)
 			new_item = new new_type(src.loc)
-			new_item.origin_tech[TECH_ARCANE] = 2
-			new_item.origin_tech[TECH_PRECURSOR] = 1
+			LAZYSET(new_item.origin_tech, TECH_ARCANE, 2)
+			LAZYSET(new_item.origin_tech, TECH_PRECURSOR, 1)
 			item_type = new_item.name
 
 		if(37)
 			// Alien boats.
 			apply_prefix = FALSE
-			var/new_boat_mat = pickweight(
+			var/new_boat_mat = pickweight(list(
 				MAT_WOOD = 100,
 				MAT_SIFWOOD = 200,
 				DEFAULT_WALL_MATERIAL = 60,
@@ -489,7 +489,7 @@
 				MAT_DURASTEEL = 2,
 				MAT_MORPHIUM = 2,
 				MAT_SUPERMATTER = 1
-				)
+				))
 			var/list/alien_stuff = list(
 				/obj/vehicle/boat,
 				/obj/vehicle/boat/dragon
@@ -522,7 +522,7 @@
 			new_item = new /obj/item/weapon/telecube/randomized(src.loc)
 
 	if(istype(new_item, /obj/item/weapon/material))
-		var/new_item_mat = pickweight(
+		var/new_item_mat = pickweight(list(
 			DEFAULT_WALL_MATERIAL = 80,
 			MAT_WOOD = 20,
 			MAT_SIFWOOD = 40,
@@ -539,7 +539,7 @@
 			MAT_DURASTEEL = 2,
 			MAT_MORPHIUM = 2,
 			MAT_SUPERMATTER = 1
-			)
+			))
 		var/obj/item/weapon/material/MW = new_item
 		MW.applies_material_colour = TRUE
 		MW.set_material(new_item_mat)
@@ -612,8 +612,8 @@
 
 		if(talkative)
 			new_item.talking_atom = new(new_item)
-			new_item.origin_tech[TECH_ARCANE] = 1
-			new_item.origin_tech[TECH_PRECURSOR] = 1
+			LAZYSET(new_item.origin_tech, TECH_ARCANE, 1)
+			LAZYSET(new_item.origin_tech, TECH_PRECURSOR, 1)
 
 		var/turf/simulated/mineral/T = get_turf(new_item)
 		if(istype(T))
@@ -623,5 +623,5 @@
 
 	else if(talkative)
 		src.talking_atom = new(src)
-		new_item.origin_tech[TECH_ARCANE] = 1
-		new_item.origin_tech[TECH_PRECURSOR] = 1
+		LAZYSET(new_item.origin_tech, TECH_ARCANE, 1)
+		LAZYSET(new_item.origin_tech, TECH_PRECURSOR, 1)


### PR DESCRIPTION
* **Fix Runtime in seed.dm,102: Cannot read null.len**
	* Gotta check if the list is non-null before checking length! Tested by spawning plants.
* **Fix Runtime in filter.dm,91: Cannot execute null.set machine()**
	* Use `user` not `usr`.  Tested by spawning the machine, opening nanoui and walking away.
* **Fix Runtime in wires.dm,120: Cannot execute null.is wirecutter().**
	* You can click "Cut" with an empty hand!  Tested by doing that.
* **Fix Runtime in loadout.dm,277: bad index**
	* Runtime happens when someone has a saved preferences loadout containing an item that currently is expected to have gear_tweaks, but at the time that the savefile was last saved, did *not* have gear tweaks.  Thus the saved prefs have null metadata.
	* Also it makes no sense to check the length of a list *inside* a for loop iterating over that list..
	* Tested by manually setting up the situation with VV and then loading/saving/spawning.
* **Fix bad index and bad arg name runtimes in find_spawning.dm**
	* Code was assuming that item.origin_tech would be an initialized list. To be safe we use LAZYSET so it will work properly even if its null.
	* Other code was calling pickweight and passing it the options as named arguments.  They are supposed to be passed as a list.
	* Tested by spawning the /obj/item/weapon/archaeological_find and fixing things until runtimes stopped.
