### PR TITLE
Stops slime securitrons from going ballistic when they get scratched

### DIFF
--- a/code/modules/mob/living/bot/SLed209bot.dm
+++ b/code/modules/mob/living/bot/SLed209bot.dm
@@ -21,6 +21,7 @@
 	xeno_harm_strength = 9
 	req_one_access = list(access_research, access_robotics)
 	botcard_access = list(access_research, access_robotics, access_xenobiology, access_xenoarch, access_tox, access_tox_storage, access_maint_tunnels)
+	retaliates = FALSE
 	var/xeno_stun_strength = 6
 
 /mob/living/bot/secbot/ed209/slime/update_icons()

--- a/code/modules/mob/living/bot/secbot.dm
+++ b/code/modules/mob/living/bot/secbot.dm
@@ -23,6 +23,7 @@
 	var/declare_arrests = FALSE // If true, announces arrests over sechuds.
 	var/threat = 0 // How much of a threat something is. Set upon acquiring a target.
 	var/attacked = FALSE // If true, gives the bot enough threat assessment to attack immediately.
+	var/retaliates = TRUE //If this type of secbot should retaliate at all - so that slime securitrons don't go ballistic the second they get glomped.
 
 	var/is_ranged = FALSE
 	var/awaiting_surrender = 0
@@ -49,6 +50,7 @@
 	desc = "A little security robot, with a slime baton subsituted for the regular one."
 	default_icon_state = "slimesecbot"
 	stun_strength = 10 // Slimebatons aren't meant for humans.
+	retaliates = FALSE // No, you're not allowed to beat the slimes to death just because they scratched you.
 
 	xeno_harm_strength = 9 // Weaker than regular slimesky but they can stun.
 	baton_glow = "#33CCFF"
@@ -154,7 +156,7 @@
 	..()
 
 /mob/living/bot/secbot/proc/react_to_attack(mob/attacker)
-	if(!on)		// We don't want it to react if it's off
+	if(!on || !retaliates)		// We don't want it to react if it's off or doesn't care
 		return
 
 	if(!target)


### PR DESCRIPTION
…so they can actually discipline properly.

Right now, the retaliation component of securitrons, which is fine and makes sense, also applies to slime securitrons.
This prevents them from administering proper discipline, as they just go crazy and repeatedly baton the slimes as soon as they recieve the inevitable glomp, as they can't be "arrested". Eventually the slimes enrage and you have a pen full of very angry slimes - the exact opposite of what it's meant to do.

So, I added a simple var to the securitron to determine if it should care about retaliating or not, and set it to false for the slime securitron. Since they already detected and disciplined disobedient slimes, this will allow them to perform their function normally.