### PR TITLE
Converts Shutoff valve monitoring into a MC program

### DIFF
--- a/code/game/machinery/computer/shutoff_monitor.dm
+++ b/code/game/machinery/computer/shutoff_monitor.dm
@@ -5,66 +5,27 @@
 	icon_screen = "power:0"
 	light_color = "#a97faa"
 	circuit = /obj/item/weapon/circuitboard/shutoff_monitor
+	var/datum/nano_module/shutoff_monitor/monitor
 
-/obj/machinery/computer/shutoff_monitor/attack_hand(var/mob/user)
+/obj/machinery/computer/shutoff_monitor/New()
+	..()
+	monitor = new(src)
+
+/obj/machinery/computer/shutoff_monitor/Destroy()
+	qdel(monitor)
+	monitor = null
+	..()
+
+/obj/machinery/computer/shutoff_monitor/attack_hand(var/mob/user as mob)
 	..()
 	ui_interact(user)
 
-/obj/machinery/computer/shutoff_monitor/attack_robot(var/mob/user) // Borgs and AI will want to see this too
-	..()
-	ui_interact(user)
-
-/obj/machinery/computer/shutoff_monitor/attack_ai(var/mob/user)
-	ui_interact(user)
-
-/obj/machinery/computer/shutoff_monitor/ui_interact(mob/user, ui_key = "shutoff_monitor", var/datum/nanoui/ui = null, var/force_open = 1, var/key_state = null)
-	var/data[0]
-	data["valves"] = list()
-	for(var/obj/machinery/atmospherics/valve/shutoff/S in GLOB.shutoff_valves)
-		data["valves"][++data["valves"].len] = list("name" = S.name, "enable" = S.close_on_leaks, "open" = S.open, "x" = S.x, "y" = S.y, "z" = S.z, "ref" = "\ref[S]")
-
-	// update the ui if it exists, returns null if no ui is passed/found
-	ui = SSnanoui.try_update_ui(user, src, ui_key, ui, data, force_open)
-	if(!ui)
-		// the ui does not exist, so we'll create a new() one
-        // for a list of parameters and their descriptions see the code docs in \code\modules\nano\nanoui.dm
-		ui = new(user, src, ui_key, "shutoff_monitor.tmpl", "Automated Shutoff Valve Monitor", 625, 700, state = key_state)
-		// when the ui is first opened this is the data it will use
-		ui.set_initial_data(data)
-		// open the new ui window
-		ui.open()
-		// auto update every 20 Master Controller tick
-		ui.set_auto_update(20) // Longer term to reduce the rate of data collection and processing
-
-/obj/machinery/computer/shutoff_monitor/Topic(href, href_list)
-	if(..())
-		return 1
-
-	if(href_list["toggle_enable"])
-		var/obj/machinery/atmospherics/valve/shutoff/S = locate(href_list["toggle_enable"])
-
-		// Invalid ref
-		if(!istype(S))
-			return 0
-
-		S.close_on_leaks = !S.close_on_leaks
-
-	if(href_list["toggle_open"])
-		var/obj/machinery/atmospherics/valve/shutoff/S = locate(href_list["toggle_open"])
-
-		// Invalid ref
-		if(!istype(S))
-			return 0
-
-		if(S.open)
-			S.close()
-		else
-			S.open()
-
-	return
-
+/obj/machinery/computer/shutoff_monitor/ui_interact(mob/user, ui_key = "shutoff_monitor", var/datum/nanoui/ui = null, var/force_open = 1)
+	monitor.ui_interact(user, ui_key, ui, force_open)
 
 /obj/machinery/computer/shutoff_monitor/update_icon()
 	..()
 	if(!(stat & (NOPOWER|BROKEN)))
 		add_overlay("ai-fixer-empty")
+	else
+		cut_overlay("ai-fixer-empty")

--- a/code/modules/modular_computers/computers/subtypes/preset_console.dm
+++ b/code/modules/modular_computers/computers/subtypes/preset_console.dm
@@ -15,6 +15,7 @@
 	hard_drive.store_file(new/datum/computer_file/program/atmos_control())
 	hard_drive.store_file(new/datum/computer_file/program/rcon_console())
 	hard_drive.store_file(new/datum/computer_file/program/camera_monitor())
+	hard_drive.store_file(new/datum/computer_file/program/shutoff_monitor())
 
 // Medical
 /obj/item/modular_computer/console/preset/medical/install_default_programs()

--- a/code/modules/modular_computers/file_system/programs/engineering/shutoff_monitor.dm
+++ b/code/modules/modular_computers/file_system/programs/engineering/shutoff_monitor.dm
@@ -1,0 +1,63 @@
+/datum/computer_file/program/shutoff_monitor
+	filename = "shutoffmonitor"
+	filedesc = "Shutoff Valve Monitoring"
+	nanomodule_path = /datum/nano_module/shutoff_monitor
+	program_icon_state = "atmos_control"
+	program_key_state = "atmos_key"
+	program_menu_icon = "wrench"
+	extended_desc = "This program allows for remote monitoring and control of emergency shutoff valves."
+	required_access = access_engine
+	requires_ntnet = 1
+	network_destination = "shutoff valve control computer"
+	size = 5
+	var/has_alert = 0
+
+/datum/nano_module/shutoff_monitor
+	name = "Shutoff Valve Monitoring"
+
+/datum/nano_module/shutoff_monitor/Topic(ref, href_list)
+	if(..())
+		return 1
+
+	if(href_list["toggle_enable"])
+		var/obj/machinery/atmospherics/valve/shutoff/S = locate(href_list["toggle_enable"])
+		if(!istype(S))
+			return 0
+		S.close_on_leaks = !S.close_on_leaks
+		return 1
+
+	if(href_list["toggle_open"])
+		var/obj/machinery/atmospherics/valve/shutoff/S = locate(href_list["toggle_open"])
+		if(!istype(S))
+			return 0
+		if(S.open)
+			S.close()
+		else
+			S.open()
+		return 1
+
+/datum/nano_module/shutoff_monitor/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1, var/datum/topic_state/state = default_state)
+	var/list/data = host.initial_data()
+	var/list/valves = list()
+
+	for(var/obj/machinery/atmospherics/valve/shutoff/S in GLOB.shutoff_valves)
+		valves.Add(list(list(
+		"name" = S.name,
+		"enabled" = S.close_on_leaks,
+		"open" = S.open,
+		"x" = S.x,
+		"y" = S.y,
+		"z" = S.z,
+		"ref" = "\ref[S]"
+		)))
+
+	data["valves"] = valves
+
+	ui = SSnanoui.try_update_ui(user, src, ui_key, ui, data, force_open)
+	if (!ui)
+		ui = new(user, src, ui_key, "shutoff_monitor.tmpl", "Shutoff Valve Monitoring", 627, 700, state = state)
+		if(host.update_layout()) // This is necessary to ensure the status bar remains updated along with rest of the UI.
+			ui.auto_update_layout = 1
+		ui.set_initial_data(data)
+		ui.open()
+		ui.set_auto_update(1)

--- a/html/changelogs/atlantiscze-valveprogram.yml
+++ b/html/changelogs/atlantiscze-valveprogram.yml
@@ -1,0 +1,5 @@
+author: atlantiscze
+delete-after: True
+
+changes: 
+  - rscadd: "Shutoff valve monitoring is now also available as a modular computer program. Its UI has also been cleaned up a little."

--- a/nano/templates/shutoff_monitor.tmpl
+++ b/nano/templates/shutoff_monitor.tmpl
@@ -1,18 +1,13 @@
 <h2>Automated Shutoff Valve Monitoring Console</h2>
 <hr>
+<table style="width:100%"><tr><th>Name<th>Position<th>Open<th>Mode<th>Actions
 {{for data.valves}}
-	<div class="item">
-		<div class="itemLabel" style="width:45%;">
-			{{:value.name}}
-		</div>
-		<div class="itemContent" style="width:55%;">
-			<span style="display:inline-block;width:45%;min-width:150px;">
-				{{:helper.link(value.open   ? 'Open'    : 'Closed',   'alert', {'toggle_open'   : value.ref})}}
-				{{:helper.link(value.enable ? 'Enabled' : 'Disabled', 'alert', {'toggle_enable' : value.ref})}}
-			</span>
-			<span style="display:inline-block;width:55%;min-width:150px;">
-				Coordinates: ({{:value.x}}, {{:value.y}}, {{:value.z}})
-			</span>
-		</div>
-	</div>
+	<tr>
+        <td>{{:value.name}}
+        <td>{{:value.x}}, {{:value.y}}, {{:value.z}}
+        <td>{{:value.open ? 'Yes' : 'No'}}
+        <td>{{:value.enabled ? 'Auto' : 'Manual'}}
+        <td>{{:helper.link(value.open ? 'Close' : 'Open', null, {'toggle_open' : value.ref}, value.enabled ? 'disabled' : null)}}
+            {{:helper.link(value.enabled ? 'Manual' : 'Auto', null, {'toggle_enable' : value.ref})}}
 {{/for}}
+</table>

--- a/polaris.dme
+++ b/polaris.dme
@@ -2340,6 +2340,7 @@
 #include "code\modules\modular_computers\file_system\programs\engineering\atmos_control.dm"
 #include "code\modules\modular_computers\file_system\programs\engineering\power_monitor.dm"
 #include "code\modules\modular_computers\file_system\programs\engineering\rcon_console.dm"
+#include "code\modules\modular_computers\file_system\programs\engineering\shutoff_monitor.dm"
 #include "code\modules\modular_computers\file_system\programs\engineering\supermatter_monitor.dm"
 #include "code\modules\modular_computers\file_system\programs\generic\camera.dm"
 #include "code\modules\modular_computers\file_system\programs\generic\configurator.dm"


### PR DESCRIPTION
- Existing consoles remain for now, only refactored to use a shared nano_module. Included by default on engineering consoles, downloadable by anyone with basic engineering access.
- Tidies up the UI a bit, prevents manual toggling of valves when they are in Auto mode (as it would immediately toggle back)