### PR TITLE
Makes holsters and webbing get along.

### DIFF
--- a/code/modules/clothing/clothing_accessories.dm
+++ b/code/modules/clothing/clothing_accessories.dm
@@ -121,13 +121,24 @@
 	set name = "Remove Accessory"
 	set category = "Object"
 	set src in usr
-	if(!istype(usr, /mob/living)) return
-	if(usr.stat) return
+
+	if(!istype(usr, /mob/living))
+		return
+
+	if(usr.stat)
+		return
+
 	var/obj/item/clothing/accessory/A
-	if(LAZYLEN(accessories))
-		A = input("Select an accessory to remove from [src]") as null|anything in accessories
+	var/accessory_amount = LAZYLEN(accessories)
+	if(accessory_amount)
+		if(accessory_amount == 1)
+			A = accessories[1] // If there's only one accessory, just remove it without any additional prompts.
+		else
+			A = input("Select an accessory to remove from \the [src]") as null|anything in accessories
+
 	if(A)
 		remove_accessory(usr,A)
+
 	if(!LAZYLEN(accessories))
 		src.verbs -= /obj/item/clothing/proc/removetie_verb
 		accessories = null

--- a/code/modules/clothing/under/accessories/holster.dm
+++ b/code/modules/clothing/under/accessories/holster.dm
@@ -2,7 +2,7 @@
 	name = "shoulder holster"
 	desc = "A handgun holster."
 	icon_state = "holster"
-	slot = ACCESSORY_SLOT_TORSO //Legacy/balance purposes
+	slot = ACCESSORY_SLOT_WEAPON
 	concealed_holster = 1
 	var/obj/item/holstered = null
 	var/holster_in = 'sound/items/holsterin.ogg'

--- a/html/changelogs/neerti-holsters.yml
+++ b/html/changelogs/neerti-holsters.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Neerti
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Holsters can now be worn alongside webbing vests."


### PR DESCRIPTION
Webbing and Holsters can now be worn at the same time. Requested at the staff meeting.
Also makes it so if you're only wearing one accessory on a piece of clothing, using the 'remove accessory' verb will immediately remove the only accessory instead of prompting you to choose an accessory.