### PR TITLE
Pressing Q now properly updates borg modules

### DIFF
--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -470,7 +470,6 @@
 				var/mob/living/silicon/robot/R = usr
 				if(R.module)
 					R.uneq_active()
-					R.hud_used.update_robot_modules_display()
 				else
 					to_chat(R, "You haven't selected a module yet.")
 

--- a/code/modules/mob/living/silicon/robot/inventory.dm
+++ b/code/modules/mob/living/silicon/robot/inventory.dm
@@ -52,7 +52,7 @@
 		module_state_3 = null
 		inv3.icon_state = "inv3"
 	updateicon()
-	usr.hud_used.update_robot_modules_display()
+	hud_used.update_robot_modules_display()
 
 /mob/living/silicon/robot/proc/uneq_all()
 	module_active = null

--- a/code/modules/mob/living/silicon/robot/inventory.dm
+++ b/code/modules/mob/living/silicon/robot/inventory.dm
@@ -52,6 +52,7 @@
 		module_state_3 = null
 		inv3.icon_state = "inv3"
 	updateicon()
+	usr.hud_used.update_robot_modules_display()
 
 /mob/living/silicon/robot/proc/uneq_all()
 	module_active = null


### PR DESCRIPTION
Previously using the Q hotkey to drop modules from the toolbar as a borg would not update to have the most recently dropped modules, until you pull a fresh module out/hit the store button/close&open the module inventory

Tested, works as I'd expect. Hopefully. I'm sleepy, feel free to scree at me with anything I can fix.