### PR TITLE
Fix: Prevent planet weather sounds in Transit

### DIFF
--- a/maps/southern_cross/southern_cross_defines.dm
+++ b/maps/southern_cross/southern_cross_defines.dm
@@ -250,8 +250,7 @@
 	expected_z_levels = list(
 		Z_LEVEL_SURFACE,
 		Z_LEVEL_SURFACE_MINE,
-		Z_LEVEL_SURFACE_WILD,
-		Z_LEVEL_TRANSIT
+		Z_LEVEL_SURFACE_WILD
 	)
 
 /obj/effect/step_trigger/teleporter/bridge/east_to_west/Initialize()


### PR DESCRIPTION
This is just a 1 line removal, planet Sif's weather patterns would play on the Transit Z-level. I see that the transit level was considered a part of Sif and I would understand that for the sky turfs, but the sound effects for snow weather and everything else also play in any other location in transit.

As a downstream I've had this removed for a while. I can at least say for certain that this prevents the sounds from playing on transit, but I honestly do not know what else this affects, and I haven't witnessed or heard of any other problems by doing this.