### PR TITLE
A Thing About Digging Sand and Mineral Processor Speed

### DIFF
--- a/code/__defines/mobs.dm
+++ b/code/__defines/mobs.dm
@@ -25,7 +25,7 @@
 #define BORGMESON 0x1
 #define BORGTHERM 0x2
 #define BORGXRAY  0x4
-#define BORGMATERIAL  8
+#define BORGMATERIAL  0x8
 
 #define STANCE_ATTACK    11 // Backwards compatability
 #define STANCE_ATTACKING 12 // Ditto

--- a/code/game/objects/items/weapons/storage/bags.dm
+++ b/code/game/objects/items/weapons/storage/bags.dm
@@ -124,7 +124,7 @@
 		to_chat(user, "<span class='notice'>You fill the [src].</span>")
 	else if(!silent)
 		to_chat(user, "<span class='notice'>You fail to pick anything up with \the [src].</span>")
-	if(istype(user.pulling, /obj/structure/ore_box/)) //Bit of a crappy way to do this, as it doubles spam for the user, but it works.
+	if(istype(user.pulling, /obj/structure/ore_box)) //Bit of a crappy way to do this, as it doubles spam for the user, but it works.
 		var/obj/structure/ore_box/O = user.pulling
 		O.attackby(src, user)
 

--- a/code/modules/mining/machine_processing.dm
+++ b/code/modules/mining/machine_processing.dm
@@ -65,7 +65,7 @@
 		dat += "<A href='?src=\ref[src];choice=claim'>Claim points.</A><br>"
 	else
 		dat += "No ID inserted.  <A href='?src=\ref[src];choice=insert'>Insert ID.</A><br>"
-
+	dat += "High-speed processing is <A href='?src=\ref[src];toggle_speed=1'>[(machine.speed_process ? "<font color='green'>active</font>" : "<font color='red'>inactive</font>")]."
 	dat += "<hr><table>"
 
 	for(var/ore in machine.ores_processing)
@@ -122,6 +122,10 @@
 
 		show_all_ores = !show_all_ores
 
+	if(href_list["toggle_speed"])
+
+		machine.toggle_speed()
+
 	if(href_list["choice"])
 		if(istype(inserted_id))
 			if(href_list["choice"] == "eject")
@@ -163,6 +167,7 @@
 	var/list/ores_stored[0]
 	var/static/list/alloy_data
 	var/active = FALSE
+	var/tick = 0
 
 	var/points = 0
 	var/static/list/ore_values = list(
@@ -208,6 +213,23 @@
 		if(src.output) break
 	return
 
+/obj/machinery/mineral/processing_unit/proc/toggle_speed(var/forced)
+	var/area/refinery_area = get_area(src)
+	if(forced)
+		speed_process = forced
+	else
+		speed_process = !speed_process // switching gears
+	if(speed_process) // high gear
+		STOP_MACHINE_PROCESSING(src)
+		START_PROCESSING(SSfastprocess, src)
+	else // low gear
+		STOP_PROCESSING(SSfastprocess, src)
+		START_MACHINE_PROCESSING(src)
+	for(var/obj/machinery/mineral/unloading_machine/unloader in refinery_area.contents)
+		unloader.toggle_speed()
+	for(var/obj/machinery/conveyor_switch/cswitch in refinery_area.contents)
+		cswitch.toggle_speed()
+
 /obj/machinery/mineral/processing_unit/process()
 
 	if (!src.output || !src.input)
@@ -217,11 +239,11 @@
 		return
 
 	var/list/tick_alloys = list()
+	if(speed_process)
+		tick++
 
 	//Grab some more ore to process this tick.
-	for(var/i = 0,i<sheets_per_tick,i++)
-		var/obj/item/weapon/ore/O = locate() in input.loc
-		if(!O) break
+	for(var/obj/item/weapon/ore/O in input.loc)
 		if(!isnull(ores_stored[O.material]))
 			ores_stored[O.material]++
 			points += ore_values[O.material] // Give Points!
@@ -309,7 +331,11 @@
 		else
 			continue
 
-	console.updateUsrDialog()
+	if(!(tick % 10) && speed_process)
+		console.updateUsrDialog()
+		tick = 0
+	else
+		console.updateUsrDialog()
 
 #undef PROCESS_NONE
 #undef PROCESS_SMELT

--- a/code/modules/mining/machine_processing.dm
+++ b/code/modules/mining/machine_processing.dm
@@ -229,6 +229,8 @@
 		unloader.toggle_speed()
 	for(var/obj/machinery/conveyor_switch/cswitch in refinery_area.contents)
 		cswitch.toggle_speed()
+	for(var/obj/machinery/mineral/stacking_machine/stacker in refinery_area.contents)
+		stacker.toggle_speed()
 
 /obj/machinery/mineral/processing_unit/process()
 

--- a/code/modules/mining/machine_stacking.dm
+++ b/code/modules/mining/machine_stacking.dm
@@ -109,6 +109,18 @@
 		return
 	return
 
+/obj/machinery/mineral/stacking_machine/proc/toggle_speed(var/forced)
+	if(forced)
+		speed_process = forced
+	else
+		speed_process = !speed_process // switching gears
+	if(speed_process) // high gear
+		STOP_MACHINE_PROCESSING(src)
+		START_PROCESSING(SSfastprocess, src)
+	else // low gear
+		STOP_PROCESSING(SSfastprocess, src)
+		START_MACHINE_PROCESSING(src)
+
 /obj/machinery/mineral/stacking_machine/process()
 	if (src.output && src.input)
 		var/turf/T = get_turf(input)

--- a/code/modules/mining/machine_unloading.dm
+++ b/code/modules/mining/machine_unloading.dm
@@ -10,7 +10,6 @@
 	var/obj/machinery/mineral/input = null
 	var/obj/machinery/mineral/output = null
 
-
 /obj/machinery/mineral/unloading_machine/Initialize()
 	. = ..()
 	for(var/dir in cardinal)
@@ -21,6 +20,18 @@
 		output = locate(/obj/machinery/mineral/output, get_step(src, dir))
 		if(output)
 			break
+
+/obj/machinery/mineral/unloading_machine/proc/toggle_speed(var/forced)
+	if(forced)
+		speed_process = forced
+	else
+		speed_process = !speed_process // switching gears
+	if(speed_process) // high gear
+		STOP_MACHINE_PROCESSING(src)
+		START_PROCESSING(SSfastprocess, src)
+	else // low gear
+		STOP_PROCESSING(SSfastprocess, src)
+		START_MACHINE_PROCESSING(src)
 
 /obj/machinery/mineral/unloading_machine/process()
 	if (src.output && src.input)

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -21,6 +21,7 @@
 	w_class = ITEMSIZE_LARGE
 	matter = list(DEFAULT_WALL_MATERIAL = 3750)
 	var/digspeed = 40 //moving the delay to an item var so R&D can make improved picks. --NEO
+	var/sand_dig = FALSE // does this thing dig sand?
 	origin_tech = list(TECH_MATERIAL = 1, TECH_ENGINEERING = 1)
 	attack_verb = list("hit", "pierced", "sliced", "attacked")
 	var/drill_sound = "pickaxe"
@@ -43,6 +44,7 @@
 	icon_state = "handdrill"
 	item_state = "jackhammer"
 	digspeed = 30
+	sand_dig = TRUE
 	origin_tech = list(TECH_MATERIAL = 2, TECH_POWER = 3, TECH_ENGINEERING = 2)
 	desc = "Yours is the drill that will pierce through the rock walls."
 	drill_verb = "drilling"
@@ -93,6 +95,7 @@
 	icon_state = "diamonddrill"
 	item_state = "jackhammer"
 	digspeed = 5 //Digs through walls, girders, and can dig up sand
+	sand_dig = TRUE
 	origin_tech = list(TECH_MATERIAL = 6, TECH_POWER = 4, TECH_ENGINEERING = 5)
 	desc = "Yours is the drill that will pierce the heavens!"
 	drill_verb = "drilling"
@@ -102,6 +105,7 @@
 	icon_state = "jackhammer"
 	item_state = "jackhammer"
 	digspeed = 15
+	sand_dig = TRUE
 	desc = "Cracks rocks with sonic blasts. This one seems like an improved design."
 	drill_verb = "hammering"
 
@@ -122,6 +126,7 @@
 	attack_verb = list("bashed", "bludgeoned", "thrashed", "whacked")
 	sharp = 0
 	edge = 1
+	var/digspeed = 40
 
 /obj/item/weapon/shovel/spade
 	name = "spade"

--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -303,19 +303,20 @@ turf/simulated/mineral/floor/light_corner
 		return
 
 	if(!density)
+		var/valid_tool = 0
+		var/digspeed = 40
 
-		var/list/usable_tools = list(
-			/obj/item/weapon/shovel,
-			/obj/item/weapon/pickaxe/diamonddrill,
-			/obj/item/weapon/pickaxe/drill,
-			/obj/item/weapon/pickaxe/borgdrill
-			)
+		if(istype(W, /obj/item/weapon/shovel))
+			var/obj/item/weapon/shovel/S = W
+			valid_tool = 1
+			digspeed = S.digspeed
 
-		var/valid_tool
-		for(var/valid_type in usable_tools)
-			if(istype(W,valid_type))
+		if(istype(W, /obj/item/weapon/pickaxe))
+			var/obj/item/weapon/pickaxe/P = W
+			if(P.sand_dig)
 				valid_tool = 1
-				break
+				digspeed = P.digspeed
+
 
 		if(valid_tool)
 			if (sand_dug)
@@ -329,7 +330,7 @@ turf/simulated/mineral/floor/light_corner
 			to_chat(user, "<span class='notice'>You start digging.</span>")
 			playsound(user, 'sound/effects/rustle1.ogg', 50, 1)
 
-			if(!do_after(user,40)) return
+			if(!do_after(user,digspeed)) return
 
 			to_chat(user, "<span class='notice'>You dug a hole.</span>")
 			GetDrilled()
@@ -543,7 +544,7 @@ turf/simulated/mineral/floor/light_corner
 	if(!density)
 		if(!sand_dug)
 			sand_dug = 1
-			for(var/i=0;i<(rand(3)+2);i++)
+			for(var/i=0;i<5;i++)
 				new/obj/item/weapon/ore/glass(src)
 			update_icon()
 		return

--- a/code/modules/recycling/conveyor2.dm
+++ b/code/modules/recycling/conveyor2.dm
@@ -44,7 +44,7 @@
 	if(forced)
 		speed_process = forced
 	else
-		peed_process = !speed_process // switching gears
+		speed_process = !speed_process // switching gears
 	if(speed_process) // high gear
 		STOP_MACHINE_PROCESSING(src)
 		START_PROCESSING(SSfastprocess, src)

--- a/code/modules/recycling/conveyor2.dm
+++ b/code/modules/recycling/conveyor2.dm
@@ -40,6 +40,18 @@
 
 	default_apply_parts()
 
+/obj/machinery/conveyor/proc/toggle_speed(var/forced)
+	if(forced)
+		speed_process = forced
+	else
+		peed_process = !speed_process // switching gears
+	if(speed_process) // high gear
+		STOP_MACHINE_PROCESSING(src)
+		START_PROCESSING(SSfastprocess, src)
+	else // low gear
+		STOP_PROCESSING(SSfastprocess, src)
+		START_MACHINE_PROCESSING(src)
+
 /obj/machinery/conveyor/proc/setmove()
 	if(operating == FORWARDS)
 		movedir = forwards
@@ -186,6 +198,7 @@
 
 	var/list/conveyors		// the list of converyors that are controlled by this switch
 	anchored = 1
+	var/speed_active = FALSE // are the linked conveyors on SSfastprocess?
 
 
 
@@ -199,6 +212,15 @@
 	for(var/obj/machinery/conveyor/C in machines)
 		if(C.id == id)
 			conveyors += C
+
+/obj/machinery/conveyor_switch/proc/toggle_speed(var/forced)
+	speed_active = !speed_active // switching gears
+	if(speed_active) // high gear
+		for(var/obj/machinery/conveyor/C in conveyors)
+			C.toggle_speed(TRUE)
+	else // low gear
+		for(var/obj/machinery/conveyor/C in conveyors)
+			C.toggle_speed(FALSE)
 
 // update the icon depending on the position
 


### PR DESCRIPTION
the changes in the mob defines and the slash or whatever are just for consistency and i probably shouldn't have poked at that anyway but they just irked me. that's not why we're here so ANYWAYS

### A Thing About Digging Sand:
- Replaces the usable_tools list for digging sand with a variable, sand_dig, for mining tools capable of digging.
- Mining tools that hit rocks faster now also dig sand faster, because digging for sand now uses the tool's toolspeed var.
- Shovels maintain their 4 second digging speed delay.

### A Thing About Processor Speed:
- The mineral processor can now switch its processing speed by a toggle on the console.
- ~~Support for the above hasn't been put on the TGUI interface, but that fancy interface isn't implemented yet, so someone can cross that bridge once it gets here.~~ It's a thing now. On Virgo.
- Also the ore processor intake is no longer limited to 10 ore chunks per process cycle or whatever.

~~The only problem now is that the ore processor on fastmode spits out ores too fast for the conveyor belts to handle.
I could fiddle about with adding a switch or something to make the conveyor belts (and maybe the ore box unloader?) pick up speed by putting them on the same fast process subsystem and linking the toggles for that to the console, but I'm not going to do that unless someone tells me to because something something scope creep.~~
I just made toggling speed mode on the mineral processor also toggle conveyor belt and unloader speed.