### PR TITLE
Fully Implements R_EVENT for Event Managers

### DIFF
--- a/code/controllers/subsystems/vote.dm
+++ b/code/controllers/subsystems/vote.dm
@@ -191,7 +191,7 @@ SUBSYSTEM_DEF(vote)
 
 /datum/controller/subsystem/vote/proc/initiate_vote(vote_type, initiator_key, automatic = FALSE, time = config.vote_period)
 	if(!mode)
-		if(started_time != null && !(check_rights(R_ADMIN) || automatic))
+		if(started_time != null && !(check_rights(R_ADMIN|R_EVENT) || automatic))
 			var/next_allowed_time = (started_time + config.vote_delay)
 			if(next_allowed_time > world.time)
 				return 0
@@ -213,7 +213,7 @@ SUBSYSTEM_DEF(vote)
 					additional_text.Add("<td align = 'center'>[M.required_players]</td>")
 				gamemode_names["secret"] = "Secret"
 			if(VOTE_CREW_TRANSFER)
-				if(!check_rights(R_ADMIN|R_MOD, 0)) // The gods care not for the affairs of the mortals
+				if(!check_rights(R_ADMIN|R_MOD|R_EVENT, 0)) // The gods care not for the affairs of the mortals
 					if(get_security_level() == "red" || get_security_level() == "delta")
 						to_chat(initiator_key, "The current alert status is too high to call for a crew transfer!")
 						return 0
@@ -269,7 +269,7 @@ SUBSYSTEM_DEF(vote)
 		return
 	var/admin = FALSE
 	if(C.holder)
-		if(C.holder.rights & R_ADMIN)
+		if(C.holder.rights & R_ADMIN|R_EVENT)
 			admin = TRUE
 
 	. = "<html><head><title>Voting Panel</title></head><body>"

--- a/code/datums/managed_browsers/feedback_viewer.dm
+++ b/code/datums/managed_browsers/feedback_viewer.dm
@@ -6,7 +6,7 @@
 	set name = "View Feedback"
 	set desc = "Open the Feedback Viewer"
 
-	if(!check_rights(R_ADMIN|R_DEBUG))
+	if(!check_rights(R_ADMIN|R_DEBUG|R_EVENT))
 		return
 
 	if(usr.client.feedback_viewer)
@@ -23,7 +23,7 @@
 	var/database/query/last_query = null
 
 /datum/managed_browser/feedback_viewer/New(client/new_client)
-	if(!check_rights(R_ADMIN|R_DEBUG, new_client)) // Just in case someone figures out a way to spawn this as non-staff.
+	if(!check_rights(R_ADMIN|R_DEBUG|R_EVENT, new_client)) // Just in case someone figures out a way to spawn this as non-staff.
 		message_admins("[new_client] tried to view feedback with insufficent permissions.")
 		qdel(src)
 

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -153,7 +153,7 @@
 	usr << browse(out, "window=edit_memory[src]")
 
 /datum/mind/Topic(href, href_list)
-	if(!check_rights(R_ADMIN))	return
+	if(!check_rights(R_ADMIN|R_FUN|R_EVENT))	return
 
 	if(href_list["add_antagonist"])
 		var/datum/antagonist/antag = all_antag_types[href_list["add_antagonist"]]

--- a/code/game/jobs/whitelist.dm
+++ b/code/game/jobs/whitelist.dm
@@ -75,7 +75,7 @@ var/list/whitelist = list()
 /proc/whitelist_overrides(mob/M)
 	if(!config.usealienwhitelist)
 		return 1
-	if(check_rights(R_ADMIN, 0, M))
+	if(check_rights(R_ADMIN|R_EVENT, 0, M))
 		return 1
 
 	return 0

--- a/code/game/verbs/ooc.dm
+++ b/code/game/verbs/ooc.dm
@@ -63,7 +63,7 @@
 						display_name = "[holder.fakekey]/([src.key])"
 					else
 						display_name = holder.fakekey
-			if(holder && !holder.fakekey && (holder.rights & R_ADMIN) && config.allow_admin_ooccolor && (src.prefs.ooccolor != initial(src.prefs.ooccolor))) // keeping this for the badmins
+			if(holder && !holder.fakekey && (holder.rights & R_ADMIN|R_FUN|R_EVENT) && config.allow_admin_ooccolor && (src.prefs.ooccolor != initial(src.prefs.ooccolor))) // keeping this for the badmins
 				to_chat(target, "<font color='[src.prefs.ooccolor]'><span class='ooc'>" + create_text_tag("ooc", "OOC:", target) + " <EM>[display_name]:</EM> <span class='message'>[msg]</span></span></font>")
 			else
 				to_chat(target, "<span class='ooc'><span class='[ooc_style]'>" + create_text_tag("ooc", "OOC:", target) + " <EM>[display_name]:</EM> <span class='message'>[msg]</span></span></span>")

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -90,7 +90,7 @@ proc/admin_notice(var/message, var/rights)
 		<A href='?src=\ref[src];getmob=\ref[M]'>Get</A> |
 		<A href='?src=\ref[src];sendmob=\ref[M]'>Send To</A>
 		<br><br>
-		[check_rights(R_ADMIN|R_MOD,0) ? "<A href='?src=\ref[src];traitor=\ref[M]'>Traitor panel</A> | " : "" ]
+		[check_rights(R_ADMIN|R_MOD|R_EVENT,0) ? "<A href='?src=\ref[src];traitor=\ref[M]'>Traitor panel</A> | " : "" ]
 		<A href='?src=\ref[src];narrateto=\ref[M]'>Narrate to</A> |
 		<A href='?src=\ref[src];subtlemessage=\ref[M]'>Subtle message</A>
 	"}
@@ -1370,7 +1370,7 @@ proc/admin_notice(var/message, var/rights)
 		return //Extra sanity check to make sure only observers are shoved into things
 
 	//Same as assume-direct-control perm requirements.
-	if (!check_rights(R_VAREDIT,0) || !check_rights(R_ADMIN|R_DEBUG,0))
+	if (!check_rights(R_VAREDIT,0) || !check_rights(R_ADMIN|R_DEBUG|R_EVENT,0))
 		return 0
 	if (!frommob.ckey)
 		return 0
@@ -1423,7 +1423,7 @@ proc/admin_notice(var/message, var/rights)
 
 	if (!istype(src,/datum/admins))
 		src = usr.client.holder
-	if (!istype(src,/datum/admins) || !check_rights(R_ADMIN))
+	if (!istype(src,/datum/admins) || !check_rights(R_ADMIN|R_EVENT|R_FUN))
 		to_chat(usr, "Error: you are not an admin!")
 		return
 
@@ -1441,7 +1441,7 @@ proc/admin_notice(var/message, var/rights)
 
 	var/msg
 
-	if(check_rights(R_ADMIN|R_MOD))
+	if(check_rights(R_ADMIN|R_MOD|R_EVENT))
 		if (H.paralysis == 0)
 			H.paralysis = 8000
 			msg = "has paralyzed [key_name(H)]."
@@ -1459,7 +1459,7 @@ proc/admin_notice(var/message, var/rights)
 
 	var/crystals
 
-	if(check_rights(R_ADMIN))
+	if(check_rights(R_ADMIN|R_EVENT))
 		crystals = input("Amount of telecrystals for [H.ckey], currently [H.mind.tcrystals].", crystals) as null|num
 		if (!isnull(crystals))
 			H.mind.tcrystals = crystals
@@ -1475,7 +1475,7 @@ proc/admin_notice(var/message, var/rights)
 
 	var/crystals
 
-	if(check_rights(R_ADMIN))
+	if(check_rights(R_ADMIN|R_EVENT))
 		crystals = input("Amount of telecrystals to give to [H.ckey], currently [H.mind.tcrystals].", crystals) as null|num
 		if (!isnull(crystals))
 			H.mind.tcrystals += crystals
@@ -1558,12 +1558,12 @@ datum/admins/var/obj/item/weapon/paper/admin/faxreply // var to hold fax replies
 		if(P.sender) // sent as a reply
 			log_admin("[key_name(src.owner)] replied to a fax message from [key_name(P.sender)]")
 			for(var/client/C in admins)
-				if((R_ADMIN | R_MOD) & C.holder.rights)
+				if((R_ADMIN | R_MOD | R_EVENT) & C.holder.rights)
 					to_chat(C, "<span class='log_message'><span class='prefix'>FAX LOG:</span>[key_name_admin(src.owner)] replied to a fax message from [key_name_admin(P.sender)] (<a href='?_src_=holder;AdminFaxView=\ref[rcvdcopy]'>VIEW</a>)</span>")
 		else
 			log_admin("[key_name(src.owner)] has sent a fax message to [destination.department]")
 			for(var/client/C in admins)
-				if((R_ADMIN | R_MOD) & C.holder.rights)
+				if((R_ADMIN | R_MOD | R_EVENT) & C.holder.rights)
 					to_chat(C, "<span class='log_message'><span class='prefix'>FAX LOG:</span>[key_name_admin(src.owner)] has sent a fax message to [destination.department] (<a href='?_src_=holder;AdminFaxView=\ref[rcvdcopy]'>VIEW</a>)</span>")
 
 	else

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -359,7 +359,6 @@ var/list/admin_verbs_event_manager = list(
 	/client/proc/cmd_event_say,
 	/client/proc/cmd_admin_pm_context,
 	/client/proc/cmd_admin_pm_panel,
-
 	/client/proc/admin_ghost,
 	/datum/admins/proc/show_player_info,
 	/client/proc/dsay,
@@ -374,7 +373,6 @@ var/list/admin_verbs_event_manager = list(
 	/client/proc/respawn_character,
 	/proc/possess,
 	/proc/release,
-
 	/datum/admins/proc/change_weather,
 	/datum/admins/proc/change_time,
 	/client/proc/admin_give_modifier,
@@ -397,8 +395,6 @@ var/list/admin_verbs_event_manager = list(
 	/client/proc/roll_dices,
 	/datum/admins/proc/call_supply_drop,
 	/datum/admins/proc/call_drop_pod,
-
-	// This is mostly the same as what admins get, but filtered down to what would be useful for running an event,
 	/datum/admins/proc/PlayerNotes,
 	/client/proc/callproc,
 	/client/proc/callproc_datum,
@@ -409,7 +405,6 @@ var/list/admin_verbs_event_manager = list(
 	/client/proc/admin_give_modifier,
 	/datum/admins/proc/cmd_admin_dress,
 	/client/proc/cmd_admin_gib_self,
-
 	/datum/admins/proc/set_tcrystals,
 	/datum/admins/proc/add_tcrystals,
 	/client/proc/invisimin,                         //allows our mob to go invisible/visible,

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -398,7 +398,7 @@ var/list/admin_verbs_event_manager = list(
 	/datum/admins/proc/call_supply_drop,
 	/datum/admins/proc/call_drop_pod,
 
-	// This is mostly the same as what admins get, but filtered down to what would be useful for running an event.
+	// This is mostly the same as what admins get, but filtered down to what would be useful for running an event,
 	/datum/admins/proc/PlayerNotes,
 	/client/proc/callproc,
 	/client/proc/callproc_datum,

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -1,6 +1,7 @@
 //admin verb groups - They can overlap if you so wish. Only one of each verb will exist in the verbs list regardless
 var/list/admin_verbs_default = list(
 	/datum/admins/proc/show_player_panel,	//shows an interface for individual players, with various links (links require additional flags,
+	/client/proc/player_panel_new, //shows an interface for all players, with links to various panels,
 	/client/proc/player_panel,
 	/client/proc/deadmin_self,			//destroys our own admin datum so we can play as a regular player,
 	/client/proc/hide_verbs,			//hides all our adminverbs,
@@ -15,7 +16,6 @@ var/list/admin_verbs_default = list(
 	)
 
 var/list/admin_verbs_admin = list(
-	/client/proc/player_panel_new, //shows an interface for all players, with links to various panels,
 	/datum/admins/proc/set_tcrystals,
 	/datum/admins/proc/add_tcrystals,
 	/client/proc/invisimin,				//allows our mob to go invisible/visible,
@@ -138,7 +138,7 @@ var/list/admin_verbs_fun = list(
 	/datum/admins/proc/call_supply_drop,
 	/datum/admins/proc/call_drop_pod,
 	/client/proc/smite,
-	/client/proc/admin_lightning_strike
+	/client/proc/admin_lightning_strike,
 	)
 
 var/list/admin_verbs_spawn = list(
@@ -359,7 +359,7 @@ var/list/admin_verbs_event_manager = list(
 	/client/proc/cmd_event_say,
 	/client/proc/cmd_admin_pm_context,
 	/client/proc/cmd_admin_pm_panel,
-	/datum/admins/proc/PlayerNotes,
+
 	/client/proc/admin_ghost,
 	/datum/admins/proc/show_player_info,
 	/client/proc/dsay,
@@ -374,10 +374,7 @@ var/list/admin_verbs_event_manager = list(
 	/client/proc/respawn_character,
 	/proc/possess,
 	/proc/release,
-	/client/proc/callproc,
-	/client/proc/callproc_datum,
-	/client/proc/debug_controller,
-	/client/proc/show_gm_status,
+
 	/datum/admins/proc/change_weather,
 	/datum/admins/proc/change_time,
 	/client/proc/admin_give_modifier,
@@ -399,7 +396,101 @@ var/list/admin_verbs_event_manager = list(
 	/client/proc/editappear,
 	/client/proc/roll_dices,
 	/datum/admins/proc/call_supply_drop,
-	/datum/admins/proc/call_drop_pod
+	/datum/admins/proc/call_drop_pod,
+
+	// This is mostly the same as what admins get, but filtered down to what would be useful for running an event.
+	/datum/admins/proc/PlayerNotes,
+	/client/proc/callproc,
+	/client/proc/callproc_datum,
+	/client/proc/debug_controller,
+	/client/proc/show_gm_status,
+	/datum/admins/proc/change_weather,
+	/datum/admins/proc/change_time,
+	/client/proc/admin_give_modifier,
+	/datum/admins/proc/cmd_admin_dress,
+	/client/proc/cmd_admin_gib_self,
+
+	/datum/admins/proc/set_tcrystals,
+	/datum/admins/proc/add_tcrystals,
+	/client/proc/invisimin,                         //allows our mob to go invisible/visible,
+	/datum/admins/proc/show_traitor_panel,  //interface which shows a mob's mind.,
+	/datum/admins/proc/show_game_mode,  //Configuration window for the current game mode.,
+	/datum/admins/proc/force_mode_latespawn, //Force the mode to try a latespawn proc,
+	/datum/admins/proc/force_antag_latespawn, //Force a specific template to try a latespawn proc,
+	/datum/admins/proc/announce,            //priority announce something to all clients.,
+	/datum/admins/proc/intercom,            //send a fake intercom message, like an arrivals announcement,
+	/datum/admins/proc/intercom_convo,      //send a fake intercom conversation, like an ATC exchange,
+	/client/proc/colorooc,                          //allows us to set a custom colour for everythign we say in ooc,
+	/client/proc/admin_ghost,                       //allows us to ghost/reenter body at will,
+	/client/proc/toggle_view_range,         //changes how far we can see,
+	/client/proc/cmd_admin_pm_context,      //right-click adminPM interface,
+	/client/proc/cmd_admin_pm_panel,        //admin-pm list,
+	/client/proc/cmd_admin_subtle_message,  //send an message to somebody as a 'voice in their head',
+	/client/proc/cmd_admin_delete,          //delete an instance/object/mob/etc,
+	/client/proc/cmd_admin_check_contents,  //displays the contents of an instance,
+	/client/proc/cmd_admin_check_player_logs,       //checks a player's attack logs,
+	/client/proc/cmd_admin_check_dialogue_logs,     //checks a player's dialogue logs,
+	/datum/admins/proc/access_news_network, //allows access of newscasters,
+	/client/proc/jumptocoord,                       //we ghost and jump to a coordinate,
+	/client/proc/Getmob,                            //teleports a mob to our location,
+	/client/proc/Getkey,                            //teleports a mob with a certain ckey to our location,
+	/client/proc/Jump,
+	/client/proc/jumptokey,                         //allows us to jump to the location of a mob with a certain ckey,
+	/client/proc/jumptomob,                         //allows us to jump to a specific mob,
+	/client/proc/jumptoturf,                        //allows us to jump to a specific turf,
+	/client/proc/admin_call_shuttle,        //allows us to call the emergency shuttle,
+	/client/proc/admin_cancel_shuttle,      //allows us to cancel the emergency shuttle, sending it back to CentCom,
+	/client/proc/cmd_admin_direct_narrate,  //send text directly to a player with no padding. Useful for narratives and fluff-text,
+	/client/proc/cmd_admin_world_narrate,   //sends text to all players with no padding,
+	/client/proc/cmd_admin_create_centcom_report,
+	/client/proc/check_words,                       //displays cult-words,
+	/client/proc/check_ai_laws,                     //shows AI and borg laws,
+	/client/proc/rename_silicon,            //properly renames silicons,
+	/client/proc/manage_silicon_laws,       // Allows viewing and editing silicon laws. ,
+	/client/proc/check_antagonists,
+	/client/proc/admin_memo,                        //admin memo system. show/delete/write. +SERVER needed to delete admin memos of others,
+	/client/proc/dsay,                                      //talk in deadchat using our ckey/fakekey,
+	/client/proc/secrets,
+	/client/proc/game_panel,                        //game panel, allows to change game-mode etc,
+	/client/proc/cmd_mod_say,
+	/client/proc/cmd_event_say,
+	/datum/admins/proc/show_player_info,
+	/client/proc/free_slot,                 //frees slot for chosen job,
+	/client/proc/cmd_admin_change_custom_event,
+	/client/proc/cmd_admin_rejuvenate,
+	/client/proc/toggleghostwriters,
+	/datum/admins/proc/show_skills,
+	/client/proc/man_up,
+	/client/proc/global_man_up,
+	/client/proc/response_team, // Response Teams admin verb,
+	/client/proc/trader_ship, // Trader ship admin verb,
+	/client/proc/allow_character_respawn,    // Allows a ghost to respawn ,
+	/client/proc/event_manager_panel,
+	/client/proc/aooc,
+	/client/proc/change_human_appearance_admin,     // Allows an admin to change the basic appearance of human-based mobs ,
+	/client/proc/change_human_appearance_self,      // Allows the human-based mob itself change its basic appearance ,
+	/client/proc/change_security_level,
+	/client/proc/makePAI,
+	/client/proc/toggle_debug_logs,
+	/client/proc/toggle_attack_logs,
+	/datum/admins/proc/paralyze_mob,
+	/client/proc/fixatmos,
+	/datum/admins/proc/sendFax,
+	/client/proc/despawn_player,
+	/datum/admins/proc/view_feedback,
+	/datum/admins/proc/capture_map,
+	/client/proc/Set_Holiday,
+	/datum/admins/proc/startnow,
+	/datum/admins/proc/restart,
+	/datum/admins/proc/delay,
+	/client/proc/cmd_mod_say,
+	/datum/admins/proc/immreboot,
+	/client/proc/everyone_random,
+	/client/proc/cmd_admin_delete,		//delete an instance/object/mob/etc,
+	/client/proc/cmd_debug_del_all,
+	/client/proc/toggle_random_events,
+	/client/proc/modify_server_news
+
 )
 
 /client/proc/add_admin_verbs()
@@ -852,7 +943,7 @@ var/list/admin_verbs_event_manager = list(
 	set name = "Rename Silicon"
 	set category = "Admin"
 
-	if(!check_rights(R_ADMIN)) return
+	if(!check_rights(R_ADMIN|R_FUN|R_EVENT)) return
 
 	var/mob/living/silicon/S = input("Select silicon.", "Rename Silicon.") as null|anything in silicon_mob_list
 	if(!S) return
@@ -867,7 +958,7 @@ var/list/admin_verbs_event_manager = list(
 	set name = "Manage Silicon Laws"
 	set category = "Admin"
 
-	if(!check_rights(R_ADMIN)) return
+	if(!check_rights(R_ADMIN|R_EVENT)) return
 
 	var/mob/living/silicon/S = input("Select silicon.", "Manage Silicon Laws") as null|anything in silicon_mob_list
 	if(!S) return
@@ -919,7 +1010,7 @@ var/list/admin_verbs_event_manager = list(
 	set desc = "Sets the station security level"
 	set category = "Admin"
 
-	if(!check_rights(R_ADMIN))	return
+	if(!check_rights(R_ADMIN|R_EVENT))	return
 	var sec_level = input(usr, "It's currently code [get_security_level()].", "Select Security Level")  as null|anything in (list("green","yellow","violet","orange","blue","red","delta")-get_security_level())
 	if(alert("Switch from code [get_security_level()] to code [sec_level]?","Change security level?","Yes","No") == "Yes")
 		set_security_level(sec_level)

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -11,7 +11,7 @@
 		return
 
 	if(href_list["ahelp"])
-		if(!check_rights(R_ADMIN|R_MOD|R_DEBUG))
+		if(!check_rights(R_ADMIN|R_MOD|R_DEBUG|R_EVENT))
 			return
 
 		var/ahelp_ref = href_list["ahelp"]
@@ -198,7 +198,7 @@
 		edit_admin_permissions()
 
 	else if(href_list["call_shuttle"])
-		if(!check_rights(R_ADMIN))	return
+		if(!check_rights(R_ADMIN|R_EVENT))	return
 
 		if( ticker.mode.name == "blob" )
 			alert("You can't call the shuttle during blob!")
@@ -905,7 +905,7 @@
 		cmd_admin_mute(M, mute_type)
 
 	else if(href_list["c_mode"])
-		if(!check_rights(R_ADMIN))	return
+		if(!check_rights(R_ADMIN|R_EVENT))	return
 
 		if(ticker && ticker.mode)
 			return alert(usr, "The game has already started.", null, null, null, null)
@@ -918,7 +918,7 @@
 		usr << browse(dat, "window=c_mode")
 
 	else if(href_list["f_secret"])
-		if(!check_rights(R_ADMIN))	return
+		if(!check_rights(R_ADMIN|R_EVENT))	return
 
 		if(ticker && ticker.mode)
 			return alert(usr, "The game has already started.", null, null, null, null)
@@ -932,7 +932,7 @@
 		usr << browse(dat, "window=f_secret")
 
 	else if(href_list["c_mode2"])
-		if(!check_rights(R_ADMIN|R_SERVER))	return
+		if(!check_rights(R_ADMIN|R_SERVER|R_EVENT))	return
 
 		if (ticker && ticker.mode)
 			return alert(usr, "The game has already started.", null, null, null, null)
@@ -945,7 +945,7 @@
 		.(href, list("c_mode"=1))
 
 	else if(href_list["f_secret2"])
-		if(!check_rights(R_ADMIN|R_SERVER))	return
+		if(!check_rights(R_ADMIN|R_SERVER|R_EVENT))	return
 
 		if(ticker && ticker.mode)
 			return alert(usr, "The game has already started.", null, null, null, null)
@@ -1311,7 +1311,7 @@
 		to_chat(src.owner, "(<a href='?src=\ref[usr];priv_msg=\ref[M]'>PM</a>) (<A HREF='?src=\ref[src];adminplayeropts=\ref[M]'>PP</A>) (<A HREF='?_src_=vars;Vars=\ref[M]'>VV</A>) (<A HREF='?src=\ref[src];subtlemessage=\ref[M]'>SM</A>) ([admin_jump_link(M, src)]) (<A HREF='?src=\ref[src];secretsadmin=check_antagonist'>CA</A>)")
 
 	else if(href_list["adminspawncookie"])
-		if(!check_rights(R_ADMIN|R_FUN))	return
+		if(!check_rights(R_ADMIN|R_FUN|R_EVENT))	return
 
 		var/mob/living/carbon/human/H = locate(href_list["adminspawncookie"])
 		if(!ishuman(H))
@@ -1335,7 +1335,7 @@
 		to_chat(H, "<font color='blue'>Your prayers have been answered!! You received the <b>best cookie</b>!</font>")
 
 	else if(href_list["adminsmite"])
-		if(!check_rights(R_ADMIN|R_FUN))	return
+		if(!check_rights(R_ADMIN|R_FUN|R_EVENT))	return
 
 		var/mob/living/carbon/human/H = locate(href_list["adminsmite"])
 		if(!ishuman(H))
@@ -1345,7 +1345,7 @@
 		owner.smite(H)
 
 	else if(href_list["BlueSpaceArtillery"])
-		if(!check_rights(R_ADMIN|R_FUN))	return
+		if(!check_rights(R_ADMIN|R_FUN|R_EVENT))	return
 
 		var/mob/living/M = locate(href_list["BlueSpaceArtillery"])
 		if(!isliving(M))
@@ -1449,38 +1449,38 @@
 		P.adminbrowse()
 
 	else if(href_list["jumpto"])
-		if(!check_rights(R_ADMIN))	return
+		if(!check_rights(R_ADMIN|R_EVENT|R_MOD))	return
 
 		var/mob/M = locate(href_list["jumpto"])
 		usr.client.jumptomob(M)
 
 	else if(href_list["getmob"])
-		if(!check_rights(R_ADMIN))	return
+		if(!check_rights(R_ADMIN|R_EVENT|R_FUN))	return
 
 		if(alert(usr, "Confirm?", "Message", "Yes", "No") != "Yes")	return
 		var/mob/M = locate(href_list["getmob"])
 		usr.client.Getmob(M)
 
 	else if(href_list["sendmob"])
-		if(!check_rights(R_ADMIN))	return
+		if(!check_rights(R_ADMIN|R_EVENT|R_FUN))	return
 
 		var/mob/M = locate(href_list["sendmob"])
 		usr.client.sendmob(M)
 
 	else if(href_list["narrateto"])
-		if(!check_rights(R_ADMIN))	return
+		if(!check_rights(R_ADMIN|R_EVENT|R_FUN))	return
 
 		var/mob/M = locate(href_list["narrateto"])
 		usr.client.cmd_admin_direct_narrate(M)
 
 	else if(href_list["subtlemessage"])
-		if(!check_rights(R_MOD,0) && !check_rights(R_ADMIN))  return
+		if(!check_rights(R_MOD|R_ADMIN|R_EVENT|R_FUN,0))  return
 
 		var/mob/M = locate(href_list["subtlemessage"])
 		usr.client.cmd_admin_subtle_message(M)
 
 	else if(href_list["traitor"])
-		if(!check_rights(R_ADMIN|R_MOD))	return
+		if(!check_rights(R_ADMIN|R_MOD|R_EVENT))	return
 
 		if(!ticker || !ticker.mode)
 			alert("The game hasn't started yet!")
@@ -1829,7 +1829,7 @@
 			populate_inactive_customitems_list(src.owner)
 
 	else if(href_list["vsc"])
-		if(check_rights(R_ADMIN|R_SERVER))
+		if(check_rights(R_ADMIN|R_SERVER|R_EVENT))
 			if(href_list["vsc"] == "airflow")
 				vsc.ChangeSettingsDialog(usr,vsc.settings)
 			if(href_list["vsc"] == "phoron")
@@ -1856,7 +1856,7 @@
 			show_player_panel(M)
 
 	else if(href_list["cryoplayer"])
-		if(!check_rights(R_ADMIN))	return
+		if(!check_rights(R_ADMIN|R_EVENT))	return
 
 		var/mob/M = locate(href_list["cryoplayer"])
 		if(!istype(M))

--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -505,7 +505,7 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 	set name = "Show Ticket List"
 	set category = "Admin"
 
-	if(!check_rights(R_ADMIN|R_MOD|R_DEBUG, TRUE))
+	if(!check_rights(R_ADMIN|R_MOD|R_DEBUG|R_EVENT, TRUE))
 		return
 
 	var/browse_to

--- a/code/modules/admin/verbs/adminjump.dm
+++ b/code/modules/admin/verbs/adminjump.dm
@@ -8,7 +8,7 @@
 	set name = "Jump to Area"
 	set desc = "Area to jump to"
 	set category = "Admin"
-	if(!check_rights(R_ADMIN|R_MOD|R_DEBUG))
+	if(!check_rights(R_ADMIN|R_MOD|R_DEBUG|R_EVENT))
 		return
 
 	if(config.allow_admin_jump)
@@ -24,7 +24,7 @@
 /client/proc/jumptoturf(var/turf/T in turfs)
 	set name = "Jump to Turf"
 	set category = "Admin"
-	if(!check_rights(R_ADMIN|R_MOD|R_DEBUG))
+	if(!check_rights(R_ADMIN|R_MOD|R_DEBUG|R_EVENT))
 		return
 	if(config.allow_admin_jump)
 		log_admin("[key_name(usr)] jumped to [T.x],[T.y],[T.z] in [T.loc]")
@@ -40,7 +40,7 @@
 	set category = "Admin"
 	set name = "Jump to Mob"
 
-	if(!check_rights(R_ADMIN|R_MOD|R_DEBUG))
+	if(!check_rights(R_ADMIN|R_MOD|R_DEBUG|R_EVENT))
 		return
 
 	if(config.allow_admin_jump)
@@ -62,7 +62,7 @@
 	set category = "Admin"
 	set name = "Jump to Coordinate"
 
-	if(!check_rights(R_ADMIN|R_MOD|R_DEBUG))
+	if(!check_rights(R_ADMIN|R_MOD|R_DEBUG|R_EVENT))
 		return
 
 	if (config.allow_admin_jump)
@@ -82,7 +82,7 @@
 	set category = "Admin"
 	set name = "Jump to Key"
 
-	if(!check_rights(R_ADMIN|R_MOD|R_DEBUG))
+	if(!check_rights(R_ADMIN|R_MOD|R_DEBUG|R_EVENT))
 		return
 
 	if(config.allow_admin_jump)
@@ -106,7 +106,7 @@
 	set category = "Admin"
 	set name = "Get Mob"
 	set desc = "Mob to teleport"
-	if(!check_rights(R_ADMIN|R_MOD|R_DEBUG))
+	if(!check_rights(R_ADMIN|R_MOD|R_DEBUG|R_EVENT))
 		return
 	if(config.allow_admin_jump)
 		log_admin("[key_name(usr)] jumped to [key_name(M)]")
@@ -124,7 +124,7 @@
 	set name = "Get Key"
 	set desc = "Key to teleport"
 
-	if(!check_rights(R_ADMIN|R_MOD|R_DEBUG))
+	if(!check_rights(R_ADMIN|R_MOD|R_DEBUG|R_EVENT))
 		return
 
 	if(config.allow_admin_jump)
@@ -152,7 +152,7 @@
 /client/proc/sendmob(var/mob/M in sortmobs())
 	set category = "Admin"
 	set name = "Send Mob"
-	if(!check_rights(R_ADMIN|R_MOD|R_DEBUG))
+	if(!check_rights(R_ADMIN|R_MOD|R_DEBUG|R_EVENT))
 		return
 	var/area/A = input(usr, "Pick an area.", "Pick an area") in return_sorted_areas()
 	if(A)

--- a/code/modules/admin/verbs/antag-ooc.dm
+++ b/code/modules/admin/verbs/antag-ooc.dm
@@ -3,7 +3,7 @@
 	set name = "AOOC"
 	set desc = "Antagonist OOC"
 
-	var/is_admin = check_rights(R_ADMIN|R_MOD, show_msg = 0)
+	var/is_admin = check_rights(R_ADMIN|R_MOD|R_EVENT, show_msg = 0)
 	var/is_antag = usr.mind && usr.mind.special_role
 
 	if(!is_antag && !is_admin) // Non-antagonists and non-admins have no business using this.
@@ -30,7 +30,7 @@
 	var/player_display = (is_admin && !is_antag) ? "[display_name]([usr.client.holder.rank])" : display_name
 
 	for(var/mob/M in mob_list)
-		if(check_rights(R_ADMIN|R_MOD, 0, M)) // Staff can see AOOC unconditionally, and with more details.
+		if(check_rights(R_ADMIN|R_MOD|R_EVENT, 0, M)) // Staff can see AOOC unconditionally, and with more details.
 			to_chat(M, "<span class='ooc'><span class='aooc'>[create_text_tag("aooc", "Antag-OOC:", M.client)] <EM>[get_options_bar(src, 0, 1, 1)]([admin_jump_link(usr, M.client.holder)]):</EM> <span class='message'>[msg]</span></span></span>")
 		else if(M.client) // Players can only see AOOC if observing, or if they are an antag type allowed to use AOOC.
 			var/datum/antagonist/A = null

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -303,7 +303,7 @@
 	set name = "Assume direct control"
 	set desc = "Direct intervention"
 
-	if(!check_rights(R_DEBUG|R_ADMIN))	return
+	if(!check_rights(R_DEBUG|R_ADMIN|R_EVENT))	return
 	if(M.ckey)
 		if(alert("This mob is being controlled by [M.ckey]. Are you sure you wish to assume control of it? [M.ckey] will be made a ghost.",,"Yes","No") != "Yes")
 			return

--- a/code/modules/admin/verbs/grief_fixers.dm
+++ b/code/modules/admin/verbs/grief_fixers.dm
@@ -2,7 +2,7 @@
 	set category = "Admin"
 	set name = "Fix Atmospherics Grief"
 
-	if(!check_rights(R_ADMIN|R_DEBUG)) return
+	if(!check_rights(R_ADMIN|R_DEBUG|R_EVENT)) return
 
 
 	if(alert("WARNING: Executing this command will perform a full reset of atmosphere. All pipelines will lose any gas that may be in them, and all zones will be reset to contain air mix as on roundstart. The supermatter engine will also be stopped (to prevent overheat due to removal of coolant). Do not use unless the station is suffering serious atmospheric issues due to grief or bug.", "Full Atmosphere Reboot", "No", "Yes") == "No")

--- a/code/modules/admin/verbs/pray.dm
+++ b/code/modules/admin/verbs/pray.dm
@@ -20,7 +20,7 @@
 	msg = "<font color='blue'>\icon[cross] <b><font color=purple>PRAY: </font>[key_name(src, 1)] (<A HREF='?_src_=holder;adminmoreinfo=\ref[src]'>?</A>) (<A HREF='?_src_=holder;adminplayeropts=\ref[src]'>PP</A>) (<A HREF='?_src_=vars;Vars=\ref[src]'>VV</A>) (<A HREF='?_src_=holder;subtlemessage=\ref[src]'>SM</A>) ([admin_jump_link(src, src)]) (<A HREF='?_src_=holder;secretsadmin=check_antagonist'>CA</A>) (<A HREF='?_src_=holder;adminspawncookie=\ref[src]'>SC</a>) (<A HREF='?_src_=holder;adminsmite=\ref[src]'>SMITE</a>):</b> [msg]</font>"
 
 	for(var/client/C in admins)
-		if(R_ADMIN & C.holder.rights)
+		if(R_ADMIN|R_EVENT & C.holder.rights)
 			if(C.is_preference_enabled(/datum/client_preference/admin/show_chat_prayers))
 				to_chat(C,msg)
 				C << 'sound/effects/ding.ogg'
@@ -32,13 +32,13 @@
 /proc/CentCom_announce(var/msg, var/mob/Sender, var/iamessage)
 	msg = "<font color='blue'><b><font color=orange>[uppertext(using_map.boss_short)]M[iamessage ? " IA" : ""]:</font>[key_name(Sender, 1)] (<A HREF='?_src_=holder;adminplayeropts=\ref[Sender]'>PP</A>) (<A HREF='?_src_=vars;Vars=\ref[Sender]'>VV</A>) (<A HREF='?_src_=holder;subtlemessage=\ref[Sender]'>SM</A>) ([admin_jump_link(Sender, src)]) (<A HREF='?_src_=holder;secretsadmin=check_antagonist'>CA</A>) (<A HREF='?_src_=holder;BlueSpaceArtillery=\ref[Sender]'>BSA</A>) (<A HREF='?_src_=holder;CentComReply=\ref[Sender]'>RPLY</A>):</b> [msg]</font>"
 	for(var/client/C in admins)
-		if(R_ADMIN & C.holder.rights)
+		if(R_ADMIN|R_EVENT & C.holder.rights)
 			to_chat(C,msg)
 			C << 'sound/machines/signal.ogg'
 
 /proc/Syndicate_announce(var/msg, var/mob/Sender)
 	msg = "<font color='blue'><b><font color=crimson>ILLEGAL:</font>[key_name(Sender, 1)] (<A HREF='?_src_=holder;adminplayeropts=\ref[Sender]'>PP</A>) (<A HREF='?_src_=vars;Vars=\ref[Sender]'>VV</A>) (<A HREF='?_src_=holder;subtlemessage=\ref[Sender]'>SM</A>) ([admin_jump_link(Sender, src)]) (<A HREF='?_src_=holder;secretsadmin=check_antagonist'>CA</A>) (<A HREF='?_src_=holder;BlueSpaceArtillery=\ref[Sender]'>BSA</A>) (<A HREF='?_src_=holder;SyndicateReply=\ref[Sender]'>RPLY</A>):</b> [msg]</font>"
 	for(var/client/C in admins)
-		if(R_ADMIN & C.holder.rights)
+		if(R_ADMIN|R_EVENT & C.holder.rights)
 			to_chat(C,msg)
 			C << 'sound/machines/signal.ogg'

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -143,10 +143,10 @@
 /client/proc/cmd_admin_godmode(mob/M as mob in mob_list)
 	set category = "Special Verbs"
 	set name = "Godmode"
-	
+
 	if(!holder)
 		return
-	
+
 	M.status_flags ^= GODMODE
 	to_chat(usr, "<font color='blue'> Toggled [(M.status_flags & GODMODE) ? "ON" : "OFF"]</font>")
 
@@ -215,7 +215,7 @@ proc/cmd_admin_mute(mob/M as mob, mute_type, automute = 0)
 
 	if(!holder)
 		return
-	
+
 	var/confirm = alert(src, "You sure?", "Confirm", "Yes", "No")
 	if(confirm != "Yes") return
 	log_admin("[key_name(src)] has added a random AI law.")
@@ -262,10 +262,10 @@ Ccomp's first proc.
 	set category = "Special Verbs"
 	set name = "Allow player to respawn"
 	set desc = "Let's the player bypass the wait to respawn or allow them to re-enter their corpse."
-	
+
 	if(!holder)
 		return
-	
+
 	var/list/ghosts= get_ghosts(1,1)
 
 	var/target = input("Please, select a ghost!", "COME BACK TO LIFE!", null, null) as null|anything in ghosts
@@ -328,10 +328,10 @@ Ccomp's first proc.
 	set category = "Server"
 	set name = "Toggle antagHUD Restrictions"
 	set desc = "Restricts players that have used antagHUD from being able to join this round."
-	
+
 	if(!holder)
 		return
-	
+
 	var/action=""
 	if(config.antag_hud_restricted)
 		for(var/mob/observer/dead/g in get_ghosts())
@@ -361,7 +361,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 	set category = "Special Verbs"
 	set name = "Spawn Character"
 	set desc = "(Re)Spawn a client's loaded character."
-	
+
 	if(!holder)
 		return
 
@@ -512,7 +512,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 
 	if(!holder)
 		return
-	
+
 	var/input = sanitize(input(usr, "Please enter anything you want the AI to do. Anything. Serious.", "What?", "") as text|null)
 	if(!input)
 		return
@@ -541,7 +541,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 
 	if(!holder)
 		return
-	
+
 	if(!mob)
 		return
 	if(!istype(M))
@@ -953,7 +953,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 	set desc = "Removes a player from the round as if they'd cryo'd."
 	set popup_menu = FALSE
 
-	if(!check_rights(R_ADMIN))
+	if(!check_rights(R_ADMIN|R_EVENT))
 		return
 
 	if(!M)

--- a/code/modules/admin/view_variables/topic.dm
+++ b/code/modules/admin/view_variables/topic.dm
@@ -68,7 +68,7 @@
 		href_list["datumrefresh"] = href_list["mob_player_panel"]
 
 	else if(href_list["give_spell"])
-		if(!check_rights(R_ADMIN|R_FUN))	return
+		if(!check_rights(R_ADMIN|R_FUN|R_EVENT))	return
 
 		var/mob/M = locate(href_list["give_spell"])
 		if(!istype(M))
@@ -79,7 +79,7 @@
 		href_list["datumrefresh"] = href_list["give_spell"]
 
 	else if(href_list["give_modifier"])
-		if(!check_rights(R_ADMIN|R_FUN|R_DEBUG))
+		if(!check_rights(R_ADMIN|R_FUN|R_DEBUG|R_EVENT))
 			return
 
 		var/mob/living/M = locate(href_list["give_modifier"])
@@ -91,7 +91,7 @@
 		href_list["datumrefresh"] = href_list["give_modifier"]
 
 	else if(href_list["give_disease2"])
-		if(!check_rights(R_ADMIN|R_FUN))	return
+		if(!check_rights(R_ADMIN|R_FUN|R_EVENT))	return
 
 		var/mob/M = locate(href_list["give_disease2"])
 		if(!istype(M))
@@ -134,7 +134,7 @@
 		href_list["datumrefresh"] = href_list["build_mode"]
 
 	else if(href_list["drop_everything"])
-		if(!check_rights(R_DEBUG|R_ADMIN))	return
+		if(!check_rights(R_DEBUG|R_ADMIN|R_EVENT))	return
 
 		var/mob/M = locate(href_list["drop_everything"])
 		if(!istype(M))
@@ -466,7 +466,7 @@
 		M.regenerate_icons()
 
 	else if(href_list["adjustDamage"] && href_list["mobToDamage"])
-		if(!check_rights(R_DEBUG|R_ADMIN|R_FUN))	return
+		if(!check_rights(R_DEBUG|R_ADMIN|R_FUN|R_EVENT))	return
 
 		var/mob/living/L = locate(href_list["mobToDamage"])
 		if(!istype(L)) return

--- a/code/modules/client/preference_setup/general/03_body.dm
+++ b/code/modules/client/preference_setup/general/03_body.dm
@@ -398,7 +398,7 @@ var/global/list/valid_bloodtypes = list("A+", "A-", "B+", "B-", "AB+", "AB-", "O
 		else
 			return TOPIC_NOACTION
 
-		if(((!(setting_species.spawn_flags & SPECIES_CAN_JOIN)) || (!is_alien_whitelisted(preference_mob(),setting_species))) && !check_rights(R_ADMIN, 0))
+		if(((!(setting_species.spawn_flags & SPECIES_CAN_JOIN)) || (!is_alien_whitelisted(preference_mob(),setting_species))) && !check_rights(R_ADMIN|R_EVENT, 0))
 			return TOPIC_NOACTION
 
 		var/prev_species = pref.species
@@ -882,7 +882,7 @@ var/global/list/valid_bloodtypes = list("A+", "A-", "B+", "B-", "AB+", "AB-", "O
 			dat += "<font color='red'><b>You cannot play as this species.</br><small>If you wish to be whitelisted, you can make an application post on <a href='?src=\ref[user];preference=open_whitelist_forum'>the forums</a>.</small></b></font></br>"
 		else if(restricted == 2)
 			dat += "<font color='red'><b>You cannot play as this species.</br><small>This species is not available for play as a station race..</small></b></font></br>"
-	if(!restricted || check_rights(R_ADMIN, 0))
+	if(!restricted || check_rights(R_ADMIN|R_EVENT, 0))
 		dat += "\[<a href='?src=\ref[src];set_species=[pref.species_preview]'>select</a>\]"
 	dat += "</center></body>"
 

--- a/code/modules/client/preference_setup/global/01_ui.dm
+++ b/code/modules/client/preference_setup/global/01_ui.dm
@@ -93,4 +93,4 @@
 	return ..()
 
 /datum/category_item/player_setup_item/player_global/ui/proc/can_select_ooc_color(var/mob/user)
-	return config.allow_admin_ooccolor && check_rights(R_ADMIN, 0, user)
+	return config.allow_admin_ooccolor && check_rights(R_ADMIN|R_EVENT|R_FUN, 0, user)

--- a/code/modules/client/preference_setup/global/setting_datums.dm
+++ b/code/modules/client/preference_setup/global/setting_datums.dm
@@ -215,7 +215,7 @@ var/list/_client_preferences_by_type
 * Staff Preferences *
 ********************/
 /datum/client_preference/admin/may_toggle(var/mob/preference_mob)
-	return check_rights(R_ADMIN, 0, preference_mob)
+	return check_rights(R_ADMIN|R_EVENT, 0, preference_mob)
 
 /datum/client_preference/mod/may_toggle(var/mob/preference_mob)
 	return check_rights(R_MOD|R_ADMIN, 0, preference_mob)

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -379,7 +379,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	return 0
 
 /mob/observer/dead/check_holy(var/turf/T)
-	if(check_rights(R_ADMIN|R_FUN, 0, src))
+	if(check_rights(R_ADMIN|R_FUN|R_EVENT, 0, src))
 		return 0
 
 	return (T && T.holy) && (is_manifest || (mind in cult.current_antagonists))
@@ -554,7 +554,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		if(cult.current_antagonists.len > config.cult_ghostwriter_req_cultists)
 			ghosts_can_write = 1
 
-	if(!ghosts_can_write && !check_rights(R_ADMIN, 0)) //Let's allow for admins to write in blood for events and the such.
+	if(!ghosts_can_write && !check_rights(R_ADMIN|R_EVENT|R_FUN, 0)) //Let's allow for admins to write in blood for events and the such.
 		to_chat(src, "<font color='red'>The veil is not thin enough for you to do that.</font>")
 		return
 
@@ -682,7 +682,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	return 1
 
 /mob/observer/dead/proc/can_admin_interact()
-	return check_rights(R_ADMIN, 0, src)
+	return check_rights(R_ADMIN|R_EVENT, 0, src)
 
 /mob/observer/dead/verb/toggle_ghostsee()
 	set name = "Toggle Ghost Vision"

--- a/code/modules/mob/living/carbon/human/appearance.dm
+++ b/code/modules/mob/living/carbon/human/appearance.dm
@@ -147,7 +147,7 @@
 	for(var/current_species_name in GLOB.all_species)
 		var/datum/species/current_species = GLOB.all_species[current_species_name]
 
-		if(check_whitelist && config.usealienwhitelist && !check_rights(R_ADMIN, 0, src)) //If we're using the whitelist, make sure to check it!
+		if(check_whitelist && config.usealienwhitelist && !check_rights(R_ADMIN|R_EVENT, 0, src)) //If we're using the whitelist, make sure to check it!
 			if(!(current_species.spawn_flags & SPECIES_CAN_JOIN))
 				continue
 			if(whitelist.len && !(current_species_name in whitelist))

--- a/code/modules/mob/living/silicon/pai/admin.dm
+++ b/code/modules/mob/living/silicon/pai/admin.dm
@@ -3,7 +3,7 @@
 	set name = "Make pAI"
 	set category = "Admin"
 
-	if(!check_rights(R_ADMIN))
+	if(!check_rights(R_ADMIN|R_EVENT|R_DEBUG))
 		return
 
 	if(!pai_key)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -431,7 +431,7 @@
 	set category = "OOC"
 	var/is_admin = 0
 
-	if(client.holder && (client.holder.rights & R_ADMIN))
+	if(client.holder && (client.holder.rights & R_ADMIN|R_EVENT))
 		is_admin = 1
 	else if(stat != DEAD || istype(src, /mob/new_player))
 		to_chat(usr, "<font color='blue'>You must be observing to use this!</font>")

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -83,7 +83,7 @@ proc/getsensorlevel(A)
 
 
 /proc/is_admin(var/mob/user)
-	return check_rights(R_ADMIN, 0, user) != 0
+	return check_rights(R_ADMIN|R_EVENT, 0, user) != 0
 
 
 /proc/hsl2rgb(h, s, l)

--- a/code/modules/modular_computers/computers/modular_computer/interaction.dm
+++ b/code/modules/modular_computers/computers/modular_computer/interaction.dm
@@ -100,7 +100,7 @@
 /obj/item/modular_computer/attack_ghost(var/mob/observer/ghost/user)
 	if(enabled)
 		ui_interact(user)
-	else if(check_rights(R_ADMIN, 0, user))
+	else if(check_rights(R_ADMIN|R_EVENT, 0, user))
 		var/response = alert(user, "This computer is turned off. Would you like to turn it on?", "Admin Override", "Yes", "No")
 		if(response == "Yes")
 			turn_on(user)

--- a/code/modules/modular_computers/file_system/program.dm
+++ b/code/modules/modular_computers/file_system/program.dm
@@ -97,7 +97,7 @@
 		return 1
 
 	// Admin override - allows operation of any computer as aghosted admin, as if you had any required access.
-	if(istype(user, /mob/observer/dead) && check_rights(R_ADMIN, 0, user))
+	if(istype(user, /mob/observer/dead) && check_rights(R_ADMIN|R_EVENT, 0, user))
 		return 1
 
 	if(!istype(user))

--- a/code/modules/nano/interaction/admin.dm
+++ b/code/modules/nano/interaction/admin.dm
@@ -4,4 +4,4 @@
 /var/global/datum/topic_state/admin_state/admin_state = new()
 
 /datum/topic_state/admin_state/can_use_topic(var/src_object, var/mob/user)
-	return check_rights(R_ADMIN, 0, user) ? STATUS_INTERACTIVE : STATUS_CLOSE
+	return check_rights(R_ADMIN|R_EVENT, 0, user) ? STATUS_INTERACTIVE : STATUS_CLOSE

--- a/code/modules/paperwork/faxmachine.dm
+++ b/code/modules/paperwork/faxmachine.dm
@@ -236,6 +236,6 @@ var/list/adminfaxes = list()	//cache for faxes that have been sent to admins
 	msg += "Receiving '[sent.name]' via secure connection ... <a href='?_src_=holder;AdminFaxView=\ref[sent]'>view message</a></span>"
 
 	for(var/client/C in admins)
-		if(check_rights((R_ADMIN|R_MOD),0,C))
+		if(check_rights((R_ADMIN|R_MOD|R_EVENT),0,C))
 			to_chat(C,msg)
 			C << 'sound/effects/printer.ogg'

--- a/code/modules/virus2/admin.dm
+++ b/code/modules/virus2/admin.dm
@@ -4,7 +4,7 @@
 
 	if(href_list["info"])
 		// spawn or admin privileges to see info about viruses
-		if(!check_rights(R_ADMIN|R_SPAWN)) return
+		if(!check_rights(R_ADMIN|R_SPAWN|R_EVENT)) return
 
 		to_chat(usr, "Infection chance: [infectionchance]; Speed: [speed]; Spread type: [spreadtype]")
 		to_chat(usr, "Affected species: [english_list(affected_species)]")

--- a/config/example/admin_ranks.txt
+++ b/config/example/admin_ranks.txt
@@ -25,6 +25,7 @@
 # +RIGHTS (or +PERMISSIONS) = allows you to promote and/or demote people.
 # +SOUND (or +SOUNDS) = allows you to upload and play sounds
 # +SPAWN (or +CREATE) = mob transformations, spawning of most atoms including mobs (high-risk atoms, e.g. blackholes, will require the +FUN flag too)
+# +EVENT = a group of verbs that make it possible to run an event, or other badminnery.
 # +EVERYTHING (or +HOST or +ALL) = Simply gives you everything without having to type every flag
 
 Admin Observer

--- a/polaris.dme
+++ b/polaris.dme
@@ -2844,7 +2844,7 @@
 #include "code\ZAS\Zone.dm"
 #include "interface\interface.dm"
 #include "interface\skin.dmf"
-#include "maps\southern_cross\southern_cross.dm"
+#include "maps\example\example.dm"
 #include "maps\submaps\space_submaps\space.dm"
 #include "maps\submaps\surface_submaps\mountains\mountains.dm"
 #include "maps\submaps\surface_submaps\mountains\mountains_areas.dm"

--- a/polaris.dme
+++ b/polaris.dme
@@ -2844,7 +2844,7 @@
 #include "code\ZAS\Zone.dm"
 #include "interface\interface.dm"
 #include "interface\skin.dmf"
-#include "maps\example\example.dm"
+#include "maps\southern_cross\southern_cross.dm"
 #include "maps\submaps\space_submaps\space.dm"
 #include "maps\submaps\surface_submaps\mountains\mountains.dm"
 #include "maps\submaps\surface_submaps\mountains\mountains_areas.dm"


### PR DESCRIPTION
#6812 wasn't nearly enough it seems, so instead of a quick fix, let's try a thorough fix instead.

I went through every verb list tied to `R_ADMIN` and `R_SERVER`, and copied every verb that would be useful for running an event into the event manager verb list, which was actually unused until this PR. I also went through every verb which checked for `R_ADMIN`, and added a `|R_EVENT` beside it if it should be usable for event managers. I've also added the +EVENT flag to the example config documentation, since it was previously undocumented.

This was tested on a test server with myself, Rand0, Mechoid, and Schnayy, and there did not appear to be any event-related verbs that are missing. I'm hoping I got them all.

The permissions system really needs to go down in flames and be rewritten but no time for that.