### PR TITLE
Increases automute detection interval to 1s

### DIFF
--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -164,6 +164,7 @@
 proc/cmd_admin_mute(mob/M as mob, mute_type, automute = 0)
 	if(automute)
 		if(!config.automute_on)
+			to_world("automute off")
 			return
 	else
 		if(!usr || !usr.client)
@@ -176,8 +177,10 @@ proc/cmd_admin_mute(mob/M as mob, mute_type, automute = 0)
 		if(M.client.holder)
 			to_chat(usr, "<font color='red'>Error: cmd_admin_mute: You cannot mute an admin/mod.</font>")
 	if(!M.client)
+		to_world("no client")
 		return
 	if(M.client.holder)
+		to_world("holder")
 		return
 
 	var/muteunmute
@@ -190,7 +193,9 @@ proc/cmd_admin_mute(mob/M as mob, mute_type, automute = 0)
 		if(MUTE_ADMINHELP)	mute_string = "adminhelp, admin PM and ASAY"
 		if(MUTE_DEADCHAT)	mute_string = "deadchat and DSAY"
 		if(MUTE_ALL)		mute_string = "everything"
-		else				return
+		else
+			to_world("inv mute type")
+			return
 
 	if(automute)
 		muteunmute = "auto-muted"

--- a/code/modules/client/spam_prevention.dm
+++ b/code/modules/client/spam_prevention.dm
@@ -3,8 +3,9 @@
 	var/last_message_time = 0
 	var/spam_alert = 0
 
-/client/proc/handle_spam_prevention(var/mute_type = MUTE_ALL, var/spam_delay = 0.5 SECONDS)
-	if(world.time - last_message_time < spam_delay)
+/client/proc/handle_spam_prevention(var/mute_type = MUTE_ALL, var/spam_delay = SPAM_TRIGGER_AUTOMUTE)
+	to_world("handle_spam_prevention at D[world.time - last_message_time], T[world.time]")
+	if(world.time - last_message_time < SPAM_TRIGGER_AUTOMUTE)
 		spam_alert++
 		if(spam_alert > 5)
 			cmd_admin_mute(src.mob, mute_type, 1)


### PR DESCRIPTION
This is intended to catch the recent bout of ooc spammers  that've been touring the ss13 community trying to smear the World server the past few weeks, Unfortunately, the system appears to be in working order, which means they were posting slow enough to avoid it. We do not at present have any better ideas to combat such an issue, and cultists will need to be careful not to mute themselves by clicking on runes too frequently.

But for the fact that cultists still have to click on 10 different runes, I'd consider caching recent messages to try and catch people repeating themselves several times, but as it stands that seems most likely to catch cultists.