### PR TITLE
Actually adds (and TESTS) exclude_mobs parameter to visible_message

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -472,12 +472,14 @@
 // Use for objects performing visible actions
 // message is output to anyone who can see, e.g. "The [src] does something!"
 // blind_message (optional) is what blind people will hear e.g. "You hear something!"
-/atom/proc/visible_message(var/message, var/blind_message)
+/atom/proc/visible_message(var/message, var/blind_message, var/list/exclude_mobs = null)
 
 	var/list/see = get_mobs_and_objs_in_view_fast(get_turf(src),world.view,remote_ghosts = FALSE)
 
 	var/list/seeing_mobs = see["mobs"]
 	var/list/seeing_objs = see["objs"]
+	if(LAZYLEN(exclude_mobs))
+		seeing_mobs -= exclude_mobs
 
 	for(var/obj in seeing_objs)
 		var/obj/O = obj

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -76,24 +76,14 @@
 // message is the message output to anyone who can see e.g. "[src] does something!"
 // self_message (optional) is what the src mob sees  e.g. "You do something!"
 // blind_message (optional) is what blind people will hear e.g. "You hear something!"
-/mob/visible_message(var/message, var/self_message, var/blind_message)
-
-	var/list/see = get_mobs_and_objs_in_view_fast(get_turf(src),world.view,remote_ghosts = FALSE)
-
-	var/list/seeing_mobs = see["mobs"]
-	var/list/seeing_objs = see["objs"]
-
-	for(var/obj in seeing_objs)
-		var/obj/O = obj
-		O.show_message(message, 1, blind_message, 2)
-	for(var/mob in seeing_mobs)
-		var/mob/M = mob
-		if(self_message && M == src)
-			M.show_message( self_message, 1, blind_message, 2)
-		else if(M.see_invisible >= invisibility && MOB_CAN_SEE_PLANE(M, plane))
-			M.show_message(message, 1, blind_message, 2)
-		else if(blind_message)
-			M.show_message(blind_message, 2)
+/mob/visible_message(var/message, var/self_message, var/blind_message, var/list/exclude_mobs = null)
+	if(self_message)
+		if(LAZYLEN(exclude_mobs))
+			exclude_mobs |= src
+		else
+			exclude_mobs = list(src)
+		src.show_message(self_message, 1, blind_message, 2)
+	. = ..()
 
 // Returns an amount of power drawn from the object (-1 if it's not viable).
 // If drain_check is set it will not actually drain power, just return a value.

--- a/code/modules/multiz/zshadow.dm
+++ b/code/modules/multiz/zshadow.dm
@@ -114,10 +114,10 @@
 		shadow.set_dir(new_dir)
 
 // Transfer messages about what we are doing to upstairs
-/mob/visible_message(var/message, var/self_message, var/blind_message)
+/mob/visible_message(var/message, var/self_message, var/blind_message, var/list/exclude_mobs = null)
 	. = ..()
 	if(shadow)
-		shadow.visible_message(message, self_message, blind_message)
+		shadow.visible_message(message, self_message, blind_message, exclude_mobs)
 
 /mob/zshadow/set_typing_indicator(var/state)
 	if(!typing_indicator)


### PR DESCRIPTION
Fixes runtime:
![runtime](https://puu.sh/Gl3Jb/f03f26e8c9.png)

Tested.
Refactored `/mob/visible_message()` to not be copy-pasta of `/atom/proc/visible_message()` with a tiny bit added for self_message