### PR TITLE
Splits circuit clothes IC interaction to ctrl-shift-click

### DIFF
--- a/code/modules/integrated_electronics/core/assemblies.dm
+++ b/code/modules/integrated_electronics/core/assemblies.dm
@@ -265,9 +265,11 @@
 	else if(istype(I, /obj/item/device/integrated_electronics/wirer) || istype(I, /obj/item/device/integrated_electronics/debugger) || I.is_screwdriver())
 		if(opened)
 			interact(user)
+			return TRUE
 		else
 			to_chat(user, "<span class='warning'>\The [src] isn't opened, so you can't fiddle with the internal components.  \
 			Try using a crowbar.</span>")
+			return FALSE
 
 	else if(istype(I, /obj/item/device/integrated_electronics/detailer))
 		var/obj/item/device/integrated_electronics/detailer/D = I
@@ -365,3 +367,7 @@
 /obj/item/device/electronic_assembly/proc/on_unanchored()
 	for(var/obj/item/integrated_circuit/IC in contents)
 		IC.on_unanchored()
+
+// Returns TRUE if I is something that could/should have a valid interaction. Used to tell circuitclothes to hit the circuit with something instead of the clothes
+/obj/item/device/electronic_assembly/proc/is_valid_tool(var/obj/item/I)
+	return I.is_crowbar() || I.is_screwdriver() || istype(I, /obj/item/integrated_circuit) || istype(I, /obj/item/weapon/cell/device) || istype(I, /obj/item/device/integrated_electronics)

--- a/code/modules/integrated_electronics/core/assemblies/clothing.dm
+++ b/code/modules/integrated_electronics/core/assemblies/clothing.dm
@@ -51,13 +51,12 @@
 		IC.examine(user)
 	..()
 
-/obj/item/clothing/attackby(obj/item/I, mob/user)
-	if(IC)
-		// This needs to be done in a better way...
-		if(I.is_crowbar() || I.is_screwdriver() || istype(I, /obj/item/integrated_circuit) || istype(I, /obj/item/weapon/cell/device) || istype(I, /obj/item/device/integrated_electronics) )
-			IC.attackby(I, user)
-	else
-		..()
+/obj/item/clothing/CtrlShiftClick(mob/user)
+	var/turf/T = get_turf(src)
+	if(!T.AdjacentQuick(user)) // So people aren't messing with these from across the room
+		return FALSE
+	var/obj/item/I = user.get_active_hand() // ctrl-shift-click doesn't give us the item, we have to fetch it
+	return IC.attackby(I, user)
 
 /obj/item/clothing/attack_self(mob/user)
 	if(IC)
@@ -105,6 +104,7 @@
 /obj/item/clothing/under/circuitry
 	name = "electronic jumpsuit"
 	desc = "It's a wearable case for electronics. This on is a black jumpsuit with wiring weaved into the fabric."
+	description_info = "Control-shift-click on this with an item in hand to use it on the integrated circuit."
 	icon_state = "circuitry"
 	worn_state = "circuitry"
 
@@ -118,6 +118,7 @@
 	name = "electronic gloves"
 	desc = "It's a wearable case for electronics. This one is a pair of black gloves, with wires woven into them. A small \
 	device with a screen is attached to the left glove."
+	description_info = "Control-shift-click on this with an item in hand to use it on the integrated circuit."
 	icon_state = "circuitry"
 	item_state = "circuitry"
 
@@ -131,6 +132,7 @@
 	name = "electronic goggles"
 	desc = "It's a wearable case for electronics. This one is a pair of goggles, with wiring sticking out. \
 	Could this augment your vision?" // Sadly it won't, or at least not yet.
+	description_info = "Control-shift-click on this with an item in hand to use it on the integrated circuit."
 	icon_state = "circuitry"
 	item_state = "night" // The on-mob sprite would be identical anyways.
 
@@ -143,6 +145,7 @@
 	name = "electronic boots"
 	desc = "It's a wearable case for electronics. This one is a pair of boots, with wires attached to a small \
 	cover."
+	description_info = "Control-shift-click on this with an item in hand to use it on the integrated circuit."
 	icon_state = "circuitry"
 	item_state = "circuitry"
 
@@ -155,6 +158,7 @@
 	name = "electronic headwear"
 	desc = "It's a wearable case for electronics. This one appears to be a very technical-looking piece that \
 	goes around the collar, with a heads-up-display attached on the right."
+	description_info = "Control-shift-click on this with an item in hand to use it on the integrated circuit."
 	icon_state = "circuitry"
 	item_state = "circuitry"
 
@@ -166,6 +170,7 @@
 /obj/item/clothing/ears/circuitry
 	name = "electronic earwear"
 	desc = "It's a wearable case for electronics. This one appears to be a technical-looking headset."
+	description_info = "Control-shift-click on this with an item in hand to use it on the integrated circuit."
 	icon = 'icons/obj/clothing/ears.dmi'
 	icon_state = "circuitry"
 	item_state = "circuitry"
@@ -179,6 +184,7 @@
 	name = "electronic chestpiece"
 	desc = "It's a wearable case for electronics. This one appears to be a very technical-looking vest, that \
 	almost looks professionally made, however the wiring popping out betrays that idea."
+	description_info = "Control-shift-click on this with an item in hand to use it on the integrated circuit."
 	icon_state = "circuitry"
 	item_state = "circuitry"
 

--- a/html/changelogs/atermonera_circuitpants_holstered.yml
+++ b/html/changelogs/atermonera_circuitpants_holstered.yml
@@ -1,0 +1,5 @@
+author: Atermonera
+delete-after: True
+changes: 
+  - bugfix: "Circuit clothes can have accessories attached."
+  - tweak: "Control-shift-click on circuit clothes to use items on the circuit."


### PR DESCRIPTION
Fixes #6441
[tested](https://puu.sh/FtOvR/c8d4392018.gif)
Updated usage is in the extended description that goes on the examine tab, and in the changelog.

I initially considered using alt-click, as is usually my wont, but quickly discovered that if the mouse moved so much as a [hair](https://puu.sh/FtNYk/ac698d8c64.mp4) (Note mouse movement in last few frames) then it would _also_ remove the clothes.
I then considered middle-mouse, but discovered that that's hardcoded to just swap_hands, and hardsuits use enough spaghetti to manipulate that as is.
Perhaps in the future add middle-click and make it swaphands only if that returns FALSE...