### PR TITLE
[Feature Tweak] Message Fixy For Snowballs/Kickstands

### DIFF
--- a/code/game/objects/items/weapons/material/misc.dm
+++ b/code/game/objects/items/weapons/material/misc.dm
@@ -73,12 +73,14 @@
 
 /obj/item/weapon/material/snow/snowball/attack_self(mob/user as mob)
 	if(user.a_intent == I_HURT)
-		visible_message("[user] has smashed the snowball in their hand!", "You smash the snowball in your hand.")
+		visible_message("[user] has smashed the snowball in their hand!")
+		to_chat(user, "<span class='notice'>You smash the snowball in your hand.</span>")
 		var/atom/S = new /obj/item/stack/material/snow(user.loc)
 		del(src)
 		user.put_in_hands(S)
 	else
-		visible_message("[user] starts compacting the snowball.", "You start compacting the snowball.")
+		visible_message("[user] starts compacting the snowball.")
+		to_chat(user, "<span class='notice'>You start compacting the snowball.</span>")
 		if(do_after(user, 2 SECONDS))
 			var/atom/S = new /obj/item/weapon/material/snow/snowball/reinforced(user.loc)
 			del(src)

--- a/code/game/objects/items/weapons/material/misc.dm
+++ b/code/game/objects/items/weapons/material/misc.dm
@@ -71,15 +71,15 @@
 	w_class = ITEMSIZE_SMALL
 	attack_verb = list("mushed", "splatted", "splooshed", "splushed") // Words that totally exist.
 
-/obj/item/weapon/material/snow/snowball/attack_self(mob/user as mob)
+/obj/item/weapon/material/snow/snowball/attack_self(mob/user as mob)	//TFF 22/33/20 - changes to to_chat line to be show only to self. ToDo: proper fix for the thing.
 	if(user.a_intent == I_HURT)
-		visible_message("[user] has smashed the snowball in their hand!")
+		//visible_message("[user] has smashed the snowball in their hand!", "You smash the snowball in your hand.")
 		to_chat(user, "<span class='notice'>You smash the snowball in your hand.</span>")
 		var/atom/S = new /obj/item/stack/material/snow(user.loc)
 		del(src)
 		user.put_in_hands(S)
 	else
-		visible_message("[user] starts compacting the snowball.")
+		//visible_message("[user] starts compacting the snowball.", "You start compacting the snowball.")
 		to_chat(user, "<span class='notice'>You start compacting the snowball.</span>")
 		if(do_after(user, 2 SECONDS))
 			var/atom/S = new /obj/item/weapon/material/snow/snowball/reinforced(user.loc)

--- a/code/game/objects/items/weapons/material/misc.dm
+++ b/code/game/objects/items/weapons/material/misc.dm
@@ -71,7 +71,7 @@
 	w_class = ITEMSIZE_SMALL
 	attack_verb = list("mushed", "splatted", "splooshed", "splushed") // Words that totally exist.
 
-/obj/item/weapon/material/snow/snowball/attack_self(mob/user as mob)	//TFF 22/33/20 - changes to to_chat line to be show only to self. ToDo: proper fix for the thing.
+/obj/item/weapon/material/snow/snowball/attack_self(mob/user as mob)
 	if(user.a_intent == I_HURT)
 		//visible_message("[user] has smashed the snowball in their hand!", "You smash the snowball in your hand.")
 		to_chat(user, "<span class='notice'>You smash the snowball in your hand.</span>")

--- a/code/modules/vehicles/bike.dm
+++ b/code/modules/vehicles/bike.dm
@@ -71,7 +71,7 @@
 		turn_off()
 		src.visible_message("\The [src] putters before turning off.", "You hear something putter slowly.")
 
-/obj/vehicle/bike/verb/kickstand()
+/obj/vehicle/bike/verb/kickstand(var/mob/user as mob)	//TFF 22/3/20 - Tweaking the visible_message output so it's not "You put kickstand down" to everyone.
 	set name = "Toggle Kickstand"
 	set category = "Vehicle"
 	set src in view(0)
@@ -82,12 +82,12 @@
 	if(usr.incapacitated()) return
 
 	if(kickstand)
-		src.visible_message("You put up \the [src]'s kickstand.")
+		visible_message("[user] puts up \the [src]'s kickstand.")
 	else
 		if(istype(src.loc,/turf/space) || istype(src.loc, /turf/simulated/floor/water))
 			to_chat(usr, "<span class='warning'> You don't think kickstands work here...</span>")
 			return
-		src.visible_message("You put down \the [src]'s kickstand.")
+		visible_message("[user] puts down \the [src]'s kickstand.")
 		if(pulledby)
 			pulledby.stop_pulling()
 

--- a/html/changelogs/TheFurryFeline - Message_Fixy_For_Snowballs_and_Kickstands.yml
+++ b/html/changelogs/TheFurryFeline - Message_Fixy_For_Snowballs_and_Kickstands.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: TheFurryFeline
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Change output of messages relating to snowball compacting and bike kickstand actions."


### PR DESCRIPTION
Tweaks output of messages for snowball destroying/compacting and kickstand interactions. 

Would like some advice about the visible_message stuff since that's where it was going wrong in the first place and gave weird messages to everyone. Seen it do "You compact the snowball" to everyone. Same for the kickstands.

Changelog Notes:

- Tweaks bike kickstand usage message and snowball compacting/crushing message to give the name of its user rather than a public weirdness of "You put down/up the kickstand" or "You smash the snowball" or "You start compacting the snowball in your hand".