### PR TITLE
Fix Adv. Suit Belt

### DIFF
--- a/code/modules/clothing/spacesuits/rig/suits/robotics.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/robotics.dm
@@ -1,7 +1,7 @@
-//Mining suit
+//Advanced Exploration 	Suit
 /obj/item/weapon/rig/robotics
 	name = "advanced suit control belt"
-	suit_type = "advanced suit"
+	suit_type = "advanced"
 	desc = "A lightweight suit combining the utility of a RIG with the wearability of a voidsuit."
 	icon_state = "void_explorer2"
 	slot_flags = SLOT_BELT
@@ -14,8 +14,8 @@
 	rigsuit_max_pressure = 8 * ONE_ATMOSPHERE
 	rigsuit_min_pressure = 0
 
-	chest_type = /obj/item/clothing/suit/space/rig
-	helm_type =  /obj/item/clothing/head/helmet/space/rig
+	chest_type = /obj/item/clothing/suit/space/rig/advsuit
+	helm_type =  /obj/item/clothing/head/helmet/space/rig/advsuit
 	boot_type =  null
 	glove_type = null
 	cell_type =  null
@@ -27,3 +27,12 @@
 
 	req_access = list()
 	req_one_access = list()
+
+/obj/item/clothing/head/helmet/space/rig/advsuit
+	name = "suit helmet"
+
+/obj/item/clothing/suit/space/rig/advsuit
+	name = "voidsuit"
+	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS|HANDS|FEET
+	heat_protection =	 UPPER_TORSO|LOWER_TORSO|LEGS|ARMS|HANDS|FEET
+	cold_protection =	 UPPER_TORSO|LOWER_TORSO|LEGS|ARMS|HANDS|FEET


### PR DESCRIPTION
This thing doesn't protect you from phoron contamination when deployed, despite being a full suit. This PR fixes that by properly subtyping the suit component so that `HANDS|FEET` can be added to the various protection groups without messing with any other suits.