### PR TITLE
Cancelling choosing someone to admin PM won't say "no mob"

### DIFF
--- a/code/modules/admin/verbs/adminpm.dm
+++ b/code/modules/admin/verbs/adminpm.dm
@@ -32,6 +32,8 @@
 		else
 			targets["(No Mob) - [T]"] = T
 	var/target = input(src,"To whom shall we send a message?","Admin PM",null) as null|anything in sortList(targets)
+	if(!target) //Admin canceled
+		return
 	cmd_admin_pm(targets[target],null)
 	feedback_add_details("admin_verb","Admin PM") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 


### PR DESCRIPTION
As per title. Hitting cancel on the "choose person to pm" list (F7?) Will now no longer put a message in chat saying that mob couldn't be found.