### PR TITLE
Autochangelog fix 3

### DIFF
--- a/.github/workflows/autochangelog.yml
+++ b/.github/workflows/autochangelog.yml
@@ -1,6 +1,6 @@
 name: Autochangelog
 on: 
-    pull_request:
+    pull_request_target:
         types: closed
         branches:
             - master
@@ -17,7 +17,6 @@ jobs:
           - uses: /actions/checkout@v2
             with:
                 ref: ${{ github.head_ref }}
-                token: ${{ secrets.Autochangelog_Autocommit_Token }}
           - name: Ensure +x on CI directory
             run: |
                 chmod -R +x ./tools/ci


### PR DESCRIPTION
(Tested with the exact same text as the second(? third? I've lost count) PR, which failed because gthub is a fuck
Requested by basically everyone who knows that this is a thing elsewhere, merry christmas I guess.
🆑
experimental - Adds new github action to automatically update the changelog from merged PR descriptions
/🆑

Let's hope that this actually makes a changelog entry and I don't have to add this entry to another PR