### PR TITLE
Give Mining Drones a proper fire delay.

### DIFF
--- a/code/modules/mob/living/simple_mob/subtypes/mechanical/drones/mining_drone.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/mechanical/drones/mining_drone.dm
@@ -32,7 +32,7 @@
 	movement_cooldown = 5
 	hovering = TRUE
 
-	base_attack_cooldown = 5
+	base_attack_cooldown = 2.5 SECONDS
 	projectiletype = /obj/item/projectile/energy/excavate
 	projectilesound = 'sound/weapons/pulse3.ogg'
 


### PR DESCRIPTION
From half a second to 2.5 seconds, because I'm a donk and didn't actually change it after testing.

Normal Dron:
- .5 delay, 10 damage, 5 Seconds = 100 damage, 0 pen
Mining Dron:
- 2.5 delay, 30 damage, 5 seconds = 60 damage, 60 pen