### PR TITLE
High-priority Job Display

### DIFF
--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -91,8 +91,10 @@
 			stat("Players: [totalPlayers]", "Players Ready: [totalPlayersReady]")
 			totalPlayers = 0
 			totalPlayersReady = 0
+			var/datum/job/refJob = null
 			for(var/mob/new_player/player in player_list)
-				stat("[player.key]", (player.ready)?("(Playing)"):(null))
+				refJob = player.client.prefs.get_highest_job()
+				stat("[player.key]", (player.ready)?("(Playing as: [(refJob)?(refJob.title):("Unknown")])"):(null))
 				totalPlayers++
 				if(player.ready)totalPlayersReady++
 

--- a/code/modules/mob/new_player/preferences_setup.dm
+++ b/code/modules/mob/new_player/preferences_setup.dm
@@ -266,3 +266,24 @@
 	preview_icon.Blend(stamp, ICON_OVERLAY, 49, 1)
 
 	preview_icon.Scale(preview_icon.Width() * 2, preview_icon.Height() * 2) // Scaling here to prevent blurring in the browser.
+
+/datum/preferences/proc/get_highest_job()
+	var/datum/job/highJob
+	// Determine what job is marked as 'High' priority, and dress them up as such.
+	if(job_civilian_low & ASSISTANT)
+		highJob = job_master.GetJob("Assistant")
+	else
+		for(var/datum/job/job in job_master.occupations)
+			var/job_flag
+			switch(job.department_flag)
+				if(CIVILIAN)
+					job_flag = job_civilian_high
+				if(MEDSCI)
+					job_flag = job_medsci_high
+				if(ENGSEC)
+					job_flag = job_engsec_high
+			if(job.flag == job_flag)
+				highJob = job
+				break
+
+	return highJob


### PR DESCRIPTION
Readying in Lobby now shows the name of the job you have set to 'High', so people can more easily decide what to play without needing to wait until the round starts. If you have no job set to high, it will display "Unknown".