### PR TITLE
Allows backpacks to be carried on most hardsuits

### DIFF
--- a/code/modules/clothing/spacesuits/rig/suits/alien.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/alien.dm
@@ -51,7 +51,13 @@
 	item_flags = THICKMATERIAL
 	siemens_coefficient = 0.2
 	offline_slowdown = 5
-	allowed = list(/obj/item/weapon/gun,/obj/item/device/flashlight,/obj/item/weapon/tank,/obj/item/device/suit_cooling_unit)
+	allowed = list(
+		/obj/item/weapon/gun,
+		/obj/item/device/flashlight,
+		/obj/item/weapon/tank,
+		/obj/item/device/suit_cooling_unit,
+		/obj/item/weapon/storage
+		)
 
 	air_type = /obj/item/weapon/tank/vox
 

--- a/code/modules/clothing/spacesuits/rig/suits/combat.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/combat.dm
@@ -12,7 +12,14 @@
 	offline_vision_restriction = 1
 
 	helm_type = /obj/item/clothing/head/helmet/space/rig/combat
-	allowed = list(/obj/item/weapon/gun,/obj/item/device/flashlight,/obj/item/weapon/tank,/obj/item/device/suit_cooling_unit,/obj/item/weapon/melee/baton)
+	allowed = list(
+		/obj/item/weapon/gun,
+		/obj/item/device/flashlight,
+		/obj/item/weapon/tank,
+		/obj/item/device/suit_cooling_unit,
+		/obj/item/weapon/melee/baton,
+		/obj/item/weapon/storage
+		)
 
 
 /obj/item/weapon/rig/combat/equipped
@@ -42,10 +49,26 @@
 	slowdown = 1
 	offline_slowdown = 3
 	offline_vision_restriction = 1
-	allowed = list(/obj/item/device/flashlight, /obj/item/weapon/tank,/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/weapon/handcuffs, \
-	/obj/item/device/t_scanner, /obj/item/weapon/rcd, /obj/item/weapon/weldingtool, /obj/item/weapon/tool, /obj/item/device/multitool, \
-	/obj/item/device/radio, /obj/item/device/analyzer,/obj/item/weapon/storage/briefcase/inflatable, /obj/item/weapon/melee/baton, /obj/item/weapon/gun, \
-	/obj/item/weapon/storage/firstaid, /obj/item/weapon/reagent_containers/hypospray, /obj/item/roller, /obj/item/device/suit_cooling_unit)
+	allowed = list(
+		/obj/item/device/flashlight,
+		/obj/item/weapon/tank,
+		/obj/item/ammo_magazine,
+		/obj/item/ammo_casing,
+		/obj/item/weapon/handcuffs,
+		/obj/item/device/t_scanner,
+		/obj/item/weapon/rcd,
+		/obj/item/weapon/weldingtool,
+		/obj/item/weapon/tool,
+		/obj/item/device/multitool,
+		/obj/item/device/radio,
+		/obj/item/device/analyzer,
+		/obj/item/weapon/melee/baton,
+		/obj/item/weapon/gun,
+		/obj/item/weapon/storage,
+		/obj/item/weapon/reagent_containers/hypospray,
+		/obj/item/roller,
+		/obj/item/device/suit_cooling_unit
+		)
 
 	chest_type = /obj/item/clothing/suit/space/rig/military
 	helm_type = /obj/item/clothing/head/helmet/space/rig/military

--- a/code/modules/clothing/spacesuits/rig/suits/ert.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/ert.dm
@@ -14,10 +14,25 @@
 	siemens_coefficient= 0.5
 
 	armor = list(melee = 60, bullet = 50, laser = 30,energy = 15, bomb = 30, bio = 100, rad = 100)
-	allowed = list(/obj/item/device/flashlight, /obj/item/weapon/tank, /obj/item/device/t_scanner, /obj/item/weapon/rcd, /obj/item/weapon/tool/crowbar, \
-	/obj/item/weapon/tool/screwdriver, /obj/item/weapon/weldingtool, /obj/item/weapon/tool/wirecutters, /obj/item/weapon/tool/wrench, /obj/item/device/multitool, \
-	/obj/item/device/radio, /obj/item/device/analyzer,/obj/item/weapon/storage/briefcase/inflatable, /obj/item/weapon/melee/baton, /obj/item/weapon/gun, \
-	/obj/item/weapon/storage/firstaid, /obj/item/weapon/reagent_containers/hypospray, /obj/item/roller)
+	allowed = list(
+		/obj/item/device/flashlight,
+		/obj/item/weapon/tank,
+		/obj/item/device/t_scanner,
+		/obj/item/weapon/rcd,
+		/obj/item/weapon/tool/crowbar,
+		/obj/item/weapon/tool/screwdriver,
+		/obj/item/weapon/weldingtool,
+		/obj/item/weapon/tool/wirecutters,
+		/obj/item/weapon/tool/wrench,
+		/obj/item/device/multitool,
+		/obj/item/device/radio,
+		/obj/item/device/analyzer,
+		/obj/item/weapon/storage,
+		/obj/item/weapon/melee/baton,
+		/obj/item/weapon/gun,
+		/obj/item/weapon/reagent_containers/hypospray,
+		/obj/item/roller
+		)
 
 	initial_modules = list(
 		/obj/item/rig_module/ai_container,

--- a/code/modules/clothing/spacesuits/rig/suits/light.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/light.dm
@@ -4,7 +4,17 @@
 	desc = "A lighter, less armoured rig suit."
 	icon_state = "ninja_rig"
 	suit_type = "light suit"
-	allowed = list(/obj/item/weapon/gun,/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/weapon/melee/baton,/obj/item/weapon/handcuffs,/obj/item/weapon/tank,/obj/item/device/suit_cooling_unit,/obj/item/weapon/cell)
+	allowed = list(
+		/obj/item/weapon/gun,
+		/obj/item/ammo_magazine,
+		/obj/item/ammo_casing,
+		/obj/item/weapon/melee/baton,
+		/obj/item/weapon/handcuffs,
+		/obj/item/weapon/tank,
+		/obj/item/device/suit_cooling_unit,
+		/obj/item/weapon/cell,
+		/obj/item/weapon/storage
+		)
 	armor = list(melee = 50, bullet = 15, laser = 50, energy = 10, bomb = 25, bio = 0, rad = 0)
 	emp_protection = 10
 	slowdown = 0

--- a/code/modules/clothing/spacesuits/rig/suits/merc.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/merc.dm
@@ -14,7 +14,18 @@
 	siemens_coefficient = 0.3
 	glove_type = /obj/item/clothing/gloves/gauntlets/rig/eva
 	helm_type = /obj/item/clothing/head/helmet/space/rig/merc
-	allowed = list(/obj/item/device/flashlight,/obj/item/weapon/tank,/obj/item/device/suit_cooling_unit,/obj/item/weapon/gun,/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/weapon/melee/baton,/obj/item/weapon/melee/energy/sword,/obj/item/weapon/handcuffs)
+	allowed = list(
+		/obj/item/device/flashlight,
+		/obj/item/weapon/tank,
+		/obj/item/device/suit_cooling_unit,
+		/obj/item/weapon/gun,
+		/obj/item/ammo_magazine,
+		/obj/item/ammo_casing,
+		/obj/item/weapon/melee/baton,
+		/obj/item/weapon/melee/energy/sword,
+		/obj/item/weapon/handcuffs,
+		/obj/item/weapon/storage
+		)
 
 	initial_modules = list(
 		/obj/item/rig_module/mounted,

--- a/code/modules/clothing/spacesuits/rig/suits/pmc.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/pmc.dm
@@ -12,10 +12,25 @@
 	req_access = list(access_cent_specops)
 
 	armor = list(melee = 60, bullet = 50, laser = 35,energy = 15, bomb = 30, bio = 100, rad = 95)
-	allowed = list(/obj/item/device/flashlight, /obj/item/weapon/tank, /obj/item/device/t_scanner, /obj/item/weapon/rcd, /obj/item/weapon/tool/crowbar, \
-	/obj/item/weapon/tool/screwdriver, /obj/item/weapon/weldingtool, /obj/item/weapon/tool/wirecutters, /obj/item/weapon/tool/wrench, /obj/item/device/multitool, \
-	/obj/item/device/radio, /obj/item/device/analyzer,/obj/item/weapon/storage/briefcase/inflatable, /obj/item/weapon/melee/baton, /obj/item/weapon/gun, \
-	/obj/item/weapon/storage/firstaid, /obj/item/weapon/reagent_containers/hypospray, /obj/item/roller)
+	allowed = list(
+		/obj/item/device/flashlight,
+		/obj/item/weapon/tank,
+		/obj/item/device/t_scanner,
+		/obj/item/weapon/rcd,
+		/obj/item/weapon/tool/crowbar,
+		/obj/item/weapon/tool/screwdriver,
+		/obj/item/weapon/weldingtool,
+		/obj/item/weapon/tool/wirecutters,
+		/obj/item/weapon/tool/wrench,
+		/obj/item/device/multitool,
+		/obj/item/device/radio,
+		/obj/item/device/analyzer,
+		/obj/item/weapon/melee/baton,
+		/obj/item/weapon/gun,
+		/obj/item/weapon/storage,
+		/obj/item/weapon/reagent_containers/hypospray,
+		/obj/item/roller
+		)
 
 /obj/item/weapon/rig/pmc/commander
 	name = "PMC-C hardsuit control module"

--- a/code/modules/clothing/spacesuits/rig/suits/station.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/station.dm
@@ -35,8 +35,7 @@
 		/obj/item/device/flashlight,
 		/obj/item/weapon/tank,
 		/obj/item/device/suit_cooling_unit,
-		/obj/item/weapon/storage/briefcase,
-		/obj/item/weapon/storage/secure/briefcase
+		/obj/item/weapon/storage,
 		)
 
 	req_access = list()
@@ -83,7 +82,7 @@
 		/obj/item/device/flashlight,
 		/obj/item/weapon/tank,
 		/obj/item/device/suit_cooling_unit,
-		/obj/item/weapon/storage/bag/ore,
+		/obj/item/weapon/storage,
 		/obj/item/device/t_scanner,
 		/obj/item/weapon/pickaxe,
 		/obj/item/weapon/rcd
@@ -121,7 +120,7 @@
 		/obj/item/device/flashlight,
 		/obj/item/weapon/tank,
 		/obj/item/device/suit_cooling_unit,
-		/obj/item/weapon/storage/briefcase/inflatable,
+		/obj/item/weapon/storage,
 		/obj/item/device/t_scanner,
 		/obj/item/weapon/rcd
 		)
@@ -167,7 +166,7 @@
 		/obj/item/device/flashlight,
 		/obj/item/weapon/tank,
 		/obj/item/device/suit_cooling_unit,
-		/obj/item/weapon/storage/briefcase/inflatable,
+		/obj/item/weapon/storage,
 		/obj/item/device/t_scanner,
 		/obj/item/weapon/rcd
 		)
@@ -211,7 +210,7 @@
 		/obj/item/weapon/tank,
 		/obj/item/device/suit_cooling_unit,
 		/obj/item/stack/flag,
-		/obj/item/weapon/storage/excavation,
+		/obj/item/weapon/storage,
 		/obj/item/weapon/pickaxe,
 		/obj/item/device/healthanalyzer,
 		/obj/item/device/measuring_tape,
@@ -221,8 +220,8 @@
 		/obj/item/device/gps,
 		/obj/item/device/beacon_locator,
 		/obj/item/device/radio/beacon,
-		/obj/item/weapon/pickaxe/hand,
-		/obj/item/weapon/storage/bag/fossils)
+		/obj/item/weapon/pickaxe/hand
+		)
 
 	req_access = list()
 	req_one_access = list()
@@ -255,7 +254,7 @@
 		/obj/item/device/flashlight,
 		/obj/item/weapon/tank,
 		/obj/item/device/suit_cooling_unit,
-		/obj/item/weapon/storage/firstaid,
+		/obj/item/weapon/storage,
 		/obj/item/device/healthanalyzer,
 		/obj/item/stack/medical,
 		/obj/item/roller
@@ -295,7 +294,8 @@
 		/obj/item/device/flashlight,
 		/obj/item/weapon/tank,
 		/obj/item/device/suit_cooling_unit,
-		/obj/item/weapon/melee/baton
+		/obj/item/weapon/melee/baton,
+		/obj/item/weapon/storage
 		)
 
 	req_access = list()

--- a/html/changelogs/atlantiscze-hardsuit.yml
+++ b/html/changelogs/atlantiscze-hardsuit.yml
@@ -1,0 +1,6 @@
+author: atlantiscze
+
+delete-after: True
+
+changes: 
+  - rscadd: "Hardsuits now allow backpacks to be carried in storage slot. This is limited to hardsuits which are worn on the back slot."


### PR DESCRIPTION
- Backpacks can be carried on suit storage slot of those hardsuits that occupy back slot (breacher excluded).
- Now, i understand this may be a somewhat controversial change. Feel free to close this PR if you believe it does not fit. Just opening this as i've received this suggestion from another player, and i in fact tried proposing the same thing back at Bay when hardsuits as we know them were added.
- Reformatted some of the allowed lists while i was at it. Makes future modifications somewhat less likely to hit merge conflicts with each entry on its own line.

My balance perspective (long rant):
Hardsuits, as-is, fill very specific roles. In general, unless you absolutely need one of the modules or some specific function (for example, 100% RAD resist combined with EVA capability of CE suit) you don't want to use them, as they require you to trade-in your back slot (which is what this PR aims to change), therefore significantly reducing carrying capacity. Of course, this has its workarounds - usually dragging crates around, or carrying your backpack in hand. This provides minimal actual restriction (you can still carry tons of stuff), but acts as quite major inconvenience and annoyance for the player (you have to juggle with items, keep placing stuff on the ground, etc - generally just clicking 10x more). In total, the only real effect is that it slows you down a bit due to all the clicking required.

Therefore i believe this change is not as massive buff as it might seem in first place. Sure, it lets you carry more things on yourself, but you could also do that easily with a crate or by holding backpack in hand. It just makes doing so more convenient and comfortable to the player.