### PR TITLE
Fixes various lightning strike bugs

### DIFF
--- a/code/controllers/subsystems/planets.dm
+++ b/code/controllers/subsystems/planets.dm
@@ -24,7 +24,7 @@ SUBSYSTEM_DEF(planets)
 	..()
 
 /datum/controller/subsystem/planets/proc/createPlanets()
-	var/list/planet_datums = subtypesof(/datum/planet)
+	var/list/planet_datums = using_map.planet_datums_to_make
 	for(var/P in planet_datums)
 		var/datum/planet/NP = new P()
 		planets.Add(NP)

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -638,13 +638,14 @@
 		return
 
 	var/datum/planet/planet = input(usr, "Which planet do you want to modify the weather on?", "Change Weather") in SSplanets.planets
-	var/datum/weather/new_weather = input(usr, "What weather do you want to change to?", "Change Weather") as null|anything in planet.weather_holder.allowed_weather_types
-	if(new_weather)
-		planet.weather_holder.change_weather(new_weather)
-		planet.weather_holder.rebuild_forecast()
-		var/log = "[key_name(src)] changed [planet.name]'s weather to [new_weather]."
-		message_admins(log)
-		log_admin(log)
+	if(istype(planet))
+		var/datum/weather/new_weather = input(usr, "What weather do you want to change to?", "Change Weather") as null|anything in planet.weather_holder.allowed_weather_types
+		if(new_weather)
+			planet.weather_holder.change_weather(new_weather)
+			planet.weather_holder.rebuild_forecast()
+			var/log = "[key_name(src)] changed [planet.name]'s weather to [new_weather]."
+			message_admins(log)
+			log_admin(log)
 
 /datum/admins/proc/change_time()
 	set category = "Debug"
@@ -655,20 +656,20 @@
 		return
 
 	var/datum/planet/planet = input(usr, "Which planet do you want to modify time on?", "Change Time") in SSplanets.planets
+	if(istype(planet))
+		var/datum/time/current_time_datum = planet.current_time
+		var/new_hour = input(usr, "What hour do you want to change to?", "Change Time", text2num(current_time_datum.show_time("hh"))) as null|num
+		if(!isnull(new_hour))
+			var/new_minute = input(usr, "What minute do you want to change to?", "Change Time", text2num(current_time_datum.show_time("mm")) ) as null|num
+			if(!isnull(new_minute))
+				var/type_needed = current_time_datum.type
+				var/datum/time/new_time = new type_needed()
+				new_time = new_time.add_hours(new_hour)
+				new_time = new_time.add_minutes(new_minute)
+				planet.current_time = new_time
+				spawn(1)
+					planet.update_sun()
 
-	var/datum/time/current_time_datum = planet.current_time
-	var/new_hour = input(usr, "What hour do you want to change to?", "Change Time", text2num(current_time_datum.show_time("hh"))) as null|num
-	if(!isnull(new_hour))
-		var/new_minute = input(usr, "What minute do you want to change to?", "Change Time", text2num(current_time_datum.show_time("mm")) ) as null|num
-		if(!isnull(new_minute))
-			var/type_needed = current_time_datum.type
-			var/datum/time/new_time = new type_needed()
-			new_time = new_time.add_hours(new_hour)
-			new_time = new_time.add_minutes(new_minute)
-			planet.current_time = new_time
-			spawn(1)
-				planet.update_sun()
-
-			var/log = "[key_name(src)] changed [planet.name]'s time to [planet.current_time.show_time("hh:mm")]."
-			message_admins(log)
-			log_admin(log)
+				var/log = "[key_name(src)] changed [planet.name]'s time to [planet.current_time.show_time("hh:mm")]."
+				message_admins(log)
+				log_admin(log)

--- a/code/modules/admin/verbs/lightning_strike.dm
+++ b/code/modules/admin/verbs/lightning_strike.dm
@@ -1,6 +1,6 @@
 /client/proc/admin_lightning_strike()
 	set name = "Lightning Strike"
-	set desc = "Causes lightning to strike on your tile. This will hurt things on or nearby it severely."
+	set desc = "Causes lightning to strike on your tile. This can be made to hurt things on or nearby it severely."
 	set category = "Fun"
 
 	if(!check_rights(R_FUN))
@@ -28,7 +28,7 @@
 
 	// Do a lightning flash for the whole planet, if the turf belongs to a planet.
 	var/datum/planet/P = null
-	P = SSplanets.z_to_planet[T.z]
+	P = LAZYACCESS(SSplanets.z_to_planet, T.z)
 	if(P)
 		var/datum/weather_holder/holder = P.weather_holder
 		flick("lightning_flash", holder.special_visuals)
@@ -64,7 +64,7 @@
 	// Otherwise only those on the current z-level will hear it.
 	var/sound = get_sfx("thunder")
 	for(var/mob/M in player_list)
-		if((P && M.z in P.expected_z_levels) || M.z == T.z)
+		if( (P && (M.z in P.expected_z_levels)) || M.z == T.z)
 			if(M.is_preference_enabled(/datum/client_preference/weather_sounds))
 				M.playsound_local(get_turf(M), soundin = sound, vol = 70, vary = FALSE, is_global = TRUE)
 

--- a/code/modules/power/tesla/energy_ball.dm
+++ b/code/modules/power/tesla/energy_ball.dm
@@ -168,6 +168,8 @@
 	C.electrocute_act(500, src, def_zone = BP_TORSO)
 
 /proc/tesla_zap(atom/source, zap_range = 3, power, explosive = FALSE, stun_mobs = TRUE)
+	if(!source) // Some mobs and maybe some objects delete themselves when they die.
+		return
 	. = source.dir
 	if(power < 1000)
 		return

--- a/maps/southern_cross/southern_cross_defines.dm
+++ b/maps/southern_cross/southern_cross_defines.dm
@@ -83,6 +83,8 @@
 
 	unit_test_exempt_from_atmos = list(/area/tcomm/chamber)
 
+	planet_datums_to_make = list(/datum/planet/sif)
+
 
 // Short range computers see only the six main levels, others can see the surrounding surface levels.
 /datum/map/southern_cross/get_map_levels(var/srcz, var/long_range = TRUE)

--- a/maps/~map_system/maps.dm
+++ b/maps/~map_system/maps.dm
@@ -97,6 +97,8 @@ var/list/all_maps = list()
 	var/list/unit_test_exempt_from_apc = list()
 	var/list/unit_test_z_levels //To test more than Z1, set your z-levels to test here.
 
+	var/list/planet_datums_to_make = list() // Types of `/datum/planet`s that will be instantiated by SSPlanets.
+
 /datum/map/New()
 	..()
 	if(zlevel_datum_type)


### PR DESCRIPTION
- Makes planet initialization use a list defined on the map datum, instead of initializing all planetary datums. This is done to fix the runtime that happens when a lightning storm processes on the test map, and `pick()` tried to choose from an empty list. The Southern Cross will make the Sif datum, like before.
- Makes verbs to change weather/time a bit more robust if there is no planet.
- Makes planet finding code for lightning effects (planet-wide visual flash, planet wide thunder) more robust with `LAZYACCESS()`, which fixes a runtime that happens when an admin uses lightning strike on the station.
- Fixes very stupid order of operations logic error because `in` is really weird in byond and gets evaluated first apparently. This also caused a runtime.
- Fixes runtime that occurs when a mob that is struck by lightning instantly dies and deletes itself, thus causing a null reference to be used for the tesla bounce.