### PR TITLE
Convert /material to it's correct absolute path /datum/material

### DIFF
--- a/code/controllers/subsystems/supply.dm
+++ b/code/controllers/subsystems/supply.dm
@@ -103,7 +103,7 @@ SUBSYSTEM_DEF(supply)
 					// Sell phoron and platinum
 					if(istype(A, /obj/item/stack))
 						var/obj/item/stack/P = A
-						var/material/mat = P.get_material()
+						var/datum/material/mat = P.get_material()
 						if(mat?.supply_conversion_value)
 							EC.contents[EC.contents.len]["value"] = P.get_amount() * mat.supply_conversion_value
 						EC.contents[EC.contents.len]["quantity"] = P.get_amount()

--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -335,7 +335,7 @@
 
 /obj/machinery/autolathe/dismantle()
 	for(var/mat in stored_material)
-		var/material/M = get_material_by_name(mat)
+		var/datum/material/M = get_material_by_name(mat)
 		if(!istype(M))
 			continue
 		var/obj/item/stack/material/S = new M.stack_type(get_turf(src))

--- a/code/game/machinery/deployable.dm
+++ b/code/game/machinery/deployable.dm
@@ -14,7 +14,7 @@ Barricades
 	density = 1.0
 	var/health = 100
 	var/maxhealth = 100
-	var/material/material
+	var/datum/material/material
 
 /obj/structure/barricade/New(var/newloc, var/material_name)
 	..(newloc)

--- a/code/game/machinery/doors/blast_door.dm
+++ b/code/game/machinery/doors/blast_door.dm
@@ -19,7 +19,7 @@
 	icon = 'icons/obj/doors/rapid_pdoor.dmi'
 	icon_state = null
 	min_force = 20 //minimum amount of force needed to damage the door with a melee weapon
-	var/material/implicit_material
+	var/datum/material/implicit_material
 	// Icon states for different shutter types. Simply change this instead of rewriting the update_icon proc.
 	var/icon_state_open = null
 	var/icon_state_opening = null

--- a/code/game/machinery/pipe/pipelayer.dm
+++ b/code/game/machinery/pipe/pipelayer.dm
@@ -145,7 +145,7 @@
 /obj/machinery/pipelayer/proc/eject_metal()
 	var/amount_ejected = 0
 	while (metal >= 1)
-		var/material/M = get_material_by_name(DEFAULT_WALL_MATERIAL)
+		var/datum/material/M = get_material_by_name(DEFAULT_WALL_MATERIAL)
 		var/obj/item/stack/material/S = new M.stack_type(get_turf(src))
 		S.amount = min(metal, S.max_amount)
 		metal -= S.amount

--- a/code/game/mecha/mech_fabricator.dm
+++ b/code/game/mecha/mech_fabricator.dm
@@ -274,7 +274,7 @@
 /obj/machinery/mecha_part_fabricator/proc/eject_materials(var/material, var/amount) // 0 amount = 0 means ejecting a full stack; -1 means eject everything
 	var/recursive = amount == -1 ? 1 : 0
 	var/matstring = lowertext(material)
-	var/material/M = get_material_by_name(matstring)
+	var/datum/material/M = get_material_by_name(matstring)
 
 	var/obj/item/stack/material/S = M.place_sheet(get_turf(src))
 	if(amount <= 0)

--- a/code/game/mecha/mech_prosthetics.dm
+++ b/code/game/mecha/mech_prosthetics.dm
@@ -326,7 +326,7 @@
 /obj/machinery/pros_fabricator/proc/eject_materials(var/material, var/amount) // 0 amount = 0 means ejecting a full stack; -1 means eject everything
 	var/recursive = amount == -1 ? 1 : 0
 	var/matstring = lowertext(material)
-	var/material/M = get_material_by_name(matstring)
+	var/datum/material/M = get_material_by_name(matstring)
 
 	var/obj/item/stack/material/S = M.place_sheet(get_turf(src))
 	if(amount <= 0)

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -169,7 +169,7 @@
 		if ((pass_color || recipe.pass_color))
 			if(!color)
 				if(recipe.use_material)
-					var/material/MAT = get_material_by_name(recipe.use_material)
+					var/datum/material/MAT = get_material_by_name(recipe.use_material)
 					if(MAT.icon_colour)
 						O.color = MAT.icon_colour
 				else

--- a/code/game/objects/items/weapons/material/material_armor.dm
+++ b/code/game/objects/items/weapons/material/material_armor.dm
@@ -27,7 +27,7 @@ Protectiveness | Armor %
 
 // Putting these at /clothing/ level saves a lot of code duplication in armor/helmets/gauntlets/etc
 /obj/item/clothing
-	var/material/material = null // Why isn't this a datum?
+	var/datum/material/material = null // Why isn't this a datum?
 	var/applies_material_color = TRUE
 	var/unbreakable = FALSE
 	var/default_material = null // Set this to something else if you want material attributes on init.

--- a/code/game/objects/items/weapons/material/material_weapons.dm
+++ b/code/game/objects/items/weapons/material/material_weapons.dm
@@ -24,7 +24,7 @@
 	var/thrown_force_divisor = 0.5
 	var/dulled_divisor = 0.5	//Just drops the damage by half
 	var/default_material = DEFAULT_WALL_MATERIAL
-	var/material/material
+	var/datum/material/material
 	var/drops_debris = 1
 
 /obj/item/weapon/material/New(var/newloc, var/material_key)

--- a/code/game/objects/structures/bonfire.dm
+++ b/code/game/objects/structures/bonfire.dm
@@ -9,7 +9,7 @@
 	var/burning = FALSE
 	var/next_fuel_consumption = 0 // world.time of when next item in fuel list gets eatten to sustain the fire.
 	var/grill = FALSE
-	var/material/material
+	var/datum/material/material
 	var/set_temperature = T0C + 30	//K
 	var/heating_power = 80000
 

--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -11,8 +11,8 @@
 	var/current_damage = 0
 	var/cover = 50 //how much cover the girder provides against projectiles.
 	var/default_material = DEFAULT_WALL_MATERIAL
-	var/material/girder_material
-	var/material/reinf_material
+	var/datum/material/girder_material
+	var/datum/material/reinf_material
 	var/reinforcing = 0
 	var/applies_material_colour = 1
 
@@ -226,7 +226,7 @@
 		to_chat(user, "<span class='notice'>There isn't enough material here to construct a wall.</span>")
 		return 0
 
-	var/material/M = name_to_material[S.default_type]
+	var/datum/material/M = name_to_material[S.default_type]
 	if(!istype(M))
 		return 0
 
@@ -267,7 +267,7 @@
 		to_chat(user, "<span class='notice'>There isn't enough material here to reinforce the girder.</span>")
 		return 0
 
-	var/material/M = name_to_material[S.default_type]
+	var/datum/material/M = name_to_material[S.default_type]
 	if(!istype(M) || M.integrity < 50)
 		to_chat(user, "You cannot reinforce \the [src] with that; it is too soft.")
 		return 0
@@ -401,7 +401,7 @@
 			var/turf/simulated/wall/new_T = get_turf(src) // Ref to the wall we just built.
 			// Apparently set_material(...) for walls requires refs to the material singletons and not strings.
 			// This is different from how other material objects with their own set_material(...) do it, but whatever.
-			var/material/M = name_to_material[the_rcd.material_to_use]
+			var/datum/material/M = name_to_material[the_rcd.material_to_use]
 			new_T.set_material(M, the_rcd.make_rwalls ? M : null, girder_material)
 			new_T.add_hiddenprint(user)
 			qdel(src)

--- a/code/game/objects/structures/gravemarker.dm
+++ b/code/game/objects/structures/gravemarker.dm
@@ -17,7 +17,7 @@
 	var/epitaph = ""		//A quick little blurb
 //	var/dir_locked = 0		//Can it be spun?	Not currently implemented
 
-	var/material/material
+	var/datum/material/material
 
 /obj/structure/gravemarker/New(var/newloc, var/material_name)
 	..(newloc)

--- a/code/game/objects/structures/simple_doors.dm
+++ b/code/game/objects/structures/simple_doors.dm
@@ -7,7 +7,7 @@
 	icon = 'icons/obj/doors/material_doors.dmi'
 	icon_state = "metal"
 
-	var/material/material
+	var/datum/material/material
 	var/state = 0 //closed, 1 == open
 	var/isSwitchingStates = 0
 	var/hardness = 1

--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -17,8 +17,8 @@
 	can_buckle = 1
 	buckle_dir = SOUTH
 	buckle_lying = 1
-	var/material/material
-	var/material/padding_material
+	var/datum/material/material
+	var/datum/material/padding_material
 	var/base_icon = "bed"
 	var/applies_material_colour = 1
 

--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -239,7 +239,7 @@
 
 /obj/structure/bed/chair/sofa/update_icon()
 	if(applies_material_colour && sofa_material)
-		var/material/color_material = get_material_by_name(sofa_material)
+		var/datum/material/color_material = get_material_by_name(sofa_material)
 		color = color_material.icon_colour
 
 		if(sofa_material == "carpet")

--- a/code/game/objects/structures/stool_bed_chair_nest/stools.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/stools.dm
@@ -12,8 +12,8 @@ var/global/list/stool_cache = list() //haha stool
 	throwforce = 10
 	w_class = ITEMSIZE_HUGE
 	var/base_icon = "stool_base"
-	var/material/material
-	var/material/padding_material
+	var/datum/material/material
+	var/datum/material/padding_material
 
 /obj/item/weapon/stool/padded
 	icon_state = "stool_padded_preview" //set for the map

--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -155,7 +155,7 @@
 			var/turf/simulated/wall/T = get_turf(src) // Ref to the wall we just built.
 			// Apparently set_material(...) for walls requires refs to the material singletons and not strings.
 			// This is different from how other material objects with their own set_material(...) do it, but whatever.
-			var/material/M = name_to_material[the_rcd.material_to_use]
+			var/datum/material/M = name_to_material[the_rcd.material_to_use]
 			T.set_material(M, the_rcd.make_rwalls ? M : null, M)
 			T.add_hiddenprint(user)
 			return TRUE

--- a/code/game/turfs/simulated/wall_icon.dm
+++ b/code/game/turfs/simulated/wall_icon.dm
@@ -31,7 +31,7 @@
 	update_icon()
 
 
-/turf/simulated/wall/proc/set_material(var/material/newmaterial, var/material/newrmaterial, var/material/newgmaterial)
+/turf/simulated/wall/proc/set_material(var/datum/material/newmaterial, var/datum/material/newrmaterial, var/datum/material/newgmaterial)
 	material = newmaterial
 	reinf_material = newrmaterial
 	if(!newgmaterial)

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -14,9 +14,9 @@
 	var/global/damage_overlays[16]
 	var/active
 	var/can_open = 0
-	var/material/girder_material
-	var/material/material
-	var/material/reinf_material
+	var/datum/material/girder_material
+	var/datum/material/material
+	var/datum/material/reinf_material
 	var/last_state
 	var/construction_stage
 

--- a/code/modules/hydroponics/beekeeping/beehive.dm
+++ b/code/modules/hydroponics/beekeeping/beehive.dm
@@ -248,7 +248,7 @@
 	..()
 	recipes = wax_recipes
 
-/material/wax
+/datum/material/wax
 	name = "wax"
 	stack_type = /obj/item/stack/material/wax
 	icon_colour = "#fff343"

--- a/code/modules/materials/material_recipes.dm
+++ b/code/modules/materials/material_recipes.dm
@@ -1,9 +1,9 @@
-/material/proc/get_recipes()
+/datum/material/proc/get_recipes()
 	if(!recipes)
 		generate_recipes()
 	return recipes
 
-/material/proc/generate_recipes()
+/datum/material/proc/generate_recipes()
 	recipes = list()
 
 	// If is_brittle() returns true, these are only good for a single strike.
@@ -29,7 +29,7 @@
 		recipes += new/datum/stack_recipe("[display_name] knife", /obj/item/weapon/material/knife/plastic, 1, on_floor = 1, supplied_material = "[name]", pass_stack_color = TRUE)
 		recipes += new/datum/stack_recipe("[display_name] blade", /obj/item/weapon/material/butterflyblade, 6, time = 20, one_per_turf = 0, on_floor = 1, supplied_material = "[name]", pass_stack_color = TRUE)
 
-/material/steel/generate_recipes()
+/datum/material/steel/generate_recipes()
 	..()
 	recipes += new/datum/stack_recipe_list("office chairs",list( \
 		new/datum/stack_recipe("dark office chair", /obj/structure/bed/chair/office/dark, 5, one_per_turf = 1, on_floor = 1), \
@@ -104,7 +104,7 @@
 		))
 	recipes += new/datum/stack_recipe("desk bell", /obj/item/weapon/deskbell, 1, on_floor = 1, supplied_material = "[name]")
 
-/material/plasteel/generate_recipes()
+/datum/material/plasteel/generate_recipes()
 	..()
 	recipes += new/datum/stack_recipe("AI core", /obj/structure/AIcore, 4, time = 50, one_per_turf = 1)
 	recipes += new/datum/stack_recipe("Metal crate", /obj/structure/closet/crate, 10, time = 50, one_per_turf = 1)
@@ -113,16 +113,16 @@
 	recipes += new/datum/stack_recipe("roller bed", /obj/item/roller, 5, time = 30, on_floor = 1)
 	recipes += new/datum/stack_recipe("whetstone", /obj/item/weapon/whetstone, 2, time = 10)
 
-/material/stone/generate_recipes()
+/datum/material/stone/generate_recipes()
 	..()
 	recipes += new/datum/stack_recipe("planting bed", /obj/machinery/portable_atmospherics/hydroponics/soil, 3, time = 10, one_per_turf = 1, on_floor = 1)
 
-/material/stone/marble/generate_recipes()
+/datum/material/stone/marble/generate_recipes()
 	..()
 	recipes += new/datum/stack_recipe("light marble floor tile", /obj/item/stack/tile/wmarble, 1, 4, 20)
 	recipes += new/datum/stack_recipe("dark marble floor tile", /obj/item/stack/tile/bmarble, 1, 4, 20)
 
-/material/plastic/generate_recipes()
+/datum/material/plastic/generate_recipes()
 	..()
 	recipes += new/datum/stack_recipe("plastic crate", /obj/structure/closet/crate/plastic, 10, one_per_turf = 1, on_floor = 1, pass_stack_color = TRUE)
 	recipes += new/datum/stack_recipe("plastic bag", /obj/item/weapon/storage/bag/plasticbag, 3, on_floor = 1, pass_stack_color = TRUE)
@@ -140,7 +140,7 @@
 	recipes += new/datum/stack_recipe("plastic fishtank", /obj/item/glass_jar/fish/plastic, 2, time = 30 SECONDS)
 	recipes += new/datum/stack_recipe("reagent tubing", /obj/item/stack/hose, 1, 4, 20, pass_stack_color = TRUE)
 
-/material/wood/generate_recipes()
+/datum/material/wood/generate_recipes()
 	..()
 	recipes += new/datum/stack_recipe("oar", /obj/item/weapon/oar, 2, time = 30, supplied_material = "[name]", pass_stack_color = TRUE)
 	recipes += new/datum/stack_recipe("boat", /obj/vehicle/boat, 20, time = 10 SECONDS, supplied_material = "[name]", pass_stack_color = TRUE)
@@ -161,11 +161,11 @@
 	recipes += new/datum/stack_recipe("crude fishing rod", /obj/item/weapon/material/fishing_rod/built, 8, time = 10 SECONDS, pass_stack_color = TRUE)
 	recipes += new/datum/stack_recipe("noticeboard", /obj/structure/noticeboard, 1)
 
-/material/wood/log/generate_recipes()
+/datum/material/wood/log/generate_recipes()
 	recipes = list()
 	recipes += new/datum/stack_recipe("bonfire", /obj/structure/bonfire, 5, time = 50, supplied_material = "[name]", pass_stack_color = TRUE)
 
-/material/cardboard/generate_recipes()
+/datum/material/cardboard/generate_recipes()
 	..()
 	recipes += new/datum/stack_recipe("box", /obj/item/weapon/storage/box, pass_stack_color = TRUE)
 	recipes += new/datum/stack_recipe("donut box", /obj/item/weapon/storage/box/donut/empty, pass_stack_color = TRUE)
@@ -184,7 +184,7 @@
 		new/datum/stack_recipe("yellow folder", /obj/item/weapon/folder/yellow), \
 		))
 
-/material/snow/generate_recipes()
+/datum/material/snow/generate_recipes()
 	recipes = list()
 	recipes += new/datum/stack_recipe("snowball", /obj/item/weapon/material/snow/snowball, 1, time = 10)
 	recipes += new/datum/stack_recipe("snow brick", /obj/item/stack/material/snowbrick, 2, time = 10)
@@ -192,7 +192,7 @@
 	recipes += new/datum/stack_recipe("snow robot", /obj/structure/snowman/borg, 2, time = 10)
 	recipes += new/datum/stack_recipe("snow spider", /obj/structure/snowman/spider, 3, time = 20)
 
-/material/snowbrick/generate_recipes()
+/datum/material/snowbrick/generate_recipes()
 	recipes = list()
 	recipes += new/datum/stack_recipe("[display_name] door", /obj/structure/simple_door, 10, one_per_turf = 1, on_floor = 1, supplied_material = "[name]")
 	recipes += new/datum/stack_recipe("[display_name] barricade", /obj/structure/barricade, 5, time = 50, one_per_turf = 1, on_floor = 1, supplied_material = "[name]")
@@ -203,7 +203,7 @@
 	recipes += new/datum/stack_recipe("[display_name] wall girders", /obj/structure/girder, 2, time = 50, one_per_turf = 1, on_floor = 1, supplied_material = "[name]")
 	recipes += new/datum/stack_recipe("[display_name] ashtray", /obj/item/weapon/material/ashtray, 2, one_per_turf = 1, on_floor = 1, supplied_material = "[name]")
 
-/material/wood/sif/generate_recipes()
+/datum/material/wood/sif/generate_recipes()
 	..()
 	recipes += new/datum/stack_recipe("alien wood floor tile", /obj/item/stack/tile/wood/sif, 1, 4, 20, pass_stack_color = TRUE)
 	for(var/datum/stack_recipe/r_recipe in recipes)
@@ -214,11 +214,11 @@
 			recipes -= r_recipe
 			continue
 
-/material/supermatter/generate_recipes()
+/datum/material/supermatter/generate_recipes()
 	recipes = list()
 	recipes += new/datum/stack_recipe("supermatter shard", /obj/machinery/power/supermatter/shard, 30 , one_per_turf = 1, time = 600, on_floor = 1)
 
-/material/cloth/generate_recipes()
+/datum/material/cloth/generate_recipes()
 	recipes = list()
 	recipes += new/datum/stack_recipe("woven net", /obj/item/weapon/material/fishing_net, 10, time = 30 SECONDS, pass_stack_color = TRUE)
 	recipes += new/datum/stack_recipe("bedsheet", /obj/item/weapon/bedsheet, 10, time = 30 SECONDS, pass_stack_color = TRUE)
@@ -236,7 +236,7 @@
 	recipes += new/datum/stack_recipe("belt pouch", /obj/item/weapon/storage/belt/fannypack/white, 25, time = 1 MINUTE, pass_stack_color = TRUE)
 	recipes += new/datum/stack_recipe("crude bandage", /obj/item/stack/medical/crude_pack, 1, time = 2 SECONDS, pass_stack_color = TRUE)
 
-/material/resin/generate_recipes()
+/datum/material/resin/generate_recipes()
 	recipes = list()
 	recipes += new/datum/stack_recipe("[display_name] door", /obj/structure/simple_door/resin, 10, one_per_turf = 1, on_floor = 1, supplied_material = "[name]", pass_stack_color = TRUE)
 	recipes += new/datum/stack_recipe("[display_name] barricade", /obj/effect/alien/resin/wall, 5, time = 5 SECONDS, one_per_turf = 1, on_floor = 1, pass_stack_color = TRUE)

--- a/code/modules/materials/material_sheets.dm
+++ b/code/modules/materials/material_sheets.dm
@@ -14,7 +14,7 @@
 		)
 
 	var/default_type = DEFAULT_WALL_MATERIAL
-	var/material/material
+	var/datum/material/material
 	var/perunit = SHEET_MATERIAL_AMOUNT
 	var/apply_colour //temp pending icon rewrite
 	drop_sound = 'sound/items/drop/axe.ogg'

--- a/code/modules/materials/materials.dm
+++ b/code/modules/materials/materials.dm
@@ -45,7 +45,7 @@ var/list/name_to_material
 
 //mostly for convenience
 /obj/proc/get_material_name()
-	var/material/material = get_material()
+	var/datum/material/material = get_material()
 	if(material)
 		return material.name
 
@@ -53,8 +53,8 @@ var/list/name_to_material
 /proc/populate_material_list(force_remake=0)
 	if(name_to_material && !force_remake) return // Already set up!
 	name_to_material = list()
-	for(var/type in typesof(/material) - /material)
-		var/material/new_mineral = new type
+	for(var/type in typesof(/datum/material) - /datum/material)
+		var/datum/material/new_mineral = new type
 		if(!new_mineral.name)
 			continue
 		name_to_material[lowertext(new_mineral.name)] = new_mineral
@@ -67,13 +67,13 @@ var/list/name_to_material
 	return name_to_material[name]
 
 /proc/material_display_name(name)
-	var/material/material = get_material_by_name(name)
+	var/datum/material/material = get_material_by_name(name)
 	if(material)
 		return material.display_name
 	return null
 
 // Material definition and procs follow.
-/material
+/datum/material
 	var/name	                          // Unique name for use in indexing the list.
 	var/display_name                      // Prettier name for display.
 	var/use_name
@@ -137,7 +137,7 @@ var/list/name_to_material
 	var/rotting_touch_message = "crumbles under your touch"
 
 // Placeholders for light tiles and rglass.
-/material/proc/build_rod_product(var/mob/user, var/obj/item/stack/used_stack, var/obj/item/stack/target_stack)
+/datum/material/proc/build_rod_product(var/mob/user, var/obj/item/stack/used_stack, var/obj/item/stack/target_stack)
 	if(!rod_product)
 		to_chat(user, "<span class='warning'>You cannot make anything out of \the [target_stack]</span>")
 		return
@@ -150,7 +150,7 @@ var/list/name_to_material
 	S.add_fingerprint(user)
 	S.add_to_stacks(user)
 
-/material/proc/build_wired_product(var/mob/living/user, var/obj/item/stack/used_stack, var/obj/item/stack/target_stack)
+/datum/material/proc/build_wired_product(var/mob/living/user, var/obj/item/stack/used_stack, var/obj/item/stack/target_stack)
 	if(!wire_product)
 		to_chat(user, "<span class='warning'>You cannot make anything out of \the [target_stack]</span>")
 		return
@@ -165,7 +165,7 @@ var/list/name_to_material
 	user.put_in_hands(product)
 
 // Make sure we have a display name and shard icon even if they aren't explicitly set.
-/material/New()
+/datum/material/New()
 	..()
 	if(!display_name)
 		display_name = name
@@ -175,15 +175,15 @@ var/list/name_to_material
 		shard_icon = shard_type
 
 // This is a placeholder for proper integration of windows/windoors into the system.
-/material/proc/build_windows(var/mob/living/user, var/obj/item/stack/used_stack)
+/datum/material/proc/build_windows(var/mob/living/user, var/obj/item/stack/used_stack)
 	return 0
 
 // Weapons handle applying a divisor for this value locally.
-/material/proc/get_blunt_damage()
+/datum/material/proc/get_blunt_damage()
 	return weight //todo
 
 // Return the matter comprising this material.
-/material/proc/get_matter()
+/datum/material/proc/get_matter()
 	var/list/temp_matter = list()
 	if(islist(composite_material))
 		for(var/material_string in composite_material)
@@ -193,61 +193,61 @@ var/list/name_to_material
 	return temp_matter
 
 // As above.
-/material/proc/get_edge_damage()
+/datum/material/proc/get_edge_damage()
 	return hardness //todo
 
 // Snowflakey, only checked for alien doors at the moment.
-/material/proc/can_open_material_door(var/mob/living/user)
+/datum/material/proc/can_open_material_door(var/mob/living/user)
 	return 1
 
 // Currently used for weapons and objects made of uranium to irradiate things.
-/material/proc/products_need_process()
+/datum/material/proc/products_need_process()
 	return (radioactivity>0) //todo
 
 // Used by walls when qdel()ing to avoid neighbor merging.
-/material/placeholder
+/datum/material/placeholder
 	name = "placeholder"
 
 // Places a girder object when a wall is dismantled, also applies reinforced material.
-/material/proc/place_dismantled_girder(var/turf/target, var/material/reinf_material, var/material/girder_material)
+/datum/material/proc/place_dismantled_girder(var/turf/target, var/datum/material/reinf_material, var/datum/material/girder_material)
 	var/obj/structure/girder/G = new(target)
 	if(reinf_material)
 		G.reinf_material = reinf_material
 		G.reinforce_girder()
 	if(girder_material)
-		if(istype(girder_material, /material))
+		if(istype(girder_material, /datum/material))
 			girder_material = girder_material.name
 		G.set_material(girder_material)
 
 
 // General wall debris product placement.
 // Not particularly necessary aside from snowflakey cult girders.
-/material/proc/place_dismantled_product(var/turf/target)
+/datum/material/proc/place_dismantled_product(var/turf/target)
 	place_sheet(target)
 
 // Debris product. Used ALL THE TIME.
-/material/proc/place_sheet(var/turf/target)
+/datum/material/proc/place_sheet(var/turf/target)
 	if(stack_type)
 		return new stack_type(target)
 
 // As above.
-/material/proc/place_shard(var/turf/target)
+/datum/material/proc/place_shard(var/turf/target)
 	if(shard_type)
 		return new /obj/item/weapon/material/shard(target, src.name)
 
 // Used by walls and weapons to determine if they break or not.
-/material/proc/is_brittle()
+/datum/material/proc/is_brittle()
 	return !!(flags & MATERIAL_BRITTLE)
 
-/material/proc/combustion_effect(var/turf/T, var/temperature)
+/datum/material/proc/combustion_effect(var/turf/T, var/temperature)
 	return
 
 // Used by walls to do on-touch things, after checking for crumbling and open-ability.
-/material/proc/wall_touch_special(var/turf/simulated/wall/W, var/mob/living/L)
+/datum/material/proc/wall_touch_special(var/turf/simulated/wall/W, var/mob/living/L)
 	return
 
 // Datum definitions follow.
-/material/uranium
+/datum/material/uranium
 	name = "uranium"
 	stack_type = /obj/item/stack/material/uranium
 	radioactivity = 12
@@ -259,7 +259,7 @@ var/list/name_to_material
 	door_icon_base = "stone"
 	supply_conversion_value = 2
 
-/material/diamond
+/datum/material/diamond
 	name = "diamond"
 	stack_type = /obj/item/stack/material/diamond
 	flags = MATERIAL_UNMELTABLE
@@ -275,7 +275,7 @@ var/list/name_to_material
 	stack_origin_tech = list(TECH_MATERIAL = 6)
 	supply_conversion_value = 8
 
-/material/gold
+/datum/material/gold
 	name = "gold"
 	stack_type = /obj/item/stack/material/gold
 	icon_colour = "#EDD12F"
@@ -287,11 +287,11 @@ var/list/name_to_material
 	sheet_plural_name = "ingots"
 	supply_conversion_value = 2
 
-/material/gold/bronze //placeholder for ashtrays
+/datum/material/gold/bronze //placeholder for ashtrays
 	name = "bronze"
 	icon_colour = "#EDD12F"
 
-/material/silver
+/datum/material/silver
 	name = "silver"
 	stack_type = /obj/item/stack/material/silver
 	icon_colour = "#D1E6E3"
@@ -304,7 +304,7 @@ var/list/name_to_material
 	supply_conversion_value = 2
 
 //R-UST port
-/material/supermatter
+/datum/material/supermatter
 	name = "supermatter"
 	icon_colour = "#FFFF00"
 	stack_type = /obj/item/stack/material/supermatter
@@ -322,7 +322,7 @@ var/list/name_to_material
 	is_fusion_fuel = 1
 	stack_origin_tech = list(TECH_MATERIAL = 8, TECH_PHORON = 5, TECH_BLUESPACE = 4)
 
-/material/phoron
+/datum/material/phoron
 	name = "phoron"
 	stack_type = /obj/item/stack/material/phoron
 	ignition_point = PHORON_MINIMUM_BURN_TEMPERATURE
@@ -338,7 +338,7 @@ var/list/name_to_material
 
 /*
 // Commenting this out while fires are so spectacularly lethal, as I can't seem to get this balanced appropriately.
-/material/phoron/combustion_effect(var/turf/T, var/temperature, var/effect_multiplier)
+/datum/material/phoron/combustion_effect(var/turf/T, var/temperature, var/effect_multiplier)
 	if(isnull(ignition_point))
 		return 0
 	if(temperature < ignition_point)
@@ -353,7 +353,7 @@ var/list/name_to_material
 	return round(totalPhoron/100)
 */
 
-/material/stone
+/datum/material/stone
 	name = "sandstone"
 	stack_type = /obj/item/stack/material/sandstone
 	icon_base = "stone"
@@ -369,7 +369,7 @@ var/list/name_to_material
 	sheet_singular_name = "brick"
 	sheet_plural_name = "bricks"
 
-/material/stone/marble
+/datum/material/stone/marble
 	name = "marble"
 	icon_colour = "#AAAAAA"
 	weight = 26
@@ -378,7 +378,7 @@ var/list/name_to_material
 	stack_type = /obj/item/stack/material/marble
 	supply_conversion_value = 2
 
-/material/steel
+/datum/material/steel
 	name = DEFAULT_WALL_MATERIAL
 	stack_type = /obj/item/stack/material/steel
 	integrity = 150
@@ -388,7 +388,7 @@ var/list/name_to_material
 	icon_reinf = "reinf_over"
 	icon_colour = "#666666"
 
-/material/steel/hull
+/datum/material/steel/hull
 	name = MAT_STEELHULL
 	stack_type = /obj/item/stack/material/steel/hull
 	integrity = 250
@@ -397,10 +397,10 @@ var/list/name_to_material
 	icon_reinf = "reinf_mesh"
 	icon_colour = "#666677"
 
-/material/steel/hull/place_sheet(var/turf/target) //Deconstructed into normal steel sheets.
+/datum/material/steel/hull/place_sheet(var/turf/target) //Deconstructed into normal steel sheets.
 	new /obj/item/stack/material/steel(target)
 
-/material/diona
+/datum/material/diona
 	name = "biomass"
 	icon_colour = null
 	stack_type = null
@@ -408,19 +408,19 @@ var/list/name_to_material
 	icon_base = "diona"
 	icon_reinf = "noreinf"
 
-/material/diona/place_dismantled_product()
+/datum/material/diona/place_dismantled_product()
 	return
 
-/material/diona/place_dismantled_girder(var/turf/target)
+/datum/material/diona/place_dismantled_girder(var/turf/target)
 	spawn_diona_nymph(target)
 
-/material/steel/holographic
+/datum/material/steel/holographic
 	name = "holo" + DEFAULT_WALL_MATERIAL
 	display_name = DEFAULT_WALL_MATERIAL
 	stack_type = null
 	shard_type = SHARD_NONE
 
-/material/plasteel
+/datum/material/plasteel
 	name = "plasteel"
 	stack_type = /obj/item/stack/material/plasteel
 	integrity = 400
@@ -437,7 +437,7 @@ var/list/name_to_material
 	composite_material = list(DEFAULT_WALL_MATERIAL = SHEET_MATERIAL_AMOUNT, "platinum" = SHEET_MATERIAL_AMOUNT) //todo
 	supply_conversion_value = 6
 
-/material/plasteel/hull
+/datum/material/plasteel/hull
 	name = MAT_PLASTEELHULL
 	stack_type = /obj/item/stack/material/plasteel/hull
 	integrity = 600
@@ -446,11 +446,11 @@ var/list/name_to_material
 	icon_colour = "#777788"
 	explosion_resistance = 40
 
-/material/plasteel/hull/place_sheet(var/turf/target) //Deconstructed into normal plasteel sheets.
+/datum/material/plasteel/hull/place_sheet(var/turf/target) //Deconstructed into normal plasteel sheets.
 	new /obj/item/stack/material/plasteel(target)
 
 // Very rare alloy that is reflective, should be used sparingly.
-/material/durasteel
+/datum/material/durasteel
 	name = "durasteel"
 	stack_type = /obj/item/stack/material/durasteel/hull
 	integrity = 600
@@ -467,7 +467,7 @@ var/list/name_to_material
 	composite_material = list("plasteel" = SHEET_MATERIAL_AMOUNT, "diamond" = SHEET_MATERIAL_AMOUNT) //shrug
 	supply_conversion_value = 9
 
-/material/durasteel/hull //The 'Hardball' of starship hulls.
+/datum/material/durasteel/hull //The 'Hardball' of starship hulls.
 	name = MAT_DURASTEELHULL
 	icon_base = "hull"
 	icon_reinf = "reinf_mesh"
@@ -475,10 +475,10 @@ var/list/name_to_material
 	explosion_resistance = 90
 	reflectivity = 0.9
 
-/material/durasteel/hull/place_sheet(var/turf/target) //Deconstructed into normal durasteel sheets.
+/datum/material/durasteel/hull/place_sheet(var/turf/target) //Deconstructed into normal durasteel sheets.
 	new /obj/item/stack/material/durasteel(target)
 
-/material/plasteel/titanium
+/datum/material/plasteel/titanium
 	name = MAT_TITANIUM
 	stack_type = /obj/item/stack/material/titanium
 	conductivity = 2.38
@@ -487,16 +487,16 @@ var/list/name_to_material
 	icon_colour = "#D1E6E3"
 	icon_reinf = "reinf_metal"
 
-/material/plasteel/titanium/hull
+/datum/material/plasteel/titanium/hull
 	name = MAT_TITANIUMHULL
 	stack_type = /obj/item/stack/material/titanium/hull
 	icon_base = "hull"
 	icon_reinf = "reinf_mesh"
 
-/material/plasteel/titanium/hull/place_sheet(var/turf/target) //Deconstructed into normal titanium sheets.
+/datum/material/plasteel/titanium/hull/place_sheet(var/turf/target) //Deconstructed into normal titanium sheets.
 	new /obj/item/stack/material/titanium(target)
 
-/material/glass
+/datum/material/glass
 	name = "glass"
 	stack_type = /obj/item/stack/material/glass
 	flags = MATERIAL_BRITTLE
@@ -517,7 +517,7 @@ var/list/name_to_material
 	created_fulltile_window = /obj/structure/window/basic/full
 	rod_product = /obj/item/stack/material/glass/reinforced
 
-/material/glass/build_windows(var/mob/living/user, var/obj/item/stack/used_stack)
+/datum/material/glass/build_windows(var/mob/living/user, var/obj/item/stack/used_stack)
 
 	if(!user || !used_stack || !created_window || !created_fulltile_window || !window_options.len)
 		return 0
@@ -588,10 +588,10 @@ var/list/name_to_material
 	new build_path(T, build_dir, 1)
 	return 1
 
-/material/glass/proc/is_reinforced()
+/datum/material/glass/proc/is_reinforced()
 	return (hardness > 35) //todo
 
-/material/glass/reinforced
+/datum/material/glass/reinforced
 	name = "rglass"
 	display_name = "reinforced glass"
 	stack_type = /obj/item/stack/material/glass/reinforced
@@ -611,7 +611,7 @@ var/list/name_to_material
 	wire_product = null
 	rod_product = null
 
-/material/glass/phoron
+/datum/material/glass/phoron
 	name = "borosilicate glass"
 	display_name = "borosilicate glass"
 	stack_type = /obj/item/stack/material/glass/phoronglass
@@ -625,7 +625,7 @@ var/list/name_to_material
 	wire_product = null
 	rod_product = /obj/item/stack/material/glass/phoronrglass
 
-/material/glass/phoron/reinforced
+/datum/material/glass/phoron/reinforced
 	name = "reinforced borosilicate glass"
 	display_name = "reinforced borosilicate glass"
 	stack_type = /obj/item/stack/material/glass/phoronrglass
@@ -640,7 +640,7 @@ var/list/name_to_material
 	composite_material = list() //todo
 	rod_product = null
 
-/material/plastic
+/datum/material/plastic
 	name = "plastic"
 	stack_type = /obj/item/stack/material/plastic
 	flags = MATERIAL_BRITTLE
@@ -655,13 +655,13 @@ var/list/name_to_material
 	melting_point = T0C+371 //assuming heat resistant plastic
 	stack_origin_tech = list(TECH_MATERIAL = 3)
 
-/material/plastic/holographic
+/datum/material/plastic/holographic
 	name = "holoplastic"
 	display_name = "plastic"
 	stack_type = null
 	shard_type = SHARD_NONE
 
-/material/graphite
+/datum/material/graphite
 	name = MAT_GRAPHITE
 	stack_type = /obj/item/stack/material/graphite
 	flags = MATERIAL_BRITTLE
@@ -677,7 +677,7 @@ var/list/name_to_material
 	radiation_resistance = 15
 	stack_origin_tech = list(TECH_MATERIAL = 2, TECH_MAGNET = 2)
 
-/material/osmium
+/datum/material/osmium
 	name = "osmium"
 	stack_type = /obj/item/stack/material/osmium
 	icon_colour = "#9999FF"
@@ -687,7 +687,7 @@ var/list/name_to_material
 	conductivity = 100
 	supply_conversion_value = 6
 
-/material/tritium
+/datum/material/tritium
 	name = "tritium"
 	stack_type = /obj/item/stack/material/tritium
 	icon_colour = "#777777"
@@ -697,7 +697,7 @@ var/list/name_to_material
 	is_fusion_fuel = 1
 	conductive = 0
 
-/material/deuterium
+/datum/material/deuterium
 	name = "deuterium"
 	stack_type = /obj/item/stack/material/deuterium
 	icon_colour = "#999999"
@@ -707,7 +707,7 @@ var/list/name_to_material
 	is_fusion_fuel = 1
 	conductive = 0
 
-/material/mhydrogen
+/datum/material/mhydrogen
 	name = "mhydrogen"
 	stack_type = /obj/item/stack/material/mhydrogen
 	icon_colour = "#E6C5DE"
@@ -716,7 +716,7 @@ var/list/name_to_material
 	is_fusion_fuel = 1
 	supply_conversion_value = 6
 
-/material/platinum
+/datum/material/platinum
 	name = "platinum"
 	stack_type = /obj/item/stack/material/platinum
 	icon_colour = "#9999FF"
@@ -727,7 +727,7 @@ var/list/name_to_material
 	sheet_plural_name = "ingots"
 	supply_conversion_value = 5
 
-/material/iron
+/datum/material/iron
 	name = "iron"
 	stack_type = /obj/item/stack/material/iron
 	icon_colour = "#5C5454"
@@ -736,7 +736,7 @@ var/list/name_to_material
 	sheet_singular_name = "ingot"
 	sheet_plural_name = "ingots"
 
-/material/lead
+/datum/material/lead
 	name = MAT_LEAD
 	stack_type = /obj/item/stack/material/lead
 	icon_colour = "#273956"
@@ -749,7 +749,7 @@ var/list/name_to_material
 
 // Particle Smasher and other exotic materials.
 
-/material/verdantium
+/datum/material/verdantium
 	name = MAT_VERDANTIUM
 	stack_type = /obj/item/stack/material/verdantium
 	icon_base = "metal"
@@ -770,7 +770,7 @@ var/list/name_to_material
 	sheet_plural_name = "sheets"
 	supply_conversion_value = 8
 
-/material/morphium
+/datum/material/morphium
 	name = MAT_MORPHIUM
 	stack_type = /obj/item/stack/material/morphium
 	icon_base = "metal"
@@ -791,13 +791,13 @@ var/list/name_to_material
 	stack_origin_tech = list(TECH_MATERIAL = 8, TECH_ILLEGAL = 1, TECH_PHORON = 4, TECH_BLUESPACE = 4, TECH_ARCANE = 1)
 	supply_conversion_value = 13
 
-/material/morphium/hull
+/datum/material/morphium/hull
 	name = MAT_MORPHIUMHULL
 	stack_type = /obj/item/stack/material/morphium/hull
 	icon_base = "hull"
 	icon_reinf = "reinf_mesh"
 
-/material/valhollide
+/datum/material/valhollide
 	name = MAT_VALHOLLIDE
 	stack_type = /obj/item/stack/material/valhollide
 	icon_base = "stone"
@@ -820,7 +820,7 @@ var/list/name_to_material
 
 
 // Adminspawn only, do not let anyone get this.
-/material/alienalloy
+/datum/material/alienalloy
 	name = "alienalloy"
 	display_name = "durable alloy"
 	stack_type = null
@@ -834,31 +834,31 @@ var/list/name_to_material
 	protectiveness = 80 // 80%
 
 // Likewise.
-/material/alienalloy/elevatorium
+/datum/material/alienalloy/elevatorium
 	name = "elevatorium"
 	display_name = "elevator panelling"
 	icon_colour = "#666666"
 
 // Ditto.
-/material/alienalloy/dungeonium
+/datum/material/alienalloy/dungeonium
 	name = "dungeonium"
 	display_name = "ultra-durable"
 	icon_base = "dungeon"
 	icon_colour = "#FFFFFF"
 
-/material/alienalloy/bedrock
+/datum/material/alienalloy/bedrock
 	name = "bedrock"
 	display_name = "impassable rock"
 	icon_base = "rock"
 	icon_colour = "#FFFFFF"
 
-/material/alienalloy/alium
+/datum/material/alienalloy/alium
 	name = "alium"
 	display_name = "alien"
 	icon_base = "alien"
 	icon_colour = "#FFFFFF"
 
-/material/resin
+/datum/material/resin
 	name = "resin"
 	icon_colour = "#35343a"
 	icon_base = "resin"
@@ -874,13 +874,13 @@ var/list/name_to_material
 	stack_origin_tech = list(TECH_MATERIAL = 8, TECH_PHORON = 4, TECH_BLUESPACE = 4, TECH_BIO = 7)
 	stack_type = /obj/item/stack/material/resin
 
-/material/resin/can_open_material_door(var/mob/living/user)
+/datum/material/resin/can_open_material_door(var/mob/living/user)
 	var/mob/living/carbon/M = user
 	if(istype(M) && locate(/obj/item/organ/internal/xenos/hivenode) in M.internal_organs)
 		return 1
 	return 0
 
-/material/resin/wall_touch_special(var/turf/simulated/wall/W, var/mob/living/L)
+/datum/material/resin/wall_touch_special(var/turf/simulated/wall/W, var/mob/living/L)
 	var/mob/living/carbon/M = L
 	if(istype(M) && locate(/obj/item/organ/internal/xenos/hivenode) in M.internal_organs)
 		to_chat(M, "<span class='alien'>\The [W] shudders under your touch, starting to become porous.</span>")
@@ -892,7 +892,7 @@ var/list/name_to_material
 		return 1
 	return 0
 
-/material/wood
+/datum/material/wood
 	name = MAT_WOOD
 	stack_type = /obj/item/stack/material/wood
 	icon_colour = "#9c5930"
@@ -915,7 +915,7 @@ var/list/name_to_material
 	sheet_singular_name = "plank"
 	sheet_plural_name = "planks"
 
-/material/wood/log
+/datum/material/wood/log
 	name = MAT_LOG
 	icon_base = "log"
 	stack_type = /obj/item/stack/material/log
@@ -923,25 +923,25 @@ var/list/name_to_material
 	sheet_plural_name = "pile"
 	pass_stack_colors = TRUE
 
-/material/wood/log/sif
+/datum/material/wood/log/sif
 	name = MAT_SIFLOG
 	icon_colour = "#0099cc" // Cyan-ish
 	stack_origin_tech = list(TECH_MATERIAL = 2, TECH_BIO = 2)
 	stack_type = /obj/item/stack/material/log/sif
 
-/material/wood/holographic
+/datum/material/wood/holographic
 	name = "holowood"
 	display_name = "wood"
 	stack_type = null
 	shard_type = SHARD_NONE
 
-/material/wood/sif
+/datum/material/wood/sif
 	name = MAT_SIFWOOD
 	stack_type = /obj/item/stack/material/wood/sif
 	icon_colour = "#0099cc" // Cyan-ish
 	stack_origin_tech = list(TECH_MATERIAL = 2, TECH_BIO = 2) // Alien wood would presumably be more interesting to the analyzer.
 
-/material/cardboard
+/datum/material/cardboard
 	name = "cardboard"
 	stack_type = /obj/item/stack/material/cardboard
 	flags = MATERIAL_BRITTLE
@@ -961,7 +961,7 @@ var/list/name_to_material
 	radiation_resistance = 1
 	pass_stack_colors = TRUE
 
-/material/snow
+/datum/material/snow
 	name = MAT_SNOW
 	stack_type = /obj/item/stack/material/snow
 	flags = MATERIAL_BRITTLE
@@ -979,7 +979,7 @@ var/list/name_to_material
 	sheet_plural_name = "pile" //Just a bigger pile
 	radiation_resistance = 1
 
-/material/snowbrick //only slightly stronger than snow, used to make igloos mostly
+/datum/material/snowbrick //only slightly stronger than snow, used to make igloos mostly
 	name = "packed snow"
 	flags = MATERIAL_BRITTLE
 	stack_type = /obj/item/stack/material/snowbrick
@@ -997,7 +997,7 @@ var/list/name_to_material
 	sheet_plural_name = "bricks"
 	radiation_resistance = 1
 
-/material/cloth //todo
+/datum/material/cloth //todo
 	name = "cloth"
 	stack_origin_tech = list(TECH_MATERIAL = 2)
 	door_icon_base = "wood"
@@ -1008,7 +1008,7 @@ var/list/name_to_material
 	conductive = 0
 	pass_stack_colors = TRUE
 
-/material/cult
+/datum/material/cult
 	name = "cult"
 	display_name = "disturbing stone"
 	icon_base = "cult"
@@ -1019,21 +1019,21 @@ var/list/name_to_material
 	sheet_plural_name = "bricks"
 	conductive = 0
 
-/material/cult/place_dismantled_girder(var/turf/target)
+/datum/material/cult/place_dismantled_girder(var/turf/target)
 	new /obj/structure/girder/cult(target, "cult")
 
-/material/cult/place_dismantled_product(var/turf/target)
+/datum/material/cult/place_dismantled_product(var/turf/target)
 	new /obj/effect/decal/cleanable/blood(target)
 
-/material/cult/reinf
+/datum/material/cult/reinf
 	name = "cult2"
 	display_name = "human remains"
 
-/material/cult/reinf/place_dismantled_product(var/turf/target)
+/datum/material/cult/reinf/place_dismantled_product(var/turf/target)
 	new /obj/effect/decal/remains/human(target)
 
 //TODO PLACEHOLDERS:
-/material/leather
+/datum/material/leather
 	name = "leather"
 	icon_colour = "#5C4831"
 	stack_origin_tech = list(TECH_MATERIAL = 2)
@@ -1043,7 +1043,7 @@ var/list/name_to_material
 	protectiveness = 3 // 13%
 	conductive = 0
 
-/material/carpet
+/datum/material/carpet
 	name = "carpet"
 	display_name = "comfy"
 	use_name = "red upholstery"
@@ -1056,7 +1056,7 @@ var/list/name_to_material
 	protectiveness = 1 // 4%
 	conductive = 0
 
-/material/cotton
+/datum/material/cotton
 	name = "cotton"
 	display_name ="cotton"
 	icon_colour = "#FFFFFF"
@@ -1067,7 +1067,7 @@ var/list/name_to_material
 	conductive = 0
 
 // This all needs to be OOP'd and use inheritence if its ever used in the future.
-/material/cloth_teal
+/datum/material/cloth_teal
 	name = "teal"
 	display_name ="teal"
 	use_name = "teal cloth"
@@ -1078,7 +1078,7 @@ var/list/name_to_material
 	protectiveness = 1 // 4%
 	conductive = 0
 
-/material/cloth_black
+/datum/material/cloth_black
 	name = "black"
 	display_name = "black"
 	use_name = "black cloth"
@@ -1089,7 +1089,7 @@ var/list/name_to_material
 	protectiveness = 1 // 4%
 	conductive = 0
 
-/material/cloth_green
+/datum/material/cloth_green
 	name = "green"
 	display_name = "green"
 	use_name = "green cloth"
@@ -1100,7 +1100,7 @@ var/list/name_to_material
 	protectiveness = 1 // 4%
 	conductive = 0
 
-/material/cloth_puple
+/datum/material/cloth_puple
 	name = "purple"
 	display_name = "purple"
 	use_name = "purple cloth"
@@ -1111,7 +1111,7 @@ var/list/name_to_material
 	protectiveness = 1 // 4%
 	conductive = 0
 
-/material/cloth_blue
+/datum/material/cloth_blue
 	name = "blue"
 	display_name = "blue"
 	use_name = "blue cloth"
@@ -1122,7 +1122,7 @@ var/list/name_to_material
 	protectiveness = 1 // 4%
 	conductive = 0
 
-/material/cloth_beige
+/datum/material/cloth_beige
 	name = "beige"
 	display_name = "beige"
 	use_name = "beige cloth"
@@ -1133,7 +1133,7 @@ var/list/name_to_material
 	protectiveness = 1 // 4%
 	conductive = 0
 
-/material/cloth_lime
+/datum/material/cloth_lime
 	name = "lime"
 	display_name = "lime"
 	use_name = "lime cloth"
@@ -1144,7 +1144,7 @@ var/list/name_to_material
 	protectiveness = 1 // 4%
 	conductive = 0
 
-/material/cloth_yellow
+/datum/material/cloth_yellow
 	name = "yellow"
 	display_name = "yellow"
 	use_name = "yellow cloth"
@@ -1155,7 +1155,7 @@ var/list/name_to_material
 	protectiveness = 1 // 4%
 	conductive = 0
 
-/material/cloth_orange
+/datum/material/cloth_orange
 	name = "orange"
 	display_name = "orange"
 	use_name = "orange cloth"
@@ -1166,7 +1166,7 @@ var/list/name_to_material
 	protectiveness = 1 // 4%
 	conductive = 0
 
-/material/toy_foam
+/datum/material/toy_foam
 	name = "foam"
 	display_name = "foam"
 	use_name = "foam"

--- a/code/modules/mining/machine_processing.dm
+++ b/code/modules/mining/machine_processing.dm
@@ -279,7 +279,7 @@
 				var/can_make = CLAMP(ores_stored[metal],0,sheets_per_tick-sheets)
 				if(can_make%2>0) can_make--
 
-				var/material/M = get_material_by_name(O.compresses_to)
+				var/datum/material/M = get_material_by_name(O.compresses_to)
 
 				if(!istype(M) || !can_make || ores_stored[metal] < 1)
 					continue
@@ -293,7 +293,7 @@
 
 				var/can_make = CLAMP(ores_stored[metal],0,sheets_per_tick-sheets)
 
-				var/material/M = get_material_by_name(O.smelts_to)
+				var/datum/material/M = get_material_by_name(O.smelts_to)
 				if(!istype(M) || !can_make || ores_stored[metal] < 1)
 					continue
 

--- a/code/modules/power/fusion/fuel_assembly/fuel_assembly.dm
+++ b/code/modules/power/fusion/fuel_assembly/fuel_assembly.dm
@@ -19,7 +19,7 @@
 
 /obj/item/weapon/fuel_assembly/Initialize()
 	. = ..()
-	var/material/material = get_material_by_name(fuel_type)
+	var/datum/material/material = get_material_by_name(fuel_type)
 	if(istype(material))
 		name = "[material.use_name] fuel rod assembly"
 		desc = "A fuel rod for a fusion reactor. This one is made from [material.use_name]."

--- a/code/modules/power/fusion/fuel_assembly/fuel_compressor.dm
+++ b/code/modules/power/fusion/fuel_assembly/fuel_compressor.dm
@@ -49,7 +49,7 @@
 
 	if(istype(thing, /obj/item/stack/material))
 		var/obj/item/stack/material/M = thing
-		var/material/mat = M.get_material()
+		var/datum/material/mat = M.get_material()
 		if(!mat.is_fusion_fuel)
 			to_chat(user, "<span class='warning'>It would be pointless to make a fuel rod out of [mat.use_name].</span>")
 			return

--- a/code/modules/projectiles/guns/magnetic/magnetic_construction.dm
+++ b/code/modules/projectiles/guns/magnetic/magnetic_construction.dm
@@ -11,7 +11,7 @@
 
 	if(istype(thing, /obj/item/stack/material) && construction_stage == 1)
 		var/obj/item/stack/material/reinforcing = thing
-		var/material/reinforcing_with = reinforcing.get_material()
+		var/datum/material/reinforcing_with = reinforcing.get_material()
 		if(reinforcing_with.name == DEFAULT_WALL_MATERIAL) // Steel
 			if(reinforcing.get_amount() < 5)
 				to_chat(user, "<span class='warning'>You need at least 5 [reinforcing.singular_name]\s for this task.</span>")

--- a/code/modules/radiation/radiation.dm
+++ b/code/modules/radiation/radiation.dm
@@ -36,7 +36,7 @@
 			cached_rad_resistance += O.rad_resistance
 
 		else if(O.density) //So open doors don't get counted
-			var/material/M = O.get_material()
+			var/datum/material/M = O.get_material()
 			if(!M)	continue
 			cached_rad_resistance += (M.weight + M.radiation_resistance) / config.radiation_material_resistance_divisor
 	// Looks like storing the contents length is meant to be a basic check if the cache is stale due to items enter/exiting.  Better than nothing so I'm leaving it as is. ~Leshana

--- a/code/modules/research/protolathe.dm
+++ b/code/modules/research/protolathe.dm
@@ -207,7 +207,7 @@
 	var/recursive = amount == -1 ? 1 : 0
 	material = lowertext(material)
 	var/obj/item/stack/material/mattype
-	var/material/MAT = get_material_by_name(material)
+	var/datum/material/MAT = get_material_by_name(material)
 
 	if(!MAT)
 		return

--- a/code/modules/research/rdmachines.dm
+++ b/code/modules/research/rdmachines.dm
@@ -18,7 +18,7 @@
 	return
 
 /obj/machinery/r_n_d/proc/getMaterialType(var/name)
-	var/material/M = get_material_by_name(name)
+	var/datum/material/M = get_material_by_name(name)
 	if(M && M.stack_type)
 		return M.stack_type
 	return null

--- a/code/modules/tables/debug.dm
+++ b/code/modules/tables/debug.dm
@@ -7,7 +7,7 @@
 		material = get_material_by_name("debugium")
 		..()
 
-/material/debug
+/datum/material/debug
 	name = "debugium"
 	stack_type = /obj/item/stack/material/debug
 	icon_base = "debug"

--- a/code/modules/tables/tables.dm
+++ b/code/modules/tables/tables.dm
@@ -18,8 +18,8 @@
 	var/can_plate = 1
 
 	var/manipulating = 0
-	var/material/material = null
-	var/material/reinforced = null
+	var/datum/material/material = null
+	var/datum/material/reinforced = null
 
 	// Gambling tables. I'd prefer reinforced with carpet/felt/cloth/whatever, but AFAIK it's either harder or impossible to get /obj/item/stack/material of those.
 	// Convert if/when you can easily get stacks of these.
@@ -235,7 +235,7 @@
 
 // Returns the material to set the table to.
 /obj/structure/table/proc/common_material_add(obj/item/stack/material/S, mob/user, verb) // Verb is actually verb without 'e' or 'ing', which is added. Works for 'plate'/'plating' and 'reinforce'/'reinforcing'.
-	var/material/M = S.get_material()
+	var/datum/material/M = S.get_material()
 	if(!istype(M))
 		to_chat(user, "<span class='warning'>You cannot [verb]e \the [src] with \the [S].</span>")
 		return null
@@ -251,7 +251,7 @@
 	return M
 
 // Returns the material to set the table to.
-/obj/structure/table/proc/common_material_remove(mob/user, material/M, delay, what, type_holding, sound)
+/obj/structure/table/proc/common_material_remove(mob/user, datum/material/M, delay, what, type_holding, sound)
 	if(!M.stack_type)
 		to_chat(user, "<span class='warning'>You are unable to remove the [what] from this [src]!</span>")
 		return M
@@ -320,7 +320,7 @@
 	if(full_return || prob(20))
 		new /obj/item/stack/material/steel(src.loc)
 	else
-		var/material/M = get_material_by_name(DEFAULT_WALL_MATERIAL)
+		var/datum/material/M = get_material_by_name(DEFAULT_WALL_MATERIAL)
 		S = M.place_shard(loc)
 		if(S) shards += S
 	qdel(src)

--- a/code/modules/vehicles/boat.dm
+++ b/code/modules/vehicles/boat.dm
@@ -10,7 +10,7 @@
 	move_delay = 3 // Rather slow, but still faster than swimming, and won't get you wet.
 	max_buckled_mobs = 2
 	anchored = FALSE
-	var/material/material = null
+	var/datum/material/material = null
 	var/riding_datum_type = /datum/riding/boat/small
 
 /obj/vehicle/boat/sifwood/New(newloc, material_name)
@@ -43,7 +43,7 @@
 	icon_state = "oar"
 	item_state = "oar"
 	force = 12
-	var/material/material = null
+	var/datum/material/material = null
 
 /obj/item/weapon/oar/sifwood/New(newloc, material_name)
 	..(newloc, MAT_SIFWOOD)

--- a/code/unit_tests/research_tests.dm
+++ b/code/unit_tests/research_tests.dm
@@ -54,7 +54,7 @@
 		design = new design_type() // Unfortunately we have to actually instantiate to get a list.
 
 		for(var/material_name in design.materials)
-			var/material/material = get_material_by_name(material_name)
+			var/datum/material/material = get_material_by_name(material_name)
 			if(!material)
 				log_unit_test("The entry [design_type] has invalid material type [material_name]")
 				number_of_issues++


### PR DESCRIPTION
When you define a path like
```
/material
    var/name = "x"
```
BYOND actually converts it to
```
/datum/material
````
under the hood. It's best to reflect this instead of defining new top level paths, as it's harder to search for.

Follows the convention from /tg/'s contributing guide: https://github.com/tgstation/tgstation/blob/master/.github/CONTRIBUTING.md#datum-type-paths-must-began-with-datum