### PR TITLE
Nerfs Chameleon Kit Boxes

### DIFF
--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -142,15 +142,7 @@
 	name = "chameleon kit"
 	desc = "Comes with all the clothes you need to impersonate most people.  Acting lessons sold seperately."
 	starts_with = list(
-		/obj/item/clothing/under/chameleon,
-		/obj/item/clothing/head/chameleon,
-		/obj/item/clothing/suit/chameleon,
-		/obj/item/clothing/shoes/chameleon,
-		/obj/item/weapon/storage/backpack/chameleon,
-		/obj/item/clothing/gloves/chameleon,
-		/obj/item/clothing/mask/chameleon,
-		/obj/item/clothing/glasses/chameleon,
-		/obj/item/clothing/accessory/chameleon,
+		/obj/item/weapon/storage/backpack/chameleon/full,
 		/obj/item/weapon/gun/energy/chameleon
 	)
 

--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -223,7 +223,7 @@
 		/obj/item/clothing/gloves/chameleon,
 		/obj/item/clothing/mask/chameleon,
 		/obj/item/clothing/glasses/chameleon,
-		/obj/item/clothing/accessory/chameleon,
+		/obj/item/clothing/accessory/chameleon
 	)
 
 //********************

--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -214,6 +214,18 @@
 		var/mob/M = src.loc
 		M.update_inv_back()
 
+/obj/item/weapon/storage/backpack/chameleon/full
+	starts_with = list(
+		/obj/item/clothing/under/chameleon,
+		/obj/item/clothing/head/chameleon,
+		/obj/item/clothing/suit/chameleon,
+		/obj/item/clothing/shoes/chameleon,
+		/obj/item/clothing/gloves/chameleon,
+		/obj/item/clothing/mask/chameleon,
+		/obj/item/clothing/glasses/chameleon,
+		/obj/item/clothing/accessory/chameleon,
+	)
+
 //********************
 //**Chameleon Gloves**
 //********************


### PR DESCRIPTION
Because of the way chameleon kits start with items, the boxes start with a ton of storage slots to hold all the items. Sometimes people grab the boxes, dump out the original contents and stuff a ton of stuff into them as a result.

This refactors it so that all the chameleon stuff starts in the backpack instead, so chameleon kit boxes themselves are no longer superboxes