### PR TITLE
Reverts #7560, Adds Proper check to syringes.dm and flora.dm for borgs

### DIFF
--- a/code/_onclick/cyborg.dm
+++ b/code/_onclick/cyborg.dm
@@ -72,8 +72,6 @@
 
 		W.attack_self(src)
 		return
-	if(A.type==/obj/structure/flora/pottedplant || A.parent_type==/obj/structure/flora/pottedplant)
-		return
 
 	// cyborgs are prohibited from using storage items so we can I think safely remove (A.loc in contents)
 	if(A == loc || (A in loc) || (A in contents))

--- a/code/game/objects/structures/flora/flora.dm
+++ b/code/game/objects/structures/flora/flora.dm
@@ -233,6 +233,9 @@
 		. += "<span class='filter_notice'><i>You can see something in there...</i></span>"
 
 /obj/structure/flora/pottedplant/attackby(obj/item/I, mob/user)
+	if(issilicon(user))
+		return // Don't try to put modules in here, you're a borg. TODO: Inventory refactor to not be ass.
+	
 	if(stored_item)
 		to_chat(user, "<span class='notice'>[I] won't fit in. There already appears to be something in here...</span>")
 		return

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -64,7 +64,7 @@
 		to_chat(user, "<span class='warning'>This syringe is broken!</span>")
 		return
 
-	if(user.a_intent == I_HURT && ismob(target) && !isrobot(user))
+	if(user.a_intent == I_HURT && ismob(target))
 		if((CLUMSY in user.mutations) && prob(50))
 			target = user
 		syringestab(target, user)
@@ -298,7 +298,8 @@
 	var/trans = reagents.trans_to_mob(target, syringestab_amount_transferred, CHEM_BLOOD)
 	if(isnull(trans)) trans = 0
 	add_attack_logs(user,target,"Stabbed with [src.name] containing [contained], trasferred [trans] units")
-	break_syringe(target, user)
+	if(!issilicon(user))
+		break_syringe(target, user)
 
 /obj/item/weapon/reagent_containers/syringe/proc/break_syringe(mob/living/carbon/target, mob/living/carbon/user)
 	desc += " It is broken."


### PR DESCRIPTION
ACTUALLY fixes problems with borgs permanently breaking their syringes and being able to put modules into potted plants, which causes unwanted fuckery.

Reverts #7560
