### PR TITLE
Gives mob xenos full darksight

### DIFF
--- a/code/modules/mob/living/simple_mob/subtypes/animal/space/alien.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/space/alien.dm
@@ -18,6 +18,7 @@
 
 	maxHealth = 100
 	health = 100
+	see_in_dark = 7
 
 	harm_intent_damage = 5
 	melee_damage_lower = 25


### PR DESCRIPTION
Because they're xenomorphs. Hiding in the dark won't save you.