### PR TITLE
Disables Swarmer Drones

### DIFF
--- a/code/modules/gamemaster/event2/events/security/swarm_boarder.dm
+++ b/code/modules/gamemaster/event2/events/security/swarm_boarder.dm
@@ -5,6 +5,7 @@
 	departments = list(DEPARTMENT_EVERYONE, DEPARTMENT_SECURITY, DEPARTMENT_ENGINEERING)
 	chaos = 60
 	chaotic_threshold = EVENT_CHAOS_THRESHOLD_HIGH_IMPACT
+	enabled = FALSE // Turns out they are in fact grossly OP.
 	var/safe_for_extended = FALSE
 
 /datum/event2/meta/swarm_boarder/get_weight()


### PR DESCRIPTION
I actually forgot to do this before the event system went permanently live so that's on me.
Anyways this turns off swarmer drones from being able to be picked by the GM system, since right now they're, to put it charitably, poorly balanced and implemented (being super-maint drones is very clunky to me but thats not the main thing).
When the GM system spawns one in, it tends to result in a ghost becoming the drone, then that player essentially never being able to lose due to infinite re-tries and the crew has to fight off drones for the rest of the round or until they or the drone gets bored.
There's been quite a few number of rounds that have devolved due to them so for now it's probably best to turn them off for the time being.