### PR TITLE
[PORT] Make glass firedoors constructable/deconstructable.

### DIFF
--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -290,6 +290,7 @@
 					FA.anchored = 1
 					FA.density = 1
 					FA.wired = 1
+					FA.glass = glass
 					FA.update_icon()
 					qdel(src)
 		return

--- a/code/game/machinery/doors/firedoor_assembly.dm
+++ b/code/game/machinery/doors/firedoor_assembly.dm
@@ -7,8 +7,13 @@ obj/structure/firedoor_assembly
 	opacity = 0
 	density = 1
 	var/wired = 0
+	var/glass = FALSE
 
 obj/structure/firedoor_assembly/update_icon()
+	if(glass)
+		icon = 'icons/obj/doors/DoorHazardGlass.dmi'
+	else
+		icon = 'icons/obj/doors/DoorHazard.dmi'
 	if(anchored)
 		icon_state = "door_anchored"
 	else
@@ -41,7 +46,10 @@ obj/structure/firedoor_assembly/attackby(obj/item/C, mob/user as mob)
 			playsound(src.loc, 'sound/items/Deconstruct.ogg', 50, 1)
 			user.visible_message("<span class='warning'>[user] has inserted a circuit into \the [src]!</span>",
 								  "You have inserted the circuit into \the [src]!")
-			new /obj/machinery/door/firedoor(src.loc)
+			if(glass)
+				new /obj/machinery/door/firedoor/glass(loc)
+			else
+				new /obj/machinery/door/firedoor(loc)
 			qdel(C)
 			qdel(src)
 		else
@@ -52,18 +60,39 @@ obj/structure/firedoor_assembly/attackby(obj/item/C, mob/user as mob)
 		user.visible_message("<span class='warning'>[user] has [anchored ? "" : "un" ]secured \the [src]!</span>",
 							  "You have [anchored ? "" : "un" ]secured \the [src]!")
 		update_icon()
-	else if(!anchored && istype(C, /obj/item/weapon/weldingtool))
+	else if((glass || !anchored) && istype(C, /obj/item/weapon/weldingtool))
 		var/obj/item/weapon/weldingtool/WT = C
 		if(WT.remove_fuel(0, user))
-			user.visible_message("<span class='warning'>[user] dissassembles \the [src].</span>",
-			"You start to dissassemble \the [src].")
-			if(do_after(user, 40))
-				if(!src || !WT.isOn()) return
-				user.visible_message("<span class='warning'>[user] has dissassembled \the [src].</span>",
-									"You have dissassembled \the [src].")
-				new /obj/item/stack/material/steel(src.loc, 2)
-				qdel(src)
+			playsound(src, WT.usesound, 50, 1)
+			if(glass)
+				user.visible_message("<span class='warning'>[user] welds the glass panel out of \the [src].</span>",
+									"<span class='notice'>You start to weld the glass panel out of \the [src].</span>")
+				if(do_after(user, 40 * WT.toolspeed, src) && WT.isOn())
+					to_chat(user, "<span class='notice'>You welded the glass panel out!</span>")
+					new /obj/item/stack/material/glass/reinforced(drop_location())
+					glass = FALSE
+					update_icon()
+				return
+			if(!anchored)
+				user.visible_message("<span class='warning'>[user] dissassembles \the [src].</span>", "You start to dissassemble \the [src].")
+				if(do_after(user, 40 * WT.toolspeed, src) && WT.isOn())
+					user.visible_message("<span class='warning'>[user] has dissassembled \the [src].</span>",
+										"You have dissassembled \the [src].")
+					new /obj/item/stack/material/steel(drop_location(), 2)
+					qdel(src)
+				return
 		else
 			to_chat(user, "<span class='notice'>You need more welding fuel.</span>")
+	else if(istype(C, /obj/item/stack/material) && C.get_material_name() == "rglass" && !glass)
+		var/obj/item/stack/S = C
+		if (S.get_amount() >= 1)
+			playsound(src.loc, 'sound/items/Crowbar.ogg', 100, 1)
+			user.visible_message("<span class='info'>[user] adds [S.name] to \the [src].</span>",
+								"<span class='notice'>You start to install [S.name] into \the [src].</span>")
+			if(do_after(user, 40, src) && !glass && S.use(1))
+				to_chat(user, "<span class='notice'>You installed reinforced glass windows into \the [src].</span>")
+				glass = TRUE
+				update_icon()
+
 	else
 		..(C, user)

--- a/html/changelogs/Leshana-vplk-glass-firedoors.yml
+++ b/html/changelogs/Leshana-vplk-glass-firedoors.yml
@@ -1,0 +1,4 @@
+author: Leshana
+delete-after: True
+changes: 
+  - rscadd: "Glass Emergency Shutters are now constructable and deconstructing them will give you the glass back."


### PR DESCRIPTION
Port of VOREStation/VOREStation#7176
When you take a part a glass firedoor, it now becomes a glass firedoor assembly instead of an opaque one.   You can put in and cut out glass panels into the assemblies just like how it works with airlocks.