### PR TITLE
Allows non-base welders to remove graffiti

### DIFF
--- a/code/modules/persistence/graffiti.dm
+++ b/code/modules/persistence/graffiti.dm
@@ -39,10 +39,10 @@
 	to_chat(user,  "It reads \"[message]\".")
 
 /obj/effect/decal/writing/attackby(var/obj/item/thing, var/mob/user)
-	if(is_hot(thing))
+	if(istype(thing, /obj/item/weapon/weldingtool))
 		var/obj/item/weapon/weldingtool/welder = thing
 		if(welder.isOn() && welder.remove_fuel(0,user) && do_after(user, 5, src) && !QDELETED(src))
-			playsound(src.loc, 'sound/items/Welder2.ogg', 50, 1)
+			playsound(src.loc, welder.usesound, 50, 1)
 			user.visible_message("<span class='notice'>\The [user] clears away some graffiti.</span>")
 			qdel(src)
 	else if(thing.sharp)


### PR DESCRIPTION
Assuming it was intended to only be welders, this was the wrong proc to be checking for it and would've runtimed if someone used like, a lit match or igniter on some graffiti.
Also, for whatever reason there's an untyped is_hot proc that's limited to specific types but returns a temperature value, and a more useful is_hot proc on items, but it only returns true/false. The miracles of ss13