### PR TITLE
Fixes supermatter monitoring EPR indicator showing Undefined

### DIFF
--- a/code/modules/modular_computers/file_system/programs/engineering/supermatter_monitor.dm
+++ b/code/modules/modular_computers/file_system/programs/engineering/supermatter_monitor.dm
@@ -77,6 +77,7 @@
 		data["SM_power"] = active.power
 		data["SM_ambienttemp"] = air.temperature
 		data["SM_ambientpressure"] = air.return_pressure()
+		data["SM_EPR"] = active.get_epr()
 		//data["SM_EPR"] = active.get_epr()
 		if(air.total_moles)
 			data["SM_gas_O2"] = round(100*air.gas["oxygen"]/air.total_moles,0.01)

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -131,6 +131,16 @@
 	return SUPERMATTER_INACTIVE
 
 
+/obj/machinery/power/supermatter/proc/get_epr()
+	var/turf/T = get_turf(src)
+	if(!istype(T))
+		return
+	var/datum/gas_mixture/air = T.return_air()
+	if(!air)
+		return 0
+	return round((air.total_moles / air.group_multiplier) / 23.1, 0.01)
+
+
 /obj/machinery/power/supermatter/proc/explode()
 	message_admins("Supermatter exploded at ([x],[y],[z] - <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'>JMP</a>)",0,1)
 	log_game("SUPERMATTER([x],[y],[z]) Exploded. Power:[power], Oxygen:[oxygen], Damage:[damage], Integrity:[get_integrity()]")


### PR DESCRIPTION
Hoooo boy first code commit for ss13 in years. An isolated incident or beginning of something terrible?

- This mirrors original sources from Bay. Nano file was apparently moved from there, but code file was not.
- As for intent of this function (i coded it originally on Bay), EPR can be considered "Amount of canisters worth of gas in the core chamber", hence the weird 23.1 constant. Unlike pressure reading, this does not change with temperature, so it can be used to accurately monitor actual amount of gas in the chamber without having to take temperature in effect.
- I know the constant is kind of shady. It could possibly be recalculated using atmos constants, but i suck at math too much to do that. If anyone who knows atmos math can find a better alternative, i will gladly toss it in instead.