### PR TITLE
Ghost sechud verb, shift-click examine, alt-click turf tab

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -255,12 +255,15 @@
 /atom/proc/AltClick(var/mob/user)
 	var/turf/T = get_turf(src)
 	if(T && user.TurfAdjacent(T))
-		if(user.listed_turf == T)
-			user.listed_turf = null
-		else
-			user.listed_turf = T
-			user.client.statpanel = "Turf"
+		user.ToggleTurfTab(T)
 	return 1
+	
+/mob/proc/ToggleTurfTab(var/turf/T)
+	if(listed_turf == T)
+		listed_turf = null
+	else
+		listed_turf = T
+		client.statpanel = "Turf"
 
 /mob/proc/TurfAdjacent(var/turf/T)
 	return T.AdjacentQuick(src)

--- a/code/_onclick/observer.dm
+++ b/code/_onclick/observer.dm
@@ -33,6 +33,15 @@
 		return
 	if(!checkClickCooldown()) return
 	setClickCooldown(4)
+	var/list/modifiers = params2list(params)
+	if(modifiers["shift"])
+		examinate(A)
+		return
+	if(modifiers["alt"]) // alt and alt-gr (rightalt)
+		var/turf/T = get_turf(A)
+		if(T && TurfAdjacent(T))
+			ToggleTurfTab(T)
+			return
 	// You are responsible for checking config.ghost_interaction when you override this function
 	// Not all of them require checking, see below
 	A.attack_ghost(src)

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -24,6 +24,7 @@
 							//Note that this is not a reliable way to determine if admins started as observers, since they change mobs a lot.
 	var/has_enabled_antagHUD = 0
 	var/medHUD = 0
+	var/secHUD = 0
 	var/antagHUD = 0
 	universal_speak = 1
 	var/atom/movable/following = null
@@ -284,6 +285,19 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	plane_holder.set_vis(VIS_CH_HEALTH, medHUD)
 	plane_holder.set_vis(VIS_CH_STATUS_OOC, medHUD)
 	to_chat(src, "<font color='blue'><B>Medical HUD [medHUD ? "Enabled" : "Disabled"]</B></font>")
+
+/mob/observer/dead/verb/toggle_secHUD()
+	set category = "Ghost"
+	set name = "Toggle Security HUD"
+	set desc = "Toggles Security HUD allowing you to see people's displayed ID's job, wanted status, etc"
+
+	secHUD = !secHUD
+	plane_holder.set_vis(VIS_CH_ID, secHUD)
+	plane_holder.set_vis(VIS_CH_WANTED, secHUD)
+	plane_holder.set_vis(VIS_CH_IMPTRACK, secHUD)
+	plane_holder.set_vis(VIS_CH_IMPLOYAL, secHUD)
+	plane_holder.set_vis(VIS_CH_IMPCHEM, secHUD)
+	to_chat(src, "<font color='blue'><B>Security HUD [secHUD ? "Enabled" : "Disabled"]</B></font>")
 
 /mob/observer/dead/verb/toggle_antagHUD()
 	set category = "Ghost"

--- a/html/changelogs/Meghan Rossi - ghostqol.yml
+++ b/html/changelogs/Meghan Rossi - ghostqol.yml
@@ -1,0 +1,6 @@
+author: Meghan Rossi
+delete-after: True
+changes: 
+  - rscadd: "Ghosts now have a toggleable security HUD.  Use the "Toggle Security HUD" verb in the ghost tab to enable it"
+  - rscadd: "Ghosts can now shift-click things to examine them."
+  - rscadd: "Ghosts can now alt-click adjacent things to open the turf tab."


### PR DESCRIPTION
*Ghosts now have a toggleable security HUD.  Use the "Toggle Security HUD" verb in the ghost tab to enable it.
*Ghosts can now shift-click things to examine them.
*Ghosts can now alt-click adjacent things to open the turf tab.