### PR TITLE
Jetpack cleanup, don't use fuel when unneeded

### DIFF
--- a/code/game/objects/items/weapons/tanks/jetpack.dm
+++ b/code/game/objects/items/weapons/tanks/jetpack.dm
@@ -58,21 +58,27 @@
 
 	to_chat(usr, "You toggle the thrusters [on? "on":"off"].")
 
-/obj/item/weapon/tank/jetpack/proc/allow_thrust(num, mob/living/user as mob)
+/obj/item/weapon/tank/jetpack/proc/get_gas_supply()
+	return air_contents
+
+/obj/item/weapon/tank/jetpack/proc/can_thrust(num)
 	if(!on)
 		return 0
-	if((num < 0.005 || air_contents.total_moles < num))
+
+	var/datum/gas_mixture/fuel = get_gas_supply()
+	if(num < 0.005 || !fuel || fuel.total_moles < num)
 		ion_trail.stop()
 		return 0
 
-	var/datum/gas_mixture/G = air_contents.remove(num)
+	return 1
 
-	var/allgases = G.gas["carbon_dioxide"] + G.gas["nitrogen"] + G.gas["oxygen"] + G.gas["phoron"]
-	if(allgases >= 0.005)
-		return 1
+/obj/item/weapon/tank/jetpack/proc/do_thrust(num, mob/living/user)
+	if(!can_thrust(num))
+		return 0
 
-	qdel(G)
-	return
+	var/datum/gas_mixture/fuel = get_gas_supply()
+	fuel.remove(num)
+	return 1
 
 /obj/item/weapon/tank/jetpack/ui_action_click()
 	toggle()
@@ -116,24 +122,5 @@
 	. = ..()
 	. += "It's a jetpack. If you can see this, report it on the bug tracker."
 
-/obj/item/weapon/tank/jetpack/rig/allow_thrust(num, mob/living/user as mob)
-
-	if(!(src.on))
-		return 0
-
-	if(!istype(holder) || !holder.air_supply)
-		return 0
-
-	var/obj/item/weapon/tank/pressure_vessel = holder.air_supply
-
-	if((num < 0.005 || pressure_vessel.air_contents.total_moles < num))
-		src.ion_trail.stop()
-		return 0
-
-	var/datum/gas_mixture/G = pressure_vessel.air_contents.remove(num)
-
-	var/allgases = G.gas["carbon_dioxide"] + G.gas["nitrogen"] + G.gas["oxygen"] + G.gas["phoron"]
-	if(allgases >= 0.005)
-		return 1
-	qdel(G)
-	return
+/obj/item/weapon/tank/jetpack/rig/get_gas_supply()
+	return holder?.air_supply?.air_contents

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -160,29 +160,30 @@
 
 #undef HUMAN_LOWEST_SLOWDOWN
 
+/mob/living/carbon/human/get_jetpack()
+	if(back)
+		var/obj/item/weapon/rig/rig = get_rig()
+		if(istype(back, /obj/item/weapon/tank/jetpack))
+			return back
+		else if(istype(rig))
+			for(var/obj/item/rig_module/maneuvering_jets.module in rig.installed_modules)
+				return module.jets
+
 /mob/living/carbon/human/Process_Spacemove(var/check_drift = 0)
 	//Can we act?
 	if(restrained())	return 0
 
+	if(..()) //Can move due to other reasons, don't use jetpack fuel
+		return 1
+
 	//Do we have a working jetpack?
-	var/obj/item/weapon/tank/jetpack/thrust
-	if(back)
-		if(istype(back,/obj/item/weapon/tank/jetpack))
-			thrust = back
-		else if(istype(get_rig(),/obj/item/weapon/rig))
-			var/obj/item/weapon/rig/rig = get_rig()
-			for(var/obj/item/rig_module/maneuvering_jets/module in rig.installed_modules)
-				thrust = module.jets
-				break
+	var/obj/item/weapon/tank/jetpack/thrust = get_jetpack()
 
 	if(thrust)
-		if(((!check_drift) || (check_drift && thrust.stabilization_on)) && (!lying) && (thrust.allow_thrust(0.01, src)))
+		if(((!check_drift) || (check_drift && thrust.stabilization_on)) && (!lying) && (thrust.do_thrust(0.01, src)))
 			inertia_dir = 0
 			return 1
 
-	//If no working jetpack then use the other checks
-	if(..())
-		return 1
 	return 0
 
 
@@ -190,7 +191,11 @@
 	//If knocked out we might just hit it and stop.  This makes it possible to get dead bodies and such.
 
 	if(species.flags & NO_SLIP)
-		return
+		return 0
+
+	var/obj/item/weapon/tank/jetpack/thrust = get_jetpack()
+	if(thrust?.can_thrust(0.01))
+		return 0
 
 	if(stat)
 		prob_slip = 0 // Changing this to zero to make it line up with the comment, and also, make more sense.

--- a/code/modules/mob/living/silicon/robot/robot_movement.dm
+++ b/code/modules/mob/living/silicon/robot/robot_movement.dm
@@ -1,16 +1,28 @@
+/mob/living/silicon/robot/get_jetpack()
+	if(module)
+		for(var/obj/item/weapon/tank/jetpack/J in module.modules)
+			return J
+
+/mob/living/silicon/robot/Check_Shoegrip()
+	return module && module.no_slip
+
 /mob/living/silicon/robot/Process_Spaceslipping(var/prob_slip)
+	var/obj/item/weapon/tank/jetpack/thrust = get_jetpack()
+	if(thrust?.can_thrust(0.01))
+		return 0
 	if(module && module.no_slip)
 		return 0
 	..(prob_slip)
 
-/mob/living/silicon/robot/Process_Spacemove()
-	if(module)
-		for(var/obj/item/weapon/tank/jetpack/J in module.modules)
-			if(istype(J, /obj/item/weapon/tank/jetpack))
-				if(J.allow_thrust(0.01))
-					return 1
-	if(..())
+/mob/living/silicon/robot/Process_Spacemove(var/check_drift = 0)
+	if(..())//Can move due to other reasons, don't use jetpack fuel
 		return 1
+
+	var/obj/item/weapon/tank/jetpack/thrust = get_jetpack()
+	if(thrust && (!check_drift || (check_drift && thrust.stabilization_on)) && thrust.do_thrust(0.01))
+		inertia_dir = 0
+		return 1
+
 	return 0
 
  //No longer needed, but I'll leave it here incase we plan to re-use it.

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -387,6 +387,9 @@
 /mob/proc/Post_Incorpmove()
 	return
 
+/mob/proc/get_jetpack()
+	return
+
 ///Process_Spacemove
 ///Called by /client/Move()
 ///For moving in space


### PR DESCRIPTION
Jetpacks will not not use fuel if you're capable of moving for other reasons, like being next to a wall or along lattices.
Jetpacks can now use N2O and whatever other gas you manage to get into them, instead of only N2/O2/CO2/Plasma.
Borgs can now drift with their jetpack stabilizers off, to conserve fuel when needed.