### PR TITLE
Slightly clean disposal pipe construction code.

### DIFF
--- a/code/__defines/construction.dm
+++ b/code/__defines/construction.dm
@@ -63,6 +63,28 @@
 #define PIPING_DEFAULT_LAYER_ONLY 4			//can only exist at PIPING_LAYER_DEFAULT
 #define PIPING_CARDINAL_AUTONORMALIZE 8		//north/south east/west doesn't matter, auto normalize on build.
 
+// Disposals Construction
+// Future: Eliminate these type codes by adding disposals equivilent of pipe_state.
+#define DISPOSAL_PIPE_STRAIGHT 0
+#define DISPOSAL_PIPE_CORNER 1
+#define DISPOSAL_PIPE_JUNCTION 2
+#define DISPOSAL_PIPE_JUNCTION_FLIPPED 3
+#define DISPOSAL_PIPE_JUNCTION_Y 4
+#define DISPOSAL_PIPE_TRUNK 5
+#define DISPOSAL_PIPE_BIN 6
+#define DISPOSAL_PIPE_OUTLET 7
+#define DISPOSAL_PIPE_CHUTE 8
+#define DISPOSAL_PIPE_SORTER 9
+#define DISPOSAL_PIPE_SORTER_FLIPPED 10
+#define DISPOSAL_PIPE_UPWARD 11
+#define DISPOSAL_PIPE_DOWNWARD 12
+#define DISPOSAL_PIPE_TAGGER 13
+#define DISPOSAL_PIPE_TAGGER_PARTIAL 14
+
+#define DISPOSAL_SORT_NORMAL 0
+#define DISPOSAL_SORT_WILDCARD 1
+#define DISPOSAL_SORT_UNTAGGED 2
+
 // Macro for easy use of boilerplate code for searching for a valid node connection.
 #define STANDARD_ATMOS_CHOOSE_NODE(node_num, direction) \
 	for(var/obj/machinery/atmospherics/target in get_step(src, direction)) { \

--- a/code/modules/recycling/disposal-construction.dm
+++ b/code/modules/recycling/disposal-construction.dm
@@ -14,71 +14,95 @@
 	level = 2
 	var/sortType = ""
 	var/ptype = 0
-	// 0=straight, 1=bent, 2=junction-j1, 3=junction-j2, 4=junction-y, 5=trunk, 6=disposal bin, 7=outlet, 8=inlet 9=pipe-j1s 10=pipe-j2s
 	var/subtype = 0
 	var/dpdir = 0	// directions as disposalpipe
 	var/base_state = "pipe-s"
 
-	// update iconstate and dpdir due to dir and type
+/obj/structure/disposalconstruct/New(var/newturf, var/newtype, var/newdir, var/flipped, var/newsubtype)
+	..(newturf)
+	ptype = newtype
+	dir = newdir
+	// Disposals handle "bent"/"corner" strangely, handle this specially.
+	if(ptype == DISPOSAL_PIPE_STRAIGHT && dir in cornerdirs)
+		ptype = DISPOSAL_PIPE_CORNER
+		switch(dir)
+			if(NORTHWEST)
+				dir = WEST
+			if(NORTHEAST)
+				dir = NORTH
+			if(SOUTHWEST)
+				dir = SOUTH
+			if(SOUTHEAST)
+				dir = EAST
+
+	switch(ptype)
+		if(DISPOSAL_PIPE_BIN, DISPOSAL_PIPE_OUTLET, DISPOSAL_PIPE_CHUTE)
+			density = 1
+		if(DISPOSAL_PIPE_SORTER, DISPOSAL_PIPE_SORTER_FLIPPED)
+			subtype = newsubtype
+
+	if(flipped)
+		do_a_flip()
+	else
+		update() // do_a_flip() calls update anyway, so, lazy way of catching unupdated pipe!
+
+// update iconstate and dpdir due to dir and type
 /obj/structure/disposalconstruct/proc/update()
 	var/flip = turn(dir, 180)
 	var/left = turn(dir, 90)
 	var/right = turn(dir, -90)
 
 	switch(ptype)
-		if(0)
+		if(DISPOSAL_PIPE_STRAIGHT)
 			base_state = "pipe-s"
 			dpdir = dir | flip
-		if(1)
+		if(DISPOSAL_PIPE_CORNER)
 			base_state = "pipe-c"
 			dpdir = dir | right
-		if(2)
+		if(DISPOSAL_PIPE_JUNCTION)
 			base_state = "pipe-j1"
 			dpdir = dir | right | flip
-		if(3)
+		if(DISPOSAL_PIPE_JUNCTION_FLIPPED)
 			base_state = "pipe-j2"
 			dpdir = dir | left | flip
-		if(4)
+		if(DISPOSAL_PIPE_JUNCTION_Y)
 			base_state = "pipe-y"
 			dpdir = dir | left | right
-		if(5)
+		if(DISPOSAL_PIPE_TRUNK)
 			base_state = "pipe-t"
 			dpdir = dir
 		 // disposal bin has only one dir, thus we don't need to care about setting it
-		if(6)
+		if(DISPOSAL_PIPE_BIN)
 			if(anchored)
 				base_state = "disposal"
 			else
 				base_state = "condisposal"
-		if(7)
+		if(DISPOSAL_PIPE_OUTLET)
 			base_state = "outlet"
 			dpdir = dir
-		if(8)
+		if(DISPOSAL_PIPE_CHUTE)
 			base_state = "intake"
 			dpdir = dir
-		if(9)
+		if(DISPOSAL_PIPE_SORTER)
 			base_state = "pipe-j1s"
 			dpdir = dir | right | flip
-		if(10)
+		if(DISPOSAL_PIPE_SORTER_FLIPPED)
 			base_state = "pipe-j2s"
 			dpdir = dir | left | flip
-///// Z-Level stuff
-		if(11)
+		if(DISPOSAL_PIPE_UPWARD)
 			base_state = "pipe-u"
 			dpdir = dir
-		if(12)
+		if(DISPOSAL_PIPE_DOWNWARD)
 			base_state = "pipe-d"
 			dpdir = dir
-		if(13)
+		if(DISPOSAL_PIPE_TAGGER)
 			base_state = "pipe-tagger"
 			dpdir = dir | flip
-		if(14)
+		if(DISPOSAL_PIPE_TAGGER_PARTIAL)
 			base_state = "pipe-tagger-partial"
 			dpdir = dir | flip
 
-
-///// Z-Level stuff
-	if(!(ptype in list(6, 7, 8, 11, 12, 13, 14)))
+	if(!(ptype in list(DISPOSAL_PIPE_BIN, DISPOSAL_PIPE_OUTLET, DISPOSAL_PIPE_CHUTE, DISPOSAL_PIPE_UPWARD, DISPOSAL_PIPE_DOWNWARD, DISPOSAL_PIPE_TAGGER, DISPOSAL_PIPE_TAGGER_PARTIAL)))
 		icon_state = "con[base_state]"
 	else
 		icon_state = base_state
@@ -123,58 +147,59 @@
 		to_chat(usr, "You must unfasten the pipe before flipping it.")
 		return
 
-	set_dir(turn(dir, 180))
+	do_a_flip()
+
+/obj/structure/disposalconstruct/proc/do_a_flip()
 	switch(ptype)
-		if(2)
-			ptype = 3
-		if(3)
-			ptype = 2
-		if(9)
-			ptype = 10
-		if(10)
-			ptype = 9
+		if(DISPOSAL_PIPE_JUNCTION)
+			ptype = DISPOSAL_PIPE_JUNCTION_FLIPPED
+		if(DISPOSAL_PIPE_JUNCTION_FLIPPED)
+			ptype = DISPOSAL_PIPE_JUNCTION
+		if(DISPOSAL_PIPE_SORTER)
+			ptype = DISPOSAL_PIPE_SORTER_FLIPPED
+		if(DISPOSAL_PIPE_SORTER_FLIPPED)
+			ptype = DISPOSAL_PIPE_SORTER
 
 	update()
 
 // returns the type path of disposalpipe corresponding to this item dtype
 /obj/structure/disposalconstruct/proc/dpipetype()
 	switch(ptype)
-		if(0,1)
+		if(DISPOSAL_PIPE_STRAIGHT,DISPOSAL_PIPE_CORNER)
 			return /obj/structure/disposalpipe/segment
-		if(2,3,4)
+		if(DISPOSAL_PIPE_JUNCTION,DISPOSAL_PIPE_JUNCTION_FLIPPED,DISPOSAL_PIPE_JUNCTION_Y)
 			return /obj/structure/disposalpipe/junction
-		if(5)
+		if(DISPOSAL_PIPE_TRUNK)
 			return /obj/structure/disposalpipe/trunk
-		if(6)
+		if(DISPOSAL_PIPE_BIN)
 			return /obj/machinery/disposal
-		if(7)
+		if(DISPOSAL_PIPE_OUTLET)
 			return /obj/structure/disposaloutlet
-		if(8)
+		if(DISPOSAL_PIPE_CHUTE)
 			return /obj/machinery/disposal/deliveryChute
-		if(9)
+		if(DISPOSAL_PIPE_SORTER)
 			switch(subtype)
-				if(0)
+				if(DISPOSAL_SORT_NORMAL)
 					return /obj/structure/disposalpipe/sortjunction
-				if(1)
+				if(DISPOSAL_SORT_WILDCARD)
 					return /obj/structure/disposalpipe/sortjunction/wildcard
-				if(2)
+				if(DISPOSAL_SORT_UNTAGGED)
 					return /obj/structure/disposalpipe/sortjunction/untagged
-		if(10)
+		if(DISPOSAL_PIPE_SORTER_FLIPPED)
 			switch(subtype)
-				if(0)
+				if(DISPOSAL_SORT_NORMAL)
 					return /obj/structure/disposalpipe/sortjunction/flipped
-				if(1)
+				if(DISPOSAL_SORT_WILDCARD)
 					return /obj/structure/disposalpipe/sortjunction/wildcard/flipped
-				if(2)
+				if(DISPOSAL_SORT_UNTAGGED)
 					return /obj/structure/disposalpipe/sortjunction/untagged/flipped
-///// Z-Level stuff
-		if(11)
+		if(DISPOSAL_PIPE_UPWARD)
 			return /obj/structure/disposalpipe/up
-		if(12)
+		if(DISPOSAL_PIPE_DOWNWARD)
 			return /obj/structure/disposalpipe/down
-		if(13)
+		if(DISPOSAL_PIPE_TAGGER)
 			return /obj/structure/disposalpipe/tagger
-		if(14)
+		if(DISPOSAL_PIPE_TAGGER_PARTIAL)
 			return /obj/structure/disposalpipe/tagger/partial
 	return
 
@@ -188,25 +213,25 @@
 	var/ispipe = 0 // Indicates if we should change the level of this pipe
 	src.add_fingerprint(user)
 	switch(ptype)
-		if(6)
+		if(DISPOSAL_PIPE_BIN)
 			nicetype = "disposal bin"
-		if(7)
+		if(DISPOSAL_PIPE_OUTLET)
 			nicetype = "disposal outlet"
-		if(8)
+		if(DISPOSAL_PIPE_CHUTE)
 			nicetype = "delivery chute"
-		if(9, 10)
+		if(DISPOSAL_PIPE_SORTER, DISPOSAL_PIPE_SORTER_FLIPPED)
 			switch(subtype)
-				if(0)
+				if(DISPOSAL_SORT_NORMAL)
 					nicetype = "sorting pipe"
-				if(1)
+				if(DISPOSAL_SORT_WILDCARD)
 					nicetype = "wildcard sorting pipe"
-				if(2)
+				if(DISPOSAL_SORT_UNTAGGED)
 					nicetype = "untagged sorting pipe"
 			ispipe = 1
-		if(13)
+		if(DISPOSAL_PIPE_TAGGER)
 			nicetype = "tagging pipe"
 			ispipe = 1
-		if(14)
+		if(DISPOSAL_PIPE_TAGGER_PARTIAL)
 			nicetype = "partial tagging pipe"
 			ispipe = 1
 		else
@@ -231,7 +256,7 @@
 				density = 1
 			to_chat(user, "You detach the [nicetype] from the underfloor.")
 		else
-			if(ptype>=6 && ptype <= 8) // Disposal or outlet
+			if(ptype == DISPOSAL_PIPE_BIN || ptype == DISPOSAL_PIPE_OUTLET || ptype == DISPOSAL_PIPE_CHUTE) // Disposal or outlet
 				if(CP) // There's something there
 					if(!istype(CP,/obj/structure/disposalpipe/trunk))
 						to_chat(user, "The [nicetype] requires a trunk underneath it in order to work.")
@@ -281,26 +306,26 @@
 						P.updateicon()
 
 						//Needs some special treatment ;)
-						if(ptype==9 || ptype==10)
+						if(ptype==DISPOSAL_PIPE_SORTER || ptype==DISPOSAL_PIPE_SORTER_FLIPPED)
 							var/obj/structure/disposalpipe/sortjunction/SortP = P
 							SortP.sortType = sortType
 							SortP.updatedir()
 							SortP.updatedesc()
 							SortP.updatename()
 
-					else if(ptype==6) // Disposal bin
+					else if(ptype==DISPOSAL_PIPE_BIN)
 						var/obj/machinery/disposal/P = new /obj/machinery/disposal(src.loc)
 						src.transfer_fingerprints_to(P)
 						P.mode = 0 // start with pump off
 
-					else if(ptype==7) // Disposal outlet
+					else if(ptype==DISPOSAL_PIPE_OUTLET)
 						var/obj/structure/disposaloutlet/P = new /obj/structure/disposaloutlet(src.loc)
 						src.transfer_fingerprints_to(P)
 						P.set_dir(dir)
 						var/obj/structure/disposalpipe/trunk/Trunk = CP
 						Trunk.linked = P
 
-					else if(ptype==8) // Disposal outlet
+					else if(ptype==DISPOSAL_PIPE_CHUTE)
 						var/obj/machinery/disposal/deliveryChute/P = new /obj/machinery/disposal/deliveryChute(src.loc)
 						src.transfer_fingerprints_to(P)
 						P.set_dir(dir)


### PR DESCRIPTION
Ported from @Holdelta's YW commits, this replaces many hard coded constant numbers with defines for readability.
Also refactors the disposals pipe dispenser to use pipe recipes in a similar way that the atmos pipe dispenser does and makes disposal pipes flip the same way that atmos pipes do for a consistent experience. 
Also adds icon states to the pipe_recipe type since it was easily available in the source port and can be useful.

