### PR TITLE
Refactor away area/New()

### DIFF
--- a/code/ATMOSPHERICS/components/unary/vent_pump.dm
+++ b/code/ATMOSPHERICS/components/unary/vent_pump.dm
@@ -80,7 +80,7 @@
 
 	icon = null
 	initial_loc = get_area(loc)
-	area_uid = initial_loc.uid
+	area_uid = "\ref[initial_loc]"
 	if (!id_tag)
 		assign_uid()
 		id_tag = num2text(uid)

--- a/code/ATMOSPHERICS/components/unary/vent_scrubber.dm
+++ b/code/ATMOSPHERICS/components/unary/vent_scrubber.dm
@@ -38,7 +38,7 @@
 
 	icon = null
 	initial_loc = get_area(loc)
-	area_uid = initial_loc.uid
+	area_uid = "\ref[initial_loc]"
 	if (!id_tag)
 		assign_uid()
 		id_tag = num2text(uid)

--- a/code/_helpers/unsorted.dm
+++ b/code/_helpers/unsorted.dm
@@ -676,7 +676,7 @@ proc/GaussRandRound(var/sigma,var/roundto)
 //Returns: all the areas in the world
 /proc/return_areas()
 	var/list/area/areas = list()
-	for(var/area/A in all_areas)
+	for(var/area/A in world)
 		areas += A
 	return areas
 
@@ -694,7 +694,7 @@ proc/GaussRandRound(var/sigma,var/roundto)
 		areatype = areatemp.type
 
 	var/list/areas = new/list()
-	for(var/area/N in all_areas)
+	for(var/area/N in world)
 		if(istype(N, areatype)) areas += N
 	return areas
 
@@ -708,7 +708,7 @@ proc/GaussRandRound(var/sigma,var/roundto)
 		areatype = areatemp.type
 
 	var/list/turfs = new/list()
-	for(var/area/N in all_areas)
+	for(var/area/N in world)
 		if(istype(N, areatype))
 			for(var/turf/T in N) turfs += T
 	return turfs
@@ -723,7 +723,7 @@ proc/GaussRandRound(var/sigma,var/roundto)
 		areatype = areatemp.type
 
 	var/list/atoms = new/list()
-	for(var/area/N in all_areas)
+	for(var/area/N in world)
 		if(istype(N, areatype))
 			for(var/atom/A in N)
 				atoms += A

--- a/code/controllers/emergency_shuttle_controller.dm
+++ b/code/controllers/emergency_shuttle_controller.dm
@@ -96,7 +96,7 @@ var/global/datum/emergency_shuttle_controller/emergency_shuttle = new
 
 	evac = 1
 	emergency_shuttle_called.Announce(replacetext(using_map.emergency_shuttle_called_message, "%ETA%", "[estimated_time] minute\s"))
-	for(var/area/A in all_areas)
+	for(var/area/A in world)
 		if(istype(A, /area/hallway))
 			A.readyalert()
 
@@ -128,7 +128,7 @@ var/global/datum/emergency_shuttle_controller/emergency_shuttle = new
 	if (evac)
 		emergency_shuttle_recalled.Announce(using_map.emergency_shuttle_recall_message)
 
-		for(var/area/A in all_areas)
+		for(var/area/A in world)
 			if(istype(A, /area/hallway))
 				A.readyreset()
 		evac = 0

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -40,13 +40,7 @@
 	var/list/forced_ambience = null
 	var/sound_env = STANDARD_STATION
 	var/turf/base_turf //The base turf type of the area, which can be used to override the z-level's base turf
-	var/global/global_uid = 0
-	var/uid
 	var/forbid_events = FALSE // If true, random events will not start inside this area.
-
-/area/New()
-	uid = ++global_uid
-	..()
 
 /area/Initialize()
 	. = ..()

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -46,8 +46,6 @@
 
 /area/New()
 	uid = ++global_uid
-	all_areas += src //Replace with /area in world? Byond optimizes X in world loops.
-	
 	..()
 
 /area/Initialize()
@@ -389,7 +387,7 @@ var/list/mob/living/forced_ambiance_list = new
 var/list/teleportlocs = list()
 
 /hook/startup/proc/setupTeleportLocs()
-	for(var/area/AR in all_areas)
+	for(var/area/AR in world)
 		if(istype(AR, /area/shuttle) || istype(AR, /area/syndicate_station) || istype(AR, /area/wizard_station)) continue
 		if(teleportlocs.Find(AR.name)) continue
 		var/turf/picked = pick(get_area_turfs(AR.type))
@@ -404,7 +402,7 @@ var/list/teleportlocs = list()
 var/list/ghostteleportlocs = list()
 
 /hook/startup/proc/setupGhostTeleportLocs()
-	for(var/area/AR in all_areas)
+	for(var/area/AR in world)
 		if(ghostteleportlocs.Find(AR.name)) continue
 		if(istype(AR, /area/aisat) || istype(AR, /area/derelict) || istype(AR, /area/tdome) || istype(AR, /area/shuttle/specops/centcom))
 			ghostteleportlocs += AR.name

--- a/code/game/gamemodes/cult/hell_universe.dm
+++ b/code/game/gamemodes/cult/hell_universe.dm
@@ -54,7 +54,7 @@ In short:
 
 
 /datum/universal_state/hell/proc/AreaSet()
-	for(var/area/A in all_areas)
+	for(var/area/A in world)
 		if(!istype(A,/area) || istype(A, /area/space))
 			continue
 

--- a/code/game/gamemodes/endgame/supermatter_cascade/universe.dm
+++ b/code/game/gamemodes/endgame/supermatter_cascade/universe.dm
@@ -84,7 +84,7 @@ The access requirements on the Asteroid Shuttles' consoles have now been revoked
 		return
 
 /datum/universal_state/supermatter_cascade/proc/AreaSet()
-	for(var/area/A in all_areas)
+	for(var/area/A in world)
 		if(!istype(A,/area) || istype(A, /area/space) || istype(A,/area/beach))
 			continue
 

--- a/code/game/gamemodes/events.dm
+++ b/code/game/gamemodes/events.dm
@@ -169,7 +169,7 @@ var/hadevent    = 0
 
 
 	var/list/area/areas = list()
-	for(var/area/A in all_areas)
+	for(var/area/A in world)
 		if(istype(A, /area/security/prison) || istype(A, /area/security/brig))
 			areas += A
 

--- a/code/game/machinery/air_alarm.dm
+++ b/code/game/machinery/air_alarm.dm
@@ -116,7 +116,7 @@
 
 /obj/machinery/alarm/proc/first_run()
 	alarm_area = get_area(src)
-	area_uid = alarm_area.uid
+	area_uid = "\ref[alarm_area]"
 	if(name == "alarm")
 		name = "[alarm_area.name] Air Alarm"
 

--- a/code/game/machinery/turret_control.dm
+++ b/code/game/machinery/turret_control.dm
@@ -51,7 +51,7 @@
 	else if(ispath(control_area))
 		control_area = locate(control_area)
 	else if(istext(control_area))
-		for(var/area/A in all_areas)
+		for(var/area/A in world)
 			if(A.name && A.name==control_area)
 				control_area = A
 				break

--- a/code/global.dm
+++ b/code/global.dm
@@ -5,7 +5,6 @@
 
 // Items that ask to be called every cycle.
 var/global/datum/datacore/data_core = null
-var/global/list/all_areas                = list()
 var/global/list/machines                 = list()	// ALL Machines, wether processing or not.
 var/global/list/processing_machines      = list()	// TODO - Move into SSmachines
 var/global/list/processing_power_items   = list()	// TODO - Move into SSmachines

--- a/code/modules/admin/secrets/random_events/gravity.dm
+++ b/code/modules/admin/secrets/random_events/gravity.dm
@@ -16,7 +16,7 @@
 		return
 
 	gravity_is_on = !gravity_is_on
-	for(var/area/A in all_areas)
+	for(var/area/A in world)
 		A.gravitychange(gravity_is_on)
 
 	feedback_inc("admin_secrets_fun_used",1)

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -341,7 +341,7 @@
 	var/list/areas_with_intercom = list()
 	var/list/areas_with_camera = list()
 
-	for(var/area/A in all_areas)
+	for(var/area/A in world)
 		if(!(A.type in areas_all))
 			areas_all.Add(A.type)
 

--- a/code/modules/events/gravity.dm
+++ b/code/modules/events/gravity.dm
@@ -15,7 +15,7 @@
 
 /datum/event/gravity/start()
 	gravity_is_on = 0
-	for(var/area/A in all_areas)
+	for(var/area/A in world)
 		if(A.z in zLevels)
 			A.gravitychange(gravity_is_on)
 
@@ -23,7 +23,7 @@
 	if(!gravity_is_on)
 		gravity_is_on = 1
 
-		for(var/area/A in all_areas)
+		for(var/area/A in world)
 			if(A.z in zLevels)
 				A.gravitychange(gravity_is_on)
 

--- a/code/modules/events/prison_break.dm
+++ b/code/modules/events/prison_break.dm
@@ -41,7 +41,7 @@
 
 
 /datum/event/prison_break/start()
-	for(var/area/A in all_areas)
+	for(var/area/A in world)
 		if(is_type_in_list(A,areaType) && !is_type_in_list(A,areaNotType))
 			areas += A
 

--- a/code/modules/gamemaster/event2/events/everyone/gravity.dm
+++ b/code/modules/gamemaster/event2/events/everyone/gravity.dm
@@ -22,12 +22,12 @@
 	Please stand by while the gravity system reinitializes.", "Gravity Failure")
 
 /datum/event2/event/gravity/start()
-	for(var/area/A in all_areas)
+	for(var/area/A in world)
 		if(A.z in get_location_z_levels())
 			A.gravitychange(FALSE)
 
 /datum/event2/event/gravity/end()
-	for(var/area/A in all_areas)
+	for(var/area/A in world)
 		if(A.z in get_location_z_levels())
 			A.gravitychange(TRUE)
 

--- a/code/modules/gamemaster/event2/events/security/prison_break.dm
+++ b/code/modules/gamemaster/event2/events/security/prison_break.dm
@@ -177,7 +177,7 @@
 
 
 /datum/event2/event/prison_break/set_up()
-	for(var/area/A in all_areas)
+	for(var/area/A in world)
 		if(is_type_in_list(A, area_types_to_break) && !is_type_in_list(A, area_types_to_ignore))
 			areas_to_break += A
 

--- a/code/modules/lighting/lighting_setup.dm
+++ b/code/modules/lighting/lighting_setup.dm
@@ -1,6 +1,6 @@
 // Create lighting overlays on all turfs with dynamic lighting in areas with dynamic lighting.
 /proc/create_all_lighting_overlays()
-	for(var/area/A in all_areas)
+	for(var/area/A in world)
 		if(!A.dynamic_lighting)
 			continue
 		for(var/turf/T in A)

--- a/code/modules/maps/tg/reader.dm
+++ b/code/modules/maps/tg/reader.dm
@@ -346,7 +346,7 @@ var/global/use_preloader = FALSE
 		var/atom/instance
 		_preloader.setup(members_attributes[index])//preloader for assigning  set variables on atom creation
 		var/atype = members[index]
-		for(var/area/A in all_areas)
+		for(var/area/A in world)
 			if(A.type == atype)
 				instance = A
 				break

--- a/code/unit_tests/map_tests.dm
+++ b/code/unit_tests/map_tests.dm
@@ -41,7 +41,7 @@
 
 	var/list/zs_to_test = using_map.unit_test_z_levels || list(1) //Either you set it, or you just get z1
 
-	for(var/area/A in all_areas)
+	for(var/area/A in world)
 		if((A.z in zs_to_test) && !(A.type in exempt_areas))
 			area_test_count++
 			var/area_good = 1


### PR DESCRIPTION
- Replace global `all_areas` list with `world`.
  - It ends up having similar performance, so might as well not bother with `all_areas`.
- Removed area's `uid` var
  - Because areas are singletons it is safe to replace the uid with \ref; areas don't get deleted.
- And with that /area/New() is empty, we can remove it, leaving just area/Initialize()

