### PR TITLE
Adds tesla generator crate to cargo

### DIFF
--- a/code/datums/supplypacks/engineering.dm
+++ b/code/datums/supplypacks/engineering.dm
@@ -151,6 +151,13 @@
 	containername = "Singularity Generator crate"
 	access = access_ce
 
+/datum/supply_pack/eng/engine/tesla_gen
+	name = "Tesla Generator crate"
+	contains = list(/obj/machinery/the_singularitygen/tesla)
+	containertype = /obj/structure/closet/crate/secure/einstein
+	containername = "Tesla Generator crate"
+	access = access_ce
+
 /datum/supply_pack/eng/engine/collector
 	name = "Collector crate"
 	contains = list(/obj/machinery/power/rad_collector = 3)

--- a/html/changelogs/Meghan Rossi - the_teslagen.yml
+++ b/html/changelogs/Meghan Rossi - the_teslagen.yml
@@ -1,0 +1,4 @@
+author: Meghan-Rossi
+delete-after: True
+changes: 
+  - rscadd: "The Tesla Generator is now available from cargo.  Coils and grounding rods for it may be printed on the protolathe and autolathe, respectively."


### PR DESCRIPTION
Adds a tesla generator crate that is orderable from cargo.  Resolves https://github.com/PolarisSS13/Polaris/issues/7716  (Coils and grounding rods are already printable in science)