### PR TITLE
Makes borg cell replacement take priority over petting

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -673,9 +673,26 @@
 
 	add_fingerprint(user)
 
+	if(opened && !wiresexposed && (!istype(user, /mob/living/silicon)))
+		var/datum/robot_component/cell_component = components["power cell"]
+		if(cell)
+			cell.update_icon()
+			cell.add_fingerprint(user)
+			user.put_in_active_hand(cell)
+			to_chat(user, "You remove \the [cell].")
+			cell = null
+			cell_component.wrapped = null
+			cell_component.installed = 0
+			updateicon()
+		else if(cell_component.installed == -1)
+			cell_component.installed = 0
+			var/obj/item/broken_device = cell_component.wrapped
+			to_chat(user, "You remove \the [broken_device].")
+			user.put_in_active_hand(broken_device)
+
 	if(istype(user,/mob/living/carbon/human))
 		var/mob/living/carbon/human/H = user
-		//Adding borg petting.  Help intent pets, Disarm intent taps, Grab should remove the battery for replacement, and Harm is punching(no damage)
+		//Adding borg petting.  Help intent pets, Disarm intent taps and Harm is punching(no damage)
 		switch(H.a_intent)
 			if(I_HELP)
 				visible_message("<span class='notice'>[H] pets [src].</span>")
@@ -695,23 +712,6 @@
 				visible_message("<span class='warning'>[H] taps [src].</span>")
 				return
 		//Addition of borg petting end
-
-	if(opened && !wiresexposed && (!istype(user, /mob/living/silicon)))
-		var/datum/robot_component/cell_component = components["power cell"]
-		if(cell)
-			cell.update_icon()
-			cell.add_fingerprint(user)
-			user.put_in_active_hand(cell)
-			to_chat(user, "You remove \the [cell].")
-			cell = null
-			cell_component.wrapped = null
-			cell_component.installed = 0
-			updateicon()
-		else if(cell_component.installed == -1)
-			cell_component.installed = 0
-			var/obj/item/broken_device = cell_component.wrapped
-			to_chat(user, "You remove \the [broken_device].")
-			user.put_in_active_hand(broken_device)
 
 //Robots take half damage from basic attacks.
 /mob/living/silicon/robot/attack_generic(var/mob/user, var/damage, var/attack_message)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -690,7 +690,7 @@
 			to_chat(user, "You remove \the [broken_device].")
 			user.put_in_active_hand(broken_device)
 
-	if(istype(user,/mob/living/carbon/human))
+	if(istype(user,/mob/living/carbon/human) && !opened)
 		var/mob/living/carbon/human/H = user
 		//Adding borg petting.  Help intent pets, Disarm intent taps and Harm is punching(no damage)
 		switch(H.a_intent)


### PR DESCRIPTION
Because its dumb that fluff interactions override important ones in such obtuse ways. Should be other way around. Now if their cover is open any hand interaction takes out the cell properly. 