### PR TITLE
Fixes pregame loop with no readied players

### DIFF
--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -46,9 +46,9 @@ var/global/datum/controller/gameticker/ticker
 
 	send2mainirc("Server lobby is loaded and open at byond://[config.serverurl ? config.serverurl : (config.server ? config.server : "[world.address]:[world.port]")]")
 
-	pregame_timeleft = config.pregame_time
 
 	do
+		pregame_timeleft = config.pregame_time
 		to_chat(world, "<B><FONT color='blue'>Welcome to the pregame lobby!</FONT></B>")
 		to_chat(world, "Please set up your character and select ready. The round will start in [pregame_timeleft] seconds.")
 		while(current_state == GAME_STATE_PREGAME)


### PR DESCRIPTION
When the config option for pregame time was added in #6795, the pregame_timeleft setting was moved out of the do while !setup loop. If the game does not set up, it would keep decrementing the counter into the negatives since it was never reset.