### PR TITLE
Ports TV-camera assembly from Bay

### DIFF
--- a/code/game/objects/items/devices/tvcamera.dm
+++ b/code/game/objects/items/devices/tvcamera.dm
@@ -93,3 +93,78 @@
 		H.update_inv_l_hand()
 		H.update_inv_belt()
 
+//Assembly by roboticist
+	
+		
+/obj/item/robot_parts/head/attackby(var/obj/item/device/assembly/S, mob/user as mob)
+	if ((!istype(S, /obj/item/device/assembly/infra)))
+		..()
+		return
+	var/obj/item/weapon/TVAssembly/A = new(user)
+	qdel(S)
+	user.put_in_hands(A)
+	to_chat(user, "<span class='notice'>You add the infrared sensor to the robot head.</span>")
+	user.drop_from_inventory(src)
+	qdel(src)
+	
+//Using camcorder icon as I can't sprite. 
+//Using robohead because of restricting to roboticist		
+/obj/item/weapon/TVAssembly
+	name = "TV Camera assembly"
+	desc = "A robotic head with an infrared sensor inside"
+	icon = 'icons/obj/robot_parts.dmi'
+	icon_state = "head"
+	item_state = "head"
+	var/buildstep = 0
+	w_class = ITEM_SIZE_LARGE
+	
+/obj/item/weapon/TVAssembly/attackby(W, mob/user)
+	switch(buildstep)
+		if(0)
+			if(istype(W, /obj/item/robot_parts/robot_component/camera))
+				var/obj/item/robot_parts/robot_component/camera/CA = W
+				to_chat(user, "<span class='notice'>You add the camera module to [src]</span>")
+				user.drop_item()
+				qdel(CA)
+				desc = "This TV camera assembly has a camera module."
+				buildstep++
+		if(1)
+			if(istype(W, /obj/item/device/taperecorder))
+				var/obj/item/device/taperecorder/T = W
+				user.drop_item()
+				qdel(T)
+				buildstep++
+				to_chat(user, "<span class='notice'>You add the tape recorder to [src]</span>")
+				desc = "This TV camera assembly has a camera and audio module."
+				return
+		if(2)
+			if(istype(W, /obj/item/stack/cable_coil))
+				var/obj/item/stack/cable_coil/C = W
+				if(!C.use(3))
+					to_chat(user, "<span class='notice'>You need three cable coils to wire the devices.</span>")
+					..()
+					return
+				C.use(3)
+				buildstep++
+				to_chat(user, "<span class='notice'>You wire the assembly</span>")
+				desc = "This TV camera assembly has wires sticking out"
+				return
+		if(3)
+			if(istype(W, /obj/item/weapon/wirecutters))
+				to_chat(user, "<span class='notice'> You trim the wires.</span>")
+				buildstep++
+				desc = "This TV camera assembly needs casing."
+				return
+		if(4)
+			if(istype(W, /obj/item/stack/material/steel))
+				var/obj/item/stack/material/steel/S = W
+				buildstep++
+				S.use(1)
+				to_chat(user, "<span class='notice'>You encase the assembly in a Ward-Takeshi casing.</span>")
+				var/turf/T = get_turf(src)
+				new /obj/item/device/tvcamera(T)
+				user.drop_from_inventory(src)
+				qdel(src)
+				return
+				
+	..()

--- a/html/changelogs/Runa Dacino - TVcamera assembly
+++ b/html/changelogs/Runa Dacino - TVcamera assembly
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: runadacino
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Ports ability to assemble a TV camera from Bay for roboticists' and journalists' enjoyment"


### PR DESCRIPTION
Copies https://github.com/Baystation12/Baystation12/pull/14875

I've recently noticed downstream you can't build TV Camera drones on demand.

How to build drones:

1. Get Robot head
2. Infrared sensor -> Makes the assembly. Looks like robot head.
3. Add robot camera
4. Add Tape recorder
5. Add 3 wires
6. Use wirecutters on assembly
7. Add 1 steel
8. Done