### PR TITLE
Adds proc to replace default cells with high cap on machinery

### DIFF
--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -334,6 +334,14 @@ Class Procs:
 	CB.apply_default_parts(src)
 	RefreshParts()
 
+/obj/machinery/proc/default_use_hicell()
+	var/obj/item/weapon/cell/C = locate(C) in component_parts
+	if(C)
+		component_parts -= C
+		qdel(C)
+		C = new /obj/item/weapon/cell/high(src)
+		component_parts += C
+
 /obj/machinery/proc/default_part_replacement(var/mob/user, var/obj/item/weapon/storage/part_replacer/R)
 	if(!istype(R))
 		return 0

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -335,7 +335,7 @@ Class Procs:
 	RefreshParts()
 
 /obj/machinery/proc/default_use_hicell()
-	var/obj/item/weapon/cell/C = locate(C) in component_parts
+	var/obj/item/weapon/cell/C = locate(/obj/item/weapon/cell) in component_parts
 	if(C)
 		component_parts -= C
 		qdel(C)

--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -24,7 +24,8 @@
 
 /obj/machinery/recharge_station/Initialize()
 	. = ..()
-	default_apply_parts()	
+	default_apply_parts()
+	default_use_hicell()
 	update_icon()
 
 /obj/machinery/recharge_station/proc/has_cell_power()

--- a/code/modules/mining/drilling/drill.dm
+++ b/code/modules/mining/drilling/drill.dm
@@ -55,6 +55,7 @@
 /obj/machinery/mining/drill/Initialize()
 	. = ..()
 	default_apply_parts()
+	default_use_hicell()
 
 /obj/machinery/mining/drill/process()
 
@@ -166,7 +167,7 @@
 			to_chat(user, "The drill already has a cell installed.")
 		else
 			user.drop_item()
-			O.loc = src
+			O.forceMove(src)
 			cell = O
 			component_parts += O
 			to_chat(user, "You install \the [O].")
@@ -178,7 +179,7 @@
 
 	if (panel_open && cell && user.Adjacent(src))
 		to_chat(user, "You take out \the [cell].")
-		cell.loc = get_turf(user)
+		cell.forceMove(get_turf(user))
 		component_parts -= cell
 		cell = null
 		return


### PR DESCRIPTION
The usage of `component_parts` to contain the cell is something that I think should be expanded to include all other machinery, because the cell in such cases is a component part. Unfortunately, I don't have the energy to go through all 346 instances of `/obj/item/weapon/cell` again to figure out where else I should refactor that usage.
Fixes #7157 without requiring map changes