### PR TITLE
Teshari name generation fix

### DIFF
--- a/code/modules/mob/language/station.dm
+++ b/code/modules/mob/language/station.dm
@@ -204,7 +204,7 @@
 		)
 
 /datum/language/seromi/get_random_name(gender)
-	return ..(gender, 1, 4, 1.5)
+	return ..(gender, 2, 4, 1.5)
 
 
 /datum/language/zaddat


### PR DESCRIPTION
This makes randomly generated (from pressing random name in character creation) Teshari names have both a pack-name and own name to match with the lore, rather than a singular name.