### PR TITLE
QoL: Small Medical Things

### DIFF
--- a/code/datums/repositories/crew.dm
+++ b/code/datums/repositories/crew.dm
@@ -48,10 +48,10 @@ var/global/datum/repository/crew/crew_repository = new()
 
 				if(C.sensor_mode >= SUIT_SENSOR_TRACKING)
 					var/area/A = get_area(H)
-					crewmemberData["area"] = sanitize(A.name)
+					crewmemberData["area"] = sanitize(A.get_name())
 					crewmemberData["x"] = pos.x
 					crewmemberData["y"] = pos.y
-					crewmemberData["z"] = pos.z
+					crewmemberData["z"] = using_map.get_zlevel_name(pos.z)
 
 				crewmembers[++crewmembers.len] = crewmemberData
 

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -30,6 +30,7 @@
 	var/used_environ = 0
 
 	var/has_gravity = 1
+	var/secret_name = FALSE // This tells certain things that display areas' names that they shouldn't display this area's name.
 	var/obj/machinery/power/apc/apc = null
 	var/no_air = null
 //	var/list/lights				// list of all lights on this area
@@ -83,7 +84,7 @@
 	// NOTE: There probably won't be any atoms in these turfs, but just in case we should call these procs.
 	A.contents.Add(T)
 	if(old_area)
-		// Handle dynamic lighting update if 
+		// Handle dynamic lighting update if
 		if(T.dynamic_lighting && old_area.dynamic_lighting != A.dynamic_lighting)
 			if(A.dynamic_lighting)
 				T.lighting_build_overlay()
@@ -420,3 +421,8 @@ var/list/ghostteleportlocs = list()
 	ghostteleportlocs = sortAssoc(ghostteleportlocs)
 
 	return 1
+
+/area/proc/get_name()
+	if(secret_name)
+		return "Unknown Area"
+	return name

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -14,9 +14,9 @@
 	clicksound = 'sound/machines/buttonbeep.ogg'
 	clickvol = 30
 
-/obj/machinery/sleep_console/New()
-	..()
+/obj/machinery/sleep_console/Initialize()
 	findsleeper()
+	return ..()
 
 /obj/machinery/sleep_console/Destroy()
 	if(sleeper)
@@ -24,14 +24,13 @@
 	return ..()
 
 /obj/machinery/sleep_console/proc/findsleeper()
-	spawn(5)
-		var/obj/machinery/sleeper/sleepernew = null
-		for(dir in list(NORTH, EAST, SOUTH, WEST)) // Loop through every direction
-			sleepernew = locate(/obj/machinery/sleeper, get_step(src, dir)) // Try to find a scanner in that direction
-			if(sleepernew)
-				sleeper = sleepernew
-				sleepernew.console = src
-				set_dir(get_dir(src, sleepernew))
+	var/obj/machinery/sleeper/sleepernew = null
+	for(var/direction in GLOB.cardinal) // Loop through every direction
+		sleepernew = locate(/obj/machinery/sleeper, get_step(src, direction)) // Try to find a scanner in that direction
+		if(sleepernew)
+			sleeper = sleepernew
+			sleepernew.console = src
+			set_dir(get_dir(src, sleepernew))
 
 
 /obj/machinery/sleep_console/attack_ai(var/mob/user)

--- a/code/game/objects/items/devices/gps.dm
+++ b/code/game/objects/items/devices/gps.dm
@@ -99,9 +99,7 @@ var/list/GPS_list = list()
 		gps_data["gps_tag"] = G.gps_tag
 
 		var/area/A = get_area(G)
-		gps_data["area_name"] = A.name
-		if(istype(A, /area/submap))
-			gps_data["area_name"] = "Unknown Area" // Avoid spoilers.
+		gps_data["area_name"] = A.get_name()
 
 		gps_data["z_name"] = using_map.get_zlevel_name(T.z)
 		gps_data["direction"] = get_adir(curr, T)

--- a/code/modules/reagents/Chemistry-Machinery.dm
+++ b/code/modules/reagents/Chemistry-Machinery.dm
@@ -18,7 +18,7 @@
 	circuit = /obj/item/weapon/circuitboard/chem_master
 	use_power = USE_POWER_IDLE
 	idle_power_usage = 20
-	var/beaker = null
+	var/obj/item/weapon/reagent_containers/beaker = null
 	var/obj/item/weapon/storage/pill_bottle/loaded_pill_bottle = null
 	var/mode = 0
 	var/condi = 0
@@ -105,7 +105,7 @@
 		data["pillBottle"] = null
 
 	if(beaker)
-		var/datum/reagents/R = beaker:reagents
+		var/datum/reagents/R = beaker.reagents
 		var/ui_reagent_beaker_list[0]
 		for(var/datum/reagent/G in R.reagent_list)
 			ui_reagent_beaker_list[++ui_reagent_beaker_list.len] = list("name" = G.name, "volume" = G.volume, "description" = G.description, "id" = G.id)
@@ -160,11 +160,15 @@
 
 	if (href_list["ejectp"])
 		if(loaded_pill_bottle)
-			loaded_pill_bottle.loc = src.loc
+			loaded_pill_bottle.forceMove(get_turf(src))
+
+			if(Adjacent(usr))
+				usr.put_in_hands(loaded_pill_bottle)
+
 			loaded_pill_bottle = null
 
 	if(beaker)
-		var/datum/reagents/R = beaker:reagents
+		var/datum/reagents/R = beaker.reagents
 		if (tab == "analyze")
 			analyze_data["name"] = href_list["name"]
 			analyze_data["desc"] = href_list["desc"]
@@ -216,7 +220,11 @@
 
 		else if (href_list["eject"])
 			if(beaker)
-				beaker:loc = src.loc
+				beaker.forceMove(get_turf(src))
+
+				if(Adjacent(usr)) // So the AI doesn't get a beaker somehow.
+					usr.put_in_hands(beaker)
+
 				beaker = null
 				reagents.clear_reagents()
 				icon_state = "mixer0"

--- a/code/modules/reagents/dispenser/dispenser2.dm
+++ b/code/modules/reagents/dispenser/dispenser2.dm
@@ -165,8 +165,11 @@
 
 	else if(href_list["ejectBeaker"])
 		if(container)
-			var/obj/item/weapon/reagent_containers/B = container
-			B.loc = loc
+			container.forceMove(get_turf(src))
+
+			if(Adjacent(usr)) // So the AI doesn't get a beaker somehow.
+				usr.put_in_hands(container)
+
 			container = null
 
 	add_fingerprint(usr)

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -242,6 +242,7 @@
 	flags = OPENCONTAINER
 
 /obj/item/weapon/reagent_containers/glass/beaker/cryoxadone
+	name = "beaker (cryoxadone)"
 	prefill = list("cryoxadone" = 30)
 
 /obj/item/weapon/reagent_containers/glass/beaker/sulphuric

--- a/html/changelogs/neerti-medical_qol_1.yml
+++ b/html/changelogs/neerti-medical_qol_1.yml
@@ -1,0 +1,39 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Neerti
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "The eject button on both the Chemical Dispenser and Chem Master will place the ejected beaker into your hands, instead of on top of the machine, if possible. (Requested by Nalarac.)"
+  - tweak: "Suit sensor consoles now display a friendly textual indicator of what z-level someone is on, instead of a number. They will also now avoid spoiling the names of Points of Interest."
+  - tweak: "The beakers containing Cryoxadone near cryogenics are now labeled. (Requested by Nalarac.)"
+  - bugfix: "The sleeper consoles now finally face towards the sleepers, at least. It only took a year for someone to fix it."

--- a/html/changelogs/neerti-medical_qol_1.yml
+++ b/html/changelogs/neerti-medical_qol_1.yml
@@ -36,4 +36,4 @@ changes:
   - tweak: "The eject button on both the Chemical Dispenser and Chem Master will place the ejected beaker into your hands, instead of on top of the machine, if possible. (Requested by Nalarac.)"
   - tweak: "Suit sensor consoles now display a friendly textual indicator of what z-level someone is on, instead of a number. They will also now avoid spoiling the names of Points of Interest."
   - tweak: "The beakers containing Cryoxadone near cryogenics are now labeled. (Requested by Nalarac.)"
-  - bugfix: "The sleeper consoles now finally face towards the sleepers, at least. It only took a year for someone to fix it."
+  - bugfix: "The sleeper consoles now finally face towards the sleepers, at last. It only took a year for someone to fix it."

--- a/maps/submaps/surface_submaps/wilderness/wilderness_areas.dm
+++ b/maps/submaps/surface_submaps/wilderness/wilderness_areas.dm
@@ -3,6 +3,7 @@
 	icon_state = "submap"
 	flags = RAD_SHIELDED
 	ambience = AMBIENCE_RUINS
+	secret_name = TRUE
 
 /area/submap/event //To be used for Events not for regular PoIs
 	name = "Unknown"


### PR DESCRIPTION
The event system project took up a lot of my time so here's a QoL PR to make up for it.
Changes:
- Chem Masters and Chem Dispensers now eject beakers into your hands instead of on top of the machine, if a free hand is available. (Nalarac)
- Cryoxadone beakers are now labeled as such. (Nalarac)
- Suit sensor computers and programs will no longer show that Thought is bad at naming PoIs like `rock3` and instead the computer will read `Unknown Area`, in the same way as GPS devices. The Z number has also been replaced with a textual indicator, again in the same way as GPSes.
- Sleeper consoles now face the sleepers, at last.

This PR would've had another thing but the code for that is expected to conflict with current PRs up quite a lot so I'm gonna put it into a separate PR so this can get in unhindered.