### PR TITLE
Updates autochangelog authentication

### DIFF
--- a/.github/workflows/autochangelog.yml
+++ b/.github/workflows/autochangelog.yml
@@ -15,6 +15,9 @@ jobs:
         if: github.event.pull_request.merged == true
         steps:
           - uses: /actions/checkout@v2
+            with:
+                ref: ${{ github.head_ref }}
+                token: ${{ secrets.Autochangelog_Autocommit_Token }}
           - name: Ensure +x on CI directory
             run: |
                 chmod -R +x ./tools/ci


### PR DESCRIPTION
🆑
experimental - Adds new github action to automatically update the changelog from merged PR descriptions
/🆑

The `AUTOCHANGELOG_AUTOCOMMIT_TOKEN` needs to be created with a personal access token for a user with push access to the repository. (I think that's what these documents are saying, anyways)
For information on creating a PAT: see [here](https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/creating-a-personal-access-token)
I _believe_ the PAT requires only the full repo scope, but it might just be the public_repository scope within that, depending upon how exactly the repo is configured.