### PR TITLE
Berserkjuice doesn't spam chat

### DIFF
--- a/code/modules/mob/_modifiers/modifiers.dm
+++ b/code/modules/mob/_modifiers/modifiers.dm
@@ -59,7 +59,7 @@
 
 // Checks if the modifier should be allowed to be applied to the mob before attaching it.
 // Override for special criteria, e.g. forbidding robots from receiving it.
-/datum/modifier/proc/can_apply(var/mob/living/L)
+/datum/modifier/proc/can_apply(var/mob/living/L, var/suppress_output = FALSE)
 	return TRUE
 
 // Checks to see if this datum should continue existing.
@@ -113,7 +113,8 @@
 // Call this to add a modifier to a mob. First argument is the modifier type you want, second is how long it should last, in ticks.
 // Third argument is the 'source' of the modifier, if it's from someone else.  If null, it will default to the mob being applied to.
 // The SECONDS/MINUTES macro is very helpful for this.  E.g. M.add_modifier(/datum/modifier/example, 5 MINUTES)
-/mob/living/proc/add_modifier(var/modifier_type, var/expire_at = null, var/mob/living/origin = null)
+// The fourth argument is a boolean to suppress failure messages, set it to true if the modifier is repeatedly applied (as chem-based modifiers are) to prevent chat-spam
+/mob/living/proc/add_modifier(var/modifier_type, var/expire_at = null, var/mob/living/origin = null, var/suppress_failure = FALSE)
 	// First, check if the mob already has this modifier.
 	for(var/datum/modifier/M in modifiers)
 		if(ispath(modifier_type, M))
@@ -130,7 +131,7 @@
 
 	// If we're at this point, the mob doesn't already have it, or it does but stacking is allowed.
 	var/datum/modifier/mod = new modifier_type(src, origin)
-	if(!mod.can_apply(src))
+	if(!mod.can_apply(src, suppress_failure))
 		qdel(mod)
 		return
 	if(expire_at)

--- a/code/modules/mob/_modifiers/modifiers_misc.dm
+++ b/code/modules/mob/_modifiers/modifiers_misc.dm
@@ -112,16 +112,18 @@ the artifact triggers the rage.
 			var/mob/living/carbon/human/H = holder
 			H.shock_stage = last_shock_stage
 
-/datum/modifier/berserk/can_apply(var/mob/living/L)
+/datum/modifier/berserk/can_apply(var/mob/living/L, var/suppress_failure = FALSE)
 	if(L.stat)
-		to_chat(L, "<span class='warning'>You can't be unconscious or dead to berserk.</span>")
+		if(!suppress_failure)
+			to_chat(L, "<span class='warning'>You can't be unconscious or dead to berserk.</span>")
 		return FALSE // It would be weird to see a dead body get angry all of a sudden.
 
 	if(!L.is_sentient())
 		return FALSE // Drones don't feel anything.
 
 	if(L.has_modifier_of_type(/datum/modifier/berserk_exhaustion))
-		to_chat(L, "<span class='warning'>You recently berserked, and cannot do so again while exhausted.</span>")
+		if(!suppress_failure)
+			to_chat(L, "<span class='warning'>You recently berserked, and cannot do so again while exhausted.</span>")
 		return FALSE // On cooldown.
 
 	if(L.isSynthetic())
@@ -135,7 +137,8 @@ the artifact triggers the rage.
 			return FALSE // Happy trees aren't affected by blood rages.
 
 	if(L.nutrition < nutrition_cost)
-		to_chat(L, "<span class='warning'>You are too hungry to berserk.</span>")
+		if(!suppress_failure)
+			to_chat(L, "<span class='warning'>You are too hungry to berserk.</span>")
 		return FALSE // Too hungry to enrage.
 
 	return ..()

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Modifiers.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Modifiers.dm
@@ -12,12 +12,13 @@
 	metabolism = REM
 
 	var/modifier_to_add = /datum/modifier/berserk
-	var/modifier_duration = 2 SECONDS	// How long, per unit dose, will this last?
+	var/modifier_duration = 3 SECONDS	// How long, per unit dose, will this last?
+										// 2 SECONDS is the resolution of life code, and the modifier will expire before chemical processing tries to re-add it
 
 /datum/reagent/modapplying/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	if(alien == IS_DIONA)
 		return
-	M.add_modifier(modifier_to_add, dose * modifier_duration)
+	M.add_modifier(modifier_to_add, modifier_duration, suppress_failure = TRUE)
 
 /datum/reagent/modapplying/cryofluid
 	name = "cryogenic slurry"


### PR DESCRIPTION
Fixes #6845 
Tested, berserk lasts until after it was first injected for 5 and 15 units. I removed the debug messages when I tested ingestion, but it lasted for more than a few seconds with a 5u pill
Using flat duration means that ingesting a reagent will give the same modifier duration as injecting it, this was the best fix I could think of without making injections last twice as long (Since ingestion is half as fast and the multipliers worked out to halving the duration).
Unfortunately because the chem tries to add the modifier _every_ time it processes, I couldn't think of an effective means of preventing the chat spam on failure without suppressing the failure outputs entirely, so I went with the latter, and it will instead rely upon the user realizing they haven't seen the "you aren't tired anymore" message and that they aren't ravenously hungry.