### PR TITLE
Creates framework for species to experience traumatic shock at different rates

### DIFF
--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -102,6 +102,7 @@
 	var/alcohol_mod =		1						// Multiplier to alcohol strength; 0.5 = half, 0 = no effect at all, 2 = double, etc.
 	var/pain_mod =			1						// Multiplier to pain effects; 0.5 = half, 0 = no effect (equal to NO_PAIN, really), 2 = double, etc.
 	var/spice_mod =			1						// Multiplier to spice/capsaicin/frostoil effects; 0.5 = half, 0 = no effect (immunity), 2 = double, etc.
+	var/trauma_mod = 		1						// Affects traumatic shock (how fast pain crit happens). 0 = no effect (immunity to pain crit), 2 = double etc.Overriden by "can_feel_pain" var	
 	// set below is EMP interactivity for nonsynth carbons
 	var/emp_sensitivity =		0			// bitflag. valid flags are: EMP_PAIN, EMP_BLIND, EMP_DEAFEN, EMP_CONFUSE, EMP_STUN, and EMP_(BRUTE/BURN/TOX/OXY)_DMG
 	var/emp_dmg_mod =		1			// Multiplier to all EMP damage sustained by the mob, if it's EMP-sensitive

--- a/code/modules/mob/living/carbon/shock.dm
+++ b/code/modules/mob/living/carbon/shock.dm
@@ -13,8 +13,7 @@
 	1.2	* src.getShockFireLoss() + 		\
 	1.2	* src.getShockBruteLoss() + 		\
 	1.7	* src.getCloneLoss() + 		\
-	2	* src.halloss + 			\
-	-1	* src.chem_effects[CE_PAINKILLER]
+	2	* src.halloss
 
 	if(src.slurring)
 		src.traumatic_shock -= 20
@@ -27,6 +26,13 @@
 				src.traumatic_shock += 30
 			else if(organ.is_dislocated())
 				src.traumatic_shock += 15
+	
+	// Some individuals/species are more or less supectible to pain. Default trauma_mod = 1. Does not affect painkillers
+	if(istype(src, /mob/living/carbon/human))
+		var/mob/living/carbon/human/H = src
+		H.traumatic_shock *= H.species.trauma_mod
+		
+	src.traumatic_shock += -1 *  src.chem_effects[CE_PAINKILLER]
 
 	if(src.traumatic_shock < 0)
 		src.traumatic_shock = 0

--- a/html/changelogs/Runa Dacino - trauma mod.yml
+++ b/html/changelogs/Runa Dacino - trauma mod.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: RunaDacino
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Adds a framework that makes it possible for different species to react to traumatic shock (pain crit) at different rates. "


### PR DESCRIPTION
I am making a trait downstream for custom species to be able to take twice the traumatic_shock from being injured in any way, and to do it I need to change base polaris files unfortunately. Same deal as spice_mod and other VORESstation custom species traits.

This does not affect polaris gameplay at all as it is implemented, but may be used to differentiate some species further if so desired by the community just like brute_mod and other traits allow differentiation.

Testing shows it works as intended, and will NOT affect Polaris.

Before the change:
100 oxloss led to 100 traumatic shock.
After the change, without trait that changes trauma_mod to be equal to 2 (essentially, Polaris experience):
100 oxloss led to 100 traumatic shock.
After the change, with trait:
100 oxloss led to 200 traumatic shock.

Also works for other sources of trauma, but they produce less pretty numbers.