### PR TITLE
Ladders respect Move Up/Down paradigm

### DIFF
--- a/code/modules/multiz/movement.dm
+++ b/code/modules/multiz/movement.dm
@@ -37,6 +37,11 @@
 		forceMove(destination)
 		return 1
 
+	var/obj/structure/ladder/ladder = locate() in start.contents
+	if((direction == UP ? ladder?.target_up : ladder?.target_down) && (ladder?.allowed_directions & direction))
+		if(src.may_climb_ladders(ladder))
+			return ladder.climbLadder(src, (direction == UP ? ladder.target_up : ladder.target_down))
+
 	if(!start.CanZPass(src, direction))
 		to_chat(src, "<span class='warning'>\The [start] is in the way.</span>")
 		return 0
@@ -46,35 +51,39 @@
 		return 0
 
 	var/area/area = get_area(src)
-	if(direction == UP && area.has_gravity() && !can_overcome_gravity())
-		var/obj/structure/lattice/lattice = locate() in destination.contents
-		var/obj/structure/catwalk/catwalk = locate() in destination.contents
-		if(lattice)
-			var/pull_up_time = max(5 SECONDS + (src.movement_delay() * 10), 1)
-			to_chat(src, "<span class='notice'>You grab \the [lattice] and start pulling yourself upward...</span>")
-			destination.audible_message("<span class='notice'>You hear something climbing up \the [lattice].</span>")
-			if(do_after(src, pull_up_time))
-				to_chat(src, "<span class='notice'>You pull yourself up.</span>")
+	if(area.has_gravity() && !can_overcome_gravity())
+		if(direction == UP)
+			var/obj/structure/lattice/lattice = locate() in destination.contents
+			var/obj/structure/catwalk/catwalk = locate() in destination.contents
+
+			if(lattice)
+				var/pull_up_time = max(5 SECONDS + (src.movement_delay() * 10), 1)
+				to_chat(src, "<span class='notice'>You grab \the [lattice] and start pulling yourself upward...</span>")
+				destination.audible_message("<span class='notice'>You hear something climbing up \the [lattice].</span>")
+				if(do_after(src, pull_up_time))
+					to_chat(src, "<span class='notice'>You pull yourself up.</span>")
+				else
+					to_chat(src, "<span class='warning'>You gave up on pulling yourself up.</span>")
+					return 0
+
+			else if(catwalk?.hatch_open)
+				var/pull_up_time = max(5 SECONDS + (src.movement_delay() * 10), 1)
+				to_chat(src, "<span class='notice'>You grab the edge of \the [catwalk] and start pulling yourself upward...</span>")
+				var/old_dest = destination
+				destination = get_step(destination, dir) // mob's dir
+				if(!destination?.Enter(src, old_dest))
+					to_chat(src, "<span class='notice'>There's something in the way up above in that direction, try another.</span>")
+					return 0
+				destination.audible_message("<span class='notice'>You hear something climbing up \the [catwalk].</span>")
+				if(do_after(src, pull_up_time))
+					to_chat(src, "<span class='notice'>You pull yourself up.</span>")
+				else
+					to_chat(src, "<span class='warning'>You gave up on pulling yourself up.</span>")
+					return 0
+
 			else
-				to_chat(src, "<span class='warning'>You gave up on pulling yourself up.</span>")
+				to_chat(src, "<span class='warning'>Gravity stops you from moving upward.</span>")
 				return 0
-		else if(catwalk?.hatch_open)
-			var/pull_up_time = max(5 SECONDS + (src.movement_delay() * 10), 1)
-			to_chat(src, "<span class='notice'>You grab the edge of \the [catwalk] and start pulling yourself upward...</span>")
-			var/old_dest = destination
-			destination = get_step(destination, dir) // mob's dir
-			if(!destination?.Enter(src, old_dest))
-				to_chat(src, "<span class='notice'>There's something in the way up above in that direction, try another.</span>")
-				return 0
-			destination.audible_message("<span class='notice'>You hear something climbing up \the [catwalk].</span>")
-			if(do_after(src, pull_up_time))
-				to_chat(src, "<span class='notice'>You pull yourself up.</span>")
-			else
-				to_chat(src, "<span class='warning'>You gave up on pulling yourself up.</span>")
-				return 0
-		else
-			to_chat(src, "<span class='warning'>Gravity stops you from moving upward.</span>")
-			return 0
 
 	for(var/atom/A in destination)
 		if(!A.CanPass(src, start, 1.5, 0))

--- a/code/modules/multiz/structures.dm
+++ b/code/modules/multiz/structures.dm
@@ -52,16 +52,7 @@
 		to_chat(M, "<span class='notice'>You fail to reach \the [src].</span>")
 		return
 
-	var/direction = target_ladder == target_up ? "up" : "down"
-
-	M.visible_message("<span class='notice'>\The [M] begins climbing [direction] \the [src]!</span>",
-	"You begin climbing [direction] \the [src]!",
-	"You hear the grunting and clanging of a metal ladder being used.")
-
-	target_ladder.audible_message("<span class='notice'>You hear something coming [direction] \the [src]</span>")
-
-	if(do_after(M, climb_time, src))
-		climbLadder(M, target_ladder)
+	climbLadder(M, target_ladder)
 
 /obj/structure/ladder/attack_ghost(var/mob/M)
 	var/target_ladder = getTargetLadder(M)
@@ -105,13 +96,21 @@
 /mob/observer/ghost/may_climb_ladders(var/ladder)
 	return TRUE
 
-/obj/structure/ladder/proc/climbLadder(var/mob/M, var/target_ladder)
-	var/turf/T = get_turf(target_ladder)
-	for(var/atom/A in T)
-		if(!A.CanPass(M, M.loc, 1.5, 0))
-			to_chat(M, "<span class='notice'>\The [A] is blocking \the [src].</span>")
-			return FALSE
-	return M.Move(T)
+/obj/structure/ladder/proc/climbLadder(var/mob/M, var/obj/target_ladder)
+	var/direction = (target_ladder == target_up ? "up" : "down")
+	M.visible_message("<span class='notice'>\The [M] begins climbing [direction] \the [src]!</span>",
+		"You begin climbing [direction] \the [src]!",
+		"You hear the grunting and clanging of a metal ladder being used.")
+
+	target_ladder.audible_message("<span class='notice'>You hear something coming [direction] \the [src]</span>")
+
+	if(do_after(M, climb_time, src))
+		var/turf/T = get_turf(target_ladder)
+		for(var/atom/A in T)
+			if(!A.CanPass(M, M.loc, 1.5, 0))
+				to_chat(M, "<span class='notice'>\The [A] is blocking \the [src].</span>")
+				return FALSE
+		return M.Move(T)
 
 /obj/structure/ladder/CanPass(obj/mover, turf/source, height, airflow)
 	return airflow || !density

--- a/html/changelogs/atermonera - move updown.yml
+++ b/html/changelogs/atermonera - move updown.yml
@@ -1,0 +1,4 @@
+author: Atermonera
+delete-after: True
+changes: 
+  - tweak: "You can use Move Up/Down to traverse ladders No popup "Which way do you want to go?" windows required for bidirectional ladders!."


### PR DESCRIPTION
Tested, works.
Ladders take precendence over just jumping down because a) safety's important kids b) jumping next to a thing that you might bump into sounds like a pretty bad idea and mostly c) it needed to precede the can_move checks because those see a hard floor and say "Nah, you don't go that way".
Part 1/many on Of Mobs and Multi-Z