### PR TITLE
Dirt Fix

### DIFF
--- a/code/game/turfs/flooring/flooring.dm
+++ b/code/game/turfs/flooring/flooring.dm
@@ -205,14 +205,18 @@ var/list/flooring_types
 	desc = "Gritty and unpleasant, just like dirt."
 	icon = 'icons/turf/outdoors.dmi'
 	icon_base = "dirt-dark"
-	flags = TURF_HAS_EDGES | TURF_REMOVE_SHOVEL
+	flags = TURF_REMOVE_SHOVEL
 	build_type = null
 	footstep_sounds = list("human" = list(
 		'sound/effects/footstep/asteroid1.ogg',
 		'sound/effects/footstep/asteroid2.ogg',
 		'sound/effects/footstep/asteroid3.ogg',
 		'sound/effects/footstep/asteroid4.ogg',
-		'sound/effects/footstep/asteroid5.ogg'))
+		'sound/effects/footstep/asteroid5.ogg',
+		'sound/effects/footstep/MedDirt1.ogg',
+		'sound/effects/footstep/MedDirt2.ogg',
+		'sound/effects/footstep/MedDirt3.ogg',
+		'sound/effects/footstep/MedDirt4.ogg',))
 
 /decl/flooring/snow
 	name = "snow"

--- a/code/game/turfs/simulated/outdoors/dirt.dm
+++ b/code/game/turfs/simulated/outdoors/dirt.dm
@@ -4,4 +4,4 @@
 	icon_state = "dirt-dark"
 	edge_blending_priority = 2
 	turf_layers = list(/turf/simulated/floor/outdoors/rocks)
-	initial_flooring = /decl/flooring/asteroid
+	initial_flooring = /decl/flooring/dirt


### PR DESCRIPTION
Sets dirt to use the dirt declaration instead of asteroid, removes the TURF_HAS_EDGES flag (which causes error overlays on dirt at the edges), and adds dirt footstep sounds which were overlooked. So Sif can have dirt again instead of sand everywhere.

Before:
![image](https://user-images.githubusercontent.com/41974248/84741127-8fb48780-af7c-11ea-91f9-01a71d5e5f18.png)

After:
![image](https://user-images.githubusercontent.com/41974248/84741154-98a55900-af7c-11ea-88a8-1fead37982b7.png)
