### PR TITLE
Adds vchat export chatlog verb

### DIFF
--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -405,18 +405,20 @@ client/verb/character_setup()
 	if(src.chatOutputLoadedAt > (world.time - 10 SECONDS))
 		alert(src, "You can only try to reload VChat every 10 seconds at most.")
 		return
-	
+
+	verbs -= /client/proc/vchat_export_log
+
 	//Log, disable
 	log_debug("[key_name(src)] reloaded VChat.")
 	winset(src, null, "outputwindow.htmloutput.is-visible=false;outputwindow.oldoutput.is-visible=false;outputwindow.chatloadlabel.is-visible=true")
-	
+
 	//The hard way
 	qdel_null(src.chatOutput)
 	chatOutput = new /datum/chatOutput(src) //veechat
 	chatOutput.send_resources()
 	spawn()
 		chatOutput.start()
-	
+
 
 //This is for getipintel.net.
 //You're welcome to replace this proc with your own that does your own cool stuff.

--- a/code/modules/vchat/js/vchat.js
+++ b/code/modules/vchat/js/vchat.js
@@ -89,6 +89,7 @@ function start_vchat() {
 	//Inform byond we're done
 	vchat_state.ready = true;
 	push_Topic('done_loading');
+	push_Topic_showingnum(this.showingnum);
 
 	//I'll do my own winsets
 	doWinset("htmloutput", {"is-visible": true});
@@ -342,6 +343,7 @@ function start_vue() {
 				}
 
 				set_storage("showingnum",this.showingnum);
+				push_Topic_showingnum(this.showingnum); // Send the buffer length back to byond so we have it in case of reconnect
 				this.attempt_archive();
 			},
 			current_categories: function(newSetting, oldSetting) {
@@ -787,6 +789,11 @@ function system_message(message) {
 //This is the other direction of communication, to push a Topic message back
 function push_Topic(topic_uri) {
 	window.location = '?_src_=chat&proc=' + topic_uri; //Yes that's really how it works.
+}
+
+// Send the showingnum back to byond
+function push_Topic_showingnum(topic_num) {
+	window.location = '?_src_=chat&showingnum=' + topic_num;
 }
 
 //Tells byond client to focus the main map window.

--- a/code/modules/vchat/vchat_client.dm
+++ b/code/modules/vchat/vchat_client.dm
@@ -15,11 +15,15 @@ GLOBAL_LIST_INIT(vchatFiles, list(
 	// First do logging in database
 	if(isclient(target))
 		var/client/C = target
-		vchat_add_message(C.ckey,message)
+		vchat_add_message(C.ckey, message)
 	else if(ismob(target))
 		var/mob/M = target
 		if(M.ckey)
-			vchat_add_message(M.ckey,message)
+			vchat_add_message(M.ckey, message)
+	else if(target == world)
+		for(var/client/C in GLOB.clients)
+			if(!QDESTROYING(C)) // Might be necessary?
+				vchat_add_message(C.ckey, message)
 
 	// Now lets either queue it for sending, or send it right now
 	if(Master.current_runlevel == RUNLEVEL_INIT || !SSchat?.subsystem_initialized)
@@ -37,6 +41,7 @@ GLOBAL_DATUM_INIT(iconCache, /savefile, new("data/iconCache.sav")) //Cache of ic
 	var/list/message_queue = list()
 	var/broken = FALSE
 	var/resources_sent = FALSE
+	var/message_buffer = 200 // Number of messages being actively shown to the user, used to play back that many messages on reconnect
 
 	var/last_topic_time = 0
 	var/too_many_topics = 0
@@ -128,11 +133,14 @@ GLOBAL_DATUM_INIT(iconCache, /savefile, new("data/iconCache.sav")) //Cache of ic
 	send_playerinfo()
 	load_database()
 
+	owner.verbs += /client/proc/vchat_export_log
+
 //Perform DB shenanigans
 /datum/chatOutput/proc/load_database()
 	set waitfor = FALSE
 	var/list/results = vchat_get_messages(owner.ckey) //If there's bad performance on reconnects, look no further
-	for(var/list/message in results)
+	for(var/i in max(1, results.len - message_buffer)) // Only send them the number of buffered messages, instead of the ENTIRE log
+		var/list/message = results[i]
 		var/count = 10
 		to_chat_immediate(owner, message["time"], message["message"])
 		count++
@@ -232,6 +240,9 @@ GLOBAL_DATUM_INIT(iconCache, /savefile, new("data/iconCache.sav")) //Cache of ic
 			loaded = FALSE
 		if("debug")
 			data = debugmsg(arglist(params))
+
+	if(href_list["showingnum"])
+		message_buffer = CLAMP(text2num(href_list["showingnum"]), 50, 2000)
 
 	if(data)
 		send_event(event = data)
@@ -354,3 +365,44 @@ var/to_chat_src
 
 		var/list/tojson = list("time" = time, "message" = message);
 		target << output(jsEncode(tojson), "htmloutput:putmessage")
+
+/client/proc/vchat_export_log()
+	set name = "Export chatlog"
+	set category = "OOC"
+
+	if(chatOutput.broken)
+		to_chat(src, "<span class='warning'>Error: VChat isn't processing your messages!</span>")
+		return
+
+	var/list/results = vchat_get_messages(ckey)
+	if(!LAZYLEN(results))
+		to_chat(src, "<span class='warning'>Error: No messages found! Please inform a dev if you do have messages!</span>")
+		return
+
+	var/o_file = "data/chatlog_tmp/[ckey]_chat_log"
+	if(fexists(o_file) && !fdel(o_file))
+		to_chat(src, "<span class='warning'>Error: Your chat log is already being prepared. Please wait until it's been downloaded before trying to export it again.</span>")
+		return
+
+	o_file = file(o_file)
+
+	// Write the CSS file to the log
+	o_file << "<html><head><style>"
+	o_file << file2text(file("code/modules/vchat/css/ss13styles.css"))
+	o_file << "</style></head><body>"
+
+	// Write the messages to the log
+	for(var/list/result in results)
+		o_file << "[result["message"]]<br>"
+
+	o_file << "</body></html>"
+
+	// Send the log to the client
+	src << ftp(o_file, "log_[time2text(world.timeofday, "YYYY_MM_DD_(hh_mm)")].html")
+
+	// clean up the file on our end
+	spawn(10 SECONDS)
+		if(!fdel(o_file))
+			spawn(1 MINUTE)
+				if(!fdel(o_file))
+					log_debug("Warning: [ckey]'s chatlog could not be deleted one minute after file transfer was initiated. It is located at 'data/chatlog_tmp/[ckey]_chat_log' and will need to be manually removed.")

--- a/html/changelogs/atermonera - vchat_exportlog.yml
+++ b/html/changelogs/atermonera - vchat_exportlog.yml
@@ -1,0 +1,5 @@
+author: Atermonera
+delete-after: True
+changes: 
+  - rscadd: "Added verb to export vchat logs, found in OOC tab when vchat has successfully loaded."
+  - tweak: "Vchat only sends you enough messages to fill your buffer on reconnect, instead of all of them."


### PR DESCRIPTION
Verb is located in OOC tab, should function exactly as the export chatlog button in vchat's settings page.
Verb is added when vchat successfully loads, removed when it's reloaded.
`to_world()` tweaked to save messages to all clients, so stuff like vote messages are saved correctly.
Changing the buffer size (how many messages are visible) sends a message to byond to update a variable in the chatOutput datum, so when you reconnect, it'll only dump as many messages as will fill up your buffer, rather than dumping all of them (30+s delay for people who've been active on long rounds). The export chatlog function in vchat's settings page is still implemented because I'm lazy, but it can no longer be expected to gather all messages, only those since you first connected. The verb is now required to get an entire round's connection.

The temp file that's generated to compile the css and messages presently tries to be deleted after 10 seconds, and 1 minute after that. The first delay was found to be necessary in some measure through testing because ftp is asynchronous, and while the client decides where and how to save the log, it'll move on to trying to delete the temp, only to discover it's locked as in-use by the OS (Or at least I presume that's what's happening).

- [ ] Switch to using callbacks to attempt to delete the file until it successfully deletes?

[tested](https://puu.sh/FMVRk/bfafca8fed.mp4) log export works. Buffer length tested and confirmed to also update correctly on the byond side.