### PR TITLE
Adds metamorphic pint glasses to RSF, autolathe, supply packs

### DIFF
--- a/code/datums/autolathe/general.dm
+++ b/code/datums/autolathe/general.dm
@@ -6,37 +6,48 @@
 	name = "water-cooler bottle"
 	path =/obj/item/weapon/reagent_containers/glass/cooler_bottle
 
-/datum/category_item/autolathe/general/drinkingglass_square
+/datum/category_item/autolathe/general/drinkingglass
+	is_stack = TRUE
+
+/datum/category_item/autolathe/general/drinkingglass/square
 	name = "half-pint glass"
 	path =/obj/item/weapon/reagent_containers/food/drinks/glass2/square
 
-/datum/category_item/autolathe/general/drinkingglass_rocks
+/datum/category_item/autolathe/general/drinkingglass/rocks
 	name = "rocks glass"
 	path =/obj/item/weapon/reagent_containers/food/drinks/glass2/rocks
 
-/datum/category_item/autolathe/general/drinkingglass_shake
+/datum/category_item/autolathe/general/drinkingglass/shake
 	name = "milkshake glass"
 	path =/obj/item/weapon/reagent_containers/food/drinks/glass2/shake
 
-/datum/category_item/autolathe/general/drinkingglass_cocktail
+/datum/category_item/autolathe/general/drinkingglass/cocktail
 	name = "cocktail glass"
 	path =/obj/item/weapon/reagent_containers/food/drinks/glass2/cocktail
 
-/datum/category_item/autolathe/general/drinkingglass_shot
+/datum/category_item/autolathe/general/drinkingglass/shot
 	name = "shot glass"
 	path =/obj/item/weapon/reagent_containers/food/drinks/glass2/shot
 
-/datum/category_item/autolathe/general/drinkingglass_pint
+/datum/category_item/autolathe/general/drinkingglass/pint
 	name = "pint glass"
 	path =/obj/item/weapon/reagent_containers/food/drinks/glass2/pint
 
-/datum/category_item/autolathe/general/drinkingglass_mug
+/datum/category_item/autolathe/general/drinkingglass/mug
 	name = "glass mug"
 	path =/obj/item/weapon/reagent_containers/food/drinks/glass2/mug
 
-/datum/category_item/autolathe/general/drinkingglass_wine
+/datum/category_item/autolathe/general/drinkingglass/wine
 	name = "wine glass"
 	path =/obj/item/weapon/reagent_containers/food/drinks/glass2/wine
+
+/datum/category_item/autolathe/general/drinkingglass/metaglass
+	name = "metamorphic glass"
+	path =/obj/item/weapon/reagent_containers/food/drinks/metaglass
+
+/datum/category_item/autolathe/general/drinkingglass/metaglass/metapint
+	name = "metamorphic pint glass"
+	path =/obj/item/weapon/reagent_containers/food/drinks/metaglass/metapint
 
 /datum/category_item/autolathe/general/flashlight
 	name = "flashlight"

--- a/code/datums/supplypacks/hospitality.dm
+++ b/code/datums/supplypacks/hospitality.dm
@@ -38,6 +38,7 @@
 			/obj/item/weapon/storage/box/glasses/shot,
 			/obj/item/weapon/storage/box/glasses/mug,
 			/obj/item/weapon/storage/box/glasses/meta,
+			/obj/item/weapon/storage/box/glasses/meta/metapint,
 			/obj/item/weapon/reagent_containers/food/drinks/shaker,
 			/obj/item/weapon/storage/box/glass_extras/straws,
 			/obj/item/weapon/storage/box/glass_extras/sticks

--- a/code/game/objects/items/weapons/RSF.dm
+++ b/code/game/objects/items/weapons/RSF.dm
@@ -19,6 +19,7 @@ RSF
 
 	var/list/container_types = list(
 		"metamorphic glass" = /obj/item/weapon/reagent_containers/food/drinks/metaglass,
+		"metamorphic pint glass" = /obj/item/weapon/reagent_containers/food/drinks/metaglass/metapint,
 		"half-pint glass" = /obj/item/weapon/reagent_containers/food/drinks/glass2/square,
 		"rocks glass" = /obj/item/weapon/reagent_containers/food/drinks/glass2/rocks,
 		"milkshake glass" = /obj/item/weapon/reagent_containers/food/drinks/glass2/shake,

--- a/code/modules/food/drinkingglass/glass_boxes.dm
+++ b/code/modules/food/drinkingglass/glass_boxes.dm
@@ -13,6 +13,7 @@
 		new /obj/item/weapon/reagent_containers/food/drinks/glass2/mug(src)
 		new /obj/item/weapon/reagent_containers/food/drinks/glass2/wine(src)
 		new /obj/item/weapon/reagent_containers/food/drinks/metaglass(src)
+		new /obj/item/weapon/reagent_containers/food/drinks/metaglass/metapint(src)
 
 /obj/item/weapon/storage/box/glasses
 	name = "box of glasses"
@@ -59,6 +60,10 @@
 /obj/item/weapon/storage/box/glasses/meta
 	name = "box of half-pint metamorphic glasses"
 	glass_type = /obj/item/weapon/reagent_containers/food/drinks/metaglass
+
+/obj/item/weapon/storage/box/glasses/meta/metapint
+	name = "box of metamorphic pint glasses"
+	glass_type = /obj/item/weapon/reagent_containers/food/drinks/metaglass/metapint
 
 /obj/item/weapon/storage/box/glass_extras
 	name = "box of cocktail garnishings"

--- a/html/changelogs/meghan rossi - metapint.yml
+++ b/html/changelogs/meghan rossi - metapint.yml
@@ -1,0 +1,7 @@
+author: Meghan Rossi
+delete-after: True
+changes: 
+  - rscadd: "The rapid service fabricator (found on service borgs) can now produce metamorphic pint glasses."
+  - rscadd: "The party supplies and bar supplies crates orderable from cargo now contain metamorphic pint glasses."
+  - rscadd: "The autolathe can now produce metamorphic pint and half-pint glasses."
+  - rscadd: "The autolathe can now produce all drinking glasses in batches of 5 or 10."


### PR DESCRIPTION
*The rapid service fabricator (found on service borgs) can now produce metamorphic pint glasses.
*The party supplies and bar supplies crates orderable from cargo now contain metamorphic pint glasses.
*The autolathe can now produce metamorphic pint and half-pint glasses.
*The autolathe can now produce all drinking glasses in batches of 5 or 10.