### PR TITLE
[SEMI-URGENT] Fixes hanging/crashing server when using the Export-Chatlog verb in OOC

### DIFF
--- a/code/modules/vchat/vchat_client.dm
+++ b/code/modules/vchat/vchat_client.dm
@@ -393,6 +393,7 @@ var/to_chat_src
 	// Write the messages to the log
 	for(var/list/result in results)
 		o_file << "[result["message"]]<br>"
+		CHECK_TICK
 
 	o_file << "</body></html>"
 


### PR DESCRIPTION
As per title. Does slow down the export, but will prevent the server or whatever from trying to export 2000+ (or however many) lines of chat at once.