### PR TITLE
Changes formatting for RESPAWN_MESSAGE configuration to be more visible

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -493,7 +493,7 @@ var/list/gamemode_cache = list()
 					config.respawn_time = raw_minutes MINUTES
 
 				if ("respawn_message")
-					config.respawn_message = value
+					config.respawn_message = "<span class='notice'><B>[value]</B></span>"
 
 				if ("servername")
 					config.server_name = value

--- a/html/changelogs/Runa Dacino - configuration formatting.yml
+++ b/html/changelogs/Runa Dacino - configuration formatting.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: RunaDacino
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Changed formatting on respawn_message to be more visible if a server changes their configuration file to have a value for respawn_message"


### PR DESCRIPTION
I was trying to change the message on respawning downstream to better reflect rules differing from Polaris.

I ran into the following issue: changing the configuration.txt for
```
## set a message to give to players when they respawn
 RESPAWN_MESSAGE
```
removes the formatting around RESPAWN_MESSAGE.

Fixed this by making the config reader, upon seeing "RESPAWN_MESSAGE is  NOT EQUAL to defined value in configuration.DM" to take the new value, and express it as a formatted string.

This helps readability, and will ensure players notice.

This does not change the formatting from intended way, merely ensures configuration.txt changes retain intended formatting.