### PR TITLE
Tweaks and fixes for the new new event system.

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -47,7 +47,7 @@
 
 	luminosity = !(dynamic_lighting)
 	icon_state = ""
-	
+
 	return INITIALIZE_HINT_LATELOAD // Areas tradiationally are initialized AFTER other atoms.
 
 /area/LateInitialize()
@@ -338,17 +338,20 @@ var/list/mob/living/forced_ambiance_list = new
 		to_chat(mob, "<span class='notice'>The sudden appearance of gravity makes you fall to the floor!</span>")
 		playsound(get_turf(src), "bodyfall", 50, 1)
 
-/area/proc/prison_break()
+/area/proc/prison_break(break_lights = TRUE, open_doors = TRUE, open_blast_doors = TRUE)
 	var/obj/machinery/power/apc/theAPC = get_apc()
 	if(theAPC.operating)
-		for(var/obj/machinery/power/apc/temp_apc in src)
-			temp_apc.overload_lighting(70)
-		for(var/obj/machinery/door/airlock/temp_airlock in src)
-			temp_airlock.prison_open()
-		for(var/obj/machinery/door/window/temp_windoor in src)
-			temp_windoor.open()
-		for(var/obj/machinery/door/blast/temp_blast in src)
-			temp_blast.open()
+		if(break_lights)
+			for(var/obj/machinery/power/apc/temp_apc in src)
+				temp_apc.overload_lighting(70)
+		if(open_doors)
+			for(var/obj/machinery/door/airlock/temp_airlock in src)
+				temp_airlock.prison_open()
+			for(var/obj/machinery/door/window/temp_windoor in src)
+				temp_windoor.open()
+		if(open_blast_doors)
+			for(var/obj/machinery/door/blast/temp_blast in src)
+				temp_blast.open()
 
 /area/has_gravity()
 	return has_gravity

--- a/code/modules/gamemaster/event2/event.dm
+++ b/code/modules/gamemaster/event2/event.dm
@@ -67,8 +67,19 @@ This allows for events that have their announcement happen after the end itself.
 
 // Returns the z-levels that are involved with the event.
 // In the future this might be handy for off-station events.
-/datum/event2/event/proc/get_location_z_levels()
-	return using_map.station_levels
+/datum/event2/event/proc/get_location_z_levels(space_only = FALSE)
+	. = using_map.station_levels.Copy()
+	if(space_only)
+		for(var/z_level in .)
+			if(is_planet_z_level(z_level))
+				. -= z_level
+
+
+/datum/event2/event/proc/is_planet_z_level(z_level)
+	var/datum/planet/P = LAZYACCESS(SSplanets.z_to_planet, z_level)
+	if(!istype(P))
+		return FALSE
+	return TRUE
 
 // Returns a list of empty turfs in the same area.
 /datum/event2/event/proc/find_random_turfs(minimum_free_space = 5, list/specific_areas = list(), ignore_occupancy = FALSE)
@@ -105,6 +116,7 @@ This allows for events that have their announcement happen after the end itself.
 		if(!ignore_occupancy && is_area_occupied(A))
 			continue // Occupied.
 		. += A
+
 
 // Starts the event.
 /datum/event2/event/proc/execute()

--- a/code/modules/gamemaster/event2/events/engineering/airlock_failure.dm
+++ b/code/modules/gamemaster/event2/events/engineering/airlock_failure.dm
@@ -4,6 +4,7 @@
 	chaos = 15
 	chaotic_threshold = EVENT_CHAOS_THRESHOLD_MEDIUM_IMPACT
 	event_type = /datum/event2/event/airlock_failure
+	var/needs_medical = FALSE
 
 /datum/event2/meta/airlock_failure/emag
 	name = "airlock failure - emag"
@@ -12,11 +13,13 @@
 /datum/event2/meta/airlock_failure/door_crush
 	name = "airlock failure - crushing"
 	event_type = /datum/event2/event/airlock_failure/door_crush
+	needs_medical = TRUE
 
 /datum/event2/meta/airlock_failure/shock
 	name = "airlock failure - shock"
 	chaos = 30
 	event_type = /datum/event2/event/airlock_failure/shock
+	needs_medical = TRUE
 
 
 /datum/event2/meta/airlock_failure/get_weight()
@@ -29,6 +32,8 @@
 
 	// Medical might be needed for some of the more violent airlock failures.
 	var/medical = metric.count_people_in_department(DEPARTMENT_MEDICAL)
+	if(!medical && needs_medical)
+		return 0
 
 	return (engineering * 20) + (medical * 20) + (synths * 20)
 

--- a/code/modules/gamemaster/event2/events/engineering/brand_intelligence.dm
+++ b/code/modules/gamemaster/event2/events/engineering/brand_intelligence.dm
@@ -1,6 +1,6 @@
 /datum/event2/meta/brand_intelligence
 	name = "vending machine malware"
-	departments = list(DEPARTMENT_EVERYONE, DEPARTMENT_EVERYONE)
+	departments = list(DEPARTMENT_ENGINEERING, DEPARTMENT_EVERYONE)
 	chaos = 10
 	chaotic_threshold = EVENT_CHAOS_THRESHOLD_LOW_IMPACT
 	event_type = /datum/event2/event/brand_intelligence

--- a/code/modules/gamemaster/event2/events/engineering/spacevine.dm
+++ b/code/modules/gamemaster/event2/events/engineering/spacevine.dm
@@ -6,7 +6,7 @@
 	event_type = /datum/event2/event/spacevine
 
 /datum/event2/meta/spacevine/get_weight()
-	return 20 + (metric.count_people_in_department(DEPARTMENT_ENGINEERING) * 20) + (metric.count_people_in_department(DEPARTMENT_EVERYONE) * 10)
+	return 20 + (metric.count_people_in_department(DEPARTMENT_ENGINEERING) * 10) + (metric.count_people_in_department(DEPARTMENT_EVERYONE) * 5)
 
 
 

--- a/code/modules/gamemaster/event2/events/engineering/window_break.dm
+++ b/code/modules/gamemaster/event2/events/engineering/window_break.dm
@@ -11,7 +11,7 @@
 	event_type = /datum/event2/event/window_break
 
 /datum/event2/meta/window_break/get_weight()
-	return metric.count_people_in_department(DEPARTMENT_ENGINEERING) * 20
+	return (metric.count_people_in_department(DEPARTMENT_ENGINEERING) * 20) / (times_ran + 1)
 
 
 

--- a/code/modules/gamemaster/event2/events/everyone/gravity.dm
+++ b/code/modules/gamemaster/event2/events/everyone/gravity.dm
@@ -7,14 +7,14 @@
 	event_type = /datum/event2/event/gravity
 
 /datum/event2/meta/gravity/get_weight()
-	return (20 + (metric.count_people_in_department(DEPARTMENT_EVERYONE) * 20)) / (times_ran + 1)
+	return (20 + (metric.count_people_in_department(DEPARTMENT_EVERYONE) * 5)) / (times_ran + 1)
 
 
 
 
 /datum/event2/event/gravity
-	length_lower_bound = 5 MINUTES
-	length_upper_bound = 10 MINUTES
+	length_lower_bound = 4 MINUTES
+	length_upper_bound = 8 MINUTES
 
 /datum/event2/event/gravity/announce()
 	command_announcement.Announce("Feedback surge detected in mass-distributions systems. \
@@ -23,12 +23,12 @@
 
 /datum/event2/event/gravity/start()
 	for(var/area/A in world)
-		if(A.z in get_location_z_levels())
+		if(A.z in get_location_z_levels(space_only = TRUE))
 			A.gravitychange(FALSE)
 
 /datum/event2/event/gravity/end()
 	for(var/area/A in world)
-		if(A.z in get_location_z_levels())
+		if(A.z in get_location_z_levels(space_only = TRUE))
 			A.gravitychange(TRUE)
 
 	command_announcement.Announce("Gravity generators are again functioning within normal parameters. Sorry for any inconvenience.", "Gravity Restored")

--- a/code/modules/gamemaster/event2/events/security/prison_break.dm
+++ b/code/modules/gamemaster/event2/events/security/prison_break.dm
@@ -86,7 +86,8 @@
 	relevant_areas = list(/area/rnd/xenobiology)
 	irrelevant_areas = list(
 		/area/rnd/xenobiology/xenoflora,
-		/area/rnd/xenobiology/xenoflora_storage
+		/area/rnd/xenobiology/xenoflora_storage,
+		/area/rnd/xenobiology/xenoflora_isolation
 	)
 
 /datum/event2/meta/prison_break/xenobio/get_odds_from_trapped_mobs()
@@ -126,6 +127,7 @@
 	var/list/areas_to_break = list()
 	var/list/area_types_to_break = null // Area types to include.
 	var/list/area_types_to_ignore = null // Area types to exclude, usually due to undesired inclusion from inheritence.
+	var/ignore_blast_doors = FALSE
 
 /datum/event2/event/prison_break/brig
 	area_display_name = "Brig"
@@ -164,8 +166,10 @@
 	area_types_to_break = list(/area/rnd/xenobiology)
 	area_types_to_ignore = list(
 		/area/rnd/xenobiology/xenoflora,
-		/area/rnd/xenobiology/xenoflora_storage
+		/area/rnd/xenobiology/xenoflora_storage,
+		/area/rnd/xenobiology/xenoflora_isolation
 	)
+	ignore_blast_doors = TRUE // Needed to avoid a breach.
 
 /datum/event2/event/prison_break/virology
 	area_display_name = "Virology"
@@ -217,7 +221,7 @@
 /datum/event2/event/prison_break/start()
 	for(var/area/A in areas_to_break)
 		spawn(0) // So we don't block the ticker.
-			A.prison_break()
+			A.prison_break(open_blast_doors = !ignore_blast_doors)
 
 // There's between 40 seconds and one minute before the whole station knows.
 // If there's a baddie engineer, they can choose to keep their early announcement to themselves and get a minute to exploit it.
@@ -225,3 +229,9 @@
 	command_announcement.Announce("[pick("Gr3y.T1d3 virus","Malignant trojan")] was detected \
 	in \the [location_name()] [area_display_name] [containment_display_desc] subroutines. Secure any compromised \
 	areas immediately. AI involvement is recommended.", "[capitalize(containment_display_desc)] Alert")
+
+	global_announcer.autosay(
+		"It is now safe to reactivate the APCs' main breakers inside [area_display_name].",
+		"[location_name()] Firewall Subroutines",
+		DEPARTMENT_ENGINEERING
+	)

--- a/code/modules/gamemaster/event2/events/security/prison_break.dm
+++ b/code/modules/gamemaster/event2/events/security/prison_break.dm
@@ -86,8 +86,7 @@
 	relevant_areas = list(/area/rnd/xenobiology)
 	irrelevant_areas = list(
 		/area/rnd/xenobiology/xenoflora,
-		/area/rnd/xenobiology/xenoflora_storage,
-		/area/rnd/xenobiology/xenoflora_isolation
+		/area/rnd/xenobiology/xenoflora_storage
 	)
 
 /datum/event2/meta/prison_break/xenobio/get_odds_from_trapped_mobs()
@@ -166,10 +165,8 @@
 	area_types_to_break = list(/area/rnd/xenobiology)
 	area_types_to_ignore = list(
 		/area/rnd/xenobiology/xenoflora,
-		/area/rnd/xenobiology/xenoflora_storage,
-		/area/rnd/xenobiology/xenoflora_isolation
+		/area/rnd/xenobiology/xenoflora_storage
 	)
-	ignore_blast_doors = TRUE // Needed to avoid a breach.
 
 /datum/event2/event/prison_break/virology
 	area_display_name = "Virology"

--- a/code/modules/gamemaster/event2/events/synthetic/ion_storm.dm
+++ b/code/modules/gamemaster/event2/events/synthetic/ion_storm.dm
@@ -6,9 +6,12 @@
 	event_type = /datum/event2/event/ion_storm
 
 /datum/event2/meta/ion_storm/get_weight()
-	var/bots = metric.count_people_in_department(DEPARTMENT_SYNTHETIC)
-	var/weight = 5 + (bots * 40) // A small chance even if no synths are on, since it can still emag beepsky.
-	return weight
+	var/list/bots = metric.get_people_in_department(DEPARTMENT_SYNTHETIC)
+	. = 5 // A small chance even if no synths are on, since it can still emag beepsky.
+	for(var/mob/living/silicon/S in bots)
+		if(istype(S, /mob/living/silicon/robot/drone)) // Drones don't get their laws screwed with, so don't count them.
+			continue
+		. += 40
 
 
 /datum/event2/event/ion_storm

--- a/code/modules/power/generator.dm
+++ b/code/modules/power/generator.dm
@@ -168,6 +168,9 @@ GLOBAL_LIST_EMPTY(all_turbines)
 		else
 			disconnect_from_network()
 		reconnect()
+		lastgenlev = 0
+		effective_gen = 0
+		updateicon()
 	else
 		..()
 

--- a/maps/southern_cross/southern_cross_events.dm
+++ b/maps/southern_cross/southern_cross_events.dm
@@ -5,3 +5,19 @@
 		/area/bridge_hallway,
 		/area/crew_quarters/heads/sc/sd
 	)
+
+// So is xenoflora isolation it seems.
+/datum/event2/meta/prison_break/xenobio
+	irrelevant_areas = list(
+		/area/rnd/xenobiology/xenoflora,
+		/area/rnd/xenobiology/xenoflora_storage,
+		/area/rnd/xenobiology/xenoflora_isolation
+	)
+
+/datum/event2/event/prison_break/xenobio
+	area_types_to_ignore = list(
+		/area/rnd/xenobiology/xenoflora,
+		/area/rnd/xenobiology/xenoflora_storage,
+		/area/rnd/xenobiology/xenoflora_isolation
+	)
+	ignore_blast_doors = TRUE // Needed to avoid a breach.


### PR DESCRIPTION
Resolves a lot of the things noted in #6984, and fixes all the bugs noted there.
Changes:
- Prison break event now tells engineering when they can turn the APCs back on.
- Xenobio prison break should stop breaking a part of xenoflora as well.
- Xenobio prison break won't touch blast doors now, and as such it won't breach xenobio, since getting slimed and ZAS'd is just a bit too unfair.
- The dangerous airlock failure events require medical to be present to be able to fire.
- Gravity failure no longer makes Sif lose gravity.
- Gravity failure lasts for less time, but still a lot longer than the current duration.
- Maint drones no longer make ion laws more likely by existing.
- TEGs that aren't hooked up won't contribute towards causing a grid check.