### PR TITLE
Species Vars Extension Pt2: Pain

### DIFF
--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -284,6 +284,20 @@
 		oxyloss = 0
 	else
 		..()
+		
+/mob/living/carbon/human/adjustHalLoss(var/amount)
+	if(species.flags & NO_PAIN)
+		halloss = 0
+	else
+		if(amount > 0)	//only multiply it by the mod if it's positive, or else it takes longer to fade too!
+			amount = amount*species.pain_mod
+		..(amount)
+
+/mob/living/carbon/human/setHalLoss(var/amount)
+	if(species.flags & NO_PAIN)
+		halloss = 0
+	else
+		..()
 
 /mob/living/carbon/human/getToxLoss()
 	if(species.flags & NO_POISON)

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -95,6 +95,7 @@
 	var/chemOD_threshold =		1						// Multiplier to overdose threshold; lower = easier overdosing
 	var/chemOD_mod =		1						// Damage modifier for overdose; higher = more damage from ODs
 	var/alcohol_mod =		1						// Multiplier to alcohol strength; 0.5 = half, 0 = no effect at all, 2 = double, etc.
+	var/pain_mod =			1						// Multiplier to pain effects; 0.5 = half, 0 = no effect (equal to NO_PAIN, really), 2 = double, etc.
 	// set below is EMP interactivity for nonsynth carbons
 	var/emp_sensitivity =		0			// bitflag. valid flags are: EMP_PAIN, EMP_BLIND, EMP_DEAFEN, EMP_CONFUSE, EMP_STUN, and EMP_(BRUTE/BURN/TOX/OXY)_DMG
 	var/emp_dmg_mod =		1			// Multiplier to all EMP damage sustained by the mob, if it's EMP-sensitive


### PR DESCRIPTION
I'd been meaning to do something like this for a long time, and it turns out it really wasn't as much of a pain (ha. ha.) as I thought it'd be! I always figured it was weird that it was basically just a binary of all pain or `NO_PAIN`.

So: this PR simply adds a `pain_mod` species-level var that, in addition with a pair of tweaked procs, multiplies incoming "positive" pain effects, such as stun baton prods or taser bolts. It doesn't multiply "negative" effects such as the halloss recovery from rest/sleep, and it doesn't apply to painkillers as they seem to use a kind of 'threshold' system (for that, use `chem_strength_pain`, which I added in a prior PR).

The tweaked procs also zero-out incoming halloss if the species has the `NO_PAIN` flag, similar to how `NO_POISON` works. I considered covering `isSynthetic` in the check as well, but decided not to.

As with SVE1 (#7249) there's no 'practical' implementation of this at this time.