### PR TITLE
Fixes examine panel icons

### DIFF
--- a/code/modules/examine/examine.dm
+++ b/code/modules/examine/examine.dm
@@ -34,7 +34,7 @@
 
 // Quickly adds the boilerplate code to add an image and padding for the image.
 /proc/desc_panel_image(var/icon_state)
-	return "[bicon(description_icons[icon_state])][EXAMINE_PANEL_PADDING]"
+	return "\icon[description_icons[icon_state]][EXAMINE_PANEL_PADDING]"
 
 /mob/living/get_description_fluff()
 	if(flavor_text) //Get flavor text for the green text.
@@ -56,7 +56,7 @@
 	description_holders["interactions"] = A.get_description_interaction()
 
 	description_holders["name"] = "[A.name]"
-	description_holders["icon"] = "[bicon(A)]"
+	description_holders["icon"] = "\icon[A]"
 	description_holders["desc"] = A.desc
 
 /mob/Stat()

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -1423,7 +1423,6 @@ window "infowindow"
 		is-default = true
 		saved-params = ""
 		highlight-color = #00aa00
-		allow-html = true
 		on-show = ".winset\"rpane.infob.is-visible=true;rpane.browseb.is-visible=true?rpane.infob.pos=130,0:rpane.infob.pos=65,0 rpane.textb.is-visible=true rpane.infob.is-checked=true rpane.rpanewindow.pos=0,30 rpane.rpanewindow.size=0x0 rpane.rpanewindow.left=infowindow\""
 		on-hide = ".winset\"rpane.infob.is-visible=false;rpane.browseb.is-visible=true?rpane.browseb.is-checked=true rpane.rpanewindow.left=browserwindow:rpane.textb.is-visible=true rpane.rpanewindow.pos=0,30 rpane.rpanewindow.size=0x0 rpane.rpanewindow.left=\""
 


### PR DESCRIPTION
The deconstruction step icons are actually images, which vchat presently doesn't like, because images aren't icons and the internal representation of graphical objects is actually very complex and poorly documented on account of being, y'know, internal. But mostly those aren't going to the chat, so why in the heck do they need to be treated as such
![tested](https://puu.sh/FpRZZ/37c0d0ce54.png)