### PR TITLE
Adds Area-Based Meson Obfuscation

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -49,6 +49,7 @@
 	var/sound_env = STANDARD_STATION
 	var/turf/base_turf //The base turf type of the area, which can be used to override the z-level's base turf
 	var/forbid_events = FALSE // If true, random events will not start inside this area.
+	var/no_spoilers = FALSE // If true, makes it much more difficult to see what is inside an area with things like mesons.
 
 /area/Initialize()
 	. = ..()
@@ -64,6 +65,8 @@
 		power_equip = 0
 		power_environ = 0
 	power_change()		// all machines set to current power level, also updates lighting icon
+	if(no_spoilers)
+		set_spoiler_obfuscation(TRUE)
 	return INITIALIZE_HINT_LATELOAD
 
 // Changes the area of T to A. Do not do this manually.
@@ -356,6 +359,8 @@ var/list/mob/living/forced_ambiance_list = new
 
 	L.lastarea = newarea
 	play_ambience(L)
+	if(no_spoilers)
+		L.disable_spoiler_vision()
 
 /area/proc/play_ambience(var/mob/living/L)
 	// Ambience goes down here -- make sure to list each area seperately for ease of adding things in later, thanks! Note: areas adjacent to each other should have the same sounds to prevent cutoff when possible.- LastyScratch
@@ -489,3 +494,15 @@ var/list/ghostteleportlocs = list()
 	if(secret_name)
 		return "Unknown Area"
 	return name
+
+GLOBAL_DATUM(spoiler_obfuscation_image, /image)
+
+/area/proc/set_spoiler_obfuscation(should_obfuscate)
+	if(!GLOB.spoiler_obfuscation_image)
+		GLOB.spoiler_obfuscation_image = image(icon = 'icons/misc/static.dmi')
+		GLOB.spoiler_obfuscation_image.plane = PLANE_MESONS
+
+	if(should_obfuscate)
+		add_overlay(GLOB.spoiler_obfuscation_image)
+	else
+		cut_overlay(GLOB.spoiler_obfuscation_image)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1647,3 +1647,23 @@
 				var/turf/T = loc
 				T.add_blood(src)
 	. = ..()
+
+// Tries to turn off item-based things that let you see through walls, like mesons.
+// Certain stuff like genetic xray vision is allowed to be kept on.
+/mob/living/carbon/human/disable_spoiler_vision()
+	// Glasses.
+	if(istype(glasses, /obj/item/clothing/glasses))
+		var/obj/item/clothing/glasses/goggles = glasses
+		if(goggles.active && (goggles.vision_flags & (SEE_TURFS|SEE_OBJS)))
+			goggles.toggle_active(src)
+			to_chat(src, span("warning", "Your [goggles.name] have suddenly turned off!"))
+
+	// RIGs.
+	var/obj/item/weapon/rig/rig = get_rig()
+	if(istype(rig) && rig.visor?.active && rig.visor.vision?.glasses)
+		var/obj/item/clothing/glasses/rig_goggles = rig.visor.vision.glasses
+		if(rig_goggles.vision_flags & (SEE_TURFS|SEE_OBJS))
+			rig.visor.deactivate()
+			to_chat(src, span("warning", "\The [rig]'s visor has shuddenly deactivated!"))
+
+	..()

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -1230,14 +1230,14 @@
 		if(blinded)
 			overlay_fullscreen("blind", /obj/screen/fullscreen/blind)
 			throw_alert("blind", /obj/screen/alert/blind)
-		
+
 		else
 			clear_fullscreens()
 			clear_alert("blind")
 
 		if(blinded)
 			overlay_fullscreen("blind", /obj/screen/fullscreen/blind)
-		
+
 		else if(!machine)
 			clear_fullscreens()
 
@@ -1297,6 +1297,11 @@
 	else //We aren't dead
 		sight &= ~(SEE_TURFS|SEE_MOBS|SEE_OBJS)
 		see_invisible = see_in_dark>2 ? SEE_INVISIBLE_LEVEL_ONE : see_invisible_default
+
+		// Do this early so certain stuff gets turned off before vision is assigned.
+		var/area/A = get_area(src)
+		if(A?.no_spoilers)
+			disable_spoiler_vision()
 
 		if(XRAY in mutations)
 			sight |= SEE_TURFS|SEE_MOBS|SEE_OBJS

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -775,10 +775,10 @@ default behaviour is:
 
 	if(pulling) // we were pulling a thing and didn't lose it during our move.
 		var/pull_dir = get_dir(src, pulling)
-		
+
 		if(pulling.anchored || !isturf(pulling.loc))
 			stop_pulling()
-			
+
 		else if(get_dist(src, pulling) > 1 || (moving_diagonally != SECOND_DIAG_STEP && ((pull_dir - 1) & pull_dir))) // puller and pullee more than one tile away or in diagonal position
 			// If it is too far away or across z-levels from old location, stop pulling.
 			if(get_dist(pulling.loc, oldloc) > 1 || pulling.loc.z != oldloc?.z)
@@ -794,7 +794,7 @@ default behaviour is:
 				stop_pulling()
 
 	if(!isturf(loc))
-		return	
+		return
 	else if(lastarea?.has_gravity == 0)
 		inertial_drift()
 	else if(!isspace(loc))
@@ -806,7 +806,7 @@ default behaviour is:
 		if(Process_Spacemove(1))
 			inertia_dir = 0
 			return
-		
+
 		var/locthen = loc
 		spawn(5)
 			if(!anchored && !pulledby && loc == locthen)
@@ -1277,3 +1277,8 @@ default behaviour is:
 		clear_alert("weightless")
 	else
 		throw_alert("weightless", /obj/screen/alert/weightless)
+
+// Tries to turn off things that let you see through walls, like mesons.
+// Each mob does vision a bit differently so this is just for inheritence and also so overrided procs can make the vision apply instantly if they call `..()`.
+/mob/living/proc/disable_spoiler_vision()
+	handle_vision()

--- a/code/modules/mob/living/silicon/robot/life.dm
+++ b/code/modules/mob/living/silicon/robot/life.dm
@@ -153,7 +153,13 @@
 /mob/living/silicon/robot/handle_regular_hud_updates()
 	var/fullbright = FALSE
 	var/seemeson = FALSE
-	if (src.stat == 2 || (XRAY in mutations) || (src.sight_mode & BORGXRAY))
+
+	var/area/A = get_area(src)
+	if(A?.no_spoilers)
+		disable_spoiler_vision()
+
+
+	if (src.stat == DEAD || (XRAY in mutations) || (src.sight_mode & BORGXRAY))
 		src.sight |= SEE_TURFS
 		src.sight |= SEE_MOBS
 		src.sight |= SEE_OBJS
@@ -187,13 +193,14 @@
 		src.sight &= ~SEE_OBJS
 		src.see_in_dark = 8
 		src.see_invisible = SEE_INVISIBLE_NOLIGHTING
-	else if (src.stat != 2)
+	else if (src.stat != DEAD)
 		src.sight &= ~SEE_MOBS
 		src.sight &= ~SEE_TURFS
 		src.sight &= ~SEE_OBJS
 		src.see_in_dark = 8 			 // see_in_dark means you can FAINTLY see in the dark, humans have a range of 3 or so, tajaran have it at 8
 		src.see_invisible = SEE_INVISIBLE_LIVING // This is normal vision (25), setting it lower for normal vision means you don't "see" things like darkness since darkness
 							 // has a "invisible" value of 15
+
 	plane_holder.set_vis(VIS_FULLBRIGHT,fullbright)
 	plane_holder.set_vis(VIS_MESONS,seemeson)
 	..()

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -1099,3 +1099,19 @@
 	if(module_active && istype(module_active,/obj/item/weapon/gripper))
 		var/obj/item/weapon/gripper/G = module_active
 		G.drop_item_nm()
+
+/mob/living/silicon/robot/disable_spoiler_vision()
+	if(sight_mode & (BORGMESON|BORGMATERIAL|BORGXRAY)) // Whyyyyyyyy have seperate defines.
+		var/i = 0
+		// Borg inventory code is very . . interesting and as such, unequiping a specific item requires jumping through some (for) loops.
+		var/current_selection_index = get_selected_module() // Will be 0 if nothing is selected.
+		for(var/thing in list(module_state_1, module_state_2, module_state_3))
+			i++
+			if(istype(thing, /obj/item/borg/sight))
+				var/obj/item/borg/sight/S = thing
+				if(S.sight_mode & (BORGMESON|BORGMATERIAL|BORGXRAY))
+					select_module(i)
+					uneq_active()
+
+		if(current_selection_index) // Select what the player had before if possible.
+			select_module(current_selection_index)


### PR DESCRIPTION
Adds a variable to areas, `no_spoilers`, which makes certain item-based vision effects like meson and material scanners not be able to see inside the area, by overlaying a static-looking layer on top that only people with mesons can see, with a similar appearance as the AI cameranet static.
When inside an area with `no_spoilers`, meson/material scanners of all kinds that I know of will turn off, ranging from glasses to RIGs to borg modules.

This makes it so mazes or other PoIs that want to hide information from the outside can now do so easily. Currently no areas use the variable.

I didn't make it work with thermals since I wasn't sure if that was needed or not, but it can be made to work with thermals later if needed.