### PR TITLE
Fix alerts not being thrown for body temps being too out of range

### DIFF
--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -682,10 +682,13 @@
 			if(bodytemperature >= species.heat_level_2)
 				if(bodytemperature >= species.heat_level_3)
 					burn_dam = HEAT_DAMAGE_LEVEL_3
+					throw_alert("temp", /obj/screen/alert/hot, 3)
 				else
 					burn_dam = HEAT_DAMAGE_LEVEL_2
+					throw_alert("temp", /obj/screen/alert/hot, 2)
 			else
 				burn_dam = HEAT_DAMAGE_LEVEL_1
+				throw_alert("temp", /obj/screen/alert/hot, 1)
 
 		take_overall_damage(burn=burn_dam, used_weapon = "High Body Temperature")
 
@@ -708,6 +711,8 @@
 					cold_dam = COLD_DAMAGE_LEVEL_1
 
 			take_overall_damage(burn=cold_dam, used_weapon = "Low Body Temperature")
+			
+	else clear_alert("temp")
 
 	// Account for massive pressure differences.  Done by Polymorph
 	// Made it possible to actually have something that can protect against high pressure... Done by Errorage. Polymorph now has an axe sticking from his head for his previous hardcoded nonsense!


### PR DESCRIPTION
Specifically for body temperatures to high/cold.
