### PR TITLE
Skip calling handle_ambience() if there is no client assigned

### DIFF
--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -45,8 +45,8 @@
 	//Check if we're on fire
 	handle_fire()
 	
-	// Handle re-running ambience to mobs if they've remained in an area.
-	handle_ambience()
+	if(client)	// Handle re-running ambience to mobs if they've remained in an area, AND have an active client assigned to them.
+		handle_ambience()
 	
 	//stuff in the stomach
 	handle_stomach()


### PR DESCRIPTION
Fixes potential CPU usage issue for EVERY single mob having that call
