### PR TITLE
Fix sector initialization overflow crash.

### DIFF
--- a/code/controllers/subsystems/skybox.dm
+++ b/code/controllers/subsystems/skybox.dm
@@ -71,8 +71,6 @@ SUBSYSTEM_DEF(skybox)
 	return skybox_cache["[z]"]
 
 /datum/controller/subsystem/skybox/proc/generate_skybox(z)
-	to_world("generating skybox for z[z]")
-
 	var/datum/skybox_settings/settings = global.using_map.get_skybox_datum(z)
 
 	var/image/res = image(settings.icon)
@@ -91,12 +89,10 @@ SUBSYSTEM_DEF(skybox)
 	if(global.using_map.use_overmap && settings.use_overmap_details)
 		var/obj/effect/overmap/visitable/O = get_overmap_sector(z)
 		if(istype(O))
-			to_world("found sector [O] \ref[O] for z[z]")
 			var/image/overmap = image(settings.icon)
 			overmap.overlays += O.generate_skybox()
 			for(var/obj/effect/overmap/visitable/other in O.loc)
 				if(other != O)
-					to_world("found secondary sector [other] \ref[other]")
 					overmap.overlays += other.get_skybox_representation()
 			overmap.appearance_flags = RESET_COLOR
 			res.overlays += overmap
@@ -121,7 +117,7 @@ SUBSYSTEM_DEF(skybox)
 	var/icon_state = "dyable"
 	var/color
 	var/random_color = FALSE
-
+	
 	var/use_stars = TRUE
 	var/star_icon = 'icons/skybox/skybox.dmi'
 	var/star_state = "stars"

--- a/code/modules/multiz/basic.dm
+++ b/code/modules/multiz/basic.dm
@@ -37,8 +37,6 @@ var/list/z_levels = list()// Each bit re... haha just kidding this is a list of 
 	return HasBelow(turf.z) ? get_step(turf, DOWN) : null
 
 /proc/GetConnectedZlevels(z)
-	if(z in using_map.map_levels)
-		return using_map.get_map_levels(z, FALSE) // Connected z levels aren't necessarily attached by multi-z, using_map shound know the details
 	. = list(z)
 	for(var/level = z, HasBelow(level), level--)
 		. |= level-1

--- a/code/modules/overmap/sectors.dm
+++ b/code/modules/overmap/sectors.dm
@@ -5,7 +5,7 @@
 	name = "map object"
 	scannable = TRUE
 
-	var/list/map_z = null
+	var/list/map_z = list()
 	var/list/extra_z_levels //if you need to manually insist that these z-levels are part of this sector, for things like edge-of-map step trigger transitions rather than multi-z complexes
 
 	var/list/initial_generic_waypoints //store landmark_tag of landmarks that should be added to the actual lists below on init.
@@ -30,8 +30,7 @@
 	if(. == INITIALIZE_HINT_QDEL)
 		return
 
-	if(!map_z)			// If map_z is already defined, we don't need to find where we are
-		find_z_levels() // This populates map_z and assigns z levels to the ship.
+	find_z_levels() // This populates map_z and assigns z levels to the ship.
 	register_z_levels() // This makes external calls to update global z level information.
 
 	if(!global.using_map.overmap_z)
@@ -59,7 +58,8 @@
 			. += A
 
 /obj/effect/overmap/visitable/proc/find_z_levels()
-	map_z = GetConnectedZlevels(z)
+	if(!LAZYLEN(map_z)) // If map_z is already populated use it as-is, otherwise start with connected z-levels.
+		map_z = GetConnectedZlevels(z)
 	if(LAZYLEN(extra_z_levels))
 		map_z |= extra_z_levels
 


### PR DESCRIPTION
Fixes critical issue of objects not being initialized if using any map other than southern_cross.

- When using the overmap,  `open_map.get_map_levels()` relies on sectors already being initialized.  Calling this proc during sector initialization causes a circular initialization dependency where the station sector needs to have been initialized and know all its z-levels in order for the station sector to be initialized and know its z-levels.   _(In the case of southern cross this is dodged by hard-coding the sector's z-levels, but all others will fail)_
- `GetConnnectedZLevels()` strictly pertains to true physical z-level vertical connectivity as used by ZAS, pipes, wires, open space, and/or movement.

**The knock on effects cause catastrophic failure of server initialization, crashing out SSAtoms initialization and making the server unplayable.**

Fix:
- Replace changes from 8c7371c5d4b900308cecdba5335989e8c9f191fe
    - Also removed debugging prints in skybox generation while I was here.
    - Reverted change to GetConnnectedZLevels to avoid the chicken-or-egg initialization issue of find_z_levels() requiring knowledge of a sector's z-levels during the attempt to determine a sector's z-levels.
    - Make find_z_levels() always called again so that lazy open space initialization works on landable ships again.
- Instead, allow static configuration of sector map_z to override the default behavior of calling GetConnectedZLevels()