### PR TITLE
Fix stupid lung runtime

### DIFF
--- a/code/modules/organs/internal/lungs.dm
+++ b/code/modules/organs/internal/lungs.dm
@@ -15,17 +15,20 @@
 
 	if(is_bruised())
 		if(prob(4))
-			spawn owner.emote("me", 1, "coughs up blood!")
+			spawn()
+				owner?.emote("me", 1, "coughs up blood!")
 			owner.drip(10)
 		if(prob(8))
-			spawn owner.emote("me", 1, "gasps for air!")
+			spawn()
+				owner?.emote("me", 1, "gasps for air!")
 			owner.AdjustLosebreath(15)
 
 	if(owner.internal_organs_by_name[O_BRAIN]) // As the brain starts having Trouble, the lungs start malfunctioning.
 		var/obj/item/organ/internal/brain/Brain = owner.internal_organs_by_name[O_BRAIN]
 		if(Brain.get_control_efficiency() <= 0.8)
 			if(prob(4 / max(0.1,Brain.get_control_efficiency())))
-				spawn owner.emote("me", 1, "gasps for air!")
+				spawn()
+					owner?.emote("me", 1, "gasps for air!")
 				owner.AdjustLosebreath(round(3 / max(0.1,Brain.get_control_efficiency())))
 
 /obj/item/organ/internal/lungs/proc/rupture()


### PR DESCRIPTION
Occasionally runtimes while doing Travis because the human it's testing suffocating in space on gets deleted and the lungs lose their owner but still try to make them gasp for air.