### PR TITLE
Remove stray 'return'

### DIFF
--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -1506,7 +1506,6 @@
 	else
 		shock_stage = min(shock_stage, 160)
 		shock_stage = max(shock_stage-1, 0)
-		return
 
 	if(stat)
 		return 0


### PR DESCRIPTION
Looks like a stray return snuck in here. No reason to stop there.
~~Also removes the bizarre HTML-encoded ASCII comas.~~