### PR TITLE
Update Random Spawners

### DIFF
--- a/code/game/objects/random/mapping.dm
+++ b/code/game/objects/random/mapping.dm
@@ -583,7 +583,7 @@
 				/obj/item/clothing/mask/breath,
 				/obj/item/clothing/mask/breath,
 				/obj/item/clothing/mask/breath,
-				/obj/structure/closet/crate/aether //AETHER
+				/obj/structure/closet/crate/aether //AETHER AIRSUPPLY
 			),
 			prob(10);list(
 				/obj/random/multiple/voidsuit/vintage,
@@ -592,7 +592,7 @@
 				/obj/random/tank,
 				/obj/item/clothing/mask/breath,
 				/obj/item/clothing/mask/breath,
-				/obj/structure/closet/crate/aether //AETHER
+				/obj/structure/closet/crate/aether //AETHER OLDSUITS
 			),
 			prob(10);list(
 				/obj/random/mre,
@@ -600,7 +600,7 @@
 				/obj/random/mre,
 				/obj/random/mre,
 				/obj/random/mre,
-				/obj/structure/closet/crate/centauri //CENTAURI
+				/obj/structure/closet/crate/centauri //CENTAURI MRES
 			),
 			prob(10);list(
 				/obj/random/drinksoft,
@@ -608,7 +608,7 @@
 				/obj/random/drinksoft,
 				/obj/random/drinksoft,
 				/obj/random/drinksoft,
-				/obj/structure/closet/crate/centauri //CENTAURI
+				/obj/structure/closet/crate/freezer/centauri //CENTAURI SODA
 			),
 			prob(10);list(
 				/obj/random/snack,
@@ -616,27 +616,29 @@
 				/obj/random/snack,
 				/obj/random/snack,
 				/obj/random/snack,
-				/obj/structure/closet/crate/centauri //CENTAURI
+				/obj/structure/closet/crate/freezer/centauri //CENTAURI SNACKS
 			),
 			prob(10);list(
 				/obj/random/powercell,
 				/obj/random/powercell,
 				/obj/random/powercell,
 				/obj/random/powercell,
-				/obj/structure/closet/crate/einstein //EINSTEIN
+				/obj/structure/closet/crate/einstein //EINSTEIN BATTERYPACK
 			),
 			prob(10);list(
 				/obj/item/weapon/circuitboard/smes,
 				/obj/random/smes_coil,
 				/obj/random/smes_coil,
-				/obj/structure/closet/crate/focalpoint //FOCAL
+				/obj/structure/closet/crate/focalpoint //FOCAL SMES
 			),
 			prob(15);list(
 				/obj/random/drinkbottle,
 				/obj/random/drinkbottle,
+				/obj/random/drinkbottle,
 				/obj/random/cigarettes,
 				/obj/random/cigarettes,
-				/obj/structure/closet/crate/gilthari //GILTHARI
+				/obj/random/cigarettes,
+				/obj/structure/closet/crate/gilthari //GILTHARI LUXURY
 			),
 			prob(15);list(
 				/obj/random/tech_supply/nofail,
@@ -674,21 +676,33 @@
 				/obj/random/projectile/random,
 				/obj/structure/closet/crate/secure/heph //HEPHAESTUS PROJECTILE
 			),
-			prob(5);list(
-				/obj/random/firstaid,
-				/obj/random/medical,
-				/obj/random/medical,
-				/obj/random/medical,
-				/obj/random/medical/lite,
-				/obj/random/medical/lite,
-				/obj/structure/closet/crate/veymed //VM
+			prob(2);list(
+				/obj/random/multiple/voidsuit/security,
+				/obj/random/tank,
+				/obj/item/clothing/mask/breath,
+				/obj/structure/closet/crate/secure/nanotrasen //NTSEC SUIT
+			),
+			prob(2);list(
+				/obj/random/multiple/voidsuit/medical,
+				/obj/random/tank,
+				/obj/item/clothing/mask/breath,
+				/obj/structure/closet/crate/secure/veymed //VM SUIT
 			),
 			prob(5);list(
 				/obj/random/firstaid,
+				/obj/random/medical,
+				/obj/random/medical,
+				/obj/random/medical,
+				/obj/random/medical/lite,
+				/obj/random/medical/lite,
+				/obj/structure/closet/crate/veymed //VM GRABBAG
+			),
+			prob(5);list(
 				/obj/random/firstaid,
 				/obj/random/firstaid,
 				/obj/random/firstaid,
-				/obj/structure/closet/crate/veymed //VM
+				/obj/random/firstaid,
+				/obj/structure/closet/crate/veymed //VM FAKS
 			),
 			prob(10);list(
 				/obj/random/tech_supply/nofail,
@@ -696,7 +710,7 @@
 				/obj/random/tech_supply/nofail,
 				/obj/random/tech_supply/nofail,
 				/obj/random/tech_supply/nofail,
-				/obj/structure/closet/crate/xion //XION
+				/obj/structure/closet/crate/xion //XION SUPPLY
 			),
 			prob(10);list(
 				/obj/random/firstaid,
@@ -705,7 +719,7 @@
 				/obj/random/medical/pillbottle,
 				/obj/random/medical/lite,
 				/obj/random/medical/lite,
-				/obj/structure/closet/crate/zenghu //ZENGHU
+				/obj/structure/closet/crate/zenghu //ZENGHU GRABBAG
 			),
 			prob(10);list(
 				/obj/random/medical/pillbottle,
@@ -713,7 +727,7 @@
 				/obj/random/medical/pillbottle,
 				/obj/random/medical/pillbottle,
 				/obj/random/medical/pillbottle,
-				/obj/structure/closet/crate/zenghu //ZENGHU
+				/obj/structure/closet/crate/zenghu //ZENGHU PILLS
 			),
 			prob(2);list(
 				/obj/random/contraband/nofail,
@@ -819,7 +833,20 @@
 				/obj/random/tech_supply/nofail,
 				/obj/random/tech_supply/nofail,
 				/obj/random/tech_supply/nofail,
-				/obj/structure/closet/crate/large/xion //XION TECH
+				/obj/structure/closet/crate/large/xion //XION TECH SUPPLY
+			),
+			prob(20);list(
+				/obj/random/tech_supply/component/nofail,
+				/obj/random/tech_supply/component/nofail,
+				/obj/random/tech_supply/component/nofail,
+				/obj/random/tech_supply/component/nofail,
+				/obj/random/tech_supply/component/nofail,
+				/obj/random/tech_supply/component/nofail,
+				/obj/random/tech_supply/component/nofail,
+				/obj/random/tech_supply/component/nofail,
+				/obj/random/tech_supply/component/nofail,
+				/obj/random/tech_supply/component/nofail,
+				/obj/structure/closet/crate/large/secure/xion //XION TECH COMPS
 			)
 		)
 /*

--- a/code/game/objects/random/mapping.dm
+++ b/code/game/objects/random/mapping.dm
@@ -626,10 +626,9 @@
 				/obj/structure/closet/crate/einstein //EINSTEIN
 			),
 			prob(10);list(
-				/obj/random/powercell,
-				/obj/random/powercell,
-				/obj/random/powercell,
-				/obj/random/powercell,
+				/obj/item/weapon/circuitboard/smes,
+				/obj/random/smes_coil,
+				/obj/random/smes_coil,
 				/obj/structure/closet/crate/focalpoint //FOCAL
 			),
 			prob(15);list(
@@ -671,7 +670,6 @@
 				/obj/structure/closet/crate/secure/heph //HEPHAESTUS ENERGY
 			),
 			prob(2);list(
-				/obj/random/projectile/random,
 				/obj/random/projectile/random,
 				/obj/random/projectile/random,
 				/obj/structure/closet/crate/secure/heph //HEPHAESTUS PROJECTILE
@@ -736,6 +734,92 @@
 				/obj/random/cash/huge,
 				/obj/random/cash/huge,
 				/obj/structure/closet/crate/secure/saare //SAARE CASH CRATE
+			)
+		)
+
+/obj/random/multiple/large_corp_crate
+	name = "random large corporate crate"
+	desc = "A random large corporate crate with thematic contents."
+	icon = 'icons/obj/storage.dmi'
+	icon_state = "largermetal"
+
+/obj/random/multiple/large_corp_crate/item_to_spawn()
+	return pick(
+			prob(30);list(
+				/obj/random/multiple/voidsuit/vintage,
+				/obj/random/multiple/voidsuit/vintage,
+				/obj/random/tank,
+				/obj/random/tank,
+				/obj/item/clothing/mask/breath,
+				/obj/item/clothing/mask/breath,
+				/obj/random/multiple/voidsuit/vintage,
+				/obj/random/multiple/voidsuit/vintage,
+				/obj/random/tank,
+				/obj/random/tank,
+				/obj/item/clothing/mask/breath,
+				/obj/item/clothing/mask/breath,
+				/obj/structure/closet/crate/large/aether //AETHER SUITSBOX
+			),
+			prob(30);list(
+				/obj/random/powercell,
+				/obj/random/powercell,
+				/obj/random/powercell,
+				/obj/random/powercell,
+				/obj/random/powercell,
+				/obj/random/powercell,
+				/obj/random/powercell,
+				/obj/random/powercell,
+				/obj/random/powercell,
+				/obj/random/powercell,
+				/obj/random/powercell,
+				/obj/random/powercell,
+				/obj/structure/closet/crate/large/einstein //EIN BATTERY MEGAPACK
+			),
+			prob(20);list(
+				/obj/item/weapon/circuitboard/smes,
+				/obj/item/weapon/circuitboard/smes,
+				/obj/random/smes_coil,
+				/obj/random/smes_coil,
+				/obj/random/smes_coil,
+				/obj/random/smes_coil,
+				/obj/random/smes_coil,
+				/obj/random/smes_coil,
+				/obj/structure/closet/crate/large/einstein //EIN SMESBOX
+			),
+			prob(2);list(
+				/obj/random/energy,
+				/obj/random/energy,
+				/obj/item/weapon/cell/device/weapon,
+				/obj/item/weapon/cell/device/weapon,
+				/obj/item/weapon/cell/device/weapon,
+				/obj/item/weapon/cell/device/weapon,
+				/obj/random/energy,
+				/obj/random/energy,
+				/obj/item/weapon/cell/device/weapon,
+				/obj/item/weapon/cell/device/weapon,
+				/obj/item/weapon/cell/device/weapon,
+				/obj/item/weapon/cell/device/weapon,
+				/obj/structure/closet/crate/large/secure/heph //HEPH ENERGY
+			),
+			prob(2);list(
+				/obj/random/projectile/random,
+				/obj/random/projectile/random,
+				/obj/random/projectile/random,
+				/obj/random/projectile/random,
+				/obj/structure/closet/crate/large/secure/heph //HEPH BALLISTICS
+			),
+			prob(20);list(
+				/obj/random/tech_supply/nofail,
+				/obj/random/tech_supply/nofail,
+				/obj/random/tech_supply/nofail,
+				/obj/random/tech_supply/nofail,
+				/obj/random/tech_supply/nofail,
+				/obj/random/tech_supply/nofail,
+				/obj/random/tech_supply/nofail,
+				/obj/random/tech_supply/nofail,
+				/obj/random/tech_supply/nofail,
+				/obj/random/tech_supply/nofail,
+				/obj/structure/closet/crate/large/xion //XION TECH
 			)
 		)
 /*

--- a/code/game/objects/random/mapping.dm
+++ b/code/game/objects/random/mapping.dm
@@ -586,11 +586,36 @@
 				/obj/structure/closet/crate/aether //AETHER
 			),
 			prob(10);list(
+				/obj/random/multiple/voidsuit/vintage,
+				/obj/random/multiple/voidsuit/vintage,
+				/obj/random/tank,
+				/obj/random/tank,
+				/obj/item/clothing/mask/breath,
+				/obj/item/clothing/mask/breath,
+				/obj/structure/closet/crate/aether //AETHER
+			),
+			prob(10);list(
 				/obj/random/mre,
 				/obj/random/mre,
 				/obj/random/mre,
 				/obj/random/mre,
 				/obj/random/mre,
+				/obj/structure/closet/crate/centauri //CENTAURI
+			),
+			prob(10);list(
+				/obj/random/drinksoft,
+				/obj/random/drinksoft,
+				/obj/random/drinksoft,
+				/obj/random/drinksoft,
+				/obj/random/drinksoft,
+				/obj/structure/closet/crate/centauri //CENTAURI
+			),
+			prob(10);list(
+				/obj/random/snack,
+				/obj/random/snack,
+				/obj/random/snack,
+				/obj/random/snack,
+				/obj/random/snack,
 				/obj/structure/closet/crate/centauri //CENTAURI
 			),
 			prob(10);list(
@@ -615,11 +640,11 @@
 				/obj/structure/closet/crate/gilthari //GILTHARI
 			),
 			prob(15);list(
-				/obj/random/tech_supply,
-				/obj/random/tech_supply/component,
-				/obj/random/tech_supply/component,
-				/obj/random/tech_supply/component,
-				/obj/random/tech_supply/component,
+				/obj/random/tech_supply/nofail,
+				/obj/random/tech_supply/component/nofail,
+				/obj/random/tech_supply/component/nofail,
+				/obj/random/tech_supply/component/nofail,
+				/obj/random/tech_supply/component/nofail,
 				/obj/structure/closet/crate/grayson //GRAYSON TECH
 			),
 			prob(15);list(
@@ -652,6 +677,7 @@
 				/obj/structure/closet/crate/secure/heph //HEPHAESTUS PROJECTILE
 			),
 			prob(5);list(
+				/obj/random/firstaid,
 				/obj/random/medical,
 				/obj/random/medical,
 				/obj/random/medical,
@@ -659,15 +685,23 @@
 				/obj/random/medical/lite,
 				/obj/structure/closet/crate/veymed //VM
 			),
+			prob(5);list(
+				/obj/random/firstaid,
+				/obj/random/firstaid,
+				/obj/random/firstaid,
+				/obj/random/firstaid,
+				/obj/structure/closet/crate/veymed //VM
+			),
 			prob(10);list(
-				/obj/random/tech_supply,
-				/obj/random/tech_supply,
-				/obj/random/tech_supply,
-				/obj/random/tech_supply,
-				/obj/random/tech_supply,
+				/obj/random/tech_supply/nofail,
+				/obj/random/tech_supply/nofail,
+				/obj/random/tech_supply/nofail,
+				/obj/random/tech_supply/nofail,
+				/obj/random/tech_supply/nofail,
 				/obj/structure/closet/crate/xion //XION
 			),
 			prob(10);list(
+				/obj/random/firstaid,
 				/obj/random/medical,
 				/obj/random/medical/pillbottle,
 				/obj/random/medical/pillbottle,
@@ -675,16 +709,33 @@
 				/obj/random/medical/lite,
 				/obj/structure/closet/crate/zenghu //ZENGHU
 			),
+			prob(10);list(
+				/obj/random/medical/pillbottle,
+				/obj/random/medical/pillbottle,
+				/obj/random/medical/pillbottle,
+				/obj/random/medical/pillbottle,
+				/obj/random/medical/pillbottle,
+				/obj/structure/closet/crate/zenghu //ZENGHU
+			),
 			prob(2);list(
-				/obj/random/contraband,
-				/obj/random/contraband,
-				/obj/random/contraband,
+				/obj/random/contraband/nofail,
+				/obj/random/contraband/nofail,
+				/obj/random/contraband/nofail,
 				/obj/random/projectile/random,
 				/obj/random/projectile/random,
 				/obj/random/mre,
 				/obj/random/mre,
 				/obj/random/mre,
-				/obj/structure/closet/crate/secure/saare //SAARE
+				/obj/structure/closet/crate/secure/saare //SAARE GUNS
+			),
+			prob(1);list(
+				/obj/random/cash/big,
+				/obj/random/cash/big,
+				/obj/random/cash/big,
+				/obj/random/cash/huge,
+				/obj/random/cash/huge,
+				/obj/random/cash/huge,
+				/obj/structure/closet/crate/secure/saare //SAARE CASH CRATE
 			)
 		)
 /*

--- a/code/game/objects/random/mapping.dm
+++ b/code/game/objects/random/mapping.dm
@@ -453,6 +453,240 @@
 			)
 		)
 
+/obj/random/multiple/ore_pile
+	name = "random ore pile"
+	desc = "A pile of random ores. High chance of a larger pile of common ores, lower chances of small piles of rarer ores."
+	icon = 'icons/obj/mining.dmi'
+	icon_state = "ore_clown"
+
+
+/obj/random/multiple/ore_pile/item_to_spawn()
+	return pick(
+			prob(10);list(
+				/obj/item/weapon/ore/coal,
+				/obj/item/weapon/ore/coal,
+				/obj/item/weapon/ore/coal,
+				/obj/item/weapon/ore/coal,
+				/obj/item/weapon/ore/coal,
+				/obj/item/weapon/ore/coal,
+				/obj/item/weapon/ore/coal,
+				/obj/item/weapon/ore/coal,
+				/obj/item/weapon/ore/coal,
+				/obj/item/weapon/ore/coal
+			),
+			prob(3);list(
+				/obj/item/weapon/ore/diamond,
+				/obj/item/weapon/ore/diamond,
+				/obj/item/weapon/ore/diamond
+			),
+			prob(15);list(
+				/obj/item/weapon/ore/glass,
+				/obj/item/weapon/ore/glass,
+				/obj/item/weapon/ore/glass,
+				/obj/item/weapon/ore/glass,
+				/obj/item/weapon/ore/glass,
+				/obj/item/weapon/ore/glass,
+				/obj/item/weapon/ore/glass,
+				/obj/item/weapon/ore/glass,
+				/obj/item/weapon/ore/glass,
+				/obj/item/weapon/ore/glass,
+				/obj/item/weapon/ore/glass,
+				/obj/item/weapon/ore/glass,
+				/obj/item/weapon/ore/glass,
+				/obj/item/weapon/ore/glass,
+				/obj/item/weapon/ore/glass
+			),
+			prob(5);list(
+				/obj/item/weapon/ore/gold,
+				/obj/item/weapon/ore/gold,
+				/obj/item/weapon/ore/gold,
+				/obj/item/weapon/ore/gold,
+				/obj/item/weapon/ore/gold
+			),
+			prob(2);list(
+				/obj/item/weapon/ore/hydrogen,
+				/obj/item/weapon/ore/hydrogen
+			),
+			prob(10);list(
+				/obj/item/weapon/ore/iron,
+				/obj/item/weapon/ore/iron,
+				/obj/item/weapon/ore/iron,
+				/obj/item/weapon/ore/iron,
+				/obj/item/weapon/ore/iron,
+				/obj/item/weapon/ore/iron,
+				/obj/item/weapon/ore/iron,
+				/obj/item/weapon/ore/iron,
+				/obj/item/weapon/ore/iron,
+				/obj/item/weapon/ore/iron
+			),
+			prob(10);list(
+				/obj/item/weapon/ore/lead,
+				/obj/item/weapon/ore/lead,
+				/obj/item/weapon/ore/lead,
+				/obj/item/weapon/ore/lead,
+				/obj/item/weapon/ore/lead,
+				/obj/item/weapon/ore/lead,
+				/obj/item/weapon/ore/lead,
+				/obj/item/weapon/ore/lead,
+				/obj/item/weapon/ore/lead,
+				/obj/item/weapon/ore/lead
+			),
+			prob(5);list(
+				/obj/item/weapon/ore/marble,
+				/obj/item/weapon/ore/marble,
+				/obj/item/weapon/ore/marble,
+				/obj/item/weapon/ore/marble,
+				/obj/item/weapon/ore/marble
+			),
+			prob(3);list(
+				/obj/item/weapon/ore/osmium,
+				/obj/item/weapon/ore/osmium,
+				/obj/item/weapon/ore/osmium
+			),
+			prob(5);list(
+				/obj/item/weapon/ore/phoron,
+				/obj/item/weapon/ore/phoron,
+				/obj/item/weapon/ore/phoron,
+				/obj/item/weapon/ore/phoron,
+				/obj/item/weapon/ore/phoron
+			),
+			prob(5);list(
+				/obj/item/weapon/ore/silver,
+				/obj/item/weapon/ore/silver,
+				/obj/item/weapon/ore/silver,
+				/obj/item/weapon/ore/silver,
+				/obj/item/weapon/ore/silver
+			),
+			prob(3);list(
+				/obj/item/weapon/ore/uranium,
+				/obj/item/weapon/ore/uranium,
+				/obj/item/weapon/ore/uranium
+			),
+			prob(2);list(
+				/obj/item/weapon/ore/verdantium,
+				/obj/item/weapon/ore/verdantium
+			),
+		)
+
+/obj/random/multiple/corp_crate
+	name = "random corporate crate"
+	desc = "A random corporate crate with thematic contents."
+	icon = 'icons/obj/storage.dmi'
+	icon_state = "crate"
+
+/obj/random/multiple/corp_crate/item_to_spawn()
+	return pick(
+			prob(10);list(
+				/obj/random/tank,
+				/obj/random/tank,
+				/obj/random/tank,
+				/obj/item/clothing/mask/breath,
+				/obj/item/clothing/mask/breath,
+				/obj/item/clothing/mask/breath,
+				/obj/structure/closet/crate/aether //AETHER
+			),
+			prob(10);list(
+				/obj/random/mre,
+				/obj/random/mre,
+				/obj/random/mre,
+				/obj/random/mre,
+				/obj/random/mre,
+				/obj/structure/closet/crate/centauri //CENTAURI
+			),
+			prob(10);list(
+				/obj/random/powercell,
+				/obj/random/powercell,
+				/obj/random/powercell,
+				/obj/random/powercell,
+				/obj/structure/closet/crate/einstein //EINSTEIN
+			),
+			prob(10);list(
+				/obj/random/powercell,
+				/obj/random/powercell,
+				/obj/random/powercell,
+				/obj/random/powercell,
+				/obj/structure/closet/crate/focalpoint //FOCAL
+			),
+			prob(15);list(
+				/obj/random/drinkbottle,
+				/obj/random/drinkbottle,
+				/obj/random/cigarettes,
+				/obj/random/cigarettes,
+				/obj/structure/closet/crate/gilthari //GILTHARI
+			),
+			prob(15);list(
+				/obj/random/tech_supply,
+				/obj/random/tech_supply/component,
+				/obj/random/tech_supply/component,
+				/obj/random/tech_supply/component,
+				/obj/random/tech_supply/component,
+				/obj/structure/closet/crate/grayson //GRAYSON TECH
+			),
+			prob(15);list(
+				/obj/random/multiple/ore_pile,
+				/obj/random/multiple/ore_pile,
+				/obj/random/multiple/ore_pile,
+				/obj/random/multiple/ore_pile,
+				/obj/structure/closet/crate/grayson //GRAYSON ORES
+			),
+			prob(15);list(
+				/obj/random/material/refined,
+				/obj/random/material/refined,
+				/obj/random/material/refined,
+				/obj/random/material/refined,
+				/obj/structure/closet/crate/grayson //GRAYSON MATS
+			),
+			prob(2);list(
+				/obj/random/energy,
+				/obj/random/energy,
+				/obj/item/weapon/cell/device/weapon,
+				/obj/item/weapon/cell/device/weapon,
+				/obj/item/weapon/cell/device/weapon,
+				/obj/item/weapon/cell/device/weapon,
+				/obj/structure/closet/crate/secure/heph //HEPHAESTUS ENERGY
+			),
+			prob(2);list(
+				/obj/random/projectile/random,
+				/obj/random/projectile/random,
+				/obj/random/projectile/random,
+				/obj/structure/closet/crate/secure/heph //HEPHAESTUS PROJECTILE
+			),
+			prob(5);list(
+				/obj/random/medical,
+				/obj/random/medical,
+				/obj/random/medical,
+				/obj/random/medical/lite,
+				/obj/random/medical/lite,
+				/obj/structure/closet/crate/veymed //VM
+			),
+			prob(10);list(
+				/obj/random/tech_supply,
+				/obj/random/tech_supply,
+				/obj/random/tech_supply,
+				/obj/random/tech_supply,
+				/obj/random/tech_supply,
+				/obj/structure/closet/crate/xion //XION
+			),
+			prob(10);list(
+				/obj/random/medical,
+				/obj/random/medical/pillbottle,
+				/obj/random/medical/pillbottle,
+				/obj/random/medical/lite,
+				/obj/random/medical/lite,
+				/obj/structure/closet/crate/zenghu //ZENGHU
+			),
+			prob(2);list(
+				/obj/random/contraband,
+				/obj/random/contraband,
+				/obj/random/contraband,
+				/obj/random/projectile/random,
+				/obj/random/projectile/random,
+				/obj/random/mre,
+				/obj/random/mre,
+				/obj/random/mre,
+				/obj/structure/closet/crate/secure/saare //SAARE
+			)
+		)
 /*
  * Turf swappers.
  */

--- a/code/game/objects/random/misc.dm
+++ b/code/game/objects/random/misc.dm
@@ -503,7 +503,7 @@
 				/obj/item/stack/material/plasteel{amount = 10})
 
 /obj/random/material/refined //Random materials for building stuff
-	name = "random refined material (refined)"
+	name = "random refined material"
 	desc = "This is a random refined metal."
 	icon = 'icons/obj/stacks.dmi'
 	icon_state = "sheet-adamantine_3"

--- a/code/game/objects/random/misc.dm
+++ b/code/game/objects/random/misc.dm
@@ -108,6 +108,27 @@
 				prob(2);/obj/item/weapon/storage/toolbox/emergency,
 				prob(1);/obj/item/weapon/storage/toolbox/syndicate)
 
+/obj/random/smes_coil
+	name = "random smes coil"
+	desc = "This is a random smes coil."
+	icon = 'icons/obj/power.dmi'
+	icon_state = "smes"
+
+/obj/random/smes_coil/item_to_spawn()
+	return pick(prob(4);/obj/item/weapon/smes_coil,
+				prob(1);/obj/item/weapon/smes_coil/super_capacity,
+				prob(1);/obj/item/weapon/smes_coil/super_io)
+
+/obj/random/pacman
+	name = "random portable generator"
+	desc = "This is a random portable generator."
+	icon = 'icons/obj/power.dmi'
+	icon_state = "portgen0"
+
+/obj/random/pacman/item_to_spawn()
+	return pick(prob(6);/obj/machinery/power/port_gen/pacman,
+				prob(3);/obj/machinery/power/port_gen/pacman/super,
+				prob(1);/obj/machinery/power/port_gen/pacman/mrs)
 
 /obj/random/tech_supply
 	name = "random tech supply"

--- a/code/game/objects/random/misc.dm
+++ b/code/game/objects/random/misc.dm
@@ -133,6 +133,10 @@
 				prob(1);/obj/item/taperoll/atmos,
 				prob(1);/obj/item/device/flashlight/maglight)
 
+/obj/random/tech_supply/nofail
+	name = "guaranteed random tech supply"
+	spawn_nothing_percentage = 0
+
 /obj/random/tech_supply/component
 	name = "random tech component"
 	desc = "This is a random machine component."
@@ -155,6 +159,10 @@
 		prob(3);/obj/item/weapon/stock_parts/scanning_module,
 		prob(2);/obj/item/weapon/stock_parts/scanning_module/adv,
 		prob(1);/obj/item/weapon/stock_parts/scanning_module/phasic)
+
+/obj/random/tech_supply/component/nofail
+	name = "guaranteed random tech component"
+	spawn_nothing_percentage = 0
 
 /obj/random/medical
 	name = "Random Medicine"
@@ -248,6 +256,10 @@
 				prob(2);/obj/item/weapon/reagent_containers/syringe/drugs,
 				prob(1);/obj/item/weapon/reagent_containers/syringe/steroid)
 
+/obj/random/contraband/nofail
+	name = "Guaranteed Random Illegal Item"
+	spawn_nothing_percentage = 0
+
 /obj/random/cash
 	name = "random currency"
 	desc = "LOADSAMONEY!"
@@ -261,6 +273,32 @@
 				prob(4);/obj/item/weapon/spacecash/c20,
 				prob(1);/obj/item/weapon/spacecash/c50,
 				prob(1);/obj/item/weapon/spacecash/c100)
+
+/obj/random/cash/big
+	name = "random currency pile"
+	desc = "DOSH!"
+	icon = 'icons/obj/items.dmi'
+	icon_state = "spacecash100"
+
+/obj/random/cash/big/item_to_spawn()
+	return pick(prob(64);/obj/item/weapon/spacecash/c10,
+				prob(32);/obj/item/weapon/spacecash/c20,
+				prob(16);/obj/item/weapon/spacecash/c50,
+				prob(8);/obj/item/weapon/spacecash/c100,
+				prob(4);/obj/item/weapon/spacecash/c200,
+				prob(2);/obj/item/weapon/spacecash/c500,
+				prob(1);/obj/item/weapon/spacecash/c1000)
+
+/obj/random/cash/huge
+	name = "random huge currency pile"
+	desc = "LOOK AT MY WAD!"
+	icon = 'icons/obj/items.dmi'
+	icon_state = "spacecash1000"
+
+/obj/random/cash/huge/item_to_spawn()
+	return pick(prob(15);/obj/item/weapon/spacecash/c200,
+				prob(10);/obj/item/weapon/spacecash/c500,
+				prob(5);/obj/item/weapon/spacecash/c1000)
 
 /obj/random/soap
 	name = "Random Soap"
@@ -291,7 +329,111 @@
 				/obj/item/weapon/reagent_containers/food/drinks/bottle/wine,
 				/obj/item/weapon/reagent_containers/food/drinks/bottle/cognac,
 				/obj/item/weapon/reagent_containers/food/drinks/bottle/rum,
-				/obj/item/weapon/reagent_containers/food/drinks/bottle/patron)
+				/obj/item/weapon/reagent_containers/food/drinks/bottle/patron,
+				/obj/item/weapon/reagent_containers/food/drinks/bottle/vermouth,
+				/obj/item/weapon/reagent_containers/food/drinks/bottle/goldschlager,
+				/obj/item/weapon/reagent_containers/food/drinks/bottle/kahlua,
+				/obj/item/weapon/reagent_containers/food/drinks/bottle/melonliquor,
+				/obj/item/weapon/reagent_containers/food/drinks/bottle/bluecuracao,
+				/obj/item/weapon/reagent_containers/food/drinks/bottle/grenadine,
+				/obj/item/weapon/reagent_containers/food/drinks/bottle/sake,
+				/obj/item/weapon/reagent_containers/food/drinks/bottle/champagne,
+				/obj/item/weapon/reagent_containers/food/drinks/bottle/peppermintschnapps,
+				/obj/item/weapon/reagent_containers/food/drinks/bottle/peachschnapps,
+				/obj/item/weapon/reagent_containers/food/drinks/bottle/lemonadeschnapps,
+				/obj/item/weapon/reagent_containers/food/drinks/bottle/small/cider,
+				/obj/item/weapon/reagent_containers/food/drinks/bottle/small/litebeer,
+				/obj/item/weapon/reagent_containers/food/drinks/bottle/small/beer,
+				/obj/item/weapon/reagent_containers/food/drinks/bottle/small/beer/silverdragon,
+				/obj/item/weapon/reagent_containers/food/drinks/bottle/small/beer/meteor)
+
+/obj/random/drinksoft
+	name = "random soft drink"
+	desc = "This is a random (once) carbonated beverage drinks can."
+	icon = 'icons/obj/drinks.dmi'
+	icon_state = "cola"
+
+/obj/random/drinksoft/item_to_spawn()
+	return pick(/obj/item/weapon/reagent_containers/food/drinks/cans/cola,
+				/obj/item/weapon/reagent_containers/food/drinks/cans/waterbottle,
+				/obj/item/weapon/reagent_containers/food/drinks/cans/space_mountain_wind,
+				/obj/item/weapon/reagent_containers/food/drinks/cans/thirteenloko,
+				/obj/item/weapon/reagent_containers/food/drinks/cans/dr_gibb,
+				/obj/item/weapon/reagent_containers/food/drinks/cans/dr_gibb_diet,
+				/obj/item/weapon/reagent_containers/food/drinks/cans/starkist,
+				/obj/item/weapon/reagent_containers/food/drinks/cans/space_up,
+				/obj/item/weapon/reagent_containers/food/drinks/cans/lemon_lime,
+				/obj/item/weapon/reagent_containers/food/drinks/cans/iced_tea,
+				/obj/item/weapon/reagent_containers/food/drinks/cans/grape_juice,
+				/obj/item/weapon/reagent_containers/food/drinks/cans/tonic,
+				/obj/item/weapon/reagent_containers/food/drinks/cans/sodawater,
+				/obj/item/weapon/reagent_containers/food/drinks/cans/gingerale,
+				/obj/item/weapon/reagent_containers/food/drinks/cans/root_beer)
+
+
+/obj/random/snack
+	name = "random snack"
+	desc = "This is a random snackfood. Probably still safe to eat?"
+	icon = 'icons/obj/food_snacks.dmi'
+	icon_state = "tastybread"
+
+/obj/random/snack/item_to_spawn()
+	return pick(/obj/item/weapon/reagent_containers/food/snacks/candy,
+				/obj/item/weapon/reagent_containers/food/snacks/candy/proteinbar,
+				/obj/item/weapon/reagent_containers/food/snacks/candy/gummy,
+				/obj/item/weapon/reagent_containers/food/snacks/candy/donor,
+				/obj/item/weapon/reagent_containers/food/snacks/candy_corn,
+				/obj/item/weapon/reagent_containers/food/snacks/chips,
+				/obj/item/weapon/reagent_containers/food/snacks/chips/bbq,
+				/obj/item/weapon/reagent_containers/food/snacks/cookie,
+				/obj/item/weapon/reagent_containers/food/snacks/cookiesnack,
+				/obj/item/weapon/reagent_containers/food/snacks/fruitbar,
+				/obj/item/weapon/reagent_containers/food/snacks/chocolatebar,
+				/obj/item/weapon/reagent_containers/food/snacks/chocolatepiece,
+				/obj/item/weapon/reagent_containers/food/snacks/chocolatepiece/white,
+				/obj/item/weapon/reagent_containers/food/snacks/chocolatepiece/truffle,
+				/obj/item/weapon/reagent_containers/food/snacks/chocolateegg,
+				/obj/item/weapon/reagent_containers/food/snacks/donut,
+				/obj/item/weapon/reagent_containers/food/snacks/donut/normal,
+				/obj/item/weapon/reagent_containers/food/snacks/donut/jelly,
+				/obj/item/weapon/reagent_containers/food/snacks/donut/cherryjelly,
+				/obj/item/weapon/reagent_containers/food/snacks/tuna,
+				/obj/item/weapon/reagent_containers/food/snacks/pistachios,
+				/obj/item/weapon/reagent_containers/food/snacks/semki,
+				/obj/item/weapon/reagent_containers/food/snacks/cb01,
+				/obj/item/weapon/reagent_containers/food/snacks/cb02,
+				/obj/item/weapon/reagent_containers/food/snacks/cb03,
+				/obj/item/weapon/reagent_containers/food/snacks/cb04,
+				/obj/item/weapon/reagent_containers/food/snacks/cb05,
+				/obj/item/weapon/reagent_containers/food/snacks/cb06,
+				/obj/item/weapon/reagent_containers/food/snacks/cb07,
+				/obj/item/weapon/reagent_containers/food/snacks/cb08,
+				/obj/item/weapon/reagent_containers/food/snacks/cb09,
+				/obj/item/weapon/reagent_containers/food/snacks/cb10,
+				/obj/item/weapon/reagent_containers/food/snacks/tofu,
+				/obj/item/weapon/reagent_containers/food/snacks/donkpocket,
+				/obj/item/weapon/reagent_containers/food/snacks/muffin,
+				/obj/item/weapon/reagent_containers/food/snacks/soylentgreen,
+				/obj/item/weapon/reagent_containers/food/snacks/soylenviridians,
+				/obj/item/weapon/reagent_containers/food/snacks/popcorn,
+				/obj/item/weapon/reagent_containers/food/snacks/sosjerky,
+				/obj/item/weapon/reagent_containers/food/snacks/no_raisin,
+				/obj/item/weapon/reagent_containers/food/snacks/spacetwinkie,
+				/obj/item/weapon/reagent_containers/food/snacks/cheesiehonkers,
+				/obj/item/weapon/reagent_containers/food/snacks/poppypretzel,
+				/obj/item/weapon/reagent_containers/food/snacks/baguette,
+				/obj/item/weapon/reagent_containers/food/snacks/carrotfries,
+				/obj/item/weapon/reagent_containers/food/snacks/candiedapple,
+				/obj/item/weapon/storage/box/admints,
+				/obj/item/weapon/reagent_containers/food/snacks/tastybread,
+				/obj/item/weapon/reagent_containers/food/snacks/liquidfood,
+				/obj/item/weapon/reagent_containers/food/snacks/liquidprotein,
+				/obj/item/weapon/reagent_containers/food/snacks/liquidvitamin,
+				/obj/item/weapon/reagent_containers/food/snacks/skrellsnacks,
+				/obj/item/weapon/reagent_containers/food/snacks/unajerky,
+				/obj/item/weapon/reagent_containers/food/snacks/croissant,
+				/obj/item/weapon/reagent_containers/food/snacks/sugarcookie,
+				/obj/item/weapon/reagent_containers/food/drinks/dry_ramen)
 
 /obj/random/meat
 	name = "random meat"

--- a/code/game/objects/random/misc.dm
+++ b/code/game/objects/random/misc.dm
@@ -326,8 +326,8 @@
 /obj/random/material //Random materials for building stuff
 	name = "random material"
 	desc = "This is a random material."
-	icon = 'icons/obj/items.dmi'
-	icon_state = "sheet-metal"
+	icon = 'icons/obj/stacks.dmi'
+	icon_state = "sheet-metal_2"
 
 /obj/random/material/item_to_spawn()
 	return pick(/obj/item/stack/material/steel{amount = 10},
@@ -338,6 +338,35 @@
 				/obj/item/stack/material/cardboard{amount = 10},
 				/obj/item/stack/rods{amount = 10},
 				/obj/item/stack/material/plasteel{amount = 10})
+
+/obj/random/material/refined //Random materials for building stuff
+	name = "random refined material (refined)"
+	desc = "This is a random refined metal."
+	icon = 'icons/obj/stacks.dmi'
+	icon_state = "sheet-adamantine_3"
+
+/obj/random/material/refined/item_to_spawn()
+	return pick(/obj/item/stack/material/steel{amount = 10},
+				/obj/item/stack/material/glass{amount = 10},
+				/obj/item/stack/material/glass/reinforced{amount = 5},
+				/obj/item/stack/material/glass/phoronglass{amount = 5},
+				/obj/item/stack/material/glass/phoronrglass{amount = 5},
+				/obj/item/stack/material/plasteel{amount = 5},
+				/obj/item/stack/material/durasteel{amount = 5},
+				/obj/item/stack/material/gold{amount = 5},
+				/obj/item/stack/material/iron{amount = 10},
+				/obj/item/stack/material/lead{amount = 10},
+				/obj/item/stack/material/diamond{amount = 3},
+				/obj/item/stack/material/deuterium{amount = 5},
+				/obj/item/stack/material/uranium{amount = 5},
+				/obj/item/stack/material/phoron{amount = 5},
+				/obj/item/stack/material/silver{amount = 5},
+				/obj/item/stack/material/platinum{amount = 5},
+				/obj/item/stack/material/mhydrogen{amount = 3},
+				/obj/item/stack/material/osmium{amount = 3},
+				/obj/item/stack/material/titanium{amount = 5},
+				/obj/item/stack/material/tritium{amount = 3},
+				/obj/item/stack/material/verdantium{amount = 2})
 
 /obj/random/tank
 	name = "random tank"

--- a/code/game/objects/random/spacesuits.dm
+++ b/code/game/objects/random/spacesuits.dm
@@ -4,7 +4,7 @@
 /obj/random/multiple/voidsuit
 	name = "Random Voidsuit"
 	desc = "This is a random voidsuit."
-	icon = 'icons/obj/clothing/suits.dmi'
+	icon = 'icons/obj/clothing/spacesuits.dmi'
 	icon_state = "void"
 
 /obj/random/multiple/voidsuit/item_to_spawn()
@@ -58,6 +58,10 @@
 				/obj/item/clothing/head/helmet/space/void/merc
 			),
 			prob(5);list(
+				/obj/item/clothing/suit/space/void/merc/fire,
+				/obj/item/clothing/head/helmet/space/void/merc/fire
+			),
+			prob(5);list(
 				/obj/item/clothing/suit/space/void/mining,
 				/obj/item/clothing/head/helmet/space/void/mining
 			),
@@ -76,13 +80,21 @@
 			prob(5);list(
 				/obj/item/clothing/suit/space/void/security/riot,
 				/obj/item/clothing/head/helmet/space/void/security/riot
+			),
+			prob(5);list(
+				/obj/item/clothing/suit/space/void/exploration,
+				/obj/item/clothing/head/helmet/space/void/exploration
+			),
+			prob(5);list(
+				/obj/item/clothing/suit/space/void/pilot,
+				/obj/item/clothing/head/helmet/space/void/pilot
 			)
 		)
 
 /obj/random/multiple/voidsuit/mining
 	name = "Random Mining Voidsuit"
 	desc = "This is a random mining voidsuit."
-	icon = 'icons/obj/clothing/suits.dmi'
+	icon = 'icons/obj/clothing/spacesuits.dmi'
 	icon_state = "rig-mining"
 
 /obj/random/multiple/voidsuit/mining/item_to_spawn()
@@ -97,11 +109,35 @@
 			)
 		)
 
+
+
+/obj/random/multiple/voidsuit/security
+	name = "Random Security Voidsuit"
+	desc = "This is a random security voidsuit."
+	icon = 'icons/obj/clothing/spacesuits.dmi'
+	icon_state = "rig-sec"
+
+/obj/random/multiple/voidsuit/security/item_to_spawn()
+	return pick(
+			prob(10);list(
+				/obj/item/clothing/suit/space/void/security,
+				/obj/item/clothing/head/helmet/space/void/security
+			),
+			prob(5);list(
+				/obj/item/clothing/suit/space/void/security/alt,
+				/obj/item/clothing/head/helmet/space/void/security/alt
+			),
+			prob(5);list(
+				/obj/item/clothing/suit/space/void/security/riot,
+				/obj/item/clothing/head/helmet/space/void/security/riot
+			)
+		)
+
 /obj/random/multiple/voidsuit/medical
-	name = "Random Mining Voidsuit"
-	desc = "This is a random mining voidsuit."
-	icon = 'icons/obj/clothing/suits.dmi'
-	icon_state = "rig-mining"
+	name = "Random Medical Voidsuit"
+	desc = "This is a random medical voidsuit."
+	icon = 'icons/obj/clothing/spacesuits.dmi'
+	icon_state = "rig-medical"
 
 /obj/random/multiple/voidsuit/medical/item_to_spawn()
 	return pick(
@@ -120,6 +156,60 @@
 			prob(4);list(
 				/obj/item/clothing/suit/space/void/medical/emt,
 				/obj/item/clothing/head/helmet/space/void/medical/emt
+			)
+		)
+
+/obj/random/multiple/voidsuit/vintage
+	name = "Random Vintage Voidsuit"
+	desc = "This is a random vintage voidsuit."
+	icon = 'icons/obj/clothing/spacesuits.dmi'
+	icon_state = "rig-vintagecrew"
+
+/obj/random/multiple/voidsuit/vintage/item_to_spawn()
+	return pick(
+			prob(20);list(
+				/obj/item/clothing/suit/space/void/refurb,
+				/obj/item/clothing/head/helmet/space/void/refurb
+			),
+			prob(20);list(
+				/obj/item/clothing/suit/space/void/refurb/engineering,
+				/obj/item/clothing/head/helmet/space/void/refurb/engineering
+			),
+			prob(10);list(
+				/obj/item/clothing/suit/space/void/refurb/medical,
+				/obj/item/clothing/head/helmet/space/void/refurb/medical
+			),
+			prob(10);list(
+				/obj/item/clothing/suit/space/void/refurb/medical,
+				/obj/item/clothing/head/helmet/space/void/refurb/medical/alt
+			),
+			prob(10);list(
+				/obj/item/clothing/suit/space/void/refurb/marine,
+				/obj/item/clothing/head/helmet/space/void/refurb/marine
+			),
+			prob(5);list(
+				/obj/item/clothing/suit/space/void/refurb/officer,
+				/obj/item/clothing/head/helmet/space/void/refurb/officer
+			),
+			prob(10);list(
+				/obj/item/clothing/suit/space/void/refurb/pilot,
+				/obj/item/clothing/head/helmet/space/void/refurb/pilot
+			),
+			prob(10);list(
+				/obj/item/clothing/suit/space/void/refurb/pilot,
+				/obj/item/clothing/head/helmet/space/void/refurb/pilot/alt
+			),
+			prob(10);list(
+				/obj/item/clothing/suit/space/void/refurb/research,
+				/obj/item/clothing/head/helmet/space/void/refurb/research
+			),
+			prob(10);list(
+				/obj/item/clothing/suit/space/void/refurb/research,
+				/obj/item/clothing/head/helmet/space/void/refurb/research/alt
+			),
+			prob(5);list(
+				/obj/item/clothing/suit/space/void/refurb/mercenary,
+				/obj/item/clothing/head/helmet/space/void/refurb/mercenary
 			)
 		)
 

--- a/html/changelogs/Killian - randomstuff.yml
+++ b/html/changelogs/Killian - randomstuff.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Killian
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Added a bunch more random spawners for mapping use."


### PR DESCRIPTION
Tweaks to the random spawner objs;
- Fixes mapmaker icons for a bunch of things so they're not null/invisible.
- Adds firebug, exploration, and pilot suits to the generic random suit spawner.
- Adds a security suit spawner (gives a regular sec suit 50% of the time, or a riot/eva 25%/25% respectively).
- Adds a vintage suit spawner (16% crew/engi/med/pilot/sci, 8% marine, 4% officer/merc) for spaceship/etc. POIs. med/pilot/sci suits may spawn with bubble helmets instead of regular ones.
- Adds a random ore-stack spawner and random refined metals spawner, which are largely self-explanatory. For the orestack, you can get a large pile of low-tier ores, or a 2-3 units of higher-tier ore.
- Adds random soft drink and snack spawners, and expands the list of alcohols in the booze spawner.
- Adds random SMES coil and portable generator spawners.
- Added some `/nofail` subtypes of spawners with no-item chances, for use in the spawners below;
- Adds a random corpo-crate spawner, which will spawn a random corporate crate with a selection of company-appropriate items. Rarity/chances are more or less arbitrary. Current sets are Aether (Life Support, vintage spacesuits), Centauri (MREs, soda, snacks), Einstein (Power Cells), Focal (SMES coils), Gilthari (Booze & Cigs), Grayson (Tech Parts, Ores, and Metals), Hephaestus (Energy & Ballistic), NT (sec voidsuit), VeyMed (medical voidsuit, HQ Medical, medkits), Xion (Tech Parts), ZengHu (Medical), and SAARE (grab bag w/ ballistic weapons, or giant cash pile).
- Adds a random large corpo-crate spawner, which has the following sets; Aether (vintage spacesuits), Einstein (power cell megapack, SMES coils), Hephaestus (energy/projectile, very rare), Xion (tech supplies. tech components).

Ideas for NT-specific crates (or more crates in general) are entirely welcome.