### PR TITLE
Fix cyborgs not being able to cook

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -430,11 +430,16 @@ var/list/global/slot_flags_enumeration = list(
 	return 1
 
 /obj/item/proc/mob_can_unequip(mob/M, slot, disable_warning = 0)
-	if(!slot) return 0
 	if(!M) return 0
 
 	if(!canremove)
 		return 0
+	
+	if(!slot)
+		if(issilicon(M))
+			return 1 // for stuff in grippers
+		return 0
+	
 	if(!M.slot_is_accessible(slot, src, disable_warning? null : M))
 		return 0
 	return 1

--- a/code/modules/food/kitchen/cooking_machines/_appliance.dm
+++ b/code/modules/food/kitchen/cooking_machines/_appliance.dm
@@ -182,7 +182,7 @@
 
 //Handles all validity checking and error messages for inserting things
 /obj/machinery/appliance/proc/can_insert(var/obj/item/I, var/mob/user)
-	if (istype(I.loc, /mob/living/silicon))
+	if (istype(I, /obj/item/weapon/gripper))
 		return 0
 	else if (istype(I.loc, /obj/item/rig_module))
 		return 0

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -178,7 +178,7 @@ var/list/slot_equipment_priority = list( \
 	if(!I) //If there's nothing to drop, the drop is automatically successful.
 		return 1
 	var/slot = get_inventory_slot(I)
-	return slot && I.mob_can_unequip(src, slot)
+	return I.mob_can_unequip(src, slot)
 
 /mob/proc/get_inventory_slot(obj/item/I)
 	var/slot = 0

--- a/html/changelogs/meghan rossi - borg cooking fix.yml
+++ b/html/changelogs/meghan rossi - borg cooking fix.yml
@@ -1,0 +1,5 @@
+author: Meghan Rossi
+delete-after: True
+changes: 
+  - bugfix: "Cyborgs can now put things into oven dishes with their grippers"
+  - bugfix: "Cyborgs can now put oven dishes in the oven with their grippers"


### PR DESCRIPTION
*Cyborgs can now put oven dishes in the oven with their grippers (if they have a gripper that can hold it, e.g. service borg's grippers)
*Cyborgs can now put things into oven dishes with their grippers