### PR TITLE
Fixes unreachable landmarks breaking spacetravel

### DIFF
--- a/code/modules/overmap/spacetravel.dm
+++ b/code/modules/overmap/spacetravel.dm
@@ -83,6 +83,10 @@ proc/overmap_spacetravel(var/turf/space/T, var/atom/movable/A)
 	if (!M)
 		return
 
+	// Is the landmark still on the map.
+	if(!isturf(M.loc))
+		return
+
 	// Don't let AI eyes yeet themselves off the map
 	if(istype(A, /mob/observer/eye))
 		return


### PR DESCRIPTION
Adds a sanity check to prevent overmap spacetravel locking onto unreachable landmarks (such as other shuttles and such that are docked inside other landmarks and thus not on the overmap itself) and getting killed by a runtime.