### PR TITLE
Arrivals Shuttle Message Fix

### DIFF
--- a/code/__defines/misc.dm
+++ b/code/__defines/misc.dm
@@ -341,3 +341,5 @@ var/global/list/##LIST_NAME = list();\
 #define JOB_SILICON_ROBOT	0x2
 #define JOB_SILICON_AI		0x4
 #define JOB_SILICON			0x6 // 2|4, probably don't set jobs to this, but good for checking
+
+#define DEFAULT_OVERMAP_RANGE 0 // Makes general computers and devices be able to connect to other overmap z-levels on the same tile.

--- a/code/defines/procs/announce.dm
+++ b/code/defines/procs/announce.dm
@@ -136,7 +136,7 @@ datum/announcement/proc/Log(message as text, message_title as text)
 
 /proc/AnnounceArrival(var/mob/living/carbon/human/character, var/rank, var/join_message, var/channel = "Common", var/zlevel)
 	if (ticker.current_state == GAME_STATE_PLAYING)
-		var/list/zlevels = zlevel ? using_map.get_map_levels(zlevel, TRUE) : null
+		var/list/zlevels = zlevel ? using_map.get_map_levels(zlevel, TRUE, om_range = DEFAULT_OVERMAP_RANGE) : null
 		if(character.mind.role_alt_title)
 			rank = character.mind.role_alt_title
 		AnnounceArrivalSimple(character.real_name, rank, join_message, channel, zlevels)

--- a/code/game/machinery/computer/camera.dm
+++ b/code/game/machinery/computer/camera.dm
@@ -43,10 +43,10 @@
 	data["current_camera"] = current_camera ? current_camera.nano_structure() : null
 	data["current_network"] = current_network
 	data["networks"] = network ? network : list()
-	
-	var/map_levels = using_map.get_map_levels(src.z, TRUE)
+
+	var/map_levels = using_map.get_map_levels(src.z, TRUE, om_range = DEFAULT_OVERMAP_RANGE)
 	data["map_levels"] = map_levels
-	
+
 	if(current_network)
 		data["cameras"] = camera_repository.cameras_in_network(current_network, map_levels)
 	if(current_camera)

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -468,7 +468,7 @@
 	control_computer._admin_logs += "[key_name(to_despawn)] ([to_despawn.mind.role_alt_title]) at [stationtime2text()]"
 	log_and_message_admins("[key_name(to_despawn)] ([to_despawn.mind.role_alt_title]) entered cryostorage.")
 
-	announce.autosay("[to_despawn.real_name], [to_despawn.mind.role_alt_title], [on_store_message]", "[on_store_name]", announce_channel, using_map.get_map_levels(z, TRUE))
+	announce.autosay("[to_despawn.real_name], [to_despawn.mind.role_alt_title], [on_store_message]", "[on_store_name]", announce_channel, using_map.get_map_levels(z, TRUE, om_range = DEFAULT_OVERMAP_RANGE))
 	//visible_message("<span class='notice'>\The [initial(name)] hums and hisses as it moves [to_despawn.real_name] into storage.</span>", 3)
 	visible_message("<span class='notice'>\The [initial(name)] [on_store_visible_message_1] [to_despawn.real_name] [on_store_visible_message_2].</span>", 3)
 

--- a/code/game/machinery/telecomms/telecomunications.dm
+++ b/code/game/machinery/telecomms/telecomunications.dm
@@ -707,4 +707,4 @@ var/global/list/obj/machinery/telecomms/telecomms_list = list()
 	if(ad_hoc && src_z == dst_z)
 		return TRUE
 
-	return src_z in using_map.get_map_levels(dst_z)
+	return src_z in using_map.get_map_levels(dst_z, TRUE, om_range = DEFAULT_OVERMAP_RANGE)

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -336,7 +336,7 @@
 		next_alarm_notice = world.time + SecondsToTicks(10)
 	if(alarm.hidden)
 		return
-	if(alarm.origin && !(get_z(alarm.origin) in using_map.get_map_levels(get_z(src), TRUE)))
+	if(alarm.origin && !(get_z(alarm.origin) in using_map.get_map_levels(get_z(src), TRUE, om_range = DEFAULT_OVERMAP_RANGE)))
 		return
 
 	var/list/alarms = queued_alarms[alarm_handler]

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -410,19 +410,19 @@
 		character.buckled.set_dir(character.dir)
 
 	ticker.mode.latespawn(character)
-	
+
 	if(J.mob_type & JOB_SILICON)
 		AnnounceCyborg(character, rank, join_message, announce_channel, character.z)
 	else
 		AnnounceArrival(character, rank, join_message, announce_channel, character.z)
 		data_core.manifest_inject(character)
 		ticker.minds += character.mind//Cyborgs and AIs handle this in the transform proc.	//TODO!!!!! ~Carn
-		
+
 	qdel(src) // Delete new_player mob
 
 /mob/new_player/proc/AnnounceCyborg(var/mob/living/character, var/rank, var/join_message, var/channel, var/zlevel)
 	if (ticker.current_state == GAME_STATE_PLAYING)
-		var/list/zlevels = zlevel ? using_map.get_map_levels(zlevel, TRUE) : null
+		var/list/zlevels = zlevel ? using_map.get_map_levels(zlevel, TRUE, om_range = DEFAULT_OVERMAP_RANGE) : null
 		if(character.mind.role_alt_title)
 			rank = character.mind.role_alt_title
 		// can't use their name here, since cyborg namepicking is done post-spawn, so we'll just say "A new Cyborg has arrived"/"A new Android has arrived"/etc.

--- a/code/modules/modular_computers/file_system/programs/generic/camera.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/camera.dm
@@ -62,7 +62,7 @@
 
 	data["networks"] = all_networks
 
-	var/list/map_levels = using_map.get_map_levels(get_z(nano_host()), TRUE)
+	var/list/map_levels = using_map.get_map_levels(get_z(nano_host()), TRUE, om_range = DEFAULT_OVERMAP_RANGE)
 
 	if(current_network)
 		data["cameras"] = camera_repository.cameras_in_network(current_network, map_levels)

--- a/code/modules/modular_computers/file_system/programs/generic/uav.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/uav.dm
@@ -41,13 +41,13 @@
 				set_current(null)
 			else // Don't reset counter until we find a UAV that's actually in range we can stay connected to
 				signal_test_counter = 20
-	
+
 	data["current_uav"] = null
 	if(current_uav)
 		data["current_uav"] = list("status" = current_uav.get_status_string(), "power" = current_uav.state == 1 ? 1 : null)
 	data["signal_strength"] = signal_strength ? signal_strength >= 2 ? "High" : "Low" : "None"
 	data["in_use"] = LAZYLEN(viewers)
-	
+
 	var/list/paired_map = list()
 	var/obj/item/modular_computer/mc_host = nano_host()
 	if(istype(mc_host))
@@ -55,7 +55,7 @@
 			var/weakref/wr = puav
 			var/obj/item/device/uav/U = wr.resolve()
 			paired_map[++paired_map.len] = list("name" = "[U ? U.nickname : "!!Missing!!"]", "uavref" = "\ref[U]")
-	
+
 	data["paired_uavs"] = paired_map
 
 	ui = SSnanoui.try_update_ui(user, src, ui_key, ui, data, force_open)
@@ -102,7 +102,7 @@
 	else if(href_list["view_uav"])
 		if(!current_uav)
 			return TOPIC_NOACTION
-		
+
 		if(current_uav.check_eye(user) < 0)
 			to_chat(usr,"<span class='warning'>The screen freezes for a moment, before returning to the UAV selection menu. It's not able to connect to that UAV.</span>")
 		else
@@ -139,7 +139,7 @@
 
 	signal_strength = 0
 	current_uav = U
-	
+
 	if(LAZYLEN(viewers))
 		for(var/weakref/W in viewers)
 			var/M = W.resolve()
@@ -172,7 +172,7 @@
 			return 0
 
 	var/list/zlevels_in_range = using_map.get_map_levels(their_z, FALSE)
-	var/list/zlevels_in_long_range = using_map.get_map_levels(their_z, TRUE) - zlevels_in_range
+	var/list/zlevels_in_long_range = using_map.get_map_levels(their_z, TRUE, om_range = DEFAULT_OVERMAP_RANGE) - zlevels_in_range
 	var/their_signal = 0
 	for(var/relay in ntnet_global.relays)
 		var/obj/machinery/ntnet_relay/R = relay
@@ -209,7 +209,7 @@
 
 	if(!current_uav)
 		return
-	
+
 	user.set_machine(nano_host())
 	user.reset_view(current_uav)
 	current_uav.add_master(user)
@@ -250,7 +250,7 @@
 	if(weakref(M) in viewers)
 		M.overlay_fullscreen("fishbed",/obj/screen/fullscreen/fishbed)
 		M.overlay_fullscreen("scanlines",/obj/screen/fullscreen/scanline)
-		
+
 		if(signal_strength <= 1)
 			M.overlay_fullscreen("whitenoise",/obj/screen/fullscreen/noise)
 		else

--- a/code/modules/modular_computers/file_system/programs/medical/suit_sensors.dm
+++ b/code/modules/modular_computers/file_system/programs/medical/suit_sensors.dm
@@ -38,7 +38,7 @@
 	data["isAI"] = isAI(user)
 
 	var/z = get_z(nano_host())
-	var/list/map_levels = using_map.get_map_levels(z, TRUE)
+	var/list/map_levels = using_map.get_map_levels(z, TRUE, om_range = DEFAULT_OVERMAP_RANGE)
 	data["map_levels"] = map_levels
 
 	data["crewmembers"] = list()

--- a/code/modules/modular_computers/hardware/network_card.dm
+++ b/code/modules/modular_computers/hardware/network_card.dm
@@ -104,7 +104,7 @@ var/global/ntnet_card_uid = 1
 		if(!holderz) //no reception in nullspace
 			return 0
 		var/list/zlevels_in_range = using_map.get_map_levels(holderz, FALSE)
-		var/list/zlevels_in_long_range = using_map.get_map_levels(holderz, TRUE) - zlevels_in_range
+		var/list/zlevels_in_long_range = using_map.get_map_levels(holderz, TRUE, om_range = DEFAULT_OVERMAP_RANGE) - zlevels_in_range
 		var/best = 0
 		for(var/relay in ntnet_global.relays)
 			var/obj/machinery/ntnet_relay/R = relay

--- a/maps/southern_cross/overmap/sectors.dm
+++ b/maps/southern_cross/overmap/sectors.dm
@@ -36,6 +36,7 @@
 	start_x =  10
 	start_y =  10
 	map_z = list(Z_LEVEL_STATION_ONE, Z_LEVEL_STATION_TWO, Z_LEVEL_STATION_THREE)
+	extra_z_levels = list(Z_LEVEL_TRANSIT) // Hopefully temporary, so arrivals announcements work.
 
 /obj/effect/overmap/visitable/planet/Sif/Initialize()
 	. = ..()

--- a/maps/southern_cross/southern_cross_defines.dm
+++ b/maps/southern_cross/southern_cross_defines.dm
@@ -97,6 +97,8 @@
 			Z_LEVEL_SURFACE_WILD
 		)
 
+// Commented out due to causing a lot of bugs. The base proc plus overmap achieves this functionality anyways.
+/*
 // Short range computers see only the six main levels, others can see the surrounding surface levels.
 /datum/map/southern_cross/get_map_levels(var/srcz, var/long_range = TRUE)
 	if (long_range && (srcz in map_levels))
@@ -117,7 +119,7 @@
 			)
 	else
 		return list(srcz) //prevents runtimes when using CMC. any Z-level not defined above will be 'isolated' and only show to GPSes/CMCs on that same Z (e.g. CentCom).
-
+*/
 /datum/map/southern_cross/perform_map_generation()
 	// First, place a bunch of submaps. This comes before tunnel/forest generation as to not interfere with the submap.
 
@@ -186,19 +188,19 @@
 /datum/map_z_level/southern_cross/surface
 	z = Z_LEVEL_SURFACE
 	name = "Plains"
-	flags = MAP_LEVEL_STATION|MAP_LEVEL_CONTACT|MAP_LEVEL_PLAYER|MAP_LEVEL_SEALED
+	flags = MAP_LEVEL_STATION|MAP_LEVEL_CONTACT|MAP_LEVEL_PLAYER|MAP_LEVEL_SEALED|MAP_LEVEL_CONSOLES
 	base_turf = /turf/simulated/floor/outdoors/rocks
 
 /datum/map_z_level/southern_cross/surface_mine
 	z = Z_LEVEL_SURFACE_MINE
 	name = "Mountains"
-	flags = MAP_LEVEL_STATION|MAP_LEVEL_CONTACT|MAP_LEVEL_PLAYER|MAP_LEVEL_SEALED
+	flags = MAP_LEVEL_STATION|MAP_LEVEL_CONTACT|MAP_LEVEL_PLAYER|MAP_LEVEL_SEALED|MAP_LEVEL_CONSOLES
 	base_turf = /turf/simulated/floor/outdoors/rocks
 
 /datum/map_z_level/southern_cross/surface_wild
 	z = Z_LEVEL_SURFACE_WILD
 	name = "Wilderness"
-	flags = MAP_LEVEL_PLAYER|MAP_LEVEL_SEALED
+	flags = MAP_LEVEL_PLAYER|MAP_LEVEL_SEALED|MAP_LEVEL_CONTACT|MAP_LEVEL_CONSOLES
 	base_turf = /turf/simulated/floor/outdoors/rocks
 
 /datum/map_z_level/southern_cross/misc


### PR DESCRIPTION
#Fixes #7067 
#Fixes #7063 
Fairly sure it fixes not being able to hear the arrivals announcement when someone joins and you're on the station.

`get_map_levels()` has caused a lot of problems, so this gets rid of the Southern Cross-specific version in favor of the base map version, which is what Virgo appears to be using, and also has the overmap specific code that we will probably need to use the overmap ourselves later down the road.

In doing so, I found another bug (more like oversight) that is caused by having the overmap system active, and having two distinct destinations house most of the z-levels. Even if they're on the same tile (as Sif and the Southern Cross are presently), they can't 'see' each other with `get_map_levels()` with the default `om_range` parameter. To fix this, I went and looked at all the 'long ranged' `get_map_levels()` calls I could find, and gave them an `om_range` argument set to a define, so they can see everything on the same overmap tile.

If Sif and the Southern Cross are moved apart later (which might be likely to happen), then the define `DEFAULT_OVERMAP_RANGE` can be changed and it should keep everything working.

Side effects: The transit Z-level, for the purposes of overmap stuff, is inside the Southern Cross. The result is that people won't fall off sensors when going on any shuttles, and radios should work while in any transit. This will hopefully not cause too many headaches, and the transit Z-level should become obsolete once the shuttles are made to be overmap shuttles.