### PR TITLE
Adds ENGINE_MAP to example config

### DIFF
--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -536,3 +536,6 @@ ENABLE_NIGHT_SHIFTS
 # ALLOW_BYOND_LINKS
 # ALLOW_DISCORD_LINKS
 ALLOW_URL_LINKS
+
+# Control which submaps are loaded for the Dynamic Engine system
+ENGINE_MAP Supermatter Engine,Edison's Bane


### PR DESCRIPTION
Just a quick thing to add the new ENGINE_MAP to the example configuration.  It's the exact example Rykka-Stormheart provided.