### PR TITLE
Fixes Runtime in ,: bad arg name 'disable_warning'

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -339,7 +339,7 @@ var/list/global/slot_flags_enumeration = list(
 //If you are making custom procs but would like to retain partial or complete functionality of this one, include a 'return ..()' to where you want this to happen.
 //Set disable_warning to 1 if you wish it to not give you outputs.
 //Should probably move the bulk of this into mob code some time, as most of it is related to the definition of slots and not item-specific
-/obj/item/proc/mob_can_equip(M as mob, slot, disable_warning = 0)
+/obj/item/proc/mob_can_equip(M as mob, slot, disable_warning = FALSE)
 	if(!slot) return 0
 	if(!M) return 0
 

--- a/code/game/objects/items/weapons/storage/internal.dm
+++ b/code/game/objects/items/weapons/storage/internal.dm
@@ -18,7 +18,7 @@
 /obj/item/weapon/storage/internal/attack_hand()
 	return		//make sure this is never picked up
 
-/obj/item/weapon/storage/internal/mob_can_equip(M as mob, slot, disable_warning = 0)
+/obj/item/weapon/storage/internal/mob_can_equip(M as mob, slot, disable_warning = FALSE)
 	return 0	//make sure this is never picked up
 
 //Helper procs to cleanly implement internal storages - storage items that provide inventory slots for other items.

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -59,7 +59,7 @@
 		user.recalculate_vis()
 
 //BS12: Species-restricted clothing check.
-/obj/item/clothing/mob_can_equip(M as mob, slot, disable_warning = 0)
+/obj/item/clothing/mob_can_equip(M as mob, slot, disable_warning = FALSE)
 
 	//if we can't equip the item anyway, don't bother with species_restricted (cuts down on spam)
 	if (!..())
@@ -323,7 +323,7 @@
 		return
 */
 
-/obj/item/clothing/gloves/mob_can_equip(mob/user, slot)
+/obj/item/clothing/gloves/mob_can_equip(mob/user, slot, disable_warning = FALSE)
 	var/mob/living/carbon/human/H = user
 
 	if(slot && slot == slot_gloves)

--- a/code/modules/clothing/gloves/arm_guards.dm
+++ b/code/modules/clothing/gloves/arm_guards.dm
@@ -7,7 +7,7 @@
 	w_class = ITEMSIZE_NORMAL
 	drop_sound = 'sound/items/drop/metalshield.ogg'
 
-/obj/item/clothing/gloves/arm_guard/mob_can_equip(var/mob/living/carbon/human/H, slot, disable_warning = 0)
+/obj/item/clothing/gloves/arm_guard/mob_can_equip(var/mob/living/carbon/human/H, slot, disable_warning = FALSE)
 	if(..()) //This will only run if no other problems occured when equiping.
 		if(H.wear_suit)
 			if(H.wear_suit.body_parts_covered & ARMS)

--- a/code/modules/clothing/gloves/gauntlets.dm
+++ b/code/modules/clothing/gloves/gauntlets.dm
@@ -14,7 +14,7 @@
 	punch_force = 5
 	var/obj/item/clothing/gloves/gloves = null	//Undergloves
 
-/obj/item/clothing/gloves/gauntlets/mob_can_equip(mob/user, slot, disable_warning = 0)
+/obj/item/clothing/gloves/gauntlets/mob_can_equip(mob/user, slot, disable_warning = FALSE)
 	var/mob/living/carbon/human/H = user
 	if(H.gloves)
 		gloves = H.gloves

--- a/code/modules/clothing/shoes/leg_guards.dm
+++ b/code/modules/clothing/shoes/leg_guards.dm
@@ -9,7 +9,7 @@
 	can_hold_knife = TRUE
 	drop_sound = 'sound/items/drop/boots.ogg'
 
-/obj/item/clothing/shoes/leg_guard/mob_can_equip(var/mob/living/carbon/human/H, slot, disable_warning = 0)
+/obj/item/clothing/shoes/leg_guard/mob_can_equip(var/mob/living/carbon/human/H, slot, disable_warning = FALSE)
 	if(..()) //This will only run if no other problems occured when equiping.
 		if(H.wear_suit)
 			if(H.wear_suit.body_parts_covered & LEGS)

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -9,7 +9,7 @@
 	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE
 	siemens_coefficient = 0.6
 
-/obj/item/clothing/suit/mob_can_equip(var/mob/living/carbon/human/H, slot, disable_warning = 0)
+/obj/item/clothing/suit/mob_can_equip(var/mob/living/carbon/human/H, slot, disable_warning = FALSE)
 	if(..()) //This will only run if no other problems occured when equiping.
 		for(var/obj/item/clothing/I in list(H.gloves, H.shoes))
 			if(I && (src.body_parts_covered & ARMS && I.body_parts_covered & ARMS) )


### PR DESCRIPTION
> proc name: mob can equip (/obj/item/clothing/gloves/mob_can_equip)
> usr: (the floor) (73,137,2) (/turf/simulated/floor/tiled) ()
> usr.loc: (the floor) (73,137,2) (/turf/simulated/floor/tiled) ()
> src: the insulated gloves (/obj/item/clothing/gloves/yellow)
> src.loc:  (/mob/living/carbon/human)
> call stack:
> the insulated gloves (/obj/item/clothing/gloves/yellow): mob can equip( (/mob/living/carbon/human), 17, null)
> the r_ear (/obj/screen/inventory): add overlays()
> the r_ear (/obj/screen/inventory): MouseEntered(null, "mapwindow.map", "icon-x=32;icon-y=18;screen-loc...")