### PR TITLE
Cutting rigs now retracts all components, to stop the dreaded pseudoprison.

### DIFF
--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -234,19 +234,10 @@
 /obj/item/weapon/rig/proc/cut_suit()
 	offline = 2
 	canremove = 1
-	for(var/obj/item/piece in list(helmet,boots,gloves,chest))
-		if(!piece) continue
-		piece.icon_state = "[suit_state]"
-		if(airtight)
-			update_airtight(piece, 0) // Unseal
-		piece.canremove = 1
-		if(istype(loc, /mob/living/carbon/human))
-			var/mob/living/carbon/human/H = loc
-			H.drop_from_inventory(piece)
-		piece.forceMove(get_turf(src))
-		piece.dropped()
-		piece.canremove = 0
-		piece.forceMove(src)
+	toggle_piece("helmet", loc, ONLY_RETRACT, TRUE)
+	toggle_piece("gauntlets", loc, ONLY_RETRACT, TRUE)
+	toggle_piece("boots", loc, ONLY_RETRACT, TRUE)
+	toggle_piece("chest", loc, ONLY_RETRACT, TRUE)
 	update_icon(1)
 
 /obj/item/weapon/rig/proc/toggle_seals(var/mob/living/carbon/human/M,var/instant)
@@ -757,15 +748,15 @@
 		wearer.wearing_rig = src
 		update_icon()
 
-/obj/item/weapon/rig/proc/toggle_piece(var/piece, var/mob/living/carbon/human/H, var/deploy_mode)
+/obj/item/weapon/rig/proc/toggle_piece(var/piece, var/mob/living/carbon/human/H, var/deploy_mode, var/forced = FALSE)
 
-	if(sealing || !cell || !cell.charge)
+	if((sealing || !cell || !cell.charge) && !forced)
 		return
 
-	if(!istype(wearer) || (!wearer.back == src && !wearer.belt == src))
+	if((!istype(wearer) || (!wearer.back == src && !wearer.belt == src)) && !forced)
 		return
 
-	if(usr == wearer && (usr.stat||usr.paralysis||usr.stunned)) // If the usr isn't wearing the suit it's probably an AI.
+	if((usr == wearer && (usr.stat||usr.paralysis||usr.stunned)) && !forced) // If the usr isn't wearing the suit it's probably an AI.
 		return
 
 	var/obj/item/check_slot

--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -231,6 +231,24 @@
 			update_airtight(piece, 0) // Unseal
 	update_icon(1)
 
+/obj/item/weapon/rig/proc/cut_suit()
+	offline = 2
+	canremove = 1
+	for(var/obj/item/piece in list(helmet,boots,gloves,chest))
+		if(!piece) continue
+		piece.icon_state = "[suit_state]"
+		if(airtight)
+			update_airtight(piece, 0) // Unseal
+		piece.canremove = 1
+		if(istype(loc, /mob/living/carbon/human))
+			var/mob/living/carbon/human/H = loc
+			H.drop_from_inventory(piece)
+		piece.forceMove(get_turf(src))
+		piece.dropped()
+		piece.canremove = 0
+		piece.forceMove(src)
+	update_icon(1)
+
 /obj/item/weapon/rig/proc/toggle_seals(var/mob/living/carbon/human/M,var/instant)
 
 	if(sealing) return

--- a/code/modules/surgery/other.dm
+++ b/code/modules/surgery/other.dm
@@ -225,7 +225,7 @@
 		rig = target.belt
 		if(!istype(rig))
 			return
-	rig.reset()
+	rig.cut_suit()
 	user.visible_message("<span class='notice'>[user] has cut through the support systems of \the [rig] on [target] with \the [tool].</span>", \
 		"<span class='notice'>You have cut through the support systems of \the [rig] on [target] with \the [tool].</span>")
 


### PR DESCRIPTION
Fix #6739
Fix #4544

Rigs now retract their components when cut off.