### PR TITLE
Remove non-global references to SSgameMaster and SSevent_ticker

### DIFF
--- a/code/controllers/subsystems/events2.dm
+++ b/code/controllers/subsystems/events2.dm
@@ -23,7 +23,7 @@ SUBSYSTEM_DEF(event_ticker)
 // Starts an event, independent of the GM system.
 // This means it will always run, and won't affect the GM system in any way, e.g. not putting the event off limits after one use.
 /datum/controller/subsystem/event_ticker/proc/start_event(event_type)
-	var/datum/event2/event/E = new event_type(src)
+	var/datum/event2/event/E = new event_type()
 	E.execute()
 	event_started(E)
 

--- a/code/controllers/subsystems/game_master.dm
+++ b/code/controllers/subsystems/game_master.dm
@@ -26,12 +26,12 @@ SUBSYSTEM_DEF(game_master)
 /datum/controller/subsystem/game_master/Initialize()
 	var/list/subtypes = subtypesof(/datum/event2/meta)
 	for(var/T in subtypes)
-		var/datum/event2/meta/M = new T(src)
+		var/datum/event2/meta/M = new T()
 		if(!M.name)
 			continue
 		available_events += M
 
-	GM = new game_master_type(src)
+	GM = new game_master_type()
 
 	if(config && !config.enable_game_master)
 		can_fire = FALSE
@@ -137,7 +137,6 @@ SUBSYSTEM_DEF(game_master)
 
 // This object makes the actual decisions.
 /datum/game_master
-	var/datum/controller/subsystem/game_master/ticker = null
 	// Multiplier for how much 'danger' is accumulated. Higer generally makes it possible for more dangerous events to be picked.
 	var/danger_modifier = 1.0
 
@@ -149,9 +148,6 @@ SUBSYSTEM_DEF(game_master)
 
 	var/ignore_time_restrictions = FALSE 	// Useful for debugging without needing to wait 20 minutes each time.
 	var/ignore_round_chaos = FALSE			// If true, the system will happily choose back to back intense events like meteors and blobs, Dwarf Fortress style.
-
-/datum/game_master/New(datum/controller/subsystem/game_master/new_ticker)
-	ticker = new_ticker
 
 /client/proc/show_gm_status()
 	set category = "Debug"

--- a/code/datums/game_masters/default.dm
+++ b/code/datums/game_masters/default.dm
@@ -71,12 +71,12 @@
 // If no list is passed, all the events will be returned.
 /datum/game_master/default/proc/filter_events_by_departments(list/departments)
 	. = list()
-	for(var/E in ticker.available_events)
+	for(var/E in SSgame_master.available_events)
 		var/datum/event2/meta/event = E
 		if(!event.enabled)
 			continue
 		if(event.chaotic_threshold && !ignore_round_chaos)
-			if(ticker.danger > event.chaotic_threshold)
+			if(SSgame_master.danger > event.chaotic_threshold)
 				continue
 		// An event has to involve all of these departments to pass.
 		var/viable = TRUE

--- a/code/datums/game_masters/other_game_masters.dm
+++ b/code/datums/game_masters/other_game_masters.dm
@@ -3,7 +3,7 @@
 // * Does not react to danger at all.
 /datum/game_master/classic/choose_event()
 	var/list/weighted_events = list()
-	for(var/E in ticker.available_events)
+	for(var/E in SSgame_master.available_events)
 		var/datum/event2/meta/event = E
 		if(!event.enabled)
 			continue
@@ -20,7 +20,7 @@
 // * Has no goals, and instead chooses randomly, ignoring weights.
 // * Does not react to danger at all.
 /datum/game_master/super_random/choose_event()
-	return pick(ticker.available_events)
+	return pick(SSgame_master.available_events)
 
 
 // The `brutal` game master tries to run dangerous events frequently.
@@ -31,7 +31,7 @@
 
 /datum/game_master/brutal/choose_event()
 	var/list/weighted_events = list()
-	for(var/E in ticker.available_events)
+	for(var/E in SSgame_master.available_events)
 		var/datum/event2/meta/event = E
 		if(!event.enabled)
 			continue

--- a/code/modules/gamemaster/event2/meta.dm
+++ b/code/modules/gamemaster/event2/meta.dm
@@ -35,25 +35,15 @@
 	// Can be used to make event repeats discouraged but not forbidden by adjusting the weight based on it.
 	var/times_ran = 0
 
-	// A reference to the system that initialized us.
-	var/datum/controller/subsystem/game_master/GM = null
-
 	// The type path to the event associated with this meta object.
 	// When the GM chooses this event, a new instance is made.
 	// Seperate instances allow for multiple concurrent events without sharing state, e.g. two blobs.
 	var/event_type = null
 
-/datum/event2/meta/New(datum/controller/subsystem/game_master/new_gm)
-	GM = new_gm
-
-/datum/event2/meta/Destroy()
-	GM = null
-	return ..()
-
 
 // Called by the GM system to actually start an event.
 /datum/event2/meta/proc/make_event()
-	var/datum/event2/event/E = new event_type(GM)
+	var/datum/event2/event/E = new event_type()
 	E.execute()
 	return E
 


### PR DESCRIPTION
### Reasoning
- I'd say it is best practice to avoid holding onto references to the subsystem instances aside from the global variables
  - As an example: if Master/Failsafe decided to restart/recover a subsystem, it fixes the global variable, but anyone out there holding a reference to the old one in their own local variables would A) prevent it from GCing and B) reference the old one that isn't getting fired anymore!
- The reference to GM was entirely unused by any event or meta-event.  (events actually didn't even store the reference being passed to their New)  so safe to remove.
-  /datum/game_master would work fine using the global refs.  Personally I also was a bit confused by the variable `ticker` referring to SSgame_master not SSgame_ticker, so its safe to remove too.