### PR TITLE
[QOL] More Readable CMC

### DIFF
--- a/nano/css/shared.css
+++ b/nano/css/shared.css
@@ -663,7 +663,15 @@ th.Silicon {
 	font-weight: bold;
 	color: #ffffff;
 }
-/* Damage colors for crew monitoring computer */
+/* Damage/health colors for crew monitoring computer */
+
+.dead {
+    color: red;
+}
+
+.alive {
+    color: #7cfc00;
+}
 
 .burn {
     color: orange;
@@ -674,7 +682,7 @@ th.Silicon {
 }
 
 .toxin {
-    color: green;
+    color: lime;
 }
 
 .oxyloss {

--- a/nano/templates/crew_monitor.tmpl
+++ b/nano/templates/crew_monitor.tmpl
@@ -22,11 +22,11 @@ Used In File(s): \code\game\machinery\computer\crew.dm
 <table class='wideTable'><tbody>
 	{{for data.crewmembers}}
 		{{if value.sensor_type == 1}}
-			<tr><td>{{:value.name}} ({{:value.assignment}})</td><td class='living'>{{:value.dead ? "<span class='bad'>Deceased</span>" : "<span class='good'>Living</span>"}}</td><td><span class="neutral">Not Available</span></td>{{if data.isAI}}<td class='tracking'>{{:helper.link('Track', null, {}, 'disabled')}}</td>{{/if}}</tr>
+			<tr><td>{{:value.name}} ({{:value.assignment}})</td><td class='living'>{{:value.dead ? "<span class='dead'>Deceased</span>" : "<span class='alive'>Living</span>"}}</td><td><span class="neutral">Not Available</span></td>{{if data.isAI}}<td class='tracking'>{{:helper.link('Track', null, {}, 'disabled')}}</td>{{/if}}</tr>
 		{{else value.sensor_type == 2}}
-			<tr><td>{{:value.name}} ({{:value.assignment}})</td><td class='living'>{{:value.dead ? "<span class='bad'>Deceased</span>" : "<span class='good'>Living</span>"}} (<span class="oxyloss">{{:value.oxy}}</span>/<span class="toxin">{{:value.tox}}</span>/<span class="burn">{{:value.fire}}</span>/<span class="brute">{{:value.brute}}</span>)</td><td><span class="neutral">Not Available</td></td>{{if data.isAI}}<td class='tracking'>{{:helper.link('Track', null, {}, 'disabled')}}</td>{{/if}}</tr>
+			<tr><td>{{:value.name}} ({{:value.assignment}})</td><td class='living'>{{:value.dead ? "<span class='dead'>Deceased</span>" : "<span class='alive'>Living</span>"}} (<span class="oxyloss">{{:value.oxy}}</span>/<span class="toxin">{{:value.tox}}</span>/<span class="burn">{{:value.fire}}</span>/<span class="brute">{{:value.brute}}</span>)</td><td><span class="neutral">Not Available</td></td>{{if data.isAI}}<td class='tracking'>{{:helper.link('Track', null, {}, 'disabled')}}</td>{{/if}}</tr>
 		{{else value.sensor_type == 3}}
-			<tr><td>{{:value.name}} ({{:value.assignment}})</td><td class='living'>{{:value.dead ? "<span class='bad'>Deceased</span>" : "<span class='good'>Living</span>"}} (<span class="oxyloss">{{:value.oxy}}</span>/<span class="toxin">{{:value.tox}}</span>/<span class="burn">{{:value.fire}}</span>/<span class="brute">{{:value.brute}}</span>)</td><td>{{:value.area}}({{:value.x}}, {{:value.y}}, {{:value.z}})</td>{{if data.isAI}}<td class='tracking'>{{:helper.link('Track', null, {'track' : value.ref})}}</td>{{/if}}</tr>
+			<tr><td>{{:value.name}} ({{:value.assignment}})</td><td class='living'>{{:value.dead ? "<span class='dead'>Deceased</span>" : "<span class='alive'>Living</span>"}} (<span class="oxyloss">{{:value.oxy}}</span>/<span class="toxin">{{:value.tox}}</span>/<span class="burn">{{:value.fire}}</span>/<span class="brute">{{:value.brute}}</span>)</td><td>{{:value.area}}({{:value.x}}, {{:value.y}}, {{:value.z}})</td>{{if data.isAI}}<td class='tracking'>{{:helper.link('Track', null, {'track' : value.ref})}}</td>{{/if}}</tr>
 		{{/if}}
 	{{/for}}
 </tbody></table>


### PR DESCRIPTION
This has been something I've taken to fixing on other servers but never pushed further along for whatever reason, so hey, now you all get it too because fuck it.

The Crew Monitoring Computer's "Living" status and Toxins Damage values are now significantly easier to read, especially on darker screens:
![image](https://user-images.githubusercontent.com/49700375/81750016-a6128380-94a4-11ea-859b-4b502187f3d3.png)