### PR TITLE
Remove Step_delay from all mech equipment.

### DIFF
--- a/code/game/mecha/equipment/tools/armor_melee.dm
+++ b/code/game/mecha/equipment/tools/armor_melee.dm
@@ -9,8 +9,6 @@
 	var/deflect_coeff = 1.15
 	var/damage_coeff = 0.8
 
-	step_delay = 0.5
-
 	equip_type = EQUIP_HULL
 
 /obj/item/mecha_parts/mecha_equipment/anticcw_armor_booster/get_equip_info()

--- a/code/game/mecha/equipment/tools/armor_ranged.dm
+++ b/code/game/mecha/equipment/tools/armor_ranged.dm
@@ -9,8 +9,6 @@
 	var/deflect_coeff = 1.15
 	var/damage_coeff = 0.8
 
-	step_delay = 1
-
 	equip_type = EQUIP_HULL
 
 /obj/item/mecha_parts/mecha_equipment/antiproj_armor_booster/handle_projectile_contact(var/obj/item/projectile/Proj, var/inc_damage)

--- a/code/game/mecha/equipment/tools/repair_droid.dm
+++ b/code/game/mecha/equipment/tools/repair_droid.dm
@@ -11,8 +11,6 @@
 	var/icon/droid_overlay
 	var/list/repairable_damage = list(MECHA_INT_TEMP_CONTROL,MECHA_INT_TANK_BREACH)
 
-	step_delay = 1
-
 	equip_type = EQUIP_HULL
 
 /obj/item/mecha_parts/mecha_equipment/repair_droid/New()

--- a/code/game/mecha/equipment/tools/shield.dm
+++ b/code/game/mecha/equipment/tools/shield.dm
@@ -7,7 +7,6 @@
 	energy_drain = 20
 	range = 0
 
-	step_delay = 0.2
 
 	var/obj/item/shield_projector/line/exosuit/my_shield = null
 	var/my_shield_type = /obj/item/shield_projector/line/exosuit
@@ -68,11 +67,9 @@
 		my_shield.attack_self(chassis.occupant)
 		if(my_shield.active)
 			set_ready_state(0)
-			step_delay = 4
 			log_message("Activated.")
 		else
 			set_ready_state(1)
-			step_delay = 1
 			log_message("Deactivated.")
 
 /obj/item/mecha_parts/mecha_equipment/combat_shield/Topic(href, href_list)

--- a/code/game/mecha/equipment/tools/shield_omni.dm
+++ b/code/game/mecha/equipment/tools/shield_omni.dm
@@ -9,8 +9,6 @@
 	energy_drain = OMNI_SHIELD_DRAIN
 	range = 0
 
-	step_delay = 0.2
-
 	var/obj/item/shield_projector/shields = null
 	var/shield_type = /obj/item/shield_projector/rectangle/mecha
 
@@ -44,11 +42,9 @@
 		shields.set_on(!shields.active)
 		if(shields.active)
 			set_ready_state(0)
-			step_delay = 4
 			log_message("Activated.")
 		else
 			set_ready_state(1)
-			step_delay = initial(step_delay)
 			log_message("Deactivated.")
 
 /obj/item/mecha_parts/mecha_equipment/omni_shield/Topic(href, href_list)

--- a/code/game/mecha/equipment/weapons/ballistic/mortar.dm
+++ b/code/game/mecha/equipment/weapons/ballistic/mortar.dm
@@ -11,8 +11,6 @@
 	projectile = /obj/item/projectile/arc/fragmentation/mortar
 	projectile_energy_cost = 600
 
-	step_delay = 2
-
 	origin_tech = list(TECH_MATERIAL = 4, TECH_COMBAT = 5, TECH_ILLEGAL = 3)
 
 /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/mortar/action_checks(atom/target)

--- a/code/game/mecha/equipment/weapons/ballistic/shotgun.dm
+++ b/code/game/mecha/equipment/weapons/ballistic/shotgun.dm
@@ -11,7 +11,6 @@
 	deviation = 0.7
 	projectile_energy_cost = 25
 
-	step_delay = 0.5
 
 	origin_tech = list(TECH_MATERIAL = 3, TECH_COMBAT = 4)
 

--- a/code/game/mecha/equipment/weapons/energy/laser.dm
+++ b/code/game/mecha/equipment/weapons/energy/laser.dm
@@ -52,7 +52,6 @@
 	projectile = /obj/item/projectile/beam/heavylaser
 	fire_sound = 'sound/weapons/lasercannonfire.ogg'
 
-	step_delay = 1
 
 	origin_tech = list(TECH_MATERIAL = 3, TECH_COMBAT = 4, TECH_MAGNET = 4)
 

--- a/code/game/mecha/equipment/weapons/explosive/missile.dm
+++ b/code/game/mecha/equipment/weapons/explosive/missile.dm
@@ -2,7 +2,6 @@
 	var/missile_speed = 2
 	var/missile_range = 30
 
-	step_delay = 0.5
 
 /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack/flare
 	name = "\improper BNI Flare Launcher"
@@ -18,7 +17,6 @@
 	missile_range = 15
 	required_type = /obj/mecha  //Why restrict it to just mining or combat mechs?
 
-	step_delay = 0
 
 	equip_type = EQUIP_UTILITY
 

--- a/code/game/mecha/equipment/weapons/fire/flamethrower.dm
+++ b/code/game/mecha/equipment/weapons/fire/flamethrower.dm
@@ -7,7 +7,6 @@
 
 	energy_drain = 30
 
-	step_delay = 0.5
 
 	projectile = /obj/item/projectile/bullet/incendiary/flamethrower/large
 	fire_sound = 'sound/weapons/towelwipe.ogg'

--- a/code/game/mecha/equipment/weapons/fire/incendiary.dm
+++ b/code/game/mecha/equipment/weapons/fire/incendiary.dm
@@ -17,4 +17,3 @@
 	fire_cooldown = 3
 	origin_tech = list(TECH_MATERIAL = 4, TECH_COMBAT = 5, TECH_PHORON = 2, TECH_ILLEGAL = 1)
 
-	step_delay = 1

--- a/code/game/mecha/equipment/weapons/weapons.dm
+++ b/code/game/mecha/equipment/weapons/weapons.dm
@@ -12,8 +12,6 @@
 	var/auto_rearm = 0 //Does the weapon reload itself after each shot?
 	required_type = list(/obj/mecha/combat, /obj/mecha/working/hoverpod/combatpod)
 
-	step_delay = 0.1
-
 	equip_type = EQUIP_WEAPON
 
 /obj/item/mecha_parts/mecha_equipment/weapon/action_checks(atom/target)


### PR DESCRIPTION
My issue is that slowdown is one of the least fun things to have to deal with in this game. To my understanding, the goal of most mech PR's lately wa make mechs more fun, so this is pretty much in direct conflict.
The info on slowdown is also very much hidden with essentially zero way for someone to know that this particular thing causes slowdown.
And if the weapon is not balanced, i'd much rather we ask ourselves if that weapon really is unbalanced and take other actions to make it so.
Not to mention with how many novelty weapons we have, there is a LOT of them which are just underpowered and situational as hell. Like the incendiary weapons which don't really affect creatures, the main target of mechs in our servers.