### PR TITLE
Fix Sundry Runtime Errors XII

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -531,7 +531,8 @@
 	cloak_animation(animation_time)
 
 	//Needs to be last so people can actually see the effect before we become invisible
-	plane = CLOAKED_PLANE
+	if(cloaked) // Ensure we are still cloaked after the animation delay
+		plane = CLOAKED_PLANE
 
 /atom/movable/proc/uncloak()
 	if(!cloaked)
@@ -566,7 +567,7 @@
 	sleep(length+5)
 
 	//Remove those
-	filters -= filters[our_filter]
+	filters -= filter(type="wave", x = 0, y = 16, size = 8, offset = 1, flags = WAVE_SIDEWAYS)
 
 	//Back to original alpha
 	alpha = initial_alpha
@@ -590,7 +591,7 @@
 	sleep(length+5)
 
 	//Remove those
-	filters -= filters[our_filter]
+	filters -= filter(type="wave", x=0, y = 16, size = 0, offset = 0, flags = WAVE_SIDEWAYS)
 
 
 // So cloaked things can see themselves, if necessary

--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -789,7 +789,7 @@
 		if(shock(user, 100))
 			return
 
-	usr.set_machine(src)
+	user.set_machine(src)
 
 	var/dat = "<HEAD><TITLE>Suit Cycler Interface</TITLE></HEAD>"
 
@@ -798,7 +798,7 @@
 
 	else if(locked)
 		dat += "<br><font color='red'><B>The [model_text ? "[model_text] " : ""]suit cycler is currently locked. Please contact your system administrator.</b></font>"
-		if(allowed(usr))
+		if(allowed(user))
 			dat += "<br><a href='?src=\ref[src];toggle_lock=1'>\[unlock unit\]</a>"
 	else
 		dat += "<h1>Suit cycler</h1>"
@@ -972,7 +972,7 @@
 	occupant.loc = get_turf(occupant)
 	occupant = null
 
-	add_fingerprint(usr)
+	add_fingerprint(user)
 	updateUsrDialog()
 	update_icon()
 

--- a/code/game/turfs/simulated/floor_attackby.dm
+++ b/code/game/turfs/simulated/floor_attackby.dm
@@ -152,10 +152,10 @@
 	if(T.type == flooring.build_type)
 		return
 	var/obj/item/weapon/W = user.is_holding_item_of_type(/obj/item/weapon)
+	if(!istype(W))
+		return
 	if(!try_deconstruct_tile(W, user))
 		return
 	if(flooring)
-		return
-	if(!istype(W))
 		return
 	attackby(T, user)

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -19,6 +19,7 @@
 
 /mob/new_player/New()
 	mob_list += src
+	initialized = TRUE // Explicitly don't use Initialize().  New players join super early and use New()
 
 /mob/new_player/verb/new_player_panel()
 	set src = usr

--- a/code/modules/mob/new_player/preferences_setup.dm
+++ b/code/modules/mob/new_player/preferences_setup.dm
@@ -194,6 +194,8 @@
 	b_skin = blue
 
 /datum/preferences/proc/dress_preview_mob(var/mob/living/carbon/human/mannequin)
+	if(!mannequin.dna) // Special handling for preview icons before SSAtoms has initailized.
+		mannequin.dna = new /datum/dna(null)
 	copy_to(mannequin, TRUE)
 
 	if(!equip_preview_mob)

--- a/code/modules/xenoarcheaology/finds/find_spawning.dm
+++ b/code/modules/xenoarcheaology/finds/find_spawning.dm
@@ -674,8 +674,9 @@
 
 		if(talkative)
 			new_item.talking_atom = new(new_item)
-			LAZYSET(new_item.origin_tech, TECH_ARCANE, 1)
-			LAZYSET(new_item.origin_tech, TECH_PRECURSOR, 1)
+			LAZYINITLIST(new_item.origin_tech)
+			new_item.origin_tech[TECH_ARCANE] += 1
+			new_item.origin_tech[TECH_PRECURSOR] += 1
 
 		var/turf/simulated/mineral/T = get_turf(new_item)
 		if(istype(T))
@@ -685,5 +686,6 @@
 
 	else if(talkative)
 		src.talking_atom = new(src)
-		LAZYSET(src.origin_tech, TECH_ARCANE, 1)
-		LAZYSET(src.origin_tech, TECH_PRECURSOR, 1)
+		LAZYINITLIST(origin_tech)
+		origin_tech[TECH_ARCANE] += 1
+		origin_tech[TECH_PRECURSOR] += 1

--- a/code/modules/xenoarcheaology/finds/find_spawning.dm
+++ b/code/modules/xenoarcheaology/finds/find_spawning.dm
@@ -685,5 +685,5 @@
 
 	else if(talkative)
 		src.talking_atom = new(src)
-		LAZYSET(new_item.origin_tech, TECH_ARCANE, 1)
-		LAZYSET(new_item.origin_tech, TECH_PRECURSOR, 1)
+		LAZYSET(src.origin_tech, TECH_ARCANE, 1)
+		LAZYSET(src.origin_tech, TECH_PRECURSOR, 1)


### PR DESCRIPTION
- Fix Runtime in suit_storage_unit.dm,792: Cannot execute null.set machine().
  - Also fixed other mixups of `usr` vs. `user` that I found in the same file.
- Another fix for Runtime in update_icons.dm,254: Cannot execute null.GetUIState().
  - This time lets just ensure dna is instantiated no matter who is calling dress_preview_mob().
- Fix Runtime in atoms_movable.dm,597: list index out of bounds
  - Happens when toggling cloak before the wave filter animation completed.  No reliable way to keep a reference or index to filters exists in BYOND, therefore we remove what we know the state of the completed animation will be.
- Fix talking artifacts downgrading arcane/precursor tech
  - Bump up the values by one for talking artifact items instead of overwriting whatever the value 
was.
- Fixes Runtime in find_spawning.dm,688: Cannot read null.origin_tech
  - If this _else if_ block is reached, new_item must not exist, so we obviously can't set origin_tech on it. Examination of the code seems to suggest the original author intended that for any "talking" items to have arcane and precursor tech; since src is now being made talking, src should get the tech.
- Fix null values being present in mob_list due to new_players existing before SSatoms init.
- Fix Runtime in floor_attackby.dm,118: Cannot execute 0.is crowbar().