### PR TITLE
Portable Generator Fixes

### DIFF
--- a/code/modules/power/port_gen.dm
+++ b/code/modules/power/port_gen.dm
@@ -181,8 +181,8 @@
 
 	//calculate the "target" temperature range
 	//This should probably depend on the external temperature somehow, but whatever.
-	var/lower_limit = 56 + power_output * temperature_gain
-	var/upper_limit = 76 + power_output * temperature_gain
+	var/lower_limit = 56 + (power_output - max_safe_output) * temperature_gain
+	var/upper_limit = 76 + (power_output - max_safe_output) * temperature_gain
 
 	/*
 		Hot or cold environments can affect the equilibrium temperature


### PR DESCRIPTION
Portable generators are supposed to have a max_safe_output value that lets you safely use portable generators at a certain power output. However, this variable is not used at all in the calculations to increase portable generator power.