### PR TITLE
Diagonal barricade cleave exploit fix

### DIFF
--- a/code/game/objects/weapons.dm
+++ b/code/game/objects/weapons.dm
@@ -36,6 +36,8 @@
 			continue
 		if(!SM.Adjacent(user) || !SM.Adjacent(target)) // Cleaving only hits mobs near the target mob and user.
 			continue
+		if(!attack_can_reach(user, SM, 1))
+			continue
 		if(resolve_attackby(SM, user, attack_modifier = 0.5)) // Hit them with the weapon.  This won't cause recursive cleaving due to the cleaving variable being set to true.
 			hit_mobs++
 


### PR DESCRIPTION
Fixes the cleave attack being able to diagonally hit unreachable mobs through blocked turfs.