### PR TITLE
adds logging variable to enable shuttle log spam

### DIFF
--- a/code/modules/shuttles/shuttle.dm
+++ b/code/modules/shuttles/shuttle.dm
@@ -30,6 +30,8 @@
 
 	var/tmp/depart_time = 0 //Similar to above, set when the shuttle leaves when long jumping. Used for progress bars.
 
+	var/debug_logging = FALSE // If set to true, the shuttle will start broadcasting its debug messages to admins
+
 	// Future Thoughts: Baystation put "docking" stuff in a subtype, leaving base type pure and free of docking stuff. Is this best?
 
 /datum/shuttle/New(_name, var/obj/effect/shuttle_landmark/initial_location)
@@ -52,7 +54,8 @@
 	else
 		current_location = SSshuttles.get_landmark(current_location)
 	if(!istype(current_location))
-		log_debug("UM whoops, no initial? [src]")
+		if(debug_logging)
+			log_shuttle("UM whoops, no initial? [src]")
 		CRASH("Shuttle '[name]' could not find its starting location landmark [current_location].")
 
 	if(src.name in SSshuttles.shuttles)
@@ -236,20 +239,25 @@
 // Returns TRUE if we actually moved, otherwise FALSE.
 /datum/shuttle/proc/attempt_move(var/obj/effect/shuttle_landmark/destination, var/interim = FALSE)
 	if(current_location == destination)
-		log_shuttle("Shuttle [src] attempted to move to [destination] but is already there!")
+		if(debug_logging)
+			log_shuttle("Shuttle [src] attempted to move to [destination] but is already there!")
 		return FALSE
 
 	if(!destination.is_valid(src))
-		log_shuttle("Shuttle [src] aborting attempt_move() because destination=[destination] is not valid")
+		if(debug_logging)
+			log_shuttle("Shuttle [src] aborting attempt_move() because destination=[destination] is not valid")
 		return FALSE
 	if(current_location.cannot_depart(src))
-		log_shuttle("Shuttle [src] aborting attempt_move() because current_location=[current_location] refuses.")
+		if(debug_logging)
+			log_shuttle("Shuttle [src] aborting attempt_move() because current_location=[current_location] refuses.")
 		return FALSE
 
-	log_shuttle("[src] moving to [destination]. Areas are [english_list(shuttle_area)]")
+	if(debug_logging)
+		log_shuttle("[src] moving to [destination]. Areas are [english_list(shuttle_area)]")
 	var/list/translation = list()
 	for(var/area/A in shuttle_area)
-		log_shuttle("Translating [A]")
+		if(debug_logging)
+			log_shuttle("Translating [A]")
 		translation += get_turf_translation(get_turf(current_location), get_turf(destination), A.contents)
 	var/old_location = current_location
 
@@ -259,11 +267,11 @@
 
 	// Actually do it! (This never fails)
 	perform_shuttle_move(destination, translation)
-	
+
 	// Observer pattern post-move
 	destination.shuttle_arrived(src)
 	GLOB.shuttle_moved_event.raise_event(src, old_location, destination)
-	
+
 	return TRUE
 
 
@@ -271,7 +279,8 @@
 //A note to anyone overriding move in a subtype. perform_shuttle_move() must absolutely not, under any circumstances, fail to move the shuttle.
 //If you want to conditionally cancel shuttle launches, that logic must go in short_jump() or long_jump()
 /datum/shuttle/proc/perform_shuttle_move(var/obj/effect/shuttle_landmark/destination, var/list/turf_translation)
-	log_shuttle("perform_shuttle_move() current=[current_location] destination=[destination]")
+	if(debug_logging)
+		log_shuttle("perform_shuttle_move() current=[current_location] destination=[destination]")
 	//to_world("move_shuttle() called for [name] leaving [origin] en route to [destination].")
 
 	//to_world("area_coming_from: [origin]")

--- a/code/modules/shuttles/shuttle_autodock.dm
+++ b/code/modules/shuttles/shuttle_autodock.dm
@@ -65,7 +65,7 @@
 		current_dock_target = docking_controller_tag
 	shuttle_docking_controller = SSshuttles.docking_registry[current_dock_target]
 	if(current_dock_target && !shuttle_docking_controller)
-		to_world("<span class='danger'>warning: shuttle [src] can't find its controller with tag [current_dock_target]!</span>")
+		log_shuttle("<span class='danger'>warning: shuttle [src] can't find its controller with tag [current_dock_target]!</span>") // No toggle because this is an error message that needs to be seen
 /*
 	Docking stuff
 */

--- a/code/modules/shuttles/shuttle_console.dm
+++ b/code/modules/shuttles/shuttle_console.dm
@@ -64,11 +64,13 @@
 	var/cannot_depart = shuttle.current_location.cannot_depart(shuttle)
 	if(cannot_depart)
 		to_chat(user, "<span class='warning'>[cannot_depart]</span>")
-		log_shuttle("Shuttle [shuttle] cannot depart [shuttle.current_location] because: [cannot_depart].")
+		if(shuttle.debug_logging)
+			log_shuttle("Shuttle [shuttle] cannot depart [shuttle.current_location] because: [cannot_depart].")
 		return FALSE
 	if(!shuttle.next_location.is_valid(shuttle))
 		to_chat(user, "<span class='warning'>Destination zone is invalid or obstructed.</span>")
-		log_shuttle("Shuttle [shuttle] destination [shuttle.next_location] is invalid.")
+		if(shuttle.debug_logging)
+			log_shuttle("Shuttle [shuttle] destination [shuttle.next_location] is invalid.")
 		return FALSE
 	return TRUE
 

--- a/code/modules/shuttles/shuttle_emergency.dm
+++ b/code/modules/shuttles/shuttle_emergency.dm
@@ -70,7 +70,7 @@
 	if (istype(user, /obj/machinery/computer/shuttle_control/emergency))	//if we were given a command by an emergency shuttle console
 		if (emergency_shuttle.autopilot)
 			emergency_shuttle.autopilot = 0
-			to_chat(world, "<span class='notice'><b>Alert: The shuttle autopilot has been overridden. Launch sequence initiated!</b></span>")
+			to_world("<span class='notice'><b>Alert: The shuttle autopilot has been overridden. Launch sequence initiated!</b></span>")
 
 	if(usr)
 		log_admin("[key_name(usr)] has overridden the departure shuttle's autopilot and activated the launch sequence.")
@@ -84,7 +84,7 @@
 	if (istype(user, /obj/machinery/computer/shuttle_control/emergency))	//if we were given a command by an emergency shuttle console
 		if (emergency_shuttle.autopilot)
 			emergency_shuttle.autopilot = 0
-			to_chat(world, "<span class='notice'><b>Alert: The shuttle autopilot has been overridden. Bluespace drive engaged!</b></span>")
+			to_world("<span class='notice'><b>Alert: The shuttle autopilot has been overridden. Bluespace drive engaged!</b></span>")
 
 	if(usr)
 		log_admin("[key_name(usr)] has overridden the departure shuttle's autopilot and forced immediate launch.")

--- a/code/modules/shuttles/shuttles_web.dm
+++ b/code/modules/shuttles/shuttles_web.dm
@@ -181,7 +181,7 @@
 				my_doors[find_doors[A.id_tag]] = A
 				find_doors -= A.id_tag
 		for(var/lost in find_doors)
-			log_debug("[my_area] shuttle computer couldn't find [lost] door!")
+			log_shuttle("[my_area] shuttle computer couldn't find [lost] door!")
 
 	if(my_sensors)
 		var/list/find_sensors = my_sensors
@@ -191,7 +191,7 @@
 				my_sensors[find_sensors[S.id_tag]] = S
 				find_sensors -= S.id_tag
 		for(var/lost in find_sensors)
-			log_debug("[my_area] shuttle computer couldn't find [lost] sensor!")
+			log_shuttle("[my_area] shuttle computer couldn't find [lost] sensor!")
 
 /obj/machinery/computer/shuttle_control/web/attackby(obj/I, mob/user)
 	var/datum/shuttle/autodock/web_shuttle/shuttle = shuttle_controller.shuttles[shuttle_tag]

--- a/code/modules/shuttles/web_datums.dm
+++ b/code/modules/shuttles/web_datums.dm
@@ -72,7 +72,7 @@
 /datum/shuttle_destination/New(var/new_master)
 	my_landmark = SSshuttles.get_landmark(my_landmark)
 	if(!my_landmark)
-		log_debug("Web shuttle destination '[name]' could not find its landmark '[my_landmark]'.")
+		log_debug("Web shuttle destination '[name]' could not find its landmark '[my_landmark]'.") // Important error message
 	master = new_master
 
 /datum/shuttle_destination/Destroy()


### PR DESCRIPTION
Fixes #7048
If you want to debug a particular shuttle you just turn the variable on with VV, or change the code to force it on when the shuttle is assembled at roundstart.