### PR TITLE
Fixes indoor-use snow not having footprints

### DIFF
--- a/code/game/turfs/flooring/flooring_premade.dm
+++ b/code/game/turfs/flooring/flooring_premade.dm
@@ -424,24 +424,20 @@
 
 #define FOOTSTEP_SPRITE_AMT 2
 
-/turf/snow/Entered(atom/A)
-    if(isliving(A))
-        var/mdir = "[A.dir]"
-        if(crossed_dirs[mdir])
-            crossed_dirs[mdir] = min(crossed_dirs[mdir] + 1, FOOTSTEP_SPRITE_AMT)
-        else
-            crossed_dirs[mdir] = 1
+// TODO: Move foortprints to a datum-component signal so they can actually be applied to other turf types, like sand, or mud
+/turf/simulated/floor/snow/Entered(atom/A)
+	if(isliving(A))
+		var/mob/living/L = A
+		if(L.hovering) // Flying things shouldn't make footprints.
+			return ..()
+		var/mdir = "[A.dir]"
+		crossed_dirs[mdir] = 1
+		update_icon()
+	. = ..()
 
-        update_icon()
-
-    . = ..()
-
-/turf/snow/update_icon()
-    cut_overlays()
-    for(var/d in crossed_dirs)
-        var/amt = crossed_dirs[d]
-
-        for(var/i in 1 to amt)
-            add_overlay(image(icon, "footprint[i]", text2num(d)))
+/turf/simulated/floor/snow/update_icon()
+	..()
+	for(var/d in crossed_dirs)
+		add_overlay(image(icon = 'icons/turf/outdoors.dmi', icon_state = "snow_footprints", dir = text2num(d)))
 
 //**** Here ends snow ****


### PR DESCRIPTION
Fixes #2418
:cl:
bugfix: You can make footprints on all snow turfs.
/:cl:
The major change is repathing the procs to be a real path, but I also copied the footprint code from the working snow type because it looks cleaner.
Footprints should probably just be moved to a DCS so that we can also have footprints on stuff like sand, but that's a bigger fix