### PR TITLE
Rewrite examine() to pass a list around

### DIFF
--- a/code/ATMOSPHERICS/components/binary_devices/dp_vent_pump.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/dp_vent_pump.dm
@@ -200,8 +200,9 @@
 		set_frequency(frequency)
 
 /obj/machinery/atmospherics/binary/dp_vent_pump/examine(mob/user)
-	if(..(user, 1))
-		to_chat(user, "A small gauge in the corner reads [round(last_flow_rate, 0.1)] L/s; [round(last_power_draw)] W")
+	. = ..()
+	if(Adjacent(user))
+		. += "A small gauge in the corner reads [round(last_flow_rate, 0.1)] L/s; [round(last_power_draw)] W"
 
 
 /obj/machinery/atmospherics/unary/vent_pump/power_change()

--- a/code/ATMOSPHERICS/components/shutoff.dm
+++ b/code/ATMOSPHERICS/components/shutoff.dm
@@ -15,8 +15,8 @@ GLOBAL_LIST_EMPTY(shutoff_valves)
 	icon_state = "vclamp[open]"
 
 /obj/machinery/atmospherics/valve/shutoff/examine(var/mob/user)
-	..()
-	to_chat(user, "The automatic shutoff circuit is [close_on_leaks ? "enabled" : "disabled"].")
+	. = ..()
+	. += "The automatic shutoff circuit is [close_on_leaks ? "enabled" : "disabled"]."
 
 /obj/machinery/atmospherics/valve/shutoff/Initialize()
 	. = ..()

--- a/code/ATMOSPHERICS/components/unary/cold_sink.dm
+++ b/code/ATMOSPHERICS/components/unary/cold_sink.dm
@@ -178,6 +178,6 @@
 	..()
 
 /obj/machinery/atmospherics/unary/freezer/examine(mob/user)
-	..(user)
+	. = ..()
 	if(panel_open)
-		to_chat(user, "The maintenance hatch is open.")
+		. += "The maintenance hatch is open."

--- a/code/ATMOSPHERICS/components/unary/heat_source.dm
+++ b/code/ATMOSPHERICS/components/unary/heat_source.dm
@@ -165,6 +165,6 @@
 	..()
 
 /obj/machinery/atmospherics/unary/heater/examine(mob/user)
-	..(user)
+	..()
 	if(panel_open)
-		to_chat(user, "The maintenance hatch is open.")
+		. += "The maintenance hatch is open."

--- a/code/ATMOSPHERICS/components/unary/vent_pump.dm
+++ b/code/ATMOSPHERICS/components/unary/vent_pump.dm
@@ -398,12 +398,13 @@
 		..()
 
 /obj/machinery/atmospherics/unary/vent_pump/examine(mob/user)
-	if(..(user, 1))
-		to_chat(user, "A small gauge in the corner reads [round(last_flow_rate, 0.1)] L/s; [round(last_power_draw)] W")
+	. = ..()
+	if(Adjacent(user))
+		. += "A small gauge in the corner reads [round(last_flow_rate, 0.1)] L/s; [round(last_power_draw)] W"
 	else
-		to_chat(user, "You are too far away to read the gauge.")
+		. += "You are too far away to read the gauge."
 	if(welded)
-		to_chat(user, "It seems welded shut.")
+		. += "It seems welded shut."
 
 /obj/machinery/atmospherics/unary/vent_pump/power_change()
 	var/old_stat = stat

--- a/code/ATMOSPHERICS/components/unary/vent_scrubber.dm
+++ b/code/ATMOSPHERICS/components/unary/vent_scrubber.dm
@@ -287,7 +287,8 @@
 		deconstruct()
 
 /obj/machinery/atmospherics/unary/vent_scrubber/examine(mob/user)
-	if(..(user, 1))
-		to_chat(user, "A small gauge in the corner reads [round(last_flow_rate, 0.1)] L/s; [round(last_power_draw)] W")
+	. = ..()
+	if(Adjacent(user))
+		. += "A small gauge in the corner reads [round(last_flow_rate, 0.1)] L/s; [round(last_power_draw)] W"
 	else
-		to_chat(user, "You are too far away to read the gauge.")
+		. += "You are too far away to read the gauge."

--- a/code/ATMOSPHERICS/components/valve.dm
+++ b/code/ATMOSPHERICS/components/valve.dm
@@ -307,5 +307,5 @@
 		deconstruct()
 
 /obj/machinery/atmospherics/valve/examine(mob/user)
-	..()
-	to_chat(user, "It is [open ? "open" : "closed"].")
+	. = ..()
+	. += "It is [open ? "open" : "closed"]."

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -169,7 +169,7 @@
 	return found
 
 //All atoms
-/atom/proc/examine(mob/user, var/distance = -1, var/infix = "", var/suffix = "")
+/atom/proc/examine(mob/user, var/infix = "", var/suffix = "")
 	//This reformat names to get a/an properly working on item descriptions when they are bloody
 	var/f_name = "\a [src][infix]."
 	if(src.blood_DNA && !istype(src, /obj/effect/decal))
@@ -182,16 +182,15 @@
 		else
 			f_name += "oil-stained [name][infix]."
 
-	to_chat(user, "[bicon(src)] That's [f_name] [suffix]")
-	to_chat(user,desc)
+	var/list/output = list("[bicon(src)] That's [f_name] [suffix]", desc)
 
 	if(user.client?.examine_text_mode == EXAMINE_MODE_INCLUDE_USAGE)
-		to_chat(user, description_info)
+		output += description_info
 
 	if(user.client?.examine_text_mode == EXAMINE_MODE_SWITCH_TO_PANEL)
 		user.client.statpanel = "Examine" // Switch to stat panel
 
-	return distance == -1 || (get_dist(src, user) <= distance)
+	return output
 
 // called by mobs when e.g. having the atom as their machine, pulledby, loc (AKA mob being inside the atom) or buckled var set.
 // see code/modules/mob/mob_movement.dm for more.

--- a/code/game/gamemodes/cult/ritual.dm
+++ b/code/game/gamemodes/cult/ritual.dm
@@ -84,9 +84,9 @@ var/global/list/rnwords = list("ire","ego","nahlizet","certum","veri","jatkaa","
 		..()
 
 	examine(mob/user)
-		..()
+		. = ..()
 		if(iscultist(user))
-			to_chat(user, "This spell circle reads: <i>[word1] [word2] [word3]</i>.")
+			. += "This spell circle reads: <i>[word1] [word2] [word3]</i>."
 
 
 	attackby(I as obj, user as mob)
@@ -422,10 +422,11 @@ var/global/list/rnwords = list("ire","ego","nahlizet","certum","veri","jatkaa","
 			return
 
 	examine(mob/user)
+		. = ..()
 		if(!iscultist(user))
-			to_chat(user, "An old, dusty tome with frayed edges and a sinister looking cover.")
+			. += "An old, dusty tome with frayed edges and a sinister looking cover."
 		else
-			to_chat(user, "The scriptures of Nar-Sie, The One Who Sees, The Geometer of Blood. Contains the details of every ritual his followers could think of. Most of these are useless, though.")
+			. += "The scriptures of Nar-Sie, The One Who Sees, The Geometer of Blood. Contains the details of every ritual his followers could think of. Most of these are useless, though."
 
 /obj/item/weapon/book/tome/cultify()
 	return

--- a/code/game/gamemodes/nuclear/pinpointer.dm
+++ b/code/game/gamemodes/nuclear/pinpointer.dm
@@ -51,10 +51,10 @@
 			icon_state = "pinonfar"
 
 /obj/item/weapon/pinpointer/examine(mob/user)
-	..(user)
+	. = ..()
 	for(var/obj/machinery/nuclearbomb/bomb in machines)
 		if(bomb.timing)
-			to_chat(user, "Extreme danger.  Arming signal detected.   Time remaining: [bomb.timeleft]")
+			. += "Extreme danger.  Arming signal detected.   Time remaining: [bomb.timeleft]"
 
 
 

--- a/code/game/gamemodes/technomancer/devices/disposable_teleporter.dm
+++ b/code/game/gamemodes/technomancer/devices/disposable_teleporter.dm
@@ -23,8 +23,8 @@
 	uses = 1
 
 /obj/item/weapon/disposable_teleporter/examine(mob/user)
-	..()
-	to_chat(user, "[uses] uses remaining.")
+	. = ..()
+	. += "[uses] uses remaining."
 
 /obj/item/weapon/disposable_teleporter/attack_self(mob/user as mob)
 	if(!uses)

--- a/code/game/machinery/CableLayer.dm
+++ b/code/game/machinery/CableLayer.dm
@@ -49,8 +49,8 @@
 			to_chat(usr, "<span class='warning'>There's no more cable on the reel.</span>")
 
 /obj/machinery/cablelayer/examine(mob/user)
-	..()
-	to_chat(user, "\The [src]'s cable reel has [cable.amount] length\s left.")
+	. = ..()
+	. += "[src]'s cable reel has [cable.amount] length\s left."
 
 /obj/machinery/cablelayer/proc/load_cable(var/obj/item/stack/cable_coil/CC)
 	if(istype(CC) && CC.amount)

--- a/code/game/machinery/atmoalter/meter.dm
+++ b/code/game/machinery/atmoalter/meter.dm
@@ -77,24 +77,22 @@
 		radio_connection.post_signal(src, signal)
 
 /obj/machinery/meter/examine(mob/user)
-	var/t = "A gas flow meter. "
+	. = ..()
 
 	if(get_dist(user, src) > 3 && !(istype(user, /mob/living/silicon/ai) || istype(user, /mob/observer/dead)))
-		t += "<span class='warning'>You are too far away to read it.</span>"
+		. += "<span class='warning'>You are too far away to read it.</span>"
 
 	else if(stat & (NOPOWER|BROKEN))
-		t += "<span class='warning'>The display is off.</span>"
+		. += "<span class='warning'>The display is off.</span>"
 
-	else if(src.target)
+	else if(target)
 		var/datum/gas_mixture/environment = target.return_air()
 		if(environment)
-			t += "The pressure gauge reads [round(environment.return_pressure(), 0.01)] kPa; [round(environment.temperature,0.01)]K ([round(environment.temperature-T0C,0.01)]&deg;C)"
+			. += "The pressure gauge reads [round(environment.return_pressure(), 0.01)] kPa; [round(environment.temperature,0.01)]K ([round(environment.temperature-T0C,0.01)]&deg;C)"
 		else
-			t += "The sensor error light is blinking."
+			. += "The sensor error light is blinking."
 	else
-		t += "The connect error light is blinking."
-
-	to_chat(user,t)
+		. += "The connect error light is blinking."
 
 /obj/machinery/meter/Click()
 

--- a/code/game/machinery/bioprinter.dm
+++ b/code/game/machinery/bioprinter.dm
@@ -87,9 +87,9 @@
 	. = ..()
 	var/biomass = get_biomass_volume()
 	if(biomass)
-		to_chat(user, "<span class='notice'>It is loaded with [biomass] units of biomass.</span>")
+		. += "<span class='notice'>It is loaded with [biomass] units of biomass.</span>"
 	else
-		to_chat(user, "<span class='notice'>It is not loaded with any biomass.</span>")
+		. += "<span class='notice'>It is not loaded with any biomass.</span>"
 
 /obj/machinery/organ_printer/RefreshParts()
 	// Print Delay updating

--- a/code/game/machinery/cell_charger.dm
+++ b/code/game/machinery/cell_charger.dm
@@ -39,12 +39,11 @@
 		overlays.Cut()
 
 /obj/machinery/cell_charger/examine(mob/user)
-	if(!..(user, 5))
-		return
-
-	to_chat(user, "[charging ? "[charging]" : "Nothing"] is in [src].")
-	if(charging)
-		to_chat(user, "Current charge: [charging.charge] / [charging.maxcharge]")
+	. = ..()
+	if(get_dist(user, src) <= 5)
+		. += "[charging ? "[charging]" : "Nothing"] is in [src]."
+		if(charging)
+			. += "Current charge: [charging.charge] / [charging.maxcharge]"
 
 /obj/machinery/cell_charger/attackby(obj/item/weapon/W, mob/user)
 	if(stat & BROKEN)

--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -534,9 +534,8 @@
 	to_chat(user, "You flip the write-protect tab to [read_only ? "protected" : "unprotected"].")
 
 /obj/item/weapon/disk/data/examine(mob/user)
-	..(user)
-	to_chat(user, text("The write-protect tab is set to [read_only ? "protected" : "unprotected"]."))
-	return
+	. = ..()
+	. += "The write-protect tab is set to [read_only ? "protected" : "unprotected"]."
 
 /*
  *	Diskette Box

--- a/code/game/machinery/computer/arcade.dm
+++ b/code/game/machinery/computer/arcade.dm
@@ -1020,13 +1020,12 @@
 	var/active = 0 //if the ship is on
 
 /obj/item/weapon/orion_ship/examine(mob/user)
-	..()
-	if(!(in_range(user, src)))
-		return
-	if(!active)
-		to_chat(user, span("notice", "There's a little switch on the bottom. It's flipped down."))
-	else
-		to_chat(user, span("notice", "There's a little switch on the bottom. It's flipped up."))
+	. = ..()
+	if(in_range(user, src))
+		if(!active)
+			. += span("notice", "There's a little switch on the bottom. It's flipped down.")
+		else
+			. += span("notice", "There's a little switch on the bottom. It's flipped up.")
 
 /obj/item/weapon/orion_ship/attack_self(mob/user)
 	if(active)

--- a/code/game/machinery/computer/guestpass.dm
+++ b/code/game/machinery/computer/guestpass.dm
@@ -19,11 +19,11 @@
 		return temp_access
 
 /obj/item/weapon/card/id/guest/examine(mob/user)
-	..(user)
+	. = ..()
 	if (world.time < expiration_time)
-		to_chat(user, "<span class='notice'>This pass expires at [worldtime2stationtime(expiration_time)].</span>")
+		. += "<span class='notice'>This pass expires at [worldtime2stationtime(expiration_time)].</span>"
 	else
-		to_chat(user, "<span class='warning'>It expired at [worldtime2stationtime(expiration_time)].</span>")
+		. += "<span class='warning'>It expired at [worldtime2stationtime(expiration_time)].</span>"
 
 /obj/item/weapon/card/id/guest/read()
 	if(!Adjacent(usr))

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -322,13 +322,13 @@
 /obj/machinery/door/examine(mob/user)
 	. = ..()
 	if(src.health <= 0)
-		to_chat(user, "\The [src] is broken!")
+		. += "It is broken!"
 	else if(src.health < src.maxhealth / 4)
-		to_chat(user, "\The [src] looks like it's about to break!")
+		. += "It looks like it's about to break!"
 	else if(src.health < src.maxhealth / 2)
-		to_chat(user, "\The [src] looks seriously damaged!")
+		. += "It looks seriously damaged!"
 	else if(src.health < src.maxhealth * 3/4)
-		to_chat(user, "\The [src] shows signs of damage!")
+		. += "It shows signs of damage!"
 
 
 /obj/machinery/door/proc/set_broken()

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -79,14 +79,15 @@
 	return get_material_by_name(DEFAULT_WALL_MATERIAL)
 
 /obj/machinery/door/firedoor/examine(mob/user)
-	. = ..(user, 1)
-	if(!. || !density)
-		return
+	. = ..()
+	
+	if(!Adjacent(user))
+		return .
 
 	if(pdiff >= FIREDOOR_MAX_PRESSURE_DIFF)
-		to_chat(user, "<span class='warning'>WARNING: Current pressure differential is [pdiff]kPa! Opening door may result in injury!</span>")
+		. += "<span class='warning'>WARNING: Current pressure differential is [pdiff]kPa! Opening door may result in injury!</span>"
 
-	to_chat(user, "<b>Sensor readings:</b>")
+	. += "<b>Sensor readings:</b>"
 	for(var/index = 1; index <= tile_info.len; index++)
 		var/o = "&nbsp;&nbsp;"
 		switch(index)
@@ -100,7 +101,7 @@
 				o += "WEST: "
 		if(tile_info[index] == null)
 			o += "<span class='warning'>DATA UNAVAILABLE</span>"
-			to_chat(user, o)
+			. += o
 			continue
 		var/celsius = convert_k2c(tile_info[index][1])
 		var/pressure = tile_info[index][2]
@@ -108,14 +109,14 @@
 		o += "[celsius]&deg;C</span> "
 		o += "<span style='color:blue'>"
 		o += "[pressure]kPa</span></li>"
-		to_chat(user, o)
+		. += o
 
 	if(islist(users_to_open) && users_to_open.len)
 		var/users_to_open_string = users_to_open[1]
 		if(users_to_open.len >= 2)
 			for(var/i = 2 to users_to_open.len)
 				users_to_open_string += ", [users_to_open[i]]"
-		to_chat(user, "These people have opened \the [src] during an alert: [users_to_open_string].")
+		. += "These people have opened \the [src] during an alert: [users_to_open_string]."
 
 /obj/machinery/door/firedoor/Bumped(atom/AM)
 	if(p_open || operating)

--- a/code/game/machinery/floorlayer.dm
+++ b/code/game/machinery/floorlayer.dm
@@ -64,12 +64,11 @@
 	..()
 
 /obj/machinery/floorlayer/examine(mob/user)
-	..()
+	. = ..()
 	var/dismantle = mode["dismantle"]
 	var/laying = mode["laying"]
 	var/collect = mode["collect"]
-	var/message = "<span class='notice'>\The [src] [!T ? "don't " : ""]has [!T ? "" : "[T.get_amount()] [T] "]tile\s, dismantle is [dismantle ? "on" : "off"], laying is [laying ? "on" : "off"], collect is [collect ? "on" : "off"].</span>"
-	to_chat(user,message)
+	. += "<span class='notice'>[src] [!T ? "don't " : ""]has [!T ? "" : "[T.get_amount()] [T] "]tile\s, dismantle is [dismantle ? "on" : "off"], laying is [laying ? "on" : "off"], collect is [collect ? "on" : "off"].</span>"
 
 /obj/machinery/floorlayer/proc/reset()
 	on=0

--- a/code/game/machinery/frame.dm
+++ b/code/game/machinery/frame.dm
@@ -210,9 +210,9 @@
 	density = TRUE
 
 /obj/structure/frame/examine(mob/user)
-	..()
+	. = ..()
 	if(circuit)
-		to_chat(user, "It has \a [circuit] installed.")
+		. += "It has \a [circuit] installed."
 
 /obj/structure/frame/proc/update_desc()
 	var/D

--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -165,21 +165,20 @@
 	to_chat(usr, "The IV drip is now [mode ? "injecting" : "taking blood"].")
 
 /obj/machinery/iv_drip/examine(mob/user)
-	..(user)
-	if(!(user in view(2)) && user != src.loc)
-		return
+	. = ..()
 
-	to_chat(user, "The IV drip is [mode ? "injecting" : "taking blood"].")
+	if(get_dist(user, src) <= 2)
+		. += "The IV drip is [mode ? "injecting" : "taking blood"]."
 
-	if(beaker)
-		if(beaker.reagents && beaker.reagents.reagent_list.len)
-			to_chat(user, "<span class='notice'>Attached is \a [beaker] with [beaker.reagents.total_volume] units of liquid.</span>")
+		if(beaker)
+			if(beaker.reagents?.reagent_list?.len)
+				. += "<span class='notice'>Attached is \a [beaker] with [beaker.reagents.total_volume] units of liquid.</span>"
+			else
+				. += "<span class='notice'>Attached is an empty [beaker].</span>"
 		else
-			to_chat(user, "<span class='notice'>Attached is an empty [beaker].</span>")
-	else
-		to_chat(user, "<span class='notice'>No chemicals are attached.</span>")
+			. += "<span class='notice'>No chemicals are attached.</span>"
 
-	to_chat(user, "<span class='notice'>[attached ? attached : "No one"] is attached.</span>")
+		. += "<span class='notice'>[attached ? attached : "No one"] is attached.</span>"
 
 /obj/machinery/iv_drip/CanPass(atom/movable/mover, turf/target)
 	if(istype(mover) && mover.checkpass(PASSTABLE)) //allow bullets, beams, thrown objects, mice, drones, and the like through.

--- a/code/game/machinery/lightswitch.dm
+++ b/code/game/machinery/lightswitch.dm
@@ -50,8 +50,9 @@
 		set_light(2, 0.1, on ? "#82FF4C" : "#F86060")
 
 /obj/machinery/light_switch/examine(mob/user)
-	if(..(user, 1))
-		to_chat(user, "A light switch. It is [on? "on" : "off"].")
+	. = ..()
+	if(Adjacent(user))
+		. += "A light switch. It is [on? "on" : "off"]."
 
 /obj/machinery/light_switch/attack_hand(mob/user)
 

--- a/code/game/machinery/oxygen_pump.dm
+++ b/code/game/machinery/oxygen_pump.dm
@@ -148,9 +148,9 @@
 /obj/machinery/oxygen_pump/examine(var/mob/user)
 	. = ..()
 	if(tank)
-		to_chat(user, "The meter shows [round(tank.air_contents.return_pressure())] kPa.")
+		. += "The meter shows [round(tank.air_contents.return_pressure())] kPa."
 	else
-		to_chat(user, "<span class='warning'>It is missing a tank!</span>")
+		. += "<span class='warning'>It is missing a tank!</span>"
 
 
 /obj/machinery/oxygen_pump/process()

--- a/code/game/machinery/pipe/pipelayer.dm
+++ b/code/game/machinery/pipe/pipelayer.dm
@@ -115,8 +115,8 @@
 	..()
 
 /obj/machinery/pipelayer/examine(mob/user)
-	..()
-	to_chat(user, "\The [src] has [metal] sheet\s, is set to produce [P_type_t], and auto-dismantling is [!a_dis?"de":""]activated.")
+	. = ..()
+	. += "[src] has [metal] sheet\s, is set to produce [P_type_t], and auto-dismantling is [!a_dis?"de":""]activated."
 
 /obj/machinery/pipelayer/proc/reset()
 	on = 0

--- a/code/game/machinery/recharger.dm
+++ b/code/game/machinery/recharger.dm
@@ -26,13 +26,13 @@
 	return
 
 /obj/machinery/recharger/examine(mob/user)
-	if(!..(user, 5))
-		return
+	. = ..()
 
-	to_chat(user, "[charging ? "[charging]" : "Nothing"] is in [src].")
-	if(charging)
-		var/obj/item/weapon/cell/C = charging.get_cell()
-		to_chat(user, "Current charge: [C.charge] / [C.maxcharge]")
+	if(get_dist(user, src) <= 5)
+		. += "[charging ? "[charging]" : "Nothing"] is in [src]."
+		if(charging)
+			var/obj/item/weapon/cell/C = charging.get_cell()
+			. += "Current charge: [C.charge] / [C.maxcharge]"
 
 /obj/machinery/recharger/attackby(obj/item/weapon/G as obj, mob/user as mob)
 	var/allowed = 0

--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -125,8 +125,8 @@
 
 
 /obj/machinery/recharge_station/examine(mob/user)
-	..(user)
-	to_chat(user, "The charge meter reads: [round(chargepercentage())]%")
+	. = ..()
+	. += "The charge meter reads: [round(chargepercentage())]%"
 
 /obj/machinery/recharge_station/proc/chargepercentage()
 	if(!cell)

--- a/code/game/machinery/spaceheater.dm
+++ b/code/game/machinery/spaceheater.dm
@@ -29,13 +29,13 @@
 		set_light(0)
 
 /obj/machinery/space_heater/examine(mob/user)
-	..(user)
+	. = ..()
 
-	to_chat(user, "The heater is [on ? "on" : "off"] and the hatch is [panel_open ? "open" : "closed"].")
+	. += "The heater is [on ? "on" : "off"] and the hatch is [panel_open ? "open" : "closed"]."
 	if(panel_open)
-		to_chat(user, "The power cell is [cell ? "installed" : "missing"].")
+		. += "The power cell is [cell ? "installed" : "missing"]."
 	else
-		to_chat(user, "The charge meter reads [cell ? round(cell.percent(),1) : 0]%")
+		. += "The charge meter reads [cell ? round(cell.percent(),1) : 0]%"
 	return
 
 /obj/machinery/space_heater/powered()

--- a/code/game/machinery/status_display.dm
+++ b/code/game/machinery/status_display.dm
@@ -146,9 +146,9 @@
 	return 0
 
 /obj/machinery/status_display/examine(mob/user)
-	. = ..(user)
+	. = ..()
 	if(mode != STATUS_DISPLAY_BLANK && mode != STATUS_DISPLAY_ALERT)
-		to_chat(user, "The display says:<br>\t[sanitize(message1)]<br>\t[sanitize(message2)]")
+		. += "The display says:<br>\t[sanitize(message1)]<br>\t[sanitize(message2)]"
 
 /obj/machinery/status_display/proc/set_message(m1, m2)
 	if(m1)

--- a/code/game/mecha/equipment/mecha_equipment.dm
+++ b/code/game/mecha/equipment/mecha_equipment.dm
@@ -34,8 +34,8 @@
 	return 0
 
 /obj/item/mecha_parts/mecha_equipment/examine(mob/user)
-	..()
-	to_chat(user, "<span class='notice'>\The [src] will fill [equip_type?"a [equip_type]":"any"] slot.</span>")
+	. = ..()
+	. += "<span class='notice'>[src] will fill [equip_type?"a [equip_type]":"any"] slot.</span>"
 
 /obj/item/mecha_parts/mecha_equipment/New()
 	..()

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -267,25 +267,23 @@
 		return 0
 
 /obj/mecha/examine(mob/user)
-	..(user)
+	. = ..()
 	var/integrity = health/initial(health)*100
 	switch(integrity)
 		if(85 to 100)
-			to_chat(user, "It's fully intact.")
+			. += "It's fully intact."
 		if(65 to 85)
-			to_chat(user, "It's slightly damaged.")
+			. += "It's slightly damaged."
 		if(45 to 65)
-			to_chat(user, "It's badly damaged.")
+			. += "It's badly damaged."
 		if(25 to 45)
-			to_chat(user, "It's heavily damaged.")
+			. += "It's heavily damaged."
 		else
-			to_chat(user, "It's falling apart.")
-	if(equipment && equipment.len)
-		to_chat(user, "It's equipped with:")
+			. += "It's falling apart."
+	if(equipment?.len)
+		. += "It's equipped with:"
 		for(var/obj/item/mecha_parts/mecha_equipment/ME in equipment)
-			to_chat(user, "[bicon(ME)] [ME]")
-	return
-
+			. += "[bicon(ME)] [ME]"
 
 /obj/mecha/proc/drop_item()//Derpfix, but may be useful in future for engineering exosuits.
 	return

--- a/code/game/objects/effects/decals/Cleanable/humans.dm
+++ b/code/game/objects/effects/decals/Cleanable/humans.dm
@@ -159,8 +159,8 @@ var/global/list/image/splatter_cache=list()
 		icon_state = "writing1"
 
 /obj/effect/decal/cleanable/blood/writing/examine(mob/user)
-	..(user)
-	to_chat(user, "It reads: <font color='[basecolor]'>\"[message]\"</font>")
+	. = ..()
+	. += "It reads: <font color='[basecolor]'>\"[message]\"</font>"
 
 /obj/effect/decal/cleanable/blood/gibs
 	name = "gibs"

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -197,7 +197,7 @@
 	src.loc = T
 
 // See inventory_sizes.dm for the defines.
-/obj/item/examine(mob/user, var/distance = -1)
+/obj/item/examine(mob/user)
 	var/size
 	switch(src.w_class)
 		if(ITEMSIZE_TINY)
@@ -210,7 +210,7 @@
 			size = "bulky"
 		if(ITEMSIZE_HUGE)
 			size = "huge"
-	return ..(user, distance, "", "It is a [size] item.")
+	return ..(user, "", "It is a [size] item.")
 
 /obj/item/attack_hand(mob/living/user as mob)
 	if (!user) return

--- a/code/game/objects/items/bells.dm
+++ b/code/game/objects/items/bells.dm
@@ -13,9 +13,9 @@
 	var/static/radial_pickup = image(icon = 'icons/mob/radial.dmi', icon_state = "radial_pickup")
 
 /obj/item/weapon/deskbell/examine(mob/user)
-	..()
+	. = ..()
 	if(broken)
-		to_chat(user,"<b>It looks damaged, the ringer is stuck firmly inside.</b>")
+		. += "<b>It looks damaged, the ringer is stuck firmly inside.</b>"
 
 /obj/item/weapon/deskbell/attack(mob/target as mob, mob/living/user as mob)
 	if(!broken)
@@ -49,7 +49,7 @@
 	// Once the player has decided their option, choose the behaviour that will happen under said option.
 	switch(choice)
 		if("examine")
-			examine(user)
+			user.examinate(src)
 
 		if("use")
 			if(check_ability(user))

--- a/code/game/objects/items/bodybag.dm
+++ b/code/game/objects/items/bodybag.dm
@@ -219,13 +219,13 @@
 		syringe.reagents.trans_to_mob(H, 30, CHEM_BLOOD)
 
 /obj/structure/closet/body_bag/cryobag/examine(mob/user)
-	..()
+	. = ..()
 	if(Adjacent(user)) //The bag's rather thick and opaque from a distance.
-		to_chat(user, "<span class='info'>You peer into \the [src].</span>")
+		. += "<span class='info'>You peer into \the [src].</span>"
 		if(syringe)
-			to_chat(user, "<span class='info'>It has a syringe added to it.</span>")
+			. += "<span class='info'>It has a syringe added to it.</span>"
 		for(var/mob/living/L in contents)
-			L.examine(user)
+			. += L.examine(user)
 
 /obj/structure/closet/body_bag/cryobag/attackby(obj/item/W, mob/user)
 	if(opened)

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -68,8 +68,9 @@ var/global/list/obj/item/device/pda/PDAs = list()
 	var/spam_proof = FALSE // If true, it can't be spammed by random events.
 
 /obj/item/device/pda/examine(mob/user)
-	if(..(user, 1))
-		to_chat(user, "The time [stationtime2text()] is displayed in the corner of the screen.")
+	. = ..()
+	if(Adjacent(user))
+		. += "The time [stationtime2text()] is displayed in the corner of the screen."
 
 /obj/item/device/pda/CtrlClick()
 	if(issilicon(usr))

--- a/code/game/objects/items/devices/communicator/communicator.dm
+++ b/code/game/objects/items/devices/communicator/communicator.dm
@@ -108,9 +108,9 @@ var/global/list/obj/item/device/communicator/all_communicators = list()
 // Parameters: user - the user doing the examining
 // Description: Allows the user to click a link when examining to look at video if one is going.
 /obj/item/device/communicator/examine(mob/user)
-	. = ..(user, 1)
-	if(. && video_source)
-		to_chat(user, "<span class='notice'>It looks like it's on a video call: <a href='?src=\ref[src];watchvideo=1'>\[view\]</a></span>")
+	. = ..()
+	if(Adjacent(user) && video_source)
+		. += "<span class='notice'>It looks like it's on a video call: <a href='?src=\ref[src];watchvideo=1'>\[view\]</a></span>"
 
 // Proc: initialize_exonet()
 // Parameters: 1 (user - the person the communicator belongs to)
@@ -131,28 +131,22 @@ var/global/list/obj/item/device/communicator/all_communicators = list()
 // Parameters: 1 (user - the person examining the device)
 // Description: Shows all the voice mobs inside the device, and their status.
 /obj/item/device/communicator/examine(mob/user)
-	if(!..(user))
-		return
-
-	var/msg = ""
+	. = ..()
+	
 	for(var/mob/living/voice/voice in contents)
-		msg += "<span class='notice'>On the screen, you can see a image feed of [voice].</span>\n"
-		msg += "<span class='warning'>"
-
+		. += "<span class='notice'>On the screen, you can see a image feed of [voice].</span>"
+		
 		if(voice && voice.key)
 			switch(voice.stat)
 				if(CONSCIOUS)
 					if(!voice.client)
-						msg += "[voice] appears to be asleep.\n" //afk
+						. += "<span class='warning'>[voice] appears to be asleep.</span>" //afk
 				if(UNCONSCIOUS)
-					msg += "[voice] doesn't appear to be conscious.\n"
+					. += "<span class='warning'>[voice] doesn't appear to be conscious.</span>"
 				if(DEAD)
-					msg += "<span class='deadsay'>[voice] appears to have died...</span>\n" //Hopefully this never has to be used.
+					. += "<span class='deadsay'>[voice] appears to have died...</span>" //Hopefully this never has to be used.
 		else
-			msg += "<span class='notice'>The device doesn't appear to be transmitting any data.</span>\n"
-		msg += "</span>"
-	to_chat(user, msg)
-	return
+			. += "<span class='notice'>The device doesn't appear to be transmitting any data.</span>"
 
 // Proc: emp_act()
 // Parameters: None

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -87,23 +87,20 @@
 		set_light(0)
 
 /obj/item/device/flashlight/examine(mob/user)
-	..()
+	. = ..()
 	if(power_use && brightness_level)
-		var/tempdesc
-		tempdesc += "\The [src] is set to [brightness_level]. "
+		. += "\The [src] is set to [brightness_level]."
 		if(cell)
-			tempdesc += "\The [src] has a \the [cell] attached. "
+			. += "\The [src] has a \the [cell] attached."
 
 			if(cell.charge <= cell.maxcharge*0.25)
-				tempdesc += "It appears to have a low amount of power remaining."
+				. += "It appears to have a low amount of power remaining."
 			else if(cell.charge > cell.maxcharge*0.25 && cell.charge <= cell.maxcharge*0.5)
-				tempdesc += "It appears to have an average amount of power remaining."
+				. += "It appears to have an average amount of power remaining."
 			else if(cell.charge > cell.maxcharge*0.5 && cell.charge <= cell.maxcharge*0.75)
-				tempdesc += "It appears to have an above average amount of power remaining."
+				. += "It appears to have an above average amount of power remaining."
 			else if(cell.charge > cell.maxcharge*0.75 && cell.charge <= cell.maxcharge)
-				tempdesc += "It appears to have a high amount of power remaining."
-
-		to_chat(user, "[tempdesc]")
+				. += "It appears to have a high amount of power remaining."
 
 /obj/item/device/flashlight/attack_self(mob/user)
 	if(power_use)

--- a/code/game/objects/items/devices/floor_painter.dm
+++ b/code/game/objects/items/devices/floor_painter.dm
@@ -110,8 +110,8 @@
 		choose_colour()
 
 /obj/item/device/floor_painter/examine(mob/user)
-	..(user)
-	to_chat(user, "It is configured to produce the '[decal]' decal with a direction of '[paint_dir]' using [paint_colour] paint.")
+	. = ..()
+	. += "It is configured to produce the '[decal]' decal with a direction of '[paint_dir]' using [paint_colour] paint."
 
 /obj/item/device/floor_painter/verb/choose_colour()
 	set name = "Choose Colour"

--- a/code/game/objects/items/devices/geiger.dm
+++ b/code/game/objects/items/devices/geiger.dm
@@ -33,9 +33,9 @@
 	update_sound()
 
 /obj/item/device/geiger/examine(mob/user)
-	..(user)
+	. = ..()
 	get_radiation()
-	to_chat(user, "<span class='warning'>[scanning ? "Ambient" : "Stored"] radiation level: [radiation_count ? radiation_count : "0"]Bq.</span>")
+	. += "<span class='warning'>[scanning ? "Ambient" : "Stored"] radiation level: [radiation_count ? radiation_count : "0"]Bq.</span>"
 
 /obj/item/device/geiger/rad_act(amount)
 	if(!amount || !scanning)

--- a/code/game/objects/items/devices/holowarrant.dm
+++ b/code/game/objects/items/devices/holowarrant.dm
@@ -13,11 +13,11 @@
 /obj/item/device/holowarrant/examine(mob/user)
 	. = ..()
 	if(active)
-		to_chat(user, "It's a holographic warrant for '[active.fields["namewarrant"]]'.")
+		. += "It's a holographic warrant for '[active.fields["namewarrant"]]'."
 	if(in_range(user, src) || istype(user, /mob/observer/dead))
-		show_content(user)
+		show_content(user) //Opens a browse window, not chatbox related
 	else
-		to_chat(user, "<span class='notice'>You have to go closer if you want to read it.</span>")
+		. += "<span class='notice'>You have to go closer if you want to read it.</span>"
 
 //hit yourself with it
 /obj/item/device/holowarrant/attack_self(mob/living/user as mob)

--- a/code/game/objects/items/devices/lightreplacer.dm
+++ b/code/game/objects/items/devices/lightreplacer.dm
@@ -64,8 +64,9 @@
 	..()
 
 /obj/item/device/lightreplacer/examine(mob/user)
-	if(..(user, 2))
-		to_chat(user, "It has [uses] lights remaining.")
+	. = ..()
+	if(get_dist(user, src) <= 2)
+		. += "It has [uses] lights remaining."
 
 /obj/item/device/lightreplacer/attackby(obj/item/W, mob/user)
 	if(istype(W, /obj/item/stack/material) && W.get_material_name() == "glass")

--- a/code/game/objects/items/devices/locker_painter.dm
+++ b/code/game/objects/items/devices/locker_painter.dm
@@ -125,8 +125,8 @@
 		choose_colour_secure()
 
 /obj/item/device/closet_painter/examine(mob/user)
-	..(user)
-	to_chat(user, "It is configured to produce the '[colour]' paint scheme or the '[colour_secure]' secure closet paint scheme.")
+	. = ..()
+	. += "It is configured to produce the '[colour]' paint scheme or the '[colour_secure]' secure closet paint scheme."
 
 /obj/item/device/closet_painter/verb/choose_colour()
 	set name = "Choose Colour"

--- a/code/game/objects/items/devices/modkit.dm
+++ b/code/game/objects/items/devices/modkit.dm
@@ -63,8 +63,8 @@
 		qdel(src)
 
 /obj/item/device/modkit/examine(mob/user)
-	..(user)
-	to_chat(user, "It looks as though it modifies hardsuits to fit [target_species] users.")
+	. = ..()
+	. += "It looks as though it modifies hardsuits to fit [target_species] users."
 
 /obj/item/device/modkit/tajaran
 	name = "tajaran hardsuit modification kit"

--- a/code/game/objects/items/devices/pipe_painter.dm
+++ b/code/game/objects/items/devices/pipe_painter.dm
@@ -27,5 +27,5 @@
 	mode = input("Which colour do you want to use?", "Pipe painter", mode) in modes
 
 /obj/item/device/pipe_painter/examine(mob/user)
-	..(user)
-	to_chat(user, "It is in [mode] mode.")
+	. = ..()
+	. += "It is in [mode] mode."

--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -37,11 +37,11 @@
 	return list_secure_channels()
 
 /obj/item/device/radio/headset/examine(mob/user)
-	if(!(..(user, 1) && radio_desc))
-		return
+	. = ..()
 
-	to_chat(user, "The following channels are available:")
-	to_chat(user, radio_desc)
+	if(radio_desc && Adjacent(user))
+		. += "The following channels are available:"
+		. += radio_desc
 
 /obj/item/device/radio/headset/handle_message_mode(mob/living/M as mob, list/message_pieces, channel)
 	if(channel == "special")

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -557,12 +557,12 @@ var/global/list/default_medbay_channels = list(
 
 /obj/item/device/radio/examine(mob/user)
 	. = ..()
+	
 	if((in_range(src, user) || loc == user))
 		if(b_stat)
-			user.show_message("<span class='notice'>\The [src] can be attached and modified!</span>")
+			. += "<span class='notice'>\The [src] can be attached and modified!</span>"
 		else
-			user.show_message("<span class='notice'>\The [src] can not be modified or attached!</span>")
-	return
+			. += "<span class='notice'>\The [src] can not be modified or attached!</span>"
 
 /obj/item/device/radio/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	..()

--- a/code/game/objects/items/devices/spy_bug.dm
+++ b/code/game/objects/items/devices/spy_bug.dm
@@ -84,9 +84,9 @@
 	camtype = /obj/machinery/camera/bug/spy
 
 /obj/item/device/camerabug/examine(mob/user)
-	. = ..(user, 0)
-	if(.)
-		to_chat(user, "It has a tiny camera inside. Needs to be both configured and brought in contact with monitor device to be fully functional.")
+	. = ..()
+	if(get_dist(user, src) == 0)
+		. += "It has a tiny camera inside. Needs to be both configured and brought in contact with monitor device to be fully functional."
 
 /obj/item/device/camerabug/attackby(obj/item/W as obj, mob/living/user as mob)
 	if(istype(W, /obj/item/device/bug_monitor))
@@ -215,9 +215,9 @@
 	origin_tech = list(TECH_DATA = 1, TECH_ENGINEERING = 1, TECH_ILLEGAL = 3)
 
 /obj/item/device/bug_monitor/spy/examine(mob/user)
-	. = ..(user, 1)
-	if(.)
-		to_chat(user, "The time '12:00' is blinking in the corner of the screen and \the [src] looks very cheaply made.")
+	. = ..()
+	if(Adjacent(user))
+		. += "The time '12:00' is blinking in the corner of the screen and \the [src] looks very cheaply made."
 
 /obj/machinery/camera/bug/check_eye(var/mob/user as mob)
 	return 0

--- a/code/game/objects/items/devices/suit_cooling.dm
+++ b/code/game/objects/items/devices/suit_cooling.dm
@@ -173,24 +173,25 @@
 		icon_state = "suitcooler0"
 
 /obj/item/device/suit_cooling_unit/examine(mob/user)
-	if(!..(user, 1))
-		return
+	. = ..()
 
-	if (on)
-		if (attached_to_suit(src.loc))
-			to_chat(user, "It's switched on and running.")
+	if(Adjacent(user))
+
+		if (on)
+			if (attached_to_suit(src.loc))
+				. += "It's switched on and running."
+			else
+				. += "It's switched on, but not attached to anything."
 		else
-			to_chat(user, "It's switched on, but not attached to anything.")
-	else
-		to_chat(user, "It is switched off.")
+			. += "It is switched off."
 
-	if (cover_open)
-		if(cell)
-			to_chat(user, "The panel is open, exposing the [cell].")
+		if (cover_open)
+			if(cell)
+				. += "The panel is open, exposing the [cell]."
+			else
+				. += "The panel is open."
+
+		if (cell)
+			. += "The charge meter reads [round(cell.percent())]%."
 		else
-			to_chat(user, "The panel is open.")
-
-	if (cell)
-		to_chat(user, "The charge meter reads [round(cell.percent())]%.")
-	else
-		to_chat(user, "It doesn't have a power cell installed.")
+			. += "It doesn't have a power cell installed."

--- a/code/game/objects/items/devices/tvcamera.dm
+++ b/code/game/objects/items/devices/tvcamera.dm
@@ -22,9 +22,9 @@
 	..()
 
 /obj/item/device/tvcamera/examine()
-	..()
-	to_chat(usr, "Video feed is [camera.status ? "on" : "off"]")
-	to_chat(usr, "Audio feed is [radio.broadcasting ? "on" : "off"]")
+	. = ..()
+	. += "Video feed is [camera.status ? "on" : "off"]"
+	. += "Audio feed is [radio.broadcasting ? "on" : "off"]"
 
 /obj/item/device/tvcamera/Initialize()
 	. = ..()

--- a/code/game/objects/items/paintkit.dm
+++ b/code/game/objects/items/paintkit.dm
@@ -11,8 +11,8 @@
 	var/list/allowed_types = list()
 
 /obj/item/device/kit/examine()
-	..()
-	to_chat(usr, "It has [uses] use\s left.")
+	. = ..()
+	. += "It has [uses] use\s left."
 
 /obj/item/device/kit/proc/use(var/amt, var/mob/user)
 	uses -= amt
@@ -216,11 +216,11 @@
 
 
 /obj/item/device/kit/paint/examine()
-	..()
-	to_chat(usr, "This kit will convert an exosuit into: [new_name].")
-	to_chat(usr, "This kit can be used on the following exosuit models:")
+	. = ..()
+	. += "This kit will convert an exosuit into: [new_name]."
+	. += "This kit can be used on the following exosuit models:"
 	for(var/exotype in allowed_types)
-		to_chat(usr, "- [capitalize(exotype)]")
+		. += "- [capitalize(exotype)]"
 
 /obj/item/device/kit/paint/customize(var/obj/mecha/M, var/mob/user)
 	if(!can_customize(M))

--- a/code/game/objects/items/robobag.dm
+++ b/code/game/objects/items/robobag.dm
@@ -27,9 +27,9 @@
 	var/obj/item/clothing/accessory/badge/corptag	// The tag on the bag.
 
 /obj/structure/closet/body_bag/cryobag/robobag/examine(mob/user)
-	..()
-	if(Adjacent(user) && corptag)
-		to_chat(user, "<span class='notice'>\The [src] has a [corptag] attached to it.</span>")
+	. = ..()
+	if(corptag && Adjacent(user))
+		. += "<span class='notice'>[src] has a [corptag] attached to it.</span>"
 
 /obj/structure/closet/body_bag/cryobag/robobag/update_icon()
 	overlays.Cut()

--- a/code/game/objects/items/stacks/marker_beacons.dm
+++ b/code/game/objects/items/stacks/marker_beacons.dm
@@ -42,9 +42,9 @@ var/list/marker_beacon_colors = list(
 	update_icon()
 
 /obj/item/stack/marker_beacon/examine(mob/user)
-	..()
-	to_chat(user, "<span class='notice'>Use in-hand to place a [singular_name].</span>")
-	to_chat(user, "<span class='notice'>Alt-click to select a color. Current color is [picked_color].</span>")
+	. = ..()
+	. += "<span class='notice'>Use in-hand to place a [singular_name].</span>"
+	. += "<span class='notice'>Alt-click to select a color. Current color is [picked_color].</span>"
 
 /obj/item/stack/marker_beacon/update_icon()
 	icon_state = "[initial(icon_state)][lowertext(picked_color)]"
@@ -93,8 +93,8 @@ var/list/marker_beacon_colors = list(
 	update_icon()
 
 /obj/structure/marker_beacon/examine(mob/user)
-	..()
-	to_chat(user, "<span class='notice'>Alt-click to select a color. Current color is [picked_color].</span>")
+	. = ..()
+	. += "<span class='notice'>Alt-click to select a color. Current color is [picked_color].</span>"
 
 /obj/structure/marker_beacon/update_icon()
 	while(!picked_color || !marker_beacon_colors[picked_color])

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -58,11 +58,13 @@
 		item_state = initial(icon_state)
 
 /obj/item/stack/examine(mob/user)
-	if(..(user, 1))
+	. = ..()
+	
+	if(Adjacent(user))
 		if(!uses_charge)
-			to_chat(user, "There are [src.amount] [src.singular_name]\s in the stack.")
+			. += "There are [src.amount] [src.singular_name]\s in the stack."
 		else
-			to_chat(user, "There is enough charge for [get_amount()].")
+			. += "There is enough charge for [get_amount()]."
 
 /obj/item/stack/attack_self(mob/user as mob)
 	list_recipes(user)

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -154,8 +154,9 @@
 	drop_sound = 'sound/items/drop/gun.ogg'
 
 	examine(mob/user)
-		if(..(user, 2) && bullets)
-			to_chat(user, "<span class='notice'>It is loaded with [bullets] foam darts!</span>")
+		. = ..()
+		if(bullets && get_dist(user, src) <= 2)
+			. += "<span class='notice'>It is loaded with [bullets] foam darts!</span>"
 
 	attackby(obj/item/I as obj, mob/user as mob)
 		if(istype(I, /obj/item/toy/ammo/crossbow))
@@ -315,8 +316,8 @@
 		update_icon()
 
 /obj/item/toy/sword/examine(mob/user)
-	..()
-	to_chat(user, "<span class='notice'>Alt-click to recolor it.</span>")
+	. = ..()
+	. += "<span class='notice'>Alt-click to recolor it.</span>"
 
 /obj/item/toy/sword/attackby(obj/item/weapon/W, mob/user)
 	if(istype(W, /obj/item/device/multitool) && !active)
@@ -824,11 +825,11 @@
 	var/obj/item/stored_item	// Note: Stored items can't be bigger than the plushie itself.
 
 /obj/structure/plushie/examine(mob/user)
-	..()
+	. = ..()
 	if(opened)
-		to_chat(user, "<i>You notice an incision has been made on [src].</i>")
+		. += "<i>You notice an incision has been made on [src].</i>"
 		if(in_range(user, src) && stored_item)
-			to_chat(user, "<i>You can see something in there...</i>")
+			. += "<i>You can see something in there...</i>"
 
 /obj/structure/plushie/attack_hand(mob/user)
 	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
@@ -923,11 +924,11 @@
 
 
 /obj/item/toy/plushie/examine(mob/user)
-	..()
+	. = ..()
 	if(opened)
-		to_chat(user, "<i>You notice an incision has been made on [src].</i>")
+		. += "<i>You notice an incision has been made on [src].</i>"
 		if(in_range(user, src) && stored_item)
-			to_chat(user, "<i>You can see something in there...</i>")
+			. += "<i>You can see something in there...</i>"
 
 /obj/item/toy/plushie/attack_self(mob/user as mob)
 	if(stored_item && opened && !searching)

--- a/code/game/objects/items/weapons/RCD.dm
+++ b/code/game/objects/items/weapons/RCD.dm
@@ -40,8 +40,8 @@
 	return ..()
 
 /obj/item/weapon/rcd/examine(mob/user)
-	..()
-	to_chat(user, display_resources())
+	. = ..()
+	. += display_resources()
 
 // Used to show how much stuff (matter units, cell charge, etc) is left inside.
 /obj/item/weapon/rcd/proc/display_resources()

--- a/code/game/objects/items/weapons/RSF.dm
+++ b/code/game/objects/items/weapons/RSF.dm
@@ -33,8 +33,9 @@ RSF
 	w_class = ITEMSIZE_NORMAL
 
 /obj/item/weapon/rsf/examine(mob/user)
-	if(..(user, 0))
-		to_chat(user,"<span class='notice'>It currently holds [stored_matter]/30 fabrication-units.</span>")
+	. = ..()
+	if(get_dist(user, src) == 0)
+		. += "<span class='notice'>It currently holds [stored_matter]/30 fabrication-units.</span>"
 
 /obj/item/weapon/rsf/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	..()

--- a/code/game/objects/items/weapons/cigs_lighters.dm
+++ b/code/game/objects/items/weapons/cigs_lighters.dm
@@ -149,22 +149,21 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	..()
 
 /obj/item/clothing/mask/smokable/examine(mob/user)
-	..()
-	if(is_pipe)
-		return
-	var/smoke_percent = round((smoketime / max_smoketime) * 100)
-	switch(smoke_percent)
-		if(90 to INFINITY)
-			to_chat(user, "[src] is still fresh.")
-		if(60 to 90)
-			to_chat(user, "[src] has a good amount of burn time remaining.")
-		if(30 to 60)
-			to_chat(user, "[src] is about half finished.")
-		if(10 to 30)
-			to_chat(user, "[src] is starting to burn low.")
-		else
-			to_chat(user, "[src] is nearly burnt out!")
-
+	. = ..()
+	
+	if(!is_pipe)
+		var/smoke_percent = round((smoketime / max_smoketime) * 100)
+		switch(smoke_percent)
+			if(90 to INFINITY)
+				. += "[src] is still fresh."
+			if(60 to 90)
+				. += "[src] has a good amount of burn time remaining."
+			if(30 to 60)
+				. += "[src] is about half finished."
+			if(10 to 30)
+				. += "[src] is starting to burn low."
+			else
+				. += "[src] is nearly burnt out!"
 
 /obj/item/clothing/mask/smokable/proc/light(var/flavor_text = "[usr] lights the [name].")
 	if(!src.lit)

--- a/code/game/objects/items/weapons/ecigs.dm
+++ b/code/game/objects/items/weapons/ecigs.dm
@@ -130,8 +130,8 @@
 	create_reagents(volume)
 
 /obj/item/weapon/reagent_containers/ecig_cartridge/examine(mob/user as mob)//to see how much left
-	..()
-	to_chat(user, "The cartridge has [reagents.total_volume] units of liquid remaining.")
+	. = ..()
+	. += "The cartridge has [reagents.total_volume] units of liquid remaining."
 
 //flavours
 /obj/item/weapon/reagent_containers/ecig_cartridge/blank

--- a/code/game/objects/items/weapons/extinguisher.dm
+++ b/code/game/objects/items/weapons/extinguisher.dm
@@ -40,8 +40,9 @@
 	. = ..()
 
 /obj/item/weapon/extinguisher/examine(mob/user)
-	if(..(user, 0))
-		to_chat(user, "[bicon(src)] [src.name] contains [src.reagents.total_volume] units of water left!")
+	. = ..()
+	if(get_dist(user, src) == 0)
+		. += "[src] has [src.reagents.total_volume] units of water left!"
 
 /obj/item/weapon/extinguisher/attack_self(mob/user as mob)
 	safety = !safety

--- a/code/game/objects/items/weapons/gift_wrappaper.dm
+++ b/code/game/objects/items/weapons/gift_wrappaper.dm
@@ -164,8 +164,9 @@
 
 
 /obj/item/weapon/wrapping_paper/examine(mob/user)
-	if(..(user, 1))
-		to_chat(user, "There is about [src.amount] square units of paper left!")
+	. = ..()
+	if(Adjacent(user))
+		. += "There is about [src.amount] square units of paper left!"
 
 /obj/item/weapon/wrapping_paper/attack(mob/target as mob, mob/user as mob)
 	if (!istype(target, /mob/living/carbon/human)) return

--- a/code/game/objects/items/weapons/grenades/chem_grenade.dm
+++ b/code/game/objects/items/weapons/grenades/chem_grenade.dm
@@ -118,9 +118,9 @@
 				to_chat(user, "<span class='warning'>\The [W] is empty.</span>")
 
 /obj/item/weapon/grenade/chem_grenade/examine(mob/user)
-	..(user)
+	. = ..()
 	if(detonator)
-		to_chat(user, "With attached [detonator.name]")
+		. += "It has [detonator.name] attached to it."
 
 /obj/item/weapon/grenade/chem_grenade/activate(mob/user as mob)
 	if(active) return

--- a/code/game/objects/items/weapons/grenades/grenade.dm
+++ b/code/game/objects/items/weapons/grenades/grenade.dm
@@ -45,13 +45,12 @@
 
 
 /obj/item/weapon/grenade/examine(mob/user)
-	if(..(user, 0))
+	. = ..()
+	if(get_dist(user, src) == 0)
 		if(det_time > 1)
-			to_chat(user, "The timer is set to [det_time/10] seconds.")
-			return
-		if(det_time == null)
-			return
-		to_chat(user, "\The [src] is set for instant detonation.")
+			. += "The timer is set to [det_time/10] seconds."
+		else if(det_time == null)
+			. += "\The [src] is set for instant detonation."
 
 
 /obj/item/weapon/grenade/attack_self(mob/user as mob)

--- a/code/game/objects/items/weapons/id cards/station_ids.dm
+++ b/code/game/objects/items/weapons/id cards/station_ids.dm
@@ -32,12 +32,11 @@
 	var/survey_points = 0	// For redeeming at explorer equipment vendors.
 
 /obj/item/weapon/card/id/examine(mob/user)
-	set src in oview(1)
-	if(in_range(usr, src))
-		show(usr)
-		to_chat(usr,desc)
+	. = ..()
+	if(in_range(user, src))
+		show(user) //Not chat related
 	else
-		to_chat(usr, "<span class='warning'>It is too far away.</span>")
+		. += "<span class='warning'>It is too far away to read.</span>"
 
 /obj/item/weapon/card/id/proc/prevent_tracking()
 	return 0

--- a/code/game/objects/items/weapons/implants/implantcircuits.dm
+++ b/code/game/objects/items/weapons/implants/implantcircuits.dm
@@ -36,7 +36,7 @@
 	IC.emp_act(severity)
 
 /obj/item/weapon/implant/integrated_circuit/examine(mob/user)
-	IC.examine(user)
+	return IC.examine(user)
 
 /obj/item/weapon/implant/integrated_circuit/attackby(var/obj/item/O, var/mob/user)
 	if(O.is_crowbar() || istype(O, /obj/item/device/integrated_electronics) || istype(O, /obj/item/integrated_circuit) || O.is_screwdriver() || istype(O, /obj/item/weapon/cell/device) )

--- a/code/game/objects/items/weapons/material/chainsaw.dm
+++ b/code/game/objects/items/weapons/material/chainsaw.dm
@@ -113,9 +113,9 @@ obj/item/weapon/chainsaw/proc/get_fuel()
 	return reagents.get_reagent_amount("fuel")
 
 obj/item/weapon/chainsaw/examine(mob/user)
-	if(..(user,0))
-		if(max_fuel)
-			to_chat(usr, "<span class = 'notice'>The [src] feels like it contains roughtly [get_fuel()] units of fuel left.</span>")
+	. = ..()
+	if(max_fuel && get_dist(user, src) == 0)
+		. += "<span class = 'notice'>The [src] feels like it contains roughtly [get_fuel()] units of fuel left.</span>"
 
 obj/item/weapon/chainsaw/suicide_act(mob/user)
 	var/datum/gender/TU = gender_datums[user.get_visible_gender()]

--- a/code/game/objects/items/weapons/material/gravemarker.dm
+++ b/code/game/objects/items/weapons/material/gravemarker.dm
@@ -36,13 +36,11 @@
 	..()
 
 /obj/item/weapon/material/gravemarker/examine(mob/user)
-	..()
-	if(get_dist(src, user) < 4)
-		if(grave_name)
-			to_chat(user, "Here Lies [grave_name]")
-	if(get_dist(src, user) < 2)
-		if(epitaph)
-			to_chat(user, epitaph)
+	. = ..()
+	if(grave_name && get_dist(src, user) < 4)
+		. += "Here Lies [grave_name]"
+	if(epitaph && get_dist(src, user) < 2)
+		. += epitaph
 
 /obj/item/weapon/material/gravemarker/update_icon()
 	if(icon_changes)

--- a/code/game/objects/items/weapons/material/whetstone.dm
+++ b/code/game/objects/items/weapons/material/whetstone.dm
@@ -41,7 +41,8 @@
 
 /obj/item/weapon/material/sharpeningkit/examine(mob/user, distance)
 	. = ..()
-	to_chat(user, "There [uses == 1 ? "is" : "are"] [uses] [material] [uses == 1 ? src.material.sheet_singular_name : src.material.sheet_plural_name] left for use.")
+	. += "There [uses == 1 ? "is" : "are"] [uses] [material] [uses == 1 ? src.material.sheet_singular_name : src.material.sheet_plural_name] left for use."
+
 /obj/item/weapon/material/sharpeningkit/Initialize()
 	. = ..()
 	setrepair()

--- a/code/game/objects/items/weapons/melee/energy.dm
+++ b/code/game/objects/items/weapons/melee/energy.dm
@@ -86,14 +86,12 @@
 	return null
 
 /obj/item/weapon/melee/energy/examine(mob/user)
-	if(!..(user, 1))
-		return
-
-	if(use_cell)
+	. = ..()
+	if(use_cell && Adjacent(user))
 		if(bcell)
-			to_chat(user, "<span class='notice'>The blade is [round(bcell.percent())]% charged.</span>")
-		if(!bcell)
-			to_chat(user, "<span class='warning'>The blade does not have a power source installed.</span>")
+			. += "<span class='notice'>The blade is [round(bcell.percent())]% charged.</span>"
+		else
+			. += "<span class='warning'>The blade does not have a power source installed.</span>"
 
 /obj/item/weapon/melee/energy/attack_self(mob/living/user as mob)
 	if(use_cell)
@@ -200,8 +198,8 @@
 		update_icon()
 
 /obj/item/weapon/melee/energy/examine(mob/user)
-	..()
-	to_chat(user, "<span class='notice'>Alt-click to recolor it.</span>")
+	. = ..()
+	. += "<span class='notice'>Alt-click to recolor it.</span>"
 
 /*
  * Energy Axe

--- a/code/game/objects/items/weapons/shields.dm
+++ b/code/game/objects/items/weapons/shields.dm
@@ -215,8 +215,8 @@
 		update_icon()
 
 /obj/item/weapon/shield/energy/examine(mob/user)
-	..()
-	to_chat(user, "<span class='notice'>Alt-click to recolor it.</span>")
+	. = ..()
+	. += "<span class='notice'>Alt-click to recolor it.</span>"
 
 /obj/item/weapon/shield/riot/tele
 	name = "telescopic shield"

--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -363,13 +363,12 @@
 	max_storage_space = ITEMSIZE_COST_NORMAL * 5
 
 /obj/item/weapon/storage/backpack/parachute/examine(mob/user)
-	var/msg = desc
-	if(get_dist(src, user) <= 1)
+	. = ..()
+	if(Adjacent(user))
 		if(parachute)
-			msg += " It seems to be packed."
+			. += "It seems to be packed."
 		else
-			msg += " It seems to be unpacked."
-	to_chat(user, msg)
+			. += "It seems to be unpacked."
 
 /obj/item/weapon/storage/backpack/parachute/handleParachute()
 	parachute = FALSE	//If you parachute in, the parachute has probably been used.

--- a/code/game/objects/items/weapons/storage/bags.dm
+++ b/code/game/objects/items/weapons/storage/bags.dm
@@ -144,32 +144,30 @@
 
 
 /obj/item/weapon/storage/bag/ore/examine(mob/user)
-	..()
+	. = ..()
 
 	if(!Adjacent(user)) //Can only check the contents of ore bags if you can physically reach them.
-		return
+		return .
 
 	if(istype(user, /mob/living))
 		add_fingerprint(user)
 
 	if(!contents.len)
-		to_chat(user, "It is empty.")
-		return
+		. += "It is empty."
 
-	if(world.time > last_update + 10)
+	else if(world.time > last_update + 10)
 		update_ore_count()
 		last_update = world.time
 
-	to_chat(user, "<span class='notice'>It holds:</span>")
-	for(var/ore in stored_ore)
-		to_chat(user, "<span class='notice'>- [stored_ore[ore]] [ore]</span>")
-	return
+		. += "<span class='notice'>It holds:</span>"
+		for(var/ore in stored_ore)
+			. += "<span class='notice'>- [stored_ore[ore]] [ore]</span>"
 
 /obj/item/weapon/storage/bag/ore/open(mob/user as mob) //No opening it for the weird UI of having shit-tons of ore inside it.
 	if(world.time > last_update + 10)
 		update_ore_count()
 		last_update = world.time
-		examine(user)
+		user.examinate(src)
 
 /obj/item/weapon/storage/bag/ore/proc/update_ore_count() //Stolen from ore boxes.
 

--- a/code/game/objects/items/weapons/storage/fancy.dm
+++ b/code/game/objects/items/weapons/storage/fancy.dm
@@ -26,17 +26,15 @@
 	return
 
 /obj/item/weapon/storage/fancy/examine(mob/user)
-	if(!..(user, 1))
-		return
+	. = ..()
 
-	if(contents.len <= 0)
-		to_chat(user, "There are no [icon_type]s left in the box.")
-	else if(contents.len == 1)
-		to_chat(user, "There is one [icon_type] left in the box.")
-	else
-		to_chat(user, "There are [contents.len] [icon_type]s in the box.")
-
-	return
+	if(Adjacent(user))
+		if(!contents.len)
+			. += "There are no [icon_type]s left in the box."
+		else if(contents.len == 1)
+			. += "There is one [icon_type] left in the box."
+		else
+			. += "There are [contents.len] [icon_type]s in the box."
 
 /*
  * Egg Box

--- a/code/game/objects/items/weapons/storage/mre.dm
+++ b/code/game/objects/items/weapons/storage/mre.dm
@@ -24,7 +24,7 @@ MRE Stuff
 
 /obj/item/weapon/storage/mre/examine(mob/user)
 	. = ..()
-	to_chat(user, meal_desc)
+	. += meal_desc
 
 /obj/item/weapon/storage/mre/update_icon()
 	if(opened)

--- a/code/game/objects/items/weapons/storage/secure.dm
+++ b/code/game/objects/items/weapons/storage/secure.dm
@@ -29,8 +29,9 @@
 	use_sound = 'sound/items/storage/briefcase.ogg'
 
 	examine(mob/user)
-		if(..(user, 1))
-			to_chat(user, "The service panel is [src.open ? "open" : "closed"].")
+		. = ..()
+		if(Adjacent(user))
+			. += "The service panel is [src.open ? "open" : "closed"]."
 
 	attackby(obj/item/weapon/W as obj, mob/user as mob)
 		if(locked)

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -722,10 +722,10 @@
 	..()
 
 /obj/item/weapon/storage/trinketbox/examine(mob/user)
-	..()
+	. = ..()
 	if(open && contents.len)
 		var/display_item = contents[1]
-		to_chat(user, "<span class='notice'>\The [src] contains \the [display_item]!</span>")
+		. += "<span class='notice'>\The [src] contains \the [display_item]!</span>"
 
 /obj/item/weapon/storage/AllowDrop()
 	return TRUE

--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -101,13 +101,13 @@
 		set_light(0)
 
 /obj/item/weapon/melee/baton/examine(mob/user)
-	if(!..(user, 1))
-		return
+	. = ..()
 
-	if(bcell)
-		to_chat(user, "<span class='notice'>The baton is [round(bcell.percent())]% charged.</span>")
-	if(!bcell)
-		to_chat(user, "<span class='warning'>The baton does not have a power source installed.</span>")
+	if(Adjacent(user, src))
+		if(bcell)
+			. += "<span class='notice'>The baton is [round(bcell.percent())]% charged.</span>"
+		if(!bcell)
+			. += "<span class='warning'>The baton does not have a power source installed.</span>"
 
 /obj/item/weapon/melee/baton/attackby(obj/item/weapon/W, mob/user)
 	if(use_external_power)

--- a/code/game/objects/items/weapons/tanks/jetpack.dm
+++ b/code/game/objects/items/weapons/tanks/jetpack.dm
@@ -30,7 +30,7 @@
 /obj/item/weapon/tank/jetpack/examine(mob/user)
 	. = ..()
 	if(air_contents.total_moles < 5)
-		to_chat(user, "<span class='danger'>The meter on \the [src] indicates you are almost out of gas!</span>")
+		. += "<span class='danger'>The meter on \the [src] indicates you are almost out of gas!</span>"
 		playsound(user, 'sound/effects/alert.ogg', 50, 1)
 
 /obj/item/weapon/tank/jetpack/verb/toggle_rockets()
@@ -116,8 +116,8 @@
 	var/obj/item/weapon/rig/holder
 
 /obj/item/weapon/tank/jetpack/rig/examine()
-	to_chat(usr, "It's a jetpack. If you can see this, report it on the bug tracker.")
-	return 0
+	. = ..()
+	. += "It's a jetpack. If you can see this, report it on the bug tracker."
 
 /obj/item/weapon/tank/jetpack/rig/allow_thrust(num, mob/living/user as mob)
 

--- a/code/game/objects/items/weapons/tanks/tank_types.dm
+++ b/code/game/objects/items/weapons/tanks/tank_types.dm
@@ -22,9 +22,9 @@
 	return
 
 /obj/item/weapon/tank/oxygen/examine(mob/user)
-	if(..(user, 0) && air_contents.gas["oxygen"] < 10)
-		to_chat(user, text("<span class='warning'>The meter on \the [src] indicates you are almost out of oxygen!</span>"))
-		//playsound(usr, 'sound/effects/alert.ogg', 50, 1)
+	. = ..()
+	if(loc == user && (air_contents.gas["oxygen"] < 10))
+		. += "<span class='warning'>The meter on \the [src] indicates you are almost out of oxygen!</span>"
 
 /obj/item/weapon/tank/oxygen/yellow
 	desc = "A tank of oxygen, this one is yellow."
@@ -60,8 +60,9 @@
 	icon_state = "oxygen"
 
 /obj/item/weapon/tank/air/examine(mob/user)
-	if(..(user, 0) && air_contents.gas["oxygen"] < 1 && loc==user)
-		to_chat(user, "<span class='danger'>The meter on the [src.name] indicates you are almost out of air!</span>")
+	. = ..()
+	if(loc == user && (air_contents.gas["oxygen"] < 1))
+		. += "<span class='warning'>The meter on \the [src] indicates you are almost out of air!</span>"
 		user << sound('sound/effects/alert.ogg')
 
 /obj/item/weapon/tank/air/Initialize()
@@ -153,8 +154,9 @@
 	return
 
 /obj/item/weapon/tank/emergency/oxygen/examine(mob/user)
-	if(..(user, 0) && air_contents.gas["oxygen"] < 0.2 && loc==user)
-		to_chat(user, text("<span class='danger'>The meter on the [src.name] indicates you are almost out of air!</span>"))
+	. = ..()
+	if(loc == user && (air_contents.gas["oxygen"] < 0.2))
+		. += "<span class='danger'>The meter on the [src.name] indicates you are almost out of air!</span>"
 		user << sound('sound/effects/alert.ogg')
 
 /obj/item/weapon/tank/emergency/oxygen/engi
@@ -228,8 +230,9 @@
 	return
 
 /obj/item/weapon/tank/nitrogen/examine(mob/user)
-	if(..(user, 0) && air_contents.gas["nitrogen"] < 10)
-		to_chat(user, text("<span class='danger'>The meter on \the [src] indicates you are almost out of nitrogen!</span>"))
+	. = ..()
+	if(loc == user && (air_contents.gas["nitrogen"] < 10))
+		. += "<span class='danger'>The meter on \the [src] indicates you are almost out of nitrogen!</span>"
 		//playsound(user, 'sound/effects/alert.ogg', 50, 1)
 
 /obj/item/weapon/tank/stasis/nitro_cryo // Synthmorph bags need to have initial pressure within safe bounds for human atmospheric pressure, but low temperature to stop unwanted degredation.

--- a/code/game/objects/items/weapons/tanks/tanks.dm
+++ b/code/game/objects/items/weapons/tanks/tanks.dm
@@ -82,8 +82,8 @@ var/list/global/tank_gauge_cache = list()
 	. = ..()
 
 /obj/item/weapon/tank/examine(mob/user)
-	. = ..(user, 0)
-	if(.)
+	. = ..()
+	if(loc == user)
 		var/celsius_temperature = air_contents.temperature - T0C
 		var/descriptive
 		switch(celsius_temperature)
@@ -101,12 +101,12 @@ var/list/global/tank_gauge_cache = list()
 				descriptive = "cold"
 			else
 				descriptive = "bitterly cold"
-		to_chat(user, "<span class='notice'>\The [src] feels [descriptive].</span>")
+		. += "<span class='notice'>\The [src] feels [descriptive].</span>"
 
 	if(src.proxyassembly.assembly || wired)
-		to_chat(user, "<span class='warning'>It seems to have [wired? "some wires ": ""][wired && src.proxyassembly.assembly? "and ":""][src.proxyassembly.assembly ? "some sort of assembly ":""]attached to it.</span>")
+		. += "<span class='warning'>It seems to have [wired? "some wires ": ""][wired && src.proxyassembly.assembly? "and ":""][src.proxyassembly.assembly ? "some sort of assembly ":""]attached to it.</span>"
 	if(src.valve_welded)
-		to_chat(user, "<span class='warning'>\The [src] emergency relief valve has been welded shut!</span>")
+		. += "<span class='warning'>\The [src] emergency relief valve has been welded shut!</span>"
 
 
 /obj/item/weapon/tank/attackby(obj/item/weapon/W as obj, mob/user as mob)

--- a/code/game/objects/items/weapons/tools/combitool.dm
+++ b/code/game/objects/items/weapons/tools/combitool.dm
@@ -22,12 +22,12 @@
 	var/list/tools = list()
 	var/current_tool = 1
 
-/obj/item/weapon/combitool/examine()
-	..()
-	if(loc == usr && tools.len)
-		to_chat(usr, "It has the following fittings:")
+/obj/item/weapon/combitool/examine(mob/user)
+	. = ..()
+	if(loc == user && tools.len)
+		. += "It has the following fittings:"
 		for(var/obj/item/tool in tools)
-			to_chat(usr, "[bicon(tool)] - [tool.name][tools[current_tool]==tool?" (selected)":""]")
+			. += "[bicon(tool)] - [tool.name][tools[current_tool]==tool?" (selected)":""]")
 
 /obj/item/weapon/combitool/New()
 	..()

--- a/code/game/objects/items/weapons/tools/weldingtool.dm
+++ b/code/game/objects/items/weapons/tools/weldingtool.dm
@@ -56,9 +56,9 @@
 	return ..()
 
 /obj/item/weapon/weldingtool/examine(mob/user)
-	if(..(user, 0))
-		if(max_fuel)
-			to_chat(user, "[bicon(src)] The [src.name] contains [get_fuel()]/[src.max_fuel] units of fuel!")
+	. = ..()
+	if(max_fuel && loc == user)
+		. += "It contains [get_fuel()]/[src.max_fuel] units of fuel!"
 
 /obj/item/weapon/weldingtool/attack(atom/A, mob/living/user, def_zone)
 	if(ishuman(A) && user.a_intent == I_HELP)
@@ -556,13 +556,12 @@
 	return power_supply
 
 /obj/item/weapon/weldingtool/electric/examine(mob/user)
-	if(get_dist(src, user) > 1)
-		to_chat(user, desc)
-	else
+	. = ..()
+	if(Adjacent(user))
 		if(power_supply)
-			to_chat(user, "[bicon(src)] The [src.name] has [get_fuel()] charge left.")
+			. += "It [src.name] has [get_fuel()] charge left."
 		else
-			to_chat(user, "[bicon(src)] The [src.name] has no power cell!")
+			. += "It [src.name] has no power cell!"
 
 /obj/item/weapon/weldingtool/electric/get_fuel()
 	if(use_external_power)

--- a/code/game/objects/items/weapons/weldbackpack.dm
+++ b/code/game/objects/items/weapons/weldbackpack.dm
@@ -144,9 +144,8 @@
 		src.add_fingerprint(usr)
 
 /obj/item/weapon/weldpack/examine(mob/user)
-	..(user)
-	to_chat(user, "[bicon(src)] [src.reagents.total_volume] units of fuel left!")
-	return
+	. = ..()
+	. += "It has [src.reagents.total_volume] units of fuel left!"
 
 /obj/item/weapon/weldpack/survival
 	name = "emergency welding kit"

--- a/code/game/objects/structures/barsign.dm
+++ b/code/game/objects/structures/barsign.dm
@@ -14,16 +14,16 @@
 		. -= "Off"
 
 /obj/structure/sign/double/barsign/examine(mob/user)
-	..()
+	. = ..()
 	switch(icon_state)
 		if("Off")
-			to_chat(user, "It appears to be switched off.")
+			. += "It appears to be switched off."
 		if("narsiebistro")
-			to_chat(user, "It shows a picture of a large black and red being. Spooky!")
+			. += "It shows a picture of a large black and red being. Spooky!"
 		if("on", "empty")
-			to_chat(user, "The lights are on, but there's no picture.")
+			. += "The lights are on, but there's no picture."
 		else
-			to_chat(user, "It says '[icon_state]'")
+			. += "It says '[icon_state]'"
 
 /obj/structure/sign/double/barsign/New()
 	..()

--- a/code/game/objects/structures/bedsheet_bin.dm
+++ b/code/game/objects/structures/bedsheet_bin.dm
@@ -170,16 +170,14 @@ LINEN BINS
 
 
 /obj/structure/bedsheetbin/examine(mob/user)
-	..(user)
+	. = ..()
 
 	if(amount < 1)
-		to_chat(user, "There are no bed sheets in the bin.")
-		return
-	if(amount == 1)
-		to_chat(user, "There is one bed sheet in the bin.")
-		return
-	to_chat(user, "There are [amount] bed sheets in the bin.")
-
+		. += "There are no bed sheets in the bin."
+	else if(amount == 1)
+		. += "There is one bed sheet in the bin."
+	else
+		. += "There are [amount] bed sheets in the bin."
 
 /obj/structure/bedsheetbin/update_icon()
 	switch(amount)

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -57,24 +57,25 @@
 	update_icon()
 
 /obj/structure/closet/examine(mob/user)
-	if(!src.opened && (..(user, 1) || isobserver(user)))
+	. = ..()
+	if(Adjacent(user) || isobserver(user))
 		var/content_size = 0
 		for(var/obj/item/I in src.contents)
 			if(!I.anchored)
 				content_size += CEILING(I.w_class/2, 1)
 		if(!content_size)
-			to_chat(user, "It is empty.")
+			. += "It is empty."
 		else if(storage_capacity > content_size*4)
-			to_chat(user, "It is barely filled.")
+			. += "It is barely filled."
 		else if(storage_capacity > content_size*2)
-			to_chat(user, "It is less than half full.")
+			. += "It is less than half full."
 		else if(storage_capacity > content_size)
-			to_chat(user, "There is still some free space.")
+			. += "There is still some free space."
 		else
-			to_chat(user, "It is full.")
+			. += "It is full."
 
 	if(!src.opened && isobserver(user))
-		to_chat(user, "It contains: [counting_english_list(contents)]")
+		. += "It contains: [counting_english_list(contents)]"
 
 /obj/structure/closet/CanPass(atom/movable/mover, turf/target)
 	if(wall_mounted)

--- a/code/game/objects/structures/crates_lockers/vehiclecage.dm
+++ b/code/game/objects/structures/crates_lockers/vehiclecage.dm
@@ -9,9 +9,9 @@
 	var/paint_color = "#666666"
 
 /obj/structure/vehiclecage/examine(mob/user)
-	..()
+	. = ..()
 	if(my_vehicle)
-		to_chat(user, "<span class='notice'>It seems to contain \the [my_vehicle].</span>")
+		. += "<span class='notice'>It seems to contain \the [my_vehicle].</span>"
 
 /obj/structure/vehiclecage/Initialize()
 	. = ..()

--- a/code/game/objects/structures/fence.dm
+++ b/code/game/objects/structures/fence.dm
@@ -32,9 +32,9 @@
 
 	switch(hole_size)
 		if(MEDIUM_HOLE)
-			user.show_message("There is a large hole in \the [src].")
+			. += "There is a large hole in it."
 		if(LARGE_HOLE)
-			user.show_message("\The [src] has been completely cut through.")
+			. += "It has been completely cut through."
 
 /obj/structure/fence/get_description_interaction()
 	var/list/results = list()

--- a/code/game/objects/structures/flora.dm
+++ b/code/game/objects/structures/flora.dm
@@ -36,9 +36,9 @@
 		max_harvests = max(0, rand(min_harvests, max_harvests)) // Incase you want to weight it more toward 'not harvestable', set min_harvests to a negative value.
 
 /obj/structure/flora/examine(mob/user)
-	. = ..(user)
+	. = ..()
 	if(harvest_count < max_harvests)
-		to_chat(user, "<span class='notice'>\The [src] seems to have something hanging from it.</span>")
+		. += "<span class='notice'>It seems to have something hanging from it.</span>"
 
 /obj/structure/flora/attackby(var/obj/item/weapon/W, var/mob/living/user)
 	if(can_harvest(W))
@@ -225,9 +225,9 @@
 	var/obj/item/stored_item
 	
 /obj/structure/flora/pottedplant/examine(mob/user)
-	..()
+	. = ..()
 	if(in_range(user, src) && stored_item)
-		to_chat(user, "<i>You can see something in there...</i>")
+		. += "<i>You can see something in there...</i>"
 
 /obj/structure/flora/pottedplant/attackby(obj/item/I, mob/user)
 	if(stored_item)

--- a/code/game/objects/structures/gravemarker.dm
+++ b/code/game/objects/structures/gravemarker.dm
@@ -30,13 +30,11 @@
 	color = material.icon_colour
 
 /obj/structure/gravemarker/examine(mob/user)
-	..()
-	if(get_dist(src, user) < 4)
-		if(grave_name)
-			to_chat(user, "Here Lies [grave_name]")
-	if(get_dist(src, user) < 2)
-		if(epitaph)
-			to_chat(user, epitaph)
+	. = ..()
+	if(grave_name && get_dist(src, user) < 4)
+		. += "Here Lies [grave_name]"
+	if(epitaph && get_dist(src, user) < 2)
+		. += epitaph
 
 /obj/structure/gravemarker/CanPass(atom/movable/mover, turf/target)
 	if(istype(mover) && mover.checkpass(PASSTABLE))

--- a/code/game/objects/structures/janicart.dm
+++ b/code/game/objects/structures/janicart.dm
@@ -24,10 +24,9 @@ GLOBAL_LIST_BOILERPLATE(all_janitorial_carts, /obj/structure/janitorialcart)
 
 
 /obj/structure/janitorialcart/examine(mob/user)
-	if(..(user, 1))
-		to_chat(user, "[src] [bicon(src)] contains [reagents.total_volume] unit\s of liquid!")
-	//everything else is visible, so doesn't need to be mentioned
-
+	. = ..()
+	if(Adjacent(user))
+		. += "It contains [reagents.total_volume] unit\s of liquid!"
 
 /obj/structure/janitorialcart/attackby(obj/item/I, mob/user)
 	if(istype(I, /obj/item/weapon/storage/bag/trash) && !mybag)
@@ -186,12 +185,11 @@ GLOBAL_LIST_BOILERPLATE(all_janitorial_carts, /obj/structure/janitorialcart)
 
 
 /obj/structure/bed/chair/janicart/examine(mob/user)
-	if(!..(user, 1))
-		return
-
-	to_chat(user, "[bicon(src)] This [callme] contains [reagents.total_volume] unit\s of water!")
-	if(mybag)
-		to_chat(user, "\A [mybag] is hanging on the [callme].")
+	. = ..()
+	if(Adjacent(user))
+		. += "This [callme] contains [reagents.total_volume] unit\s of water!"
+		if(mybag)
+			. += "\A [mybag] is hanging on the [callme]."
 
 
 /obj/structure/bed/chair/janicart/attackby(obj/item/I, mob/user)

--- a/code/game/objects/structures/mop_bucket.dm
+++ b/code/game/objects/structures/mop_bucket.dm
@@ -17,8 +17,9 @@ GLOBAL_LIST_BOILERPLATE(all_mopbuckets, /obj/structure/mopbucket)
 	..()
 
 /obj/structure/mopbucket/examine(mob/user)
-	if(..(user, 1))
-		to_chat(user, "[src] [bicon(src)] contains [reagents.total_volume] unit\s of water!")
+	. = ..()
+	if(Adjacent(user))
+		. += "It contains [reagents.total_volume] unit\s of water!"
 
 /obj/structure/mopbucket/attackby(obj/item/I, mob/user)
 	if(istype(I, /obj/item/weapon/mop))

--- a/code/game/objects/structures/noticeboard.dm
+++ b/code/game/objects/structures/noticeboard.dm
@@ -51,21 +51,18 @@
 		return
 
 /obj/structure/noticeboard/attack_hand(var/mob/user)
-	examine(user)
+	user.examinate(src)
 
 // Since Topic() never seems to interact with usr on more than a superficial
 // level, it should be fine to let anyone mess with the board other than ghosts.
 /obj/structure/noticeboard/examine(var/mob/user)
-	if(!user)
-		user = usr
-	if(user.Adjacent(src))
+	. = ..()
+	if(Adjacent(user))
 		var/dat = "<B>Noticeboard</B><BR>"
 		for(var/obj/item/weapon/paper/P in src)
 			dat += "<A href='?src=\ref[src];read=\ref[P]'>[P.name]</A> <A href='?src=\ref[src];write=\ref[P]'>Write</A> <A href='?src=\ref[src];remove=\ref[P]'>Remove</A><BR>"
 		user << browse("<HEAD><TITLE>Notices</TITLE></HEAD>[dat]","window=noticeboard")
 		onclose(user, "noticeboard")
-	else
-		..()
 
 /obj/structure/noticeboard/Topic(href, href_list)
 	..()

--- a/code/game/objects/structures/railing.dm
+++ b/code/game/objects/structures/railing.dm
@@ -46,11 +46,11 @@
 	if(health < maxhealth)
 		switch(health / maxhealth)
 			if(0.0 to 0.5)
-				to_chat(user, "<span class='warning'>It looks severely damaged!</span>")
+				. += "<span class='warning'>It looks severely damaged!</span>"
 			if(0.25 to 0.5)
-				to_chat(user, "<span class='warning'>It looks damaged!</span>")
+				. += "<span class='warning'>It looks damaged!</span>"
 			if(0.5 to 1.0)
-				to_chat(user, "<span class='notice'>It has a few scrapes and dents.</span>")
+				. += "<span class='notice'>It has a few scrapes and dents.</span>"
 
 /obj/structure/railing/take_damage(amount)
 	health -= amount

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -25,27 +25,27 @@
 	var/fulltile = FALSE // Set to true on full-tile variants.
 
 /obj/structure/window/examine(mob/user)
-	. = ..(user)
+	. = ..()
 
 	if(health == maxhealth)
-		to_chat(user, "<span class='notice'>It looks fully intact.</span>")
+		. += "<span class='notice'>It looks fully intact.</span>"
 	else
 		var/perc = health / maxhealth
 		if(perc > 0.75)
-			to_chat(user, "<span class='notice'>It has a few cracks.</span>")
+			. += "<span class='notice'>It has a few cracks.</span>"
 		else if(perc > 0.5)
-			to_chat(user, "<span class='warning'>It looks slightly damaged.</span>")
+			. += "<span class='warning'>It looks slightly damaged.</span>"
 		else if(perc > 0.25)
-			to_chat(user, "<span class='warning'>It looks moderately damaged.</span>")
+			. += "<span class='warning'>It looks moderately damaged.</span>"
 		else
-			to_chat(user, "<span class='danger'>It looks heavily damaged.</span>")
+			. += "<span class='danger'>It looks heavily damaged.</span>"
 	if(silicate)
 		if (silicate < 30)
-			to_chat(user, "<span class='notice'>It has a thin layer of silicate.</span>")
+			. += "<span class='notice'>It has a thin layer of silicate.</span>"
 		else if (silicate < 70)
-			to_chat(user, "<span class='notice'>It is covered in silicate.</span>")
+			. += "<span class='notice'>It is covered in silicate.</span>"
 		else
-			to_chat(user, "<span class='notice'>There is a thick layer of silicate covering it.</span>")
+			. += "<span class='notice'>There is a thick layer of silicate covering it.</span>"
 
 /obj/structure/window/take_damage(var/damage = 0,  var/sound_effect = 1)
 	var/initialhealth = health

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -120,21 +120,21 @@
 
 //Appearance
 /turf/simulated/wall/examine(mob/user)
-	. = ..(user)
+	. = ..()
 
 	if(!damage)
-		to_chat(user, "<span class='notice'>It looks fully intact.</span>")
+		. += "<span class='notice'>It looks fully intact.</span>"
 	else
 		var/dam = damage / material.integrity
 		if(dam <= 0.3)
-			to_chat(user, "<span class='warning'>It looks slightly damaged.</span>")
+			. += "<span class='warning'>It looks slightly damaged.</span>"
 		else if(dam <= 0.6)
-			to_chat(user, "<span class='warning'>It looks moderately damaged.</span>")
+			. += "<span class='warning'>It looks moderately damaged.</span>"
 		else
-			to_chat(user, "<span class='danger'>It looks heavily damaged.</span>")
+			. += "<span class='danger'>It looks heavily damaged.</span>"
 
 	if(locate(/obj/effect/overlay/wallrot) in src)
-		to_chat(user, "<span class='warning'>There is fungus growing on [src].</span>")
+		. += "<span class='warning'>There is fungus growing on [src].</span>"
 
 //Damage
 

--- a/code/modules/assembly/assembly.dm
+++ b/code/modules/assembly/assembly.dm
@@ -80,14 +80,12 @@
 	return PROCESS_KILL
 
 /obj/item/device/assembly/examine(mob/user)
-	..(user)
+	. = ..()
 	if((in_range(src, user) || loc == user))
 		if(secured)
-			to_chat(user, "\The [src] is ready!")
+			. += "\The [src] is ready!"
 		else
-			to_chat(user, "\The [src] can be attached!")
-	return
-
+			. += "\The [src] can be attached!"
 
 /obj/item/device/assembly/attack_self(mob/user as mob)
 	if(!user)	return 0

--- a/code/modules/assembly/holder.dm
+++ b/code/modules/assembly/holder.dm
@@ -57,12 +57,12 @@
 		master.update_icon()
 
 /obj/item/device/assembly_holder/examine(mob/user)
-	..(user)
+	. = ..()
 	if ((in_range(src, user) || src.loc == user))
 		if (src.secured)
-			to_chat(user, "\The [src] is ready!")
+			. += "\The [src] is ready!"
 		else
-			to_chat(user, "\The [src] can be attached!")
+			. += "\The [src] can be attached!"
 
 /obj/item/device/assembly_holder/HasProximity(atom/movable/AM as mob|obj)
 	if(a_left)

--- a/code/modules/assembly/mousetrap.dm
+++ b/code/modules/assembly/mousetrap.dm
@@ -8,9 +8,9 @@
 
 
 /obj/item/device/assembly/mousetrap/examine(var/mob/user)
-	..(user)
+	. = ..(user)
 	if(armed)
-		to_chat(user, "It looks like it's armed.")
+		. += "It looks like it's armed."
 
 /obj/item/device/assembly/mousetrap/update_icon()
 	if(armed)

--- a/code/modules/blob2/blobs/base_blob.dm
+++ b/code/modules/blob2/blobs/base_blob.dm
@@ -64,11 +64,11 @@ GLOBAL_LIST_EMPTY(all_blobs)
 	return FALSE
 
 /obj/structure/blob/examine(mob/user)
-	..()
+	. = ..()
 	if(!overmind)
-		to_chat(user, "It seems inert.") // Dead blob.
+		. += "It seems inert." // Dead blob.
 	else
-		to_chat(user, overmind.blob_type.desc)
+		. += overmind.blob_type.desc
 
 /obj/structure/blob/get_description_info()
 	if(overmind)

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -827,16 +827,16 @@
 
 
 /obj/item/clothing/under/examine(mob/user)
-	..(user)
+	. = ..()
 	switch(src.sensor_mode)
 		if(0)
-			to_chat(user, "Its sensors appear to be disabled.")
+			. += "Its sensors appear to be disabled."
 		if(1)
-			to_chat(user, "Its binary life sensors appear to be enabled.")
+			. += "Its binary life sensors appear to be enabled."
 		if(2)
-			to_chat(user, "Its vital tracker appears to be enabled.")
+			. += "Its vital tracker appears to be enabled."
 		if(3)
-			to_chat(user, "Its vital tracker and tracking beacon appear to be enabled.")
+			. += "Its vital tracker and tracking beacon appear to be enabled."
 
 /obj/item/clothing/under/proc/set_sensors(mob/usr as mob)
 	var/mob/M = usr

--- a/code/modules/clothing/clothing_accessories.dm
+++ b/code/modules/clothing/clothing_accessories.dm
@@ -67,10 +67,9 @@
 		src.add_fingerprint(usr)
 
 /obj/item/clothing/examine(var/mob/user)
-	..(user)
+	. = ..(user)
 	if(LAZYLEN(accessories))
-		for(var/obj/item/clothing/accessory/A in accessories)
-			to_chat(user, "\A [A] is attached to it.")
+		. += "It has the following attached: [counting_english_list(accessories)]"
 
 /**
  *  Attach accessory A to src

--- a/code/modules/clothing/shoes/magboots.dm
+++ b/code/modules/clothing/shoes/magboots.dm
@@ -78,11 +78,8 @@
 	wearer = null
 
 /obj/item/clothing/shoes/magboots/examine(mob/user)
-	..(user)
-	var/state = "disabled"
-	if(item_flags & NOSLIP)
-		state = "enabled"
-	to_chat(user, "Its mag-pulse traction system appears to be [state].")
+	. = ..()
+	. += "Its mag-pulse traction system appears to be [item_flags & NOSLIP ? "enabled" : "disabled"]."
 
 /obj/item/clothing/shoes/magboots/vox
 
@@ -126,6 +123,6 @@
 		canremove = 1
 
 /obj/item/clothing/shoes/magboots/vox/examine(mob/user)
-	..(user)
-	if (magpulse)
-		to_chat(user, "It would be hard to take these off without relaxing your grip first.")//theoretically this message should only be seen by the wearer when the claws are equipped.
+	. = ..()
+	if(magpulse)
+		. += "It would be hard to take these off without relaxing your grip first." // Theoretically this message should only be seen by the wearer when the claws are equipped.

--- a/code/modules/clothing/spacesuits/breaches.dm
+++ b/code/modules/clothing/spacesuits/breaches.dm
@@ -224,7 +224,7 @@ var/global/list/breach_burn_descriptors = list(
 	..()
 
 /obj/item/clothing/suit/space/examine(mob/user)
-	..(user)
-	if(can_breach && breaches && breaches.len)
+	. = ..()
+	if(can_breach && breaches?.len)
 		for(var/datum/breach/B in breaches)
-			to_chat(user, "<font color='red'><B>It has \a [B.descriptor].</B></font>")
+			. += "<font color='red'><B>It has \a [B.descriptor].</B></font>"

--- a/code/modules/clothing/spacesuits/rig/modules/modules.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/modules.dm
@@ -55,14 +55,14 @@
 	var/list/stat_rig_module/stat_modules = new()
 
 /obj/item/rig_module/examine()
-	..()
+	. = ..()
 	switch(damage)
 		if(0)
-			to_chat(usr, "It is undamaged.")
+			. += "It is undamaged."
 		if(1)
-			to_chat(usr, "It is badly damaged.")
+			. += "It is badly damaged."
 		if(2)
-			to_chat(usr, "It is almost completely destroyed.")
+			. += "It is almost completely destroyed."
 
 /obj/item/rig_module/attackby(obj/item/W as obj, mob/user as mob)
 

--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -94,22 +94,21 @@
 	var/datum/effect/effect/system/spark_spread/spark_system
 
 /obj/item/weapon/rig/examine()
-	to_chat(usr, "This is [bicon(src)][src.name].")
-	to_chat(usr, "[src.desc]")
+	. = ..()
 	if(wearer)
 		for(var/obj/item/piece in list(helmet,gloves,chest,boots))
 			if(!piece || piece.loc != wearer)
 				continue
-			to_chat(usr, "[bicon(piece)] \The [piece] [piece.gender == PLURAL ? "are" : "is"] deployed.")
+			. += "[bicon(piece)] \The [piece] [piece.gender == PLURAL ? "are" : "is"] deployed."
 
 	if(src.loc == usr)
-		to_chat(usr, "The access panel is [locked? "locked" : "unlocked"].")
-		to_chat(usr, "The maintenance panel is [open ? "open" : "closed"].")
-		to_chat(usr, "Hardsuit systems are [offline ? "<span class='warning'>offline</span>" : "<span class='notice'>online</span>"].")
-		to_chat(usr, "The cooling stystem is [cooling_on ? "active" : "inactive"].")
+		. += "The access panel is [locked? "locked" : "unlocked"]."
+		. += "The maintenance panel is [open ? "open" : "closed"]."
+		. += "Hardsuit systems are [offline ? "<span class='warning'>offline</span>" : "<span class='notice'>online</span>"]."
+		. += "The cooling stystem is [cooling_on ? "active" : "inactive"]."
 
 		if(open)
-			to_chat(usr, "It's equipped with [english_list(installed_modules)].")
+			. += "It's equipped with [english_list(installed_modules)]."
 
 /obj/item/weapon/rig/New()
 	..()

--- a/code/modules/clothing/spacesuits/spacesuits.dm
+++ b/code/modules/clothing/spacesuits/spacesuits.dm
@@ -58,10 +58,10 @@
 		camera.c_tag = usr.name
 		to_chat(usr, "<font color='blue'>User scanned as [camera.c_tag]. Camera activated.</font>")
 
-/obj/item/clothing/head/helmet/space/examine()
-	..()
-	if(camera_networks && get_dist(usr,src) <= 1)
-		to_chat(usr, "This helmet has a built-in camera. It's [camera ? "" : "in"]active.")
+/obj/item/clothing/head/helmet/space/examine(mob/user)
+	. = ..()
+	if(camera_networks && Adjacent(user))
+		. += "This helmet has a built-in camera. It's [camera ? "" : "in"]active."
 
 /obj/item/clothing/suit/space
 	name = "Space suit"

--- a/code/modules/clothing/spacesuits/void/void.dm
+++ b/code/modules/clothing/spacesuits/void/void.dm
@@ -68,13 +68,11 @@
 	var/obj/item/device/suit_cooling_unit/cooler = null// Cooling unit, for FBPs.  Cannot be installed alongside a tank.
 
 /obj/item/clothing/suit/space/void/examine(user)
-	..(user)
-	var/list/part_list = new
+	. = ..()
 	for(var/obj/item/I in list(helmet,boots,tank,cooler))
-		part_list += "\a [I]"
-	to_chat(user, "\The [src] has [english_list(part_list)] installed.")
+		. += "It has \a [I] installed."
 	if(tank && in_range(src,user))
-		to_chat(user, "<span class='notice'>The wrist-mounted pressure gauge reads [max(round(tank.air_contents.return_pressure()),0)] kPa remaining in \the [tank].</span>")
+		. += "<span class='notice'>The wrist-mounted pressure gauge reads [max(round(tank.air_contents.return_pressure()),0)] kPa remaining in \the [tank].</span>"
 
 /obj/item/clothing/suit/space/void/refit_for_species(var/target_species)
 	..()

--- a/code/modules/clothing/under/accessories/holster.dm
+++ b/code/modules/clothing/under/accessories/holster.dm
@@ -79,11 +79,11 @@
 	..()
 
 /obj/item/clothing/accessory/holster/examine(mob/user)
-	..(user)
-	if (holstered)
-		to_chat(user, "A [holstered] is holstered here.")
+	. = ..(user)
+	if(holstered)
+		. += "A [holstered] is holstered here."
 	else
-		to_chat(user, "It is empty.")
+		. += "It is empty."
 
 /obj/item/clothing/accessory/holster/on_attached(obj/item/clothing/under/S, mob/user as mob)
 	..()

--- a/code/modules/detectivework/tools/evidencebag.dm
+++ b/code/modules/detectivework/tools/evidencebag.dm
@@ -91,5 +91,6 @@
 	return
 
 /obj/item/weapon/evidencebag/examine(mob/user)
-	..(user)
-	if (stored_item) user.examinate(stored_item)
+	. = ..()
+	if(stored_item)
+		user.examinate(stored_item)

--- a/code/modules/economy/cash.dm
+++ b/code/modules/economy/cash.dm
@@ -158,6 +158,6 @@ proc/spawn_money(var/sum, spawnloc, mob/living/carbon/human/human_user as mob)
 	update_icon() return  //space cash
 
 /obj/item/weapon/spacecash/ewallet/examine(mob/user)
-	..(user)
-	if (!(user in view(2)) && user!=src.loc) return
-	to_chat(user, "<font color='blue'>Charge card's owner: [src.owner_name]. Thalers remaining: [src.worth].</font>")
+	. = ..()
+	if(Adjacent(user))
+		. += "<span class='notice'>Charge card's owner: [src.owner_name]. Thalers remaining: [src.worth].</span>"

--- a/code/modules/economy/cash_register.dm
+++ b/code/modules/economy/cash_register.dm
@@ -32,14 +32,14 @@
 
 
 /obj/machinery/cash_register/examine(mob/user as mob)
-	..(user)
+	. = ..(user)
 	if(transaction_amount)
-		to_chat(user, "It has a purchase of [transaction_amount] pending[transaction_purpose ? " for [transaction_purpose]" : ""].")
+		. += "It has a purchase of [transaction_amount] pending[transaction_purpose ? " for [transaction_purpose]" : ""]."
 	if(cash_open)
 		if(cash_stored)
-			to_chat(user, "It holds [cash_stored] Thaler\s of money.")
+			. += "It holds [cash_stored] Thaler\s."
 		else
-			to_chat(user, "It's completely empty.")
+			. += "It's completely empty."
 
 
 /obj/machinery/cash_register/attack_hand(mob/user as mob)

--- a/code/modules/economy/retail_scanner.dm
+++ b/code/modules/economy/retail_scanner.dm
@@ -57,10 +57,9 @@
 		interact(user)
 
 /obj/item/device/retail_scanner/examine(mob/user as mob)
-	..(user)
+	. = ..()
 	if(transaction_amount)
-		to_chat(user, "It has a purchase of [transaction_amount] pending[transaction_purpose ? " for [transaction_purpose]" : ""].")
-
+		. += "It has a purchase of [transaction_amount] pending[transaction_purpose ? " for [transaction_purpose]" : ""]."
 
 /obj/item/device/retail_scanner/interact(mob/user as mob)
 	var/dat = "<h2>Retail Scanner<hr></h2>"

--- a/code/modules/fishing/fishing_rod.dm
+++ b/code/modules/fishing/fishing_rod.dm
@@ -32,11 +32,11 @@
 /obj/item/weapon/material/fishing_rod/built
 	strung = FALSE
 
-/obj/item/weapon/material/fishing_rod/examine(mob/M as mob)
-	..()
+/obj/item/weapon/material/fishing_rod/examine(mob/user)
+	. = ..()
 	if(Bait)
-		to_chat(M, "<span class='notice'>\The [src] has \the [Bait] hanging on its hook.</span>")
-		Bait.examine(M)
+		. += "<span class='notice'>It has [Bait] hanging on its hook: </span>"
+		. += Bait.examine(user)
 
 /obj/item/weapon/material/fishing_rod/CtrlClick(mob/user)
 	if((src.loc == user || Adjacent(user)) && Bait)

--- a/code/modules/food/drinkingglass/drinkingglass.dm
+++ b/code/modules/food/drinkingglass/drinkingglass.dm
@@ -28,21 +28,21 @@
 	matter = list("glass" = 60)
 
 /obj/item/weapon/reagent_containers/food/drinks/glass2/examine(mob/M as mob)
-	..()
+	. = ..()
 
 	for(var/I in extras)
 		if(istype(I, /obj/item/weapon/glass_extra))
-			to_chat(M, "There is \a [I] in \the [src].")
+			. += "There is \a [I] in \the [src]."
 		else if(istype(I, /obj/item/weapon/reagent_containers/food/snacks/fruit_slice))
-			to_chat(M, "There is \a [I] on the rim.")
+			. += "There is \a [I] on the rim."
 		else
-			to_chat(M, "There is \a [I] somewhere on the glass. Somehow.")
+			. += "There is \a [I] somewhere on the glass. Somehow."
 
 	if(has_ice())
-		to_chat(M, "There is some ice floating in the drink.")
+		. += "There is some ice floating in the drink."
 
 	if(has_fizz())
-		to_chat(M, "It is fizzing slightly.")
+		. += "It is fizzing slightly."
 
 /obj/item/weapon/reagent_containers/food/drinks/glass2/proc/has_ice()
 	if(reagents.reagent_list.len > 0)

--- a/code/modules/food/food/drinks.dm
+++ b/code/modules/food/food/drinks.dm
@@ -72,18 +72,18 @@
 	playsound(user.loc, 'sound/items/drink.ogg', rand(10, 50), 1)
 
 /obj/item/weapon/reagent_containers/food/drinks/examine(mob/user)
-	if(!..(user, 1))
-		return
-	if(!reagents || reagents.total_volume == 0)
-		to_chat(user, "<span class='notice'>\The [src] is empty!</span>")
-	else if (reagents.total_volume <= volume * 0.25)
-		to_chat(user, "<span class='notice'>\The [src] is almost empty!</span>")
-	else if (reagents.total_volume <= volume * 0.66)
-		to_chat(user, "<span class='notice'>\The [src] is half full!</span>")
-	else if (reagents.total_volume <= volume * 0.90)
-		to_chat(user, "<span class='notice'>\The [src] is almost full!</span>")
-	else
-		to_chat(user, "<span class='notice'>\The [src] is full!</span>")
+	. = ..()
+	if(Adjacent(user))
+		if(!reagents?.total_volume)
+			. += "<span class='notice'>It is empty!</span>"
+		else if (reagents.total_volume <= volume * 0.25)
+			. += "<span class='notice'>It is almost empty!</span>"
+		else if (reagents.total_volume <= volume * 0.66)
+			. += "<span class='notice'>It is half full!</span>"
+		else if (reagents.total_volume <= volume * 0.90)
+			. += "<span class='notice'>It is almost full!</span>"
+		else
+			. += "<span class='notice'>It is full!</span>"
 
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/code/modules/food/food/sandwich.dm
+++ b/code/modules/food/food/sandwich.dm
@@ -79,9 +79,10 @@
 	..()
 
 /obj/item/weapon/reagent_containers/food/snacks/csandwich/examine(mob/user)
-	..(user)
-	var/obj/item/O = pick(contents)
-	to_chat(user, "<font color='blue'>You think you can see [O.name] in there.</font>")
+	. = ..()
+	if(contents.len)
+		var/obj/item/O = pick(contents)
+		. += "<font color='blue'>You think you can see [O.name] in there.</font>"
 
 /obj/item/weapon/reagent_containers/food/snacks/csandwich/attack(mob/M as mob, mob/user as mob, def_zone)
 

--- a/code/modules/food/food/snacks.dm
+++ b/code/modules/food/food/snacks.dm
@@ -140,16 +140,16 @@
 	return 0
 
 /obj/item/weapon/reagent_containers/food/snacks/examine(mob/user)
-	if(!..(user, 1))
-		return
-	if (bitecount==0)
-		return
-	else if (bitecount==1)
-		to_chat(user, "<font color='blue'>\The [src] was bitten by someone!</font>")
-	else if (bitecount<=3)
-		to_chat(user, "<font color='blue'>\The [src] was bitten [bitecount] times!</font>")
-	else
-		to_chat(user, "<font color='blue'>\The [src] was bitten multiple times!</font>")
+	. = ..()
+	if(Adjacent(user))
+		if(bitecount==0)
+			return .
+		else if (bitecount==1)
+			. += "<span class='notice'>It was bitten by someone!</span>"
+		else if (bitecount<=3)
+			. += "<span class='notice'>It was bitten [bitecount] times!</span>"
+		else
+			. += "<span class='notice'>It was bitten multiple times!</span>"
 
 /obj/item/weapon/reagent_containers/food/snacks/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	if(istype(W,/obj/item/weapon/storage))

--- a/code/modules/food/kitchen/cooking_machines/_cooker.dm
+++ b/code/modules/food/kitchen/cooking_machines/_cooker.dm
@@ -39,10 +39,10 @@
 	cooking = new_setting
 	icon_state = new_setting ? on_icon : off_icon
 
-/obj/machinery/cooker/examine()
-	..()
-	if(cooking_obj && Adjacent(usr))
-		to_chat(usr, "You can see \a [cooking_obj] inside.")
+/obj/machinery/cooker/examine(mob/user)
+	. = ..()
+	if(cooking_obj && Adjacent(user))
+		. += "You can see \a [cooking_obj] inside."
 
 /obj/machinery/cooker/attackby(var/obj/item/I, var/mob/user)
 

--- a/code/modules/food/kitchen/gibber.dm
+++ b/code/modules/food/kitchen/gibber.dm
@@ -87,8 +87,8 @@
 		src.startgibbing(user)
 
 /obj/machinery/gibber/examine()
-	..()
-	to_chat(usr, "The safety guard is [emagged ? "<span class='danger'>disabled</span>" : "enabled"].")
+	. = ..()
+	. += "The safety guard is [emagged ? "<span class='danger'>disabled</span>" : "enabled"]."
 
 /obj/machinery/gibber/emag_act(var/remaining_charges, var/mob/user)
 	emagged = !emagged

--- a/code/modules/games/cards.dm
+++ b/code/modules/games/cards.dm
@@ -348,11 +348,11 @@
 	user.visible_message("<span class = 'notice'>\The [user] [concealed ? "conceals" : "reveals"] their hand.</span>")
 
 /obj/item/weapon/hand/examine(mob/user)
-	..(user)
+	. = ..()
 	if((!concealed) && cards.len)
-		to_chat(user,"It contains: ")
+		. += "It contains: "
 		for(var/datum/playingcard/P in cards)
-			to_chat(user,"\The [P.name].")
+			. += "\The [P.name]."
 
 /obj/item/weapon/hand/verb/Removecard()
 

--- a/code/modules/hydroponics/beekeeping/beehive.dm
+++ b/code/modules/hydroponics/beekeeping/beehive.dm
@@ -31,9 +31,9 @@
 				overlays += "bees3"
 
 /obj/machinery/beehive/examine(var/mob/user)
-	..()
+	. = ..()
 	if(!closed)
-		to_chat(user, "The lid is open.")
+		. += "The lid is open."
 
 /obj/machinery/beehive/attackby(var/obj/item/I, var/mob/user)
 	if(I.is_crowbar())

--- a/code/modules/hydroponics/seed_packets.dm
+++ b/code/modules/hydroponics/seed_packets.dm
@@ -60,9 +60,9 @@ GLOBAL_LIST_BOILERPLATE(all_seed_packs, /obj/item/seeds)
 		src.desc = "It's labelled as coming from [seed.display_name]."
 
 /obj/item/seeds/examine(mob/user)
-	..(user)
+	. = ..()
 	if(seed && !seed.roundstart)
-		to_chat(user, "It's tagged as variety #[seed.uid].")
+		. += "It's tagged as variety #[seed.uid]."
 
 /obj/item/seeds/cutting
 	name = "cuttings"

--- a/code/modules/hydroponics/trays/tray.dm
+++ b/code/modules/hydroponics/trays/tray.dm
@@ -1,5 +1,6 @@
 /obj/machinery/portable_atmospherics/hydroponics
 	name = "hydroponics tray"
+	desc = "A tray usually full of fluid for growing plants."
 	icon = 'icons/obj/hydroponics_machines.dmi'
 	icon_state = "hydrotray3"
 	density = 1
@@ -607,32 +608,31 @@
 	else if(dead)
 		remove_dead(user)
 
-/obj/machinery/portable_atmospherics/hydroponics/examine()
-
-	..()
+/obj/machinery/portable_atmospherics/hydroponics/examine(mob/user)
+	. = ..()
 
 	if(seed)
-		to_chat(usr, "<span class='notice'>[seed.display_name] are growing here.</span>")
+		. += "<span class='notice'>[seed.display_name] are growing here.</span>"
 	else
-		to_chat(usr, "[src] is empty.")
+		. += "It is empty."
 
-	if(!Adjacent(usr))
-		return
+	if(!Adjacent(user))
+		return .
 
-	to_chat(usr, "Water: [round(waterlevel,0.1)]/100")
-	to_chat(usr, "Nutrient: [round(nutrilevel,0.1)]/10")
+	. += "Water: [round(waterlevel,0.1)]/100"
+	. += "Nutrient: [round(nutrilevel,0.1)]/10"
 
 	if(seed)
 		if(weedlevel >= 5)
-			to_chat(usr, "\The [src] is <span class='danger'>infested with weeds</span>!")
+			. += "It is <span class='danger'>infested with weeds</span>!"
 		if(pestlevel >= 5)
-			to_chat(usr, "\The [src] is <span class='danger'>infested with tiny worms</span>!")
+			. += "It is <span class='danger'>infested with tiny worms</span>!"
 		if(dead)
-			to_chat(usr, "<span class='danger'>The plant is dead.</span>")
+			. += "It has <span class='danger'>a dead plant</span>!"
 		else if(health <= (seed.get_trait(TRAIT_ENDURANCE)/ 2))
-			to_chat(usr, "The plant looks <span class='danger'>unhealthy</span>.")
+			. += "It has <span class='danger'>an unhealthy plant</span>!"
 	if(frozen == 1)
-		to_chat(usr, "<span class='notice'>It is cryogenically frozen.</span>")
+		. += "<span class='notice'>It is cryogenically frozen.</span>"
 	if(mechanical)
 		var/turf/T = loc
 		var/datum/gas_mixture/environment
@@ -655,7 +655,7 @@
 			var/light_available = T.get_lumcount() * 5
 			light_string = "a light level of [light_available] lumens"
 
-		to_chat(usr, "The tray's sensor suite is reporting [light_string] and a temperature of [environment.temperature]K at [environment.return_pressure()] kPa in the [environment_type] environment")
+		. += "The tray's sensor suite is reporting [light_string] and a temperature of [environment.temperature]K at [environment.return_pressure()] kPa in the [environment_type] environment."
 
 /obj/machinery/portable_atmospherics/hydroponics/verb/close_lid_verb()
 	set name = "Toggle Tray Lid"

--- a/code/modules/integrated_electronics/core/assemblies.dm
+++ b/code/modules/integrated_electronics/core/assemblies.dm
@@ -172,13 +172,10 @@
 			return id_card
 
 /obj/item/device/electronic_assembly/examine(mob/user)
-	. = ..(user, 1)
-	if(.)
+	. = ..()
+	if(Adjacent(user))
 		for(var/obj/item/integrated_circuit/IC in contents)
-			IC.external_examine(user)
-	//	for(var/obj/item/integrated_circuit/output/screen/S in contents)
-	//		if(S.stuff_to_display)
-	//			to_chat(user, "There's a little screen labeled '[S.name]', which displays '[S.stuff_to_display]'.")
+			. += IC.external_examine(user)
 		if(opened)
 			interact(user)
 

--- a/code/modules/integrated_electronics/core/assemblies/clothing.dm
+++ b/code/modules/integrated_electronics/core/assemblies/clothing.dm
@@ -47,9 +47,9 @@
 	..()
 
 /obj/item/clothing/examine(mob/user)
+	. = ..()
 	if(IC)
-		IC.examine(user)
-	..()
+		. += IC.examine(user)
 
 /obj/item/clothing/CtrlShiftClick(mob/user)
 	var/turf/T = get_turf(src)

--- a/code/modules/integrated_electronics/core/assemblies/device.dm
+++ b/code/modules/integrated_electronics/core/assemblies/device.dm
@@ -46,10 +46,10 @@
 		return
 
 /obj/item/device/assembly/electronic_assembly/examine(mob/user)
-	.=..(user, 1)
+	. = ..()
 	if(EA)
 		for(var/obj/item/integrated_circuit/IC in EA.contents)
-			IC.external_examine(user)
+			. += IC.external_examine(user)
 
 /obj/item/device/assembly/electronic_assembly/verb/toggle()
 	set src in usr

--- a/code/modules/integrated_electronics/core/integrated_circuit.dm
+++ b/code/modules/integrated_electronics/core/integrated_circuit.dm
@@ -4,28 +4,29 @@ a creative player the means to solve many problems.  Circuits are held inside an
 */
 
 /obj/item/integrated_circuit/examine(mob/user)
-	interact(user)
-	external_examine(user)
 	. = ..()
+	. += external_examine(user)
+	interact(user)
 
 // This should be used when someone is examining while the case is opened.
 /obj/item/integrated_circuit/proc/internal_examine(mob/user)
-	to_chat(user, "This board has [inputs.len] input pin\s, [outputs.len] output pin\s and [activators.len] activation pin\s.")
+	. = list()
+	. += "This board has [inputs.len] input pin\s, [outputs.len] output pin\s and [activators.len] activation pin\s."
 	for(var/datum/integrated_io/I in inputs)
 		if(I.linked.len)
-			to_chat(user, "The '[I]' is connected to [I.get_linked_to_desc()].")
+			. += "The '[I]' is connected to [I.get_linked_to_desc()]."
 	for(var/datum/integrated_io/O in outputs)
 		if(O.linked.len)
-			to_chat(user, "The '[O]' is connected to [O.get_linked_to_desc()].")
+			. += "The '[O]' is connected to [O.get_linked_to_desc()]."
 	for(var/datum/integrated_io/activate/A in activators)
 		if(A.linked.len)
-			to_chat(user, "The '[A]' is connected to [A.get_linked_to_desc()].")
-	any_examine(user)
+			. += "The '[A]' is connected to [A.get_linked_to_desc()]."
+	. += any_examine(user)
 	interact(user)
 
 // This should be used when someone is examining from an 'outside' perspective, e.g. reading a screen or LED.
 /obj/item/integrated_circuit/proc/external_examine(mob/user)
-	any_examine(user)
+	return any_examine(user)
 
 /obj/item/integrated_circuit/proc/any_examine(mob/user)
 	return

--- a/code/modules/integrated_electronics/subtypes/memory.dm
+++ b/code/modules/integrated_electronics/subtypes/memory.dm
@@ -19,7 +19,7 @@
 	..()
 
 /obj/item/integrated_circuit/memory/examine(mob/user)
-	..()
+	. = ..()
 	var/i
 	for(i = 1, i <= outputs.len, i++)
 		var/datum/integrated_io/O = outputs[i]
@@ -30,7 +30,7 @@
 				data = "[d]"
 		else if(!isnull(O.data))
 			data = O.data
-		to_chat(user, "\The [src] has [data] saved to address [i].")
+		. += "\The [src] has [data] saved to address [i]."
 
 /obj/item/integrated_circuit/memory/do_work()
 	for(var/i = 1 to inputs.len)

--- a/code/modules/integrated_electronics/subtypes/output.dm
+++ b/code/modules/integrated_electronics/subtypes/output.dm
@@ -20,7 +20,7 @@
 	stuff_to_display = null
 
 /obj/item/integrated_circuit/output/screen/any_examine(mob/user)
-	to_chat(user, "There is a little screen labeled '[name]', which displays [!isnull(stuff_to_display) ? "'[stuff_to_display]'" : "nothing"].")
+	return "There is a little screen labeled '[name]', which displays [!isnull(stuff_to_display) ? "'[stuff_to_display]'" : "nothing"]."
 
 /obj/item/integrated_circuit/output/screen/do_work()
 	var/datum/integrated_io/I = inputs[1]
@@ -333,7 +333,7 @@
 	else
 		text_output += "\an ["\improper[initial_name]"] labeled '[name]'"
 	text_output += " which is currently [get_pin_data(IC_INPUT, 1) ? "lit <font color=[led_color]>¤</font>" : "unlit."]"
-	to_chat(user,jointext(text_output,null))
+	return jointext(text_output,null)
 
 /obj/item/integrated_circuit/output/led/red
 	name = "red LED"

--- a/code/modules/library/lib_machines.dm
+++ b/code/modules/library/lib_machines.dm
@@ -470,6 +470,7 @@ datum/borrowbook // Datum used to keep track of who has borrowed what when and f
  */
 /obj/machinery/libraryscanner
 	name = "scanner"
+	desc = "A scanner for scanning in books and papers."
 	icon = 'icons/obj/library.dmi'
 	icon_state = "bigscanner"
 	anchored = 1

--- a/code/modules/mining/fulton.dm
+++ b/code/modules/mining/fulton.dm
@@ -14,7 +14,7 @@ var/global/list/total_extraction_beacons = list()
 
 /obj/item/extraction_pack/examine()
 	. = ..()
-	usr.show_message("It has [uses_left] use\s remaining.", 1)
+	. += "It has [uses_left] use\s remaining."
 
 /obj/item/extraction_pack/attack_self(mob/user)
 	var/list/possible_beacons = list()

--- a/code/modules/mining/ore_box.dm
+++ b/code/modules/mining/ore_box.dm
@@ -39,26 +39,24 @@
 			stored_ore[O.name] = 1
 
 /obj/structure/ore_box/examine(mob/user)
-	to_chat(user, "That's an [src].")
-	to_chat(user, desc)
+	. = ..()
 
 	if(!Adjacent(user)) //Can only check the contents of ore boxes if you can physically reach them.
-		return
+		return .
 
 	add_fingerprint(user)
 
 	if(!contents.len)
-		to_chat(user, "It is empty.")
-		return
+		. += "It is empty."
+		return .
 
 	if(world.time > last_update + 10)
 		update_ore_count()
 		last_update = world.time
 
-	to_chat(user, "It holds:")
+	. += "It holds:"
 	for(var/ore in stored_ore)
-		to_chat(user, "- [stored_ore[ore]] [ore]")
-	return
+		. += "- [stored_ore[ore]] [ore]"
 
 /obj/structure/ore_box/verb/empty_box()
 	set name = "Empty Ore Box"

--- a/code/modules/mining/ore_redemption_machine/mine_point_items.dm
+++ b/code/modules/mining/ore_redemption_machine/mine_point_items.dm
@@ -38,9 +38,9 @@
 	..()
 
 /obj/item/weapon/card/mining_point_card/examine(mob/user)
-	..(user)
-	to_chat(user, "There's [mine_points] excavation points on the card.")
-	to_chat(user, "There's [survey_points] survey points on the card.")
+	. = ..()
+	. += "There's [mine_points] excavation points on the card."
+	. += "There's [survey_points] survey points on the card."
 
 /obj/item/weapon/card/mining_point_card/survey
 	mine_points = 0

--- a/code/modules/mob/living/carbon/brain/MMI.dm
+++ b/code/modules/mob/living/carbon/brain/MMI.dm
@@ -196,24 +196,20 @@
 	return	//Doesn't do anything right now because none of the things that can be done to a regular MMI make any sense for these
 
 /obj/item/device/mmi/digital/examine(mob/user)
-	if(!..(user))
-		return
-
-	var/msg = "<span class='info'>*---------*</span>\nThis is [bicon(src)] \a <EM>[src]</EM>!\n[desc]\n"
-	msg += "<span class='warning'>"
+	. = ..()
 
 	if(src.brainmob && src.brainmob.key)
 		switch(src.brainmob.stat)
 			if(CONSCIOUS)
-				if(!src.brainmob.client)	msg += "It appears to be in stand-by mode.\n" //afk
-			if(UNCONSCIOUS)		msg += "<span class='warning'>It doesn't seem to be responsive.</span>\n"
-			if(DEAD)			msg += "<span class='deadsay'>It appears to be completely inactive.</span>\n"
+				if(!src.brainmob.client)
+					. += "<span class='warning'>It appears to be in stand-by mode.</span>" //afk
+			if(UNCONSCIOUS)
+				. += "<span class='warning'>It doesn't seem to be responsive.</span>"
+			if(DEAD)
+				. += "<span class='deadsay'>It appears to be completely inactive.</span>"
 	else
-		msg += "<span class='deadsay'>It appears to be completely inactive.</span>\n"
-	msg += "</span><span class='info'>*---------*</span>"
-	to_chat(user,msg)
-	return
-
+		. += "<span class='deadsay'>It appears to be completely inactive.</span>"
+		
 /obj/item/device/mmi/digital/emp_act(severity)
 	if(!src.brainmob)
 		return

--- a/code/modules/mob/living/carbon/brain/posibrain.dm
+++ b/code/modules/mob/living/carbon/brain/posibrain.dm
@@ -85,25 +85,6 @@
 		M.show_message("<font color='blue'>The positronic brain buzzes and beeps, and the golden lights fade away. Perhaps you could try again?</font>")
 	playsound(src, 'sound/misc/buzzbeep.ogg', 50, 1)
 
-/obj/item/device/mmi/digital/posibrain/examine(mob/user)
-	if(!..(user))
-		return
-
-	var/msg = "<span class='info'>*---------*</span>\nThis is [bicon(src)] \a <EM>[src]</EM>!\n[desc]\n"
-	msg += "<span class='warning'>"
-
-	if(src.brainmob && src.brainmob.key)
-		switch(src.brainmob.stat)
-			if(CONSCIOUS)
-				if(!src.brainmob.client)	msg += "It appears to be in stand-by mode.\n" //afk
-			if(UNCONSCIOUS)		msg += "<span class='warning'>It doesn't seem to be responsive.</span>\n"
-			if(DEAD)			msg += "<span class='deadsay'>It appears to be completely inactive.</span>\n"
-	else
-		msg += "<span class='deadsay'>It appears to be completely inactive.</span>\n"
-	msg += "</span><span class='info'>*---------*</span>"
-	to_chat(user,msg)
-	return
-
 /obj/item/device/mmi/digital/posibrain/emp_act(severity)
 	if(!src.brainmob)
 		return

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -1,10 +1,11 @@
 /mob/living/carbon/human/examine(mob/user)
+	// . = ..() //Note that we don't call parent. We build the list by ourselves.
+
 	var/skip_gear = 0
 	var/skip_body = 0
 
 	if(alpha <= EFFECTIVE_INVIS)
-		src.loc.examine(user)
-		return
+		return src.loc.examine(user) // Returns messages as if they examined wherever the human was
 
 	var/looks_synth = looksSynthetic()
 
@@ -75,12 +76,6 @@
 		BP_L_LEG = skip_body & EXAMINE_SKIPLEGS,
 		BP_R_LEG = skip_body & EXAMINE_SKIPLEGS)
 
-	var/list/msg = list("<span class='info'>*---------*<br>This is ")
-
-	msg += "[bicon(src)] " //fucking BYOND: this should stop dreamseeker crashing if we -somehow- examine somebody before their icon is generated
-
-	msg += "<EM>[src.name]</EM>"
-
 	var/datum/gender/T = gender_datums[get_visible_gender()]
 
 	if((skip_gear & EXAMINE_SKIPJUMPSUIT) && (skip_body & EXAMINE_SKIPFACE)) //big suits/masks/helmets make it hard to tell their gender
@@ -98,6 +93,7 @@
 		// Just in case someone VVs the gender to something strange. It'll runtime anyway when it hits usages, better to CRASH() now with a helpful message.
 		CRASH("Gender datum was null; key was '[((skip_gear & EXAMINE_SKIPJUMPSUIT) && (skip_body & EXAMINE_SKIPFACE)) ? PLURAL : gender]'")
 
+	var/name_ender = ""
 	if(!((skip_gear & EXAMINE_SKIPJUMPSUIT) && (skip_body & EXAMINE_SKIPFACE)))
 		if(looks_synth)
 			var/use_gender = "a synthetic"
@@ -106,16 +102,12 @@
 			else if(gender == FEMALE)
 				use_gender = "a gynoid"
 
-			msg += ", <b><font color='#555555'>[use_gender]!</font></b>"
+			name_ender = ", <b><font color='#555555'>[use_gender]!</font></b>[species.get_additional_examine_text(src)]"
 
 		else if(species.name != "Human")
-			msg += ", <b><font color='[species.get_flesh_colour(src)]'>\a [species.get_examine_name()]!</font></b>"
+			name_ender = ", <b><font color='[species.get_flesh_colour(src)]'>\a [species.get_examine_name()]!</font></b>[species.get_additional_examine_text(src)]"
 
-	var/extra_species_text = species.get_additional_examine_text(src)
-	if(extra_species_text)
-		msg += "[extra_species_text]"
-
-	msg += "<br>"
+	var/list/msg = list("<span class='info'>*---------*","This is [bicon(src)] <EM>[src.name]</EM>[name_ender]")
 
 	//uniform
 	if(w_uniform && !(skip_gear & EXAMINE_SKIPJUMPSUIT) && w_uniform.show_examine)
@@ -138,16 +130,16 @@
 					tie_msg += " Attached to it is [english_list(accessories_visible)]."
 
 		if(w_uniform.blood_DNA)
-			msg += "<span class='warning'>[T.He] [T.is] wearing [bicon(w_uniform)] [w_uniform.gender==PLURAL?"some":"a"] [(w_uniform.blood_color != SYNTH_BLOOD_COLOUR) ? "blood" : "oil"]-stained [w_uniform.name]![tie_msg]</span><br>"
+			msg += "<span class='warning'>[T.He] [T.is] wearing [bicon(w_uniform)] [w_uniform.gender==PLURAL?"some":"a"] [(w_uniform.blood_color != SYNTH_BLOOD_COLOUR) ? "blood" : "oil"]-stained [w_uniform.name]![tie_msg]</span>"
 		else
-			msg += "[T.He] [T.is] wearing [bicon(w_uniform)] \a [w_uniform].[tie_msg]<br>"
+			msg += "[T.He] [T.is] wearing [bicon(w_uniform)] \a [w_uniform].[tie_msg]"
 
 	//head
 	if(head && !(skip_gear & EXAMINE_SKIPHELMET) && head.show_examine)
 		if(head.blood_DNA)
-			msg += "<span class='warning'>[T.He] [T.is] wearing [bicon(head)] [head.gender==PLURAL?"some":"a"] [(head.blood_color != SYNTH_BLOOD_COLOUR) ? "blood" : "oil"]-stained [head.name] on [T.his] head!</span><br>"
+			msg += "<span class='warning'>[T.He] [T.is] wearing [bicon(head)] [head.gender==PLURAL?"some":"a"] [(head.blood_color != SYNTH_BLOOD_COLOUR) ? "blood" : "oil"]-stained [head.name] on [T.his] head!</span>"
 		else
-			msg += "[T.He] [T.is] wearing [bicon(head)] \a [head] on [T.his] head.<br>"
+			msg += "[T.He] [T.is] wearing [bicon(head)] \a [head] on [T.his] head."
 
 	//suit/armour
 	if(wear_suit)
@@ -158,73 +150,73 @@
 				tie_msg += " Attached to it is [english_list(U.accessories)]."
 
 		if(wear_suit.blood_DNA)
-			msg += "<span class='warning'>[T.He] [T.is] wearing [bicon(wear_suit)] [wear_suit.gender==PLURAL?"some":"a"] [(wear_suit.blood_color != SYNTH_BLOOD_COLOUR) ? "blood" : "oil"]-stained [wear_suit.name][tie_msg]!</span><br>"
+			msg += "<span class='warning'>[T.He] [T.is] wearing [bicon(wear_suit)] [wear_suit.gender==PLURAL?"some":"a"] [(wear_suit.blood_color != SYNTH_BLOOD_COLOUR) ? "blood" : "oil"]-stained [wear_suit.name][tie_msg]!</span>"
 		else
-			msg += "[T.He] [T.is] wearing [bicon(wear_suit)] \a [wear_suit].[tie_msg]<br>"
+			msg += "[T.He] [T.is] wearing [bicon(wear_suit)] \a [wear_suit].[tie_msg]"
 
 		//suit/armour storage
 		if(s_store && !(skip_gear & EXAMINE_SKIPSUITSTORAGE) && s_store.show_examine)
 			if(s_store.blood_DNA)
-				msg += "<span class='warning'>[T.He] [T.is] carrying [bicon(s_store)] [s_store.gender==PLURAL?"some":"a"] [(s_store.blood_color != SYNTH_BLOOD_COLOUR) ? "blood" : "oil"]-stained [s_store.name] on [T.his] [wear_suit.name]!</span><br>"
+				msg += "<span class='warning'>[T.He] [T.is] carrying [bicon(s_store)] [s_store.gender==PLURAL?"some":"a"] [(s_store.blood_color != SYNTH_BLOOD_COLOUR) ? "blood" : "oil"]-stained [s_store.name] on [T.his] [wear_suit.name]!</span>"
 			else
-				msg += "[T.He] [T.is] carrying [bicon(s_store)] \a [s_store] on [T.his] [wear_suit.name].<br>"
+				msg += "[T.He] [T.is] carrying [bicon(s_store)] \a [s_store] on [T.his] [wear_suit.name]."
 
 	//back
 	if(back && !(skip_gear & EXAMINE_SKIPBACKPACK) && back.show_examine)
 		if(back.blood_DNA)
-			msg += "<span class='warning'>[T.He] [T.has] [bicon(back)] [back.gender==PLURAL?"some":"a"] [(back.blood_color != SYNTH_BLOOD_COLOUR) ? "blood" : "oil"]-stained [back] on [T.his] back.</span><br>"
+			msg += "<span class='warning'>[T.He] [T.has] [bicon(back)] [back.gender==PLURAL?"some":"a"] [(back.blood_color != SYNTH_BLOOD_COLOUR) ? "blood" : "oil"]-stained [back] on [T.his] back.</span>"
 		else
-			msg += "[T.He] [T.has] [bicon(back)] \a [back] on [T.his] back.<br>"
+			msg += "[T.He] [T.has] [bicon(back)] \a [back] on [T.his] back."
 
 	//left hand
 	if(l_hand && l_hand.show_examine)
 		if(l_hand.blood_DNA)
-			msg += "<span class='warning'>[T.He] [T.is] holding [bicon(l_hand)] [l_hand.gender==PLURAL?"some":"a"] [(l_hand.blood_color != SYNTH_BLOOD_COLOUR) ? "blood" : "oil"]-stained [l_hand.name] in [T.his] left hand!</span><br>"
+			msg += "<span class='warning'>[T.He] [T.is] holding [bicon(l_hand)] [l_hand.gender==PLURAL?"some":"a"] [(l_hand.blood_color != SYNTH_BLOOD_COLOUR) ? "blood" : "oil"]-stained [l_hand.name] in [T.his] left hand!</span>"
 		else
-			msg += "[T.He] [T.is] holding [bicon(l_hand)] \a [l_hand] in [T.his] left hand.<br>"
+			msg += "[T.He] [T.is] holding [bicon(l_hand)] \a [l_hand] in [T.his] left hand."
 
 	//right hand
 	if(r_hand && r_hand.show_examine)
 		if(r_hand.blood_DNA)
-			msg += "<span class='warning'>[T.He] [T.is] holding [bicon(r_hand)] [r_hand.gender==PLURAL?"some":"a"] [(r_hand.blood_color != SYNTH_BLOOD_COLOUR) ? "blood" : "oil"]-stained [r_hand.name] in [T.his] right hand!</span><br>"
+			msg += "<span class='warning'>[T.He] [T.is] holding [bicon(r_hand)] [r_hand.gender==PLURAL?"some":"a"] [(r_hand.blood_color != SYNTH_BLOOD_COLOUR) ? "blood" : "oil"]-stained [r_hand.name] in [T.his] right hand!</span>"
 		else
-			msg += "[T.He] [T.is] holding [bicon(r_hand)] \a [r_hand] in [T.his] right hand.<br>"
+			msg += "[T.He] [T.is] holding [bicon(r_hand)] \a [r_hand] in [T.his] right hand."
 
 	//gloves
 	if(gloves && !(skip_gear & EXAMINE_SKIPGLOVES) && gloves.show_examine)
 		if(gloves.blood_DNA)
-			msg += "<span class='warning'>[T.He] [T.has] [bicon(gloves)] [gloves.gender==PLURAL?"some":"a"] [(gloves.blood_color != SYNTH_BLOOD_COLOUR) ? "blood" : "oil"]-stained [gloves.name] on [T.his] hands!</span><br>"
+			msg += "<span class='warning'>[T.He] [T.has] [bicon(gloves)] [gloves.gender==PLURAL?"some":"a"] [(gloves.blood_color != SYNTH_BLOOD_COLOUR) ? "blood" : "oil"]-stained [gloves.name] on [T.his] hands!</span>"
 		else
-			msg += "[T.He] [T.has] [bicon(gloves)] \a [gloves] on [T.his] hands.<br>"
+			msg += "[T.He] [T.has] [bicon(gloves)] \a [gloves] on [T.his] hands."
 	else if(blood_DNA && !(skip_body & EXAMINE_SKIPHANDS))
-		msg += "<span class='warning'>[T.He] [T.has] [(hand_blood_color != SYNTH_BLOOD_COLOUR) ? "blood" : "oil"]-stained hands!</span><br>"
+		msg += "<span class='warning'>[T.He] [T.has] [(hand_blood_color != SYNTH_BLOOD_COLOUR) ? "blood" : "oil"]-stained hands!</span>"
 
 	//handcuffed?
 	if(handcuffed && handcuffed.show_examine)
 		if(istype(handcuffed, /obj/item/weapon/handcuffs/cable))
-			msg += "<span class='warning'>[T.He] [T.is] [bicon(handcuffed)] restrained with cable!</span><br>"
+			msg += "<span class='warning'>[T.He] [T.is] [bicon(handcuffed)] restrained with cable!</span>"
 		else
-			msg += "<span class='warning'>[T.He] [T.is] [bicon(handcuffed)] handcuffed!</span><br>"
+			msg += "<span class='warning'>[T.He] [T.is] [bicon(handcuffed)] handcuffed!</span>"
 
 	//buckled
 	if(buckled)
-		msg += "<span class='warning'>[T.He] [T.is] [bicon(buckled)] buckled to [buckled]!</span><br>"
+		msg += "<span class='warning'>[T.He] [T.is] [bicon(buckled)] buckled to [buckled]!</span>"
 
 	//belt
 	if(belt && !(skip_gear & EXAMINE_SKIPBELT) && belt.show_examine)
 		if(belt.blood_DNA)
-			msg += "<span class='warning'>[T.He] [T.has] [bicon(belt)] [belt.gender==PLURAL?"some":"a"] [(belt.blood_color != SYNTH_BLOOD_COLOUR) ? "blood" : "oil"]-stained [belt.name] about [T.his] waist!</span><br>"
+			msg += "<span class='warning'>[T.He] [T.has] [bicon(belt)] [belt.gender==PLURAL?"some":"a"] [(belt.blood_color != SYNTH_BLOOD_COLOUR) ? "blood" : "oil"]-stained [belt.name] about [T.his] waist!</span>"
 		else
-			msg += "[T.He] [T.has] [bicon(belt)] \a [belt] about [T.his] waist.<br>"
+			msg += "[T.He] [T.has] [bicon(belt)] \a [belt] about [T.his] waist."
 
 	//shoes
 	if(shoes && !(skip_gear & EXAMINE_SKIPSHOES) && shoes.show_examine)
 		if(shoes.blood_DNA)
-			msg += "<span class='warning'>[T.He] [T.is] wearing [bicon(shoes)] [shoes.gender==PLURAL?"some":"a"] [(shoes.blood_color != SYNTH_BLOOD_COLOUR) ? "blood" : "oil"]-stained [shoes.name] on [T.his] feet!</span><br>"
+			msg += "<span class='warning'>[T.He] [T.is] wearing [bicon(shoes)] [shoes.gender==PLURAL?"some":"a"] [(shoes.blood_color != SYNTH_BLOOD_COLOUR) ? "blood" : "oil"]-stained [shoes.name] on [T.his] feet!</span>"
 		else
-			msg += "[T.He] [T.is] wearing [bicon(shoes)] \a [shoes] on [T.his] feet.<br>"
+			msg += "[T.He] [T.is] wearing [bicon(shoes)] \a [shoes] on [T.his] feet."
 	else if(feet_blood_DNA && !(skip_body & EXAMINE_SKIPHANDS))
-		msg += "<span class='warning'>[T.He] [T.has] [(feet_blood_color != SYNTH_BLOOD_COLOUR) ? "blood" : "oil"]-stained feet!</span><br>"
+		msg += "<span class='warning'>[T.He] [T.has] [(feet_blood_color != SYNTH_BLOOD_COLOUR) ? "blood" : "oil"]-stained feet!</span>"
 
 	//mask
 	if(wear_mask && !(skip_gear & EXAMINE_SKIPMASK) && wear_mask.show_examine)
@@ -233,24 +225,24 @@
 			descriptor = "in [T.his] mouth"
 
 		if(wear_mask.blood_DNA)
-			msg += "<span class='warning'>[T.He] [T.has] [bicon(wear_mask)] [wear_mask.gender==PLURAL?"some":"a"] [(wear_mask.blood_color != SYNTH_BLOOD_COLOUR) ? "blood" : "oil"]-stained [wear_mask.name] [descriptor]!</span><br>"
+			msg += "<span class='warning'>[T.He] [T.has] [bicon(wear_mask)] [wear_mask.gender==PLURAL?"some":"a"] [(wear_mask.blood_color != SYNTH_BLOOD_COLOUR) ? "blood" : "oil"]-stained [wear_mask.name] [descriptor]!</span>"
 		else
-			msg += "[T.He] [T.has] [bicon(wear_mask)] \a [wear_mask] [descriptor].<br>"
+			msg += "[T.He] [T.has] [bicon(wear_mask)] \a [wear_mask] [descriptor]."
 
 	//eyes
 	if(glasses && !(skip_gear & EXAMINE_SKIPEYEWEAR) && glasses.show_examine)
 		if(glasses.blood_DNA)
-			msg += "<span class='warning'>[T.He] [T.has] [bicon(glasses)] [glasses.gender==PLURAL?"some":"a"] [(glasses.blood_color != SYNTH_BLOOD_COLOUR) ? "blood" : "oil"]-stained [glasses] covering [T.his] eyes!</span><br>"
+			msg += "<span class='warning'>[T.He] [T.has] [bicon(glasses)] [glasses.gender==PLURAL?"some":"a"] [(glasses.blood_color != SYNTH_BLOOD_COLOUR) ? "blood" : "oil"]-stained [glasses] covering [T.his] eyes!</span>"
 		else
-			msg += "[T.He] [T.has] [bicon(glasses)] \a [glasses] covering [T.his] eyes.<br>"
+			msg += "[T.He] [T.has] [bicon(glasses)] \a [glasses] covering [T.his] eyes."
 
 	//left ear
 	if(l_ear && !(skip_gear & EXAMINE_SKIPEARS) && l_ear.show_examine)
-		msg += "[T.He] [T.has] [bicon(l_ear)] \a [l_ear] on [T.his] left ear.<br>"
+		msg += "[T.He] [T.has] [bicon(l_ear)] \a [l_ear] on [T.his] left ear."
 
 	//right ear
 	if(r_ear && !(skip_gear & EXAMINE_SKIPEARS) && r_ear.show_examine)
-		msg += "[T.He] [T.has] [bicon(r_ear)] \a [r_ear] on [T.his] right ear.<br>"
+		msg += "[T.He] [T.has] [bicon(r_ear)] \a [r_ear] on [T.his] right ear."
 
 	//ID
 	if(wear_id && wear_id.show_examine)
@@ -262,35 +254,35 @@
 			var/obj/item/weapon/card/id/idcard = wear_id
 			id = idcard.registered_name
 		if(id && (id != real_name) && (get_dist(src, usr) <= 1) && prob(10))
-			msg += "<span class='warning'>[T.He] [T.is] wearing [bicon(wear_id)] \a [wear_id] yet something doesn't seem right...</span><br>"
+			msg += "<span class='warning'>[T.He] [T.is] wearing [bicon(wear_id)] \a [wear_id] yet something doesn't seem right...</span>"
 		else*/
-		msg += "[T.He] [T.is] wearing [bicon(wear_id)] \a [wear_id].<br>"
+		msg += "[T.He] [T.is] wearing [bicon(wear_id)] \a [wear_id]."
 
 	//Jitters
 	if(is_jittery)
 		if(jitteriness >= 300)
-			msg += "<span class='warning'><B>[T.He] [T.is] convulsing violently!</B></span><br>"
+			msg += "<span class='warning'><B>[T.He] [T.is] convulsing violently!</B></span>"
 		else if(jitteriness >= 200)
-			msg += "<span class='warning'>[T.He] [T.is] extremely jittery.</span><br>"
+			msg += "<span class='warning'>[T.He] [T.is] extremely jittery.</span>"
 		else if(jitteriness >= 100)
-			msg += "<span class='warning'>[T.He] [T.is] twitching ever so slightly.</span><br>"
+			msg += "<span class='warning'>[T.He] [T.is] twitching ever so slightly.</span>"
 
 	//splints
 	for(var/organ in BP_ALL)
 		var/obj/item/organ/external/o = get_organ(organ)
 		if(o && o.splinted && o.splinted.loc == o)
-			msg += "<span class='warning'>[T.He] [T.has] \a [o.splinted] on [T.his] [o.name]!</span><br>"
+			msg += "<span class='warning'>[T.He] [T.has] \a [o.splinted] on [T.his] [o.name]!</span>"
 
 	if(suiciding)
-		msg += "<span class='warning'>[T.He] appears to have commited suicide... there is no hope of recovery.</span><br>"
+		msg += "<span class='warning'>[T.He] appears to have commited suicide... there is no hope of recovery.</span>"
 
 	if(mSmallsize in mutations)
-		msg += "[T.He] [T.is] very short!<br>"
+		msg += "[T.He] [T.is] very short!"
 
 	if (src.stat)
-		msg += "<span class='warning'>[T.He] [T.is]n't responding to anything around [T.him] and seems to be asleep.</span><br>"
+		msg += "<span class='warning'>[T.He] [T.is]n't responding to anything around [T.him] and seems to be asleep.</span>"
 		if((stat == 2 || src.losebreath) && get_dist(user, src) <= 3)
-			msg += "<span class='warning'>[T.He] [T.does] not appear to be breathing.</span><br>"
+			msg += "<span class='warning'>[T.He] [T.does] not appear to be breathing.</span>"
 		if(istype(user, /mob/living/carbon/human) && !user.stat && Adjacent(user))
 			user.visible_message("<b>[usr]</b> checks [src]'s pulse.", "You check [src]'s pulse.")
 		spawn(15)
@@ -301,16 +293,16 @@
 					to_chat(user, "<span class='deadsay'>[T.He] [T.has] a pulse!</span>")
 
 	if(fire_stacks)
-		msg += "[T.He] [T.is] covered in some liquid.<br>"
+		msg += "[T.He] [T.is] covered in some liquid."
 	if(on_fire)
-		msg += "<span class='warning'>[T.He] [T.is] on fire!.</span><br>"
+		msg += "<span class='warning'>[T.He] [T.is] on fire!.</span>"
 
 	var/ssd_msg = species.get_ssd(src)
 	if(ssd_msg && (!should_have_organ("brain") || has_brain()) && stat != DEAD)
 		if(!key)
-			msg += "<span class='deadsay'>[T.He] [T.is] [ssd_msg]. It doesn't look like [T.he] [T.is] waking up anytime soon.</span><br>"
+			msg += "<span class='deadsay'>[T.He] [T.is] [ssd_msg]. It doesn't look like [T.he] [T.is] waking up anytime soon.</span>"
 		else if(!client)
-			msg += "<span class='deadsay'>[T.He] [T.is] [ssd_msg].</span><br>"
+			msg += "<span class='deadsay'>[T.He] [T.is] [ssd_msg].</span>"
 
 	var/list/wound_flavor_text = list()
 	var/list/is_bleeding = list()
@@ -323,9 +315,9 @@
 
 		var/obj/item/organ/external/E = organs_by_name[organ_tag]
 		if(!E)
-			wound_flavor_text["[organ_descriptor]"] = "<span class='warning'><b>[T.He] [T.is] missing [T.his] [organ_descriptor].</b></span><br>"
+			wound_flavor_text["[organ_descriptor]"] = "<span class='warning'><b>[T.He] [T.is] missing [T.his] [organ_descriptor].</b></span>"
 		else if(E.is_stump())
-			wound_flavor_text["[organ_descriptor]"] = "<span class='warning'><b>[T.He] [T.has] a stump where [T.his] [organ_descriptor] should be.</b></span><br>"
+			wound_flavor_text["[organ_descriptor]"] = "<span class='warning'><b>[T.He] [T.has] a stump where [T.his] [organ_descriptor] should be.</b></span>"
 		else
 			continue
 
@@ -334,47 +326,51 @@
 			if((temp.organ_tag in hidden) && hidden[temp.organ_tag])
 				continue //Organ is hidden, don't talk about it
 			if(temp.status & ORGAN_DESTROYED)
-				wound_flavor_text["[temp.name]"] = "<span class='warning'><b>[T.He] [T.is] missing [T.his] [temp.name].</b></span><br>"
+				wound_flavor_text["[temp.name]"] = "<span class='warning'><b>[T.He] [T.is] missing [T.his] [temp.name].</b></span>"
 				continue
 
 			if(!looks_synth && temp.robotic == ORGAN_ROBOT)
 				if(!(temp.brute_dam + temp.burn_dam))
-					wound_flavor_text["[temp.name]"] = "[T.He] [T.has] a [temp.name].<br>"
+					wound_flavor_text["[temp.name]"] = "[T.He] [T.has] a [temp.name]."
 				else
-					wound_flavor_text["[temp.name]"] = "<span class='warning'>[T.He] [T.has] a [temp.name] with [temp.get_wounds_desc()]!</span><br>"
+					wound_flavor_text["[temp.name]"] = "<span class='warning'>[T.He] [T.has] a [temp.name] with [temp.get_wounds_desc()]!</span>"
 				continue
 			else if(temp.wounds.len > 0 || temp.open)
 				if(temp.is_stump() && temp.parent_organ && organs_by_name[temp.parent_organ])
 					var/obj/item/organ/external/parent = organs_by_name[temp.parent_organ]
-					wound_flavor_text["[temp.name]"] = "<span class='warning'>[T.He] has [temp.get_wounds_desc()] on [T.his] [parent.name].</span><br>"
+					wound_flavor_text["[temp.name]"] = "<span class='warning'>[T.He] has [temp.get_wounds_desc()] on [T.his] [parent.name].</span>"
 				else
-					wound_flavor_text["[temp.name]"] = "<span class='warning'>[T.He] has [temp.get_wounds_desc()] on [T.his] [temp.name].</span><br>"
+					wound_flavor_text["[temp.name]"] = "<span class='warning'>[T.He] has [temp.get_wounds_desc()] on [T.his] [temp.name].</span>"
 			else
 				wound_flavor_text["[temp.name]"] = ""
 			if(temp.dislocated == 2)
-				wound_flavor_text["[temp.name]"] += "<span class='warning'>[T.His] [temp.joint] is dislocated!</span><br>"
+				wound_flavor_text["[temp.name]"] += "<span class='warning'>[T.His] [temp.joint] is dislocated!</span>"
 			if(temp.brute_dam > temp.min_broken_damage || (temp.status & (ORGAN_BROKEN | ORGAN_MUTATED)))
-				wound_flavor_text["[temp.name]"] += "<span class='warning'>[T.His] [temp.name] is dented and swollen!</span><br>"
+				wound_flavor_text["[temp.name]"] += "<span class='warning'>[T.His] [temp.name] is dented and swollen!</span>"
 
 			if(temp.germ_level > INFECTION_LEVEL_TWO && !(temp.status & ORGAN_DEAD))
-				wound_flavor_text["[temp.name]"] += "<span class='warning'>[T.His] [temp.name] looks very infected!</span><br>"
+				wound_flavor_text["[temp.name]"] += "<span class='warning'>[T.His] [temp.name] looks very infected!</span>"
 			else if(temp.status & ORGAN_DEAD)
-				wound_flavor_text["[temp.name]"] += "<span class='warning'>[T.His] [temp.name] looks rotten!</span><br>"
+				wound_flavor_text["[temp.name]"] += "<span class='warning'>[T.His] [temp.name] looks rotten!</span>"
 
 			if(temp.status & ORGAN_BLEEDING)
-				is_bleeding["[temp.name]"] += "<span class='danger'>[T.His] [temp.name] is bleeding!</span><br>"
+				is_bleeding["[temp.name]"] += "<span class='danger'>[T.His] [temp.name] is bleeding!</span>"
 
 			if(temp.applied_pressure == src)
-				applying_pressure = "<span class='info'>[T.He] is applying pressure to [T.his] [temp.name].</span><br>"
+				applying_pressure = "<span class='info'>[T.He] is applying pressure to [T.his] [temp.name].</span>"
 
 	for(var/limb in wound_flavor_text)
-		msg += wound_flavor_text[limb]
+		var/flavor = wound_flavor_text[limb]
+		if(flavor)
+			msg += flavor
 	for(var/limb in is_bleeding)
-		msg += is_bleeding[limb]
+		var/blood = is_bleeding[limb]
+		if(blood)
+			msg += blood
 	for(var/implant in get_visible_implants(0))
-		msg += "<span class='danger'>[src] [T.has] \a [implant] sticking out of [T.his] flesh!</span><br>"
+		msg += "<span class='danger'>[src] [T.has] \a [implant] sticking out of [T.his] flesh!</span>"
 	if(digitalcamo)
-		msg += "[T.He] [T.is] repulsively uncanny!<br>"
+		msg += "[T.He] [T.is] repulsively uncanny!"
 
 	if(hasHUD(user,"security"))
 		var/perpname = name
@@ -392,8 +388,8 @@
 			if(R.fields["name"] == perpname)
 				criminal = R.fields["criminal"]
 
-		msg += "<span class = 'deptradio'>Criminal status:</span> <a href='?src=\ref[src];criminal=1'>\[[criminal]\]</a><br>"
-		msg += "<span class = 'deptradio'>Security records:</span> <a href='?src=\ref[src];secrecord=`'>\[View\]</a>  <a href='?src=\ref[src];secrecordadd=`'>\[Add comment\]</a><br>"
+		msg += "<span class='deptradio'>Criminal status:</span> <a href='?src=\ref[src];criminal=1'>\[[criminal]\]</a>"
+		msg += "<span class='deptradio'>Security records:</span> <a href='?src=\ref[src];secrecord=`'>\[View\]</a>  <a href='?src=\ref[src];secrecordadd=`'>\[Add comment\]</a>"
 
 	if(hasHUD(user,"medical"))
 		var/perpname = name
@@ -411,15 +407,17 @@
 			if (R.fields["name"] == perpname)
 				medical = R.fields["p_stat"]
 
-		msg += "<span class = 'deptradio'>Physical status:</span> <a href='?src=\ref[src];medical=1'>\[[medical]\]</a><br>"
-		msg += "<span class = 'deptradio'>Medical records:</span> <a href='?src=\ref[src];medrecord=`'>\[View\]</a> <a href='?src=\ref[src];medrecordadd=`'>\[Add comment\]</a><br>"
+		msg += "<span class='deptradio'>Physical status:</span> <a href='?src=\ref[src];medical=1'>\[[medical]\]</a>"
+		msg += "<span class='deptradio'>Medical records:</span> <a href='?src=\ref[src];medrecord=`'>\[View\]</a> <a href='?src=\ref[src];medrecordadd=`'>\[Add comment\]</a>"
 
 
-	if(print_flavor_text())
-		msg += "[print_flavor_text()]<br>"
+	var/flavor_text = print_flavor_text()
+	if(flavor_text)
+		msg += "[flavor_text]"
 
-	msg += "*---------*</span><br>"
-	msg += applying_pressure
+	msg += "*---------*</span>"
+	if(applying_pressure)
+		msg += applying_pressure
 
 	var/show_descs = show_descriptors_to(user)
 	if(show_descs)
@@ -428,9 +426,9 @@
 	if(pose)
 		if(!findtext(pose, regex("\[.?!]$"))) // Will be zero if the last character is not a member of [.?!]
 			pose = addtext(pose,".") //Makes sure all emotes end with a period.
-		msg += "<br>[T.He] [pose]"
+		msg += "<br>[T.He] [pose]" //<br> intentional, extra gap.
 
-	to_chat(user, jointext(msg, null))
+	return msg
 
 //Helper procedure. Called by /mob/living/carbon/human/examine() and /mob/living/carbon/human/Topic() to determine HUD access to security and medical records.
 /proc/hasHUD(mob/M as mob, hudtype)

--- a/code/modules/mob/living/silicon/ai/examine.dm
+++ b/code/modules/mob/living/silicon/ai/examine.dm
@@ -1,42 +1,39 @@
 /mob/living/silicon/ai/examine(mob/user)
-	if(!..(user))
-		return
+	. = ..()
 
-	var/msg = ""
 	if (src.stat == DEAD)
-		msg += "<span class='deadsay'>It appears to be powered-down.</span>\n"
+		. += "<span class='deadsay'>It appears to be powered-down.</span>"
 	else
-		msg += "<span class='warning'>"
 		if (src.getBruteLoss())
 			if (src.getBruteLoss() < 30)
-				msg += "It looks slightly dented.\n"
+				. += "<span class='warning'>It looks slightly dented.</span>"
 			else
-				msg += "<B>It looks severely dented!</B>\n"
+				. += "<span class='warning'><B>It looks severely dented!</B></span>"
 		if (src.getFireLoss())
 			if (src.getFireLoss() < 30)
-				msg += "It looks slightly charred.\n"
+				. += "<span class='warning'>It looks slightly charred.</span>"
 			else
-				msg += "<B>Its casing is melted and heat-warped!</B>\n"
+				. += "<span class='warning'><B>Its casing is melted and heat-warped!</B></span>"
 		if (src.getOxyLoss() && (aiRestorePowerRoutine != 0 && !APU_power))
 			if (src.getOxyLoss() > 175)
-				msg += "<B>It seems to be running on backup power. Its display is blinking a \"BACKUP POWER CRITICAL\" warning.</B>\n"
+				. += "<span class='warning'><B>It seems to be running on backup power. Its display is blinking a \"BACKUP POWER CRITICAL\" warning.</B></span>"
 			else if(src.getOxyLoss() > 100)
-				msg += "<B>It seems to be running on backup power. Its display is blinking a \"BACKUP POWER LOW\" warning.</B>\n"
+				. += "<span class='warning'><B>It seems to be running on backup power. Its display is blinking a \"BACKUP POWER LOW\" warning.</B></span>"
 			else
-				msg += "It seems to be running on backup power.\n"
+				. += "<span class='warning'>It seems to be running on backup power.</span>"
 
 		if (src.stat == UNCONSCIOUS)
-			msg += "It is non-responsive and displaying the text: \"RUNTIME: Sensory Overload, stack 26/3\".\n"
-		msg += "</span>"
+			. += "<span class='warning'>It is non-responsive and displaying the text: \"RUNTIME: Sensory Overload, stack 26/3\".</span>"
+
 		if(deployed_shell)
-			msg += "The wireless networking light is blinking.\n"
-	msg += "*---------*"
+			. += "The wireless networking light is blinking."
+
+	. += "*---------*"
+	
 	if(hardware && (hardware.owner == src))
-		msg += "<br>"
-		msg += hardware.get_examine_desc()
-	to_chat(user,msg)
+		. += hardware.get_examine_desc()
+	
 	user.showLaws(src)
-	return
 
 /mob/proc/showLaws(var/mob/living/silicon/S)
 	return

--- a/code/modules/mob/living/silicon/pai/examine.dm
+++ b/code/modules/mob/living/silicon/pai/examine.dm
@@ -1,19 +1,17 @@
 /mob/living/silicon/pai/examine(mob/user)
-	..(user, infix = ", personal AI")
+	. = ..(user, infix = ", personal AI")
 
-	var/msg = ""
 	switch(src.stat)
 		if(CONSCIOUS)
-			if(!src.client)	msg += "\nIt appears to be in stand-by mode." //afk
-		if(UNCONSCIOUS)		msg += "\n<span class='warning'>It doesn't seem to be responding.</span>"
-		if(DEAD)			msg += "\n<span class='deadsay'>It looks completely unsalvageable.</span>"
-	msg += "\n*---------*"
+			if(!src.client)	. += "It appears to be in stand-by mode." //afk
+		if(UNCONSCIOUS)		. += "<span class='warning'>It doesn't seem to be responding.</span>"
+		if(DEAD)			. += "<span class='deadsay'>It looks completely unsalvageable.</span>"
+	. += "*---------*"
 
-	if(print_flavor_text()) msg += "\n[print_flavor_text()]\n"
+	if(print_flavor_text()) . += "\n[print_flavor_text()]\n"
 
 	if (pose)
-		if( findtext(pose,".",length(pose)) == 0 && findtext(pose,"!",length(pose)) == 0 && findtext(pose,"?",length(pose)) == 0 )
+		if(!findtext(pose, regex("\[.?!]$"))) // Will be zero if the last character is not a member of [.?!]
 			pose = addtext(pose,".") //Makes sure all emotes end with a period.
-		msg += "\nIt is [pose]"
-
-	to_chat(user,msg)
+		. += "<br>It is [pose]" //Extra <br> intentional
+		

--- a/code/modules/mob/living/silicon/robot/drone/drone_items.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_items.dm
@@ -29,10 +29,10 @@
 	var/force_holder = null //
 
 /obj/item/weapon/gripper/examine(mob/user)
-	..()
+	. = ..()
 	if(wrapped)
-		to_chat(user, "<span class='notice'>\The [src] is holding \the [wrapped].</span>")
-		wrapped.examine(user)
+		. += "<span class='notice'>\The [src] is holding \the [wrapped].</span>"
+		. += wrapped.examine(user)
 
 /obj/item/weapon/gripper/CtrlClick(mob/user)
 	drop_item()

--- a/code/modules/mob/living/silicon/robot/drone/drone_manufacturer.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_manufacturer.dm
@@ -63,9 +63,9 @@
 		visible_message("\The [src] voices a strident beep, indicating a drone chassis is prepared.")
 
 /obj/machinery/drone_fabricator/examine(mob/user)
-	..(user)
+	. = ..()
 	if(produce_drones && drone_progress >= 100 && istype(user,/mob/observer/dead) && config.allow_drone_spawn && count_drones() < config.max_maint_drones)
-		to_chat(user, "<BR><B>A drone is prepared. Select 'Join As Drone' from the Ghost tab to spawn as a maintenance drone.</B>")
+		. += "<br><B>A drone is prepared. Select 'Join As Drone' from the Ghost tab to spawn as a maintenance drone.</B>"
 
 /obj/machinery/drone_fabricator/proc/create_drone(var/client/player)
 

--- a/code/modules/mob/living/silicon/robot/examine.dm
+++ b/code/modules/mob/living/silicon/robot/examine.dm
@@ -1,46 +1,41 @@
 /mob/living/silicon/robot/examine(mob/user)
 	var/custom_infix = custom_name ? ", [modtype] [braintype]" : ""
-	..(user, infix = custom_infix)
+	. = ..(user, infix = custom_infix)
 
-	var/msg = ""
-	msg += "<span class='warning'>"
 	if (src.getBruteLoss())
 		if (src.getBruteLoss() < 75)
-			msg += "It looks slightly dented.\n"
+			. += "<span class='warning'>It looks slightly dented.</span>"
 		else
-			msg += "<B>It looks severely dented!</B>\n"
+			. += "<span class='warning'><B>It looks severely dented!</B></span>"
 	if (src.getFireLoss())
 		if (src.getFireLoss() < 75)
-			msg += "It looks slightly charred.\n"
+			. += "<span class='warning'>It looks slightly charred.</span>"
 		else
-			msg += "<B>It looks severely burnt and heat-warped!</B>\n"
-	msg += "</span>"
+			. += "<span class='warning'><B>It looks severely burnt and heat-warped!</B></span>"
 
 	if(opened)
-		msg += "<span class='warning'>Its cover is open and the power cell is [cell ? "installed" : "missing"].</span>\n"
+		. += "<span class='warning'>Its cover is open and the power cell is [cell ? "installed" : "missing"].</span>"
 	else
-		msg += "Its cover is closed.\n"
+		. += "Its cover is closed."
 
 	if(!has_power)
-		msg += "<span class='warning'>It appears to be running on backup power.</span>\n"
+		. += "<span class='warning'>It appears to be running on backup power.</span>"
 
 	switch(src.stat)
 		if(CONSCIOUS)
 			if(shell)
-				msg += "It appears to be an [deployed ? "active" : "empty"] AI shell.\n"
+				. += "It appears to be an [deployed ? "active" : "empty"] AI shell."
 			else if(!src.client)
-				msg += "It appears to be in stand-by mode.\n" //afk
-		if(UNCONSCIOUS)		msg += "<span class='warning'>It doesn't seem to be responding.</span>\n"
-		if(DEAD)			msg += "<span class='deadsay'>It looks completely unsalvageable.</span>\n"
-	msg += "*---------*"
+				. += "It appears to be in stand-by mode." //afk
+		if(UNCONSCIOUS)		. += "<span class='warning'>It doesn't seem to be responding.</span>"
+		if(DEAD)			. += "<span class='deadsay'>It looks completely unsalvageable.</span>"
+	. += "*---------*"
 
-	if(print_flavor_text()) msg += "\n[print_flavor_text()]\n"
+	if(print_flavor_text()) . += "<br>[print_flavor_text()]"
 
 	if (pose)
-		if( findtext(pose,".",length(pose)) == 0 && findtext(pose,"!",length(pose)) == 0 && findtext(pose,"?",length(pose)) == 0 )
+		if(!findtext(pose, regex("\[.?!]$"))) // Will be zero if the last character is not a member of [.?!]
 			pose = addtext(pose,".") //Makes sure all emotes end with a period.
-		msg += "\nIt is [pose]"
+		. += "<br>It is [pose]" //Extra <br> intentional
 
-	to_chat(user,msg)
 	user.showLaws(src)
-	return

--- a/code/modules/mob/living/silicon/robot/robot_items.dm
+++ b/code/modules/mob/living/silicon/robot/robot_items.dm
@@ -430,10 +430,9 @@
 	max_doors = 5
 
 /obj/item/weapon/inflatable_dispenser/examine(var/mob/user)
-	if(!..(user))
-		return
-	to_chat(user, "It has [stored_walls] wall segment\s and [stored_doors] door segment\s stored.")
-	to_chat(user, "It is set to deploy [mode ? "doors" : "walls"]")
+	. = ..()
+	. += "It has [stored_walls] wall segment\s and [stored_doors] door segment\s stored."
+	. += "It is set to deploy [mode ? "doors" : "walls"]"
 
 /obj/item/weapon/inflatable_dispenser/attack_self()
 	mode = !mode

--- a/code/modules/mob/living/simple_mob/subtypes/animal/pets/parrot.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/pets/parrot.dm
@@ -90,9 +90,9 @@
 		my_headset = null
 
 /mob/living/simple_mob/animal/passive/bird/parrot/examine(mob/user)
-	..()
+	. = ..()
 	if(my_headset)
-		to_chat(user, "It is wearing \a [my_headset].")
+		. += "It is wearing \a [my_headset]."
 
 /mob/living/simple_mob/animal/passive/bird/parrot/Initialize()
 	if(my_headset)

--- a/code/modules/mob/living/simple_mob/subtypes/illusion/illusion.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/illusion/illusion.dm
@@ -41,9 +41,9 @@
 // this is to prevent easy checks from the opposing force.
 /mob/living/simple_mob/illusion/examine(mob/user)
 	if(copying)
-		copying.examine(user)
-		return
-	..()
+		return copying.examine(user)
+	else
+		return list("???")
 
 /mob/living/simple_mob/illusion/bullet_act(obj/item/projectile/P)
 	if(!P)

--- a/code/modules/mob/living/simple_mob/subtypes/occult/constructs/_construct.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/occult/constructs/_construct.dm
@@ -133,18 +133,13 @@
 	return ..()
 
 /mob/living/simple_mob/construct/examine(mob/user)
-	..(user)
-	var/msg = "<span cass='info'>*---------*\nThis is [bicon(src)] \a <EM>[src]</EM>!\n"
-	if (src.health < src.getMaxHealth())
-		msg += "<span class='warning'>"
-		if (src.health >= src.getMaxHealth()/2)
-			msg += "It looks slightly dented.\n"
+	. = ..(user)
+	var/max = getMaxHealth()
+	if (health < max)
+		if (health >= max/2)
+			. += "<span class='warning'>It looks slightly dented.</span>"
 		else
-			msg += "<B>It looks severely dented!</B>\n"
-		msg += "</span>"
-	msg += "*---------*</span>"
-
-	to_chat(user,msg)
+			. += "<span class='warning'><B>It looks severely dented!</B></span>"
 
 //Constructs levitate, can fall from a shuttle with no harm, and are piloted by either damned spirits or some otherworldly entity. Let 'em float in space.
 /mob/living/simple_mob/construct/Process_Spacemove()

--- a/code/modules/mob/living/simple_mob/subtypes/slime/xenobio/xenobio.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/slime/xenobio/xenobio.dm
@@ -73,25 +73,25 @@
 	..()
 
 /mob/living/simple_mob/slime/xenobio/examine(mob/user)
-	..()
+	. = ..()
 	if(hat)
-		to_chat(user, "It is wearing \a [hat].")
+		. += "It is wearing \a [hat]."
 
 	if(stat == DEAD)
-		to_chat(user, "It appears to be dead.")
+		. += "It appears to be dead."
 	else if(incapacitated(INCAPACITATION_DISABLED))
-		to_chat(user, "It appears to be incapacitated.")
+		. += "It appears to be incapacitated."
 	else if(harmless)
-		to_chat(user, "It appears to have been pacified.")
+		. += "It appears to have been pacified."
 	else
 		if(has_AI())
 			var/datum/ai_holder/simple_mob/xenobio_slime/AI = ai_holder
 			if(AI.rabid)
-				to_chat(user, "It seems very, very angry and upset.")
+				. += "It seems very, very angry and upset."
 			else if(AI.obedience >= 5)
-				to_chat(user, "It looks rather obedient.")
+				. += "It looks rather obedient."
 			else if(AI.discipline)
-				to_chat(user, "It has been subjugated by force, at least for now.")
+				. += "It has been subjugated by force, at least for now."
 
 /mob/living/simple_mob/slime/xenobio/proc/make_adult()
 	if(is_adult)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -229,7 +229,10 @@
 		return 1
 
 	face_atom(A)
-	A.examine(src)
+	var/list/results = A.examine(src)
+	if(!results || !results.len)
+		results = list("You were unable to examine that. Tell a developer!")
+	to_chat(src, jointext(results, "<br>"))
 
 /mob/verb/pointed(atom/A as mob|obj|turf in view())
 	set name = "Point To"

--- a/code/modules/modular_computers/computers/modular_computer/damage.dm
+++ b/code/modules/modular_computers/computers/modular_computer/damage.dm
@@ -1,9 +1,9 @@
 /obj/item/modular_computer/examine(var/mob/user)
 	. = ..()
 	if(damage > broken_damage)
-		to_chat(user, "<span class='danger'>It is heavily damaged!</span>")
+		. += "<span class='danger'>It is heavily damaged!</span>"
 	else if(damage)
-		to_chat(user, "It is damaged.")
+		. += "It is damaged."
 
 /obj/item/modular_computer/proc/break_apart()
 	visible_message("\The [src] breaks apart!")

--- a/code/modules/modular_computers/hardware/_hardware.dm
+++ b/code/modules/modular_computers/hardware/_hardware.dm
@@ -75,11 +75,11 @@
 /obj/item/weapon/computer_hardware/examine(var/mob/user)
 	. = ..()
 	if(damage > damage_failure)
-		to_chat(user, "<span class='danger'>It seems to be severely damaged!</span>")
+		. += "<span class='danger'>It seems to be severely damaged!</span>"
 	else if(damage > damage_malfunction)
-		to_chat(user, "<span class='notice'>It seems to be damaged!</span>")
+		. += "<span class='notice'>It seems to be damaged!</span>"
 	else if(damage)
-		to_chat(user, "It seems to be slightly damaged.")
+		. += "It seems to be slightly damaged."
 
 // Damages the component. Contains necessary checks. Negative damage "heals" the component.
 /obj/item/weapon/computer_hardware/take_damage(var/amount)

--- a/code/modules/multiz/turf.dm
+++ b/code/modules/multiz/turf.dm
@@ -65,11 +65,12 @@
 		O.hide(0)
 
 /turf/simulated/open/examine(mob/user, distance, infix, suffix)
-	if(..(user, 2))
+	. = ..()
+	if(Adjacent(user))
 		var/depth = 1
 		for(var/T = GetBelow(src); isopenspace(T); T = GetBelow(T))
 			depth += 1
-		to_chat(user, "It is about [depth] levels deep.")
+		. += "It is about [depth] levels deep."
 
 /**
 * Update icon and overlays of open space to be that of the turf below, plus any visible objects on that turf.

--- a/code/modules/multiz/zshadow.dm
+++ b/code/modules/multiz/zshadow.dm
@@ -37,7 +37,7 @@
 	if(!owner)
 	 	// The only time we should have a null owner is if we are in nullspace. Help figure out why we were examined.
 		crash_with("[src] ([type]) @ [log_info_line()] was examined by [user] @ [global.log_info_line(user)]")
-		return
+		return list()
 	return owner.examine(user, distance, infix, suffix)
 
 // Relay some stuff they hear

--- a/code/modules/organs/internal/brain.dm
+++ b/code/modules/organs/internal/brain.dm
@@ -113,11 +113,11 @@ GLOBAL_LIST_BOILERPLATE(all_brain_organs, /obj/item/organ/internal/brain)
 	callHook("debrain", list(brainmob))
 
 /obj/item/organ/internal/brain/examine(mob/user) // -- TLE
-	..(user)
+	. = ..()
 	if(brainmob && brainmob.client)//if thar be a brain inside... the brain.
-		to_chat(user, "You can feel the small spark of life still left in this one.")
+		. += "You can feel the small spark of life still left in this one."
 	else
-		to_chat(user, "This one seems particularly lifeless. Perhaps it will regain some of its luster later..")
+		. += "This one seems particularly lifeless. Perhaps it will regain some of its luster later..."
 
 /obj/item/organ/internal/brain/removed(var/mob/living/user)
 

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -158,9 +158,9 @@ var/list/organ_cache = list()
 		handle_germ_effects()
 
 /obj/item/organ/examine(mob/user)
-	..(user)
+	. = ..()
 	if(status & ORGAN_DEAD)
-		to_chat(user, "<span class='notice'>The decay has set in.</span>")
+		. += "<span class='notice'>Decay appears to have set in.</span>"
 
 /obj/item/organ/proc/handle_germ_effects()
 	//** Handle the effects of infections

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -144,13 +144,12 @@
 	return ..()
 
 /obj/item/organ/external/examine()
-	..()
+	. = ..()
 	if(in_range(usr, src) || istype(usr, /mob/observer/dead))
 		for(var/obj/item/I in contents)
 			if(istype(I, /obj/item/organ))
 				continue
-			to_chat(usr, "<span class='danger'>There is \a [I] sticking out of it.</span>")
-	return
+			. += "<span class='danger'>There is \a [I] sticking out of it.</span>"
 
 /obj/item/organ/external/attackby(obj/item/weapon/W as obj, mob/living/user as mob)
 	switch(stage)

--- a/code/modules/overmap/ships/computers/sensors.dm
+++ b/code/modules/overmap/ships/computers/sensors.dm
@@ -164,13 +164,13 @@
 /obj/machinery/shipsensors/examine(mob/user)
 	. = ..()
 	if(health <= 0)
-		to_chat(user, "\The [src] is wrecked.")
+		. += "<span class='danger'>It is wrecked.</span>"
 	else if(health < max_health * 0.25)
-		to_chat(user, "<span class='danger'>\The [src] looks like it's about to break!</span>")
+		. += "<span class='danger'>It looks like it's about to break!</span>"
 	else if(health < max_health * 0.5)
-		to_chat(user, "<span class='danger'>\The [src] looks seriously damaged!</span>")
+		. += "<span class='danger'>It looks seriously damaged!</span>"
 	else if(health < max_health * 0.75)
-		to_chat(user, "\The [src] shows signs of damage!")
+		. += "It shows signs of damage!"
 
 /obj/machinery/shipsensors/bullet_act(var/obj/item/projectile/Proj)
 	take_damage(Proj.get_structure_damage())

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -136,12 +136,11 @@
 	free_space -= length(strip_html_properly(new_text))
 
 /obj/item/weapon/paper/examine(mob/user)
-	..()
+	. = ..()
 	if(in_range(user, src) || istype(user, /mob/observer/dead))
 		show_content(usr)
 	else
-		to_chat(user, "<span class='notice'>You have to go closer if you want to read it.</span>")
-	return
+		. += "<span class='notice'>You have to go closer if you want to read it.</span>"
 
 /obj/item/weapon/paper/proc/show_content(var/mob/user, var/forceshow=0)
 	if(!(istype(user, /mob/living/carbon/human) || istype(user, /mob/observer/dead) || istype(user, /mob/living/silicon)) && !forceshow)

--- a/code/modules/paperwork/paper_bundle.dm
+++ b/code/modules/paperwork/paper_bundle.dm
@@ -96,11 +96,11 @@
 				to_chat(user, "<font color='red'>You must hold \the [P] steady to burn \the [src].</font>")
 
 /obj/item/weapon/paper_bundle/examine(mob/user)
-	if(..(user, 1))
-		src.show_content(user)
+	. = ..()
+	if(Adjacent(user))
+		show_content(user)
 	else
-		to_chat(user, "<span class='notice'>It is too far away.</span>")
-	return
+		. += "<span class='notice'>It is too far away.</span>"
 
 /obj/item/weapon/paper_bundle/proc/show_content(mob/user as mob)
 	var/dat

--- a/code/modules/paperwork/paperbin.dm
+++ b/code/modules/paperwork/paperbin.dm
@@ -94,13 +94,12 @@
 
 
 /obj/item/weapon/paper_bin/examine(mob/user)
-	if(get_dist(src, user) <= 1)
+	. = ..()
+	if(Adjacent(user))
 		if(amount)
-			to_chat(user, "<span class='notice'>There " + (amount > 1 ? "are [amount] papers" : "is one paper") + " in the bin.</span>")
+			. += "<span class='notice'>There " + (amount > 1 ? "are [amount] papers" : "is one paper") + " in the bin.</span>"
 		else
-			to_chat(user, "<span class='notice'>There are no papers in the bin.</span>")
-	return
-
+			. += "<span class='notice'>There are no papers in the bin.</span>"
 
 /obj/item/weapon/paper_bin/update_icon()
 	if(amount < 1)

--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -26,8 +26,9 @@
 	RefreshParts()
 
 /obj/machinery/photocopier/examine(mob/user as mob)
-	if(..(user, 1))
-		to_chat(user, "The screen shows there's [toner ? "[toner]" : "no"] toner left in the printer.")
+	. = ..()
+	if(Adjacent(user))
+		. += "The screen shows there's [toner ? "[toner]" : "no"] toner left in the printer."
 
 /obj/machinery/photocopier/attack_ai(mob/user as mob)
 	return attack_hand(user)

--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -51,11 +51,12 @@ var/global/photo_count = 0
 	..()
 
 /obj/item/weapon/photo/examine(mob/user)
+	//This is one time we're not going to call parent, because photos are 'secret' unless you're close enough.
 	if(in_range(user, src))
 		show(user)
-		to_chat(user,desc)
+		return list(desc)
 	else
-		to_chat(user, "<span class='notice'>It is too far away.</span>")
+		return list("<span class='notice'>It is too far away to examine.</span>")
 
 /obj/item/weapon/photo/proc/show(mob/user as mob)
 	user << browse_rsc(img, "tmp_photo_[id].png")

--- a/code/modules/power/antimatter/fuel.dm
+++ b/code/modules/power/antimatter/fuel.dm
@@ -68,8 +68,9 @@
 
 
 /obj/item/weapon/fuel/examine(mob/user)
-	if(get_dist(src, user) <= 1)
-		to_chat(user, "A magnetic storage ring, it contains [fuel]kg of [content ? content : "nothing"].")
+	. = ..()
+	if(Adjacent(user))
+		. += "It contains [fuel]kg of [content ? content : "nothing"]."
 
 /obj/item/weapon/fuel/proc/injest(mob/M as mob)
 	switch(content)

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -251,29 +251,30 @@
 		src.update()
 
 /obj/machinery/power/apc/examine(mob/user)
-	if(..(user, 1))
+	. = ..()
+	if(Adjacent(user))
 		if(stat & BROKEN)
-			to_chat(user, "This APC is broken.")
-			return
-		if(opened)
+			. += "This APC is broken."
+
+		else if(opened)
 			if(has_electronics && terminal)
-				to_chat(user, "The cover is [opened==2?"removed":"open"] and [ cell ? "a power cell is installed" : "the power cell is missing"].")
+				. += "The cover is [opened == 2 ? "removed" : "open"] and [ cell ? "a power cell is installed" : "the power cell is missing"]."
 			else if (!has_electronics && terminal)
-				to_chat(user, "The frame is wired, but the electronics are missing.")
+				. += "The frame is wired, but the electronics are missing."
 			else if (has_electronics && !terminal)
-				to_chat(user, "The electronics are installed, but not wired.")
+				. += "The electronics are installed, but not wired."
 			else /* if (!has_electronics && !terminal) */
-				to_chat(user, "It's just an empty metal frame.")
+				. += "It's just an empty metal frame."
 
 		else
 			if (wiresexposed)
-				to_chat(user, "The cover is closed and the wires are exposed.")
+				. += "The cover is closed and the wires are exposed."
 			else if ((locked && emagged) || hacker) //Some things can cause locked && emagged. Malf AI causes hacker.
-				to_chat(user, "The cover is closed, but the panel is unresponsive.")
+				. += "The cover is closed, but the panel is unresponsive."
 			else if(!locked && emagged) //Normal emag does this.
-				to_chat(user, "The cover is closed, but the panel is flashing an error.")
+				. += "The cover is closed, but the panel is flashing an error."
 			else
-				to_chat(user, "The cover is closed.")
+				. += "The cover is closed."
 
 
 // update the APC icon to show the three base states

--- a/code/modules/power/breaker_box.dm
+++ b/code/modules/power/breaker_box.dm
@@ -6,6 +6,7 @@
 
 /obj/machinery/power/breakerbox
 	name = "Breaker Box"
+	desc = "Large machine with heavy duty switching circuits used for advanced grid control."
 	icon = 'icons/obj/power.dmi'
 	icon_state = "bbox_off"
 	//directwired = 0
@@ -40,11 +41,11 @@
 	set_state(1)
 
 /obj/machinery/power/breakerbox/examine(mob/user)
-	to_chat(user, "Large machine with heavy duty switching circuits used for advanced grid control")
+	. = ..()
 	if(on)
-		to_chat(user, "<font color='green'>It seems to be online.</font>")
+		. += "<span class='notice'>It seems to be online.</span>"
 	else
-		to_chat(user, "<font color='red'>It seems to be offline.</font>")
+		. += "<span class='warning'>It seems to be offline.</span>"
 
 /obj/machinery/power/breakerbox/attack_ai(mob/user)
 	if(update_locked)

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -604,20 +604,13 @@ obj/structure/cable/proc/cableColor(var/colorC)
 		w_class = ITEMSIZE_SMALL
 
 /obj/item/stack/cable_coil/examine(mob/user)
-	var/msg = ""
-
+	. = ..()
 	if(get_amount() == 1)
-		msg += "A short piece of power cable."
+		. += "Just a short piece remains."
 	else if(get_amount() == 2)
-		msg += "A piece of power cable."
-	else
-		msg += "A coil of power cable."
-
-		if(get_dist(src, user) <= 1)
-			msg += " There are [get_amount()] lengths of cable in the coil."
-
-	to_chat(user, msg)
-
+		. += "Just a couple of short pieces remain."
+	else if(Adjacent(user))
+		. += "There are [get_amount()] lengths of cable in the coil."
 
 /obj/item/stack/cable_coil/verb/make_restraint()
 	set name = "Make Cable Restraints"
@@ -987,12 +980,10 @@ obj/structure/cable/proc/cableColor(var/colorC)
 	return 0
 
 /obj/item/stack/cable_coil/alien/examine(mob/user)
-	var/msg = "A spool of cable."
+	. = ..()
 
-	if(get_dist(src, user) <= 1)
-		msg += " It doesn't seem to have a beginning, or an end."
-
-	to_chat(user, msg)
+	if(Adjacent(user))
+		. += "It doesn't seem to have a beginning, or an end."
 
 /obj/item/stack/cable_coil/alien/attack_hand(mob/user as mob)
 	if (user.get_inactive_hand() == src)

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -145,10 +145,10 @@
 
 
 /obj/item/weapon/cell/examine(mob/user)
-	..()
-	if(get_dist(src, user) <= 1)
-		to_chat(user, " It has a power rating of [maxcharge].\nThe charge meter reads [round(src.percent() )]%.")
-	return
+	. = ..()
+	if(Adjacent(user))
+		. += "It has a power rating of [maxcharge]."
+		. += "The charge meter reads [round(src.percent() )]%."
 
 /obj/item/weapon/cell/attackby(obj/item/W, mob/user)
 	..()

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -56,23 +56,22 @@ var/global/list/light_type_cache = list()
 			icon_state = "tube-empty"
 
 /obj/machinery/light_construct/examine(mob/user)
-	if(!..(user, 2))
-		return
-
-	switch(src.stage)
-		if(1)
-			to_chat(user, "It's an empty frame.")
-		if(2)
-			to_chat(user, "It's wired.")
-		if(3)
-			to_chat(user, "The casing is closed.")
-	if(cell_connectors)
-		if(cell)
-			to_chat(user, "You see [cell] inside the casing.")
+	. = ..()
+	if(get_dist(user, src) <= 2)
+		switch(stage)
+			if(1)
+				. += "It's an empty frame."
+			if(2)
+				. += "It's wired."
+			if(3)
+				. += "The casing is closed."
+		if(cell_connectors)
+			if(cell)
+				. += "You see [cell] inside the casing."
+			else
+				. += "The casing has no power cell for backup power."
 		else
-			to_chat(user, "The casing has no power cell for backup power.")
-	else
-		to_chat(user, "<span class='danger'>This casing doesn't support power cells for backup power.</span>")
+			. += "<span class='danger'>This casing doesn't support power cells for backup power.</span>"
 
 /obj/machinery/light_construct/attack_hand(mob/user)
 	. = ..()
@@ -438,18 +437,19 @@ var/global/list/light_type_cache = list()
 
 // examine verb
 /obj/machinery/light/examine(mob/user)
+	. = ..()
 	var/fitting = get_fitting_name()
 	switch(status)
 		if(LIGHT_OK)
-			to_chat(user, "[desc] It is turned [on? "on" : "off"].")
+			. += "It is turned [on? "on" : "off"]."
 		if(LIGHT_EMPTY)
-			to_chat(user, "[desc] The [fitting] has been removed.")
+			. += "The [fitting] has been removed."
 		if(LIGHT_BURNED)
-			to_chat(user, "[desc] The [fitting] is burnt out.")
+			. += "The [fitting] is burnt out."
 		if(LIGHT_BROKEN)
-			to_chat(user, "[desc] The [fitting] has been smashed.")
+			. += "The [fitting] has been smashed."
 	if(cell)
-		to_chat(user, "Its backup power charge meter reads [round((cell.charge / cell.maxcharge) * 100, 0.1)]%.")
+		. += "Its backup power charge meter reads [round((cell.charge / cell.maxcharge) * 100, 0.1)]%."
 
 /obj/machinery/light/proc/get_fitting_name()
 	var/obj/item/weapon/light/L = light_type

--- a/code/modules/power/pacman2.dm
+++ b/code/modules/power/pacman2.dm
@@ -51,8 +51,8 @@
 		power_gen = round(initial(power_gen) * (max(2, temp_rating) / 2))
 
 	examine(mob/user)
-		..(user)
-		to_chat(user, "<font color='blue'>The generator has [P.air_contents.phoron] units of fuel left, producing [power_gen] per cycle.</font>")
+		. = ..()
+		. += "<span class='notice'>The generator has [P.air_contents.phoron] units of fuel left, producing [power_gen] per cycle.</span>"
 
 	handleInactive()
 		heat -= 2

--- a/code/modules/power/port_gen.dm
+++ b/code/modules/power/port_gen.dm
@@ -48,12 +48,12 @@
 		return
 
 /obj/machinery/power/port_gen/examine(mob/user)
-	if(!..(user,1 ))
-		return
-	if(active)
-		to_chat(user, "<span class='notice'>The generator is on.</span>")
-	else
-		to_chat(user, "<span class='notice'>The generator is off.</span>")
+	. = ..()
+	if(Adjacent(user)) //It literally has a light on the sprite, are you sure this is necessary?
+		if(active)
+			. += "<span class='notice'>The generator is on.</span>"
+		else
+			. += "<span class='notice'>The generator is off.</span>"
 
 /obj/machinery/power/port_gen/emp_act(severity)
 	var/duration = 6000 //ten minutes
@@ -144,13 +144,13 @@
 	power_gen = round(initial(power_gen) * (max(2, temp_rating) / 2))
 
 /obj/machinery/power/port_gen/pacman/examine(mob/user)
-	..(user)
-	to_chat(user, "\The [src] appears to be producing [power_gen*power_output] W.")
-	to_chat(user, "There [sheets == 1 ? "is" : "are"] [sheets] sheet\s left in the hopper.")
+	. = ..()
+	. += "It appears to be producing [power_gen*power_output] W."
+	. += "There [sheets == 1 ? "is" : "are"] [sheets] sheet\s left in the hopper."
 	if(IsBroken())
-		to_chat(user, "<span class='warning'>\The [src] seems to have broken down.</span>")
+		. += "<span class='warning'>It seems to have broken down.</span>"
 	if(overheating)
-		to_chat(user, "<span class='danger'>\The [src] is overheating!</span>")
+		. += "<span class='danger'>It is overheating!</span>"
 
 /obj/machinery/power/port_gen/pacman/HasFuel()
 	var/needed_sheets = power_output / time_per_sheet

--- a/code/modules/power/singularity/collector.dm
+++ b/code/modules/power/singularity/collector.dm
@@ -103,9 +103,9 @@ var/global/list/rad_collectors = list()
 	return ..()
 
 /obj/machinery/power/rad_collector/examine(mob/user)
-	if (..(user, 3))
-		to_chat(user, "The meter indicates that \the [src] is collecting [last_power] W.")
-		return 1
+	. = ..()
+	if(get_dist(user, src) <= 3)
+		. += "The meter indicates that it is collecting [last_power] W."
 
 /obj/machinery/power/rad_collector/ex_act(severity)
 	switch(severity)

--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -267,15 +267,15 @@
 			qdel(src)
 
 /obj/machinery/power/emitter/examine(mob/user)
-	..()
+	. = ..()
 	var/integrity_percentage = round((integrity / initial(integrity)) * 100)
 	switch(integrity_percentage)
 		if(0 to 30)
-			to_chat(user, "<span class='danger'>\The [src] is close to falling apart!</span>")
+			. += "<span class='danger'>It is close to falling apart!</span>"
 		if(31 to 70)
-			to_chat(user, "<span class='danger'>\The [src] is damaged.</span>")
+			. += "<span class='danger'>It is damaged.</span>"
 		if(77 to 99)
-			to_chat(user, "<span class='warning'>\The [src] is slightly damaged.</span>")
+			. += "<span class='warning'It is slightly damaged.</span>"
 
 //R-UST port
 /obj/machinery/power/emitter/proc/get_initial_fire_delay()

--- a/code/modules/power/singularity/particle_accelerator/particle_accelerator.dm
+++ b/code/modules/power/singularity/particle_accelerator/particle_accelerator.dm
@@ -112,20 +112,17 @@ So, hopefully this is helpful if any more icons are to be added/changed/wonderin
 	return 1
 
 /obj/structure/particle_accelerator/examine(mob/user)
-	switch(src.construction_state)
+	. = ..()
+	
+	switch(construction_state)
 		if(0)
-			src.desc = text("A [name], looks like it's not attached to the flooring")
+			. += "Looks like it's not attached to the flooring."
 		if(1)
-			src.desc = text("A [name], it is missing some cables")
+			. += "It is missing some cables."
 		if(2)
-			src.desc = text("A [name], the panel is open")
+			. += "The panel is open."
 		if(3)
-			src.desc = text("The [name] is assembled")
-			if(powered)
-				src.desc = src.desc_holder
-	..()
-	return
-
+			. += "It is assembled."
 
 /obj/structure/particle_accelerator/attackby(obj/item/W, mob/user)
 	if(istool(W))
@@ -295,19 +292,17 @@ So, hopefully this is helpful if any more icons are to be added/changed/wonderin
 	return
 
 /obj/machinery/particle_accelerator/examine(mob/user)
-	switch(src.construction_state)
+	. = ..()
+	
+	switch(construction_state)
 		if(0)
-			src.desc = text("A [name], looks like it's not attached to the flooring")
+			. += "Looks like it's not attached to the flooring."
 		if(1)
-			src.desc = text("A [name], it is missing some cables")
+			. += "It is missing some cables."
 		if(2)
-			src.desc = text("A [name], the panel is open")
+			. += "The panel is open."
 		if(3)
-			src.desc = text("The [name] is assembled")
-			if(powered)
-				src.desc = src.desc_holder
-	..()
-	return
+			. += "It is assembled."
 
 
 /obj/machinery/particle_accelerator/attackby(obj/item/W, mob/user)

--- a/code/modules/power/singularity/particle_accelerator/particle_smasher.dm
+++ b/code/modules/power/singularity/particle_accelerator/particle_smasher.dm
@@ -37,11 +37,11 @@
 	..()
 
 /obj/machinery/particle_smasher/examine(mob/user)
-	..()
-	if(user in view(1))
-		to_chat(user, "<span class='notice'>\The [src] contains:</span>")
+	. = ..()
+	if(Adjacent(user))
+		. += "<span class='notice'>\The [src] contains:</span>"
 		for(var/obj/item/I in contents)
-			to_chat(user, "<span class='notice'>\the [I]</span>")
+			. += "<span class='notice'>\the [I]</span>"
 
 /obj/machinery/particle_smasher/attackby(obj/item/W as obj, mob/user as mob)
 	if(W.type == /obj/item/device/analyzer)

--- a/code/modules/power/tesla/energy_ball.dm
+++ b/code/modules/power/tesla/energy_ball.dm
@@ -71,10 +71,9 @@
 		energy = 0 // ensure we dont have miniballs of miniballs
 
 /obj/singularity/energy_ball/examine(mob/user)
-	..()
+	. = ..()
 	if(orbiting_balls.len)
-		to_chat(user, "The amount of orbiting mini-balls is [orbiting_balls.len].")
-
+		. += "The amount of orbiting mini-balls is [orbiting_balls.len]."
 
 /obj/singularity/energy_ball/proc/move_the_basket_ball(var/move_amount)
 	//we face the last thing we zapped, so this lets us favor that direction a bit

--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -51,9 +51,9 @@
 		icon_state = "[initial(icon_state)]-spent"
 
 /obj/item/ammo_casing/examine(mob/user)
-	..()
+	. = ..()
 	if (!BB)
-		to_chat(user, "This one is spent.")
+		. += "This one is spent."
 
 //Gun loading types
 #define SINGLE_CASING 	1	//The gun only accepts ammo_casings. ammo_magazines should never have this as their mag_type.
@@ -183,8 +183,8 @@
 		icon_state = (new_state)? new_state : initial(icon_state)
 
 /obj/item/ammo_magazine/examine(mob/user)
-	..()
-	to_chat(user, "There [(stored_ammo.len == 1)? "is" : "are"] [stored_ammo.len] round\s left!")
+	. = ..()
+	. += "There [(stored_ammo.len == 1)? "is" : "are"] [stored_ammo.len] round\s left!"
 
 //magazine icon state caching
 /var/global/list/magazine_icondata_keys = list()

--- a/code/modules/projectiles/ammunition/magnetic.dm
+++ b/code/modules/projectiles/ammunition/magnetic.dm
@@ -11,4 +11,4 @@
 
 /obj/item/weapon/magnetic_ammo/examine(mob/user)
 	. = ..()
-	to_chat(user, "There [(remaining == 1)? "is" : "are"] [remaining] flechette\s left!")
+	. += "There [(remaining == 1)? "is" : "are"] [remaining] flechette\s left!"

--- a/code/modules/projectiles/ammunition/smartmag.dm
+++ b/code/modules/projectiles/ammunition/smartmag.dm
@@ -50,12 +50,12 @@
 			produce()
 
 /obj/item/ammo_magazine/smart/examine(mob/user)
-	..()
+	. = ..()
 
 	if(attached_cell)
-		to_chat(user, "<span class='notice'>\The [src] is loaded with a [attached_cell.name]. It is [round(attached_cell.percent())]% charged.</span>")
+		. += "<span class='notice'>\The [src] is loaded with a [attached_cell.name]. It is [round(attached_cell.percent())]% charged.</span>"
 	else
-		to_chat(user, "<span class='warning'>\The [src] does not appear to have a power source installed.</span>")
+		. += "<span class='warning'>\The [src] does not appear to have a power source installed.</span>"
 
 /obj/item/ammo_magazine/smart/update_icon()
 	if(attached_cell)

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -710,7 +710,7 @@
 	. = ..()
 	if(firemodes.len > 1)
 		var/datum/firemode/current_mode = firemodes[sel_mode]
-		to_chat(user, "The fire selector is set to [current_mode.name].")
+		. += "The fire selector is set to [current_mode.name]."
 
 /obj/item/weapon/gun/proc/switch_firemodes(mob/user)
 	if(firemodes.len <= 1)

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -178,12 +178,11 @@
 	if(power_supply)
 		if(charge_cost)
 			var/shots_remaining = round(power_supply.charge / max(1, charge_cost))	// Paranoia
-			to_chat(user, "Has [shots_remaining] shot\s remaining.")
+			. += "Has [shots_remaining] shot\s remaining."
 		else
-			to_chat(user, "Has infinite shots remaining.")
+			. += "Has infinite shots remaining."
 	else
-		to_chat(user, "Does not have a power cell.")
-	return
+		. += "Does not have a power cell."
 
 /obj/item/weapon/gun/energy/update_icon(var/ignore_inhands)
 	if(power_supply == null)

--- a/code/modules/projectiles/guns/launcher/crossbow.dm
+++ b/code/modules/projectiles/guns/launcher/crossbow.dm
@@ -208,18 +208,18 @@
 	icon_state = "crossbowframe[buildstate]"
 
 /obj/item/weapon/crossbowframe/examine(mob/user)
-	..(user)
+	. = ..()
 	switch(buildstate)
 		if(1)
-			to_chat(user, "It has a loose rod frame in place.")
+			. += "It has a loose rod frame in place."
 		if(2)
-			to_chat(user, "It has a steel backbone welded in place.")
+			. += "It has a steel backbone welded in place."
 		if(3)
-			to_chat(user, "It has a steel backbone and a cell mount installed.")
+			. += "It has a steel backbone and a cell mount installed."
 		if(4)
-			to_chat(user, "It has a steel backbone, plastic lath and a cell mount installed.")
+			. += "It has a steel backbone, plastic lath and a cell mount installed."
 		if(5)
-			to_chat(user, "It has a steel cable loosely strung across the lath.")
+			. += "It has a steel cable loosely strung across the lath."
 
 /obj/item/weapon/crossbowframe/attackby(obj/item/W as obj, mob/user as mob)
 	if(istype(W,/obj/item/stack/rods))

--- a/code/modules/projectiles/guns/launcher/grenade_launcher.dm
+++ b/code/modules/projectiles/guns/launcher/grenade_launcher.dm
@@ -36,11 +36,12 @@
 	update_icon()
 
 /obj/item/weapon/gun/launcher/grenade/examine(mob/user)
-	if(..(user, 2))
+	. = ..()
+	if(get_dist(user, src) <= 2)
 		var/grenade_count = grenades.len + (chambered? 1 : 0)
-		to_chat(user, "Has [grenade_count] grenade\s remaining.")
+		. += "Has [grenade_count] grenade\s remaining."
 		if(chambered)
-			to_chat(user, "\A [chambered] is chambered.")
+			. += "\A [chambered] is chambered."
 
 /obj/item/weapon/gun/launcher/grenade/proc/load(obj/item/weapon/grenade/G, mob/user)
 	if(G.loadable)

--- a/code/modules/projectiles/guns/launcher/pneumatic.dm
+++ b/code/modules/projectiles/guns/launcher/pneumatic.dm
@@ -99,13 +99,13 @@
 	return launched
 
 /obj/item/weapon/gun/launcher/pneumatic/examine(mob/user)
-	if(!..(user, 2))
-		return
-	to_chat(user, "The valve is dialed to [pressure_setting]%.")
-	if(tank)
-		to_chat(user, "The tank dial reads [tank.air_contents.return_pressure()] kPa.")
-	else
-		to_chat(user, "Nothing is attached to the tank valve!")
+	. = ..()
+	if(get_dist(user, src) <= 2)
+		. += "The valve is dialed to [pressure_setting]%."
+		if(tank)
+			. += "The tank dial reads [tank.air_contents.return_pressure()] kPa."
+		else
+			. += "Nothing is attached to the tank valve!"
 
 /obj/item/weapon/gun/launcher/pneumatic/update_release_force(obj/item/projectile)
 	if(tank)
@@ -150,18 +150,18 @@
 	icon_state = "pneumatic[buildstate]"
 
 /obj/item/weapon/cannonframe/examine(mob/user)
-	..(user)
+	. = ..()
 	switch(buildstate)
 		if(1)
-			to_chat(user, "It has a pipe segment installed.")
+			. += "It has a pipe segment installed."
 		if(2)
-			to_chat(user, "It has a pipe segment welded in place.")
+			. += "It has a pipe segment welded in place."
 		if(3)
-			to_chat(user, "It has an outer chassis installed.")
+			. += "It has an outer chassis installed."
 		if(4)
-			to_chat(user, "It has an outer chassis welded in place.")
+			. += "It has an outer chassis welded in place."
 		if(5)
-			to_chat(user, "It has a transfer valve installed.")
+			. += "It has a transfer valve installed."
 
 /obj/item/weapon/cannonframe/attackby(obj/item/W as obj, mob/user as mob)
 	if(istype(W,/obj/item/pipe))

--- a/code/modules/projectiles/guns/launcher/rocket.dm
+++ b/code/modules/projectiles/guns/launcher/rocket.dm
@@ -17,9 +17,9 @@
 	var/list/rockets = new/list()
 
 /obj/item/weapon/gun/launcher/rocket/examine(mob/user)
-	if(!..(user, 2))
-		return
-	to_chat(user, "<font color='blue'>[rockets.len] / [max_rockets] rockets.</font>")
+	. = ..()
+	if(get_dist(user, src) <= 2)
+		. += "<font color='blue'>[rockets.len] / [max_rockets] rockets.</font>"
 
 /obj/item/weapon/gun/launcher/rocket/attackby(obj/item/I as obj, mob/user as mob)
 	if(istype(I, /obj/item/ammo_casing/rocket))

--- a/code/modules/projectiles/guns/magnetic/bore.dm
+++ b/code/modules/projectiles/guns/magnetic/bore.dm
@@ -24,7 +24,9 @@
 
 /obj/item/weapon/gun/magnetic/matfed/examine(mob/user)
 	. = ..()
-	show_ammo(user)
+	var/ammotext = show_ammo()
+	if(ammotext)
+		. += ammotext
 
 /obj/item/weapon/gun/magnetic/matfed/update_icon()
 	var/list/overlays_to_add = list()
@@ -69,9 +71,9 @@
 /obj/item/weapon/gun/magnetic/matfed/use_ammo()
 	mat_storage -= mat_cost
 
-/obj/item/weapon/gun/magnetic/matfed/show_ammo(var/mob/user)
+/obj/item/weapon/gun/magnetic/matfed/show_ammo()
 	if(mat_storage)
-		to_chat(user, "<span class='notice'>It has [mat_storage] out of [max_mat_storage] units of [ammo_material] loaded.</span>")
+		return list("<span class='notice'>It has [mat_storage] out of [max_mat_storage] units of [ammo_material] loaded.</span>")
 
 /obj/item/weapon/gun/magnetic/matfed/attackby(var/obj/item/thing, var/mob/user)
 	if(removable_components)

--- a/code/modules/projectiles/guns/magnetic/gasthrower.dm
+++ b/code/modules/projectiles/guns/magnetic/gasthrower.dm
@@ -65,14 +65,14 @@
 	Tank.air_contents.remove(moles_to_pull)
 
 /obj/item/weapon/gun/magnetic/gasthrower/show_ammo(var/mob/user)
-	..()
+	. = ..()
 
 	if(loaded)
 		var/obj/item/weapon/tank/T = loaded
-		to_chat(user, "<span class='notice'>\The [T]'s pressure meter shows: [T.air_contents.return_pressure()] kpa.</span>")
+		. += "<span class='notice'>\The [T]'s pressure meter shows: [T.air_contents.return_pressure()] kpa.</span>"
 
 		switch(check_ammo())
 			if(TRUE)
-				to_chat(user, "<span class='notice'>\The [src]'s display registers a proper fuel mixture.</span>")
+				. += "<span class='notice'>\The [src]'s display registers a proper fuel mixture.</span>"
 			if(FALSE)
-				to_chat(user, "<span class='warning'>\The [src]'s display registers an improper fuel mixture.</span>")
+				. += "<span class='warning'>\The [src]'s display registers an improper fuel mixture.</span>"

--- a/code/modules/projectiles/guns/magnetic/magnetic.dm
+++ b/code/modules/projectiles/guns/magnetic/magnetic.dm
@@ -66,28 +66,30 @@
 	overlays = overlays_to_add
 	..()
 
-/obj/item/weapon/gun/magnetic/proc/show_ammo(var/mob/user)
+/obj/item/weapon/gun/magnetic/proc/show_ammo()
+	var/list/ammotext = list()
 	if(loaded)
-		to_chat(user, "<span class='notice'>It has \a [loaded] loaded.</span>")
+		ammotext += "<span class='notice'>It has \a [loaded] loaded.</span>"
+
+	return ammotext
 
 /obj/item/weapon/gun/magnetic/examine(var/mob/user)
-	. = ..(user, 2)
-	if(.)
-		show_ammo(user)
+	. = ..()
+	if(get_dist(user, src) <= 2)
+		. += show_ammo()
 
 		if(cell)
-			to_chat(user, "<span class='notice'>The installed [cell.name] has a charge level of [round((cell.charge/cell.maxcharge)*100)]%.</span>")
+			. += "<span class='notice'>The installed [cell.name] has a charge level of [round((cell.charge/cell.maxcharge)*100)]%.</span>"
 		if(capacitor)
-			to_chat(user, "<span class='notice'>The installed [capacitor.name] has a charge level of [round((capacitor.charge/capacitor.max_charge)*100)]%.</span>")
+			. += "<span class='notice'>The installed [capacitor.name] has a charge level of [round((capacitor.charge/capacitor.max_charge)*100)]%.</span>"
 
 		if(!cell || !capacitor)
-			to_chat(user, "<span class='notice'>The capacitor charge indicator is blinking <font color ='[COLOR_RED]'>red</font>. Maybe you should check the cell or capacitor.</span>")
+			. += "<span class='notice'>The capacitor charge indicator is blinking <font color ='[COLOR_RED]'>red</font>. Maybe you should check the cell or capacitor.</span>"
 		else
 			if(capacitor.charge < power_cost)
-				to_chat(user, "<span class='notice'>The capacitor charge indicator is <font color ='[COLOR_ORANGE]'>amber</font>.</span>")
+				. += "<span class='notice'>The capacitor charge indicator is <font color ='[COLOR_ORANGE]'>amber</font>.</span>"
 			else
-				to_chat(user, "<span class='notice'>The capacitor charge indicator is <font color ='[COLOR_GREEN]'>green</font>.</span>")
-		return TRUE
+				. += "<span class='notice'>The capacitor charge indicator is <font color ='[COLOR_GREEN]'>green</font>.</span>"
 
 /obj/item/weapon/gun/magnetic/attackby(var/obj/item/thing, var/mob/user)
 

--- a/code/modules/projectiles/guns/magnetic/magnetic_construction.dm
+++ b/code/modules/projectiles/guns/magnetic/magnetic_construction.dm
@@ -88,22 +88,22 @@
 	icon_state = "coilgun_construction_[construction_stage]"
 
 /obj/item/weapon/coilgun_assembly/examine(var/mob/user)
-	. = ..(user,2)
-	if(.)
+	. = ..()
+	if(get_dist(user, src) <= 2)
 		switch(construction_stage)
 			if(2)
-				to_chat(user, "<span class='notice'>It has a metal frame loosely shaped around the stock.</span>")
+				. += "<span class='notice'>It has a metal frame loosely shaped around the stock.</span>"
 			if(3)
-				to_chat(user, "<span class='notice'>It has a metal frame duct-taped to the stock.</span>")
+				. += "<span class='notice'>It has a metal frame duct-taped to the stock.</span>"
 			if(4)
-				to_chat(user, "<span class='notice'>It has a length of pipe attached to the body.</span>")
+				. += "<span class='notice'>It has a length of pipe attached to the body.</span>"
 			if(4)
-				to_chat(user, "<span class='notice'>It has a length of pipe welded to the body.</span>")
+				. += "<span class='notice'>It has a length of pipe welded to the body.</span>"
 			if(6)
-				to_chat(user, "<span class='notice'>It has a cable mount and capacitor jack wired to the frame.</span>")
+				. += "<span class='notice'>It has a cable mount and capacitor jack wired to the frame.</span>"
 			if(7)
-				to_chat(user, "<span class='notice'>It has a single superconducting coil threaded onto the barrel.</span>")
+				. += "<span class='notice'>It has a single superconducting coil threaded onto the barrel.</span>"
 			if(8)
-				to_chat(user, "<span class='notice'>It has a pair of superconducting coils threaded onto the barrel.</span>")
+				. += "<span class='notice'>It has a pair of superconducting coils threaded onto the barrel.</span>"
 			if(9)
-				to_chat(user, "<span class='notice'>It has three superconducting coils attached to the body, waiting to be secured.</span>")
+				. += "<span class='notice'>It has three superconducting coils attached to the body, waiting to be secured.</span>"

--- a/code/modules/projectiles/guns/magnetic/magnetic_railgun.dm
+++ b/code/modules/projectiles/guns/magnetic/magnetic_railgun.dm
@@ -31,12 +31,12 @@
 
 // Not going to check type repeatedly, if you code or varedit
 // load_type and get runtime errors, don't come crying to me.
-/obj/item/weapon/gun/magnetic/railgun/show_ammo(var/mob/user)
+/obj/item/weapon/gun/magnetic/railgun/show_ammo()
 	var/obj/item/weapon/rcd_ammo/ammo = loaded
 	if (ammo)
-		to_chat(user, "<span class='notice'>There are [ammo.remaining] shot\s remaining in \the [loaded].</span>")
+		return list("<span class='notice'>There are [ammo.remaining] shot\s remaining in \the [loaded].</span>")
 	else
-		to_chat(user, "<span class='notice'>There is nothing loaded.</span>")
+		return list("<span class='notice'>There is nothing loaded.</span>")
 
 /obj/item/weapon/gun/magnetic/railgun/check_ammo()
 	var/obj/item/weapon/rcd_ammo/ammo = loaded
@@ -77,9 +77,9 @@
 		)
 
 /obj/item/weapon/gun/magnetic/railgun/automatic/examine(var/mob/user)
-	. = ..(user,1)
-	if(.)
-		to_chat(user, "<span class='notice'>Someone has scratched <i>Ultima Ratio Regum</i> onto the side of the barrel.</span>")
+	. = ..()
+	if(Adjacent(user))
+		. += "<span class='notice'>Someone has scratched <i>Ultima Ratio Regum</i> onto the side of the barrel.</span>"
 
 /obj/item/weapon/gun/magnetic/railgun/flechette
 	name = "flechette gun"

--- a/code/modules/projectiles/guns/projectile.dm
+++ b/code/modules/projectiles/guns/projectile.dm
@@ -230,11 +230,10 @@
 		update_icon() //make sure to do this after unsetting ammo_magazine
 
 /obj/item/weapon/gun/projectile/examine(mob/user)
-	..(user)
+	. = ..()
 	if(ammo_magazine)
-		to_chat(user, "It has \a [ammo_magazine] loaded.")
-	to_chat(user, "Has [getAmmo()] round\s remaining.")
-	return
+		. += "It has \a [ammo_magazine] loaded."
+	. += "It has [getAmmo()] round\s remaining."
 
 /obj/item/weapon/gun/projectile/proc/getAmmo()
 	var/bullets = 0

--- a/code/modules/projectiles/guns/projectile/automatic.dm
+++ b/code/modules/projectiles/guns/projectile/automatic.dm
@@ -186,11 +186,11 @@
 	return
 
 /obj/item/weapon/gun/projectile/automatic/z8/examine(mob/user)
-	..()
+	. = ..()
 	if(launcher.chambered)
-		to_chat(user, "\The [launcher] has \a [launcher.chambered] loaded.")
+		. += "\The [launcher] has \a [launcher.chambered] loaded."
 	else
-		to_chat(user, "\The [launcher] is empty.")
+		. += "\The [launcher] is empty."
 
 /obj/item/weapon/gun/projectile/automatic/l6_saw
 	name = "light machine gun"

--- a/code/modules/projectiles/guns/projectile/dartgun.dm
+++ b/code/modules/projectiles/guns/projectile/dartgun.dm
@@ -100,16 +100,13 @@
 		fill_dart(dart)
 
 /obj/item/weapon/gun/projectile/dartgun/examine(mob/user)
-	//update_icon()
-	//if (!..(user, 2))
-	//	return
-	..()
-	if (beakers.len)
-		to_chat(user, "<font color='blue'>[src] contains:</font>")
+	. = ..()
+	if(beakers.len)
+		. += "<span class='notice'>[src] contains:</span>"
 		for(var/obj/item/weapon/reagent_containers/glass/beaker/B in beakers)
 			if(B.reagents && B.reagents.reagent_list.len)
 				for(var/datum/reagent/R in B.reagents.reagent_list)
-					to_chat(user, "<font color='blue'>[R.volume] units of [R.name]</font>")
+					. += "<span class='notice'>[R.volume] units of [R.name]</span>"
 
 /obj/item/weapon/gun/projectile/dartgun/attackby(obj/item/I as obj, mob/user as mob)
 	if(istype(I, /obj/item/weapon/reagent_containers/glass))

--- a/code/modules/projectiles/guns/projectile/revolver.dm
+++ b/code/modules/projectiles/guns/projectile/revolver.dm
@@ -249,14 +249,14 @@ obj/item/weapon/gun/projectile/revolver/detective45/verb/rename_gun()
 			chamber_offset = rand(0,max_shells - loaded.len)
 
 /obj/item/weapon/gun/projectile/revolver/lemat/examine(mob/user)
-	..()
+	. = ..()
 	if(secondary_loaded)
 		var/to_print
 		for(var/round in secondary_loaded)
 			to_print += round
-		to_chat(user, "\The [src] has a secondary barrel loaded with \a [to_print]")
+		. += "It has a secondary barrel loaded with \a [to_print]"
 	else
-		to_chat(user, "\The [src] has a secondary barrel that is empty.")
+		. += "It has a secondary barrel that is empty."
 
 
 //Ported from Bay

--- a/code/modules/projectiles/guns/vox.dm
+++ b/code/modules/projectiles/guns/vox.dm
@@ -34,8 +34,8 @@
 		update_icon()
 
 /obj/item/weapon/gun/launcher/spikethrower/examine(mob/user)
-	..(user)
-	to_chat(user, "It has [spikes] spike\s remaining.")
+	. = ..()
+	. += "It has [spikes] spike\s remaining."
 
 /obj/item/weapon/gun/launcher/spikethrower/update_icon()
 	icon_state = "spikethrower[spikes]"

--- a/code/modules/reagents/dispenser/cartridge.dm
+++ b/code/modules/reagents/dispenser/cartridge.dm
@@ -22,14 +22,14 @@
 		setLabel(R.name)
 
 /obj/item/weapon/reagent_containers/chem_disp_cartridge/examine(mob/user)
-	..()
-	to_chat(user, "It has a capacity of [volume] units.")
+	. = ..()
+	. += "It has a capacity of [volume] units."
 	if(reagents.total_volume <= 0)
-		to_chat(user, "It is empty.")
+		. += "It is empty."
 	else
-		to_chat(user, "It contains [reagents.total_volume] units of liquid.")
+		. += "It contains [reagents.total_volume] units of liquid."
 	if(!is_open_container())
-		to_chat(user, "The cap is sealed.")
+		. += "The cap is sealed."
 
 /obj/item/weapon/reagent_containers/chem_disp_cartridge/verb/verb_set_label(L as text)
 	set name = "Set Cartridge Label"

--- a/code/modules/reagents/dispenser/dispenser2.dm
+++ b/code/modules/reagents/dispenser/dispenser2.dm
@@ -26,8 +26,8 @@
 			add_cartridge(new type(src))
 
 /obj/machinery/chemical_dispenser/examine(mob/user)
-	..()
-	to_chat(user, "It has [cartridges.len] cartridges installed, and has space for [DISPENSER_MAX_CARTRIDGES - cartridges.len] more.")
+	. = ..()
+	. += "It has [cartridges.len] cartridges installed, and has space for [DISPENSER_MAX_CARTRIDGES - cartridges.len] more."
 
 /obj/machinery/chemical_dispenser/proc/add_cartridge(obj/item/weapon/reagent_containers/chem_disp_cartridge/C, mob/user)
 	if(!istype(C))

--- a/code/modules/reagents/distilling/distilling.dm
+++ b/code/modules/reagents/distilling/distilling.dm
@@ -109,31 +109,31 @@
 	..()
 
 /obj/machinery/portable_atmospherics/powered/reagent_distillery/examine(mob/user)
-	..()
-	if(get_dist(user, src) < 3)
-		to_chat(user, "<span class='notice'>\The [src] is powered [on ? "on" : "off"].</span>")
+	. = ..()
+	if(get_dist(user, src) <= 2)
+		. += "<span class='notice'>\The [src] is powered [on ? "on" : "off"].</span>"
 
-		to_chat(user, "<span class='notice'>\The [src]'s gauges read:</span>")
+		. += "<span class='notice'>\The [src]'s gauges read:</span>"
 		if(!use_atmos)
-			to_chat(user, "<span class='notice'>- Target Temperature:</span> <span class='warning'>[target_temp]</span>")
-		to_chat(user, "<span class='notice'>- Temperature:</span> <span class='warning'>[current_temp]</span>")
+			. += "<span class='notice'>- Target Temperature:</span> <span class='warning'>[target_temp]</span>"
+		. += "<span class='notice'>- Temperature:</span> <span class='warning'>[current_temp]</span>"
 
 		if(InputBeaker)
 			if(InputBeaker.reagents.reagent_list.len)
-				to_chat(user, "<span class='notice'>\The [src]'s input beaker holds [InputBeaker.reagents.total_volume] units of liquid.</span>")
+				. += "<span class='notice'>\The [src]'s input beaker holds [InputBeaker.reagents.total_volume] units of liquid.</span>"
 			else
-				to_chat(user, "<span class='notice'>\The [src]'s input beaker is empty!</span>")
+				. += "<span class='notice'>\The [src]'s input beaker is empty!</span>"
 
 		if(Reservoir.reagents.reagent_list.len)
-			to_chat(user, "<span class='notice'>\The [src]'s internal buffer holds [Reservoir.reagents.total_volume] units of liquid.</span>")
+			. += "<span class='notice'>\The [src]'s internal buffer holds [Reservoir.reagents.total_volume] units of liquid.</span>"
 		else
-			to_chat(user, "<span class='notice'>\The [src]'s internal buffer is empty!</span>")
+			. += "<span class='notice'>\The [src]'s internal buffer is empty!</span>"
 
 		if(OutputBeaker)
 			if(OutputBeaker.reagents.reagent_list.len)
-				to_chat(user, "<span class='notice'>\The [src]'s output beaker holds [OutputBeaker.reagents.total_volume] units of liquid.</span>")
+				. += "<span class='notice'>\The [src]'s output beaker holds [OutputBeaker.reagents.total_volume] units of liquid.</span>"
 			else
-				to_chat(user, "<span class='notice'>\The [src]'s output beaker is empty!</span>")
+				. += "<span class='notice'>\The [src]'s output beaker is empty!</span>"
 
 /obj/machinery/portable_atmospherics/powered/reagent_distillery/verb/toggle_power(mob/user = usr)
 	set name = "Toggle Distillery Heating"
@@ -186,7 +186,7 @@
 
 	switch(choice)
 		if("examine")
-			examine(user)
+			user.examinate(src)
 
 		if("use")
 			toggle_power(user)

--- a/code/modules/reagents/reagent_containers/borghydro.dm
+++ b/code/modules/reagents/reagent_containers/borghydro.dm
@@ -116,12 +116,10 @@
 			to_chat(usr, "<span class='notice'>Synthesizer is now producing '[R.name]'.</span>")
 
 /obj/item/weapon/reagent_containers/borghypo/examine(mob/user)
-	if(!..(user, 2))
-		return
-
-	var/datum/reagent/R = SSchemistry.chemical_reagents[reagent_ids[mode]]
-
-	to_chat(user, "<span class='notice'>It is currently producing [R.name] and has [reagent_volumes[reagent_ids[mode]]] out of [volume] units left.</span>")
+	. = ..()
+	if(get_dist(user, src) <= 2)
+		var/datum/reagent/R = SSchemistry.chemical_reagents[reagent_ids[mode]]
+		. += "<span class='notice'>It is currently producing [R.name] and has [reagent_volumes[reagent_ids[mode]]] out of [volume] units left.</span>"
 
 /obj/item/weapon/reagent_containers/borghypo/service
 	name = "cyborg drink synthesizer"

--- a/code/modules/reagents/reagent_containers/dropper.dm
+++ b/code/modules/reagents/reagent_containers/dropper.dm
@@ -14,12 +14,12 @@
 	drop_sound = 'sound/items/drop/glass.ogg'
 
 /obj/item/weapon/reagent_containers/dropper/examine(var/mob/user)
-	if(!..(user, 2))
-		return
-	if(reagents && reagents.reagent_list.len)
-		to_chat(user, "<span class='notice'>It contains [reagents.total_volume] units of liquid.</span>")
-	else
-		to_chat(user, "<span class='notice'>It is empty.</span>")
+	. = ..()
+	if(get_dist(user, src) <= 2)
+		if(reagents && reagents.reagent_list.len)
+			. += "<span class='notice'>It contains [reagents.total_volume] units of liquid.</span>"
+		else
+			. += "<span class='notice'>It is empty.</span>"
 
 /obj/item/weapon/reagent_containers/dropper/afterattack(var/obj/target, var/mob/user, var/proximity)
 	if(!target.reagents || !proximity) return

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -59,14 +59,14 @@
 	base_desc = desc
 
 /obj/item/weapon/reagent_containers/glass/examine(var/mob/user)
-	if(!..(user, 2))
-		return
-	if(reagents && reagents.reagent_list.len)
-		to_chat(user, "<span class='notice'>It contains [reagents.total_volume] units of liquid.</span>")
-	else
-		to_chat(user, "<span class='notice'>It is empty.</span>")
-	if(!is_open_container())
-		to_chat(user, "<span class='notice'>Airtight lid seals it completely.</span>")
+	. = ..()
+	if(get_dist(user, src) <= 2)
+		if(reagents && reagents.reagent_list.len)
+			. += "<span class='notice'>It contains [reagents.total_volume] units of liquid.</span>"
+		else
+			. += "<span class='notice'>It is empty.</span>"
+		if(!is_open_container())
+			. += "<span class='notice'>Airtight lid seals it completely.</span>"
 
 /obj/item/weapon/reagent_containers/glass/attack_self()
 	..()

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -164,11 +164,11 @@
 		icon_state = "[initial(icon_state)]0"
 
 /obj/item/weapon/reagent_containers/hypospray/autoinjector/examine(mob/user)
-	. = ..(user)
+	. = ..()
 	if(reagents && reagents.reagent_list.len)
-		to_chat(user, "<span class='notice'>It is currently loaded.</span>")
+		. += "<span class='notice'>It is currently loaded.</span>"
 	else
-		to_chat(user, "<span class='notice'>It is spent.</span>")
+		. += "<span class='notice'>It is spent.</span>"
 
 /obj/item/weapon/reagent_containers/hypospray/autoinjector/detox
 	name = "autoinjector (antitox)"

--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -79,9 +79,9 @@
 	to_chat(user, "<span class='notice'>You adjusted the pressure nozzle. You'll now use [amount_per_transfer_from_this] units per spray.</span>")
 
 /obj/item/weapon/reagent_containers/spray/examine(mob/user)
-	if(..(user, 0) && loc == user)
-		to_chat(user, "[round(reagents.total_volume)] units left.")
-	return
+	. = ..()
+	if(loc == user)
+		. += "[round(reagents.total_volume)] units left."
 
 /obj/item/weapon/reagent_containers/spray/verb/empty()
 
@@ -133,8 +133,9 @@
 	reagents.add_reagent("condensedcapsaicin", 40)
 
 /obj/item/weapon/reagent_containers/spray/pepper/examine(mob/user)
-	if(..(user, 1))
-		to_chat(user, "The safety is [safety ? "on" : "off"].")
+	. = ..()
+	if(Adjacent(user))
+		. += "The safety is [safety ? "on" : "off"]."
 
 /obj/item/weapon/reagent_containers/spray/pepper/attack_self(var/mob/user)
 	safety = !safety

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -25,14 +25,14 @@
 	. = ..()
 
 /obj/structure/reagent_dispensers/examine(mob/user)
-	if(!..(user, 2))
-		return
-	to_chat(user, "<span class='notice'>It contains:</span>")
-	if(reagents && reagents.reagent_list.len)
-		for(var/datum/reagent/R in reagents.reagent_list)
-			to_chat(user, "<span class='notice'>[R.volume] units of [R.name]</span>")
-	else
-		to_chat(user, "<span class='notice'>Nothing.</span>")
+	. = ..()
+	if(get_dist(user, src) <= 2)
+		. += "<span class='notice'>It contains:</span>"
+		if(reagents && reagents.reagent_list.len)
+			for(var/datum/reagent/R in reagents.reagent_list)
+				. += "<span class='notice'>[R.volume] units of [R.name]</span>"
+		else
+			. += "<span class='notice'>Nothing.</span>"
 
 /obj/structure/reagent_dispensers/verb/set_APTFT() //set amount_per_transfer_from_this
 	set name = "Set transfer amount"
@@ -100,12 +100,12 @@
 	reagents.add_reagent("fuel",1000)
 
 /obj/structure/reagent_dispensers/fueltank/examine(mob/user)
-	if(!..(user, 2))
-		return
-	if (modded)
-		to_chat(user, "<span class='warning'>Fuel faucet is wrenched open, leaking the fuel!</span>")
-	if(rig)
-		to_chat(user, "<span class='notice'>There is some kind of device rigged to the tank.</span>")
+	. = ..()
+	if(get_dist(user, src) <= 2)
+		if(modded)
+			. += "<span class='warning'>Fuel faucet is wrenched open, leaking the fuel!</span>"
+		if(rig)
+			. += "<span class='notice'>There is some kind of device rigged to the tank.</span>"
 
 /obj/structure/reagent_dispensers/fueltank/attack_hand()
 	if (rig)
@@ -234,9 +234,9 @@
 	update_icon()
 
 /obj/structure/reagent_dispensers/water_cooler/examine(mob/user)
-	..()
+	. = ..()
 	if(cupholder)
-		to_chat(user, "<span class='notice'>There are [cups] cups in the cup dispenser.</span>")
+		. += "<span class='notice'>There are [cups] cups in the cup dispenser.</span>"
 
 /obj/structure/reagent_dispensers/water_cooler/attackby(obj/item/I as obj, mob/user as mob)
 	if(I.is_wrench())

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -102,12 +102,12 @@
 			overlays += I
 
 	examine(mob/user)
-		if(..(user, 4))
+		. = ..()
+		if(get_dist(user, src) <= 4)
 			if(sortTag)
-				to_chat(user, "<span class='notice'>It is labeled \"[sortTag]\"</span>")
+				. += "<span class='notice'>It is labeled \"[sortTag]\"</span>"
 			if(examtext)
-				to_chat(user, "<span class='notice'>It has a note attached which reads, \"[examtext]\"</span>")
-		return
+				. += "<span class='notice'>It has a note attached which reads, \"[examtext]\"</span>"
 
 /obj/item/smallDelivery
 	desc = "A small wrapped package."
@@ -209,12 +209,11 @@
 			overlays += I
 
 	examine(mob/user)
-		if(..(user, 4))
+		if(get_dist(user, src) <= 4)
 			if(sortTag)
-				to_chat(user, "<span class='notice'>It is labeled \"[sortTag]\"</span>")
+				. += "<span class='notice'>It is labeled \"[sortTag]\"</span>"
 			if(examtext)
-				to_chat(user, "<span class='notice'>It has a note attached which reads, \"[examtext]\"</span>")
-		return
+				. += "<span class='notice'>It has a note attached which reads, \"[examtext]\"</span>"
 
 /obj/item/weapon/packageWrap
 	name = "package wrapper"
@@ -312,10 +311,9 @@
 		return
 
 	examine(mob/user)
-		if(..(user, 0))
-			to_chat(user, "<font color='blue'>There are [amount] units of package wrap left!</font>")
-
-		return
+		. = ..()
+		if(get_dist(user, src) <= 0)
+			. += "<font color='blue'>There are [amount] units of package wrap left!</font>"
 
 /obj/structure/bigDelivery/Destroy()
 	if(wrapped) //sometimes items can disappear. For example, bombs. --rastaf0

--- a/code/modules/research/message_server.dm
+++ b/code/modules/research/message_server.dm
@@ -82,9 +82,8 @@ var/global/list/obj/machinery/message_server/message_servers = list()
 	return
 
 /obj/machinery/message_server/examine(mob/user, distance, infix, suffix)
-	if(..())
-		to_chat(user, "It appears to be [active ? "online" : "offline"].")
-	
+	. = ..()
+	. += "It appears to be [active ? "online" : "offline"]."	
 
 /obj/machinery/message_server/proc/GenerateKey()
 	//Feel free to move to Helpers.

--- a/code/modules/shieldgen/directional_shield.dm
+++ b/code/modules/shieldgen/directional_shield.dm
@@ -203,9 +203,9 @@
 			playsound(get_turf(src), 'sound/machines/defib_safetyOff.ogg', 75, 0)
 
 /obj/item/shield_projector/examine(var/mob/user)
-	..()
-	if(get_dist(src, user) <= 1)
-		to_chat(user, "\The [src]'s shield matrix is at [round( (shield_health / max_shield_health) * 100, 0.01)]% strength.")
+	. = ..()
+	if(Adjacent(user))
+		. += "Its shield matrix is at [round( (shield_health / max_shield_health) * 100, 0.01)]% strength."
 
 /obj/item/shield_projector/emp_act(var/severity)
 	adjust_health(-max_shield_health / severity) // A strong EMP will kill the shield instantly, but weaker ones won't on the first hit.

--- a/code/modules/shieldgen/handheld_defuser.dm
+++ b/code/modules/shieldgen/handheld_defuser.dm
@@ -47,7 +47,7 @@
 		STOP_PROCESSING(SSobj, src)
 	to_chat(usr, "You turn \the [src] [enabled ? "on" : "off"].")
 
-/obj/item/weapon/shield_diffuser/examine()
+/obj/item/weapon/shield_diffuser/examine(mob/user)
 	. = ..()
-	to_chat(usr, "The charge meter reads [cell ? cell.percent() : 0]%")
-	to_chat(usr, "It is [enabled ? "enabled" : "disabled"].")
+	. += "The charge meter reads [cell ? cell.percent() : 0]%"
+	. += "It is [enabled ? "enabled" : "disabled"]."

--- a/code/modules/shieldgen/shield_diffuser.dm
+++ b/code/modules/shieldgen/shield_diffuser.dm
@@ -69,6 +69,6 @@
 
 /obj/machinery/shield_diffuser/examine(var/mob/user)
 	. = ..()
-	to_chat(user, "It is [enabled ? "enabled" : "disabled"].")
+	. += "It is [enabled ? "enabled" : "disabled"]."
 	if(alarm)
-		to_chat(user, "A red LED labeled \"Proximity Alarm\" is blinking on the control panel.")
+		. += "A red LED labeled \"Proximity Alarm\" is blinking on the control panel."

--- a/code/modules/tables/tables.dm
+++ b/code/modules/tables/tables.dm
@@ -90,11 +90,11 @@
 	if(health < maxhealth)
 		switch(health / maxhealth)
 			if(0.0 to 0.5)
-				to_chat(user, "<span class='warning'>It looks severely damaged!</span>")
+				. += "<span class='warning'>It looks severely damaged!</span>"
 			if(0.25 to 0.5)
-				to_chat(user, "<span class='warning'>It looks damaged!</span>")
+				. += "<span class='warning'>It looks damaged!</span>"
 			if(0.5 to 1.0)
-				to_chat(user, "<span class='notice'>It has a few scrapes and dents.</span>")
+				. += "<span class='notice'>It has a few scrapes and dents.</span>"
 
 /obj/structure/table/attackby(obj/item/weapon/W, mob/user)
 

--- a/code/modules/vehicles/cargo_train.dm
+++ b/code/modules/vehicles/cargo_train.dm
@@ -192,14 +192,10 @@
 		return ..()
 
 /obj/vehicle/train/engine/examine(mob/user)
-	if(!..(user, 1))
-		return
-
-	if(!istype(usr, /mob/living/carbon/human))
-		return
-
-	to_chat(user, "The power light is [on ? "on" : "off"].\nThere are[key ? "" : " no"] keys in the ignition.")
-	to_chat(user, "The charge meter reads [cell? round(cell.percent(), 0.01) : 0]%")
+	. = ..()
+	if(ishuman(user) && Adjacent(user))
+		. += "The power light is [on ? "on" : "off"].\nThere are[key ? "" : " no"] keys in the ignition."
+		. += "The charge meter reads [cell? round(cell.percent(), 0.01) : 0]%"
 
 /obj/vehicle/train/engine/verb/start_engine()
 	set name = "Start engine"

--- a/code/modules/virus2/items_devices.dm
+++ b/code/modules/virus2/items_devices.dm
@@ -66,9 +66,9 @@
 		qdel(src)
 
 /obj/item/weapon/virusdish/examine(mob/user)
-	..()
+	. = ..()
 	if(basic_info)
-		to_chat(user, "[basic_info] : <a href='?src=\ref[src];info=1'>More Information</a>")
+		. += "[basic_info] : <a href='?src=\ref[src];info=1'>More Information</a>"
 
 /obj/item/weapon/virusdish/Topic(href, href_list)
 	. = ..()

--- a/code/modules/xenoarcheaology/sampling.dm
+++ b/code/modules/xenoarcheaology/sampling.dm
@@ -93,8 +93,9 @@
 	var/obj/item/weapon/evidencebag/filled_bag
 
 /obj/item/device/core_sampler/examine(var/mob/user)
-	if(..(user, 2))
-		to_chat(user, "<span class='notice'>Used to extract geological core samples - this one is [sampled_turf ? "full" : "empty"], and has [num_stored_bags] bag[num_stored_bags != 1 ? "s" : ""] remaining.</span>")
+	. = ..()
+	if(get_dist(user, src) <= 2)
+		. += "<span class='notice'>Used to extract geological core samples - this one is [sampled_turf ? "full" : "empty"], and has [num_stored_bags] bag[num_stored_bags != 1 ? "s" : ""] remaining.</span>"
 
 /obj/item/device/core_sampler/attackby(var/obj/item/I, var/mob/living/user)
 	if(istype(I, /obj/item/weapon/evidencebag))

--- a/code/modules/xenoarcheaology/tools/tools_pickaxe.dm
+++ b/code/modules/xenoarcheaology/tools/tools_pickaxe.dm
@@ -195,6 +195,5 @@
 			icon_state = "excavationdrill5" //The other 2 sprites are comically long. Let's just cut it at 5.
 
 /obj/item/weapon/pickaxe/excavationdrill/examine(mob/user)
-	..()
-	var/depth = excavation_amount
-	to_chat(user, "<span class='info'>It is currently set at [depth]cms.</span>")
+	. = ..()
+	. += "<span class='info'>It is currently set at [excavation_amount]cms.</span>"

--- a/code/modules/xenobio/items/extracts.dm
+++ b/code/modules/xenobio/items/extracts.dm
@@ -33,11 +33,11 @@
 	..()
 
 /obj/item/slime_extract/examine(mob/user)
-	..()
+	. = ..()
 	if(uses)
-		to_chat(user, "This extract has [uses] more use\s.")
+		. += "This extract has [uses] more use\s."
 	else
-		to_chat(user, "This extract is inert.")
+		. += "This extract is inert."
 
 /datum/chemical_reaction/slime
 	var/required = null


### PR DESCRIPTION
This is how /tg/ does it. It's faster than each object having it's own separate to_chat messages that it enqueues which wastes time sending that information to the client in separate chunks, and makes SSchat do more work.

I tried to not change anything that would be considered 'balance'. There are SO MANY 'interesting' choices about 'how far away' is too far away to see something. Why can you see the contents of a jetpack at any distance, but the contents of an oxygen tank only when holding it? Why can you see the ammo in an RCD and RSF at different ranges? Why do air tanks play a sound at you in their examine()? SO MANY QUESTIONS.

Regardless, the only changes I made aside from the necessary ones for this were grammar, replacing <font> with <span> that I noticed, and any time an object repeatedly said it's name or reused it's icon a bunch, I replaced with "It". So there's no "That's a box. It's for holding things. The box looks damaged". 