### PR TITLE
Fix Janicart PDA bug from Aro's Rewrite of Janicarts.

### DIFF
--- a/code/game/objects/items/devices/PDA/cart.dm
+++ b/code/game/objects/items/devices/PDA/cart.dm
@@ -515,7 +515,10 @@ var/list/civilian_cartridges = list(
 				if(bl.z != cl.z)
 					continue
 				var/direction = get_dir(src,B)
-				CartData[++CartData.len] = list("x" = bl.x, "y" = bl.y, "dir" = uppertext(dir2text(direction)), "status" = B.reagents.total_volume/100)
+				var/status = "No Bucket"
+				if(B.mybucket)
+					status = B.mybucket.reagents.total_volume / 100
+				CartData[++CartData.len] = list("x" = bl.x, "y" = bl.y, "dir" = uppertext(dir2text(direction)), "status" = status)
 		if(!CartData.len)
 			CartData[++CartData.len] = list("x" = 0, "y" = 0, dir=null, status = null)
 


### PR DESCRIPTION
Upstream port of https://github.com/VOREStation/VOREStation/pull/8404

Fixes create_NanoUI_values() crashing before it returns the data, thus crashing everything else, because reagents was `null`, as a result of Aro's redoing of the janitor carts to not have a bucket by default.
