### PR TITLE
Fixes the diagonal density melee exploit

### DIFF
--- a/code/game/gamemodes/changeling/changeling_powers.dm
+++ b/code/game/gamemodes/changeling/changeling_powers.dm
@@ -182,20 +182,20 @@ turf/proc/AdjacentTurfsRangedSting()
 			add = 0
 		if(add && TurfBlockedNonWindow(t))
 			add = 0
-			for(var/obj/O in t)
-				if(!O.density)
+		for(var/obj/O in t)
+			if(O.density)
+				add = 0
+				break
+			if(istype(O, /obj/machinery/door))
+				//not sure why this doesn't fire on LinkBlocked()
+				add = 0
+				break
+			for(var/type in allowed)
+				if (istype(O, type))
 					add = 1
 					break
-				if(istype(O, /obj/machinery/door))
-					//not sure why this doesn't fire on LinkBlocked()
-					add = 0
-					break
-				for(var/type in allowed)
-					if (istype(O, type))
-						add = 1
-						break
-				if(!add)
-					break
+			if(!add)
+				break
 		if(add)
 			L.Add(t)
 	return L


### PR DESCRIPTION
God this whole mess needs to be replaced with some proper code with modern standards. TIL every item attack ingame gets run through an ass-backwards spaghetti proc in changeling powers and the proc itself was apparently this busted the whole time.