### PR TITLE
Fixes discarding cards onto walls

### DIFF
--- a/code/modules/games/cards.dm
+++ b/code/modules/games/cards.dm
@@ -343,7 +343,8 @@
 		H.update_icon()
 		src.update_icon()
 		usr.visible_message("<span class = 'notice'>\The [usr] plays \the [discarding].</span>")
-		H.loc = get_step(usr,usr.dir)
+		H.loc = get_turf(usr)
+		H.Move(get_step(usr,usr.dir))
 
 	if(!cards.len)
 		qdel(src)


### PR DESCRIPTION
Fixes #991 
:cl:
bugfix - You can no longer discard cards into walls
bugfix: You can make footprints on all snow turfs.
adds - Adds ghost follow link to emotes
/:cl: