### PR TITLE
Improves mecha strafing

### DIFF
--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -20,6 +20,7 @@
 /obj/mecha
 	name = "Mecha"
 	desc = "Exosuit"
+	description_info = "Alt click to strafe."
 	icon = 'icons/mecha/mecha.dmi'
 	density = 1							//Dense. To raise the heat.
 	opacity = 1							///opaque. Menacing.

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -1917,6 +1917,9 @@
 			else//Everyone else gets the normal noise
 				who << sound('sound/mecha/nominal.ogg',volume=50)
 
+/obj/mecha/AltClick(mob/living/user)
+	if(user == occupant)
+		strafing()
 
 /obj/mecha/verb/view_stats()
 	set name = "View Stats"

--- a/html/changelogs/BlinsKot - strafing.yml
+++ b/html/changelogs/BlinsKot - strafing.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Blinskot
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "You can now alt click to toggle strafing in mechs."


### PR DESCRIPTION
- You can now toggle strafing by alt+clicking your mech, which should be much easier to control mid combat than trying to use the action button.

Ported from TG.