### PR TITLE
Distillery tweaks

### DIFF
--- a/code/datums/supplypacks/medical.dm
+++ b/code/datums/supplypacks/medical.dm
@@ -339,14 +339,14 @@
 /datum/supply_pack/med/distillery
 	name = "Chemical distiller crate"
 	contains = list(/obj/machinery/portable_atmospherics/powered/reagent_distillery = 1)
-	cost = 175
+	cost = 50
 	containertype = /obj/structure/largecrate
 	containername = "Chemical distiller crate"
 
 /datum/supply_pack/med/advdistillery
 	name = "Industrial Chemical distiller crate"
 	contains = list(/obj/machinery/portable_atmospherics/powered/reagent_distillery/industrial = 1)
-	cost = 250
+	cost = 150
 	containertype = /obj/structure/largecrate
 	containername = "Industrial Chemical distiller crate"
 

--- a/html/changelogs/atermonera_distillery.yml
+++ b/html/changelogs/atermonera_distillery.yml
@@ -1,0 +1,6 @@
+author: Atermonera
+delete-after: True
+changes: 
+  - rscadd: "Basic distillery (not the industrial-) will ping when it reaches its target temperature."
+  - tweak: "Basic distillery uses logistic curve to determine temperature change, and should be much faster."
+  - tweak: "Industrial distillery respects gas laws, particularly as pertains to low temperatures."


### PR DESCRIPTION
Basic distillery uses logistic temp change, fixes #6846 
Basic distillery pings when at temp
Industrial distillery respects gas laws, fixes #6844 
Distillery examine text describes whether the thing is turned on, what temperature it's at, and how full each of its beakers are, if you're within 2 tiles (magic number, open to debate)
Distilleries have verbs in the object tab to turn them off and on and to start mixing, should be accessible view right-click context menu as well

Logistic temperature change was tested, and to go from 293K to 500K took roughly 6 minutes, down from theoretically forever because round() with 1 parameter is floor() and floor(1+/-0.5) has a growth rate of 0.5 (50% of the time it'll grow by 1, other half gets floored to 0)