### PR TITLE
Stop bots standing around blocking doors

### DIFF
--- a/code/modules/mob/living/bot/bot.dm
+++ b/code/modules/mob/living/bot/bot.dm
@@ -201,6 +201,12 @@
 			else
 				startPatrol()
 		else
+			if(locate(/obj/machinery/door) in loc && !pulledby) //Don't hang around blocking doors, but don't run off if someone tries to pull us through one.
+				var/turf/my_turf = get_turf(src)
+				var/list/can_go = my_turf.CardinalTurfsWithAccess(botcard)
+				if(LAZYLEN(can_go))
+					if(step_towards(src, pick(can_go)))
+						return
 			handleIdle()
 
 /mob/living/bot/proc/handleRegular()

--- a/code/modules/mob/living/bot/bot.dm
+++ b/code/modules/mob/living/bot/bot.dm
@@ -201,7 +201,7 @@
 			else
 				startPatrol()
 		else
-			if(locate(/obj/machinery/door) in loc && !pulledby) //Don't hang around blocking doors, but don't run off if someone tries to pull us through one.
+			if((locate(/obj/machinery/door) in loc) && !pulledby) //Don't hang around blocking doors, but don't run off if someone tries to pull us through one.
 				var/turf/my_turf = get_turf(src)
 				var/list/can_go = my_turf.CardinalTurfsWithAccess(botcard)
 				if(LAZYLEN(can_go))

--- a/html/changelogs/meghan rossi - bots clear doorways.yml
+++ b/html/changelogs/meghan rossi - bots clear doorways.yml
@@ -1,0 +1,4 @@
+author: Meghan Rossi
+delete-after: True
+changes: 
+  - tweak: "Bots that are idle in doorways (including firedoors and blastdoors) will move out of the way."


### PR DESCRIPTION
Idle bots will move out of doorways, including turfs with firedoors or blastdoors.