### PR TITLE
Mobs don't get lost in space

### DIFF
--- a/code/modules/overmap/spacetravel.dm
+++ b/code/modules/overmap/spacetravel.dm
@@ -71,8 +71,9 @@ proc/get_deepspace(x,y)
 /mob/lost_in_space()
 	return isnull(client)
 
-/mob/living/carbon/human/lost_in_space()
-	return isnull(client) && !key && stat == DEAD
+/mob/living/lost_in_space()
+	return FALSE
+	// return isnull(client) && !key && stat == DEAD // Allows bodies that players have ghosted from to be deleted - Ater
 
 proc/overmap_spacetravel(var/turf/space/T, var/atom/movable/A)
 	if (!T || !A)


### PR DESCRIPTION
Fixes #7712 
Spoke with vore devs, they said their map really only loops between the 3 space z levels, and besides that anything (much less mobs) hardly ever gets spaced. If it becomes problematic later, I've left the old check in for reference.