### PR TITLE
Excludes AI shells from event probability calculations

### DIFF
--- a/code/modules/metric/department.dm
+++ b/code/modules/metric/department.dm
@@ -70,6 +70,11 @@
 	if(!department)
 		return
 	for(var/mob/M in player_list)
+		// Do not count AI's shells
+		if(isrobot(M))
+			var/mob/living/silicon/robot/R = M
+			if(R.shell)
+				continue
 		if(department != DEPARTMENT_EVERYONE && guess_department(M) != department) // Ignore people outside the department we're counting.
 			continue
 		if(assess_player_activity(M) < cutoff)


### PR DESCRIPTION
- This seems to be quite an issue on lowpop, with high danger events (strong blobs for example) firing just because the AI has an engineering/security shell(s) available. They are still one player, however, therefore it results in very hard to handle situations when trying to go a 1v1 against strong blobs with remotely controlled engineering shell (as you can't control more than one at a time)