### PR TITLE
Rewrite airlock electronics

### DIFF
--- a/code/game/machinery/doors/airlock_electronics.dm
+++ b/code/game/machinery/doors/airlock_electronics.dm
@@ -64,7 +64,7 @@
 	if (usr.stat || usr.restrained() || (!ishuman(usr) && !istype(usr,/mob/living/silicon)))
 		return
 	if (href_list["close"])
-		usr << browse(null, "window=airlock")
+		usr << browse(null, "window=airlock_electronics")
 		return
 
 	if (href_list["login"])

--- a/code/game/machinery/doors/airlock_electronics.dm
+++ b/code/game/machinery/doors/airlock_electronics.dm
@@ -1,5 +1,3 @@
-//This file was auto-corrected by findeclaration.exe on 25.5.2012 20:42:31
-
 /obj/item/weapon/airlock_electronics
 	name = "airlock electronics"
 	icon = 'icons/obj/doors/door_assembly.dmi'
@@ -8,106 +6,148 @@
 
 	matter = list(DEFAULT_WALL_MATERIAL = 50,"glass" = 50)
 
-	req_access = list(access_engine)
+	req_one_access = list(access_engine) // Access to unlock the device, ignored if emagged
+	var/list/apply_any_access = list(access_engine) // Can apply any access, not just their own
 
 	var/secure = 0 //if set, then wires will be randomized and bolts will drop if the door is broken
 	var/list/conf_access = null
 	var/one_access = 0 //if set to 1, door would receive req_one_access instead of req_access
 	var/last_configurator = null
 	var/locked = 1
+	var/emagged = 0
 
-	attack_self(mob/user as mob)
-		if (!ishuman(user) && !istype(user,/mob/living/silicon/robot))
-			return ..(user)
+/obj/item/weapon/airlock_electronics/emag_act(var/remaining_charges, var/mob/user)
+	if(!emagged)
+		emagged = 1
+		to_chat(user, "<span class='notice'>You remove the access restrictions on [src]!</span>")
+		return 1
 
-		var/t1 = text("<B>Access control</B><br>\n")
+/obj/item/weapon/airlock_electronics/attack_self(mob/user as mob)
+	if (!ishuman(user) && !istype(user,/mob/living/silicon/robot))
+		return ..(user)
 
-		if (last_configurator)
-			t1 += "Operator: [last_configurator]<br>"
+	var/t1 = text("<B>Access control</B><br>\n")
 
-		if (locked)
-			t1 += "<a href='?src=\ref[src];login=1'>Swipe ID</a><hr>"
-		else
-			t1 += "<a href='?src=\ref[src];logout=1'>Block</a><hr>"
+	if (last_configurator)
+		t1 += "Operator: [last_configurator]<br>"
 
-			t1 += "Access requirement is set to "
-			t1 += one_access ? "<a style='color: green' href='?src=\ref[src];one_access=1'>ONE</a><hr>" : "<a style='color: red' href='?src=\ref[src];one_access=1'>ALL</a><hr>"
+	if (locked)
+		t1 += "<a href='?src=\ref[src];login=1'>Unlock Interface</a><hr>"
+	else
+		t1 += "<a href='?src=\ref[src];logout=1'>Lock Interface</a><hr>"
 
-			t1 += conf_access == null ? "<font color=red>All</font><br>" : "<a href='?src=\ref[src];access=all'>All</a><br>"
+		t1 += "Access requirement is set to "
+		t1 += one_access ? "<a style='color: green' href='?src=\ref[src];one_access=1'>ONE</a><hr>" : "<a style='color: red' href='?src=\ref[src];one_access=1'>ALL</a><hr>"
 
-			t1 += "<br>"
+		t1 += conf_access == null ? "<font color=red>All</font><br>" : "<a href='?src=\ref[src];access=all'>All</a><br>"
 
-			var/list/accesses = get_all_station_access()
-			for (var/acc in accesses)
-				var/aname = get_access_desc(acc)
+		t1 += "<br>"
 
-				if (!conf_access || !conf_access.len || !(acc in conf_access))
-					t1 += "<a href='?src=\ref[src];access=[acc]'>[aname]</a><br>"
-				else if(one_access)
-					t1 += "<a style='color: green' href='?src=\ref[src];access=[acc]'>[aname]</a><br>"
-				else
-					t1 += "<a style='color: red' href='?src=\ref[src];access=[acc]'>[aname]</a><br>"
+		var/list/accesses = get_available_accesses(user)
+		for (var/acc in accesses)
+			var/aname = get_access_desc(acc)
 
-		t1 += text("<p><a href='?src=\ref[];close=1'>Close</a></p>\n", src)
-
-		user << browse(t1, "window=airlock_electronics")
-		onclose(user, "airlock")
-
-	Topic(href, href_list)
-		..()
-		if (usr.stat || usr.restrained() || (!ishuman(usr) && !istype(usr,/mob/living/silicon)))
-			return
-		if (href_list["close"])
-			usr << browse(null, "window=airlock")
-			return
-
-		if (href_list["login"])
-			if(istype(usr,/mob/living/silicon))
-				src.locked = 0
-				src.last_configurator = usr.name
+			if (!conf_access || !conf_access.len || !(acc in conf_access))
+				t1 += "<a href='?src=\ref[src];access=[acc]'>[aname]</a><br>"
+			else if(one_access)
+				t1 += "<a style='color: green' href='?src=\ref[src];access=[acc]'>[aname]</a><br>"
 			else
-				var/obj/item/I = usr.get_active_hand()
-				if (istype(I, /obj/item/device/pda))
-					var/obj/item/device/pda/pda = I
-					I = pda.id
-				if (I && src.check_access(I))
+				t1 += "<a style='color: red' href='?src=\ref[src];access=[acc]'>[aname]</a><br>"
+
+	t1 += text("<p><a href='?src=\ref[];close=1'>Close</a></p>\n", src)
+
+	user << browse(t1, "window=airlock_electronics")
+	onclose(user, "airlock")
+
+/obj/item/weapon/airlock_electronics/Topic(href, href_list)
+	..()
+	if (usr.stat || usr.restrained() || (!ishuman(usr) && !istype(usr,/mob/living/silicon)))
+		return
+	if (href_list["close"])
+		usr << browse(null, "window=airlock")
+		return
+
+	if (href_list["login"])
+		if(emagged)
+			src.locked = 0
+			src.last_configurator = usr.name
+		else if(issilicon(usr))
+			src.locked = 0
+			src.last_configurator = usr.name
+		else if(isliving(usr))
+			var/obj/item/weapon/card/id/id
+			if(ishuman(usr))
+				var/mob/living/carbon/human/H = usr
+				id = H.get_idcard()
+				// In their ID slot?
+				if(id && src.check_access(id))
 					src.locked = 0
-					src.last_configurator = I:registered_name
+					src.last_configurator = id.registered_name
+			// Still locked, human handling didn't do it!
+			if(locked)
+				var/obj/item/I = usr.get_active_hand()
+				id = I?.GetID()
+				if(id && src.check_access(id))
+					src.locked = 0
+					src.last_configurator = id.registered_name
 
-		if (locked)
-			return
+	if (locked)
+		return
 
-		if (href_list["logout"])
-			locked = 1
+	if (href_list["logout"])
+		locked = 1
 
-		if (href_list["one_access"])
-			one_access = !one_access
+	if (href_list["one_access"])
+		one_access = !one_access
 
-		if (href_list["access"])
-			toggle_access(href_list["access"])
+	if (href_list["access"])
+		toggle_access(href_list["access"])
 
-		attack_self(usr)
+	attack_self(usr)
 
-	proc
-		toggle_access(var/acc)
-			if (acc == "all")
+/obj/item/weapon/airlock_electronics/proc/toggle_access(var/acc)
+	if (acc == "all")
+		conf_access = null
+	else
+		var/req = text2num(acc)
+
+		if (conf_access == null)
+			conf_access = list()
+
+		if (!(req in conf_access))
+			conf_access += req
+		else
+			conf_access -= req
+			if (!conf_access.len)
 				conf_access = null
-			else
-				var/req = text2num(acc)
 
-				if (conf_access == null)
-					conf_access = list()
+/obj/item/weapon/airlock_electronics/proc/get_available_accesses(var/mob/user)
+	var/obj/item/weapon/card/id/id
+	if(ishuman(user))
+		var/mob/living/carbon/human/H = user
+		id = H.get_idcard()
+	else if(issilicon(user))
+		var/mob/living/silicon/R = user
+		id = R.idcard
 
-				if (!(req in conf_access))
-					conf_access += req
-				else
-					conf_access -= req
-					if (!conf_access.len)
-						conf_access = null
-
+	// Nothing
+	if(!id || !id.access)
+		return list()
+	
+	// Has engineer access, can put any access
+	else if(has_access(null, apply_any_access, id.access))
+		return get_all_station_access()
+	
+	// Not an engineer, can only pick your own accesses to program
+	else
+		return id.access
 
 /obj/item/weapon/airlock_electronics/secure
 	name = "secure airlock electronics"
 	desc = "designed to be somewhat more resistant to hacking than standard electronics."
 	origin_tech = list(TECH_DATA = 2)
 	secure = 1
+
+/obj/item/weapon/airlock_electronics/secure/emag_act(var/remaining_charges, var/mob/user)
+	to_chat(user, "<span class='warning'>You don't appear to be able to bypass this hardened device!</span>")
+	return -1


### PR DESCRIPTION
- Airlock electronics do a better job trying to find your ID. You don't need it in your hand to swipe your ID, it can read it from your ID slot, etc.
- Configuration access can be bypassed via emag (not on secure airlock electronics).
- Even bypassed, if you don't have engineer access, you can't set accesses other than the ones on your current ID (presumably those aren't actually stored on the device? I dunno.)
- Converts the access you need to be able to apply 'any' access into a separate var. Defaults to access_engine (so no change, but we need this for offmap spawns being able to build their own airlocks).
- If you unlock it (either via emag or because you have an ID in req_one_access), and you don't have an access in the apply_any_access list, you can apply whatever accesses your own ID card has, but not 'every station access' like before.