### PR TITLE
Increase mob default reload time from 1 second to 4 seconds.

### DIFF
--- a/code/modules/mob/living/simple_mob/combat.dm
+++ b/code/modules/mob/living/simple_mob/combat.dm
@@ -143,7 +143,7 @@
 
 	if(do_after(src, reload_time))
 		if(reload_sound)
-			playsound(src, reload_sound, 50, 1)
+			playsound(src, reload_sound, 70, 1)
 		reload_count = 0
 		. = TRUE
 	else

--- a/code/modules/mob/living/simple_mob/simple_mob.dm
+++ b/code/modules/mob/living/simple_mob/simple_mob.dm
@@ -92,7 +92,7 @@
 	var/needs_reload = FALSE							// If TRUE, mob needs to reload occasionally
 	var/reload_max = 1									// How many shots the mob gets before it has to reload, will not be used if needs_reload is FALSE
 	var/reload_count = 0								// A counter to keep track of how many shots the mob has fired so far. Reloads when it hits reload_max.
-	var/reload_time = 1 SECONDS							// How long it takes for a mob to reload. This is to buy a player a bit of time to run or fight.
+	var/reload_time = 4 SECONDS							// How long it takes for a mob to reload. This is to buy a player a bit of time to run or fight.
 	var/reload_sound = 'sound/weapons/flipblade.ogg'	// What sound gets played when the mob successfully reloads. Defaults to the same sound as reloading guns. Can be null.
 
 	//Mob melee settings


### PR DESCRIPTION
This is to make it more visible whenever a mob actually reloads. Currently, a slight second of a break doesn't look like much on the opposing end.
The noise has been increased to 70 to make more likely someone actually hears it in the chaos.