### PR TITLE
Tweak Fire, Flamethrowers, and Water.

### DIFF
--- a/code/modules/mob/_modifiers/fire.dm
+++ b/code/modules/mob/_modifiers/fire.dm
@@ -32,8 +32,11 @@
 			expire()
 
 	else if(holder.fire_stacks > 0)
-		holder.fire_stacks -= 1
+		holder.fire_stacks -= 0.5
 
 /datum/modifier/fire/stack_managed/intense
 	mob_overlay_state = "on_fire_intense"
 	damage_per_tick = 10
+
+/datum/modifier/fire/stack_managed/weak
+	damage_per_tick = 1

--- a/code/modules/mob/living/carbon/human/human_resist.dm
+++ b/code/modules/mob/living/carbon/human/human_resist.dm
@@ -1,6 +1,6 @@
 /mob/living/carbon/human/process_resist()
 	//drop && roll
-	if(on_fire && !buckled)
+	if((on_fire || has_modifier_of_type(/datum/modifier/fire)) && !buckled)
 		adjust_fire_stacks(-1.2)
 		Weaken(3)
 		spin(32,2)
@@ -9,7 +9,7 @@
 			"<span class='notice'>You stop, drop, and roll!</span>"
 			)
 		sleep(30)
-		if(fire_stacks <= 0)
+		if(fire_stacks <= 0 && !(has_modifier_of_type(/datum/modifier/fire)))
 			visible_message(
 				"<span class='danger'>[src] has successfully extinguished themselves!</span>",
 				"<span class='notice'>You extinguish yourself.</span>"

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -363,6 +363,9 @@
 		handle_light()
 		update_fire()
 
+	if(has_modifier_of_type(/datum/modifier/fire))
+		remove_modifiers_of_type(/datum/modifier/fire)
+
 /mob/living/proc/update_fire()
 	return
 

--- a/code/modules/projectiles/guns/magnetic/gasthrower.dm
+++ b/code/modules/projectiles/guns/magnetic/gasthrower.dm
@@ -9,6 +9,7 @@
 	one_handed_penalty = 20
 	origin_tech = list(TECH_COMBAT = 5, TECH_MATERIAL = 4, TECH_ILLEGAL = 2, TECH_PHORON = 4)
 	w_class = ITEMSIZE_LARGE
+	slowdown = 1
 
 	burst = 3
 	burst_delay = 1

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -271,10 +271,11 @@
 /obj/item/projectile/bullet/incendiary/flamethrower/tiny
 	damage = 2
 	incendiary = 0
-	modifier_type_to_apply = /datum/modifier/fire/weak
+	flammability = 2
+	modifier_type_to_apply = /datum/modifier/fire/stack_managed/weak
 	modifier_duration = 20 SECONDS
-	range = 7
-	agony = 3
+	range = 6
+	agony = 0
 
 /* Practice rounds and blanks */
 

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Core.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Core.dm
@@ -167,10 +167,10 @@
 			S.visible_message("<span class='warning'>[S]'s flesh sizzles where the water touches it!</span>", "<span class='danger'>Your flesh burns in the water!</span>")
 
 		// Then extinguish people on fire.
-		var/needed = L.fire_stacks * 5
+		var/needed = max(0,L.fire_stacks) * 5
 		if(amount > needed)
 			L.ExtinguishMob()
-		L.adjust_fire_stacks(-(amount / 5))
+		L.water_act(amount / 25) // Div by 25, as water_act multiplies it by 5 in order to calculate firestack modification.
 		remove_self(needed)
 
 /datum/reagent/water/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)


### PR DESCRIPTION
Fixes #6864 
Water now properly extinguishes again (especially regarding fire modifiers), and won't duplicate itself. Flamethrowers tweaked again to be properly sane, but dangerous. Again.

Fixes:
- Extinguishers work on normal fire -and- modifier fire.
- Gasthrower properly uses stack based fire modifiers which extinguish over time faster when you have no fire_stacks.
- Resisting will also attempt to extinguish modifier fire.

Tweaks:
- Water now calls water_act on touch_mob, rather than directly touching fire stacks. Related to fix above.
- Gasthrower has slowdown of 1 when held due to being a volatile weapon, and does not do agony.