### PR TITLE
Accessory colors aren't modified by clothing colors

### DIFF
--- a/code/modules/clothing/under/accessories/accessory.dm
+++ b/code/modules/clothing/under/accessories/accessory.dm
@@ -4,16 +4,17 @@
 	icon = 'icons/obj/clothing/ties.dmi'
 	icon_state = "bluetie"
 	item_state_slots = list(slot_r_hand_str = "", slot_l_hand_str = "")
+	appearance_flags = RESET_COLOR	// Stops has_suit's color from being multiplied onto the accessory
 	slot_flags = SLOT_TIE
 	w_class = ITEMSIZE_SMALL
 	var/slot = ACCESSORY_SLOT_DECOR
-	var/obj/item/clothing/has_suit = null		//the suit the tie may be attached to
-	var/image/inv_overlay = null	//overlay used when attached to clothing.
+	var/obj/item/clothing/has_suit = null		// The suit the tie may be attached to
+	var/image/inv_overlay = null				// Overlay used when attached to clothing.
 	var/image/mob_overlay = null
 	var/overlay_state = null
 	var/concealed_holster = 0
-	var/mob/living/carbon/human/wearer = null //To check if the wearer changes, so species spritesheets change properly.
-	var/list/on_rolled = list()	//used when jumpsuit sleevels are rolled ("rolled" entry) or it's rolled down ("down"). Set to "none" to hide in those states.
+	var/mob/living/carbon/human/wearer = null 	// To check if the wearer changes, so species spritesheets change properly.
+	var/list/on_rolled = list()					// Used when jumpsuit sleevels are rolled ("rolled" entry) or it's rolled down ("down"). Set to "none" to hide in those states.
 	sprite_sheets = list(SPECIES_TESHARI = 'icons/mob/species/seromi/ties.dmi') //Teshari can into webbing, too!
 
 /obj/item/clothing/accessory/Destroy()
@@ -29,6 +30,9 @@
 			inv_overlay = image(icon = icon_override, icon_state = tmp_icon_state, dir = SOUTH)
 		else
 			inv_overlay = image(icon = INV_ACCESSORIES_DEF_ICON, icon_state = tmp_icon_state, dir = SOUTH)
+
+		inv_overlay.color = src.color
+		inv_overlay.appearance_flags = appearance_flags	// Stops has_suit's color from being multiplied onto the accessory
 	return inv_overlay
 
 /obj/item/clothing/accessory/proc/get_mob_overlay()
@@ -65,6 +69,7 @@
 	else
 		mob_overlay.color = src.color
 
+	mob_overlay.appearance_flags = appearance_flags	// Stops has_suit's color from being multiplied onto the accessory
 	return mob_overlay
 
 //when user attached an accessory to S
@@ -72,8 +77,8 @@
 	if(!istype(S))
 		return
 	has_suit = S
-	loc = has_suit
-	has_suit.overlays += get_inv_overlay()
+	src.forceMove(S)
+	has_suit.add_overlay(get_inv_overlay())
 
 	if(user)
 		to_chat(user, "<span class='notice'>You attach \the [src] to \the [has_suit].</span>")
@@ -82,7 +87,7 @@
 /obj/item/clothing/accessory/proc/on_removed(var/mob/user)
 	if(!has_suit)
 		return
-	has_suit.overlays -= get_inv_overlay()
+	has_suit.cut_overlay(get_inv_overlay())
 	has_suit = null
 	if(user)
 		usr.put_in_hands(src)


### PR DESCRIPTION
Tested, it works on mob sprites, but for some reason does _not_ work on inventory sprites, as shown:
![test](https://puu.sh/Gfeoe/75f11c6111.png)

I have no idea why this isn't working for inventory sprites, after diving rather unsuccessfully into the code involved in turning get_inv_overlay() into an actual overlay.

The _old_ behaviour was that of the inventory sprites, applied as well to the worn sprites, wherein the color of the accessory would be multiplied by the color of the clothing it is attached to, such that a pure red cloak (or armband, or what have you), when multiplied by a pure green kimono (or shirt, or what have you), results in the former becoming perfectly black (or in most cases, nearly black/distinctly not the color you're looking for.