### PR TITLE
Add Mechs damage & penetration thresholds along with other improvements.

### DIFF
--- a/code/game/mecha/combat/durand.dm
+++ b/code/game/mecha/combat/durand.dm
@@ -16,6 +16,9 @@
 	var/defence_deflect = 35
 	wreckage = /obj/effect/decal/mecha_wreckage/durand
 
+	damage_minimum = 15			//Big stompy
+	minimum_penetration = 25
+
 	max_hull_equip = 2
 	max_weapon_equip = 1
 	max_utility_equip = 2

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -907,8 +907,8 @@
 		src.log_append_to_last("Armor saved.")
 
 	else if(W.force < damage_minimum)	//Is your attack too PATHETIC to do anything. 3 damage to a person shouldn't do anything to a mech.
-		src.occupant_message("<span class='notice'>\The [A] bounces off the armor.</span>")
-		src.visible_message("\The [A] bounces off \the [src] armor")
+		src.occupant_message("<span class='notice'>\The [W] bounces off the armor.</span>")
+		src.visible_message("\The [W] bounces off \the [src] armor")
 		return
 
 	else if(W.armor_penetration < minimum_penetration)	//If you don't have enough pen, you won't do full damage

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -16,21 +16,21 @@
 	name = "Mecha"
 	desc = "Exosuit"
 	icon = 'icons/mecha/mecha.dmi'
-	density = 1 //Dense. To raise the heat.
-	opacity = 1 ///opaque. Menacing.
-	anchored = 1 //no pulling around.
-	unacidable = 1 //and no deleting hoomans inside
-	layer = MOB_LAYER //icon draw layer
-	infra_luminosity = 15 //byond implementation is bugged.
-	var/initial_icon = null //Mech type for resetting icon. Only used for reskinning kits (see custom items)
+	density = 1							//Dense. To raise the heat.
+	opacity = 1							///opaque. Menacing.
+	anchored = 1						//no pulling around.
+	unacidable = 1						//and no deleting hoomans inside
+	layer = MOB_LAYER					//icon draw layer
+	infra_luminosity = 15				//byond implementation is bugged.
+	var/initial_icon = null				//Mech type for resetting icon. Only used for reskinning kits (see custom items)
 	var/can_move = 1
 	var/mob/living/carbon/occupant = null
-	var/step_in = 10 //make a step in step_in/10 sec.
-	var/dir_in = 2//What direction will the mech face when entered/powered on? Defaults to South.
+	var/step_in = 10					//make a step in step_in/10 sec.
+	var/dir_in = 2						//What direction will the mech face when entered/powered on? Defaults to South.
 	var/step_energy_drain = 10
-	var/health = 300 //health is health
-	var/maxhealth = 300 //maxhealth is maxhealth.
-	var/deflect_chance = 10 //chance to deflect the incoming projectiles, hits, or lesser the effect of ex_act.
+	var/health = 300 					//health is health
+	var/maxhealth = 300 				//maxhealth is maxhealth.
+	var/deflect_chance = 10 			//chance to deflect the incoming projectiles, hits, or lesser the effect of ex_act.
 	//the values in this list show how much damage will pass through, not how much will be absorbed.
 	var/list/damage_absorption = list("brute"=0.8,"fire"=1.2,"bullet"=0.9,"laser"=1,"energy"=1,"bomb"=1)
 	var/obj/item/weapon/cell/cell
@@ -39,15 +39,15 @@
 	var/last_message = 0
 	var/add_req_access = 1
 	var/maint_access = 1
-	var/dna	//dna-locking the mech
-	var/list/proc_res = list() //stores proc owners, like proc_res["functionname"] = owner reference
+	var/dna								//dna-locking the mech
+	var/list/proc_res = list() 			//stores proc owners, like proc_res["functionname"] = owner reference
 	var/datum/effect/effect/system/spark_spread/spark_system = new
 	var/lights = 0
 	var/lights_power = 6
 	var/force = 0
 
 	var/mech_faction = null
-	var/firstactivation = 0 //It's simple. If it's 0, no one entered it yet. Otherwise someone entered it at least once.
+	var/firstactivation = 0 			//It's simple. If it's 0, no one entered it yet. Otherwise someone entered it at least once.
 
 	var/stomp_sound = 'sound/mecha/mechstep.ogg'
 	var/swivel_sound = 'sound/mecha/mechturn.ogg'
@@ -62,16 +62,16 @@
 	var/obj/item/device/radio/radio = null
 
 	var/max_temperature = 25000
-	var/internal_damage_threshold = 50 //health percentage below which internal damage is possible
-	var/internal_damage = 0 //contains bitflags
+	var/internal_damage_threshold = 50	//health percentage below which internal damage is possible
+	var/internal_damage = 0 			//contains bitflags
 
 	var/list/operation_req_access = list()//required access level for mecha operation
 	var/list/internals_req_access = list(access_engine,access_robotics)//required access level to open cell compartment
 
-	var/datum/global_iterator/pr_int_temp_processor //normalizes internal air mixture temperature
-	var/datum/global_iterator/pr_inertial_movement //controls intertial movement in spesss
-	var/datum/global_iterator/pr_give_air //moves air from tank to cabin
-	var/datum/global_iterator/pr_internal_damage //processes internal damage
+	var/datum/global_iterator/pr_int_temp_processor 	//normalizes internal air mixture temperature
+	var/datum/global_iterator/pr_inertial_movement 		//controls intertial movement in spesss
+	var/datum/global_iterator/pr_give_air 				//moves air from tank to cabin
+	var/datum/global_iterator/pr_internal_damage		//processes internal damage
 
 
 	var/wreckage

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -32,7 +32,17 @@
 	var/maxhealth = 300 				//maxhealth is maxhealth.
 	var/deflect_chance = 10 			//chance to deflect the incoming projectiles, hits, or lesser the effect of ex_act.
 	//the values in this list show how much damage will pass through, not how much will be absorbed.
-	var/list/damage_absorption = list("brute"=0.8,"fire"=1.2,"bullet"=0.9,"laser"=1,"energy"=1,"bomb"=1)
+	var/list/damage_absorption = list(
+									"brute"=0.8,
+									"fire"=1.2,
+									"bullet"=0.9,
+									"laser"=1,
+									"energy"=1,
+									"bomb"=1,
+									"bio"=1,
+									"rad"=1
+									)
+
 	var/obj/item/weapon/cell/cell
 	var/state = 0
 	var/list/log = new

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -43,8 +43,9 @@
 									"rad"=1
 									)
 
-	var/damage_minimum = 10			//Incoming damage lower than this won't actually deal damage. Scrapes shouldn't be a real thing.
-	var/minimum_penetration = 20	//Incoming damage won't be fully applied if you don't have at least 20. Almost all AP clears this.
+	var/damage_minimum = 10				//Incoming damage lower than this won't actually deal damage. Scrapes shouldn't be a real thing.
+	var/minimum_penetration = 20		//Incoming damage won't be fully applied if you don't have at least 20. Almost all AP clears this.
+	var/fail_penetration_value = 0.66	//By how much failing to penetrate reduces your shit. 66% by default.
 
 	var/obj/item/weapon/cell/cell
 	var/state = 0
@@ -749,7 +750,7 @@
 			else if(O.armor_penetration < minimum_penetration)	//If you don't have enough pen, you won't do full damage
 				src.occupant_message("<span class='notice'>\The [A] struggles to bypass \the [src] armor.</span>")
 				src.visible_message("\The [A] struggles to bypass \the [src] armor")
-				pass_damage_reduc_mod = 0.66	//This will apply to reduce damage to 2/3 or 66%
+				pass_damage_reduc_mod = fail_penetration_value	//This will apply to reduce damage to 2/3 or 66% by default
 			else
 				src.occupant_message("<span class='notice'>\The [A] manages to pierces \the [src] armor.</span>")
 				src.visible_message("\The [A] manages to pierces \the [src] armor")
@@ -805,7 +806,7 @@
 		else if(Proj.armor_penetration < minimum_penetration)	//If you don't have enough pen, you won't do full damage
 			src.occupant_message("<span class='notice'>\The [Proj] struggles to pierce \the [src] armor.</span>")
 			src.visible_message("\The [Proj] struggles to pierce \the [src] armor")
-			pass_damage_reduc_mod = 0.66	//This will apply to reduce damage to 2/3 or 66%
+			pass_damage_reduc_mod = fail_penetration_value	//This will apply to reduce damage to 2/3 or 66% by default
 		else
 			src.occupant_message("<span class='notice'>\The [Proj] manages to pierce \the [src] armor.</span>")
 			src.visible_message("\The [Proj] manages to pierce \the [src] armor")
@@ -913,7 +914,7 @@
 	else if(W.armor_penetration < minimum_penetration)	//If you don't have enough pen, you won't do full damage
 		src.occupant_message("<span class='notice'>\The [W] struggles to bypass \the [src] armor.</span>")
 		src.visible_message("\The [W] struggles to bypass \the [src] armor")
-		pass_damage_reduc_mod = 0.66	//This will apply to reduce damage to 2/3 or 66%
+		pass_damage_reduc_mod = fail_penetration_value	//This will apply to reduce damage to 2/3 or 66% by default
 
 	else
 		pass_damage_reduc_mod = 1		//Just making sure.
@@ -2088,7 +2089,7 @@
 	src.log_message("Attacked. Attacker - [user].",1)
 	user.do_attack_animation(src)
 
-	//var/pass_damage
+	//var/pass_damage	//See the comment in the larger greyed out block below.
 	//var/pass_damage_reduc_mod
 	if(prob(src.deflect_chance))//Deflected
 		src.log_append_to_last("Armor saved.")
@@ -2104,11 +2105,11 @@
 		playsound(src, 'sound/effects/Glasshit.ogg', 50, 1)
 		return
 
-/*
+/*//Commented out for not playing well with penetration questions.
 	else if(user.mob.attack_armor_pen < minimum_penetration)//Not enough armor penetration
 		src.occupant_message("<span class='notice'>\The [user] struggles to pierce \the [src] armor.</span>")
 		src.visible_message("\The [user] struggles to pierce \the [src] armor")
-		pass_damage_reduc_mod = 0.66	//This will apply to reduce damage to 2/3 or 66%
+		pass_damage_reduc_mod = fail_penetration_value	//This will apply to reduce damage to 2/3 or 66% by default.
 */
 
 	else

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -743,8 +743,8 @@
 			var/pass_damage = O.throwforce
 			var/pass_damage_reduc_mod
 			if(pass_damage <= damage_minimum)//Too little to go through.
-			src.occupant_message("<span class='notice'>\The [A] bounces off the armor.</span>")
-			src.visible_message("\The [A] bounces off \the [src] armor")
+				src.occupant_message("<span class='notice'>\The [A] bounces off the armor.</span>")
+				src.visible_message("\The [A] bounces off \the [src] armor")
 				return
 
 			else if(O.armor_penetration < minimum_penetration)	//If you don't have enough pen, you won't do full damage

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -743,8 +743,8 @@
 			var/pass_damage = O.throwforce
 			var/pass_damage_reduc_mod
 			if(pass_damage <= damage_minimum)//Too little to go through.
-				src.occupant_message("<span class='notice'>\The [A] doesn't dents \the [src] paint.</span>")
-				src.visible_message("\The [A] doesn't dents \the [src] armor")
+			src.occupant_message("<span class='notice'>\The [A] bounces off the armor.</span>")
+			src.visible_message("\The [A] bounces off \the [src] armor")
 				return
 
 			else if(O.armor_penetration < minimum_penetration)	//If you don't have enough pen, you won't do full damage
@@ -799,8 +799,8 @@
 			pass_damage = ME.handle_projectile_contact(Proj, pass_damage)
 
 		if(pass_damage < damage_minimum)//too pathetic to really damage you.
-			src.occupant_message("<span class='notice'>\The [Proj] doesn't dents \the [src] paint.</span>")
-			src.visible_message("\The [Proj] doesn't dents \the [src] armor")
+			src.occupant_message("<span class='notice'>The armor deflects incoming projectile.</span>")
+			src.visible_message("The [src.name] armor deflects\the [Proj]")
 			return
 
 		else if(Proj.armor_penetration < minimum_penetration)	//If you don't have enough pen, you won't do full damage
@@ -907,8 +907,8 @@
 		src.log_append_to_last("Armor saved.")
 
 	else if(W.force < damage_minimum)	//Is your attack too PATHETIC to do anything. 3 damage to a person shouldn't do anything to a mech.
-		src.occupant_message("<span class='notice'>\The [W] doesn't dents \the [src] paint.</span>")
-		src.visible_message("\The [W] doesn't dents \the [src] armor")
+		src.occupant_message("<span class='notice'>\The [A] bounces off the armor.</span>")
+		src.visible_message("\The [A] bounces off \the [src] armor")
 		return
 
 	else if(W.armor_penetration < minimum_penetration)	//If you don't have enough pen, you won't do full damage

--- a/code/game/mecha/working/ripley.dm
+++ b/code/game/mecha/working/ripley.dm
@@ -10,6 +10,8 @@
 	wreckage = /obj/effect/decal/mecha_wreckage/ripley
 	cargo_capacity = 10
 
+	minimum_penetration = 10
+
 /obj/mecha/working/ripley/Destroy()
 	for(var/atom/movable/A in src.cargo)
 		A.loc = loc


### PR DESCRIPTION
If you do not enough damage, it will simply bounce off consistently. Something that does 1 damage to a person would be so ridiculously nothing to a metal, possibly combat mech that it shouldn't achieve anything.
- If you throw, shoot or wack at a mech, unless the damage is decent, it will pretty much do nothing but cosmetic damage. Aka 0.

Additionally, armor reduces the effectiveness of attacks without a minimum of armor piercing.
- A flat hit with an hammer might be damaging to a squishy human, but it would probably not be all that effective against armored outerskin. The damage will be reduced to 2/3 or x0.66 to remark on this.

The values of the thresholds are modular for each mech and can be integrated in certain processes, like the Durand mode for example. The actual reduction value for failing to penetrate is also modular. 

-----------------------------------------------------
Other, lesser changes which are bundled in because Sourcetree can be a pain:
- Made the list for armor vertical instead of horizontal for easier read. Added bio & radioactive checks.
- Indented some comments to be easier to read.
- Added a couple comments of my own.