### PR TITLE
Fix blood from artifacts breaking the pathogenic isolator

### DIFF
--- a/code/modules/virus2/isolator.dm
+++ b/code/modules/virus2/isolator.dm
@@ -73,7 +73,7 @@
 
 				var/mob/living/carbon/human/D = B.data["donor"]
 				pathogen_pool.Add(list(list(\
-					"name" = "[D.get_species()] [B.name]", \
+					"name" = "[istype(D) ? "[D.get_species()] " : ""][B.name]", \
 					"dna" = B.data["blood_DNA"], \
 					"unique_id" = V.uniqueID, \
 					"reference" = "\ref[V]", \

--- a/html/changelogs/Meghan Rossi - isolator fix.yml
+++ b/html/changelogs/Meghan Rossi - isolator fix.yml
@@ -1,0 +1,4 @@
+author: Meghan-Rossi
+delete-after: True
+changes: 
+  - bugfix: "Blood from artifacts will no longer break the pathogenic isolator."


### PR DESCRIPTION
Prevents blood not drawn from a humanmob (such as blood from artifact replenishing bowls or blood spawned in in reagent cartridges) from breaking the pathogenic isolator's interface.