### PR TITLE
Gives mice non-default melee stats

### DIFF
--- a/code/modules/mob/living/simple_mob/subtypes/animal/passive/mouse.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/passive/mouse.dm
@@ -10,6 +10,8 @@
 
 	maxHealth = 5
 	health = 5
+	melee_damage_lower = 1
+	melee_damage_upper = 3
 
 	movement_cooldown = 1.5
 


### PR DESCRIPTION
Fixes mice having no melee damage stats, meaning they just inherited the default values, which are apparently enough to one-click delete lockers and crates and stuff like that.