### PR TITLE
QoL: Safety Walk.

### DIFF
--- a/code/modules/mob/living/living_movement.dm
+++ b/code/modules/mob/living/living_movement.dm
@@ -10,3 +10,12 @@
 
 /mob/CanZASPass(turf/T, is_zone)
 	return ATMOS_PASS_YES
+
+/mob/living/SelfMove(turf/n, direct)
+	// If on walk intent, don't willingly step into hazardous tiles.
+	// Unless the walker is confused.
+	if(m_intent == "walk" && confused <= 0)
+		if(!n.is_safe_to_enter(src))
+			to_chat(src, span("warning", "\The [n] is dangerous to move into."))
+			return FALSE // In case any code wants to know if movement happened.
+	return ..() // Parent call should make the mob move.

--- a/code/modules/multiz/turf.dm
+++ b/code/modules/multiz/turf.dm
@@ -152,6 +152,9 @@
 
 /turf/simulated/open/is_safe_to_enter(mob/living/L)
 	if(L.can_fall())
+		for(var/obj/O in contents)
+			if(!O.CanFallThru(L, GetBelow(src)))
+				return TRUE // Can't fall through this, like lattice or catwalk.
 		if(!locate(/obj/structure/stairs) in GetBelow(src))
-			return FALSE
+			return FALSE // Falling on stairs is safe.
 	return ..()


### PR DESCRIPTION
~We can dance if we want to.~
Makes being on walk intent forbid you from willingly walking into a tile that would harm you. The logic for that decision is the same code that AI mobs use to not suicide next to lava. Unwilling movement such as being pushed will still make you enter regardless. If your mob is confused, you can still walk into an unsafe tile as well, so be careful.
Tiles considered unsafe (off the top of my head)
- Lava is unsafe unless there is something on top of the lava (catwalk), or you can fly.
- Water, if you can take damage from water (slimes, prommies, and hivebots) and can't fly.
- Tiles with cliffs on them, if moving into the tile would make you walk off the cliff, and you cannot fly.
- Open tiles, if entering it would make you fall, and there are no stairs on the bottom (because thats how stairs work for some reason).