### PR TITLE
Disable breaking fragile floor tiles with the crowbar

### DIFF
--- a/code/game/turfs/simulated/floor_attackby.dm
+++ b/code/game/turfs/simulated/floor_attackby.dm
@@ -121,9 +121,9 @@
 		if(broken || burnt)
 			to_chat(user, "<span class='notice'>You remove the broken [flooring.descriptor].</span>")
 			make_plating()
-		else if(flooring.flags & TURF_IS_FRAGILE)
-			to_chat(user, "<span class='danger'>You forcefully pry off the [flooring.descriptor], destroying them in the process.</span>")
-			make_plating()
+		//else if(flooring.flags & TURF_IS_FRAGILE)//Not fucking fun
+		//	to_chat(user, "<span class='danger'>You forcefully pry off the [flooring.descriptor], destroying them in the process.</span>")
+		//	make_plating()
 		else if(flooring.flags & TURF_REMOVE_CROWBAR)
 			to_chat(user, "<span class='notice'>You lever off the [flooring.descriptor].</span>")
 			make_plating(1)

--- a/code/game/turfs/simulated/floor_attackby.dm
+++ b/code/game/turfs/simulated/floor_attackby.dm
@@ -121,10 +121,10 @@
 		if(broken || burnt)
 			to_chat(user, "<span class='notice'>You remove the broken [flooring.descriptor].</span>")
 			make_plating()
-		//else if(flooring.flags & TURF_IS_FRAGILE)//Not fucking fun
-		//	to_chat(user, "<span class='danger'>You forcefully pry off the [flooring.descriptor], destroying them in the process.</span>")
-		//	make_plating()
-		else if(flooring.flags & TURF_REMOVE_CROWBAR)
+		//else if(flooring.flags & TURF_IS_FRAGILE)
+		//	to_chat(user, "<span class='notice'>You pry off the [flooring.descriptor].</span>")
+		//	make_plating(1)
+		else if(flooring.flags & TURF_REMOVE_CROWBAR || TURF_IS_FRAGILE)
 			to_chat(user, "<span class='notice'>You lever off the [flooring.descriptor].</span>")
 			make_plating(1)
 		else


### PR DESCRIPTION
It's not fun, it adds nothing to the gameplay and it isn't clear what breaks and what does. I see seriously zero reasons to keep this.
This include wood and some of the floor in robotics for example.