### PR TITLE
Change VChat sqllite error message handler

### DIFF
--- a/code/modules/vchat/vchat_db.dm
+++ b/code/modules/vchat/vchat_db.dm
@@ -24,7 +24,7 @@ GLOBAL_DATUM(vchatdb, /database)
 //For INSERT/CREATE/DELETE, etc that return a RowsAffected.
 /proc/vchat_exec_update(var/query)
 	if(!check_vchat())
-		log_debug("There's no vchat database open but you tried to query it with: [query]")
+		log_world("There's no vchat database open but you tried to query it with: [query]")
 		return FALSE
 
 	//Solidify our query
@@ -35,7 +35,7 @@ GLOBAL_DATUM(vchatdb, /database)
 
 	//Handle errors
 	if(q.Error())
-		log_debug("Query \"[islist(query)?query[1]:query]\" ended in error [q.ErrorMsg()]")
+		log_world("Query \"[islist(query)?query[1]:query]\" ended in error [q.ErrorMsg()]")
 		return FALSE
 
 	return q.RowsAffected()
@@ -43,7 +43,7 @@ GLOBAL_DATUM(vchatdb, /database)
 //For SELECT, that return results.
 /proc/vchat_exec_query(var/query)
 	if(!check_vchat())
-		log_debug("There's no vchat database open but you tried to query it!")
+		log_world("There's no vchat database open but you tried to query it!")
 		return FALSE
 
 	//Solidify our query
@@ -54,7 +54,7 @@ GLOBAL_DATUM(vchatdb, /database)
 
 	//Handle errors
 	if(q.Error())
-		log_debug("Query \"[islist(query)?query[1]:query]\" ended in error [q.ErrorMsg()]")
+		log_world("Query \"[islist(query)?query[1]:query]\" ended in error [q.ErrorMsg()]")
 		return FALSE
 
 	//Return any results


### PR DESCRIPTION
log_debug uses to_chat, which can in a very strange case where world.time is null or 0, enter into an infinite loop because of the constraints on the table that require world.time to be set