### PR TITLE
borg chargers work for hardsuit wearers

### DIFF
--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -87,25 +87,44 @@
 	else if(ishuman(occupant))
 		var/mob/living/carbon/human/H = occupant
 
-		// In case they somehow end up with positive values for otherwise unobtainable damage...
-		if(H.getToxLoss() > 0)
-			H.adjustToxLoss(-(rand(1,3)))
-		if(H.getOxyLoss() > 0)
-			H.adjustOxyLoss(-(rand(1,3)))
-		if(H.getCloneLoss() > 0)
-			H.adjustCloneLoss(-(rand(1,3)))
-		if(H.getBrainLoss() > 0)
-			H.adjustBrainLoss(-(rand(1,3)))
+		if(H.isSynthetic())
+			// In case they somehow end up with positive values for otherwise unobtainable damage...
+			if(H.getToxLoss() > 0)
+				H.adjustToxLoss(-(rand(1,3)))
+			if(H.getOxyLoss() > 0)
+				H.adjustOxyLoss(-(rand(1,3)))
+			if(H.getCloneLoss() > 0)
+				H.adjustCloneLoss(-(rand(1,3)))
+			if(H.getBrainLoss() > 0)
+				H.adjustBrainLoss(-(rand(1,3)))
 
-		// Also recharge their internal battery.
-		if(H.isSynthetic() && H.nutrition < MAX_NUTRITION)
-			H.nutrition = min(H.nutrition+10, MAX_NUTRITION)
-			cell.use(7000/450*10)
+			// Also recharge their internal battery.
+			if(H.isSynthetic() && H.nutrition < MAX_NUTRITION)
+				H.nutrition = min(H.nutrition+10, MAX_NUTRITION)
+				cell.use(7000/450*10)
 
-		// And clear up radiation
-		if(H.radiation > 0)
-			H.radiation = max(H.radiation - rand(5, 15), 0)
+			// And clear up radiation
+			if(H.radiation > 0)
+				H.radiation = max(H.radiation - rand(5, 15), 0)
 
+		if(H.wearing_rig) // stepping into a borg charger to charge your rig and fix your shit
+			var/obj/item/weapon/rig/wornrig = H.get_rig()
+			if(wornrig) // just to make sure
+				for(var/obj/item/rig_module/storedmod in wornrig.installed_modules)
+					if(weld_rate && storedmod.damage && cell.checked_use(weld_power_use * weld_rate * CELLRATE))
+						to_chat(H, "<span class='notice'>[storedmod] is repaired!</span>")
+						storedmod.damage = 0
+				if(wornrig.chest)
+					var/obj/item/clothing/suit/space/rig/rigchest = wornrig.chest
+					if(weld_rate && rigchest.damage && cell.checked_use(weld_power_use * weld_rate * CELLRATE))
+						rigchest.breaches = list()
+						rigchest.calc_breach_damage()
+						to_chat(H, "<span class='notice'>[rigchest] is repaired!</span>")
+				if(wornrig.cell)
+					var/obj/item/weapon/cell/rigcell = wornrig.cell
+					var/diff = min(rigcell.maxcharge - rigcell.charge, charging_power * CELLRATE) // Capped by charging_power / tick
+					var/charge_used = cell.use(diff)
+					rigcell.give(charge_used)
 
 /obj/machinery/recharge_station/examine(mob/user)
 	. = ..()
@@ -237,7 +256,7 @@
 
 	else if(istype(L,  /mob/living/carbon/human))
 		var/mob/living/carbon/human/H = L
-		if(H.isSynthetic())
+		if(H.isSynthetic() || H.wearing_rig)
 			add_fingerprint(H)
 			H.reset_view(src)
 			H.forceMove(src)


### PR DESCRIPTION
Hardsuit wearers can step into cyborg rechargers to recharge their suit, repair their modules, and fix any chestpiece breaches if they manage to bungle it up badly enough to get a suit breach on their hardsuit.
Repairs on modules and chestpieces require the suitable upgrade/part tiers.