### PR TITLE
cleans up advanced_who output

### DIFF
--- a/code/game/verbs/advanced_who.dm
+++ b/code/game/verbs/advanced_who.dm
@@ -7,24 +7,36 @@
 
 	var/list/Lines = list()
 
-	if(holder && (R_ADMIN & holder.rights || R_MOD & holder.rights))
+	if(holder)
 		for(var/client/C in GLOB.clients)
-			var/entry = "\t[C.key]"
+			var/entry = "<tr><td>[C.key]"
 			if(C.holder && C.holder.fakekey)
 				entry += " <i>(as [C.holder.fakekey])</i>"
-			entry += " - Playing as [C.mob.real_name]"
-			switch(C.mob.stat)
-				if(UNCONSCIOUS)
-					entry += " - <font color='darkgray'><b>Unconscious</b></font>"
-				if(DEAD)
-					if(isobserver(C.mob))
-						var/mob/observer/dead/O = C.mob
-						if(O.started_as_observer)
-							entry += " - <font color='gray'>Observing</font>"
-						else
-							entry += " - <font color='black'><b>DEAD</b></font>"
+
+			entry += "</td><td>"
+
+			if(C.mob.real_name)
+				switch(C.mob.stat)
+					if(UNCONSCIOUS)
+						entry += "<span class='darkgray'><b>Unconscious</b></span>" // these are literally all spans so I can apply .inverted to them because black on dark grey isn't legible
+
+					if(DEAD)
+						if(isobserver(C.mob))
+							var/mob/observer/dead/O = C.mob
+							if(O.started_as_observer)
+								entry += "<span class='gray'>Observing</span>"
+							else
+								entry += "<span class='black'><b>Died</b></span>"
+
 					else
-						entry += " - <font color='black'><b>DEAD</b></font>"
+						entry += "<span class='green'>Playing</span>"
+
+				entry += " as [C.mob.real_name]"
+
+			else if(isnewplayer(C.mob))
+				entry += "<span class='blue'>In lobby</b></span>"
+
+			entry += "</td><td>"
 
 			var/age
 			if(isnum(C.player_age))
@@ -33,14 +45,20 @@
 				age = 0
 
 			if(age <= 1)
-				age = "<font color='#ff0000'><b>[age]</b></font>"
+				age = "<span class='red'><b>[age]</b></span>"
 			else if(age < 10)
-				age = "<font color='#ff8c00'><b>[age]</b></font>"
+				age = "<span class='orange'><b>[age]</b></span>"
 
-			entry += " - [age]"
+			entry += "Age: [age]"
+			entry += "</td><td>"
 
 			if(is_special_character(C.mob))
-				entry += " - <b><font color='red'>Antagonist</font></b>"
+				if(C.mob?.mind?.special_role)
+					entry += "<b><span class='red'>[C.mob.mind.special_role]</span></b>"
+				else
+					entry += "<b><span class='red'>Antagonist</span></b>"
+
+			entry += "</td><td>"
 
 			if(C.is_afk())
 				var/seconds = C.last_activity_seconds()
@@ -48,7 +66,9 @@
 				entry += "[round(seconds / 60)] minutes, "
 				entry += "[seconds % 60] seconds)"
 
+			entry += "</td><td>"
 			entry += " (<A HREF='?_src_=holder;adminmoreinfo=\ref[C.mob]'>?</A>)"
+			entry += "</td></tr>"
 
 			Lines += entry
 	else
@@ -60,16 +80,17 @@
 				entry += "[C.key]"
 			var/mob/observer/dead/O = C.mob
 			if(isobserver(O))
-				entry += " - <font color='gray'>Observing</font>"
+				entry += " - <span class='gray'>Observing</span><br>"
 			else if(istype(O,/mob/new_player))
-				entry += " - <font color='blue'>In Lobby</font>"
+				entry += " - <span class='blue'>In Lobby</span><br>"
 			else
-				entry += " - <font color='green'>Playing</font>"
+				entry += " - <span class='green'>Playing</span><br>"
 			Lines += entry
 
+	msg += "<table>"
 	for(var/line in sortList(Lines))
-		msg += "[line]\n"
-
+		msg += "[line]"
+	msg += "</table>"
 	msg += "<b>Total Players: [length(Lines)]</b>"
-	msg = "<span class='info'>" + msg + "</span>"
+	msg = "<span class='filter_info'>" + msg + "</span>"
 	to_chat(src, msg)

--- a/code/game/verbs/advanced_who.dm
+++ b/code/game/verbs/advanced_who.dm
@@ -34,7 +34,7 @@
 				entry += " as [C.mob.real_name]"
 
 			else if(isnewplayer(C.mob))
-				entry += "<span class='blue'>In lobby</b></span>"
+				entry += "<span class='blue'><b>In lobby</b></span>"
 
 			entry += "</td><td>"
 

--- a/code/modules/vchat/css/ss13styles.css
+++ b/code/modules/vchat/css/ss13styles.css
@@ -164,12 +164,27 @@ h1.alert, h2.alert		{color: #000000;}
 .bug					{color: #9e9e39;}
 .vox					{color: #AA00AA;}
 .promethean				{color: #5A5A5A; font-family:"Comic Sans MS","Comic Sans",cursive;}
-.inverted .promethean	{color: #A5A5A5; font-family:"Comic Sans MS","Comic Sans",cursive;}
+.inverted .promethean			{color: #A5A5A5; font-family:"Comic Sans MS","Comic Sans",cursive;}
 .zaddat					{color: #941C1C;}
 .rough					{font-family: "Trebuchet MS", cursive, sans-serif;}
 .say_quote				{font-family: Georgia, Verdana, sans-serif;}
 .terminus				{font-family: "Times New Roman", Times, serif, sans-serif}
 .interface				{color: #330033;}
+
+.black					{color: #000000;}
+.darkgray				{color: #808080;}
+.gray					{color: #A9A9A9;}
+.red					{color: #FF0000;}
+.orange					{color: #FF8C00;}
+.blue					{color: #0000FF;}
+.green					{color: #00DD00;}
+.inverted .black			{color: #606060;}
+.inverted .darkgray			{color: #808080;}
+.inverted .gray				{color: #A9A9A9;}
+.inverted .red				{color: #FF4444;}
+.inverted .orange			{color: #FF8C00;}
+.inverted .blue				{color: #6666FF;}
+.inverted .green			{color: #44FF44;}
 
 /*BIG IMG.icon 			{width: 32px; height: 32px;}*/
 img.icon				{vertical-align: middle; max-height: 1em;}

--- a/code/stylesheet.dm
+++ b/code/stylesheet.dm
@@ -115,4 +115,13 @@ BIG IMG.icon 			{width: 32px; height: 32px;}
 .debug_debug					{color:#0000FF;}
 .debug_trace					{color:#888888;}
 
+.black					{color: #000000;}
+.darkgray				{color: #808080;}
+.gray					{color: #A9A9A9;}
+.red					{color: #FF0000;}
+.orange					{color: #FF8C00;}
+.blue					{color: #0000FF;}
+.green					{color: #00DD00;}
+
+
 </style>"}


### PR DESCRIPTION
Tested with and without vchat enabled, it's a lot cleaner with vchat on because it can process html in a much more reasonable manner. Dark mode colors were chosen to be much more readable (mostly by decreasing the saturation of red, blue, and green)
For admins:
With Vchat:
![two players](https://puu.sh/FJkxS/30a78f7400.png)
![dark mode lobby color](https://puu.sh/FJkKj/1f08a60214.png)
![dark mode playing color](https://puu.sh/FJkKu/55b8bcd8bd.png)
Without Vchat:
![two players](https://puu.sh/FJkyN/bdbc59cac4.png) (Note the misalignment of table cells)

For players, it functions as-is, but it also gets more legible colors on dark mode.