### PR TITLE
Add a random mech spawner (Not mapped in yet)

### DIFF
--- a/code/game/mecha/combat/durand.dm
+++ b/code/game/mecha/combat/durand.dm
@@ -6,7 +6,7 @@
 	step_in = 4
 	dir_in = 1 //Facing North.
 	health = 400
-	maxhealth = 400
+	maxhealth = 400			//Don't forget to update the /old variant if  you change this number.
 	deflect_chance = 20
 	damage_absorption = list("brute"=0.5,"fire"=1.1,"bullet"=0.65,"laser"=0.85,"energy"=0.9,"bomb"=0.8)
 	max_temperature = 30000
@@ -62,3 +62,13 @@
 		src.defence_mode()
 	return
 */
+
+//Meant for random spawns.
+/obj/mecha/combat/durand/old
+	desc = "An aging combat exosuit utilized by many corporations. Originally developed to combat hostile alien lifeforms. This one is particularly worn looking and likely isn't as sturdy."
+
+/obj/mecha/combat/durand/old/New()
+	..()
+	health = 25
+	maxhealth = 350	//Just slightly worse.
+	cell.charge = rand(0, (cell.charge/2))

--- a/code/game/mecha/combat/gygax.dm
+++ b/code/game/mecha/combat/gygax.dm
@@ -135,5 +135,5 @@
 /obj/mecha/combat/gygax/old/New()
 	..()
 	health = 25
-	maxhealth = 300	//Just slightly worse.
+	maxhealth = 250	//Just slightly worse.
 	cell.charge = rand(0, (cell.charge/2))

--- a/code/game/mecha/combat/gygax.dm
+++ b/code/game/mecha/combat/gygax.dm
@@ -6,7 +6,7 @@
 	step_in = 3
 	dir_in = 1 //Facing North.
 	health = 300
-	maxhealth = 300
+	maxhealth = 300			//Don't forget to update the /old variant if  you change this number.
 	deflect_chance = 15
 	damage_absorption = list("brute"=0.75,"fire"=1,"bullet"=0.8,"laser"=0.7,"energy"=0.85,"bomb"=1)
 	max_temperature = 25000
@@ -127,3 +127,13 @@
 			H.recalculate_vis()
 	..()
 	return
+
+//Meant for random spawns.
+/obj/mecha/combat/gygax/old
+	desc = "A lightweight, security exosuit. Popular among private and corporate security. This one is particularly worn looking and likely isn't as sturdy."
+
+/obj/mecha/combat/gygax/old/New()
+	..()
+	health = 25
+	maxhealth = 300	//Just slightly worse.
+	cell.charge = rand(0, (cell.charge/2))

--- a/code/game/mecha/combat/marauder.dm
+++ b/code/game/mecha/combat/marauder.dm
@@ -155,3 +155,12 @@
 	health = 25
 	maxhealth = 400	//Just slightly worse.
 	cell.charge = rand(0, (cell.charge/2))
+
+/obj/mecha/combat/marauder/old/Initialize()
+	..()
+	var/obj/item/mecha_parts/mecha_equipment/ME
+	if(equipment.len)
+		for(ME in equipment)
+			ME.detach()
+			qdel(ME)
+			return

--- a/code/game/mecha/combat/marauder.dm
+++ b/code/game/mecha/combat/marauder.dm
@@ -6,7 +6,7 @@
 	initial_icon = "marauder"
 	step_in = 5
 	health = 500
-	maxhealth = 500
+	maxhealth = 500		//Don't forget to update the /old variant if  you change this number.
 	deflect_chance = 25
 	damage_absorption = list("brute"=0.5,"fire"=0.7,"bullet"=0.45,"laser"=0.6,"energy"=0.7,"bomb"=0.7)
 	max_temperature = 60000
@@ -145,3 +145,17 @@
 						"}
 	output += ..()
 	return output
+
+//Meant for random spawns.
+/obj/mecha/combat/marauder/old
+	desc = "Heavy-duty, combat exosuit, developed after the Durand model. Rarely found among civilian populations. This one is particularly worn looking and likely isn't as sturdy."
+
+/obj/mecha/combat/marauder/old/New()
+	..()
+	health = 25
+	maxhealth = 400	//Just slightly worse.
+	cell.charge = rand(0, (cell.charge/2))
+
+/obj/mecha/combat/marauder/old/Initialize()	//Nothing for u
+	..()
+	return

--- a/code/game/mecha/combat/marauder.dm
+++ b/code/game/mecha/combat/marauder.dm
@@ -155,7 +155,3 @@
 	health = 25
 	maxhealth = 400	//Just slightly worse.
 	cell.charge = rand(0, (cell.charge/2))
-
-/obj/mecha/combat/marauder/old/Initialize()	//Nothing for u
-	..()
-	return

--- a/code/game/mecha/combat/phazon.dm
+++ b/code/game/mecha/combat/phazon.dm
@@ -6,8 +6,8 @@
 	step_in = 1
 	dir_in = 1 //Facing North.
 	step_energy_drain = 3
-	health = 200
-	maxhealth = 200
+	health = 200		//God this is low
+	maxhealth = 200		//Don't forget to update the /old variant if  you change this number.
 	deflect_chance = 30
 	damage_absorption = list("brute"=0.7,"fire"=0.7,"bullet"=0.7,"laser"=0.7,"energy"=0.7,"bomb"=0.7)
 	max_temperature = 25000
@@ -141,3 +141,13 @@
 			damtype = "halloss"
 	src.occupant_message("Melee damage type switched to [new_damtype]")
 	return
+
+//Meant for random spawns.
+/obj/mecha/combat/phazon/old
+	desc = "An exosuit which can only be described as 'WTF?'. This one is particularly worn looking and likely isn't as sturdy."
+
+/obj/mecha/combat/phazon/old/New()
+	..()
+	health = 25
+	maxhealth = 150	//Just slightly worse.
+	cell.charge = rand(0, (cell.charge/2))

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -76,7 +76,7 @@
 
 	var/wreckage
 
-	var/list/equipment = new
+	var/list/equipment = new		//This lists holds what stuff you bolted onto your baby ride
 	var/obj/item/mecha_parts/mecha_equipment/selected
 	var/max_equip = 2
 	var/datum/events/events

--- a/code/game/mecha/medical/odysseus.dm
+++ b/code/game/mecha/medical/odysseus.dm
@@ -131,3 +131,13 @@
 	ME.attach(src)
 	ME = new /obj/item/mecha_parts/mecha_equipment/tool/syringe_gun
 	ME.attach(src)
+
+//Meant for random spawns.
+/obj/mecha/medical/odysseus/old
+	desc = "An aging combat exosuit utilized by many corporations. Originally developed to combat hostile alien lifeforms. This one is particularly worn looking and likely isn't as sturdy."
+
+/obj/mecha/medical/odysseus/old/New()
+	..()
+	health = 25
+	maxhealth = 100	//Just slightly worse.
+	cell.charge = rand(0, (cell.charge/2))

--- a/code/game/mecha/working/ripley.dm
+++ b/code/game/mecha/working/ripley.dm
@@ -6,7 +6,7 @@
 	step_in = 6
 	max_temperature = 20000
 	health = 200
-	maxhealth = 200
+	maxhealth = 200		//Don't forget to update the /old variant if  you change this number.
 	wreckage = /obj/effect/decal/mecha_wreckage/ripley
 	cargo_capacity = 10
 
@@ -79,3 +79,12 @@
 		qdel (B)
 
 
+//Meant for random spawns.
+/obj/mecha/working/ripley/mining/old
+	desc = "An old, dusty mining ripley."
+
+/obj/mecha/working/ripley/mining/old/New()
+	..()
+	health = 25
+	maxhealth = 190	//Just slightly worse.
+	cell.charge = rand(0, cell.charge)

--- a/code/game/objects/random/mechs.dm
+++ b/code/game/objects/random/mechs.dm
@@ -13,7 +13,7 @@
 				/obj/mecha/combat/marauder,
 				/obj/mecha/combat/marauder/seraph,
 				/obj/mecha/combat/marauder/mauler,
-				/obj/mecha/medical/odysseus
+				/obj/mecha/medical/odysseus,
 				/obj/mecha/combat/phazon,
 				/obj/mecha/combat/phazon/janus,
 				/obj/mecha/combat/durand,

--- a/code/game/objects/random/mechs.dm
+++ b/code/game/objects/random/mechs.dm
@@ -1,0 +1,40 @@
+/obj/random/mech
+	name = "random mech"
+	desc = "This is a random single mech."
+	icon = 'icons/mecha/mecha.dmi'
+	icon_state = "old_durand"
+	drop_get_turf = FALSE
+
+//This list includes the phazon, gorilla and mauler. You might want to use something else if balance is a concern.
+/obj/random/mech/item_to_spawn()
+	return pick(/obj/mecha/combat/gygax,
+				/obj/mecha/combat/gygax/serenity,
+				/obj/mecha/combat/gygax/dark,
+				/obj/mecha/combat/marauder,
+				/obj/mecha/combat/marauder/seraph,
+				/obj/mecha/combat/marauder/mauler,
+				/obj/mecha/medical/odysseus
+				/obj/mecha/combat/phazon,
+				/obj/mecha/combat/phazon/janus,
+				/obj/mecha/combat/durand,
+				/obj/mecha/working/ripley,
+				/obj/mecha/working/ripley/firefighter,
+				/obj/mecha/working/ripley/deathripley,
+				/obj/mecha/working/ripley/mining)
+
+
+/obj/random/mech/old
+	name = "random mech"
+	desc = "This is a random single old mech."
+	icon = 'icons/mecha/mecha.dmi'
+	icon_state = "old_durand"
+	drop_get_turf = FALSE
+
+//Note that all of those are worn out and have slightly less maximal health than the standard.
+/obj/random/mech/old/item_to_spawn()
+	return pick(prob(10);/obj/mecha/combat/gygax/old,
+				prob(1);/obj/mecha/combat/marauder/old,
+				prob(1);/obj/mecha/combat/phazon/old,
+				prob(10);/obj/mecha/combat/durand/old,
+				prob(15);/obj/mecha/medical/odysseus/old,
+				prob(20);/obj/mecha/working/ripley/mining/old)

--- a/code/game/objects/random/mechs.dm
+++ b/code/game/objects/random/mechs.dm
@@ -22,6 +22,22 @@
 				/obj/mecha/working/ripley/deathripley,
 				/obj/mecha/working/ripley/mining)
 
+/obj/random/mech/weaker
+	name = "random mech"
+	desc = "This is a random single mech. Those are less potent and more common."
+	icon = 'icons/mecha/mecha.dmi'
+	icon_state = "old_durand"
+	drop_get_turf = FALSE
+
+/obj/random/mech/weaker/item_to_spawn()
+	return pick(/obj/mecha/combat/gygax,
+				/obj/mecha/combat/gygax/serenity,
+				/obj/mecha/medical/odysseus,
+				/obj/mecha/combat/durand,
+				/obj/mecha/working/ripley,
+				/obj/mecha/working/ripley/firefighter,
+				/obj/mecha/working/ripley/deathripley,
+				/obj/mecha/working/ripley/mining)
 
 /obj/random/mech/old
 	name = "random mech"

--- a/polaris.dme
+++ b/polaris.dme
@@ -1158,6 +1158,7 @@
 #include "code\game\objects\random\guns_and_ammo.dm"
 #include "code\game\objects\random\maintenance.dm"
 #include "code\game\objects\random\mapping.dm"
+#include "code\game\objects\random\mechs.dm"
 #include "code\game\objects\random\misc.dm"
 #include "code\game\objects\random\mob.dm"
 #include "code\game\objects\random\spacesuits.dm"


### PR DESCRIPTION
- Add a few variants of worn down, slightly busted mechs, this is specifically intended for mech bay later on.
- Add a random spawner with pretty much every mecho inside of it.

The purpose of the first one is just to increase mech usage, by giving out some shittier versions out if you actually map in the spawner. 
If i had an idea how, i might make it so they are partially built and/or have a need for heavier repairs, closer to cyborgs needing armor swaps.