### PR TITLE
Fix bug with in-round constructed teleporters

### DIFF
--- a/code/game/machinery/teleporter.dm
+++ b/code/game/machinery/teleporter.dm
@@ -18,10 +18,10 @@
 	..()
 	underlays.Cut()
 	underlays += image('icons/obj/stationobjs.dmi', icon_state = "telecomp-wires")
-	teleport_control = new(src)
 
 /obj/machinery/computer/teleporter/Initialize()
 	. = ..()
+	teleport_control = new(src)
 	var/obj/machinery/teleport/station/station = null
 	var/obj/machinery/teleport/hub/hub = null
 	


### PR DESCRIPTION
Existing order of operations won't work after SSatoms init (tries to modify teleport_control before New() has gotten far enough to instantiate it)