### PR TITLE
Door shock() always has a cooldown

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -637,13 +637,10 @@ About the new airlock wires panel:
 		return 0
 	if(hasShocked)
 		return 0	//Already shocked someone recently?
-	if(..())
-		hasShocked = 1
-		sleep(10)
+	. = ..()
+	hasShocked = 1
+	spawn(10)
 		hasShocked = 0
-		return 1
-	else
-		return 0
 
 
 /obj/machinery/door/airlock/update_icon()


### PR DESCRIPTION
Fixes #877 
The issue was that ..() only returned TRUE if the mob was stunned, i.e., if they actually took damage
In theory this fix could be abused by multiple people, i.e., if one person were to trigger the shock, another could interact with it safely in the brief period before it resets. In practice, I expect this will require timing too precise to reliably achieve, but if it does become an issue then I suppose a fix for that would be to store the has_shocked in a list, with an entry for each mob that interacts with the door while it's electrified