### PR TITLE
Fixes compile errors in code\modules\projectiles\broken.dm:42,44

### DIFF
--- a/code/modules/projectiles/broken.dm
+++ b/code/modules/projectiles/broken.dm
@@ -37,7 +37,7 @@
 						var/res_name = ""
 						if(ispath(res,/obj/item/stack/material))
 							var/obj/item/stack/material/mat_stack = res
-							var/material/mat = get_material_by_name("[initial(mat_stack.default_type)]")
+							var/datum/material/mat = get_material_by_name("[initial(mat_stack.default_type)]")
 							if(material_needs[resource]>1)
 								res_name = "[mat.use_name] [mat.sheet_plural_name]"
 							else


### PR DESCRIPTION
`error: mat.use_name: undefined type: mat.use_name`

No idea why travis hasn't thrown a fit. Possibly version related? I test on 513.1522
#7635 appears to have been the cause.