### PR TITLE
Fix HTML Injection bug in saycode

### DIFF
--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -211,14 +211,14 @@
 		// There are a few things that will make us want to ignore all other languages in - namely, HIVEMIND languages.
 		var/datum/language/L = current[1]
 		if(L && (L.flags & HIVEMIND || L.flags & SIGNLANG))
-			return new /datum/multilingual_say_piece(L, trim(strip_prefixes(message)))
+			return new /datum/multilingual_say_piece(L, trim(sanitize(strip_prefixes(message))))
 
 		if(i + 1 > length(prefix_locations)) // We are out of lookaheads, that means the rest of the message is in cur lang
-			var/spoke_message = handle_autohiss(trim(copytext(message, current[3])), L)
+			var/spoke_message = sanitize(handle_autohiss(trim(copytext(message, current[3])), L))
 			. += new /datum/multilingual_say_piece(current[1], spoke_message)
 		else
 			var/next = prefix_locations[i + 1] // We look ahead at the next message to see where we need to stop.
-			var/spoke_message = handle_autohiss(trim(copytext(message, current[3], next[2])), L)
+			var/spoke_message = sanitize(handle_autohiss(trim(copytext(message, current[3], next[2])), L))
 			. += new /datum/multilingual_say_piece(current[1], spoke_message)
 
 /* These are here purely because it would be hell to try to convert everything over to using the multi-lingual system at once */


### PR DESCRIPTION
Discovered on a downstream that there's actually no HTML filtering in saycode at all, so you could write `<h1>meow</h1>` and it'd happily gobble up the HTML tags.

This is the "least intrusive" approach to fixing that-- it just escapes any html tags in a say message, so they'll print to chat as `Shadow Larkens says, "<h1>Meow</h1>"` instead of being stripped away or anything like that.