### PR TITLE
Fix trying to put people on themselves with the stripping menu

### DIFF
--- a/code/modules/mob/living/carbon/human/stripping.dm
+++ b/code/modules/mob/living/carbon/human/stripping.dm
@@ -58,14 +58,22 @@
 	var/stripping
 	var/obj/item/held = user.get_active_hand()
 	if(!istype(held) || is_robot_module(held))
+		stripping = TRUE
+	else
+		var/obj/item/weapon/holder/holder = held
+		if(istype(holder) && src == holder.held_mob)
+			stripping = TRUE
+		else
+			var/obj/item/weapon/grab/grab = held
+			if(istype(grab) && grab.affecting == src)
+				stripping = TRUE
+		
+	if(stripping)
 		if(!istype(target_slot))  // They aren't holding anything valid and there's nothing to remove, why are we even here?
 			return
 		if(!target_slot.canremove)
 			to_chat(user, "<span class='warning'>You cannot remove \the [src]'s [target_slot.name].</span>")
 			return
-		stripping = 1
-
-	if(stripping)
 		visible_message("<span class='danger'>\The [user] is trying to remove \the [src]'s [target_slot.name]!</span>")
 	else
 		if(slot_to_strip == slot_wear_mask && istype(held, /obj/item/weapon/grenade))

--- a/html/changelogs/Meghan Rossi - stripping.yml
+++ b/html/changelogs/Meghan Rossi - stripping.yml
@@ -1,0 +1,4 @@
+author: Meghan-Rossi
+delete-after: True
+changes: 
+  - tweak: "If you try to put someone in one of their own slots using the stripping menu, now you will instead try to strip that slot."


### PR DESCRIPTION
*If you try to put someone in one of their own slots using the stripping menu, now you will instead try to strip that slot.

This always seems to be what people trying this actually mean to do, I've made this mistake and seen a few others make it too.  This also fixes buggy behavior downstream where people can actually succeed in putting people on themselves.