### PR TITLE
Prevent acid glands from melting non-simulated turfs

### DIFF
--- a/code/modules/mob/living/carbon/human/species/xenomorphs/alien_powers.dm
+++ b/code/modules/mob/living/carbon/human/species/xenomorphs/alien_powers.dm
@@ -173,6 +173,8 @@
 			if(F.flooring && (F.flooring.flags & TURF_ACID_IMMUNE))
 */
 			cannot_melt = 1
+		else
+			cannot_melt = 1
 
 	if(cannot_melt)
 		to_chat(src, "<span class='alium'>You cannot dissolve this object.</span>")


### PR DESCRIPTION
These are generally not intended to be destroyed and usually turn directly into space turfs regardless of location. If anyone can think of any non-simulated turfs that xenos should be able to melt through, please mention it. Acid already doesn't function on mineral turfs.