### PR TITLE
Fix runtimes in lungs.dm

### DIFF
--- a/code/modules/organs/internal/lungs.dm
+++ b/code/modules/organs/internal/lungs.dm
@@ -15,28 +15,29 @@
 
 	if(is_bruised())
 		if(prob(4))
-			spawn owner.emote("me", 1, "coughs up blood!")
+			spawn owner?.emote("me", 1, "coughs up blood!")
 			owner.drip(10)
 		if(prob(8))
-			spawn owner.emote("me", 1, "gasps for air!")
+			spawn owner?.emote("me", 1, "gasps for air!")
 			owner.AdjustLosebreath(15)
 
 	if(owner.internal_organs_by_name[O_BRAIN]) // As the brain starts having Trouble, the lungs start malfunctioning.
 		var/obj/item/organ/internal/brain/Brain = owner.internal_organs_by_name[O_BRAIN]
 		if(Brain.get_control_efficiency() <= 0.8)
 			if(prob(4 / max(0.1,Brain.get_control_efficiency())))
-				spawn owner.emote("me", 1, "gasps for air!")
+				spawn owner?.emote("me", 1, "gasps for air!")
 				owner.AdjustLosebreath(round(3 / max(0.1,Brain.get_control_efficiency())))
 
 /obj/item/organ/internal/lungs/proc/rupture()
-	var/obj/item/organ/external/parent = owner.get_organ(parent_organ)
-	if(istype(parent))
-		owner.custom_pain("You feel a stabbing pain in your [parent.name]!", 50)
+	if(owner)
+		var/obj/item/organ/external/parent = owner.get_organ(parent_organ)
+		if(istype(parent))
+			owner.custom_pain("You feel a stabbing pain in your [parent.name]!", 50)
 	bruise()
 
 /obj/item/organ/internal/lungs/handle_germ_effects()
 	. = ..() //Up should return an infection level as an integer
-	if(!.) return
+	if(!. || !owner) return
 
 	//Bacterial pneumonia
 	if (. >= 1)
@@ -54,6 +55,6 @@
 	..()
 	var/mob/living/carbon/human/H = null
 	spawn(15)
-		if(ishuman(owner))
+		if(owner && ishuman(owner))
 			H = owner
 			color = H.species.blood_color


### PR DESCRIPTION
Prevents lungs with null owner from causing runtimes.  Lungs can have null owner if they are removed (e.g. via surgery) and also sometimes seem to end up with null owner during unit testing, at least downstream.  This sometimes at random causes travis to fail the tests.