### PR TITLE
Adds preference to output description_info with examine text

### DIFF
--- a/code/__defines/preferences.dm
+++ b/code/__defines/preferences.dm
@@ -1,0 +1,6 @@
+#define EXAMINE_MODE_DEFAULT		 0
+#define EXAMINE_MODE_INCLUDE_USAGE	 1
+#define EXAMINE_MODE_SWITCH_TO_PANEL 2
+
+// Should be one higher than the above
+#define EXAMINE_MODE_MAX			 3

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -185,6 +185,12 @@
 	to_chat(user, "[bicon(src)] That's [f_name] [suffix]")
 	to_chat(user,desc)
 
+	if(user.client?.examine_text_mode == EXAMINE_MODE_INCLUDE_USAGE)
+		to_chat(user, description_info)
+
+	if(user.client?.examine_text_mode == EXAMINE_MODE_SWITCH_TO_PANEL)
+		user.client.statpanel = "Examine" // Switch to stat panel
+
 	return distance == -1 || (get_dist(src, user) <= distance)
 
 // called by mobs when e.g. having the atom as their machine, pulledby, loc (AKA mob being inside the atom) or buckled var set.

--- a/code/modules/client/client defines.dm
+++ b/code/modules/client/client defines.dm
@@ -28,6 +28,8 @@
 	var/chatOutputLoadedAt
 
 	var/adminhelped = 0
+	var/examine_text_mode = 0 // Just examine text, include usage (description_info), switch to examine panel.
+
 
 		///////////////
 		//SOUND STUFF//

--- a/code/modules/client/preferences_toggle_procs.dm
+++ b/code/modules/client/preferences_toggle_procs.dm
@@ -293,6 +293,26 @@
 
 	feedback_add_details("admin_verb","THInstm") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
+
+// Not attached to a pref datum because those are strict binary toggles
+/client/verb/toggle_examine_mode()
+	set name = "Toggle Examine Mode"
+	set category = "Preferences"
+	set desc = "Control the additional behaviour of examining things"
+
+	examine_text_mode++
+	examine_text_mode %= EXAMINE_MODE_MAX // This cycles through them because if you're already specifically being routed to the examine panel, you probably don't need to have the extra text printed to chat
+	switch(examine_text_mode)				// ... And I only wanted to add one verb
+		if(EXAMINE_MODE_DEFAULT)
+			to_chat(src, "Examining things will only output the base examine text, and you will not be redirected to the examine panel automatically.")
+
+		if(EXAMINE_MODE_INCLUDE_USAGE)
+			to_chat(src, "Examining things will also print any extra usage information normally included in the examine panel to the chat.")
+
+		if(EXAMINE_MODE_SWITCH_TO_PANEL)
+			to_chat(src, "Examining things will direct you to the examine panel, where you can view extended information about the thing.")
+
+
 //Toggles for Staff
 //Developers
 

--- a/html/changelogs/atermonera_examine_pref.yml
+++ b/html/changelogs/atermonera_examine_pref.yml
@@ -1,0 +1,4 @@
+author: Atermonera
+delete-after: True
+changes: 
+  - rscadd: "Added a preference to switch between a few extra modes of examining things. Verb in the preferences tab."

--- a/polaris.dme
+++ b/polaris.dme
@@ -52,6 +52,7 @@
 #include "code\__defines\mobs.dm"
 #include "code\__defines\objects.dm"
 #include "code\__defines\planets.dm"
+#include "code\__defines\preferences.dm"
 #include "code\__defines\process_scheduler.dm"
 #include "code\__defines\qdel.dm"
 #include "code\__defines\research.dm"


### PR DESCRIPTION
![tested](https://puu.sh/FtPmo/848167d451.png)

Doesn't use formatting because the examine panel uses font and b tags instead of span classes.
Only has a mode for usage info because people have complained about the usage of various objects being not-immediately-obvious on examining them because that usage instead went to the examine tab that nobody looks at, or something.
Also has a mode to send people to the examine panel, so that they look at it or something.

If people start complaining about the others, which can in rare instances be walls of text, then maybe I'll look at adding modes for those, and maybe splitting these into two separate prefs