### PR TITLE
Allow separate overlays file for modular computers

### DIFF
--- a/code/modules/modular_computers/computers/modular_computer/core.dm
+++ b/code/modules/modular_computers/computers/modular_computer/core.dm
@@ -42,6 +42,8 @@
 	return 1
 
 /obj/item/modular_computer/Initialize()
+	if(!overlay_icon)
+		overlay_icon = icon
 	START_PROCESSING(SSobj, src)
 	install_default_hardware()
 	if(hard_drive)
@@ -72,20 +74,20 @@
 
 	overlays.Cut()
 	if(bsod)
-		overlays.Add("bsod")
+		overlays += image(icon = overlay_icon, icon_state = "bsod")
 		return
 	if(!enabled)
 		if(icon_state_screensaver)
-			overlays.Add(icon_state_screensaver)
+			overlays += image(icon = overlay_icon, icon_state = icon_state_screensaver)
 		set_light(0)
 		return
 	set_light(light_strength)
 	if(active_program)
-		overlays.Add(active_program.program_icon_state ? active_program.program_icon_state : icon_state_menu)
+		overlays += image(icon = overlay_icon, icon_state = active_program.program_icon_state ? active_program.program_icon_state : icon_state_menu)
 		if(active_program.program_key_state)
-			overlays.Add(active_program.program_key_state)
+			overlays += image(icon = overlay_icon, icon_state = active_program.program_key_state)
 	else
-		overlays.Add(icon_state_menu)
+		overlays += image(icon = overlay_icon, icon_state = icon_state_menu)
 
 /obj/item/modular_computer/proc/turn_on(var/mob/user)
 	if(bsod)

--- a/code/modules/modular_computers/computers/modular_computer/variables.dm
+++ b/code/modules/modular_computers/computers/modular_computer/variables.dm
@@ -23,6 +23,7 @@
 	// If you create a program which is limited to Laptops and Consoles you don't have to add it's icon_state overlay for Tablets too, for example.
 
 	icon = null												// This thing isn't meant to be used on it's own. Subtypes should supply their own icon.
+	var/overlay_icon = null									// Icon file used for overlays
 	icon_state = null
 	center_of_mass = null									// No pixelshifting by placing on tables, etc.
 	randpixel = 0											// And no random pixelshifting on-creation either.


### PR DESCRIPTION
so that shells don't have to be in the same icon file as all program icons for that brand of shell