### PR TITLE
Xenoarch fix

### DIFF
--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -416,7 +416,7 @@ turf/simulated/mineral/floor/light_corner
 				var/datum/find/F = finds[1]
 				if(newDepth > F.excavation_required) // Digging too deep can break the item. At least you won't summon a Balrog (probably)
 					fail_message = ". <b>[pick("There is a crunching noise","[W] collides with some different rock","Part of the rock face crumbles away","Something breaks under [W]")]</b>"
-				wreckfinds(P.destroy_artefacts)
+					wreckfinds(P.destroy_artefacts)
 			to_chat(user, "<span class='notice'>You start [P.drill_verb][fail_message].</span>")
 
 			if(do_after(user,P.digspeed))

--- a/html/changelogs/prismaticgynoid - xenoarch_fix.yml
+++ b/html/changelogs/prismaticgynoid - xenoarch_fix.yml
@@ -1,0 +1,6 @@
+author: PrismaticGynoid
+
+delete-after: True
+
+changes: 
+  - bugfix: "Fixes xenoarch artifacts breaking when performing excavation correctly."


### PR DESCRIPTION
Fixes the bug in xenoarchaeology where there was a significant chance an artifact would break or come out as a strange rock, even when you did everything correctly. Now that only happens if you did the excavation wrong.