### PR TITLE
Fixes dismantled machines deleting inserted IDs

### DIFF
--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -418,10 +418,9 @@ Class Procs:
 
 /obj/machinery/proc/dismantle()
 	playsound(src, 'sound/items/Crowbar.ogg', 50, 1)
-	if(contents)
-		for(var/atom/A in contents)
-			if(istype(A,/obj/item/weapon/card/id))
-				A.forceMove(src.loc)
+	for(var/obj/I in contents)
+		if(istype(I,/obj/item/weapon/card/id))
+			I.forceMove(src.loc)
 	//TFF 3/6/19 - port Cit RP fix of infinite frames. If it doesn't have a circuit board, don't create a frame. Return a smack instead. BONK!
 	if(!circuit)
 		return 0

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -418,6 +418,10 @@ Class Procs:
 
 /obj/machinery/proc/dismantle()
 	playsound(src, 'sound/items/Crowbar.ogg', 50, 1)
+	if(contents)
+		for(var/atom/A in contents)
+			if(istype(A,/obj/item/weapon/card/id))
+				A.forceMove(src.loc)
 	//TFF 3/6/19 - port Cit RP fix of infinite frames. If it doesn't have a circuit board, don't create a frame. Return a smack instead. BONK!
 	if(!circuit)
 		return 0


### PR DESCRIPTION
Machines no longer delete people's ID cards whenever they attempt the most obvious route of getting their card back from an unpowered machine.