### PR TITLE
Cloning Sickness no longer makes you immune to tasers.

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -411,7 +411,7 @@ default behaviour is:
 			if(!isnull(M.incoming_hal_damage_percent))
 				amount *= M.incoming_hal_damage_percent
 			if(!isnull(M.disable_duration_percent))
-				amount *= M.incoming_hal_damage_percent
+				amount *= M.disable_duration_percent
 	else if(amount < 0)
 		for(var/datum/modifier/M in modifiers)
 			if(!isnull(M.incoming_healing_percent))


### PR DESCRIPTION
Fixes typo in halloss code that made all incoming halloss become 0 if any modifier that used `disable_duration_percent` was applied to a living mob.