### PR TITLE
Adds tg-style fast(ish) magazine restocking.

### DIFF
--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -59,7 +59,7 @@
 			if(box.caliber == bullet.caliber && bullet.BB)
 				if (boolets < 1)
 					to_chat(user, "<span class='notice'>You start collecting shells.</span>") // Say it here so it doesn't get said if we don't find anything useful.
-				if(do_after(usr,5,box))
+				if(do_after(user,5,box))
 					if(box.stored_ammo.len >= box.max_ammo) // Double check because these can change during the wait.
 						break
 					if(bullet.loc != floor)

--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -29,8 +29,8 @@
 	set_dir(pick(cardinal)) //spin spent casings
 	update_icon()
 
-/obj/item/ammo_casing/attackby(obj/item/weapon/W as obj, mob/user as mob)
-	if(W.is_screwdriver())
+/obj/item/ammo_casing/attackby(obj/item/I as obj, mob/user as mob)
+	if(I.is_screwdriver())
 		if(!BB)
 			to_chat(user, "<font color='blue'>There is no bullet in the casing to inscribe anything into.</font>")
 			return
@@ -45,6 +45,39 @@
 		else
 			to_chat(user, "<font color='blue'>You inscribe \"[label_text]\" into \the [initial(BB.name)].</font>")
 			BB.name = "[initial(BB.name)] (\"[label_text]\")"
+	else if(istype(I, /obj/item/ammo_magazine) && isturf(loc)) // Mass magazine reloading.
+		var/obj/item/ammo_magazine/box = I
+		if (!box.can_remove_ammo || box.reloading)
+			return ..()
+
+		box.reloading = TRUE
+		var/boolets = 0
+		var/turf/floor = loc
+		for(var/obj/item/ammo_casing/bullet in floor)
+			if(box.stored_ammo.len >= box.max_ammo)
+				break
+			if(box.caliber == bullet.caliber && bullet.BB)
+				if (boolets < 1)
+					to_chat(user, "<span class='notice'>You start collecting shells.</span>") // Say it here so it doesn't get said if we don't find anything useful.
+				if(do_after(usr,5,box))
+					if(box.stored_ammo.len >= box.max_ammo) // Double check because these can change during the wait.
+						break
+					if(bullet.loc != floor)
+						continue
+					bullet.forceMove(box)
+					box.stored_ammo.Add(bullet)
+					box.update_icon()
+					boolets++
+				else
+					break
+
+		if(boolets > 0)
+			to_chat(user, "<span class='notice'>You collect [boolets] shell\s. [box] now contains [box.stored_ammo.len] shell\s.</span>")
+		else
+			to_chat(user, "<span class='warning'>You fail to collect anything!</span>")
+		box.reloading = FALSE
+	else
+		return ..()
 
 /obj/item/ammo_casing/update_icon()
 	if(!BB)
@@ -84,6 +117,7 @@
 	var/initial_ammo = null
 
 	var/can_remove_ammo = TRUE	// Can this thing have bullets removed one-by-one? As of first implementation, only affects smart magazines
+	var/reloading = FALSE		//  Is this magazine being reloaded, currently? - Currently only useful for automatic pickups, ignored by manual reloading.
 
 	var/multiple_sprites = 0
 	//because BYOND doesn't support numbers as keys in associative lists
@@ -115,7 +149,7 @@
 			to_chat(user, "<span class='warning'>[src] is full!</span>")
 			return
 		user.remove_from_mob(C)
-		C.loc = src
+		C.forceMove(src)
 		stored_ammo.Add(C)
 		update_icon()
 	if(istype(W, /obj/item/ammo_magazine/clip))
@@ -131,7 +165,7 @@
 			return
 		var/obj/item/ammo_casing/AC = L.stored_ammo[1] //select the next casing.
 		L.stored_ammo -= AC //Remove this casing from loaded list of the clip.
-		AC.loc = src
+		AC.forceMove(src)
 		stored_ammo.Insert(1, AC) //add it to the head of our magazine's list
 		L.update_icon()
 	playsound(src, 'sound/weapons/flipblade.ogg', 50, 1)

--- a/html/changelogs/forfoxsake - fastmagazines.yml
+++ b/html/changelogs/forfoxsake - fastmagazines.yml
@@ -1,0 +1,6 @@
+author: ForFoxSake
+
+delete-after: True
+
+changes: 
+  - rscadd: "Ported tgstation styled magazine restocking. Hit a bullet on a table or floor with a partially empty magazine to start restocking."


### PR DESCRIPTION
This PR adds tg-style magazine restocking. For the longest time tgstation has had the ability to instantly load a magazine from a pile of bullets lying on the ground.
Personally I feel like this is long over-due for being ported to virtually every branch of modern SS13, individually clicking 7 or more 2x6 pixel sprites to then click on the magazine is a long and tedious process that's fun for no one.

Now, on tgstation and it's derived code-bases the process takes place in a single game tick, which I figured would be undesirable here. To deal with that potential issue I've added a slight delay to the process of adding each bullet to the magazine. It's a small delay, that as far as I can tell, will always be faster than a player actually picking the bullet up. (I'm not gunna say for certain though, maybe someone out there can click things _really really fast_.)
But that should at least make it feel like there's an action taking place, and not that the process is being glossed over.

I've explicitly tested the code with the standard .45 pistol magazine, the .45 speedloader and the top loading 9mm magazine, to ensure that incorrect ammo types can't be snuck into magazines with this method, and that magazines can't be overloaded with this method.  As the code is located in /obj/item/ammo_magazine, almost all ammo containers will function in the same way, with the exception of shotgun shell boxes, since those are regular boxes and not ammo containers.

I am open to suggestions or requests involving this PR, but be aware that I don't check github very often, so please ping me in the discord if my attention is needed.