### PR TITLE
Moves the varset for DNA injector readying out of the for loop

### DIFF
--- a/code/game/dna/dna_modifier.dm
+++ b/code/game/dna/dna_modifier.dm
@@ -331,7 +331,7 @@
 		connected = locate(/obj/machinery/dna_scannernew, get_step(src, dir))
 		if(connected)
 			break
-		VARSET_IN(src, injector_ready, TRUE, 25 SECONDS)
+	VARSET_IN(src, injector_ready, TRUE, 25 SECONDS)
 
 /obj/machinery/computer/scan_consolenew/proc/all_dna_blocks(var/list/buffer)
 	var/list/arr = list()


### PR DESCRIPTION
Since the DNA injector readying was done inside the loop for detecting adjacent scanners and was preceded by a break, it never actually got done if there was an adjacent scanner.
This just moves it out of the loop so it actually happens and injectors are made.