### PR TITLE
Add airless versions of some Eris floors, tweak layers

### DIFF
--- a/code/__defines/_planes+layers.dm
+++ b/code/__defines/_planes+layers.dm
@@ -64,10 +64,11 @@ What is the naming convention for planes or layers?
 	#define ABOVE_UTILITY		2.5 // Above stuff like pipes and wires
 #define TURF_PLANE				-45 // Turfs themselves, most flooring
 	#define WATER_FLOOR_LAYER	2.0 // The 'bottom' of water tiles.
+	#define BUILTIN_DECAL_LAYER 2.01 // For floors that automatically add decal overlays
+	#define MAPPER_DECAL_LAYER	2.02 // For intentionally placed floor decal overlays
 	#define UNDERWATER_LAYER	2.5 // Anything on this layer will render under the water layer.
 	#define WATER_LAYER			3.0 // Layer for water overlays.
 	#define ABOVE_TURF_LAYER	3.1	// Snow and wallmounted/floormounted equipment
-	#define TURF_DECAL_LAYER	3.2 // Mapped in floor decals, not automatic edges/corners
 #define DECAL_PLANE				-44 // Permanent decals
 #define DIRTY_PLANE				-43 // Nonpermanent decals
 #define BLOOD_PLANE				-42 // Blood is really dirty, but we can do special stuff if we separate it

--- a/code/game/turfs/flooring/flooring.dm
+++ b/code/game/turfs/flooring/flooring.dm
@@ -117,7 +117,7 @@ var/list/flooring_types
 /decl/flooring/proc/get_plating_type(var/turf/T)
 	return plating_type
 
-/decl/flooring/proc/get_flooring_overlay(var/cache_key, var/icon_base, var/icon_dir = 0, var/layer = ABOVE_TURF_LAYER)
+/decl/flooring/proc/get_flooring_overlay(var/cache_key, var/icon_base, var/icon_dir = 0, var/layer = BUILTIN_DECAL_LAYER)
 	if(!flooring_cache[cache_key])
 		var/image/I = image(icon = icon, icon_state = icon_base, dir = icon_dir)
 		I.layer = layer

--- a/code/game/turfs/flooring/flooring_decals.dm
+++ b/code/game/turfs/flooring/flooring_decals.dm
@@ -7,6 +7,7 @@ var/list/floor_decals = list()
 	name = "floor decal"
 	icon = 'icons/turf/flooring/decals.dmi'
 	plane = DECAL_PLANE
+	layer = MAPPER_DECAL_LAYER
 	var/supplied_dir
 
 /obj/effect/floor_decal/New(var/newloc, var/newdir, var/newcolour)
@@ -29,7 +30,7 @@ var/list/floor_decals = list()
 		var/image/I = floor_decals[cache_key]
 		if(!I)
 			I = image(icon = icon, icon_state = icon_state, dir = dir)
-			I.layer = TURF_DECAL_LAYER
+			I.layer = MAPPER_DECAL_LAYER
 			I.color = color
 			I.alpha = alpha
 			floor_decals[cache_key] = I

--- a/code/game/turfs/simulated/floor_types_eris.dm
+++ b/code/game/turfs/simulated/floor_types_eris.dm
@@ -913,17 +913,16 @@
 	movable_atom_whitelist = list(list(/obj/machinery/door/airlock, list(), 2))
 	*/
 
-/obj/item/stack/tile/floor/rplating
-	name = "reinforced plating"
-	singular_name = "dark floor tile"
-	icon_state = "tile_dark"
-	matter = list(MAT_STEEL = 1)
-
 /turf/simulated/floor/plating/eris
 	name = "reinforced plating"
 	icon = 'icons/turf/flooring/eris/plating.dmi'
 	icon_state = "plating"
 	initial_flooring = /decl/flooring/reinforced/plating
+
+/turf/simulated/floor/plating/eris/airless
+	oxygen = 0
+	nitrogen = 0
+	temperature = TCMB
 
 //==========UNDERPLATING==============\\
 /decl/flooring/reinforced/plating/under
@@ -932,7 +931,6 @@
 	descriptor = "support beams"
 	icon_base = "under"
 	flags = TURF_HAS_CORNERS | TURF_HAS_EDGES | TURF_CAN_BURN | TURF_CAN_BREAK
-	can_paint = 1
 	has_base_range = 0
 	is_plating = TRUE
 
@@ -958,8 +956,11 @@
 /turf/simulated/floor/plating/eris/under
 	name = "underplating"
 	icon_state = "under"
-	icon = 'icons/turf/flooring/eris/plating.dmi'
 	initial_flooring = /decl/flooring/reinforced/plating/under
+/turf/simulated/floor/plating/eris/under/airless
+	oxygen = 0
+	nitrogen = 0
+	temperature = TCMB
 
 //============HULL PLATING=========\\
 /decl/flooring/reinforced/plating/hull
@@ -1002,6 +1003,12 @@
 	icon = 'icons/turf/flooring/eris/hull.dmi'
 	icon_state = "hullcenter0"
 	initial_flooring = /decl/flooring/reinforced/plating/hull
+
+/turf/simulated/floor/hull/airless
+	oxygen = 0
+	nitrogen = 0
+	temperature = TCMB
+
 /*
 /turf/simulated/floor/hull/New()
 	if(icon_state != "hullcenter0")


### PR DESCRIPTION
Just makes floor decal layers super specific, so mapped in ones will show up above the Eris ones, since if a mapper places a decal by hand, it should likely be displayed.