### PR TITLE
Fix combinination_cook() creating items with no reagents

### DIFF
--- a/code/modules/food/kitchen/cooking_machines/_appliance.dm
+++ b/code/modules/food/kitchen/cooking_machines/_appliance.dm
@@ -480,7 +480,8 @@
 	CI.container.reagents.trans_to_holder(buffer, CI.container.reagents.total_volume)
 
 	var/obj/item/weapon/reagent_containers/food/snacks/result = new cook_path(CI.container)
-	buffer.trans_to(result, buffer.total_volume)
+	buffer.trans_to_holder(result.reagents, buffer.total_volume) //trans_to doesn't handle food items well, so
+																 //just call trans_to_holder instead
 
 	//Filling overlay
 	var/image/I = image(result.icon, "[result.icon_state]_filling")


### PR DESCRIPTION
This branch just changes combination_cook() to apply the total reagents directly to the datum of the created food. Should make it so the cereal maker, candy machine and custom oven options all work properly now. Fixes #7549