### PR TITLE
Offload Defibrillatability from NO_SCAN

### DIFF
--- a/code/__defines/species_languages.dm
+++ b/code/__defines/species_languages.dm
@@ -1,15 +1,16 @@
 // Species flags.
-#define NO_MINOR_CUT      0x1    // Can step on broken glass with no ill-effects. Either thick skin (diona), cut resistant (slimes) or incorporeal (shadows)
-#define IS_PLANT          0x2    // Is a treeperson.
-#define NO_SCAN           0x4    // Cannot be scanned in a DNA machine/genome-stolen.
-#define NO_PAIN           0x8    // Cannot suffer halloss/recieves deceptive health indicator.
-#define NO_SLIP           0x10   // Cannot fall over.
-#define NO_POISON         0x20   // Cannot not suffer toxloss.
-#define NO_EMBED		  0x40	 // Can step on broken glass with no ill-effects and cannot have shrapnel embedded in it.
-#define NO_HALLUCINATION  0x80	 // Don't hallucinate, ever
-#define NO_BLOOD		  0x100  // Never bleed, never show blood amount
-#define UNDEAD			  0x200	 // Various things that living things don't do, mostly for skeletons
-#define NO_INFECT		  0x400  // Don't allow infections in limbs or organs, similar to IS_PLANT, without other strings.
+#define NO_MINOR_CUT      	0x1	// Can step on broken glass with no ill-effects. Either thick skin (diona), cut resistant (slimes) or incorporeal (shadows)
+#define IS_PLANT          	0x2	// Is a treeperson.
+#define NO_SCAN           	0x4	// Cannot be scanned in a DNA machine/genome-stolen.
+#define NO_PAIN           	0x8	// Cannot suffer halloss/recieves deceptive health indicator.
+#define NO_SLIP           	0x10	// Cannot fall over.
+#define NO_POISON         	0x20	// Cannot not suffer toxloss.
+#define NO_EMBED		0x40	// Can step on broken glass with no ill-effects and cannot have shrapnel embedded in it.
+#define NO_HALLUCINATION  	0x80	// Don't hallucinate, ever
+#define NO_BLOOD		0x100	// Never bleed, never show blood amount
+#define UNDEAD			0x200	// Various things that living things don't do, mostly for skeletons
+#define NO_INFECT		0x400	// Don't allow infections in limbs or organs, similar to IS_PLANT, without other strings.
+#define NO_DEFIB		0x800	// Don't allow them to be defibbed
 // unused: 0x8000 - higher than this will overflow
 
 // Species EMP vuln for carbons

--- a/code/game/objects/items/devices/defib.dm
+++ b/code/game/objects/items/devices/defib.dm
@@ -265,8 +265,8 @@
 
 //Checks for various conditions to see if the mob is revivable
 /obj/item/weapon/shockpaddles/proc/can_defib(mob/living/carbon/human/H) //This is checked before doing the defib operation
-	if((H.species.flags & NO_SCAN))
-		return "buzzes, \"Unrecogized physiology. Operation aborted.\""
+	if((H.species.flags & NO_DEFIB))
+		return "buzzes, \"Incompatible physiology. Operation aborted.\""
 	else if(H.isSynthetic() && !use_on_synthetic)
 		return "buzzes, \"Synthetic Body. Operation aborted.\""
 	else if(!H.isSynthetic() && use_on_synthetic)

--- a/code/modules/client/preference_setup/general/03_body.dm
+++ b/code/modules/client/preference_setup/general/03_body.dm
@@ -874,6 +874,8 @@ var/global/list/valid_bloodtypes = list("A+", "A-", "B+", "B-", "AB+", "AB-", "O
 		dat += "</br><b>Does not have a respiratory system.</b>"
 	if(current_species.flags & NO_SCAN)
 		dat += "</br><b>Does not have DNA.</b>"
+	if(current_species.flags & NO_DEFIB)
+		dat += "</br><b>Cannot be defibrillated.</b>"
 	if(current_species.flags & NO_PAIN)
 		dat += "</br><b>Does not feel pain.</b>"
 	if(current_species.flags & NO_SLIP)

--- a/code/modules/mob/living/carbon/human/species/outsider/event.dm
+++ b/code/modules/mob/living/carbon/human/species/outsider/event.dm
@@ -199,6 +199,9 @@ Variables you may want to make use of are:
 
 /datum/species/event1/proc/toggle_cloning()
 	flags ^= NO_SCAN
+	
+/datum/species/event1/proc/toggle_defibbing()
+	flags ^= NO_DEFIB
 
 /datum/species/event1/proc/toggle_pain()
 	flags ^= NO_PAIN

--- a/code/modules/mob/living/carbon/human/species/outsider/shadow.dm
+++ b/code/modules/mob/living/carbon/human/species/outsider/shadow.dm
@@ -20,7 +20,7 @@
 	remains_type = /obj/effect/decal/cleanable/ash
 	death_message = "dissolves into ash..."
 
-	flags = NO_SCAN | NO_SLIP | NO_POISON | NO_MINOR_CUT
+	flags = NO_SCAN | NO_SLIP | NO_POISON | NO_MINOR_CUT | NO_DEFIB
 	spawn_flags = SPECIES_IS_RESTRICTED
 
 	genders = list(NEUTER)

--- a/code/modules/mob/living/carbon/human/species/outsider/skeleton.dm
+++ b/code/modules/mob/living/carbon/human/species/outsider/skeleton.dm
@@ -11,7 +11,7 @@
 	max_age = 110
 	health_hud_intensity = 1.5
 
-	flags = NO_SCAN | NO_PAIN | NO_SLIP | NO_POISON | NO_MINOR_CUT | NO_BLOOD | UNDEAD
+	flags = NO_SCAN | NO_PAIN | NO_SLIP | NO_POISON | NO_MINOR_CUT | NO_BLOOD | UNDEAD | NO_DEFIB
 	spawn_flags = SPECIES_IS_RESTRICTED
 	appearance_flags = null
 

--- a/code/modules/mob/living/carbon/human/species/outsider/vox.dm
+++ b/code/modules/mob/living/carbon/human/species/outsider/vox.dm
@@ -46,7 +46,7 @@
 	poison_type = "oxygen"
 	siemens_coefficient = 0.2
 
-	flags = NO_SCAN
+	flags = NO_SCAN | NO_DEFIB
 	spawn_flags = SPECIES_IS_WHITELISTED
 	appearance_flags = HAS_EYE_COLOR | HAS_HAIR_COLOR
 

--- a/code/modules/mob/living/carbon/human/species/station/golem.dm
+++ b/code/modules/mob/living/carbon/human/species/station/golem.dm
@@ -7,7 +7,7 @@
 
 	language = "Sol Common" //todo?
 	unarmed_types = list(/datum/unarmed_attack/stomp, /datum/unarmed_attack/kick, /datum/unarmed_attack/punch)
-	flags = NO_PAIN | NO_SCAN | NO_POISON | NO_MINOR_CUT
+	flags = NO_PAIN | NO_SCAN | NO_POISON | NO_MINOR_CUT | NO_DEFIB
 	spawn_flags = SPECIES_IS_RESTRICTED
 	siemens_coefficient = 0
 

--- a/code/modules/mob/living/carbon/human/species/station/prometheans.dm
+++ b/code/modules/mob/living/carbon/human/species/station/prometheans.dm
@@ -25,7 +25,7 @@ var/datum/species/shapeshifter/promethean/prometheans
 	bump_flag =        SLIME
 	swap_flags =       MONKEY|SLIME|SIMPLE_ANIMAL
 	push_flags =       MONKEY|SLIME|SIMPLE_ANIMAL
-	flags =            NO_SCAN | NO_SLIP | NO_MINOR_CUT | NO_HALLUCINATION | NO_INFECT
+	flags =            NO_SCAN | NO_SLIP | NO_MINOR_CUT | NO_HALLUCINATION | NO_INFECT | NO_DEFIB
 	appearance_flags = HAS_SKIN_COLOR | HAS_EYE_COLOR | HAS_HAIR_COLOR | RADIATION_GLOWS | HAS_UNDERWEAR
 	spawn_flags		 = SPECIES_CAN_JOIN | SPECIES_IS_WHITELISTED
 	health_hud_intensity = 2

--- a/code/modules/mob/living/carbon/human/species/station/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station.dm
@@ -521,7 +521,7 @@
 
 	body_temperature = T0C + 15		//make the plant people have a bit lower body temperature, why not
 
-	flags = NO_SCAN | IS_PLANT | NO_PAIN | NO_SLIP | NO_MINOR_CUT
+	flags = NO_SCAN | IS_PLANT | NO_PAIN | NO_SLIP | NO_MINOR_CUT | NO_DEFIB
 	spawn_flags = SPECIES_CAN_JOIN | SPECIES_IS_WHITELISTED
 
 	blood_color = "#004400"

--- a/code/modules/mob/living/carbon/human/species/xenomorphs/alien_species.dm
+++ b/code/modules/mob/living/carbon/human/species/xenomorphs/alien_species.dm
@@ -24,7 +24,7 @@
 	cold_level_2 = -1
 	cold_level_3 = -1
 
-	flags =  NO_SCAN | NO_PAIN | NO_SLIP | NO_POISON | NO_MINOR_CUT | NO_INFECT
+	flags =  NO_SCAN | NO_PAIN | NO_SLIP | NO_POISON | NO_MINOR_CUT | NO_INFECT | NO_DEFIB
 	spawn_flags = SPECIES_IS_RESTRICTED
 
 	reagent_tag = IS_XENOS


### PR DESCRIPTION
Simple extension to species flags; adds NO_DEFIB and offloads defibrillatability (is that a word? it's a word now) from the NO_SCAN flag. Also fixes a minor typo in defibbing anything with NO_SCAN, adds a toggle for event species, and an entry in species preview for character creation.

Currently everything that has NO_SCAN also now has NO_DEFIB. I leave implementation at the discretion of staff.