### PR TITLE
Streamline Job Alt Titles

### DIFF
--- a/code/game/jobs/job/assistant.dm
+++ b/code/game/jobs/job/assistant.dm
@@ -18,7 +18,7 @@
 
 	outfit_type = /decl/hierarchy/outfit/job/assistant
 	job_description = "An Assistant does whatever is requested of them. Though they are part of the crew, they have no real authority."
-	alt_titles = list("Assistant" = /datum/alt_title/assistant, "Technical Assistant" = /datum/alt_title/tech_assist,
+	alt_titles = list("Technical Assistant" = /datum/alt_title/tech_assist,
 						"Medical Intern"= /datum/alt_title/med_intern, "Research Assistant" = /datum/alt_title/research_assist,
 						"Visitor" = /datum/alt_title/visitor)
 
@@ -29,10 +29,6 @@
 		return list()
 
 // Assistant Alt Titles
-/datum/alt_title/assistant
-	title = "Assistant"
-	title_blurb = "An Assistant does whatever is requested of them. Though they are part of the crew, they have no real authority."
-
 /datum/alt_title/tech_assist
 	title = "Technical Assistant"
 	title_blurb = "A Technical Assistant attempts to provide whatever the Engineering department needs. They are not proper Engineers, and are \

--- a/code/game/jobs/job/captain.dm
+++ b/code/game/jobs/job/captain.dm
@@ -29,7 +29,7 @@ var/datum/announcement/minor/captain_announcement = new(do_newscast = 1)
 	job_description = "The Colony Director manages the other Command Staff, and through them the rest of the station. Though they have access to everything, \
 						they do not understand everything, and are expected to delegate tasks to the appropriate crew member. The Colony Director is expected to \
 						have an understanding of Standard Operating Procedure, and is subject to it, and legal action, in the same way as every other crew member."
-	alt_titles = list("Colony Director" = /datum/alt_title/captain, "Site Manager" = /datum/alt_title/site_manager,
+	alt_titles = list("Site Manager" = /datum/alt_title/site_manager,
 						"Overseer" = /datum/alt_title/overseer)
 
 /*
@@ -44,9 +44,6 @@ var/datum/announcement/minor/captain_announcement = new(do_newscast = 1)
 
 
 // Captain Alt Titles
-/datum/alt_title/captain	// Screw it, this is the default, it has the default path
-	title = "Colony Director"
-
 /datum/alt_title/site_manager
 	title = "Site Manager"
 
@@ -79,7 +76,7 @@ var/datum/announcement/minor/captain_announcement = new(do_newscast = 1)
 	job_description = "The Head of Personnel manages the Service department, the Exploration team, and most other civilians. They also \
 						manage the Supply department, through the Quartermaster. In addition, the Head of Personnel oversees the personal accounts \
 						of the crew, including their money and access. If necessary, the Head of Personnel is first in line to assume Acting Command."
-	alt_titles = list("Head of Personnel" = /datum/alt_title/hop, "Crew Resources Officer" = /datum/alt_title/cro)
+	alt_titles = list("Crew Resources Officer" = /datum/alt_title/cro)
 
 	access = list(access_security, access_sec_doors, access_brig, access_forensics_lockers,
 			            access_medical, access_engine, access_change_ids, access_ai_upload, access_eva, access_heads,
@@ -95,9 +92,6 @@ var/datum/announcement/minor/captain_announcement = new(do_newscast = 1)
 			            access_hop, access_RC_announce, access_keycard_auth, access_gateway)
 
 // HOP Alt Titles
-/datum/alt_title/hop
-	title = "Head of Personnel"
-
 /datum/alt_title/cro
 	title = "Crew Resources Officer"
 
@@ -126,6 +120,3 @@ var/datum/announcement/minor/captain_announcement = new(do_newscast = 1)
 	job_description = "A Command Secretary handles paperwork duty for the Heads of Staff, so they can better focus on managing their departments. \
 						They are not Heads of Staff, and have no real authority."
 
-// Command Secretary Alt Title
-/datum/alt_title/command_secretary
-	title = "Command Secretary"

--- a/code/game/jobs/job/civilian.dm
+++ b/code/game/jobs/job/civilian.dm
@@ -19,12 +19,9 @@
 
 	outfit_type = /decl/hierarchy/outfit/job/service/bartender
 	job_description = "A Bartender mixes drinks for the crew. They generally have permission to charge for drinks or deny service to unruly patrons."
-	alt_titles = list("Bartender" = /datum/alt_title/bartender, "Barista" = /datum/alt_title/barista)
+	alt_titles = list("Barista" = /datum/alt_title/barista)
 
 // Bartender Alt Titles
-/datum/alt_title/bartender
-	title = "Bartender"
-
 /datum/alt_title/barista
 	title = "Barista"
 	title_blurb = "A barista mans the Cafe, serving primarily non-alcoholic drinks to the crew. They generally have permission to charge for drinks \
@@ -50,12 +47,9 @@
 
 	outfit_type = /decl/hierarchy/outfit/job/service/chef
 	job_description = "A Chef cooks food for the crew. They generally have permission to charge for food or deny service to unruly diners."
-	alt_titles = list("Chef" = /datum/alt_title/chef, "Cook" = /datum/alt_title/cook)
+	alt_titles = list("Cook" = /datum/alt_title/cook)
 
 // Chef Alt Titles
-/datum/alt_title/chef
-	title = "Chef"
-
 /datum/alt_title/cook
 	title = "Cook"
 	title_blurb = "A Cook has the same duties, though they may be less experienced."
@@ -79,12 +73,9 @@
 
 	outfit_type = /decl/hierarchy/outfit/job/service/gardener
 	job_description = "A Botanist grows plants for the Chef and Bartender."
-	alt_titles = list("Botanist" = /datum/alt_title/botanist, "Gardener" = /datum/alt_title/gardener)
+	alt_titles = list("Gardener" = /datum/alt_title/gardener)
 
 //Botanist Alt Titles
-/datum/alt_title/botanist
-	title = "Botanist"
-
 /datum/alt_title/gardener
 	title = "Gardener"
 	title_blurb = "A Gardener may be less professional than their counterparts, and are more likely to tend to the public gardens if they aren't needed elsewhere."
@@ -113,12 +104,9 @@
 
 	outfit_type = /decl/hierarchy/outfit/job/cargo/qm
 	job_description = "The Quartermaster manages the Supply department, checking cargo orders and ensuring supplies get to where they are needed."
-	alt_titles = list("Quartermaster" = /datum/alt_title/qm, "Supply Chief" = /datum/alt_title/supply_chief)
+	alt_titles = list("Supply Chief" = /datum/alt_title/supply_chief)
 
 // Quartermaster Alt Titles
-/datum/alt_title/qm
-	title = "Quartermaster"
-
 /datum/alt_title/supply_chief
 	title = "Supply Chief"
 
@@ -142,10 +130,6 @@
 	job_description = "A Cargo Technician fills and delivers cargo orders. They are encouraged to return delivered crates to the Cargo Shuttle, \
 						because Central Command gives a partial refund."
 
-// Cargo Tech Alt Titles
-/datum/alt_title/cargo_tech
-	title = "Cargo Tech"
-
 //////////////////////////////////
 //			Shaft Miner
 //////////////////////////////////
@@ -166,11 +150,7 @@
 
 	outfit_type = /decl/hierarchy/outfit/job/cargo/mining
 	job_description = "A Shaft Miner mines and processes minerals to be delivered to departments that need them."
-	alt_titles = list("Shaft Miner" = /datum/alt_title/miner, "Drill Technician" = /datum/alt_title/drill_tech)
-
-// Shaft Miner Alt Titles
-/datum/alt_title/miner
-	title = "Shaft Miner"
+	alt_titles = list("Drill Technician" = /datum/alt_title/drill_tech)
 
 /datum/alt_title/drill_tech
 	title = "Drill Technician"
@@ -195,12 +175,9 @@
 
 	outfit_type = /decl/hierarchy/outfit/job/service/janitor
 	job_description = "A Janitor keeps the station clean, as long as it doesn't interfere with active crime scenes."
-	alt_titles = list("Janitor" = /datum/alt_title/janitor, "Custodian" = /datum/alt_title/custodian)
+	alt_titles = list("Custodian" = /datum/alt_title/custodian)
 
 // Janitor Alt Titles
-/datum/alt_title/janitor
-	title = "Janitor"
-
 /datum/alt_title/custodian
 	title = "Custodian"
 
@@ -223,12 +200,9 @@
 
 	outfit_type = /decl/hierarchy/outfit/job/librarian
 	job_description = "The Librarian curates the book selection in the Library, so the crew might enjoy it."
-	alt_titles = list("Librarian" = /datum/alt_title/librarian, "Journalist" = /datum/alt_title/journalist, "Writer" = /datum/alt_title/writer)
+	alt_titles = list("Journalist" = /datum/alt_title/journalist, "Writer" = /datum/alt_title/writer)
 
 // Librarian Alt Titles
-/datum/alt_title/librarian
-	title = "Librarian"
-
 /datum/alt_title/journalist
 	title = "Journalist"
 	title_blurb = "The Journalist uses the Library as a base of operations, from which they can report the news and goings-on on the station with their camera."
@@ -268,7 +242,3 @@
 	if(.)
 		H.implant_loyalty(H)
 */
-
-// IAA Alt Titles
-/datum/alt_title/iaa
-	title = "Internal Affairs Agent"

--- a/code/game/jobs/job/civilian_chaplain.dm
+++ b/code/game/jobs/job/civilian_chaplain.dm
@@ -14,12 +14,9 @@
 
 	outfit_type = /decl/hierarchy/outfit/job/chaplain
 	job_description = "The Chaplain ministers to the spiritual needs of the crew."
-	alt_titles = list("Chaplain" = /datum/alt_title/chaplain, "Counselor" = /datum/alt_title/counselor)
+	alt_titles = list("Counselor" = /datum/alt_title/counselor)
 
 // Chaplain Alt Titles
-/datum/alt_title/chaplain
-	title = "Chaplain"
-
 /datum/alt_title/counselor
 	title = "Counselor"
 	title_blurb = "The Counselor attends to the emotional needs of the crew, without a specific medicinal or spiritual focus."

--- a/code/game/jobs/job/engineering.dm
+++ b/code/game/jobs/job/engineering.dm
@@ -35,10 +35,6 @@
 						of manpower as much as they handle hands-on operations and repairs. They are also expected to keep the rest of the station informed of \
 						any structural threats to the station that may be hazardous to health or disruptive to work."
 
-// Chief Engineer Alt Titles
-/datum/alt_title/chief_engineer
-	title = "Chief Engineer"
-
 //////////////////////////////////
 //			Engineer
 //////////////////////////////////
@@ -55,7 +51,7 @@
 	economic_modifier = 5
 	access = list(access_eva, access_engine, access_engine_equip, access_tech_storage, access_maint_tunnels, access_external_airlocks, access_construction, access_atmospherics)
 	minimal_access = list(access_eva, access_engine, access_engine_equip, access_tech_storage, access_maint_tunnels, access_external_airlocks, access_construction)
-	alt_titles = list("Station Engineer" = /datum/alt_title/engineer, "Maintenance Technician" = /datum/alt_title/maint_tech,
+	alt_titles = list("Maintenance Technician" = /datum/alt_title/maint_tech,
 						"Engine Technician" = /datum/alt_title/engine_tech, "Electrician" = /datum/alt_title/electrician)
 
 	minimal_player_age = 3
@@ -65,9 +61,6 @@
 						generated and distributed. On quiet shifts, they may be called upon to make cosmetic alterations to the station."
 
 // Engineer Alt Titles
-/datum/alt_title/engineer
-	title = "Station Engineer"
-
 /datum/alt_title/maint_tech
 	title = "Maintenance Technician"
 	title_blurb = "A Maintenance Technician is generally a junior Engineer, and can be expected to run the mildly unpleasant or boring tasks that other \
@@ -105,7 +98,3 @@
 	outfit_type = /decl/hierarchy/outfit/job/engineering/atmos
 	job_description = "An Atmospheric Technician is primarily concerned with keeping the station's atmosphere breathable. They are expected to have a good \
 						understanding of the pipes, vents, and scrubbers that move gasses around the station, and to be familiar with proper firefighting procedure."
-
-// Atmos Tech Alt Titles
-/datum/alt_title/atmos_tech
-	title = "Atmospheric Technician"

--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -13,7 +13,7 @@
 	var/current_positions = 0             // How many players have this job
 	var/supervisors = null                // Supervisors, who this person answers to directly
 	var/selection_color = "#ffffff"       // Selection screen color
-	var/list/alt_titles = list()          // List of alternate titles; if a job has alt-titles, it MUST have one for the base job
+	var/list/alt_titles = null            // List of alternate titles; There is no need for an alt-title datum for the base job title.
 	var/req_admin_notify                  // If this is set to 1, a text is printed to the player when jobs are assigned, telling him that he should let admins know that he has to disconnect.
 	var/minimal_player_age = 0            // If you have use_age_restriction_for_jobs config option enabled and the database set up, this option will add a requirement for players to be at least minimal_player_age days old. (meaning they first signed in at least that many days before.)
 	var/list/departments = list()         // List of departments this job belongs to, if any. The first one on the list will be the 'primary' department.
@@ -46,13 +46,9 @@
 
 /datum/job/proc/get_outfit(var/mob/living/carbon/human/H, var/alt_title)
 	if(alt_title && alt_titles)
-		for(var/alt in alt_titles)
-			if(alt_title == alt)
-				var/typepath = alt_titles[alt]
-				var/datum/alt_title/A = new typepath()
-				if(A.title_outfit)
-					. = A.title_outfit
-
+		var/datum/alt_title/A = alt_titles[alt_title]
+		if(A && initial(A.title_outfit))
+			. = initial(A.title_outfit)
 	. = . || outfit_type
 	. = outfit_by_type(.)
 
@@ -133,12 +129,11 @@
 	message |= job_description
 
 	if(alt_title && alt_titles)
-		for(var/alt in alt_titles)
-			if(alt_title == alt)
-				var/typepath = alt_titles[alt]
-				var/datum/alt_title/A = new typepath()
-				if(A.title_blurb)
-					message |= A.title_blurb
+		var/typepath = alt_titles[alt_title]
+		if(typepath)
+			var/datum/alt_title/A = new typepath()
+			if(A.title_blurb)
+				message |= A.title_blurb
 	return message
 
 /datum/job/proc/get_job_icon()

--- a/code/game/jobs/job/medical.dm
+++ b/code/game/jobs/job/medical.dm
@@ -32,10 +32,6 @@
 						transported to Medical for treatment. They are expected to keep the crew informed about threats to their health and safety, and \
 						about the importance of Suit Sensors."
 
-// CMO Alt Titles
-/datum/alt_title/cmo
-	title = "Chief Medical Officer"
-
 //////////////////////////////////
 //		Medical Doctor
 //////////////////////////////////
@@ -56,16 +52,13 @@
 	job_description = "A Medical Doctor is a Jack-of-All-Trades Medical title, covering a variety of skill levels and minor specializations. They are likely \
 						familiar with basic first aid, and a number of accompanying medications, and can generally save, if not cure, a majority of the \
 						patients they encounter."
-	alt_titles = list("Medical Doctor" = /datum/alt_title/doctor,
+	alt_titles = list(
 					"Surgeon" = /datum/alt_title/surgeon,
 					"Emergency Physician" = /datum/alt_title/emergency_physician,
 					"Nurse" = /datum/alt_title/nurse,
 					"Virologist" = /datum/alt_title/virologist)
 
 //Medical Doctor Alt Titles
-/datum/alt_title/doctor
-	title = "Medical Doctor"
-
 /datum/alt_title/surgeon
 	title = "Surgeon"
 	title_blurb = "A Surgeon specializes in providing surgical aid to injured patients, up to and including amputation and limb reattachement. They are expected \
@@ -114,12 +107,9 @@
 	outfit_type = /decl/hierarchy/outfit/job/medical/chemist
 	job_description = "A Chemist produces and maintains a stock of basic to advanced chemicals for medical and occasionally research use. \
 						They are likely to know the use and dangers of many lab-produced chemicals."
-	alt_titles = list("Chemist" = /datum/alt_title/chemist, "Pharmacist" = /datum/alt_title/pharmacist)
+	alt_titles = list("Pharmacist" = /datum/alt_title/pharmacist)
 
 // Chemist Alt Titles
-/datum/alt_title/chemist
-	title = "Chemist"
-
 /datum/alt_title/pharmacist
 	title = "Pharmacist"
 	title_blurb = "A Pharmacist focuses on the chemical needs of the Medical Department, and often offers to fill crew prescriptions at their discretion."
@@ -145,10 +135,6 @@
 	outfit_type = /decl/hierarchy/outfit/job/medical/geneticist
 	job_description = "A Geneticist operates genetic manipulation equipment to repair any genetic defects encountered in crew, from cloning or radiation as examples. \
 						When required, geneticists have the skills to clone, and are the superior choice when available for doing so."
-
-// Geneticist Alt Titles
-/datum/alt_title/geneticist
-	title = "Geneticist"
 */
 
 //////////////////////////////////
@@ -170,12 +156,9 @@
 	outfit_type = /decl/hierarchy/outfit/job/medical/psychiatrist
 	job_description = "A Psychiatrist provides mental health services to crew members in need. They may also be called upon to determine whatever \
 					ails the mentally unwell, frequently under Security supervision. They understand the effects of various psychoactive drugs."
-	alt_titles = list("Psychiatrist" = /datum/alt_title/psychiatrist, "Psychologist" = /datum/alt_title/psychologist)
+	alt_titles = list("Psychologist" = /datum/alt_title/psychologist)
 
 //Psychiatrist Alt Titles
-/datum/alt_title/psychiatrist
-	title = "Psychiatrist"
-
 /datum/alt_title/psychologist
 	title = "Psychologist"
 	title_blurb =  "A Psychologist provides mental health services to crew members in need, focusing more on therapy than medication. They may also be \
@@ -201,12 +184,9 @@
 	outfit_type = /decl/hierarchy/outfit/job/medical/paramedic
 	job_description = "A Paramedic is primarily concerned with the recovery of patients who are unable to make it to the Medical Department on their own. \
 						They may also be called upon to keep patients stable when Medical is busy or understaffed."
-	alt_titles = list("Paramedic" = /datum/alt_title/paramedic, "Emergency Medical Technician" = /datum/alt_title/emt)
+	alt_titles = list("Emergency Medical Technician" = /datum/alt_title/emt)
 
 // Paramedic Alt Titles
-/datum/alt_title/paramedic
-	title = "Paramedic"
-
 /datum/alt_title/emt
 	title = "Emergency Medical Technician"
 	title_blurb = "An Emergency Medical Technician is primarily concerned with the recovery of patients who are unable to make it to the Medical Department on their \

--- a/code/game/jobs/job/science.dm
+++ b/code/game/jobs/job/science.dm
@@ -33,12 +33,9 @@
 						at least with regards to anything occuring in the Research department, and to inform the crew of any disruptions that \
 						might originate from Research. The Research Director often has at least passing knowledge of most of the Research department, but \
 						are encouraged to allow their staff to perform their own duties."
-	alt_titles = list("Research Director" = /datum/alt_title/research_director, "Research Supervisor" = /datum/alt_title/research_supervisor)
+	alt_titles = list("Research Supervisor" = /datum/alt_title/research_supervisor)
 
 // Research Director Alt Titles
-/datum/alt_title/research_director
-	title = "Research Director"
-	
 /datum/alt_title/research_supervisor
 	title = "Research Supervisor"
 	
@@ -65,13 +62,10 @@
 	job_description = "A Scientist is a generalist working in the Research department, with general knowledge of the scientific process, as well as \
 						the principles and requirements of Research and Development. They may also formulate experiments of their own devising, if \
 						they find an appropriate topic."
-	alt_titles = list("Scientist" = /datum/alt_title/scientist, "Xenoarchaeologist" = /datum/alt_title/xenoarch, "Anomalist" = /datum/alt_title/anomalist, \
+	alt_titles = list("Xenoarchaeologist" = /datum/alt_title/xenoarch, "Anomalist" = /datum/alt_title/anomalist, \
 						"Phoron Researcher" = /datum/alt_title/phoron_research)
 
 // Scientist Alt Titles
-/datum/alt_title/scientist
-	title = "Scientist"
-
 /datum/alt_title/xenoarch
 	title = "Xenoarchaeologist"
 	title_blurb = "A Xenoarchaeologist enters digsites in search of artifacts of alien origin. These digsites are frequently in vacuum or other inhospitable \
@@ -110,12 +104,9 @@
 	outfit_type = /decl/hierarchy/outfit/job/science/xenobiologist
 	job_description = "A Xenobiologist studies esoteric lifeforms, usually in the relative safety of their lab. They attempt to find ways to benefit \
 						from the byproducts of these lifeforms, and their main subject at present is the Giant Slime."
-	alt_titles = list("Xenobiologist" = /datum/alt_title/xenobio, "Xenobotanist" = /datum/alt_title/xenobot)
+	alt_titles = list("Xenobotanist" = /datum/alt_title/xenobot)
 
 // Xenibiologist Alt Titles
-/datum/alt_title/xenobio
-	title = "Xenobiologist"
-
 /datum/alt_title/xenobot
 	title = "Xenobotanist"
 	title_blurb = "A Xenobotanist grows and cares for a variety of abnormal, custom made, and frequently dangerous plant life. When the products of these plants \
@@ -142,12 +133,9 @@
 	outfit_type = /decl/hierarchy/outfit/job/science/roboticist
 	job_description = "A Roboticist maintains and repairs the station's synthetics, including crew with prosthetic limbs. \
 						They can also assist the station by producing simple robots and even pilotable exosuits."
-	alt_titles = list("Roboticist" = /datum/alt_title/roboticist, "Biomechanical Engineer" = /datum/alt_title/biomech, "Mechatronic Engineer" = /datum/alt_title/mech_tech)
+	alt_titles = list("Biomechanical Engineer" = /datum/alt_title/biomech, "Mechatronic Engineer" = /datum/alt_title/mech_tech)
 
 // Roboticist Alt Titles
-/datum/alt_title/roboticist
-	title = "Roboticist"
-
 /datum/alt_title/biomech
 	title = "Biomechanical Engineer"
 	title_blurb = "A Biomechanical Engineer primarily works on prosthetics, and the organic parts attached to them. They may have some \

--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -30,12 +30,9 @@
 	job_description = "	The Head of Security manages the Security Department, keeping the station safe and making sure the rules are followed. They are expected to \
 						keep the other Department Heads, and the rest of the crew, aware of developing situations that may be a threat. If necessary, the HoS may \
 						perform the duties of absent Security roles, such as distributing gear from the Armory."
-	alt_titles = list("Head of Security" = /datum/alt_title/hos, "Security Commander" = /datum/alt_title/sec_commander, "Chief of Security" = /datum/alt_title/sec_chief)
+	alt_titles = list("Security Commander" = /datum/alt_title/sec_commander, "Chief of Security" = /datum/alt_title/sec_chief)
 
 // Head of Security Alt Titles
-/datum/alt_title/hos
-	title = "Head of Security"
-
 /datum/alt_title/sec_commander
 	title = "Security Commander"
 
@@ -67,10 +64,6 @@
 						Armoury gear in a crisis, and retrieving it when the crisis has passed. In an emergency, the Warden may be called upon to direct the \
 						Security Department as a whole."
 
-// Warden Alt Titles
-/datum/alt_title/warden
-	title = "Warden"
-
 //////////////////////////////////
 //			Detective
 //////////////////////////////////
@@ -92,12 +85,9 @@
 	outfit_type = /decl/hierarchy/outfit/job/security/detective
 	job_description = "A Detective works to help Security find criminals who have not properly been identified, through interviews and forensic work. \
 						For crimes only witnessed after the fact, or those with no survivors, they attempt to piece together what they can from pure evidence."
-	alt_titles = list("Detective" = /datum/alt_title/detective, "Forensic Technician" = /datum/alt_title/forensic_tech)
+	alt_titles = list("Forensic Technician" = /datum/alt_title/forensic_tech)
 
 // Detective Alt Titles
-/datum/alt_title/detective
-	title = "Detective"
-
 /datum/alt_title/forensic_tech
 	title = "Forensic Technician"
 	title_blurb = "A Forensic Technician works more with hard evidence and labwork than a Detective, but they share the purpose of solving crimes."
@@ -125,12 +115,9 @@
 	job_description = "A Security Officer is concerned with maintaining the safety and security of the station as a whole, dealing with external threats and \
 						apprehending criminals. A Security Officer is responsible for the health, safety, and processing of any prisoner they arrest. \
 						No one is above the Law, not Security or Command."
-	alt_titles = list("Security Officer" = /datum/alt_title/sec_officer, "Junior Officer" = /datum/alt_title/junior_officer)
+	alt_titles = list("Junior Officer" = /datum/alt_title/junior_officer)
 
 // Security Officer Alt Titles
-/datum/alt_title/sec_officer
-	title = "Security Officer"
-
 /datum/alt_title/junior_officer
 	title = "Junior Officer"
 	title_blurb = "A Junior Officer is an inexperienced Security Officer. They likely have training, but not experience, and are frequently \

--- a/code/game/jobs/job/silicon.dm
+++ b/code/game/jobs/job/silicon.dm
@@ -23,10 +23,6 @@
 						The AI is required to follow its Laws, and Lawbound Synthetics that are linked to it are expected to follow \
 						the AI's commands, and their own Laws."
 
-//AI Alt Titles
-/datum/alt_title/ai
-	title = "AI"
-
 // AI procs
 /datum/job/ai/equip(var/mob/living/carbon/human/H)
 	if(!H)	return 0
@@ -61,12 +57,9 @@
 	outfit_type = /decl/hierarchy/outfit/job/silicon/cyborg
 	job_description = "A Cyborg is a mobile station synthetic, piloted by a cybernetically preserved brain. It is considered a person, but is still required \
 						to follow its Laws."
-	alt_titles = list("Cyborg" = /datum/alt_title/cyborg, "Robot" = /datum/alt_title/robot, "Drone" = /datum/alt_title/drone)
+	alt_titles = list("Robot" = /datum/alt_title/robot, "Drone" = /datum/alt_title/drone)
 
 // Cyborg Alt Titles
-/datum/alt_title/cyborg
-	title = "Cyborg"
-
 /datum/alt_title/robot
 	title = "Robot"
 	title_blurb = "A Robot is a mobile station synthetic, piloted by an advanced piece of technology called a Positronic Brain. It is considered a person, \


### PR DESCRIPTION
Continues PolarisSS13/Polaris#6725, implementing suggestions to reduce extra code.
- Remove the need for an alt title to be declared for the job's main title.
- Don't allocate a list if no alt titles are used, and use the indexes provided instead of looping to search the alt titles list.

All the existing preferences code except for two procs already expected the main title to be absent from the alt_titles list, so this is consistent with prior expectations.