### PR TITLE
Fix Asset Cache Verification - BYOND Bugfix

### DIFF
--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -1158,6 +1158,7 @@ window "mainwindow"
 		anchor1 = none
 		anchor2 = none
 		is-visible = false
+		auto-format = false
 		saved-params = ""
 	elem "hotkey_toggle"
 		type = BUTTON


### PR DESCRIPTION
BYOND is injecting html to load js shims into json files returned by xhr. this will get fixed in a later byond release, but this disables the functionality for the asset cache skin control today.

Fix to be removed once the HTML injection is removed from asset cache (pending a BYOND change).

Virgo PR Here: https://github.com/VOREStation/VOREStation/pull/8691

Bug Report about how this is "intended" http://www.byond.com/forum/post/2602776
