### PR TITLE
Relocate handle_ambience() to human/life() to reduce CPU usage

### DIFF
--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -72,6 +72,8 @@
 		handle_shock()
 
 		handle_pain()
+		
+		handle_ambience() // Handle re-running ambience to mobs if they've remained in an area.
 
 		handle_medical_side_effects()
 
@@ -1809,6 +1811,13 @@
 		return // Still no brain.
 
 	brain.tick_defib_timer()
+	
+/mob/living/carbon/human/proc/handle_ambience() // If you're in an ambient area and have not moved out of it for x time, we're going to play ambience again to you, to help break up the silence.
+	if(life_tick % 5) // Every 5 seconds, we're going to do the check, to help slow down the number of checks.
+		if(world.time >= (lastareachange + 30 SECONDS)) // Every 30 seconds, we're going to run a 35% chance to play ambience.
+			var/area/A = get_area(src)
+			if(A)
+				A.play_ambience(src)
 
 #undef HUMAN_MAX_OXYLOSS
 #undef HUMAN_CRIT_MAX_OXYLOSS

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -45,9 +45,6 @@
 	//Check if we're on fire
 	handle_fire()
 	
-	// Handle re-running ambience to mobs if they've remained in an area.
-	handle_ambience()
-	
 	//stuff in the stomach
 	handle_stomach()
 
@@ -90,12 +87,6 @@
 
 /mob/living/proc/handle_stomach()
 	return
-
-/mob/living/proc/handle_ambience() // If you're in an ambient area and have not moved out of it for x time, we're going to play ambience again to you, to help break up the silence.
-	if(world.time >= (lastareachange + 30 SECONDS)) // Every 30 seconds, we're going to run a 35% chance to play ambience.
-		var/area/A = get_area(src)
-		if(A)
-			A.play_ambience(src)
 
 /mob/living/proc/update_pulling()
 	if(pulling)


### PR DESCRIPTION
Turns out the /mob/living/Life() being called every second MAY be causing movement/lag issues. If this resolves it, then we know it was this, if not, then there's a further yet-to-be-found cause.
