### PR TITLE
Fixes null grab runtime breaking mob movement

### DIFF
--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -292,7 +292,7 @@
 		// It's just us and another person
 		if(grablist.len == 1)
 			var/mob/M = grablist[1]
-			if(!my_mob.Adjacent(M)) //Oh no, we moved away
+			if(M && !my_mob.Adjacent(M)) //Oh no, we moved away
 				M.Move(pre_move_loc, get_dir(M, pre_move_loc), total_delay) //Have them step towards where we were
 
 		// It's a grab chain


### PR DESCRIPTION
Adds a sanity check to prevent the client move proc from runtiming between setting and clearing the "busy time" between movements. In other words, the proc sets "moving" to 1 to prevent other movement before the current one is finished and having a null in the grablist will runtime the proc before it can set "moving" back to 0, effectively leaving the client locked in that "busy time" for good. fixes #7238