### PR TITLE
Fix timing error that allowed processing to reference a nulled list.

### DIFF
--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -441,15 +441,15 @@
 	setAngle(Get_Angle(source, target))
 
 /obj/item/projectile/Destroy()
+	if(hitscan)
+		finalize_hitscan_and_generate_tracers()
+	STOP_PROCESSING(SSprojectiles, src)
 
 	if(impacted_mobs)
 		if(LAZYLEN(impacted_mobs))
 			impacted_mobs.Cut()
 		impacted_mobs = null
 
-	if(hitscan)
-		finalize_hitscan_and_generate_tracers()
-	STOP_PROCESSING(SSprojectiles, src)
 	qdel(trajectory)
 	return ..()
 


### PR DESCRIPTION
Will fix projectiles having a 50/50 chance of runtiming and sitting on the turf of impact due to timing errors.