### PR TITLE
Hoorah. More Typo Fixy

### DIFF
--- a/code/modules/events/solar_storm.dm
+++ b/code/modules/events/solar_storm.dm
@@ -18,7 +18,7 @@
 
 
 /datum/event/solar_storm/start()
-	command_announcement.Announce("The solar storm has reached the station. Please refain from EVA and remain inside the station until it has passed.", "Anomaly Alert")
+	command_announcement.Announce("The solar storm has reached the station. Please refrain from EVA and remain inside the station until it has passed.", "Anomaly Alert")
 	adjust_solar_output(5)
 
 

--- a/code/modules/gamemaster/event2/events/everyone/solar_storm.dm
+++ b/code/modules/gamemaster/event2/events/everyone/solar_storm.dm
@@ -22,7 +22,7 @@
 	adjust_solar_output(1.5)
 
 /datum/event2/event/solar_storm/start()
-	command_announcement.Announce("The solar storm has reached the station. Please refain from EVA and remain inside the station until it has passed.", "Anomaly Alert")
+	command_announcement.Announce("The solar storm has reached the station. Please refrain from EVA and remain inside the station until it has passed.", "Anomaly Alert")
 	adjust_solar_output(5)
 
 /datum/event2/event/solar_storm/event_tick()


### PR DESCRIPTION
Fancy that a downstream noticed this and got me to check all the way up here. So fix here, too for all the rest down the line.

Changelog Notes:

- Fixes typo in Solar Storm announcement with refrain being spelled "refain" instead.