### PR TITLE
Silly admins can't blindly break movement irreparably

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -44,7 +44,7 @@
 		pulledby = null
 
 /atom/movable/vv_edit_var(var_name, var_value)
-	if(GLOB.VVpixelmovement[var_name])			//Pixel movement is not yet implemented, changing this will break everything irreversibly.
+	if(var_name in GLOB.VVpixelmovement)			//Pixel movement is not yet implemented, changing this will break everything irreversibly.
 		return FALSE
 	return ..()
 

--- a/code/modules/admin/view_variables/modify_variables.dm
+++ b/code/modules/admin/view_variables/modify_variables.dm
@@ -310,6 +310,13 @@ GLOBAL_PROTECT(VVpixelmovement)
 		if(!variable)
 			return
 
+	if(variable in GLOB.VVpixelmovement)
+		if(!check_rights(R_DEBUG))
+			return
+		var/prompt = alert(src, "Editing this var may irreparably break tile gliding for the rest of the round. THIS CAN'T BE UNDONE", "DANGER", "ABORT ", "Continue", " ABORT")
+		if (prompt != "Continue")
+			return
+
 	if(!O.can_vv_get(variable))
 		return
 


### PR DESCRIPTION
Fixes #6759 
[tested](https://puu.sh/Fotkg/dd3631ab4e.mp4)

The code was copied from the mass-edit protections