### PR TITLE
Tweak Ventcrawl To Allow Allowed Items to be Worn

### DIFF
--- a/code/modules/ventcrawl/ventcrawl.dm
+++ b/code/modules/ventcrawl/ventcrawl.dm
@@ -62,8 +62,8 @@ var/list/ventcrawl_machinery = list(
 			listed = TRUE
 			break
 
-	//Only allow it if it's "IN" the mob, not equipped on/being held
-	if(listed && !get_inventory_slot(carried_item))
+	//Only allow it if it's "IN" the mob, not equipped on/being held. //Disabled, as it's very annoying that, for example, Pun Pun has no way to ventcrawl with his suit if given the verb, since the list of allowed items is ignored for worn items.
+	if(listed/* && !get_inventory_slot(carried_item)*/)
 		return 1
 
 /mob/living/carbon/is_allowed_vent_crawl_item(var/obj/item/carried_item)


### PR DESCRIPTION
Allows mobs to ventcrawl with any item in their allowed items list, even if it's worn or carried.