### PR TITLE
RPED QoL Tweak(s)/Unimplemented RPED Variant

### DIFF
--- a/code/defines/obj/weapon.dm
+++ b/code/defines/obj/weapon.dm
@@ -297,7 +297,7 @@
 
 /obj/item/weapon/storage/part_replacer
 	name = "rapid part exchange device"
-	desc = "Special mechanical module made to store, sort, and apply standard machine parts."
+	desc = "A special mechanical module made to store, sort, and apply standard machine parts."
 	icon_state = "RPED"
 	w_class = ITEMSIZE_HUGE
 	can_hold = list(/obj/item/weapon/stock_parts)
@@ -311,10 +311,11 @@
 	max_storage_space = 100
 	drop_sound = 'sound/items/drop/device.ogg'
 	pickup_sound = 'sound/items/pickup/device.ogg'
+	var/panel_req = TRUE
 
 /obj/item/weapon/storage/part_replacer/adv
 	name = "advanced rapid part exchange device"
-	desc = "Special mechanical module made to store, sort, and apply standard machine parts.  This one has a greatly upgraded storage capacity"
+	desc = "A special mechanical module made to store, sort, and apply standard machine parts.  This one has a greatly upgraded storage capacity."
 	icon_state = "RPED"
 	w_class = ITEMSIZE_HUGE
 	can_hold = list(/obj/item/weapon/stock_parts)
@@ -327,6 +328,31 @@
 	max_w_class = ITEMSIZE_NORMAL
 	max_storage_space = 400
 
+/obj/item/weapon/storage/part_replacer/adv/discount_bluespace
+	name = "discount bluespace rapid part exchange device"
+	desc = "A special mechanical module made to store, sort, and apply standard machine parts.  This one has a further increased storage capacity, \
+	and the ability to work on machines with closed maintenance panels."
+	storage_slots = 400
+	max_storage_space = 800
+	panel_req = FALSE
+
+/obj/item/weapon/storage/part_replacer/drop_contents() // hacky-feeling tier-based drop system
+	hide_from(usr)
+	var/turf/T = get_turf(src)
+	var/lowest_rating = INFINITY // We want the lowest-part tier rating in the RPED so we only drop the lowest-tier parts.
+	/*
+	* Why not just use the stock part's rating variable?
+	* Future-proofing for a potential future where stock parts aren't the only thing that can fit in an RPED.
+	* see: /tg/ and /vg/'s RPEDs fitting power cells, beakers, etc.
+	*/
+	for(var/obj/item/B in contents)
+		if(B.rped_rating() < lowest_rating)
+			lowest_rating = B.rped_rating()
+	for(var/obj/item/B in contents)
+		if(B.rped_rating() > lowest_rating)
+			continue
+		remove_from_storage(B, T)
+	
 /obj/item/weapon/stock_parts
 	name = "stock part"
 	desc = "What?"
@@ -341,6 +367,9 @@
 	src.pixel_x = rand(-5.0, 5)
 	src.pixel_y = rand(-5.0, 5)
 	..()
+
+/obj/item/weapon/stock_parts/get_rating()
+	return rating
 
 //Rank 1
 

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -319,7 +319,10 @@ Class Procs:
 		return 0
 	if(!component_parts)
 		return 0
-	if(panel_open)
+	to_chat(user, "<span class='notice'>Following parts detected in the machine:</span>")
+	for(var/obj/item/C in component_parts) //var/var/obj/item/C? // man that was awful to read why did you tell me that was there?
+		to_chat(user, "<span class='notice'>    [C.name]</span>")
+	if(panel_open || !R.panel_req)
 		var/obj/item/weapon/circuitboard/CB = circuit
 		var/P
 		for(var/obj/item/weapon/stock_parts/A in component_parts)
@@ -339,10 +342,6 @@ Class Procs:
 						break
 			update_icon()
 			RefreshParts()
-	else
-		to_chat(user, "<span class='notice'>Following parts detected in the machine:</span>")
-		for(var/var/obj/item/C in component_parts) //var/var/obj/item/C?
-			to_chat(user, "<span class='notice'>    [C.name]</span>")
 	return 1
 
 // Default behavior for wrenching down machines.  Supports both delay and instant modes.

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -319,8 +319,8 @@ Class Procs:
 		return 0
 	if(!component_parts)
 		return 0
-	to_chat(user, "<span class='notice'>Following parts detected in the machine:</span>")
-	for(var/obj/item/C in component_parts) //var/var/obj/item/C? // man that was awful to read why did you tell me that was there?
+	to_chat(user, "<span class='notice'>Following parts detected in [src]:</span>")
+	for(var/obj/item/C in component_parts)
 		to_chat(user, "<span class='notice'>    [C.name]</span>")
 	if(panel_open || !R.panel_req)
 		var/obj/item/weapon/circuitboard/CB = circuit

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -943,3 +943,12 @@ modules/mob/living/carbon/human/life.dm if you die, you will be zoomed out.
 
 /obj/item/proc/openTip(location, control, params, user)
 	openToolTip(user, src, params, title = name, content = desc)
+
+// These procs are for RPEDs and part ratings. The concept for this was borrowed from /vg/station.
+// Gets the rating of the item, used in stuff like machine construction.
+/obj/item/proc/get_rating()
+	return FALSE
+
+// Like the above, but used for RPED sorting of parts.
+/obj/item/proc/rped_rating()
+	return get_rating()

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -523,9 +523,11 @@
 
 	if(((!(ishuman(usr) || isrobot(usr))) && (src.loc != usr)) || usr.stat || usr.restrained())
 		return
+	drop_contents()
 
-	var/turf/T = get_turf(src)
+/obj/item/weapon/storage/proc/drop_contents() // why is this a proc? literally just for RPEDs
 	hide_from(usr)
+	var/turf/T = get_turf(src)
 	for(var/obj/item/I in contents)
 		remove_from_storage(I, T)
 


### PR DESCRIPTION
MISC:
Fiddles about with some procs and some description grammar but that doesn't really matter in the end because
# WE'VE GOT SOME SWEET SWEET RPED QUALITY OF LIFE HERE
inspired by /vg/station, can't find the original PR for the lowest-tier-part-dropping thing but the clickdrag-RPED-to-DA thing is directly inspired by vgstation13#28338
- RPEDs now drop their lowest tier parts.
- RPEDs can be click-dragged onto a deconstructive analyzer to deconstruct their lowest-tier parts.
### unimplemented RPED mentioned in title:
- UNIMPLEMENTED BUT THERE AS A PROOF OF CONCEPT
- "discount bluespace rapid part exchange device"
- holds EVEN MORE PARTS (400, compared to adv. RPED's 200 and normal RPED's 50)
- works on machines with closed panels