### PR TITLE
Fixes Intellicore grabbing AI multiple times

### DIFF
--- a/code/game/objects/items/devices/aicard.dm
+++ b/code/game/objects/items/devices/aicard.dm
@@ -115,6 +115,9 @@
 	show_message(span("critical", "\The [user] is transferring you into \the [src]!"))
 
 	if(do_after(user, 100))
+		if(carded_ai)
+			to_chat(user, "<span class='danger'>Transfer failed:</span> Existing AI found on remote device. Remove existing AI to install a new one.")
+			return 0
 		if(istype(ai.loc, /turf/))
 			new /obj/structure/AIcore/deactivated(get_turf(ai))
 


### PR DESCRIPTION
- If you click multiple times during the do_after timer, you may try to grab the AI multiple times, possibly breaking stuff.
- Should fix #5179 (at least i believe this is what caused it, as something duplicates the call in rigsuit code) 