### PR TITLE
Makes using BYOND Filters easier.

### DIFF
--- a/code/_helpers/visual_filters.dm
+++ b/code/_helpers/visual_filters.dm
@@ -1,0 +1,36 @@
+// These involve BYOND's built in filters that do visual effects, and not stuff that distinguishes between things.
+
+// All of this ported from TG.
+/atom/movable
+	var/list/filter_data // For handling persistent filters
+
+/proc/cmp_filter_data_priority(list/A, list/B)
+	return A["priority"] - B["priority"]
+
+/atom/movable/proc/add_filter(filter_name, priority, list/params)
+	LAZYINITLIST(filter_data)
+	var/list/p = params.Copy()
+	p["priority"] = priority
+	filter_data[filter_name] = p
+	update_filters()
+
+/atom/movable/proc/update_filters()
+	filters = null
+	filter_data = sortTim(filter_data, /proc/cmp_filter_data_priority, TRUE)
+	for(var/f in filter_data)
+		var/list/data = filter_data[f]
+		var/list/arguments = data.Copy()
+		arguments -= "priority"
+		filters += filter(arglist(arguments))
+
+/atom/movable/proc/get_filter(filter_name)
+	if(filter_data && filter_data[filter_name])
+		return filters[filter_data.Find(filter_name)]
+
+// Polaris Extensions
+/atom/movable/proc/remove_filter(filter_name)
+	var/thing = get_filter(filter_name)
+	if(thing)
+		LAZYREMOVE(filter_data, filter_name)
+		filters -= thing
+		update_filters()

--- a/code/modules/mob/_modifiers/modifiers.dm
+++ b/code/modules/mob/_modifiers/modifiers.dm
@@ -20,6 +20,9 @@
 	var/light_intensity = null			// Ditto. Not implemented yet.
 	var/mob_overlay_state = null		// Icon_state for an overlay to apply to a (human) mob while this exists.  This is actually implemented.
 	var/client_color = null				// If set, the client will have the world be shown in this color, from their perspective.
+	var/list/filter_parameters = null	// If set, will add a filter to the holder with the parameters in this var. Must be a list.
+	var/filter_priority = 1				// Used to make filters be applied in a specific order, if that is important.
+	var/filter_instance = null			// Instance of a filter created with the `filter_parameters` list. This exists to make `animate()` calls easier. Don't set manually.
 
 	// Now for all the different effects.
 	// Percentage modifiers are expressed as a multipler. (e.g. +25% damage should be written as 1.25)
@@ -82,6 +85,8 @@
 		holder.update_transform()
 	if(client_color)
 		holder.update_client_color()
+	if(LAZYLEN(filter_parameters))
+		holder.remove_filter(REF(src))
 	qdel(src)
 
 // Override this for special effects when it gets added to the mob.
@@ -150,6 +155,9 @@
 		update_transform()
 	if(mod.client_color)
 		update_client_color()
+	if(LAZYLEN(mod.filter_parameters))
+		add_filter(REF(mod), mod.filter_priority, mod.filter_parameters)
+		mod.filter_instance = get_filter(REF(mod))
 
 	return mod
 

--- a/code/modules/mob/_modifiers/modifiers_misc.dm
+++ b/code/modules/mob/_modifiers/modifiers_misc.dm
@@ -388,3 +388,13 @@ the artifact triggers the rage.
 	if(holder.stat != DEAD)
 		holder.visible_message("<span class='alien'>\The [holder] collapses, the life draining from their body.</span>")
 		holder.death()
+
+/datum/modifier/outline_test
+	name = "Outline Test"
+	desc = "This only exists to prove filter effects work and gives an example of how to animate() the resulting filter object."
+
+	filter_parameters = list(type = "outline", size = 1, color = "#FFFFFF", flags = OUTLINE_SHARP)
+
+/datum/modifier/outline_test/tick()
+	animate(filter_instance, size = 3, time = 0.25 SECONDS)
+	animate(size = 1, 0.25 SECONDS)

--- a/polaris.dme
+++ b/polaris.dme
@@ -105,6 +105,7 @@
 #include "code\_helpers\type2type.dm"
 #include "code\_helpers\unsorted.dm"
 #include "code\_helpers\view.dm"
+#include "code\_helpers\visual_filters.dm"
 #include "code\_helpers\sorts\__main.dm"
 #include "code\_helpers\sorts\comparators.dm"
 #include "code\_helpers\sorts\TimSort.dm"


### PR DESCRIPTION
Ports TG's filter helpers, and adds an extension on top so you can remove those filters as well as add them.
Also ties it to the modifier system.
Adds a `/datum/modifier/outline_test` that shows how to use filters to add an effect to the modifier, and how to use `animate()` calls on it.
Here's a video of what the outline one looks like. https://streamable.com/bg1jg4

This was inside my technomancer branch but I thought it'd be better to bring this over separately for the sake of Ater's health. Will bring more stuff over later.