### PR TITLE
Fixes taking items out of sewn plushies

### DIFF
--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -902,7 +902,7 @@
 /obj/structure/plushie/attack_hand(mob/user)
 	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 
-	if(stored_item && !searching)
+	if(stored_item && opened && !searching)
 		searching = TRUE
 		if(do_after(user, 10))
 			to_chat(user, "You find \icon[stored_item] [stored_item] in [src]!")
@@ -999,7 +999,7 @@
 			to_chat(user, "<i>You can see something in there...</i>")
 
 /obj/item/toy/plushie/attack_self(mob/user as mob)
-	if(stored_item && !searching)
+	if(stored_item && opened && !searching)
 		searching = TRUE
 		if(do_after(user, 10))
 			to_chat(user, "You find \icon[stored_item] [stored_item] in [src]!")


### PR DESCRIPTION
Just fixes an oversight/check failure. Currently you can take items out of plushies that are sewn shut. 

With this fix you'll be able to only take things out when you re-open 'em again.