### PR TITLE
Fixes runtime in add_reagent()

### DIFF
--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -115,7 +115,7 @@
 	for(var/datum/reagent/current in reagent_list)
 		if(current.id == id)
 			if(current.id == "blood")
-				if(!isnull(data["species"]) && !isnull(current.data["species"]) && data["species"] != current.data["species"])	// Species bloodtypes are already incompatible, this just stops it from mixing into the one already in a container.
+				if(LAZYLEN(data) && !isnull(data["species"]) && !isnull(current.data["species"]) && data["species"] != current.data["species"])	// Species bloodtypes are already incompatible, this just stops it from mixing into the one already in a container.
 					continue
 
 			current.volume += amount


### PR DESCRIPTION
Bad index: data["species"] when data is not a list.
> Runtime in Chemistry-Holder.dm,118: bad index
> proc name: add reagent (/datum/reagents/proc/add_reagent)
> usr: (the floor) (167,111,2) (/turf/simulated/floor/tiled/white) (XXXXXX)
> usr.loc: (the floor) (167,111,2) (/turf/simulated/floor/tiled/white) (XXXXXX)
> src: /datum/reagents (/datum/reagents)
> call stack:
> /datum/reagents (/datum/reagents): add reagent("blood", 127.078, null, 0)
> XXXXXX XXXXXX (/mob/living/carbon/human): restore blood()
> XXXXXX XXXXXX (/mob/living/carbon/human): Revive()
> the strange object (/obj/changeling_revive_holder): Revive()