### PR TITLE
[Untested] Emotes won't be foiled by pesky capitals

### DIFF
--- a/code/modules/mob/living/carbon/alien/emote.dm
+++ b/code/modules/mob/living/carbon/alien/emote.dm
@@ -6,6 +6,7 @@
 		act = copytext(act, 1, t1)
 
 	var/muzzled = is_muzzled()
+	act = lowertext(act)
 
 	switch(act)
 		if("sign")


### PR DESCRIPTION
If an asterisk is found at the beginning of a message (so any emote, basically), the text after it will get lowercased.