### PR TITLE
Fix most borosilicate shards disappearing instantly after being made

### DIFF
--- a/code/game/objects/items/weapons/material/shards.dm
+++ b/code/game/objects/items/weapons/material/shards.dm
@@ -152,4 +152,4 @@
 	..(loc, "steel")
 
 /obj/item/weapon/material/shard/phoron/New(loc)
-	..(loc, "phglass")
+	..(loc, "borosilicate glass")

--- a/html/changelogs/Meghan Rossi - borosilicate shard fix.yml
+++ b/html/changelogs/Meghan Rossi - borosilicate shard fix.yml
@@ -1,0 +1,4 @@
+author: Meghan-Rossi
+delete-after: True
+changes: 
+  - bugfix: "Fixed borosilicate glass not producing shards in most situations."


### PR DESCRIPTION
*Fixed borosilicate glass not producing shards in most situations.