### PR TITLE
Fix matches and SSobj/SSprocessing

### DIFF
--- a/code/game/objects/items/weapons/cigs_lighters.dm
+++ b/code/game/objects/items/weapons/cigs_lighters.dm
@@ -60,6 +60,15 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 			burn_out()
 	return ..()
 
+/obj/item/weapon/flame/match/proc/light(var/mob/user)
+	playsound(src, 'sound/items/cigs_lighters/matchstick_lit.ogg', 25, 0, -1)
+	lit = 1
+	damtype = "burn"
+	icon_state = "match_lit"
+	name = "burning match"
+	desc = "A match. This one is presently on fire."
+	START_PROCESSING(SSobj, src)
+
 /obj/item/weapon/flame/match/proc/burn_out()
 	lit = 0
 	burnt = 1

--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -407,17 +407,13 @@
 	can_hold = list(/obj/item/weapon/flame/match)
 	starts_with = list(/obj/item/weapon/flame/match = 10)
 
-/obj/item/weapon/storage/box/matches/attackby(obj/item/weapon/flame/match/W as obj, mob/user as mob)
+/obj/item/weapon/storage/box/matches/attackby(var/obj/item/weapon/flame/match/W, var/mob/user)
 	if(istype(W) && !W.lit && !W.burnt)
 		if(prob(25))
-			playsound(src.loc, 'sound/items/cigs_lighters/matchstick_lit.ogg', 25, 0, -1)
+			W.light(user)
 			user.visible_message("<span class='notice'>[user] manages to light the match on the matchbox.</span>")
-			W.lit = 1
-			W.damtype = "burn"
-			W.icon_state = "match_lit"
-			START_PROCESSING(SSprocessing, W)
 		else
-			playsound(src.loc, 'sound/items/cigs_lighters/matchstick_hit.ogg', 25, 0, -1)
+			playsound(src, 'sound/items/cigs_lighters/matchstick_hit.ogg', 25, 0, -1)
 	W.update_icon()
 	return
 


### PR DESCRIPTION
Not a very good example of object-oriented programming here. The matchbox does all the work for lighting the match, and adds it to SSprocessing, but then in another file, in another folder, the match tries to remove itself from SSobj when it's burned out. Which it can't because it's not in SSobj it was put in SSprocessing.