### PR TITLE
Add serial comma

### DIFF
--- a/code/_helpers/_lists.dm
+++ b/code/_helpers/_lists.dm
@@ -16,7 +16,7 @@
  */
 
 //Returns a list in plain english as a string
-/proc/english_list(var/list/input, nothing_text = "nothing", and_text = " and ", comma_text = ", ", final_comma_text = "")
+/proc/english_list(var/list/input, nothing_text = "nothing", and_text = " and ", comma_text = ", ", final_comma_text = ",")
 	// this proc cannot be merged with counting_english_list to maintain compatibility
 	// with shoddy use of this proc for code logic and for cases that require original order
 	switch(input.len)
@@ -26,7 +26,7 @@
 		else  return "[jointext(input, comma_text, 1, -1)][final_comma_text][and_text][input[input.len]]"
 
 //Returns a newline-separated list that counts equal-ish items, outputting count and item names, optionally with icons and specific determiners
-/proc/counting_english_list(var/list/input, output_icons = TRUE, determiners = DET_NONE, nothing_text = "nothing", line_prefix = "\t", first_item_prefix = "\n", last_item_suffix = "\n", and_text = "\n", comma_text = "\n", final_comma_text = "")
+/proc/counting_english_list(var/list/input, output_icons = TRUE, determiners = DET_NONE, nothing_text = "nothing", line_prefix = "\t", first_item_prefix = "\n", last_item_suffix = "\n", and_text = "\n", comma_text = "\n", final_comma_text = ",")
 	var/list/counts = list() // counted input items
 	var/list/items = list() // actual objects for later reference (for icons and formatting)
 


### PR DESCRIPTION
Use of the comma is consistent with the conventional practice of the region.
It matches the spoken cadence of sentences better.
It can resolve ambiguity.
Its use is consistent with other means of separating items in a list (for example, when semicolons are used to separate items, one is always included before the last item).
Its omission may suggest a stronger connection between the last two items in a series than actually exists.
Its use can "prevent any misreading that the last item is part of the preceding one".

I eagerly await my bikeshed label.