### PR TITLE
Port SSnightshift from Paradise

### DIFF
--- a/code/__defines/lighting.dm
+++ b/code/__defines/lighting.dm
@@ -82,6 +82,7 @@
 #define LIGHT_COLOR_INCANDESCENT_TUBE "#FFFEB8"
 #define LIGHT_COLOR_INCANDESCENT_BULB "#FFDDBB"
 #define LIGHT_COLOR_INCANDESCENT_FLASHLIGHT "#FFCC66"
+#define LIGHT_COLOR_NIGHTSHIFT "#EFCC86"
 
 //Fake ambient occlusion filter
 #define AMBIENT_OCCLUSION filter(type="drop_shadow", x=0, y=-2, size=4, offset=3, color="#04080F80")

--- a/code/__defines/subsystems.dm
+++ b/code/__defines/subsystems.dm
@@ -68,8 +68,9 @@ var/global/list/runlevel_flags = list(RUNLEVEL_LOBBY, RUNLEVEL_SETUP, RUNLEVEL_G
 #define INIT_ORDER_ASSETS		-3
 #define INIT_ORDER_PLANETS		-4
 #define INIT_ORDER_HOLOMAPS		-5
-#define INIT_ORDER_OVERLAY		-6
-#define INIT_ORDER_ALARM		-7
+#define INIT_ORDER_NIGHTSHIFT	-6
+#define INIT_ORDER_OVERLAY		-7
+#define INIT_ORDER_ALARM		-8
 #define INIT_ORDER_OPENSPACE	-10
 #define INIT_ORDER_XENOARCH		-20
 #define INIT_ORDER_CIRCUIT		-21
@@ -84,6 +85,7 @@ var/global/list/runlevel_flags = list(RUNLEVEL_LOBBY, RUNLEVEL_SETUP, RUNLEVEL_G
 // If the subsystem isn't listed here it's either DEFAULT or PROCESS (if it's a processing subsystem child)
 #define FIRE_PRIORITY_SHUTTLES		5
 #define FIRE_PRIORITY_SUPPLY		5
+#define FIRE_PRIORITY_NIGHTSHIFT	5
 #define FIRE_PRIORITY_ORBIT			8
 #define FIRE_PRIORITY_VOTE			9
 #define FIRE_PRIORITY_AI			10

--- a/code/_helpers/time.dm
+++ b/code/_helpers/time.dm
@@ -35,25 +35,25 @@
 
 	return wtime + (time_offset + wusage) * world.tick_lag
 
-var/roundstart_hour
+GLOBAL_VAR_INIT(roundstart_hour, pick(2,7,12,17))
 var/station_date = ""
 var/next_station_date_change = 1 DAY
 
-#define duration2stationtime(time) time2text(station_time_in_ticks + time, "hh:mm")
-#define worldtime2stationtime(time) time2text(roundstart_hour HOURS + time, "hh:mm")
-#define round_duration_in_ticks (round_start_time ? world.time - round_start_time : 0)
-#define station_time_in_ticks (roundstart_hour HOURS + round_duration_in_ticks)
+#define duration2stationtime(time) time2text(station_time_in_ds + time, "hh:mm")
+#define worldtime2stationtime(time) time2text(GLOB.roundstart_hour HOURS + time, "hh:mm")
+#define round_duration_in_ds (GLOB.round_start_time ? world.time - GLOB.round_start_time : 0)
+#define station_time_in_ds (GLOB.roundstart_hour HOURS + round_duration_in_ds)
 
 /proc/stationtime2text()
-	return time2text(station_time_in_ticks, "hh:mm")
+	return time2text(station_time_in_ds, "hh:mm") //For some reason, this is not accurate. It's expecting some other kind of times, maybe? Like ones from world.realtime?
 
 /proc/stationdate2text()
 	var/update_time = FALSE
-	if(station_time_in_ticks > next_station_date_change)
+	if(station_time_in_ds > next_station_date_change)
 		next_station_date_change += 1 DAY
 		update_time = TRUE
 	if(!station_date || update_time)
-		var/extra_days = round(station_time_in_ticks / (1 DAY)) DAYS
+		var/extra_days = round(station_time_in_ds / (1 DAY)) DAYS
 		var/timeofday = world.timeofday + extra_days
 		station_date = num2text((text2num(time2text(timeofday, "YYYY"))+544)) + "-" + time2text(timeofday, "MM-DD")
 	return station_date
@@ -83,19 +83,19 @@ proc/isDay(var/month, var/day)
 
 var/next_duration_update = 0
 var/last_round_duration = 0
-var/round_start_time = 0
+GLOBAL_VAR_INIT(round_start_time, 0)
 
 /hook/roundstart/proc/start_timer()
-	round_start_time = world.time
+	GLOB.round_start_time = world.time
 	return 1
 
 /proc/roundduration2text()
-	if(!round_start_time)
+	if(!GLOB.round_start_time)
 		return "00:00"
 	if(last_round_duration && world.time < next_duration_update)
 		return last_round_duration
 
-	var/mills = round_duration_in_ticks // 1/10 of a second, not real milliseconds but whatever
+	var/mills = round_duration_in_ds // 1/10 of a second, not real milliseconds but whatever
 	//var/secs = ((mills % 36000) % 600) / 10 //Not really needed, but I'll leave it here for refrence.. or something
 	var/mins = round((mills % 36000) / 600)
 	var/hours = round(mills / 36000)
@@ -111,10 +111,6 @@ var/round_start_time = 0
 /proc/process_schedule_interval(var/process_name)
 	var/datum/controller/process/process = processScheduler.getProcess(process_name)
 	return process.schedule_interval
-
-/hook/startup/proc/set_roundstart_hour()
-	roundstart_hour = pick(2,7,12,17)
-	return 1
 
 /var/midnight_rollovers = 0
 /var/rollovercheck_last_timeofday = 0

--- a/code/_helpers/time.dm
+++ b/code/_helpers/time.dm
@@ -45,7 +45,7 @@ var/next_station_date_change = 1 DAY
 #define station_time_in_ds (GLOB.roundstart_hour HOURS + round_duration_in_ds)
 
 /proc/stationtime2text()
-	return time2text(station_time_in_ds, "hh:mm") //For some reason, this is not accurate. It's expecting some other kind of times, maybe? Like ones from world.realtime?
+	return time2text(station_time_in_ds + GLOB.timezoneOffset, "hh:mm")
 
 /proc/stationdate2text()
 	var/update_time = FALSE
@@ -63,6 +63,13 @@ var/next_station_date_change = 1 DAY
 	var/date_portion = time2text(world.timeofday, "YYYY-MM-DD")
 	var/time_portion = time2text(world.timeofday, "hh:mm:ss")
 	return "[date_portion]T[time_portion]"
+
+/proc/get_timezone_offset()
+	var/midnight_gmt_here = text2num(time2text(0,"hh")) * 36000
+	if(midnight_gmt_here > 12 HOURS)
+		return 24 HOURS - midnight_gmt_here
+	else
+		return midnight_gmt_here
 
 /proc/gameTimestamp(format = "hh:mm:ss", wtime=null)
 	if(!wtime)

--- a/code/controllers/autotransfer.dm
+++ b/code/controllers/autotransfer.dm
@@ -12,6 +12,6 @@ datum/controller/transfer_controller/Destroy()
 
 datum/controller/transfer_controller/process()
 	currenttick = currenttick + 1
-	if (round_duration_in_ticks >= timerbuffer - 1 MINUTE)
+	if (round_duration_in_ds >= timerbuffer - 1 MINUTE)
 		SSvote.autotransfer()
 		timerbuffer = timerbuffer + config.vote_autotransfer_interval

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -270,6 +270,9 @@ var/list/gamemode_cache = list()
 	// disables the annoying "You have already logged in this round, disconnect or be banned" popup for multikeying, because it annoys the shit out of me when testing.
 	var/disable_cid_warn_popup = FALSE
 
+	// whether or not to use the nightshift subsystem to perform lighting changes
+	var/static/enable_night_shifts = FALSE
+
 /datum/configuration/New()
 	var/list/L = typesof(/datum/game_mode) - /datum/game_mode
 	for (var/T in L)
@@ -887,6 +890,9 @@ var/list/gamemode_cache = list()
 
 				if("disable_cid_warn_popup")
 					config.disable_cid_warn_popup = TRUE
+
+				if("enable_night_shifts")
+					config.enable_night_shifts = TRUE
 
 				else
 					log_misc("Unknown setting in configuration: '[name]'")

--- a/code/controllers/subsystems/game_master.dm
+++ b/code/controllers/subsystems/game_master.dm
@@ -109,7 +109,7 @@ SUBSYSTEM_DEF(game_master)
 		return FALSE
 
 	// Last minute antagging is bad for humans to do, so the GM will respect the start and end of the round.
-	var/mills = round_duration_in_ticks
+	var/mills = round_duration_in_ds
 	var/mins = round((mills % 36000) / 600)
 	var/hours = round(mills / 36000)
 

--- a/code/controllers/subsystems/nightshift.dm
+++ b/code/controllers/subsystems/nightshift.dm
@@ -20,7 +20,7 @@ SUBSYSTEM_DEF(nightshift)
 	return ..()
 
 /datum/controller/subsystem/nightshift/fire(resumed = FALSE)
-	if(round_duration_in_ticks < nightshift_first_check)
+	if(round_duration_in_ds < nightshift_first_check)
 		return
 	check_nightshift()
 

--- a/code/controllers/subsystems/nightshift.dm
+++ b/code/controllers/subsystems/nightshift.dm
@@ -1,0 +1,62 @@
+SUBSYSTEM_DEF(nightshift)
+	name = "Night Shift"
+	init_order = INIT_ORDER_NIGHTSHIFT
+	priority = FIRE_PRIORITY_NIGHTSHIFT
+	wait = 60 SECONDS
+	flags = SS_NO_TICK_CHECK
+
+	var/nightshift_active = FALSE
+	var/nightshift_first_check = 30 SECONDS
+
+	var/high_security_mode = FALSE
+
+/datum/controller/subsystem/nightshift/Initialize()
+	if(!config.enable_night_shifts)
+		can_fire = FALSE
+	/*
+	if(config.randomize_shift_time)
+		GLOB.gametime_offset = rand(0, 23) HOURS
+	*/
+	return ..()
+
+/datum/controller/subsystem/nightshift/fire(resumed = FALSE)
+	if(round_duration_in_ticks < nightshift_first_check)
+		return
+	check_nightshift()
+
+/datum/controller/subsystem/nightshift/proc/announce(message)
+	var/announce_z
+	if(using_map.station_levels.len)
+		announce_z = pick(using_map.station_levels)
+	priority_announcement.Announce(message, new_title = "Automated Lighting System Announcement", new_sound = 'sound/misc/notice2.ogg', zlevel = announce_z)
+
+/datum/controller/subsystem/nightshift/proc/check_nightshift(check_canfire=FALSE) //This is called from elsewhere, like setting the alert levels
+	if(check_canfire && !can_fire)
+		return
+	var/emergency = security_level > SEC_LEVEL_GREEN
+	var/announcing = TRUE
+	var/night_time = using_map.get_nightshift()
+	if(high_security_mode != emergency)
+		high_security_mode = emergency
+		if(night_time)
+			announcing = FALSE
+			if(!emergency)
+				announce("Restoring night lighting configuration to normal operation.")
+			else
+				announce("Disabling night lighting: Station is in a state of emergency.")
+	if(emergency)
+		night_time = FALSE
+	if(nightshift_active != night_time)
+		update_nightshift(night_time, announcing)
+
+/datum/controller/subsystem/nightshift/proc/update_nightshift(active, announce = TRUE)
+	nightshift_active = active
+	if(announce)
+		if(active)
+			announce("Good evening, crew. To reduce power consumption and stimulate the circadian rhythms of some species, all of the lights aboard the station have been dimmed for the night.")
+		else
+			announce("Good morning, crew. As it is now day time, all of the lights aboard the station have been restored to their former brightness.")
+	for(var/obj/machinery/power/apc/apc in machines)
+		if(apc.z in using_map.station_levels)
+			apc.set_nightshift(active, TRUE)
+			CHECK_TICK

--- a/code/controllers/subsystems/planets.dm
+++ b/code/controllers/subsystems/planets.dm
@@ -6,16 +6,16 @@ SUBSYSTEM_DEF(planets)
 	flags = SS_BACKGROUND
 	runlevels = RUNLEVEL_GAME | RUNLEVEL_POSTGAME
 
-	var/list/new_outdoor_turfs = list()
-	var/list/new_outdoor_walls = list()
+	var/static/list/new_outdoor_turfs = list()
+	var/static/list/new_outdoor_walls = list()
 
-	var/list/planets = list()
-	var/list/z_to_planet = list()
+	var/static/list/planets = list()
+	var/static/list/z_to_planet = list()
 
-	var/list/currentrun = list()
+	var/static/list/currentrun = list()
 
-	var/list/needs_sun_update = list()
-	var/list/needs_temp_update = list()
+	var/static/list/needs_sun_update = list()
+	var/static/list/needs_temp_update = list()
 
 /datum/controller/subsystem/planets/Initialize(timeofday)
 	admin_notice("<span class='danger'>Initializing planetary weather.</span>", R_DEBUG)

--- a/code/game/gamemodes/game_mode_latespawn.dm
+++ b/code/game/gamemodes/game_mode_latespawn.dm
@@ -34,7 +34,7 @@
 	if(emergency_shuttle.shuttle && (emergency_shuttle.shuttle.moving_status == SHUTTLE_WARMUP || emergency_shuttle.shuttle.moving_status == SHUTTLE_INTRANSIT))
 		return // Don't do anything if the shuttle's coming.
 
-	var/mills = round_duration_in_ticks
+	var/mills = round_duration_in_ds
 	var/mins = round((mills % 36000) / 600)
 	var/hours = round(mills / 36000)
 

--- a/code/game/machinery/exonet_node.dm
+++ b/code/game/machinery/exonet_node.dm
@@ -185,7 +185,7 @@
 // Description: This writes to the logs list, so that people can see what people are doing on the Exonet ingame.  Note that this is not an admin logging function.
 // 		Communicators are already logged seperately.
 /obj/machinery/exonet_node/proc/write_log(var/origin_address, var/target_address, var/data_type, var/content)
-	//var/timestamp = time2text(station_time_in_ticks, "hh:mm:ss")
+	//var/timestamp = time2text(station_time_in_ds, "hh:mm:ss")
 	var/timestamp = "[stationdate2text()] [stationtime2text()]"
 	var/msg = "[timestamp] | FROM [origin_address] TO [target_address] | TYPE: [data_type] | CONTENT: [content]"
 	logs.Add(msg)

--- a/code/game/machinery/newscaster.dm
+++ b/code/game/machinery/newscaster.dm
@@ -79,7 +79,7 @@
 	newMsg.body = msg
 	newMsg.time_stamp = "[stationtime2text()]"
 	newMsg.is_admin_message = adminMessage
-	newMsg.post_time = round_duration_in_ticks // Should be almost universally unique
+	newMsg.post_time = round_duration_in_ds // Should be almost universally unique
 	if(message_type)
 		newMsg.message_type = message_type
 	if(photo)

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -16,7 +16,7 @@
 	if(config && config.log_runtime)
 		log = file("data/logs/runtime/[time2text(world.realtime,"YYYY-MM-DD-(hh-mm-ss)")]-runtime.log")
 
-	GLOB.timezoneOffset = text2num(time2text(0,"hh")) * 36000
+	GLOB.timezoneOffset = get_timezone_offset()
 
 	callHook("startup")
 	init_vchat()

--- a/code/modules/events/event_container.dm
+++ b/code/modules/events/event_container.dm
@@ -22,7 +22,7 @@ var/global/list/severity_to_string = list(EVENT_LEVEL_MUNDANE = "Mundane", EVENT
 	var/last_world_time = 0
 
 /datum/event_container/process()
-	if(!round_start_time)
+	if(!GLOB.round_start_time)
 		return //don't do events if the round hasn't even started yet
 
 	if(!next_event_time)

--- a/code/modules/integrated_electronics/subtypes/time.dm
+++ b/code/modules/integrated_electronics/subtypes/time.dm
@@ -86,10 +86,10 @@
 	power_draw_per_use = 4
 
 /obj/item/integrated_circuit/time/clock/do_work()
-	set_pin_data(IC_OUTPUT, 1, time2text(station_time_in_ticks, "hh:mm:ss") )
-	set_pin_data(IC_OUTPUT, 2, text2num(time2text(station_time_in_ticks, "hh") ) )
-	set_pin_data(IC_OUTPUT, 3, text2num(time2text(station_time_in_ticks, "mm") ) )
-	set_pin_data(IC_OUTPUT, 4, text2num(time2text(station_time_in_ticks, "ss") ) )
+	set_pin_data(IC_OUTPUT, 1, time2text(station_time_in_ds, "hh:mm:ss") )
+	set_pin_data(IC_OUTPUT, 2, text2num(time2text(station_time_in_ds, "hh") ) )
+	set_pin_data(IC_OUTPUT, 3, text2num(time2text(station_time_in_ds, "mm") ) )
+	set_pin_data(IC_OUTPUT, 4, text2num(time2text(station_time_in_ds, "ss") ) )
 
 	push_data()
 	activate_pin(2)

--- a/code/modules/planet/time.dm
+++ b/code/modules/planet/time.dm
@@ -11,27 +11,29 @@
 
 /datum/time/New(new_time)
 	if(new_time)
+		if(new_time >= seconds_in_day)
+			new_time = rollover(new_time)
 		seconds_stored = new_time
 	..()
 
 /datum/time/proc/add_seconds(amount)
 	var/answer = seconds_stored + amount * 10
 	if(answer >= seconds_in_day)
-		rollover(answer)
+		answer = rollover(answer)
 	return new type(answer)
 
 /datum/time/proc/add_minutes(amount)
 	var/real_amount = amount * seconds_in_minute
 	var/answer = real_amount + seconds_stored
 	if(answer >= seconds_in_day)
-		rollover(answer)
+		answer = rollover(answer)
 	return new type(answer)
 
 /datum/time/proc/add_hours(amount)
 	var/real_amount = amount * seconds_in_hour
 	var/answer = real_amount + seconds_stored
 	if(answer >= seconds_in_day)
-		rollover(answer)
+		answer = rollover(answer)
 	return new type(answer)
 
 /datum/time/proc/rollover(time)

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -921,6 +921,14 @@
 	if(!can_use(usr, 1))
 		return 1
 
+	if(href_list["nightshift"])
+		if(last_nightshift_switch > world.time + 10 SECONDS) // don't spam...
+			to_chat(usr, "<span class='warning'>[src]'s night lighting circuit breaker is still cycling!</span>")
+			return 0
+		last_nightshift_switch = world.time
+		set_nightshift(!nightshift_lights)
+		return 1
+
 	if(locked && !issilicon(usr) )
 		if(isobserver(usr) )
 			var/mob/observer/dead/O = usr	//Added to allow admin nanoUI interactions.
@@ -973,13 +981,6 @@
 		environ = setsubsystem(val)
 		update_icon()
 		update()
-
-	else if(href_list["nightshift"])
-		if(last_nightshift_switch > world.time + 10 SECONDS) // don't spam...
-			to_chat(usr, "<span class='warning'>[src]'s night lighting circuit breaker is still cycling!</span>")
-			return 0
-		last_nightshift_switch = world.time
-		set_nightshift(!nightshift_lights)
 
 	else if (href_list["overload"])
 		if(istype(usr, /mob/living/silicon))

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -928,7 +928,7 @@
 		return 1
 
 	if(href_list["nightshift"])
-		if(last_nightshift_switch > world.time + 10 SECONDS) // don't spam...
+		if(last_nightshift_switch > world.time - 10 SECONDS) // don't spam...
 			to_chat(usr, "<span class='warning'>[src]'s night lighting circuit breaker is still cycling!</span>")
 			return 0
 		last_nightshift_switch = world.time

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -119,6 +119,9 @@
 	var/global/list/status_overlays_lighting
 	var/global/list/status_overlays_environ
 	var/alarms_hidden = FALSE //If power alarms from this APC are visible on consoles
+	
+	var/nightshift_lights = FALSE
+	var/last_nightshift_switch = 0
 
 /obj/machinery/power/apc/updateDialog()
 	if (stat & (BROKEN|MAINT))
@@ -798,6 +801,7 @@
 		"coverLocked" = coverlocked,
 		"siliconUser" = issilicon(user) || isobserver(user), //I add observer here so admins can have more control, even if it makes 'siliconUser' seem inaccurate.
 		"emergencyLights" = !emergency_lights,
+		"nightshiftLights" = nightshift_lights,
 
 		"powerChannels" = list(
 			list(
@@ -969,6 +973,13 @@
 		environ = setsubsystem(val)
 		update_icon()
 		update()
+
+	else if(href_list["nightshift"])
+		if(last_nightshift_switch > world.time + 10 SECONDS) // don't spam...
+			to_chat(usr, "<span class='warning'>[src]'s night lighting circuit breaker is still cycling!</span>")
+			return 0
+		last_nightshift_switch = world.time
+		set_nightshift(!nightshift_lights)
 
 	else if (href_list["overload"])
 		if(istype(usr, /mob/living/silicon))
@@ -1366,5 +1377,14 @@ obj/machinery/power/apc/proc/autoset(var/cur_state, var/on)
 	spawn(15 MINUTES) // Protection against someone deconning the grid checker after a grid check happens, preventing infinte blackout.
 		if(src && grid_check == TRUE)
 			grid_check = FALSE
+
+/obj/machinery/power/apc/proc/set_nightshift(on, var/automated)
+	set waitfor = FALSE
+	if(automated && istype(area, /area/shuttle))
+		return
+	nightshift_lights = on
+	for(var/obj/machinery/light/L in area)
+		L.nightshift_mode(on)
+		CHECK_TICK
 
 #undef APC_UPDATE_ICON_COOLDOWN

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -39,6 +39,10 @@
 #define POWERCHAN_ON       2
 #define POWERCHAN_ON_AUTO  3
 
+#define NIGHTSHIFT_AUTO 1
+#define NIGHTSHIFT_NEVER 2
+#define NIGHTSHIFT_ALWAYS 3
+
 //NOTE: STUFF STOLEN FROM AIRLOCK.DM thx
 
 /obj/machinery/power/apc/critical
@@ -121,6 +125,7 @@
 	var/alarms_hidden = FALSE //If power alarms from this APC are visible on consoles
 	
 	var/nightshift_lights = FALSE
+	var/nightshift_setting = NIGHTSHIFT_AUTO
 	var/last_nightshift_switch = 0
 
 /obj/machinery/power/apc/updateDialog()
@@ -802,6 +807,7 @@
 		"siliconUser" = issilicon(user) || isobserver(user), //I add observer here so admins can have more control, even if it makes 'siliconUser' seem inaccurate.
 		"emergencyLights" = !emergency_lights,
 		"nightshiftLights" = nightshift_lights,
+		"nightshiftSetting" = nightshift_setting,
 
 		"powerChannels" = list(
 			list(
@@ -926,7 +932,8 @@
 			to_chat(usr, "<span class='warning'>[src]'s night lighting circuit breaker is still cycling!</span>")
 			return 0
 		last_nightshift_switch = world.time
-		set_nightshift(!nightshift_lights)
+		nightshift_setting = text2num(href_list["nightshift"])
+		update_nightshift()
 		return 1
 
 	if(locked && !issilicon(usr) )
@@ -1384,8 +1391,19 @@ obj/machinery/power/apc/proc/autoset(var/cur_state, var/on)
 	if(automated && istype(area, /area/shuttle))
 		return
 	nightshift_lights = on
+	update_nightshift()
+
+/obj/machinery/power/apc/proc/update_nightshift()
+	var/new_state = nightshift_lights
+
+	switch(nightshift_setting)
+		if(NIGHTSHIFT_NEVER)
+			new_state = FALSE
+		if(NIGHTSHIFT_ALWAYS)
+			new_state = TRUE
+
 	for(var/obj/machinery/light/L in area)
-		L.nightshift_mode(on)
+		L.nightshift_mode(new_state)
 		CHECK_TICK
 
 #undef APC_UPDATE_ICON_COOLDOWN

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -240,8 +240,17 @@ var/global/list/light_type_cache = list()
 	var/bulb_emergency_pow_mul = 0.75	// the multiplier for determining the light's power in emergency mode
 	var/bulb_emergency_pow_min = 0.5	// the minimum value for the light's power in emergency mode
 
+	var/nightshift_enabled = FALSE
+	var/nightshift_allowed = TRUE
+	var/brightness_range_ns
+	var/brightness_power_ns
+	var/brightness_color_ns
+
 /obj/machinery/light/flicker
 	auto_flicker = TRUE
+
+/obj/machinery/light/no_nightshift
+	nightshift_allowed = FALSE
 
 // the smaller bulb light fixture
 
@@ -370,7 +379,10 @@ var/global/list/light_type_cache = list()
 /obj/machinery/light/proc/update(var/trigger = 1)
 	update_icon()
 	if(on)
-		if(light_range != brightness_range || light_power != brightness_power || light_color != brightness_color)
+		var/correct_range = nightshift_enabled ? brightness_range_ns : brightness_range
+		var/correct_power = nightshift_enabled ? brightness_power_ns : brightness_power
+		var/correct_color = nightshift_enabled ? brightness_color_ns : brightness_color
+		if(light_range != correct_range || light_power != correct_power || light_color != correct_color)
 			if(!auto_flicker)
 				switchcount++
 			if(rigged)
@@ -388,7 +400,7 @@ var/global/list/light_type_cache = list()
 					set_light(0)
 			else
 				update_use_power(USE_POWER_ACTIVE)
-				set_light(brightness_range, brightness_power, brightness_color)
+				set_light(correct_range, correct_power, correct_color)
 	else if(has_emergency_power(LIGHT_EMERGENCY_POWER_USE) && !turned_off())
 		update_use_power(USE_POWER_IDLE)
 		emergency_mode = TRUE
@@ -399,6 +411,13 @@ var/global/list/light_type_cache = list()
 
 	update_active_power_usage((light_range * light_power) * LIGHTING_POWER_FACTOR)
 
+/obj/machinery/light/proc/nightshift_mode(var/state)
+	if(!nightshift_allowed)
+		return
+
+	if(state != nightshift_enabled)
+		nightshift_enabled = state
+		update(FALSE)
 
 /obj/machinery/light/attack_generic(var/mob/user, var/damage)
 	if(!damage)
@@ -459,9 +478,14 @@ var/global/list/light_type_cache = list()
 	status = L.status
 	switchcount = L.switchcount
 	rigged = L.rigged
+
 	brightness_range = L.brightness_range
 	brightness_power = L.brightness_power
 	brightness_color = L.brightness_color
+
+	brightness_range_ns = L.nightshift_range
+	brightness_power_ns = L.nightshift_power
+	brightness_color_ns = L.nightshift_color
 
 // attack with item - insert light (if right type), otherwise try to break the light
 
@@ -825,6 +849,10 @@ var/global/list/light_type_cache = list()
 	var/brightness_power = 1
 	var/brightness_color = LIGHT_COLOR_INCANDESCENT_TUBE
 
+	var/nightshift_range = 8
+	var/nightshift_power = 0.7
+	var/nightshift_color = LIGHT_COLOR_NIGHTSHIFT
+
 /obj/item/weapon/light/tube
 	name = "light tube"
 	desc = "A replacement light tube."
@@ -841,6 +869,9 @@ var/global/list/light_type_cache = list()
 	brightness_range = 15
 	brightness_power = 9
 
+	nightshift_range = 10
+	nightshift_power = 0.9
+
 /obj/item/weapon/light/bulb
 	name = "light bulb"
 	desc = "A replacement light bulb."
@@ -851,6 +882,9 @@ var/global/list/light_type_cache = list()
 	brightness_range = 5
 	brightness_power = 4
 	brightness_color = LIGHT_COLOR_INCANDESCENT_BULB
+
+	nightshift_range = 3
+	nightshift_power = 0.35
 
 /obj/item/weapon/light/throw_impact(atom/hit_atom)
 	..()

--- a/code/modules/security levels/security levels.dm
+++ b/code/modules/security levels/security levels.dm
@@ -64,10 +64,6 @@
 				else
 					security_announcement_down.Announce("[config.alert_desc_red_downto]", "Attention! Code red!")
 				security_level = SEC_LEVEL_RED
-				/*	- At the time of commit, setting status displays didn't work properly
-				var/obj/machinery/computer/communications/CC = locate(/obj/machinery/computer/communications,world)
-				if(CC)
-					CC.post_status("alert", "redalert")*/
 			if(SEC_LEVEL_DELTA)
 				security_announcement_up.Announce("[config.alert_desc_delta]", "Attention! Delta alert level reached!", new_sound = 'sound/effects/siren.ogg')
 				security_level = SEC_LEVEL_DELTA
@@ -84,6 +80,9 @@
 			atc.reroute_traffic(yes = 1) // Tell them fuck off we're busy.
 		else
 			atc.reroute_traffic(yes = 0)
+
+		spawn()
+			SSnightshift.check_nightshift()
 
 
 /proc/get_security_level()

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -516,3 +516,6 @@ SQLITE_FEEDBACK_MIN_AGE 7
 
 ## Uncomment this if you want to disable the popup alert for people on the same CID (Don't do this on a live server if you ban multikeying)
 #DISABLE_CID_WARN_POPUP
+
+## Comment this out if you don't want to use the 'nightshift lighting' subsystem to adjust lights based on ingame time
+ENABLE_NIGHT_SHIFTS

--- a/maps/~map_system/maps.dm
+++ b/maps/~map_system/maps.dm
@@ -136,8 +136,7 @@ var/list/all_maps = list()
 
 	// We have to invent a time
 	else
-		var/seconds_stationtime = round(station_time_in_ticks*0.1) //Not actually ticks......
-		var/datum/time/T = new(seconds_stationtime)
+		var/datum/time/T = new (station_time_in_ds)
 		return T
 
 // Returns a boolean for if it's night or not on a particular zlevel
@@ -145,7 +144,7 @@ var/list/all_maps = list()
 	if(!z)
 		z = 1
 	var/datum/time/now = get_zlevel_time(z)
-	var/percent = now.seconds_stored / now.seconds_in_day
+	var/percent = now.seconds_stored / now.seconds_in_day //practically all of these are in DS
 
 	// First quarter, last quarter
 	if(percent < 0.25 || percent > 0.75)

--- a/maps/~map_system/maps.dm
+++ b/maps/~map_system/maps.dm
@@ -129,9 +129,9 @@ var/list/all_maps = list()
 /datum/map/proc/get_zlevel_time(var/z)
 	if(!z)
 		z = 1
-	var/datum/planet/P = SSplanets.z_to_planet[z]
+	var/datum/planet/P = z <= SSplanets.z_to_planet.len ? SSplanets.z_to_planet[z] : null
 	// We found a planet tied to that zlevel, give them the time
-	if(istype(P))
+	if(P?.current_time)
 		return P.current_time
 
 	// We have to invent a time

--- a/maps/~map_system/maps.dm
+++ b/maps/~map_system/maps.dm
@@ -22,21 +22,26 @@ var/list/all_maps = list()
 	var/full_name = "Unnamed Map"
 	var/path
 
-	var/list/zlevels = list()
 	var/zlevel_datum_type			// If populated, all subtypes of this type will be instantiated and used to populate the *_levels lists.
-
-	var/list/station_levels = list() // Z-levels the station exists on
-	var/list/admin_levels = list()   // Z-levels for admin functionality (Centcom, shuttle transit, etc)
-	var/list/contact_levels = list() // Z-levels that can be contacted from the station, for eg announcements
-	var/list/player_levels = list()  // Z-levels a character can typically reach
-	var/list/sealed_levels = list()  // Z-levels that don't allow random transit at edge
-	var/list/xenoarch_exempt_levels = list()	//Z-levels exempt from xenoarch finds and digsites spawning.
-	var/list/empty_levels = null     // Empty Z-levels that may be used for various things (currently used by bluespace jump)
-
-	var/list/map_levels              // Z-levels available to various consoles, such as the crew monitor (when that gets coded in). Defaults to station_levels if unset.
 	var/list/base_turf_by_z = list() // Custom base turf by Z-level. Defaults to world.turf for unlisted Z-levels
 
+	// Automatically populated lists made static for faster lookups
+	var/static/list/zlevels = list()
+	var/static/list/station_levels = list() // Z-levels the station exists on
+	var/static/list/admin_levels = list()   // Z-levels for admin functionality (Centcom, shuttle transit, etc)
+	var/static/list/contact_levels = list() // Z-levels that can be contacted from the station, for eg announcements
+	var/static/list/player_levels = list()  // Z-levels a character can typically reach
+	var/static/list/sealed_levels = list()  // Z-levels that don't allow random transit at edge
+	var/static/list/xenoarch_exempt_levels = list()	//Z-levels exempt from xenoarch finds and digsites spawning.
+	var/static/list/empty_levels = null     // Empty Z-levels that may be used for various things (currently used by bluespace jump)
+	// End Static Lists
+
+	// Z-levels available to various consoles, such as the crew monitor. Defaults to station_levels if unset.
+	var/list/map_levels
+	
+	// E-mail TLDs to use for NTnet modular computer e-mail addresses
 	var/list/usable_email_tlds = list("freemail.nt")
+
 	//This list contains the z-level numbers which can be accessed via space travel and the percentile chances to get there.
 	var/list/accessible_z_levels = list()
 
@@ -119,6 +124,40 @@ var/list/all_maps = list()
 		default_skybox = new default_skybox()
 	else
 		default_skybox = new()
+
+// Gets the current time on a current zlevel, and returns a time datum
+/datum/map/proc/get_zlevel_time(var/z)
+	if(!z)
+		z = 1
+	var/datum/planet/P = SSplanets.z_to_planet[z]
+	// We found a planet tied to that zlevel, give them the time
+	if(istype(P))
+		return P.current_time
+
+	// We have to invent a time
+	else
+		var/seconds_stationtime = round(station_time_in_ticks*0.1) //Not actually ticks......
+		var/datum/time/T = new(seconds_stationtime)
+		return T
+
+// Returns a boolean for if it's night or not on a particular zlevel
+/datum/map/proc/get_night(var/z)
+	if(!z)
+		z = 1
+	var/datum/time/now = get_zlevel_time(z)
+	var/percent = now.seconds_stored / now.seconds_in_day
+	testing("get_night is [percent] through the day on [z]")
+
+	// First quarter, last quarter
+	if(percent < 0.25 || percent > 0.75)
+		return TRUE
+	// Second quarter, third quarter
+	else
+		return FALSE
+
+// Boolean for if we should use SSnightshift night hours
+/datum/map/proc/get_nightshift()
+	return get_night(1) //Defaults to z1, customize however you want on your own maps
 
 /datum/map/proc/setup_map()
 	return

--- a/maps/~map_system/maps.dm
+++ b/maps/~map_system/maps.dm
@@ -146,7 +146,6 @@ var/list/all_maps = list()
 		z = 1
 	var/datum/time/now = get_zlevel_time(z)
 	var/percent = now.seconds_stored / now.seconds_in_day
-	testing("get_night is [percent] through the day on [z]")
 
 	// First quarter, last quarter
 	if(percent < 0.25 || percent > 0.75)

--- a/nano/templates/apc.tmpl
+++ b/nano/templates/apc.tmpl
@@ -206,7 +206,9 @@
 			Night Lighting:
 		</div>
 		<div class="itemContent">
-			{{:helper.link(data.nightshiftLights ? 'Enabled' : 'Disabled', data.nightshiftLights ? 'power' : 'close', {'nightshift' : 1}, null)}}
+			{{:helper.link('Disabled', null, {'nightshift' : 2}, data.nightshiftSetting == 2 ? 'selected' : null)}}
+			{{:helper.link('Automatic', null, {'nightshift' : 1}, data.nightshiftSetting == 1 ? 'selected' : null)}}
+			{{:helper.link('Enabled', null, {'nightshift' : 3}, data.nightshiftSetting == 3 ? 'selected' : null)}}
 		</div>
 	</div>
 

--- a/nano/templates/apc.tmpl
+++ b/nano/templates/apc.tmpl
@@ -201,6 +201,15 @@
 		</div>
 	</div>
 
+	<div class="item">
+		<div class="itemLabel">
+			Night Lighting:
+		</div>
+		<div class="itemContent">
+			{{:helper.link(data.nightshiftLights ? 'Enabled' : 'Disabled', data.nightshiftLights ? 'power' : 'close', {'nightshift' : 1}, null)}}
+		</div>
+	</div>
+
 	{{if data.siliconUser}}
 		<h3>System Overrides</h3>
 

--- a/polaris.dme
+++ b/polaris.dme
@@ -216,6 +216,7 @@
 #include "code\controllers\subsystems\mapping.dm"
 #include "code\controllers\subsystems\mobs.dm"
 #include "code\controllers\subsystems\nanoui.dm"
+#include "code\controllers\subsystems\nightshift.dm"
 #include "code\controllers\subsystems\open_space.dm"
 #include "code\controllers\subsystems\orbits.dm"
 #include "code\controllers\subsystems\overlays.dm"


### PR DESCRIPTION
Dims all the lights at night, based on what your map datum returns from get_nightmode(), which checks get_night, and get_zlevel_time(). You should customize those if you don't want to base it on whatever planet z1 is, otherwise it will use the fictional 'station time'.