### PR TITLE
Remove emergencyShuttle as a process controller

### DIFF
--- a/code/controllers/Processes/emergencyShuttle.dm
+++ b/code/controllers/Processes/emergencyShuttle.dm
@@ -1,9 +1,0 @@
-/datum/controller/process/emergencyShuttle/setup()
-	name = "emergency shuttle"
-	schedule_interval = 20 // every 2 seconds
-
-	if(!emergency_shuttle)
-		emergency_shuttle = new
-
-/datum/controller/process/emergencyShuttle/doWork()
-	emergency_shuttle.process()

--- a/code/controllers/emergency_shuttle_controller.dm
+++ b/code/controllers/emergency_shuttle_controller.dm
@@ -2,7 +2,7 @@
 
 // Controls the emergency shuttle
 
-var/global/datum/emergency_shuttle_controller/emergency_shuttle
+var/global/datum/emergency_shuttle_controller/emergency_shuttle = new
 
 /datum/emergency_shuttle_controller
 	var/datum/shuttle/autodock/ferry/emergency/shuttle // Set in shuttle_emergency.dm TODO - is it really?
@@ -75,8 +75,10 @@ var/global/datum/emergency_shuttle_controller/emergency_shuttle
 /datum/emergency_shuttle_controller/proc/set_launch_countdown(var/seconds)
 	wait_for_launch = 1
 	launch_time = world.time + seconds*10
+	START_PROCESSING(SSprocessing, src)
 
 /datum/emergency_shuttle_controller/proc/stop_launch_countdown()
+	STOP_PROCESSING(SSprocessing, src)
 	wait_for_launch = 0
 
 //calls the shuttle for an emergency evacuation
@@ -120,7 +122,7 @@ var/global/datum/emergency_shuttle_controller/emergency_shuttle
 /datum/emergency_shuttle_controller/proc/recall()
 	if (!can_recall()) return
 
-	wait_for_launch = 0
+	stop_launch_countdown()
 	shuttle.cancel_launch(src)
 
 	if (evac)

--- a/polaris.dme
+++ b/polaris.dme
@@ -190,7 +190,6 @@
 #include "code\controllers\subsystem.dm"
 #include "code\controllers\verbs.dm"
 #include "code\controllers\observer_listener\atom\observer.dm"
-#include "code\controllers\Processes\emergencyShuttle.dm"
 #include "code\controllers\Processes\ticker.dm"
 #include "code\controllers\ProcessScheduler\core\process.dm"
 #include "code\controllers\ProcessScheduler\core\processScheduler.dm"


### PR DESCRIPTION
- The `emergencyShuttle` process controller (/datum/controller/process/emergencyShuttle) was just a wrapper around the true workhorse `emergency_shuttle` anyway.
- The `emergency_shuttle` (/datum/emergency_shuttle_controller) is the _actual_ controller and it only needs to process during the tiny fraction of the round when the shuttle is getting ready to launch.  Therefore we leave it non-processing initially, and just register/deregister with `SSprocessing` when it actually needs to.


Four down, two to go.