### PR TITLE
Rag Coding Fix

### DIFF
--- a/code/modules/detectivework/tools/rag.dm
+++ b/code/modules/detectivework/tools/rag.dm
@@ -105,29 +105,39 @@
 			A.clean_blood()
 
 /obj/item/weapon/reagent_containers/glass/rag/attack(atom/target as obj|turf|area, mob/user as mob , flag)
-	if(isliving(target))
-		var/mob/living/M = target
-		if(on_fire)
-			user.visible_message("<span class='danger'>\The [user] hits [target] with [src]!</span>",)
-			user.do_attack_animation(src)
-			M.IgniteMob()
-		else if(reagents.total_volume)
-			if(user.zone_sel.selecting == O_MOUTH)
-				user.do_attack_animation(src)
-				user.visible_message(
-					"<span class='danger'>\The [user] smothers [target] with [src]!</span>",
-					"<span class='warning'>You smother [target] with [src]!</span>",
-					"You hear some struggling and muffled cries of surprise"
-					)
+  if(isliving(target)) //Leaving this as isliving.
+    var/mob/living/M = target
+    if(on_fire) //Check if rag is on fire, if so igniting them and stopping.
+      user.visible_message("<span class='danger'>\The [user] hits [target] with [src]!</span>",)
+      user.do_attack_animation(src)
+      M.IgniteMob()
+    else if(user.zone_sel.selecting == O_MOUTH) //Check player target location, provided the rag is not on fire. Then check if mouth is exposed.
+      if(ishuman(target)) //Added this since player species process reagents in majority of cases.
+        var/mob/living/carbon/human/H = target
+        if(H.head && (H.head.body_parts_covered & FACE)) //Check human head coverage.
+          to_chat(user, "<span class='warning'>Remove their [H.head] first.</span>")
+          return        
+        else if(reagents.total_volume) //Final check. If the rag is not on fire and their face is uncovered, smother target.
+          user.do_attack_animation(src)
+          user.visible_message(
+            "<span class='danger'>\The [user] smothers [target] with [src]!</span>",
+            "<span class='warning'>You smother [target] with [src]!</span>",
+            "You hear some struggling and muffled cries of surprise"
+            )
+            //it's inhaled, so... maybe CHEM_BLOOD doesn't make a whole lot of sense but it's the best we can do for now
+          reagents.trans_to_mob(target, amount_per_transfer_from_this, CHEM_BLOOD)
+          update_name()
+        else
+          to_chat(user, "<span class='warning'>You can't smother this creature.</span>")
+      else
+        to_chat(user, "<span class='warning'>You can't smother this creature.</span>")
+    else
+      wipe_down(target, user)
+  else
+    wipe_down(target, user)
+    return
 
-				//it's inhaled, so... maybe CHEM_BLOOD doesn't make a whole lot of sense but it's the best we can do for now
-				reagents.trans_to_mob(target, amount_per_transfer_from_this, CHEM_BLOOD)
-				update_name()
-			else
-				wipe_down(target, user)
-		return
-
-	return ..()
+  return
 
 /obj/item/weapon/reagent_containers/glass/rag/afterattack(atom/A as obj|turf|area, mob/user as mob, proximity)
 	if(!proximity)

--- a/code/modules/detectivework/tools/rag.dm
+++ b/code/modules/detectivework/tools/rag.dm
@@ -129,17 +129,12 @@
 					update_name()
 				else
 					to_chat(user, "<span class='warning'>You can't smother this creature.</span>")
-					return
 			else
 				to_chat(user, "<span class='warning'>You can't smother this creature.</span>")
-				return
 		else
 			wipe_down(target, user)
-			return
 	else
 		wipe_down(target, user)
-		return
-
 	return
 
 /obj/item/weapon/reagent_containers/glass/rag/afterattack(atom/A as obj|turf|area, mob/user as mob, proximity)

--- a/code/modules/detectivework/tools/rag.dm
+++ b/code/modules/detectivework/tools/rag.dm
@@ -131,7 +131,7 @@
 					to_chat(user, "<span class='warning'>You can't smother this creature.</span>")
 					return
 			else
-				to_chat(user, "span class='warning'>You can't smother this creature.</span>")
+				to_chat(user, "<span class='warning'>You can't smother this creature.</span>")
 				return
 		else
 			wipe_down(target, user)

--- a/code/modules/detectivework/tools/rag.dm
+++ b/code/modules/detectivework/tools/rag.dm
@@ -105,39 +105,42 @@
 			A.clean_blood()
 
 /obj/item/weapon/reagent_containers/glass/rag/attack(atom/target as obj|turf|area, mob/user as mob , flag)
-  if(isliving(target)) //Leaving this as isliving.
-    var/mob/living/M = target
-    if(on_fire) //Check if rag is on fire, if so igniting them and stopping.
-      user.visible_message("<span class='danger'>\The [user] hits [target] with [src]!</span>",)
-      user.do_attack_animation(src)
-      M.IgniteMob()
-    else if(user.zone_sel.selecting == O_MOUTH) //Check player target location, provided the rag is not on fire. Then check if mouth is exposed.
-      if(ishuman(target)) //Added this since player species process reagents in majority of cases.
-        var/mob/living/carbon/human/H = target
-        if(H.head && (H.head.body_parts_covered & FACE)) //Check human head coverage.
-          to_chat(user, "<span class='warning'>Remove their [H.head] first.</span>")
-          return        
-        else if(reagents.total_volume) //Final check. If the rag is not on fire and their face is uncovered, smother target.
-          user.do_attack_animation(src)
-          user.visible_message(
-            "<span class='danger'>\The [user] smothers [target] with [src]!</span>",
-            "<span class='warning'>You smother [target] with [src]!</span>",
-            "You hear some struggling and muffled cries of surprise"
-            )
-            //it's inhaled, so... maybe CHEM_BLOOD doesn't make a whole lot of sense but it's the best we can do for now
-          reagents.trans_to_mob(target, amount_per_transfer_from_this, CHEM_BLOOD)
-          update_name()
-        else
-          to_chat(user, "<span class='warning'>You can't smother this creature.</span>")
-      else
-        to_chat(user, "<span class='warning'>You can't smother this creature.</span>")
-    else
-      wipe_down(target, user)
-  else
-    wipe_down(target, user)
-    return
+	if(isliving(target)) //Leaving this as isliving.
+		var/mob/living/M = target
+		if(on_fire) //Check if rag is on fire, if so igniting them and stopping.
+			user.visible_message("<span class='danger'>\The [user] hits [target] with [src]!</span>",)
+			user.do_attack_animation(src)
+			M.IgniteMob()
+		else if(user.zone_sel.selecting == O_MOUTH) //Check player target location, provided the rag is not on fire. Then check if mouth is exposed.
+			if(ishuman(target)) //Added this since player species process reagents in majority of cases.
+				var/mob/living/carbon/human/H = target
+				if(H.head && (H.head.body_parts_covered & FACE)) //Check human head coverage.
+					to_chat(user, "<span class='warning'>Remove their [H.head] first.</span>")
+					return        
+				else if(reagents.total_volume) //Final check. If the rag is not on fire and their face is uncovered, smother target.
+					user.do_attack_animation(src)
+					user.visible_message(
+						"<span class='danger'>\The [user] smothers [target] with [src]!</span>",
+						"<span class='warning'>You smother [target] with [src]!</span>",
+						"You hear some struggling and muffled cries of surprise"
+						)
+					//it's inhaled, so... maybe CHEM_BLOOD doesn't make a whole lot of sense but it's the best we can do for now
+					reagents.trans_to_mob(target, amount_per_transfer_from_this, CHEM_BLOOD)
+					update_name()
+				else
+					to_chat(user, "<span class='warning'>You can't smother this creature.</span>")
+					return
+			else
+				to_chat(user, "span class='warning'>You can't smother this creature.</span>")
+				return
+		else
+			wipe_down(target, user)
+			return
+	else
+		wipe_down(target, user)
+		return
 
-  return
+	return
 
 /obj/item/weapon/reagent_containers/glass/rag/afterattack(atom/A as obj|turf|area, mob/user as mob, proximity)
 	if(!proximity)


### PR DESCRIPTION
- A quick one file fix for a rag coding issue related to face covering helmets not providing protection to smothering should rags be filled with chloral hydrate.  

- Basic face masks will not protect against the intent, but items like welding masks and space suit helmets will.

![ragmaskdetection](https://user-images.githubusercontent.com/28820640/88364535-d0a47680-cd48-11ea-81e4-0f07c7a9e45d.png)


This is a fix for an issue brought up on a server downstream, pulled here to hopefully prevent any future conflicts arising should this file be modified in the future.