### PR TITLE
Update Human HUD Generation to Fix Internals Graphical Bug

### DIFF
--- a/code/_onclick/hud/human.dm
+++ b/code/_onclick/hud/human.dm
@@ -236,6 +236,8 @@
 		mymob.internals = new /obj/screen()
 		mymob.internals.icon = ui_style
 		mymob.internals.icon_state = "internal0"
+		if(istype(target.internal, /obj/item/weapon/tank)) //Internals on already? Iight, prove it
+			mymob.internals.icon_state = "internal1"
 		mymob.internals.name = "internal"
 		mymob.internals.screen_loc = ui_internal
 		hud_elements |= mymob.internals


### PR DESCRIPTION
Fix an issue whereby when reconnecting to the server after disconnecting/losing connection your internals HUD element will always be off, even if you're actually still breathing from a tank.
Now it checks & shows the correct state so you don't panic after lagging out IN SPACE AAAAAHHHH