### PR TITLE
QoL: Comms Consoles

### DIFF
--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -65,10 +65,7 @@
 			src.state = STATE_DEFAULT
 		if("login")
 			var/mob/M = usr
-			var/obj/item/weapon/card/id/I = M.get_active_hand()
-			if (istype(I, /obj/item/device/pda))
-				var/obj/item/device/pda/pda = I
-				I = pda.id
+			var/obj/item/weapon/card/id/I = M.GetIdCard()
 			if (I && istype(I))
 				if(src.check_access(I))
 					authenticated = 1
@@ -109,7 +106,7 @@
 				if(message_cooldown)
 					to_chat(usr, "Please allow at least one minute to pass between announcements")
 					return
-				var/input = input(usr, "Please write a message to announce to the station crew.", "Priority Announcement")
+				var/input = input(usr, "Please write a message to announce to the station crew.", "Priority Announcement") as null|message
 				if(!input || !(usr in view(1,src)))
 					return
 				crew_announcement.Announce(input)
@@ -188,7 +185,10 @@
 				if(centcomm_message_cooldown)
 					to_chat(usr, "<font color='red'>Arrays recycling.  Please stand by.</font>")
 					return
-				var/input = sanitize(input("Please choose a message to transmit to [using_map.boss_short] via quantum entanglement.  Please be aware that this process is very expensive, and abuse will lead to... termination.  Transmission does not guarantee a response. There is a 30 second delay before you may send another message, be clear, full and concise.", "To abort, send an empty message.", ""))
+				var/input = sanitize(input("Please choose a message to transmit to [using_map.boss_short] via quantum entanglement. \
+				Please be aware that this process is very expensive, and abuse will lead to... termination.  \
+				Transmission does not guarantee a response. \
+				There is a 30 second delay before you may send another message, be clear, full and concise.", "Central Command Quantum Messaging") as null|message)
 				if(!input || !(usr in view(1,src)))
 					return
 				CentCom_announce(input, usr)

--- a/code/game/machinery/status_display.dm
+++ b/code/game/machinery/status_display.dm
@@ -179,6 +179,18 @@
 		if("delta")	set_light(l_range = 4, l_power = 0.9, l_color = "#FF6633")
 	set_picture("status_display_[seclevel]")
 
+// Called when the alert level is changed.
+/obj/machinery/status_display/proc/on_alert_changed(new_level)
+	// On most alerts, this will change to a flashing alert picture in a specific color.
+	// Doing that for green alert automatically doesn't really make sense, but it is still available on the comm consoles/PDAs.
+	if(seclevel2num(new_level) == SEC_LEVEL_GREEN)
+		mode = STATUS_DISPLAY_TIME
+		set_light(0) // Remove any glow we had from the alert previously.
+		update()
+		return
+	mode = STATUS_DISPLAY_ALERT
+	display_alert(new_level)
+
 /obj/machinery/status_display/proc/set_picture(state)
 	remove_display()
 	if(!picture || picture_state != state)
@@ -229,13 +241,16 @@
 	switch(signal.data["command"])
 		if("blank")
 			mode = STATUS_DISPLAY_BLANK
+			set_light(0)
 
 		if("shuttle")
 			mode = STATUS_DISPLAY_TRANSFER_SHUTTLE_TIME
+			set_light(0)
 
 		if("message")
 			mode = STATUS_DISPLAY_MESSAGE
 			set_message(signal.data["msg1"], signal.data["msg2"])
+			set_light(0)
 
 		if("alert")
 			mode = STATUS_DISPLAY_ALERT
@@ -243,6 +258,7 @@
 
 		if("time")
 			mode = STATUS_DISPLAY_TIME
+			set_light(0)
 	update()
 
 #undef CHARS_PER_LINE

--- a/code/modules/modular_computers/file_system/programs/command/comm.dm
+++ b/code/modules/modular_computers/file_system/programs/command/comm.dm
@@ -131,7 +131,7 @@
 				if(announcment_cooldown)
 					to_chat(usr, "Please allow at least one minute to pass between announcements")
 					return TRUE
-				var/input = input(usr, "Please write a message to announce to the station crew.", "Priority Announcement") as null|text
+				var/input = input(usr, "Please write a message to announce to the station crew.", "Priority Announcement") as null|message
 				if(!input || !can_still_topic())
 					return 1
 				crew_announcement.Announce(input)
@@ -165,7 +165,10 @@
 					if(!is_relay_online())//Contact Centcom has a check, Syndie doesn't to allow for Traitor funs.
 						to_chat(usr, "<span class='warning'>No Emergency Bluespace Relay detected. Unable to transmit message.</span>")
 						return 1
-					var/input = sanitize(input("Please choose a message to transmit to Centcomm via quantum entanglement.  Please be aware that this process is very expensive, and abuse will lead to... termination.  Transmission does not guarantee a response. There is a 30 second delay before you may send another message, be clear, full and concise.", "To abort, send an empty message.", "") as null|text)
+					var/input = sanitize(input("Please choose a message to transmit to Centcomm via quantum entanglement. \
+					Please be aware that this process is very expensive, and abuse will lead to... termination. \
+					Transmission does not guarantee a response. There is a 30 second delay before you may send another message, \
+					be clear, full and concise.", "Central Command Quantum Messaging") as null|message)
 					if(!input || !can_still_topic())
 						return 1
 					CentCom_announce(input, usr)

--- a/code/modules/security levels/security levels.dm
+++ b/code/modules/security levels/security levels.dm
@@ -78,8 +78,7 @@
 				FA.set_security_level(newlevel)
 		for(var/obj/machinery/status_display/FA in machines)
 			if(FA.z in using_map.contact_levels)
-				FA.display_alert(newlevel)
-				FA.mode = 3
+				FA.on_alert_changed(newlevel)
 
 		if(level >= SEC_LEVEL_RED)
 			atc.reroute_traffic(yes = 1) // Tell them fuck off we're busy.


### PR DESCRIPTION
The first of many PRs to come that focus on quality of life changes. This one is command related.
Changes:
- Logging into the communications console no longer requires you to hold your ID or PDA in your hand. It will now check for your ID slot first, like most things do now.
- Station announcements for both comms consoles and modular computers now allows multi-line editing. (Aimless)
- Messages to Centcom now allows multi-line editing too, in both comms console and modular computer. (Nalarac)
- When the alert level is lowered to Green, the status displays will switch to displaying the current time, instead of a flashing 'green alert' status. (Nalarac)