### PR TITLE
Makes language keys case sensitive, adds unit tests for language conflicts, fixes some language conflicts

### DIFF
--- a/code/_global_vars/lists/species.dm
+++ b/code/_global_vars/lists/species.dm
@@ -1,6 +1,8 @@
 //Languages/species/whitelist.
 GLOBAL_LIST_INIT(all_species, list())
 GLOBAL_LIST_INIT(all_languages, list())
+GLOBAL_LIST_INIT(language_name_conflicts, list())
 GLOBAL_LIST_INIT(language_keys, list())						// Table of say codes for all languages
+GLOBAL_LIST_INIT(language_key_conflicts, list())
 GLOBAL_LIST_INIT(whitelisted_species, list(SPECIES_HUMAN))	// Species that require a whitelist check.
 GLOBAL_LIST_INIT(playable_species, list(SPECIES_HUMAN))		// A list of ALL playable species, whitelisted, latejoin or otherwise.

--- a/code/_helpers/global_lists.dm
+++ b/code/_helpers/global_lists.dm
@@ -153,17 +153,31 @@ var/global/list/string_slot_flags = list(
 		var/datum/job/J = new T
 		joblist[J.title] = J
 
-	//Languages and species.
+	//Languages
 	paths = typesof(/datum/language)-/datum/language
 	for(var/T in paths)
 		var/datum/language/L = new T
-		GLOB.all_languages[L.name] = L
+		if (isnull(GLOB.all_languages[L.name]))
+			GLOB.all_languages[L.name] = L
+		else
+			log_debug("Language name conflict! [T] is named [L.name], but that is taken by [GLOB.all_languages[L.name].type]")
+			if(isnull(GLOB.language_name_conflicts[L.name]))
+				GLOB.language_name_conflicts[L.name] = list(GLOB.all_languages[L.name])
+			GLOB.language_name_conflicts[L.name] += L
 
 	for (var/language_name in GLOB.all_languages)
 		var/datum/language/L = GLOB.all_languages[language_name]
+		var/lkey = lowertext(L.key)
 		if(!(L.flags & NONGLOBAL))
-			GLOB.language_keys[lowertext(L.key)] = L
+			if(isnull(GLOB.language_keys[lkey]))
+				GLOB.language_keys[lkey] = L
+			else
+				log_debug("Language key conflict! [L] has key [L.key], but that is taken by [(GLOB.language_keys[lkey])]")
+				if(isnull(GLOB.language_key_conflicts[lkey]))
+					GLOB.language_key_conflicts[lkey] = list(GLOB.language_keys[lkey])
+				GLOB.language_key_conflicts[lkey] += L
 
+	//Species
 	var/rkey = 0
 	paths = typesof(/datum/species)
 	for(var/T in paths)

--- a/code/_helpers/global_lists.dm
+++ b/code/_helpers/global_lists.dm
@@ -167,15 +167,14 @@ var/global/list/string_slot_flags = list(
 
 	for (var/language_name in GLOB.all_languages)
 		var/datum/language/L = GLOB.all_languages[language_name]
-		var/lkey = lowertext(L.key)
 		if(!(L.flags & NONGLOBAL))
-			if(isnull(GLOB.language_keys[lkey]))
-				GLOB.language_keys[lkey] = L
+			if(isnull(GLOB.language_keys[L.key]))
+				GLOB.language_keys[L.key] = L
 			else
-				log_debug("Language key conflict! [L] has key [L.key], but that is taken by [(GLOB.language_keys[lkey])]")
-				if(isnull(GLOB.language_key_conflicts[lkey]))
-					GLOB.language_key_conflicts[lkey] = list(GLOB.language_keys[lkey])
-				GLOB.language_key_conflicts[lkey] += L
+				log_debug("Language key conflict! [L] has key [L.key], but that is taken by [(GLOB.language_keys[L.key])]")
+				if(isnull(GLOB.language_key_conflicts[L.key]))
+					GLOB.language_key_conflicts[L.key] = list(GLOB.language_keys[L.key])
+				GLOB.language_key_conflicts[L.key] += L
 
 	//Species
 	var/rkey = 0

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -2,13 +2,6 @@
 #define RECOMMENDED_VERSION 501
 /world/New()
 	to_world_log("Map Loading Complete")
-	//logs
-	log_path += time2text(world.realtime, "YYYY/MM-Month/DD-Day/round-hh-mm-ss")
-	diary = file("[log_path].log")
-	href_logfile = file("[log_path]-hrefs.htm")
-	error_log = file("[log_path]-error.log")
-	debug_log = file("[log_path]-debug.log")
-	debug_log << "[log_end]\n[log_end]\nStarting up. [time_stamp()][log_end]\n---------------------[log_end]"
 	changelog_hash = md5('html/changelog.html')					//used for telling if the changelog has changed recently
 
 	if(byond_version < RECOMMENDED_VERSION)

--- a/code/global_init.dm
+++ b/code/global_init.dm
@@ -14,9 +14,15 @@ var/global/datum/global_init/init = new ()
 	Pre-map initialization stuff should go here.
 */
 /datum/global_init/New()
-
-	makeDatumRefLists()
+	//logs
+	log_path += time2text(world.realtime, "YYYY/MM-Month/DD-Day/round-hh-mm-ss")
+	diary = file("[log_path].log")
+	href_logfile = file("[log_path]-hrefs.htm")
+	error_log = file("[log_path]-error.log")
+	debug_log = file("[log_path]-debug.log")
+	debug_log << "[log_end]\n[log_end]\nStarting up. [time_stamp()][log_end]\n---------------------[log_end]"
 	load_configuration()
+	makeDatumRefLists()
 
 	initialize_integrated_circuits_list()
 

--- a/code/modules/mob/language/monkey.dm
+++ b/code/modules/mob/language/monkey.dm
@@ -4,7 +4,7 @@
 	speech_verb = "chimpers"
 	ask_verb = "chimpers"
 	exclaim_verb = "screeches"
-	key = "6"
+	key = "C"
 	syllables = list("ook","eek")
 	machine_understands = 0
 
@@ -71,7 +71,7 @@
 	speech_verb = "chirps"
 	ask_verb = "tweets"
 	exclaim_verb = "squawks"
-	key = "m"
+	key = "B"
 	flags = RESTRICTED
 	machine_understands = 0
 	space_chance = 100

--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -144,7 +144,7 @@
 		return GLOB.all_languages["Noise"]
 
 	if(length(message) >= 2 && is_language_prefix(prefix))
-		var/language_prefix = lowertext(copytext(message, 2 ,3))
+		var/language_prefix = copytext(message, 2 ,3)
 		var/datum/language/L = GLOB.language_keys[language_prefix]
 		if (can_speak(L))
 			return L

--- a/code/unit_tests/language_tests.dm
+++ b/code/unit_tests/language_tests.dm
@@ -1,0 +1,29 @@
+/datum/unit_test/language_test_shall_have_distinct_names
+	name = "LANGUAGES: Entries shall have distinct names"
+
+/datum/unit_test/language_test_shall_have_distinct_names/start_test()
+	if(length(GLOB.language_name_conflicts) != 0)
+		var/list/name_conflict_log = list()
+		for(var/conflicted_name in GLOB.language_name_conflicts)
+			name_conflict_log += "+[length(GLOB.language_name_conflicts[conflicted_name])] languages with name \"[conflicted_name]\"!"
+			for(var/datum/language/L in GLOB.language_name_conflicts[conflicted_name])
+				name_conflict_log += "+-+[L.type]"
+		fail("Some names are used by more than one language:\n" + name_conflict_log.Join("\n"))
+	else
+		pass("All languages have distinct names")
+	return 1
+
+/datum/unit_test/language_test_shall_have_distinct_keys
+	name = "LANGUAGES: Entries shall have distinct keys"
+
+/datum/unit_test/language_test_shall_have_distinct_keys/start_test()
+	if(length(GLOB.language_key_conflicts) != 0)
+		var/list/key_conflict_log = list()
+		for(var/conflicted_key in GLOB.language_key_conflicts)
+			key_conflict_log += "+[length(GLOB.language_key_conflicts[conflicted_key])] languages with key \"[conflicted_key]\"!"
+			for(var/datum/language/L in GLOB.language_key_conflicts[conflicted_key])
+				key_conflict_log += "+-+[L]([L.type])"
+		fail("Some keys are used by more than one language:\n" + key_conflict_log.Join("\n"))
+	else
+		pass("All languages in GLOB.all_languages have distinct keys")
+	return 1

--- a/html/changelogs/Meghan Rossi - Language key tweaks.yml
+++ b/html/changelogs/Meghan Rossi - Language key tweaks.yml
@@ -1,0 +1,39 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Meghan-Rossi
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Language keys are now case-sensitive."
+  - tweak: "The language key for Chimpanzee has changed from 6 to C to resolve a conflict with EAL."
+  - tweak: "The language key for Bird has changed from m to B to resolve a conflict with Mouse."
+  - tweak: "All other language keys are now lowercase-only."

--- a/polaris.dme
+++ b/polaris.dme
@@ -2805,6 +2805,7 @@
 #include "code\modules\xenobio\machinery\processor.dm"
 #include "code\modules\xgm\xgm_gas_data.dm"
 #include "code\modules\xgm\xgm_gas_mixture.dm"
+#include "code\unit_tests\language_tests.dm"
 #include "code\unit_tests\loadout_tests.dm"
 #include "code\unit_tests\map_tests.dm"
 #include "code\unit_tests\mob_tests.dm"


### PR DESCRIPTION
*Adds unit tests to catch languages with the same name or language key
*Makes language keys case sensitive (Because we were running really low on free keys to use
*Fixes Chimpanzee and EAL both using the language key "6" by changing Chimpanzee's language key to "C"
*Fixes Mouse and Bird both using the language key "m" by changing Bird's language key to "B"
*Lets log_debug work during global list initialization by moving logging and config setup slightly early in initialization

Tested and seems to work fine.