### PR TITLE
Species Vars Extension Pt3: Blood!

### DIFF
--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -128,7 +128,7 @@
 				return
 
 			// If the human is losing too much blood, beep.
-			if(((T.vessel.get_reagent_amount("blood")/T.species.blood_volume)*100) < BLOOD_VOLUME_SAFE)
+			if(T.vessel.get_reagent_amount("blood") < T.species.blood_volume*T.species.blood_level_safe)
 				visible_message("\The [src] beeps loudly.")
 
 			var/datum/reagent/B = T.take_blood(beaker,amount)

--- a/code/game/objects/items/devices/defib.dm
+++ b/code/game/objects/items/devices/defib.dm
@@ -332,14 +332,14 @@
 	if(!heart)
 		return TRUE
 
-	var/blood_volume = round((H.vessel.get_reagent_amount("blood")/H.species.blood_volume)*100)
+	var/blood_volume = H.vessel.get_reagent_amount("blood")
 	if(!heart || heart.is_broken())
 		blood_volume *= 0.3
 	else if(heart.is_bruised())
 		blood_volume *= 0.7
 	else if(heart.damage > 1)
 		blood_volume *= 0.8
-	return blood_volume < BLOOD_VOLUME_SURVIVE
+	return blood_volume < H.species.blood_volume*H.species.blood_level_fatal
 
 /obj/item/weapon/shockpaddles/proc/check_charge(var/charge_amt)
 	return 0

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -266,9 +266,11 @@ HALOGEN COUNTER	- Radcount on mobs
 			var/blood_volume = H.vessel.get_reagent_amount("blood")
 			var/blood_percent =  round((blood_volume / H.species.blood_volume)*100)
 			var/blood_type = H.dna.b_type
-			if(blood_percent <= BLOOD_VOLUME_BAD)
+			if(blood_volume <= H.species.blood_volume*H.species.blood_level_danger)
 				dat += "<span class='danger'><i>Warning: Blood Level CRITICAL: [blood_percent]% [blood_volume]cl. Type: [blood_type]</i></span><br>"
-			else if(blood_percent <= BLOOD_VOLUME_SAFE)
+			else if(blood_volume <= H.species.blood_volume*H.species.blood_level_warning)
+				dat += "<span class='danger'><i>Warning: Blood Level VERY LOW: [blood_percent]% [blood_volume]cl. Type: [blood_type]</i></span><br>"
+			else if(blood_volume <= H.species.blood_volume*H.species.blood_level_safe)
 				dat += "<span class='danger'>Warning: Blood Level LOW: [blood_percent]% [blood_volume]cl. Type: [blood_type]</span><br>"
 			else
 				dat += "<span class='notice'>Blood Level Normal: [blood_percent]% [blood_volume]cl. Type: [blood_type]</span><br>"

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1637,8 +1637,8 @@
 		if(species?.flags & NO_BLOOD)
 			bloodtrail = 0
 		else
-			var/blood_volume = round((vessel.get_reagent_amount("blood")/species.blood_volume)*100)
-			if(blood_volume < BLOOD_VOLUME_SURVIVE)
+			var/blood_volume = vessel.get_reagent_amount("blood")
+			if(blood_volume < species?.blood_volume*species?.blood_level_fatal)
 				bloodtrail = 0	//Most of it's gone already, just leave it be
 			else
 				vessel.remove_reagent("blood", 1)

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -1230,14 +1230,14 @@
 		if(blinded)
 			overlay_fullscreen("blind", /obj/screen/fullscreen/blind)
 			throw_alert("blind", /obj/screen/alert/blind)
-		
+
 		else
 			clear_fullscreens()
 			clear_alert("blind")
 
 		if(blinded)
 			overlay_fullscreen("blind", /obj/screen/fullscreen/blind)
-		
+
 		else if(!machine)
 			clear_fullscreens()
 
@@ -1568,7 +1568,7 @@
 	if(Pump)
 		temp += Pump.standard_pulse_level - PULSE_NORM
 
-	if(round(vessel.get_reagent_amount("blood")) <= BLOOD_VOLUME_BAD)	//how much blood do we have
+	if(round(vessel.get_reagent_amount("blood")) <= species.blood_volume*species.blood_level_danger)	//how much blood do we have
 		temp = temp + 3	//not enough :(
 
 	if(status_flags & FAKEDEATH)

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -43,6 +43,10 @@
 	var/short_sighted										// Permanent weldervision.
 	var/blood_volume = 560									// Initial blood volume.
 	var/bloodloss_rate = 1									// Multiplier for how fast a species bleeds out. Higher = Faster
+	var/blood_level_safe = 0.85								//"Safe" blood level; above this, you're OK
+	var/blood_level_warning = 0.75								//"Warning" blood level; above this, you're a bit woozy and will have low-level oxydamage (no more than 20, or 15 with inap)
+	var/blood_level_danger = 0.6								//"Danger" blood level; above this, you'll rapidly take up to 50 oxyloss, and it will then steadily accumulate at a lower rate
+	var/blood_level_fatal = 0.4								//"Fatal" blood level; below this, you take extremely high oxydamage
 	var/hunger_factor = 0.05								// Multiplier for hunger.
 	var/active_regen_mult = 1								// Multiplier for 'Regenerate' power speed, in human_powers.dm
 

--- a/code/modules/organs/blood.dm
+++ b/code/modules/organs/blood.dm
@@ -2,10 +2,13 @@
 				BLOOD SYSTEM
 ****************************************************/
 //Blood levels. These are percentages based on the species blood_volume var.
+//Retained for archival/reference purposes - KK
+/*
 var/const/BLOOD_VOLUME_SAFE =    85
 var/const/BLOOD_VOLUME_OKAY =    75
 var/const/BLOOD_VOLUME_BAD =     60
 var/const/BLOOD_VOLUME_SURVIVE = 40
+*/
 var/const/CE_STABLE_THRESHOLD = 0.5
 
 /mob/living/carbon/human/var/datum/reagents/vessel // Container for blood and BLOOD ONLY. Do not transfer other chems here.
@@ -88,22 +91,22 @@ var/const/CE_STABLE_THRESHOLD = 0.5
 //			dmg_coef = min(1, 10/chem_effects[CE_STABLE]) //TODO: add effect for increased damage
 //			threshold_coef = min(dmg_coef / CE_STABLE_THRESHOLD, 1)
 
-		if(blood_volume >= BLOOD_VOLUME_SAFE)
+		if(blood_volume_raw >= species.blood_volume*species.blood_level_safe)
 			if(pale)
 				pale = 0
 				update_icons_body()
-		else if(blood_volume >= BLOOD_VOLUME_OKAY)
+		else if(blood_volume_raw >= species.blood_volume*species.blood_level_warning)
 			if(!pale)
 				pale = 1
 				update_icons_body()
-				var/word = pick("dizzy","woosey","faint")
-				to_chat(src, "<font color='red'>You feel [word]</font>")
+				var/word = pick("dizzy","woozy","faint","disoriented","unsteady")
+				to_chat(src, "<font color='red'>You feel slightly [word]</font>")
 			if(prob(1))
-				var/word = pick("dizzy","woosey","faint")
+				var/word = pick("dizzy","woozy","faint","disoriented","unsteady")
 				to_chat(src, "<font color='red'>You feel [word]</font>")
 			if(getOxyLoss() < 20 * threshold_coef)
 				adjustOxyLoss(3 * dmg_coef)
-		else if(blood_volume >= BLOOD_VOLUME_BAD)
+		else if(blood_volume_raw >= species.blood_volume*species.blood_level_danger)
 			if(!pale)
 				pale = 1
 				update_icons_body()
@@ -113,13 +116,13 @@ var/const/CE_STABLE_THRESHOLD = 0.5
 			adjustOxyLoss(1 * dmg_coef)
 			if(prob(15))
 				Paralyse(rand(1,3))
-				var/word = pick("dizzy","woosey","faint")
-				to_chat(src, "<font color='red'>You feel extremely [word]</font>")
-		else if(blood_volume >= BLOOD_VOLUME_SURVIVE)
+				var/word = pick("dizzy","woozy","faint","disoriented","unsteady")
+				to_chat(src, "<font color='red'>You feel dangerously [word]</font>")
+		else if(blood_volume_raw >= species.blood_volume*species.blood_level_fatal)
 			adjustOxyLoss(5 * dmg_coef)
 //			adjustToxLoss(3 * dmg_coef)
 			if(prob(15))
-				var/word = pick("dizzy","woosey","faint")
+				var/word = pick("dizzy","woozy","faint","disoriented","unsteady")
 				to_chat(src, "<font color='red'>You feel extremely [word]</font>")
 		else //Not enough blood to survive (usually)
 			if(!pale)
@@ -131,7 +134,7 @@ var/const/CE_STABLE_THRESHOLD = 0.5
 			adjustOxyLoss(75 * dmg_coef) // 15 more than dexp fixes (also more than dex+dexp+tricord)
 
 		// Without enough blood you slowly go hungry.
-		if(blood_volume < BLOOD_VOLUME_SAFE)
+		if(blood_volume_raw < species.blood_volume*species.blood_level_safe)
 			if(nutrition >= 300)
 				adjust_nutrition(-10)
 			else if(nutrition >= 200)

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -512,7 +512,7 @@ This function completely restores a damaged organ to perfect condition.
 
 //Burn damage can cause fluid loss due to blistering and cook-off
 	if((damage > 5 || damage + burn_dam >= 15) && type == BURN && (robotic < ORGAN_ROBOT) && !(species.flags & NO_BLOOD))
-		var/fluid_loss = 0.4 * (damage/(owner.getMaxHealth() - config.health_threshold_dead)) * owner.species.blood_volume*(1 - BLOOD_VOLUME_SURVIVE/100)
+		var/fluid_loss = 0.4 * (damage/(owner.getMaxHealth() - config.health_threshold_dead)) * owner.species.blood_volume*(1 - owner.species.blood_level_fatal)
 		owner.remove_blood(fluid_loss)
 
 	// first check whether we can widen an existing wound


### PR DESCRIPTION
Time to roll up your sleeves, folks! 💉

This offloads constant blood levels to species level vars that allow greater control of thresholds for various symptoms. Want a species that gets woozy earlier but takes damage later? Can do. Want a trait that just makes you more vulnerable to blood loss in general? Go ahead.

Lightly tested to avoid carbons dropping dead on the spot, which did actually happen at one point because I forgot to tweak a couple of comparisons. I might have missed a couple of things though, so I'd appreciate a second or third pair of eyes to check the math changeovers.

Also tweaks the feedback from low blood levels for clarity/flavor.