### PR TITLE
Reduces volume of persistent filth

### DIFF
--- a/code/game/objects/effects/decals/Cleanable/tracks.dm
+++ b/code/game/objects/effects/decals/Cleanable/tracks.dm
@@ -46,6 +46,8 @@ var/global/list/image/fluidtrack_cache=list()
 	var/coming_state="blood1"
 	var/going_state="blood2"
 	var/updatedtracks=0
+	persistent = TRUE
+	generic_filth = FALSE
 
 	// dir = id in stack
 	var/list/setdirs=list(

--- a/code/game/objects/effects/decals/cleanable.dm
+++ b/code/game/objects/effects/decals/cleanable.dm
@@ -1,3 +1,10 @@
+/*
+USAGE NOTE
+For decals, the var Persistent = 'has already been saved', and is primarily used to prevent duplicate savings of generic filth (filth.dm).
+This also means 'TRUE' can be used to define a decal as "Do not save at all, even as a generic replacement." if a dirt decal is considered 'too common' to save.
+generic_filth = TRUE means when the decal is saved, it will be switched out for a generic green 'filth' decal.
+*/
+
 /obj/effect/decal/cleanable
 	plane = DIRTY_PLANE
 	var/persistent = FALSE


### PR DESCRIPTION
Specifically disabled footprints from being saved and replaced with pools of green filth, which was the source of a disproportionate amount of filth and making maintenance and its exits absolutely nasty all the time.
If it's still Too Much, further tweaks will be done (Excluding oil pools, fucking with random-spawn dirt tiles etc.) but this is a first test step.

Also added comments to the Cleanable decal file that explains the slightly weird way the vars work, for the benefit of future generations and downstreams.