### PR TITLE
Experimental: adds workflow to autoupdate changelog

### DIFF
--- a/.github/workflows/autochangelog.yml
+++ b/.github/workflows/autochangelog.yml
@@ -1,0 +1,39 @@
+name: Autochangelog
+on: 
+    pull_request:
+        types: closed
+        branches:
+            - master
+        
+env:
+    BASENAME: "polaris"
+
+jobs:
+    autochangelog:
+        name: Autochangelog
+        runs-on: ubuntu-16.04
+        if: github.event.pull_request.merged == true
+        steps:
+          - uses: /actions/checkout@v2
+          - name: Ensure +x on CI directory
+            run: |
+                chmod -R +x ./tools/ci
+          - uses: actions/setup-python@v2
+            with:
+                python-version: '3.7'
+          - name: Generate Changelog
+            run: |
+                pip install pyyaml
+                python tools/GenerateChangelog/ss13_autochangelog.py \
+                    html/changelogs \
+                    ${{ github.event.pull_request.number }} \
+                    "${{ github.event.pull_request.user.login }}" \
+                    "${{ github.event.pull_request.body }}"
+                python tools/GenerateChangelog/ss13_genchangelog.py \
+                    html/changelog.html \
+                    html/changelogs
+          - uses: stefanzweifel/git-auto-commit-action@v4
+            with:
+                commit_message: Automatic changelog generation for ${{ github.events.pull_request.number }}
+                branch: ${{ github.events.pull_request.base }}
+                commit_user_name: Autochangelog Bot

--- a/html/changelogs/KasparoVy - PR - 7760.yml
+++ b/html/changelogs/KasparoVy - PR - 7760.yml
@@ -1,37 +1,5 @@
-################################
-# Example Changelog File
-#
-# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
-#
-# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
-# When it is, any changes listed below will disappear.
-#
-# Valid Prefixes: 
-#   bugfix
-#   wip (For works in progress)
-#   tweak
-#   soundadd
-#   sounddel
-#   rscadd (general adding of nice things)
-#   rscdel (general deleting of nice things)
-#   imageadd
-#   imagedel
-#   maptweak
-#   spellcheck (typo fixes)
-#   experiment
-#################################
-
-# Your name.  
 author: KasparoVy
-
-# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
 delete-after: True
-
-# Any changes you've made.  See valid prefix list above.
-# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
-# SCREW THIS UP AND IT WON'T WORK.
-# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
-# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes: 
   - imageadd: Adds orange Teshari goggles, selectable in the loadout.
   - imageadd: Adds blindfold & new white (recolorable) blindfold to loadout.
@@ -42,4 +10,4 @@ changes:
   - rscadd: Adds a bunch of Teshari worksuits (sprites already existed).
   - imageadd: Adds some species-fitted Teshari jacket accessories (tan, charcoal, navy, burgundy, checkered).
   - tweak: Updates all Teshari undercoats and cloaks with new sprites from downstreams.
-  - fix: Fixes Teshari captain glove sprites.
+  - bugfix: Fixes Teshari captain glove sprites.

--- a/html/changelogs/Mechoid - Encumbrance.yml
+++ b/html/changelogs/Mechoid - Encumbrance.yml
@@ -1,36 +1,4 @@
-################################
-# Example Changelog File
-#
-# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
-#
-# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
-# When it is, any changes listed below will disappear.
-#
-# Valid Prefixes: 
-#   bugfix
-#   wip (For works in progress)
-#   tweak
-#   soundadd
-#   sounddel
-#   rscadd (general adding of nice things)
-#   rscdel (general deleting of nice things)
-#   imageadd
-#   imagedel
-#   maptweak
-#   spellcheck (typo fixes)
-#   experiment
-#################################
-
-# Your name.  
 author: Mechoid
-
-# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
 delete-after: True
-
-# Any changes you've made.  See valid prefix list above.
-# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
-# SCREW THIS UP AND IT WON'T WORK.
-# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
-# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes: 
   - rscadd: "Added system for exosuit over-encumbrance. Combat mechs and Ripleys have higher than default."

--- a/html/changelogs/Meghan Rossi - the_teslagen.yml
+++ b/html/changelogs/Meghan Rossi - the_teslagen.yml
@@ -1,4 +1,4 @@
 author: Meghan-Rossi
 delete-after: True
 changes: 
-  - rscadd: "The Tesla Generator is now available from cargo.  Coils and grounding rods for it may be printed on the protolathe and autolathe, respectively."
+  - rscadd: "The Tesla Generator is now available from cargo. Coils and grounding rods for it may be printed on the protolathe and autolathe, respectively."

--- a/html/changelogs/Runa Dacino -  Exosuit gripper tweak.yml
+++ b/html/changelogs/Runa Dacino -  Exosuit gripper tweak.yml
@@ -1,37 +1,5 @@
-################################
-# Example Changelog File
-#
-# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
-#
-# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
-# When it is, any changes listed below will disappear.
-#
-# Valid Prefixes: 
-#   bugfix
-#   wip (For works in progress)
-#   tweak
-#   soundadd
-#   sounddel
-#   rscadd (general adding of nice things)
-#   rscdel (general deleting of nice things)
-#   imageadd
-#   imagedel
-#   maptweak
-#   spellcheck (typo fixes)
-#   experiment
-#################################
-
-# Your name.  
-author: N3X15
-
-# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+author: RunaDacino
 delete-after: True
-
-# Any changes you've made.  See valid prefix list above.
-# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
-# SCREW THIS UP AND IT WON'T WORK.
-# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
-# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes: 
   - rscadd: "Enabled research borgs equipped with 'exosuit gripper' to be able to replace internal exosuit parts like actuators, to upgrade or to repair"
 

--- a/html/changelogs/Runa Dacino - trauma mod.yml
+++ b/html/changelogs/Runa Dacino - trauma mod.yml
@@ -1,36 +1,4 @@
-################################
-# Example Changelog File
-#
-# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
-#
-# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
-# When it is, any changes listed below will disappear.
-#
-# Valid Prefixes: 
-#   bugfix
-#   wip (For works in progress)
-#   tweak
-#   soundadd
-#   sounddel
-#   rscadd (general adding of nice things)
-#   rscdel (general deleting of nice things)
-#   imageadd
-#   imagedel
-#   maptweak
-#   spellcheck (typo fixes)
-#   experiment
-#################################
-
-# Your name.  
 author: RunaDacino
-
-# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
 delete-after: True
-
-# Any changes you've made.  See valid prefix list above.
-# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
-# SCREW THIS UP AND IT WON'T WORK.
-# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
-# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes: 
   - rscadd: "Adds a framework that makes it possible for different species to react to traumatic shock (pain crit) at different rates. "

--- a/html/changelogs/SubberTheFabulous-PR-7642.yml
+++ b/html/changelogs/SubberTheFabulous-PR-7642.yml
@@ -1,36 +1,4 @@
-################################
-# Example Changelog File
-#
-# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
-#
-# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
-# When it is, any changes listed below will disappear.
-#
-# Valid Prefixes: 
-#   bugfix
-#   wip (For works in progress)
-#   tweak
-#   soundadd
-#   sounddel
-#   rscadd (general adding of nice things)
-#   rscdel (general deleting of nice things)
-#   imageadd
-#   imagedel
-#   maptweak
-#   spellcheck (typo fixes)
-#   experiment
-#################################
-
-# Your name.  
 author: Subber
-
-# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
 delete-after: True
-
-# Any changes you've made.  See valid prefix list above.
-# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
-# SCREW THIS UP AND IT WON'T WORK.
-# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
-# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes: 
   - rscadd: "Added two new antag augments to traitor uplink: armblade and handblade."

--- a/html/changelogs/Woodrat - Vote.yml
+++ b/html/changelogs/Woodrat - Vote.yml
@@ -1,36 +1,4 @@
-################################
-# Example Changelog File
-#
-# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
-#
-# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
-# When it is, any changes listed below will disappear.
-#
-# Valid Prefixes: 
-#   bugfix
-#   wip (For works in progress)
-#   tweak
-#   soundadd
-#   sounddel
-#   rscadd (general adding of nice things)
-#   rscdel (general deleting of nice things)
-#   imageadd
-#   imagedel
-#   maptweak
-#   spellcheck (typo fixes)
-#   experiment
-#################################
-
-# Your name.  
 author: Woodrat
-
-# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
 delete-after: True
-
-# Any changes you've made.  See valid prefix list above.
-# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
-# SCREW THIS UP AND IT WON'T WORK.
-# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
-# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes: 
   - tweak: "Changes vote notification sound to that of World Server in order to help people realize there is a vote occurring."

--- a/html/changelogs/mechoid - butchery.yml
+++ b/html/changelogs/mechoid - butchery.yml
@@ -34,4 +34,4 @@ delete-after: True
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes: 
   - rscadd: "Animals can be butchered for organs and hide. Requires scraping (sharp), washing (water or washing machine), and then drying (bonfire or drying rack)."
-  - rscadd: "Organs can be butchered for meat, named "[organ] meat". Heart meat, liver meat, etc. Brains from player mobs cannot be butchered."
+  - rscadd: "Organs can be butchered for meat, named \"[organ] meat\". Heart meat, liver meat, etc. Brains from player mobs cannot be butchered."

--- a/html/changelogs/mechoid - hydroupkeep.yml
+++ b/html/changelogs/mechoid - hydroupkeep.yml
@@ -1,37 +1,5 @@
-################################
-# Example Changelog File
-#
-# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
-#
-# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
-# When it is, any changes listed below will disappear.
-#
-# Valid Prefixes: 
-#   bugfix
-#   wip (For works in progress)
-#   tweak
-#   soundadd
-#   sounddel
-#   rscadd (general adding of nice things)
-#   rscdel (general deleting of nice things)
-#   imageadd
-#   imagedel
-#   maptweak
-#   spellcheck (typo fixes)
-#   experiment
-#################################
-
-# Your name.  
 author: Mechoid
-
-# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
 delete-after: True
-
-# Any changes you've made.  See valid prefix list above.
-# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
-# SCREW THIS UP AND IT WON'T WORK.
-# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
-# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes: 
   - rscadd: "Adds Wurmwoad, a suspiciously worm-like plant that produces pods of spice."
   - rscadd: "Adds Wurmwoad to the service borg synthesizer."

--- a/tools/GenerateChangelog/ss13_autochangelog.py
+++ b/tools/GenerateChangelog/ss13_autochangelog.py
@@ -1,0 +1,121 @@
+'''
+Usage:
+    $ python ss13_autochangelog.py [--dry-run] html/changelogs [PR_number] [PR_author] [PR_Body]
+
+ss13_autochangelog.py - Generate changelog YAML files from pull request.
+'''
+
+from __future__ import print_function
+import os, sys, re, time, argparse
+from datetime import datetime, date
+from time import time
+
+today = date.today()
+
+dateformat = "%d %B %Y"
+
+opt = argparse.ArgumentParser()
+opt.add_argument('target_dir', help='The location to write changelog files to.')
+opt.add_argument('pr_numb', help='The number of the pull request.')
+opt.add_argument('pr_author', help='The author of the pull request. If specific authors aren\'t specified, the PR author will be used')
+opt.add_argument('pr_body', help='The body of the pull request to parse for changelogs.')
+
+args = opt.parse_args()
+
+all_changelog_entries = {}
+
+validPrefixes = {
+    "fix": 'bugfix',
+	"fixes": 'bugfix',
+	"bugfix": 'bugfix',
+    "wip": 'wip',
+    "tweak": 'tweak',
+	"tweaks": 'tweak',
+	"rsctweak": 'tweak',
+    "soundadd": 'soundadd',
+    "sounddel": 'sounddel',
+    "add": 'rscadd',
+    "adds": 'rscadd',
+	"rscadd": 'rscadd',
+    "del": 'rscdel',
+	"dels": 'rscdel',
+	"delete": 'rscdel',
+	"deletes": 'rscdel',
+	"rscdeldel": 'rscdel',
+	"imageadd": 'imageadd',
+    "imagedel": 'imagedel',
+    "maptweak": 'maptweak',
+	"remap": 'maptweak',
+	"remaps": 'maptweak',
+    "typo": 'spellcheck',
+	"spellcheck": 'spellcheck',
+    "experimental": 'experiment',
+	"experiments": 'experiment',
+	"experiment": 'experiment'
+}
+
+incltag = False
+new_logs = {}
+author = args.pr_author
+new = 0
+
+# Parse PR body for changelog entries
+print('Reading changelogs...')
+for line in args.pr_body.splitlines():
+	print(f"Checking line '{line}'")
+	if line[0] == "🆑": # Find the start of the changelog
+		print("Found opening :cl: tag")
+		if incltag == True: # If we're already reading logs, skip
+			continue
+		incltag = True
+		
+		# Fetch the author name
+		author = line[1:]
+		author.strip()
+		
+		if not len(author):
+			author = pr_author
+		
+		if author not in new_logs:
+			new_logs[author] = [] # Make array entry for the author
+		continue
+		
+	# If we hit a /cl, we're no longer reading logs
+	elif line == "/🆑":
+		print("Found closing /:cl: tag")
+		incltag = False
+
+	# If we aren't reading logs, we don't care about any other line contents
+	if not incltag:
+		continue
+		
+	# Split line into tag (icon) and body (comment)
+	body = re.split("[ ,:-]", line, 1)
+	if len(body) != 2:
+		continue # If there's just one word, then it can't really be a changelog, now can it
+	
+	if body[0] in validPrefixes:
+		tag = body[0]
+		body = body[1].strip(" ,-:\t\n")
+	else: # If the tag is invalid, just default to rscadd
+		tag = "rscadd"
+		body = line.strip(" ,-:\t\n")
+		
+	new_logs[author].append(f"  - {tag}: \"{body}\"")
+	new += 1
+
+print(f"Writing {new} new changelog entries.") # f supposedly formats new into the var
+
+for auth in new_logs:
+	# Sanitize authors without changes
+	if not len(new_logs[auth]):
+		continue
+	
+	f = open(os.path.join(args.target_dir, f"{auth}{args.pr_numb}.yml"), 'w')
+	print(f"Writing changes to {f}")
+	f.write(f'author: {auth}\n')
+	f.write('delete-after: True\n')
+	f.write('changes:\n')
+	for log in new_logs[auth]:
+		f.write(f'{log}\n')
+	f.close()

--- a/tools/GenerateChangelog/ss13_autochangelog.py
+++ b/tools/GenerateChangelog/ss13_autochangelog.py
@@ -74,7 +74,7 @@ for line in args.pr_body.splitlines():
 		author.strip()
 		
 		if not len(author):
-			author = pr_author
+			author = args.pr_author
 		
 		if author not in new_logs:
 			new_logs[author] = [] # Make array entry for the author
@@ -95,7 +95,7 @@ for line in args.pr_body.splitlines():
 		continue # If there's just one word, then it can't really be a changelog, now can it
 	
 	if body[0] in validPrefixes:
-		tag = body[0]
+		tag = validPrefixes[body[0]]
 		body = body[1].strip(" ,-:\t\n")
 	else: # If the tag is invalid, just default to rscadd
 		tag = "rscadd"


### PR DESCRIPTION
Requested by basically everyone who knows that this is a thing elsewhere, merry christmas I guess.
:cl:
experimental - Adds new github action to automatically update the changelog from merged PR descriptions
/:cl:
The parsing might be a little janky because I rarely write python code, but if you include a name on the cl-tag line, it should take that as the author instead of the PR author (the default). Generally speaking, the first word of each line is taken as the changelog tag (If there's just one word on the line, it'll skip the line because that's not a changelog). Full list of valid tags are at the top of the script, and adding more should be fairly straightforward because it's just a dict. The added entries for stuff like `Adds` will be weird to write with because it'll currently consume the `Adds` as the changelog tag and make everything else the entry, keep that in mind when writing your logs.
Format is as follows
> `:cl:` [Author name (optional)]
> [tag] [some combination of [ ,-:]] [Changelog entry]
> /`:cl:`

I think that format should also let you write changelogs for multiple authors in a single PR (Which I suppose might be useful for downstreams that don't have a pullbot). Since this runs on PR-closed (And skips unmerged closed PRs) mirrorbots that copy PR descs will also update downstreams with the changelogs without needing to make a separate PR to update the changelog. It will also autoprocess manually-generated .yml files, so if people want to stay old-fashioned they're more than welcome to.

Oh, and I tested this about 50 times trying to get it to work (And since I couldn't get the new script to parse the PR body correctly from CMD, that's 50 pull requests I made). A working run can be seen here: https://github.com/Atermonera/Polaris/actions/runs/438966873
And a skipped run (closed without merge) can be found here:
https://github.com/Atermonera/Polaris/actions/runs/438971145

I haven't tested this with incorrectly formatted files, because those are mostly either missing :'s or unescaped ""s inside of an entry. The latter is actually concerning but seeing as its fairly trivial for maintainers to edit PRs (Or not merge a PR until the author fixes such) I _think_ that should be fairly straightforward to deal with.