### PR TITLE
Adds preference to control multilingual behaviour

### DIFF
--- a/code/__defines/preferences.dm
+++ b/code/__defines/preferences.dm
@@ -1,6 +1,15 @@
+// Modes for examine text output
 #define EXAMINE_MODE_DEFAULT		 0
 #define EXAMINE_MODE_INCLUDE_USAGE	 1
 #define EXAMINE_MODE_SWITCH_TO_PANEL 2
 
 // Should be one higher than the above
 #define EXAMINE_MODE_MAX			 3
+
+// Modes for parsing multilingual speech
+#define MULTILINGUAL_DEFAULT			0
+#define MULTILINGUAL_SPACE				1
+#define MULTILINGUAL_DOUBLE_DELIMITER	2
+#define MULTILINGUAL_OFF				3
+
+#define MULTILINGUAL_MODE_MAX			4

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -184,10 +184,10 @@
 
 	var/list/output = list("[bicon(src)] That's [f_name] [suffix]", desc)
 
-	if(user.client?.examine_text_mode == EXAMINE_MODE_INCLUDE_USAGE)
+	if(user.client?.prefs.examine_text_mode == EXAMINE_MODE_INCLUDE_USAGE)
 		output += description_info
 
-	if(user.client?.examine_text_mode == EXAMINE_MODE_SWITCH_TO_PANEL)
+	if(user.client?.prefs.examine_text_mode == EXAMINE_MODE_SWITCH_TO_PANEL)
 		user.client.statpanel = "Examine" // Switch to stat panel
 
 	return output

--- a/code/modules/client/client defines.dm
+++ b/code/modules/client/client defines.dm
@@ -28,8 +28,6 @@
 	var/chatOutputLoadedAt
 
 	var/adminhelped = 0
-	var/examine_text_mode = 0 // Just examine text, include usage (description_info), switch to examine panel.
-
 
 		///////////////
 		//SOUND STUFF//

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -131,6 +131,10 @@ datum/preferences
 
 	var/lastnews // Hash of last seen lobby news content.
 
+	var/examine_text_mode = 0 // Just examine text, include usage (description_info), switch to examine panel.
+	var/multilingual_mode = 0 // Default behaviour, delimiter-key-space, delimiter-key-delimiter, off
+
+
 /datum/preferences/New(client/C)
 	player_setup = new(src)
 	set_biological_gender(pick(MALE, FEMALE))

--- a/code/modules/client/preferences_toggle_procs.dm
+++ b/code/modules/client/preferences_toggle_procs.dm
@@ -313,17 +313,34 @@
 	set category = "Preferences"
 	set desc = "Control the additional behaviour of examining things"
 
-	examine_text_mode++
-	examine_text_mode %= EXAMINE_MODE_MAX // This cycles through them because if you're already specifically being routed to the examine panel, you probably don't need to have the extra text printed to chat
-	switch(examine_text_mode)				// ... And I only wanted to add one verb
+	prefs.examine_text_mode++
+	prefs.examine_text_mode %= EXAMINE_MODE_MAX // This cycles through them because if you're already specifically being routed to the examine panel, you probably don't need to have the extra text printed to chat
+	switch(prefs.examine_text_mode)				// ... And I only wanted to add one verb
 		if(EXAMINE_MODE_DEFAULT)
-			to_chat(src, "Examining things will only output the base examine text, and you will not be redirected to the examine panel automatically.")
+			to_chat(src, "<span class='filter_system'>Examining things will only output the base examine text, and you will not be redirected to the examine panel automatically.</span>")
 
 		if(EXAMINE_MODE_INCLUDE_USAGE)
-			to_chat(src, "Examining things will also print any extra usage information normally included in the examine panel to the chat.")
+			to_chat(src, "<span class='filter_system'>Examining things will also print any extra usage information normally included in the examine panel to the chat.</span>")
 
 		if(EXAMINE_MODE_SWITCH_TO_PANEL)
-			to_chat(src, "Examining things will direct you to the examine panel, where you can view extended information about the thing.")
+			to_chat(src, "<span class='filter_system'>Examining things will direct you to the examine panel, where you can view extended information about the thing.</span>")
+
+/client/verb/toggle_multilingual_mode()
+	set name = "Toggle Multilingual Mode"
+	set category = "Preferences"
+	set desc = "Control the behaviour of multilingual speech parsing"
+
+	prefs.multilingual_mode++
+	prefs.multilingual_mode %= MULTILINGUAL_MODE_MAX // Cycles through the various options
+	switch(prefs.multilingual_mode)
+		if(MULTILINGUAL_DEFAULT)
+			to_chat(src, "<span class='filter_system'>Multilingual parsing will only check for the delimiter-key combination (,0galcom-2tradeband).</span>")
+		if(MULTILINGUAL_SPACE)
+			to_chat(src, "<span class='filter_system'>Multilingual parsing will enforce a space after the delimiter-key combination (,0 galcom -2still galcom). The extra space will be consumed by the pattern-matching.</span>")
+		if(MULTILINGUAL_DOUBLE_DELIMITER)
+			to_chat(src, "<span class='filter_system'>Multilingual parsing will enforce the a language delimiter after the delimiter-key combination (,0,galcom -2 still galcom). The extra delimiter will be consumed by the pattern-matching.</span>")
+		if(MULTILINGUAL_OFF)
+			to_chat(src, "<span class='filter_system'>Multilingual parsing is now disabled. Entire messages will be in the language specified at the start of the message.</span>")
 
 
 //Toggles for Staff

--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -148,8 +148,8 @@
 /mob/proc/find_valid_prefixes(message)
 	var/list/prefixes = list() // [["Common", start, end], ["Gutter", start, end]]
 	for(var/i in 1 to length(message))
-		// This grabs trimmed 3 character substrings, to allow for up to 1 prefix and 1 letter language keys
-		var/selection = trim_right(lowertext(copytext(message, i, i + 2)))
+		// This grabs 3 character substrings, to allow for up to 1 prefix, 1 letter language key, and one post-key character to more strictly control where the language breaks happen
+		var/selection = lowertext(copytext(message, i, i + 3))
 		// The first character in the selection will always be the prefix (if this is a valid language invocation)
 		var/prefix = copytext(selection, 1, 2)
 		var/language_key = copytext(selection, 2, 3)
@@ -157,6 +157,18 @@
 			// Okay, we're definitely now trying to invoke a language (probably)
 			// This "[]" is probably unnecessary but BYOND will runtime if a number is used
 			var/datum/language/L = GLOB.language_keys["[language_key]"]
+
+			// MULTILINGUAL_SPACE enforces a space after the language key
+			if(client && (client.prefs.multilingual_mode == MULTILINGUAL_SPACE) && (text2ascii(copytext(selection, 3, 4)) != 32)) // If we're looking for a space and we don't find one
+				continue
+
+			// MULTILINGUAL_DOUBLE_DELIMITER enforces a delimiter (valid prefix) after the language key
+			if(client && (client.prefs.multilingual_mode == MULTILINGUAL_DOUBLE_DELIMITER) && !is_language_prefix(copytext(selection, 3, 4)))
+				continue
+
+			if(client && (client.prefs.multilingual_mode in list(MULTILINGUAL_DEFAULT)))
+				selection = copytext(selection, 1, 3) // These modes only use two characters, not three
+
 			// It's kinda silly that we have to check L != null and this isn't done for us by can_speak (it runtimes instead), but w/e
 			if(L && can_speak(L))
 				// So we have a valid language invocation, and we can speak that language, let's make a piece for it
@@ -169,6 +181,10 @@
 		if(i == 1)
 			// This covers the case of "no prefixes in use."
 			prefixes[++prefixes.len] = list(get_default_language(), i, i)
+
+		// If multilingualism is disabled, then after the first pass we're guaranteed to have either found a language key at the start, or else there isn't one and we're using the default for the whole message
+		if(client && (client.prefs.multilingual_mode == MULTILINGUAL_OFF))
+			break
 
 	return prefixes
 

--- a/html/changelogs/atermonera_multilingual_pref.yml
+++ b/html/changelogs/atermonera_multilingual_pref.yml
@@ -1,4 +1,4 @@
-author: Shadow Quill
+author: Atermonera
 delete-after: True
 
 # Any changes you've made.  See valid prefix list above.

--- a/html/changelogs/atermonera_multilingual_pref.yml
+++ b/html/changelogs/atermonera_multilingual_pref.yml
@@ -1,0 +1,11 @@
+author: Shadow Quill
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Added a preference to control multilingual parsing behaviour, with a few different modes. Should hopefully be less punishing to people who stutter and use hyphens as a language key."
+  - tweak:  "The examine mode preference should now persist across reconnections during a single round, but if the server is fully restarted it still appears to reset. This issue is also present for the multilingual preference, and I'm still looking into it. Savefiles are crpytic."

--- a/polaris.dme
+++ b/polaris.dme
@@ -2932,7 +2932,7 @@
 #include "code\ZAS\Zone.dm"
 #include "interface\interface.dm"
 #include "interface\skin.dmf"
-#include "maps\example\example.dm"
+#include "maps\southern_cross\southern_cross.dm"
 #include "maps\submaps\_helpers.dm"
 #include "maps\submaps\space_submaps\space.dm"
 #include "maps\submaps\surface_submaps\mountains\mountains.dm"

--- a/polaris.dme
+++ b/polaris.dme
@@ -2932,7 +2932,7 @@
 #include "code\ZAS\Zone.dm"
 #include "interface\interface.dm"
 #include "interface\skin.dmf"
-#include "maps\southern_cross\southern_cross.dm"
+#include "maps\example\example.dm"
 #include "maps\submaps\_helpers.dm"
 #include "maps\submaps\space_submaps\space.dm"
 #include "maps\submaps\surface_submaps\mountains\mountains.dm"


### PR DESCRIPTION
The modes are
* Default, which functions exactly as the parser works now
* Extra space, which only makes a new language piece when there's an extra space following the language key, so matching the pattern "[delimiter][key] "
* Extra delimiter, which only makes a new language piece when there's a valid language prefix following the language key, so matching the pattern "[delimiter][key][delimiter]"
* Disabled, which will only look at the first 2 characters after trimming radio prefixes to find any language keys, and lacking those will use the default language, for the entire message.

This should hopefully be more amenable to people with characters that stutter.

Examine mode preference should persist across reconnections to a single round, but it still appears to reset on server restart.
Still looking into how to properly get these to go into the savefile
Fixes #7040 
Tested, and the preference performs as noted above for examine pref, where if I closed my client and reconnected to the server, it would persist, but if I closed and reopened the server, it would be reset. Unfortunately, I can't simply use the /datum/client_preference stuff because that is, as far as I can tell, explicitly a binary toggle, and getting these multi-mode preferences to work with that would require a not-insignificant refactor (Not to mention having to figure out how in the heck they're actually manipulating the preferences in and out of savefiles).