### PR TITLE
Improves Portal Documentation for New Mappers unfamiliar with DIR

### DIFF
--- a/code/game/objects/effects/map_effects/portal.dm
+++ b/code/game/objects/effects/map_effects/portal.dm
@@ -9,6 +9,11 @@ Portals do have some specific requirements when mapping them in;
 	- There must by one, and only one `/obj/effect/map_effect/portal/master` for each side of a portal.
 	- Both sides need to have matching `portal_id`s in order to link to each other.
 	- Each side must face opposite directions, e.g. if side A faces SOUTH, side B must face NORTH.
+	- Clarification on the above - you will be moved in the direction that the portal faces.
+	  If Side A faces south, you will be moved south. Dirs are 1/2/4/8, 1: NORTH, 2: SOUTH, 4: EAST, 8: WEST.
+	  To further explain: If your cave entrance is on the NORTH side of the map on ENTRY side, and SOUTH side on EXIT side:
+	  You will need to set the ENTRY side's dir to 2, IE SOUTH, as that's the direction you will moving coming FROM the EXIT side.
+	  IE: Directions should be set based on the direction of travel.
 	- Each side must have the same orientation, e.g. horizontal on both sides, or vertical on both sides.
 	- Portals can be made to be longer than 1x1 with `/obj/effect/map_effect/portal/line`s,
 	  but both sides must have the same length.


### PR DESCRIPTION
This isn't really needed, but more of a safety thing. I could not puzzle out the "opposite directions" until I checked the code and realized the portals forcemove you in the DIR it's facing. Therefore, if the portal was facing north, but the north is outside the map, it'd runtime.

This documentation should help new mappers, even if it is a bit 'dumbed down'.
