### PR TITLE
Autochangelog fix 6

### DIFF
--- a/.github/workflows/autochangelog.yml
+++ b/.github/workflows/autochangelog.yml
@@ -17,6 +17,8 @@ jobs:
           - uses: /actions/checkout@v2
             with:
                 ref: master
+          - name: Update repository to master
+            run: git pull "origin" master
           - name: Ensure +x on CI directory
             run: |
                 chmod -R +x ./tools/ci

--- a/tools/GenerateChangelog/ss13_autochangelog.py
+++ b/tools/GenerateChangelog/ss13_autochangelog.py
@@ -63,7 +63,7 @@ new = 0
 print('Reading changelogs...')
 for line in args.pr_body.splitlines():
 	print(f"Checking line '{line}'")
-	if line[:1] == "??": # Find the start of the changelog
+	if line[:1] == "🆑": # Find the start of the changelog
 		print("Found opening :cl: tag")
 		if incltag == True: # If we're already reading logs, skip
 			continue
@@ -81,7 +81,7 @@ for line in args.pr_body.splitlines():
 		continue
 		
 	# If we hit a /cl, we're no longer reading logs
-	elif line == "/??":
+	elif line == "/🆑":
 		print("Found closing /:cl: tag")
 		incltag = False
 


### PR DESCRIPTION
🆑
experimental - Adds new github action to automatically update the changelog from merged PR descriptions
/🆑

Apparently the encoding in the python file is important, as was discovered in fix 5