### PR TITLE
Make the tesla ball eventually run out of energy

### DIFF
--- a/code/modules/power/tesla/energy_ball.dm
+++ b/code/modules/power/tesla/energy_ball.dm
@@ -112,7 +112,7 @@
 		var/Orchiectomy_target = pick(orbiting_balls)
 		qdel(Orchiectomy_target)
 
-	else if(orbiting_balls.len)
+	else
 		dissipate() //sing code has a much better system.
 
 /obj/singularity/energy_ball/proc/new_mini_ball()
@@ -140,14 +140,14 @@
 	if (istype(target))
 		target.orbiting_balls += src
 		//TODO-LESH-DEL global.poi_list -= src
-		target.dissipate_strength = target.orbiting_balls.len
+		target.dissipate_strength = target.orbiting_balls.len + 1
 
 	. = ..()
 /obj/singularity/energy_ball/stop_orbit()
 	if (orbiting && istype(orbiting.orbiting, /obj/singularity/energy_ball))
 		var/obj/singularity/energy_ball/orbitingball = orbiting.orbiting
 		orbitingball.orbiting_balls -= src
-		orbitingball.dissipate_strength = orbitingball.orbiting_balls.len
+		orbitingball.dissipate_strength = orbitingball.orbiting_balls.len + 1
 	..()
 	if (!loc && !QDELETED(src))
 		qdel(src)

--- a/html/changelogs/Meghan Rossi - tesla dissipation.yml
+++ b/html/changelogs/Meghan Rossi - tesla dissipation.yml
@@ -1,0 +1,4 @@
+author: Meghan-Rossi
+delete-after: True
+changes: 
+  - tweak: "The tesla energy ball will now eventually disappear if not kept charged with the particle accelerator"


### PR DESCRIPTION
Currently the tesla ball only loses energy until it runs out of orbiting mini-balls, then sticks around forever.  This makes it keep losing energy until it disappears.