### PR TITLE
Revert strafing speed nerf.

### DIFF
--- a/code/game/mecha/components/actuators.dm
+++ b/code/game/mecha/components/actuators.dm
@@ -19,7 +19,7 @@
 
 	internal_damage_flag = MECHA_INT_CONTROL_LOST
 
-	var/strafing_multiplier = 1.5
+	var/strafing_multiplier = 1
 
 /obj/item/mecha_parts/component/actuator/get_step_delay()
 	return step_delay


### PR DESCRIPTION
A 1.5x modifier was added to strafing speed without much of any info. This is not something that should had been added without at least clearly saying it in the PR that introduced it.

Maybe it could comeback for shitty actuators, but seeing as we only have a single actuator variant at the moment, this has to go.

For an example, strafing with a Durand drops your speed down to un-upgraded upgraded Ripley levels. That's SLOW. 