### PR TITLE
["Feature"] Crate Breaching w/ Tools

### DIFF
--- a/code/modules/mining/abandonedcrates.dm
+++ b/code/modules/mining/abandonedcrates.dm
@@ -9,6 +9,8 @@
 	var/attempts = 10
 	var/codelen = 4
 	locked = 1
+	can_breach = FALSE	//disabled by default
+	breach_time = 300	//on the other hand if you really wanna enable it, default time is jacked up
 
 /obj/structure/closet/crate/secure/loot/New()
 	..()


### PR DESCRIPTION
For a long time, I sat thinking "hey, why can't you cut open secure crates with regular tools?"

So I decided, on a whim, to make it so you can!

This PR adds two vars to secure crates, `can_breach` and `breach_time`. The former prevents you from cutting through the locking mechanism entirely: the latter determines the time taken to breach a crate (in deciseconds). The default time is 10 seconds for most secure crates, or 20 for weapons/gear/phoron. Abandoned crates cannot be cut open.

Welding tools and surgical saws can be used to cut open crates; saws take 50% longer but don't require fuel. Better tools cut faster, as one would expect.

Breaching this way is ugly though; it leaves visible evidence on the crate's examine description, it takes a fair bit of time, and it makes noise when starting. If I could, I'd make it throw in more cutting noises, but I'm not sure how I'd do that exactly.

Using a tool on a crate won't try to cut the lock if it's already open (you'll just put your tool in it instead, like normal) or already unlocked.