### PR TITLE
Enables passtable for cleanbots

### DIFF
--- a/code/modules/mob/living/bot/cleanbot.dm
+++ b/code/modules/mob/living/bot/cleanbot.dm
@@ -4,6 +4,7 @@
 	icon_state = "cleanbot0"
 	req_one_access = list(access_robotics, access_janitor)
 	botcard_access = list(access_janitor)
+	pass_flags = PASSTABLE
 
 	locked = 0 // Start unlocked so roboticist can set them to patrol.
 	wait_if_pulled = 1


### PR DESCRIPTION
One of the most common reasons behind cleanbots getting stuck in stupid places is because they went after some mess underneath table/rack/railing/whatever without ever getting to reach it.