### PR TITLE
Fixes table/bench icon connections.

### DIFF
--- a/code/modules/tables/tables.dm
+++ b/code/modules/tables/tables.dm
@@ -323,6 +323,15 @@
 	qdel(src)
 	return shards
 
+/obj/structure/table/can_visually_connect_to(var/obj/structure/S)
+	if(istype(S,/obj/structure/table/bench) && !istype(src,/obj/structure/table/bench))
+		return FALSE
+	if(istype(src,/obj/structure/table/bench) && !istype(S,/obj/structure/table/bench))
+		return FALSE
+	if(istype(S,/obj/structure/table))
+		return TRUE
+	..()
+
 /obj/structure/table/update_icon()
 	if(flipped != 1)
 		icon_state = "blank"


### PR DESCRIPTION
- Fixes roundstart/spawned complete tables not connecting to adjacent frames or other types.
- Fixes table frames connecting into adjacent benches.

Before
![kuva](https://user-images.githubusercontent.com/13697337/88276391-a66e9c80-cce7-11ea-9569-39192a23cdec.png)
After
![kuva](https://user-images.githubusercontent.com/13697337/88276413-ae2e4100-cce7-11ea-905e-8aec515c270e.png)
