### PR TITLE
Allow fighters to traverse overmap ships predictably

### DIFF
--- a/code/modules/multi-tile/multi-tile.dm
+++ b/code/modules/multi-tile/multi-tile.dm
@@ -11,6 +11,8 @@
 		var/list/checked_turfs = list()
 		for(var/turf/T in locs)
 			var/turf/Tcheck = get_step(T, stepdir)
+			if(!Tcheck) //Map edge
+				continue
 			if(Tcheck in checked_turfs)
 				continue
 			if(Tcheck in locs)


### PR DESCRIPTION
When you reach the edge of the map in a powered, occupied fighter, you'll be asked what adjacent overmap sector you want to fly to, assuming your game is using the overmap. Otherwise you'll drift like normal. You also can't fly to surface levels or anything. Get a real ship nerd.

(Depends on https://github.com/PolarisSS13/Polaris/pull/6990)