### PR TITLE
[PORT] Sundry Bugfixes XI

### DIFF
--- a/code/game/objects/effects/chem/chemsmoke.dm
+++ b/code/game/objects/effects/chem/chemsmoke.dm
@@ -29,11 +29,10 @@
 	show_log = 0
 	var/datum/seed/seed
 
-/datum/effect/effect/system/smoke_spread/chem/spores/New(seed_name)
-	if(seed_name && plant_controller)
-		seed = plant_controller.seeds[seed_name]
-	if(!seed)
-		qdel(src)
+/datum/effect/effect/system/smoke_spread/chem/spores/New(_seed)
+	seed = _seed
+	if(!istype(seed))
+		CRASH("Invalid seed datum passed! [seed] ([seed?.type])")
 	..()
 
 /datum/effect/effect/system/smoke_spread/chem/New()

--- a/code/game/objects/items/weapons/tanks/tanks.dm
+++ b/code/game/objects/items/weapons/tanks/tanks.dm
@@ -78,7 +78,6 @@ var/list/global/tank_gauge_cache = list()
 	if(istype(loc, /obj/item/device/transfer_valve))
 		var/obj/item/device/transfer_valve/TTV = loc
 		TTV.remove_tank(src)
-		qdel(TTV)
 
 	. = ..()
 

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -131,7 +131,7 @@
 		return
 
 	var/msg = input("Message:", text("Enter the text you wish to appear to your target:")) as text
-	if(!(msg[1] == "<" && msg[length(msg)] == ">")) //You can use HTML but only if the whole thing is HTML. Tries to prevent admin 'accidents'.
+	if(msg && !(msg[1] == "<" && msg[length(msg)] == ">")) //You can use HTML but only if the whole thing is HTML. Tries to prevent admin 'accidents'.
 		msg = sanitize(msg)
 
 	if( !msg )

--- a/code/modules/hydroponics/seed.dm
+++ b/code/modules/hydroponics/seed.dm
@@ -103,7 +103,7 @@
 			var/injecting = min(5,max(1,get_trait(TRAIT_POTENCY)/3))
 			R.add_reagent(rid,injecting)
 
-	var/datum/effect/effect/system/smoke_spread/chem/spores/S = new(name)
+	var/datum/effect/effect/system/smoke_spread/chem/spores/S = new(src)
 	S.attach(T)
 	S.set_up(R, round(get_trait(TRAIT_POTENCY)/4), 0, T)
 	S.start()

--- a/code/modules/hydroponics/seed.dm
+++ b/code/modules/hydroponics/seed.dm
@@ -228,6 +228,7 @@
 		open_turfs |= origin_turf
 
 		// Flood fill to get affected turfs.
+		// NOTE: Halfass bugfix implemented using air_blocked() but this really should be redone completely ~Leshana
 		while(open_turfs.len)
 			var/turf/T = pick(open_turfs)
 			open_turfs -= T
@@ -245,11 +246,11 @@
 				var/no_los
 				var/turf/last_turf = origin_turf
 				for(var/turf/target_turf in getline(origin_turf,neighbor))
-					if(!last_turf.Enter(target_turf) || target_turf.density)
+					if(air_master.air_blocked(last_turf, target_turf))
 						no_los = 1
 						break
 					last_turf = target_turf
-				if(!no_los && !origin_turf.Enter(neighbor))
+				if(!no_los && air_master.air_blocked(origin_turf, neighbor))
 					no_los = 1
 				if(no_los)
 					closed_turfs |= neighbor

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -104,7 +104,7 @@
 		feed_sound(user)
 		return 1
 	else
-		if(istype(user, /mob/living/carbon/human))
+		if(istype(target, /mob/living/carbon/human))
 			var/mob/living/carbon/human/H = target
 			if(!H.check_has_mouth())
 				to_chat(user, "Where do you intend to put \the [src]? \The [H] doesn't have a mouth!")


### PR DESCRIPTION
Port of VOREStation/VOREStation#7057 - Fixes some runtimes that annoyed me in logs.

- Fixes Runtime in randomverbs.dm,134: list index out of bounds
- Fix Runtime in garbage.dm,337:
  - /obj/item/device/transfer_valve destroy proc was called multiple times, likely due to a qdel loop in the Destroy logic  (Hint: Yeah it was)
- Fix Runtime in reagent_containers.dm,112: undefined proc or verb /mob/living/bot/farmbot/check mouth coverage().
- Fixes Runtime in turf.dm,205: undefined variable /turf/simulated/floor/tiled/var/movement_type
  - Please do not call turf.Enter(another_turf).  My best guess is it wants to check the spread of a "cloud" of splatter, so air_canblock should be ok.
- Fixes Runtime in chemsmoke.dm,177: Cannot read null.seed_name
  - This was caused by create_spores() being called on seeds which were not registered with the plant_controller (becuase they had never been harvested)
  - Instead of registering them, we can just pass the seed datum itself, that is all the chemsmoke needs anyway.