### PR TITLE
[PORT] Ship/Shuttle Console Construction

### DIFF
--- a/code/controllers/subsystems/shuttles.dm
+++ b/code/controllers/subsystems/shuttles.dm
@@ -84,6 +84,7 @@ SUBSYSTEM_DEF(shuttles)
 		if(shuttle)
 			shuttles_made += shuttle
 	hook_up_motherships(shuttles_made)
+	hook_up_shuttle_objects(shuttles_made)
 	shuttles_to_initialize = null
 
 /datum/controller/subsystem/shuttles/proc/initialize_sectors()
@@ -164,6 +165,11 @@ SUBSYSTEM_DEF(shuttles)
 				mothership.shuttle_area |= S.shuttle_area
 			else
 				error("Shuttle [S] was unable to find mothership [mothership]!")
+
+// Let shuttles scan their owned areas for objects they want to configure (Called after mothership hookup)
+/datum/controller/subsystem/shuttles/proc/hook_up_shuttle_objects(shuttles_list)
+	for(var/datum/shuttle/S in shuttles_list)
+		S.populate_shuttle_objects()
 
 // Admin command to halt/resume overmap
 /datum/controller/subsystem/shuttles/proc/toggle_overmap(new_setting)

--- a/code/game/objects/items/weapons/circuitboards/computer/computer.dm
+++ b/code/game/objects/items/weapons/circuitboards/computer/computer.dm
@@ -177,6 +177,30 @@
 	build_path = /obj/machinery/computer/aifixer
 	origin_tech = list(TECH_DATA = 3, TECH_BIO = 2)
 
+
+/obj/item/weapon/circuitboard/helm
+	name = T_BOARD("helm control console")
+	build_path = /obj/machinery/computer/ship/helm
+
+/obj/item/weapon/circuitboard/engine
+	name = T_BOARD("engine control console")
+	build_path = /obj/machinery/computer/ship/engines
+
+/obj/item/weapon/circuitboard/nav
+	name = T_BOARD("navigation console")
+	build_path = /obj/machinery/computer/ship/navigation
+
+/obj/item/weapon/circuitboard/nav/tele
+	name = T_BOARD("navigation telescreen")
+	build_path = /obj/machinery/computer/ship/navigation/telescreen
+
+/obj/item/weapon/circuitboard/sensors
+	name = T_BOARD("sensors console")
+	build_path = /obj/machinery/computer/ship/sensors
+
+
+
+
 /obj/item/weapon/circuitboard/area_atmos
 	name = T_BOARD("area air control console")
 	build_path = /obj/machinery/computer/area_atmos

--- a/code/game/objects/items/weapons/circuitboards/computer/shuttle.dm
+++ b/code/game/objects/items/weapons/circuitboards/computer/shuttle.dm
@@ -1,0 +1,54 @@
+#ifndef T_BOARD
+#error T_BOARD macro is not defined but we need it!
+#endif
+
+//
+// Shuttle control console. Board tries to auto-link the computer if built on a shuttle.
+//
+/obj/item/weapon/circuitboard/shuttle_console
+	origin_tech = list(TECH_DATA = 3)
+	var/shuttle_category = null	// Shuttle datum's category must exactly equal this to auto-detect
+	var/shuttle_tag = null		// If set, link constructed console to this shuttle. If null, auto-detect.
+
+/obj/item/weapon/circuitboard/shuttle_console/deconstruct(obj/machinery/computer/shuttle_control/M)
+	shuttle_tag = M.shuttle_tag
+	if(shuttle_tag)
+		name = T_BOARD("[shuttle_tag] control console")
+
+// Try to auto-link the shuttle computer if it is constructed on a shuttle (and not pre-programmed)
+/obj/item/weapon/circuitboard/shuttle_console/construct(obj/machinery/computer/shuttle_control/M)
+	if(!shuttle_tag)
+		shuttle_tag = auto_detect_shuttle(M) // We don't have a preset tag, so lets try to auto-link.
+	if(shuttle_tag && M.set_shuttle_tag(shuttle_tag))
+		log_and_message_admins("[key_name_admin(usr)] built a [M] for [shuttle_tag] at [ADMIN_COORDJMP(M)]")
+		M.ping("[M] auto-links with shuttle [shuttle_tag]")
+
+// Return shuttle_tag of shuttle of current area
+/obj/item/weapon/circuitboard/shuttle_console/proc/auto_detect_shuttle(obj/machinery/computer/shuttle_control/M)
+	var/area/A = get_area(M)
+	if(!A || !(A in SSshuttles.shuttle_areas))
+		return // Definately not on a shuttle
+	for(var/shuttle_name in SSshuttles.shuttles)
+		var/datum/shuttle/S = SSshuttles.shuttles[shuttle_name]
+		if(A in S.find_childfree_areas())
+			// Found the owning shuttle! Return it if its a valid type
+			return (S.category == shuttle_category) ? S.name : null
+
+// Overmap shuttle console.
+/obj/item/weapon/circuitboard/shuttle_console/explore
+	name = T_BOARD("long range shuttle control console")
+	build_path = /obj/machinery/computer/shuttle_control/explore
+	origin_tech = list(TECH_DATA = 3, TECH_BLUESPACE = 4)
+	shuttle_category = /datum/shuttle/autodock/overmap
+
+// Multi-shuttle console
+/obj/item/weapon/circuitboard/shuttle_console/multi
+	name = T_BOARD("multi-route shuttle control console")
+	build_path = /obj/machinery/computer/shuttle_control/multi
+	shuttle_category = /datum/shuttle/autodock/multi
+
+// Basic "ferry" shuttle console
+/obj/item/weapon/circuitboard/shuttle_console/ferry
+	name = T_BOARD("basic shuttle control console")
+	build_path = /obj/machinery/computer/shuttle_control
+	shuttle_category = /datum/shuttle/autodock/ferry

--- a/code/modules/overmap/ships/computers/engine_control.dm
+++ b/code/modules/overmap/ships/computers/engine_control.dm
@@ -4,6 +4,7 @@
 	name = "engine control console"
 	icon_keyboard = "tech_key"
 	icon_screen = "engines"
+	circuit = /obj/item/weapon/circuitboard/engine
 	var/display_state = "status"
 
 /obj/machinery/computer/ship/engines/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1)

--- a/code/modules/overmap/ships/computers/helm.dm
+++ b/code/modules/overmap/ships/computers/helm.dm
@@ -19,6 +19,7 @@ GLOBAL_LIST_EMPTY(all_waypoints)
 	icon_keyboard = "teleport_key"
 	icon_screen = "helm"
 	light_color = "#7faaff"
+	circuit = /obj/item/weapon/circuitboard/helm
 	core_skill = /datum/skill/pilot
 	var/autopilot = 0
 	var/list/known_sectors = list()
@@ -225,6 +226,7 @@ GLOBAL_LIST_EMPTY(all_waypoints)
 	name = "navigation console"
 	icon_keyboard = "generic_key"
 	icon_screen = "helm"
+	circuit = /obj/item/weapon/circuitboard/nav
 
 /obj/machinery/computer/ship/navigation/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1)
 	if(!linked)
@@ -273,6 +275,7 @@ GLOBAL_LIST_EMPTY(all_waypoints)
 	icon_state = "tele_nav"
 	icon_keyboard = null
 	icon_screen = null
+	circuit = /obj/item/weapon/circuitboard/nav/tele
 	density = 0
 
 /obj/machinery/computer/ship/navigation/telescreen/update_icon()

--- a/code/modules/overmap/ships/computers/sensors.dm
+++ b/code/modules/overmap/ships/computers/sensors.dm
@@ -3,6 +3,7 @@
 	icon_keyboard = "teleport_key"
 	icon_screen = "teleport"
 	light_color = "#77fff8"
+	circuit = /obj/item/weapon/circuitboard/sensors
 	extra_view = 4
 	var/obj/machinery/shipsensors/sensors
 

--- a/code/modules/overmap/ships/computers/ship.dm
+++ b/code/modules/overmap/ships/computers/ship.dm
@@ -16,11 +16,14 @@ somewhere on that shuttle. Subtypes of these can be then used to perform ship ov
 		linked = sector
 		return 1
 
-/obj/machinery/computer/ship/proc/sync_linked()
+/obj/machinery/computer/ship/proc/sync_linked(var/user = null)
 	var/obj/effect/overmap/visitable/ship/sector = map_sectors["[z]"]
 	if(!sector)
 		return
-	return attempt_hook_up_recursive(sector)
+	. = attempt_hook_up_recursive(sector)
+	if(. && linked && user)
+		to_chat(user, "<span class='notice'>[src] reconnected to [linked]</span>")
+		user << browse(null, "window=[src]") // close reconnect dialog
 
 /obj/machinery/computer/ship/proc/attempt_hook_up_recursive(obj/effect/overmap/visitable/ship/sector)
 	if(attempt_hook_up(sector))
@@ -43,7 +46,7 @@ somewhere on that shuttle. Subtypes of these can be then used to perform ship ov
 	if(..())
 		return TOPIC_HANDLED
 	if(href_list["sync"])
-		sync_linked()
+		sync_linked(user)
 		return TOPIC_REFRESH
 	if(href_list["close"])
 		unlook(user)

--- a/code/modules/overmap/ships/computers/shuttle.dm
+++ b/code/modules/overmap/ships/computers/shuttle.dm
@@ -1,6 +1,7 @@
 //Shuttle controller computer for shuttles going between sectors
 /obj/machinery/computer/shuttle_control/explore
 	name = "general shuttle control console"
+	circuit = /obj/item/weapon/circuitboard/shuttle_console/explore
 	ui_template = "shuttle_control_console_exploration.tmpl"
 
 /obj/machinery/computer/shuttle_control/explore/get_ui_data(var/datum/shuttle/autodock/overmap/shuttle)

--- a/code/modules/shuttles/shuttle.dm
+++ b/code/modules/shuttles/shuttle.dm
@@ -74,6 +74,16 @@
 		SSsupply.shuttle = null
 	. = ..()
 
+// This is called after all shuttles have been initialized by SSshuttles, but before sectors have been initialized.
+// Importantly for subtypes, all shuttles will have been initialized and mothershuttles hooked up by the time this is called.
+/datum/shuttle/proc/populate_shuttle_objects()
+	// Scan for shuttle consoles on them needing auto-config.
+	for(var/area/A in find_childfree_areas()) // Let sub-shuttles handle their areas, only do our own.
+		for(var/obj/machinery/computer/shuttle_control/SC in A)
+			if(!SC.shuttle_tag)
+				SC.set_shuttle_tag(src.name)
+	return
+
 // This creates a graphical warning to where the shuttle is about to land, in approximately five seconds.
 /datum/shuttle/proc/create_warning_effect(var/obj/effect/shuttle_landmark/destination)
 	destination.create_warning_effect(src)

--- a/code/modules/shuttles/shuttle.dm
+++ b/code/modules/shuttles/shuttle.dm
@@ -345,6 +345,15 @@
 		qdel(P)
 	SSmachines.setup_powernets_for_cables(cables)
 
+	// Adjust areas of mothershuttle so it doesn't try and bring us with it if it jumps while we aren't on it.
+	if(mothershuttle)
+		var/datum/shuttle/MS = SSshuttles.shuttles[mothershuttle]
+		if(MS)
+			if(current_location.landmark_tag == motherdock)
+				MS.shuttle_area |= shuttle_area // We are now on mothershuttle! Bring us along!
+			else
+				MS.shuttle_area -= shuttle_area // We have left mothershuttle! Don't bring us along!
+
 	return
 
 //returns 1 if the shuttle has a valid arrive time

--- a/code/modules/shuttles/shuttle_console.dm
+++ b/code/modules/shuttles/shuttle_console.dm
@@ -126,6 +126,13 @@
 		ui.open()
 		ui.set_auto_update(1)
 
+// Call to set the linked shuttle tag; override to add behaviour to shuttle tag changes
+/obj/machinery/computer/shuttle_control/proc/set_shuttle_tag(var/new_shuttle_tag)
+	if(shuttle_tag == new_shuttle_tag)
+		return FALSE
+	shuttle_tag = new_shuttle_tag
+	return TRUE
+
 /obj/machinery/computer/shuttle_control/emag_act(var/remaining_charges, var/mob/user)
 	if (!hacked)
 		req_access = list()

--- a/code/modules/shuttles/shuttle_console_multi.dm
+++ b/code/modules/shuttles/shuttle_console_multi.dm
@@ -1,4 +1,5 @@
 /obj/machinery/computer/shuttle_control/multi
+	circuit = /obj/item/weapon/circuitboard/shuttle_console/multi
 	ui_template = "shuttle_control_console_multi.tmpl"
 
 /obj/machinery/computer/shuttle_control/multi/get_ui_data(var/datum/shuttle/autodock/multi/shuttle)

--- a/html/changelogs/Leshana-vplk-shuttle-construction.yml
+++ b/html/changelogs/Leshana-vplk-shuttle-construction.yml
@@ -1,0 +1,6 @@
+author: Leshana
+delete-after: True
+changes: 
+  - rscadd: "Added circuitboards for ship Helm, Sensors, Navigation, and Engine Control consoles."
+  - rscadd: "Added circuitboards for Exploration (Overmap) Shuttle Console."
+  - tweak: "Mappers no longer need to varedit shuttle_tag on shuttle consoles."

--- a/polaris.dme
+++ b/polaris.dme
@@ -1057,6 +1057,7 @@
 #include "code\game\objects\items\weapons\circuitboards\computer\camera_monitor.dm"
 #include "code\game\objects\items\weapons\circuitboards\computer\computer.dm"
 #include "code\game\objects\items\weapons\circuitboards\computer\research.dm"
+#include "code\game\objects\items\weapons\circuitboards\computer\shuttle.dm"
 #include "code\game\objects\items\weapons\circuitboards\computer\supply.dm"
 #include "code\game\objects\items\weapons\circuitboards\computer\telecomms.dm"
 #include "code\game\objects\items\weapons\circuitboards\machinery\biogenerator.dm"


### PR DESCRIPTION
### Additions and Fixes
- Adds circuitboards to make overmap ship computers constructable.  It is now possible to construct and deconstruct Helm, Sensors, Navigation, Engine Control in game.
- Improves linking up constructed ship computers with their ship. Actually gives feedback to player!
- Fixes Mothershuttles moving sub-shuttles when they're away.
### Auto-configuration of mapped shuttle consoles.
  - Its now possible for mappers to put shuttle consoles on a shuttle without coding a specific subtype or mapediting the shuttle_tag on them.
  - After shuttle initialization, SSshuttles gives each initialized shuttle the chance to scan its areas for consoles it wants to claim and configure.
### Shuttle console circuit boards
- Adds circuit boards for shuttle consoles. (Ferry, Multi, and Overmap).
- Deconstructing a console saves the linked shuttle tag in the board for when it is re-constructed.  New boards start blank but will auto-link if you build the console on a shuttle.
- Boards know what type of shuttle they can control and will only auto-link with a shuttle if it is the appropriate type.
- Log and admin notify whenever a new console is built to keep track of _shenanigans_.

**Note**: By default the only mapped-in shuttle consoles that are deconstrutable are overmap and multi shuttle consoles.   For any others, consoles built mid-game will be deconstrutable but the mapped-in ones will not.  That way the arrival, escape, supply ferry shuttles etc won't be messed with unless the mapper specifically chooses to override and make them that way.

Port of VOREStation/VOREStation#7211