### PR TITLE
Optimize what starts in SSobj

### DIFF
--- a/code/datums/observation/power_change.dm
+++ b/code/datums/observation/power_change.dm
@@ -1,0 +1,21 @@
+//	Observer Pattern Implementation: Area Power Change
+//		Registration type: /area
+//
+//		Raised when: An /area has a power change (the APC powers up/down or some channels are enabled/disabled)
+//
+//		Arguments that the called proc should expect:
+//			/area: The area experiencing the power change
+
+GLOBAL_DATUM_INIT(apc_event, /decl/observ/area_power_change, new)
+
+/decl/observ/area_power_change
+	name = "Area Power Change"
+	expected_type = /area
+
+/********************
+* Movement Handling *
+********************/
+
+/area/power_change()
+	. = ..()
+	GLOB.apc_event.raise_event(src)

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -20,24 +20,19 @@
 
 /obj/item/device/flashlight/Initialize()
 	. = ..()
-	update_icon()
 
-/obj/item/device/flashlight/New()
-	if(power_use)
-		START_PROCESSING(SSobj, src)
-
-		if(cell_type)
-			cell = new cell_type(src)
-			brightness_levels = list("low" = 0.25, "medium" = 0.5, "high" = 1)
-			power_usage = brightness_levels[brightness_level]
-
+	if(power_use && cell_type)
+		cell = new cell_type(src)
+		brightness_levels = list("low" = 0.25, "medium" = 0.5, "high" = 1)
+		power_usage = brightness_levels[brightness_level]
 	else
 		verbs -= /obj/item/device/flashlight/verb/toggle
-	..()
+	
+	update_icon()
 
 /obj/item/device/flashlight/Destroy()
-	if(power_use)
-		STOP_PROCESSING(SSobj, src)
+	STOP_PROCESSING(SSobj, src)
+	qdel_null(cell)
 	return ..()
 
 /obj/item/device/flashlight/get_cell()
@@ -58,18 +53,17 @@
 		update_icon()
 
 /obj/item/device/flashlight/process()
-	if(on)
-		if(cell)
-			if(brightness_level && power_usage)
-				if(power_usage < cell.charge)
-					cell.charge -= power_usage
-				else
-					cell.charge = 0
-					visible_message("<span class='warning'>\The [src] flickers before going dull.</span>")
-					set_light(0)
-					playsound(src.loc, 'sound/effects/sparks3.ogg', 10, 1, -3) //Small cue that your light went dull in your pocket.
-					on = 0
-					update_icon()
+	if(!on || !cell)
+		return PROCESS_KILL
+
+	if(brightness_level && power_usage)
+		if(cell.use(power_usage) != power_usage) // we weren't able to use our full power_usage amount!
+			visible_message("<span class='warning'>\The [src] flickers before going dull.</span>")
+			set_light(0)
+			playsound(src.loc, 'sound/effects/sparks3.ogg', 10, 1, -3) //Small cue that your light went dull in your pocket.
+			on = 0
+			update_icon()
+			return PROCESS_KILL
 
 /obj/item/device/flashlight/update_icon()
 	if(on)
@@ -111,6 +105,10 @@
 			to_chat(user, "You flick the switch on [src], but nothing happens.")
 			return 0
 	on = !on
+	if(on && power_use)
+		START_PROCESSING(SSobj, src)
+	else if(power_use)
+		STOP_PROCESSING(SSobj, src)
 	playsound(src.loc, 'sound/weapons/empty.ogg', 15, 1, -3)
 	update_icon()
 	user.update_action_buttons()

--- a/code/game/objects/items/devices/geiger.dm
+++ b/code/game/objects/items/devices/geiger.dm
@@ -13,7 +13,6 @@
 	var/datum/looping_sound/geiger/soundloop
 
 /obj/item/device/geiger/Initialize()
-	START_PROCESSING(SSobj, src)
 	soundloop = new(list(src), FALSE)
 	return ..()
 
@@ -60,6 +59,10 @@
 
 /obj/item/device/geiger/attack_self(var/mob/user)
 	scanning = !scanning
+	if(scanning)
+		START_PROCESSING(SSobj, src)
+	else
+		STOP_PROCESSING(SSobj, src)
 	update_icon()
 	update_sound()
 	to_chat(user, "<span class='notice'>[bicon(src)] You switch [scanning ? "on" : "off"] \the [src].</span>")

--- a/code/game/objects/items/devices/radio/intercom.dm
+++ b/code/game/objects/items/devices/radio/intercom.dm
@@ -10,8 +10,19 @@
 	flags = NOBLOODY
 	var/circuit = /obj/item/weapon/circuitboard/intercom
 	var/number = 0
-	var/last_tick //used to delay the powercheck
 	var/wiresexposed = 0
+
+/obj/item/device/radio/intercom/Initialize()
+	. = ..()
+	var/area/A = get_area(src)
+	if(A)
+		GLOB.apc_event.register(A, src, /obj/update_icon)
+
+/obj/item/device/radio/intercom/Destroy()
+	var/area/A = get_area(src)
+	if(A)
+		GLOB.apc_event.unregister(A, src, /obj/update_icon)
+	return ..()
 
 /obj/item/device/radio/intercom/custom
 	name = "station intercom (Custom)"
@@ -59,7 +70,6 @@
 
 /obj/item/device/radio/intercom/New()
 	..()
-	START_PROCESSING(SSobj, src)
 	circuit = new circuit(src)
 
 /obj/item/device/radio/intercom/department/medbay/New()
@@ -102,10 +112,6 @@
 	..()
 	internal_channels[num2text(RAID_FREQ)] = list(access_syndicate)
 
-/obj/item/device/radio/intercom/Destroy()
-	STOP_PROCESSING(SSobj, src)
-	return ..()
-
 /obj/item/device/radio/intercom/attack_ai(mob/user as mob)
 	src.add_fingerprint(user)
 	spawn (0)
@@ -122,15 +128,8 @@
 		wiresexposed = !wiresexposed
 		to_chat(user, "The wires have been [wiresexposed ? "exposed" : "unexposed"]")
 		playsound(src, W.usesound, 50, 1)
-		if(wiresexposed)
-			if(!on)
-				icon_state = "intercom-p_open"
-			else
-				icon_state = "intercom_open"
-		else
-			icon_state = "intercom"
-		return
-	if(wiresexposed && W.is_wirecutter())
+		update_icon()
+	else if(wiresexposed && W.is_wirecutter())
 		user.visible_message("<span class='warning'>[user] has cut the wires inside \the [src]!</span>", "You have cut the wires inside \the [src].")
 		playsound(src, W.usesound, 50, 1)
 		new/obj/item/stack/cable_coil(get_turf(src), 5)
@@ -148,7 +147,6 @@
 		qdel(src)
 	else
 		src.attack_hand(user)
-	return
 
 /obj/item/device/radio/intercom/receive_range(freq, level)
 	if (!on)
@@ -165,29 +163,20 @@
 
 	return canhear_range
 
-/obj/item/device/radio/intercom/process()
-	if(((world.timeofday - last_tick) > 30) || ((world.timeofday - last_tick) < 0))
-		last_tick = world.timeofday
+/obj/item/device/radio/intercom/update_icon()
+	var/area/A = get_area(src)
+	on = A?.powered(EQUIP)
 
-		if(!src.loc)
-			on = 0
+	if(!on)
+		if(wiresexposed)
+			icon_state = "intercom-p_open"
 		else
-			var/area/A = get_area(src)
-			if(!A)
-				on = 0
-			else
-				on = A.powered(EQUIP) // set "on" to the power status
-
-		if(!on)
-			if(wiresexposed)
-				icon_state = "intercom-p_open"
-			else
-				icon_state = "intercom-p"
+			icon_state = "intercom-p"
+	else
+		if(wiresexposed)
+			icon_state = "intercom_open"
 		else
-			if(wiresexposed)
-				icon_state = "intercom_open"
-			else
-				icon_state = initial(icon_state)
+			icon_state = initial(icon_state)
 
 /obj/item/device/radio/intercom/locked
     var/locked_frequency

--- a/code/game/objects/items/devices/suit_cooling.dm
+++ b/code/game/objects/items/devices/suit_cooling.dm
@@ -28,14 +28,17 @@
 /obj/item/device/suit_cooling_unit/ui_action_click()
 	toggle(usr)
 
-/obj/item/device/suit_cooling_unit/New()
-	START_PROCESSING(SSobj, src)
-	cell = new/obj/item/weapon/cell/high()	//comes not with the crappy default power cell - because this is dedicated EVA equipment
-	cell.loc = src
+/obj/item/device/suit_cooling_unit/Initialize()
+	. = ..()
+	cell = new/obj/item/weapon/cell/high(src)	//comes not with the crappy default power cell - because this is dedicated EVA equipment
+
+/obj/item/device/suit_cooling_unit/Destroy()
+	qdel_null(cell)
+	return ..()
 
 /obj/item/device/suit_cooling_unit/process()
 	if (!on || !cell)
-		return
+		return PROCESS_KILL
 
 	if (!ismob(loc))
 		return
@@ -106,11 +109,13 @@
 		return
 
 	on = 1
+	START_PROCESSING(SSobj, src)
 	updateicon()
 
 /obj/item/device/suit_cooling_unit/proc/turn_off(var/failed)
 	if(failed) visible_message("\The [src] clicks and whines as it powers down.")
 	on = 0
+	STOP_PROCESSING(SSobj, src)
 	updateicon()
 
 /obj/item/device/suit_cooling_unit/attack_self(var/mob/user)

--- a/code/game/objects/items/weapons/tanks/jetpack.dm
+++ b/code/game/objects/items/weapons/tanks/jetpack.dm
@@ -84,9 +84,8 @@
 	item_state_slots = list(slot_r_hand_str = "jetpack-void", slot_l_hand_str = "jetpack-void")
 
 /obj/item/weapon/tank/jetpack/void/Initialize()
-	..()
+	. = ..()
 	air_contents.adjust_gas("oxygen", (6*ONE_ATMOSPHERE)*volume/(R_IDEAL_GAS_EQUATION*T20C))
-	return
 
 /obj/item/weapon/tank/jetpack/oxygen
 	name = "jetpack (oxygen)"
@@ -95,9 +94,8 @@
 	item_state_slots = list(slot_r_hand_str = "jetpack", slot_l_hand_str = "jetpack")
 
 /obj/item/weapon/tank/jetpack/oxygen/Initialize()
-	..()
+	. = ..()
 	air_contents.adjust_gas("oxygen", (6*ONE_ATMOSPHERE)*volume/(R_IDEAL_GAS_EQUATION*T20C))
-	return
 
 /obj/item/weapon/tank/jetpack/carbondioxide
 	name = "jetpack (carbon dioxide)"
@@ -107,9 +105,8 @@
 	item_state_slots = list(slot_r_hand_str = "jetpack-black", slot_l_hand_str = "jetpack-black")
 
 /obj/item/weapon/tank/jetpack/carbondioxide/Initialize()
-	..()
+	. = ..()
 	air_contents.adjust_gas("carbon_dioxide", (6*ONE_ATMOSPHERE)*volume/(R_IDEAL_GAS_EQUATION*T20C))
-	return
 
 /obj/item/weapon/tank/jetpack/rig
 	name = "jetpack"

--- a/code/game/objects/items/weapons/tanks/tank_types.dm
+++ b/code/game/objects/items/weapons/tanks/tank_types.dm
@@ -17,9 +17,8 @@
 	distribute_pressure = ONE_ATMOSPHERE*O2STANDARD
 
 /obj/item/weapon/tank/oxygen/Initialize()
-	..()
+	. = ..()
 	air_contents.adjust_gas("oxygen", (6*ONE_ATMOSPHERE)*volume/(R_IDEAL_GAS_EQUATION*T20C))
-	return
 
 /obj/item/weapon/tank/oxygen/examine(mob/user)
 	. = ..()
@@ -43,13 +42,11 @@
 	icon_state = "anesthetic"
 
 /obj/item/weapon/tank/anesthetic/Initialize()
-	..()
+	. = ..()
 
 	air_contents.gas["oxygen"] = (3*ONE_ATMOSPHERE)*70/(R_IDEAL_GAS_EQUATION*T20C) * O2STANDARD
 	air_contents.gas["sleeping_agent"] = (3*ONE_ATMOSPHERE)*70/(R_IDEAL_GAS_EQUATION*T20C) * N2STANDARD
 	air_contents.update_values()
-
-	return
 
 /*
  * Air
@@ -66,11 +63,8 @@
 		user << sound('sound/effects/alert.ogg')
 
 /obj/item/weapon/tank/air/Initialize()
-	..()
-
+	. = ..()
 	src.air_contents.adjust_multi("oxygen", (6*ONE_ATMOSPHERE)*volume/(R_IDEAL_GAS_EQUATION*T20C) * O2STANDARD, "nitrogen", (6*ONE_ATMOSPHERE)*volume/(R_IDEAL_GAS_EQUATION*T20C) * N2STANDARD)
-
-	return
 
 /*
  * Phoron
@@ -83,10 +77,8 @@
 	slot_flags = null	//they have no straps!
 
 /obj/item/weapon/tank/phoron/Initialize()
-	..()
-
+	. = ..()
 	src.air_contents.adjust_gas("phoron", (3*ONE_ATMOSPHERE)*70/(R_IDEAL_GAS_EQUATION*T20C))
-	return
 
 /obj/item/weapon/tank/phoron/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	..()
@@ -109,10 +101,8 @@
 	slot_flags = SLOT_BACK	//these ones have straps!
 
 /obj/item/weapon/tank/vox/Initialize()
-	..()
-
+	. = ..()
 	air_contents.adjust_gas("phoron", (6*ONE_ATMOSPHERE)*volume/(R_IDEAL_GAS_EQUATION*T20C))
-	return
 
 /obj/item/weapon/tank/phoron/pressurized
 	name = "fuel can"
@@ -120,12 +110,9 @@
 	w_class = ITEMSIZE_NORMAL
 
 /obj/item/weapon/tank/phoron/pressurized/Initialize()
-	..()
-
+	. = ..()
 	adjust_scale(0.8)
-
 	air_contents.adjust_gas("phoron", (7*ONE_ATMOSPHERE)*volume/(R_IDEAL_GAS_EQUATION*T20C))
-	return
 
 /*
  * Emergency Oxygen
@@ -149,9 +136,8 @@
 	gauge_icon = "indicator_emergency"
 
 /obj/item/weapon/tank/emergency/oxygen/Initialize()
-	..()
+	. = ..()
 	src.air_contents.adjust_gas("oxygen", (10*ONE_ATMOSPHERE)*volume/(R_IDEAL_GAS_EQUATION*T20C))
-	return
 
 /obj/item/weapon/tank/emergency/oxygen/examine(mob/user)
 	. = ..()
@@ -178,9 +164,8 @@
 	volume = 10
 
 /obj/item/weapon/tank/stasis/oxygen/Initialize()
-	..()
+	. = ..()
 	src.air_contents.adjust_gas("oxygen", (3*ONE_ATMOSPHERE)*volume/(R_IDEAL_GAS_EQUATION*T20C))
-	return
 
 /obj/item/weapon/tank/emergency/nitrogen
 	name = "emergency nitrogen tank"
@@ -205,7 +190,7 @@
 	gauge_icon = "indicator_emergency"
 
 /obj/item/weapon/tank/emergency/phoron/Initialize()
-	..()
+	. = ..()
 	src.air_contents.adjust_gas("phoron", (10*ONE_ATMOSPHERE)*volume/(R_IDEAL_GAS_EQUATION*T20C))
 
 /obj/item/weapon/tank/emergency/phoron/double
@@ -224,10 +209,8 @@
 	distribute_pressure = ONE_ATMOSPHERE*O2STANDARD
 
 /obj/item/weapon/tank/nitrogen/Initialize()
-	..()
-
+	. = ..()
 	src.air_contents.adjust_gas("nitrogen", (3*ONE_ATMOSPHERE)*70/(R_IDEAL_GAS_EQUATION*T20C))
-	return
 
 /obj/item/weapon/tank/nitrogen/examine(mob/user)
 	. = ..()
@@ -243,6 +226,5 @@
 	volume = 10
 
 /obj/item/weapon/tank/stasis/nitro_cryo/Initialize()
-	..()
+	. = ..()
 	src.air_contents.adjust_gas_temp("nitrogen", (3*ONE_ATMOSPHERE)*volume/(R_IDEAL_GAS_EQUATION*TN60C), TN60C)
-	return

--- a/code/game/objects/items/weapons/tanks/tanks.dm
+++ b/code/game/objects/items/weapons/tanks/tanks.dm
@@ -59,15 +59,13 @@ var/list/global/tank_gauge_cache = list()
 
 
 /obj/item/weapon/tank/Initialize()
-	..()
+	. = ..()
 
 	src.init_proxy()
 	src.air_contents = new /datum/gas_mixture()
 	src.air_contents.volume = volume //liters
 	src.air_contents.temperature = T20C
-	START_PROCESSING(SSobj, src)
 	update_gauge()
-	return
 
 /obj/item/weapon/tank/Destroy()
 	QDEL_NULL(air_contents)
@@ -80,6 +78,13 @@ var/list/global/tank_gauge_cache = list()
 		TTV.remove_tank(src)
 
 	. = ..()
+
+/obj/item/weapon/tank/equipped() // Note that even grabbing into a hand calls this, so it should be fine as a 'has a player touched this'
+	. = ..()
+	// An attempt at optimization. There are MANY tanks during rounds that will never get touched.
+	// Don't see why any of those would explode spontaneously. So only tanks that players touch get processed.
+	// This could be optimized more, but it's a start!
+	START_PROCESSING(SSobj, src) // This has a built in safety to avoid multi-processing
 
 /obj/item/weapon/tank/examine(mob/user)
 	. = ..()

--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -124,8 +124,6 @@
 	spark_system.set_up(5, 0, src)
 	spark_system.attach(src)
 
-	START_PROCESSING(SSobj, src)
-
 	if(initial_modules && initial_modules.len)
 		for(var/path in initial_modules)
 			var/obj/item/rig_module/module = new path(src)
@@ -182,6 +180,22 @@
 	qdel(spark_system)
 	spark_system = null
 	return ..()
+
+// We only care about processing when we're on a mob
+/obj/item/weapon/rig/Moved(old_loc, direction, forced)
+	if(ismob(loc))
+		START_PROCESSING(SSobj, src)
+	else
+		STOP_PROCESSING(SSobj, src)
+
+	// If we've lost any parts, grab them back.
+	var/mob/living/M
+	for(var/obj/item/piece in list(gloves,boots,helmet,chest))
+		if(piece.loc != src && !(wearer && piece.loc == wearer))
+			if(istype(piece.loc, /mob/living))
+				M = piece.loc
+				M.unEquip(piece)
+			piece.forceMove(src)
 
 /obj/item/weapon/rig/get_worn_icon_file(var/body_type,var/slot_name,var/default_icon,var/inhands)
 	if(!inhands && (slot_name == slot_back_str || slot_name == slot_belt_str))
@@ -465,14 +479,12 @@
 		turn_cooling_off(H, 1)
 
 /obj/item/weapon/rig/process()
-	// If we've lost any parts, grab them back.
-	var/mob/living/M
-	for(var/obj/item/piece in list(gloves,boots,helmet,chest))
-		if(piece.loc != src && !(wearer && piece.loc == wearer))
-			if(istype(piece.loc, /mob/living))
-				M = piece.loc
-				M.unEquip(piece)
-			piece.forceMove(src)
+	// Not on a mob...?
+	if(!ismob(loc))
+		wearer?.wearing_rig = null
+		wearer = null
+		return PROCESS_KILL
+	
 	// Run through cooling
 	coolingProcess()
 

--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -481,7 +481,8 @@
 /obj/item/weapon/rig/process()
 	// Not on a mob...?
 	if(!ismob(loc))
-		wearer?.wearing_rig = null
+		if(wearer?.wearing_rig == src)
+			wearer.wearing_rig = null
 		wearer = null
 		return PROCESS_KILL
 	

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -401,6 +401,8 @@ var/global/list/light_type_cache = list()
 			else
 				update_use_power(USE_POWER_ACTIVE)
 				set_light(correct_range, correct_power, correct_color)
+		if(cell?.charge < cell?.maxcharge)
+			START_PROCESSING(SSobj, src)
 	else if(has_emergency_power(LIGHT_EMERGENCY_POWER_USE) && !turned_off())
 		update_use_power(USE_POWER_IDLE)
 		emergency_mode = TRUE
@@ -794,11 +796,11 @@ var/global/list/light_type_cache = list()
 	if(has_power())
 		emergency_mode = FALSE
 		update(FALSE)
-		if(cell.charge == cell.maxcharge)
+		if(!cell.give(LIGHT_EMERGENCY_POWER_USE*2)) // Recharge and stop if no more was able to be added
 			return PROCESS_KILL
-		cell.charge = min(cell.maxcharge, cell.charge + LIGHT_EMERGENCY_POWER_USE*2) //Recharge emergency power automatically while not using it
 	if(emergency_mode && !use_emergency_power(LIGHT_EMERGENCY_POWER_USE))
 		update(FALSE) //Disables emergency mode and sets the color to normal
+		return PROCESS_KILL // Drop out if we're out of cell power. These are often in POIs and there's no point in recharging.
 
 	if(auto_flicker && !flickering)
 		if(check_for_player_proximity(src, radius = 12, ignore_ghosts = FALSE, ignore_afk = TRUE))

--- a/polaris.dme
+++ b/polaris.dme
@@ -305,6 +305,7 @@
 #include "code\datums\observation\logged_in.dm"
 #include "code\datums\observation\moved.dm"
 #include "code\datums\observation\observation.dm"
+#include "code\datums\observation\power_change.dm"
 #include "code\datums\observation\shuttle_added.dm"
 #include "code\datums\observation\shuttle_moved.dm"
 #include "code\datums\observation\stat_set.dm"


### PR DESCRIPTION
On our server, reduces roundstart SSobj processing items from 1200 to 200.

Flashlights, geiger counters, suit cooling units made stateful so they only process when 'on'.

Lighting fixed a place where lights could sit forever waiting to charge their ecells, which usually happens on POIs. Eventually they run out and remove themselves now, and start charging again when the lights come on.

Intercomms made an observer event handler for area power changes and intercoms listen to that instead.