### PR TITLE
Quick fix to stop mobs in nullspace runtiming the mobs and ai subsystems

### DIFF
--- a/code/controllers/subsystems/ai.dm
+++ b/code/controllers/subsystems/ai.dm
@@ -24,7 +24,7 @@ SUBSYSTEM_DEF(ai)
 	while(currentrun.len)
 		var/datum/ai_holder/A = currentrun[currentrun.len]
 		--currentrun.len
-		if(!A || QDELETED(A) || A.busy) // Doesn't exist or won't exist soon or not doing it this tick
+		if(!A || QDELETED(A) || !A.holder?.loc || A.busy) // Doesn't exist or won't exist soon or not doing it this tick or in nullspace
 			continue
 		A.handle_strategicals()
 

--- a/code/controllers/subsystems/mobs.dm
+++ b/code/controllers/subsystems/mobs.dm
@@ -44,7 +44,7 @@ SUBSYSTEM_DEF(mobs)
 			// Right now mob.Life() is unstable enough I think we need to use a try catch.
 			// Obviously we should try and get rid of this for performance reasons when we can.
 			try
-				if(M.low_priority && M.loc &&  !(M.z in busy_z_levels))
+				if(M.low_priority &&  !(M.loc && M.z in busy_z_levels))
 					slept_mobs++
 					continue
 				M.Life(times_fired)

--- a/code/controllers/subsystems/mobs.dm
+++ b/code/controllers/subsystems/mobs.dm
@@ -44,7 +44,7 @@ SUBSYSTEM_DEF(mobs)
 			// Right now mob.Life() is unstable enough I think we need to use a try catch.
 			// Obviously we should try and get rid of this for performance reasons when we can.
 			try
-				if(M.low_priority && !(M.z in busy_z_levels))
+				if(M.low_priority && M.loc &&  !(M.z in busy_z_levels))
 					slept_mobs++
 					continue
 				M.Life(times_fired)


### PR DESCRIPTION
Note: Theoretically an error still could happen if the following happens in exactly this order:

1. Subsystem starts firing, then sleeps.
2. A new z-level is allocated.
3. A mob that previously existed prior to step 1 but was not processed during step 1 is moved to the new z-level.

But the error would clear itself after one cycle.

(This bug would cause mobs and AI subsytems to stop processing anything at all)

Upstream port of https://github.com/VOREStation/VOREStation/pull/8412