### PR TITLE
mechs trigger mines. They're not very effective...

### DIFF
--- a/code/game/objects/effects/mines.dm
+++ b/code/game/objects/effects/mines.dm
@@ -49,6 +49,9 @@
 	if(triggered)
 		return
 
+	if(istype(M, /obj/mecha))
+		explode(M)
+
 	if(istype(M, /mob/living/))
 		if(!M.hovering)
 			explode(M)
@@ -79,7 +82,7 @@
 	triggered = 1
 	s.set_up(3, 1, src)
 	s.start()
-	if(M)
+	if(istype(M))
 		M.radiation += 50
 		randmutb(M)
 		domutcheck(M,null)
@@ -96,7 +99,7 @@
 	var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread()
 	s.set_up(3, 1, src)
 	s.start()
-	if(M)
+	if(istype(M))
 		M.Stun(30)
 	visible_message("\The [src.name] flashes violently before disintegrating!")
 	spawn(0)
@@ -136,7 +139,10 @@
 	triggered = 1
 	s.set_up(3, 1, src)
 	s.start()
-	if(M)
+	if(istype(M, /obj/mecha))
+		var/obj/mecha/E = M
+		M = E.occupant
+	if(istype(M))
 		qdel(M.client)
 	spawn(0)
 		qdel(s)
@@ -195,7 +201,7 @@
 	var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread()
 	s.set_up(3, 1, src)
 	s.start()
-	if(M)
+	if(istype(M))
 		M.adjust_fire_stacks(5)
 		M.fire_act()
 	visible_message("\The [src.name] bursts into flames!")


### PR DESCRIPTION
Fixes #6608 
Results may vary. Hoverpods trigger landmines because I did not cursorily find a meaningful way of differentiating them from every non-floating mech without just using another istype, which in this case is clunky and not easily extendable and therefore a bad fix. (And also I've not seen one used in _ages_)
The kick mine is given the mech's occupant, because that's an adminbuse thing and should not be so easily bypassed. Other mines just do their normal thing and the occupant is presumed to be shielded from the immediate effects, but may be subjected to the consequences of those effects, like the phoron or n2o mines releasing gas.