### PR TITLE
Fix doppler array iconstates

### DIFF
--- a/code/game/machinery/doppler_array.dm
+++ b/code/game/machinery/doppler_array.dm
@@ -45,10 +45,7 @@ var/list/doppler_arrays = list()
 
 /obj/machinery/doppler_array/power_change()
 	..()
-	if(stat & BROKEN)
-		icon_state = "[initial(icon_state)]-broken"
+	if(!(stat & NOPOWER))
+		icon_state = initial(icon_state)
 	else
-		if(!(stat & NOPOWER))
-			icon_state = initial(icon_state)
-		else
-			icon_state = "[initial(icon_state)]-off"
+		icon_state = "[initial(icon_state)]_off"


### PR DESCRIPTION
There is no doppler-broken state, and the off state uses an underscore, not a hyphen
