### PR TITLE
Port followup misc fixes

### DIFF
--- a/code/controllers/subsystems/xenoarch.dm
+++ b/code/controllers/subsystems/xenoarch.dm
@@ -99,6 +99,9 @@ SUBSYSTEM_DEF(xenoarch)
 			if(isnull(M.artifact_find) && digsite != DIGSITE_GARDEN && digsite != DIGSITE_ANIMAL)
 				artifact_spawning_turfs.Add(archeo_turf)
 
+		//Larger maps will convince byond this is an infinite loop, so let go for a second
+		CHECK_TICK
+
 	//create artifact machinery
 	var/num_artifacts_spawn = rand(ARTIFACTSPAWNNUM_LOWER, ARTIFACTSPAWNNUM_UPPER)
 	while(artifact_spawning_turfs.len > num_artifacts_spawn)

--- a/code/game/turfs/space/space.dm
+++ b/code/game/turfs/space/space.dm
@@ -45,7 +45,7 @@
 
 		if(!AM.anchored)
 			AM.throw_at(get_step(src,reverse_direction(direction)), 5, 1)
-		else if (istype(AM, /obj/effect))
+		else if (istype(AM, /obj/effect/decal))
 			qdel(AM) //No more space blood coming with the shuttle
 
 /turf/space/proc/build_overedge(var/forced_dirs)

--- a/code/modules/maps/tg/reader.dm
+++ b/code/modules/maps/tg/reader.dm
@@ -292,6 +292,7 @@ var/global/use_preloader = FALSE
 			old_position = dpos + 1
 
 			if(!atom_def) // Skip the item if the path does not exist.  Fix your crap, mappers!
+				error("Maploader skipping undefined type: '[trim_text(copytext(full_def, 1, variables_start))]' (key=[model_key])")
 				continue
 			members.Add(atom_def)
 


### PR DESCRIPTION
After a post-overmap event sweep of necessary backported PRs that hadn't been merged to Polaris, these are the ones that I found that were needed. 

- Cause the maploader to log an error if dmm file contains an undefined type.
  - This will greatly ease debugging as otherwise the only error you might get is "Runtime in reader.dm,370: list index out of bounds", and even then only if the turf has no objects.
- Make blood etc decals vanish when overmap ships fly away.
- CHECK_TICK in xenoarch setup for the sake of largermaps.