### PR TITLE
Fixes runtime in antagonist_helpers.dm, line 15

### DIFF
--- a/code/game/antagonist/antagonist_helpers.dm
+++ b/code/game/antagonist/antagonist_helpers.dm
@@ -12,8 +12,12 @@
 			return FALSE
 		if(avoid_silicons)
 			var/datum/job/J = SSjob.get_job(player.assigned_role)
-			if(J.mob_type & JOB_SILICON)
-				return FALSE
+			if(J)
+				if(J.mob_type & JOB_SILICON)
+					return FALSE
+			else // If SSjob couldn't find a job, they don't have one yet, so the next best thing we can switch on are job preferences
+				if((player.current.client.prefs.job_engsec_high | player.current.client.prefs.job_engsec_med | player.current.client.prefs.job_engsec_low) & (AI | CYBORG)) // If they have ANY chance of being silicon
+					return FALSE
 	return TRUE
 
 /datum/antagonist/proc/antags_are_dead()


### PR DESCRIPTION
Cannot read null.mob_type

Should hopefully fix roundstart antags being absurdly picky about who gets to be bad, or at least should fix changelings, who are selected before jobs are assigned, and therefore cannot have jobs when they are selected.