### PR TITLE
Talking, and other bugs

### DIFF
--- a/code/modules/mob/language/language.dm
+++ b/code/modules/mob/language/language.dm
@@ -270,7 +270,7 @@
 			if (species_language)
 				set_default_language(GLOB.all_languages[species_language])
 			else
-				set_default_language(null)
+				set_default_language(GLOB.all_languages[LANGUAGE_GIBBERISH])
 		else
 			var/datum/language/L = locate(href_list["default_lang"])
 			if(L && (L in languages))

--- a/code/modules/mob/living/carbon/brain/brain.dm
+++ b/code/modules/mob/living/carbon/brain/brain.dm
@@ -14,6 +14,7 @@
 	var/datum/reagents/R = new/datum/reagents(1000)
 	reagents = R
 	R.my_atom = src
+	default_language = GLOB.all_languages[LANGUAGE_GALCOM]
 
 /mob/living/carbon/brain/Destroy()
 	if(key)				//If there is a mob connected to this thing. Have to check key twice to avoid false death reporting.
@@ -43,5 +44,24 @@
 /mob/living/carbon/brain/isSynthetic()
 	return istype(loc, /obj/item/device/mmi)
 
-///mob/living/carbon/brain/binarycheck()//No binary without a binary communication device
-//	return isSynthetic()
+/mob/living/carbon/brain/set_typing_indicator(var/state)
+	if(isturf(loc))
+		return ..()
+
+	if(!is_preference_enabled(/datum/client_preference/show_typing_indicator))
+		loc.cut_overlay(typing_indicator, TRUE)
+		return
+
+	if(!typing_indicator)
+		typing_indicator = new
+		typing_indicator.icon = 'icons/mob/talk.dmi'
+		typing_indicator.icon_state = "[speech_bubble_appearance()]_typing"
+
+	if(state && !typing)
+		loc.add_overlay(typing_indicator, TRUE)
+		typing = TRUE
+	else if(typing)
+		loc.cut_overlay(typing_indicator, TRUE)
+		typing = FALSE
+
+	return state

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -384,9 +384,9 @@
 			return GLOB.all_languages[LANGUAGE_GIBBERISH]
 
 	if(!species)
-		return null
+		return GLOB.all_languages[LANGUAGE_GIBBERISH]
 
-	return species.default_language ? GLOB.all_languages[species.default_language] : null
+	return species.default_language ? GLOB.all_languages[species.default_language] : GLOB.all_languages[LANGUAGE_GIBBERISH]
 
 /mob/living/carbon/proc/should_have_organ(var/organ_check)
 	return 0

--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -12,7 +12,7 @@
 
 	for(var/obj/item/organ/I in internal_organs)
 		I.removed()
-		if(istype(loc,/turf))
+		if(isturf(I?.loc)) // Some organs qdel themselves or other things when removed
 			I.throw_at(get_edge_target_turf(src,pick(alldirs)),rand(1,3),30)
 
 	for(var/obj/item/organ/external/E in src.organs)

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -38,18 +38,18 @@ var/list/department_radio_keys = list(
 
 	  //kinda localization -- rastaf0
 	  //same keys as above, but on russian keyboard layout. This file uses cp1251 as encoding.
-	  ":ê" = "right ear",	".ê" = "right ear",
-	  ":ä" = "left ear",	".ä" = "left ear",
-	  ":ø" = "intercom",	".ø" = "intercom",
-	  ":ð" = "department",	".ð" = "department",
-	  ":ñ" = "Command",		".ñ" = "Command",
-	  ":ò" = "Science",		".ò" = "Science",
-	  ":ü" = "Medical",		".ü" = "Medical",
-	  ":ó" = "Engineering",	".ó" = "Engineering",
-	  ":û" = "Security",	".û" = "Security",
-	  ":ö" = "whisper",		".ö" = "whisper",
-	  ":å" = "Mercenary",	".å" = "Mercenary",
-	  ":é" = "Supply",		".é" = "Supply",
+	  ":ï¿½" = "right ear",	".ï¿½" = "right ear",
+	  ":ï¿½" = "left ear",	".ï¿½" = "left ear",
+	  ":ï¿½" = "intercom",	".ï¿½" = "intercom",
+	  ":ï¿½" = "department",	".ï¿½" = "department",
+	  ":ï¿½" = "Command",		".ï¿½" = "Command",
+	  ":ï¿½" = "Science",		".ï¿½" = "Science",
+	  ":ï¿½" = "Medical",		".ï¿½" = "Medical",
+	  ":ï¿½" = "Engineering",	".ï¿½" = "Engineering",
+	  ":ï¿½" = "Security",	".ï¿½" = "Security",
+	  ":ï¿½" = "whisper",		".ï¿½" = "whisper",
+	  ":ï¿½" = "Mercenary",	".ï¿½" = "Mercenary",
+	  ":ï¿½" = "Supply",		".ï¿½" = "Supply",
 )
 
 
@@ -293,6 +293,15 @@ proc/get_radio_key_from_channel(var/channel)
 	var/speech_bubble_test = say_test(message)
 	var/speech_type = speech_bubble_appearance()
 	var/image/speech_bubble = image('icons/mob/talk.dmi',src,"[speech_type][speech_bubble_test]")
+	var/sb_alpha = 255
+	var/atom/loc_before_turf = src
+	while(loc_before_turf && !isturf(loc_before_turf.loc))
+		loc_before_turf = loc_before_turf.loc
+		sb_alpha -= 50
+		if(sb_alpha < 0)
+			break
+	speech_bubble.loc = loc_before_turf
+	speech_bubble.alpha = CLAMP(sb_alpha, 0, 255)
 	images_to_clients[speech_bubble] = list()
 
 	// Attempt Multi-Z Talking

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -106,8 +106,8 @@ var/list/organ_cache = list()
 	STOP_PROCESSING(SSobj, src)
 	handle_organ_mod_special(TRUE)
 	if(owner && vital)
-		owner.death()
 		owner.can_defib = 0
+		owner.death()
 
 /obj/item/organ/proc/adjust_germ_level(var/amount)		// Unless you're setting germ level directly to 0, use this proc instead
 	germ_level = CLAMP(germ_level + amount, 0, INFECTION_LEVEL_MAX)
@@ -340,7 +340,7 @@ var/list/organ_cache = list()
 	var/obj/item/organ/external/affected = owner.get_organ(parent_organ)
 	if(affected) affected.internal_organs -= src
 
-	loc = get_turf(owner)
+	forceMove(owner.drop_location())
 	START_PROCESSING(SSobj, src)
 	rejecting = null
 	var/datum/reagent/blood/organ_blood = locate(/datum/reagent/blood) in reagents.reagent_list
@@ -349,9 +349,10 @@ var/list/organ_cache = list()
 
 	if(owner && vital)
 		if(user)
-			add_attack_logs(user,owner,"Removed vital organ [src.name]")
-		owner.death()
-		owner.can_defib = 0
+			add_attack_logs(user, owner, "Removed vital organ [src.name]")
+		if(owner.stat != DEAD)
+			owner.can_defib = 0
+			owner.death()
 
 	handle_organ_mod_special(TRUE)
 

--- a/code/modules/organs/subtypes/machine.dm
+++ b/code/modules/organs/subtypes/machine.dm
@@ -88,7 +88,7 @@
 
 /obj/item/organ/internal/mmi_holder/emp_act(severity)
 	..()
-	owner.adjustToxLoss(rand(6/severity, 12/severity))
+	owner?.adjustToxLoss(rand(6/severity, 12/severity))
 
 /obj/item/organ/internal/mmi_holder/posibrain
 	name = "positronic brain interface"


### PR DESCRIPTION
There were a couple bugs I noticed while testing a species downstream.
- Brains (like the mob held inside posibrains) couldn't speak because it would runtime as they had no default language
- No speech bubbles for brains (you can't see their mobs, so that does make sense and isn't really a bug so much as is just lame)

This fixes that and tries to make it more robust to runtimes by at least giving people gibberish talk as a failsafe rather than making their language null.

Also adds speech bubbles when hiding in things, with -50 alpha per layer you're hidden in.