### PR TITLE
Gives NOREACT flag back to fixed microwaves

### DIFF
--- a/code/modules/food/kitchen/microwave.dm
+++ b/code/modules/food/kitchen/microwave.dm
@@ -100,7 +100,7 @@
 				src.icon_state = "mw"
 				src.broken = 0 // Fix it!
 				src.dirty = 0 // just to be sure
-				src.flags = OPENCONTAINER
+				src.flags = OPENCONTAINER | NOREACT
 		else
 			to_chat(user, "<span class='warning'>It's broken!</span>")
 			return 1
@@ -119,7 +119,7 @@
 				src.dirty = 0 // It's clean!
 				src.broken = 0 // just to be sure
 				src.icon_state = "mw"
-				src.flags = OPENCONTAINER
+				src.flags = OPENCONTAINER | NOREACT
 		else //Otherwise bad luck!!
 			to_chat(user, "<span class='warning'>It's dirty!</span>")
 			return 1


### PR DESCRIPTION
So that certain recipes are no longer impossible to make after repairing a dirty/broken microwave.