### PR TITLE
/atom/visible_message respects exclude_mobs

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -83,7 +83,7 @@
 		else
 			exclude_mobs = list(src)
 		src.show_message(self_message, 1, blind_message, 2)
-	. = ..()
+	. = ..(message, blind_message, exclude_mobs)
 
 // Returns an amount of power drawn from the object (-1 if it's not viable).
 // If drain_check is set it will not actually drain power, just return a value.


### PR DESCRIPTION
Tested, works. Should stop things that call visible_message from giving the source both self_message and message.