### PR TITLE
Changes exosuit gripper to be able to handle mecha components

### DIFF
--- a/code/modules/mob/living/silicon/robot/drone/drone_items.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_items.dm
@@ -218,7 +218,8 @@
 	can_hold = list(
 		/obj/item/mecha_parts/part,
 		/obj/item/mecha_parts/mecha_equipment,
-		/obj/item/mecha_parts/mecha_tracking
+		/obj/item/mecha_parts/mecha_tracking,
+		/obj/item/mecha_parts/component
 		)
 
 /obj/item/weapon/gripper/no_use //Used when you want to hold and put items in other things, but not able to 'use' the item

--- a/html/changelogs/Runa Dacino -  Exosuit gripper tweak.yml
+++ b/html/changelogs/Runa Dacino -  Exosuit gripper tweak.yml
@@ -1,0 +1,37 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: N3X15
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Enabled research borgs equipped with 'exosuit gripper' to be able to replace internal exosuit parts like actuators, to upgrade or to repair"
+


### PR DESCRIPTION
Downstream, it was noticed that borgs were unable to repair exosuits, or upgrade them as they lack the ability to interact with "component" mecha parts.

This PR is a simple one, for it merely adds components to the list of permissible items for /mech gripper.