### PR TITLE
Adds proc to properly update human icon gender

### DIFF
--- a/code/modules/admin/verbs/change_appearance.dm
+++ b/code/modules/admin/verbs/change_appearance.dm
@@ -92,15 +92,7 @@
 
 	var/new_gender = alert(usr, "Please select gender.", "Character Generation", "Male", "Female", "Neuter")
 	if (new_gender)
-		if(new_gender == "Male")
-			M.gender = MALE
-			M.dna.SetUIState(DNA_UI_GENDER, FALSE)
-		else if (new_gender == "Female")
-			M.gender = FEMALE
-			M.dna.SetUIState(DNA_UI_GENDER, TRUE)
-		else
-			M.gender = NEUTER
-			M.dna.SetUIState(DNA_UI_GENDER, FALSE)
+		M.set_gender(new_gender)
 
 	M.update_dna(M)
 	M.update_hair(FALSE)

--- a/code/modules/client/preference_setup/general/03_body.dm
+++ b/code/modules/client/preference_setup/general/03_body.dm
@@ -260,6 +260,7 @@ var/global/list/valid_bloodtypes = list("A+", "A-", "B+", "B-", "AB+", "AB-", "O
 	character.r_wing2	= pref.r_wing2
 	character.b_wing2	= pref.b_wing2
 	character.g_wing2	= pref.g_wing2
+	character.set_gender( pref.biological_gender)
 
 	// Destroy/cyborgize organs and limbs.
 	for(var/name in list(BP_HEAD, BP_L_HAND, BP_R_HAND, BP_L_ARM, BP_R_ARM, BP_L_FOOT, BP_R_FOOT, BP_L_LEG, BP_R_LEG, BP_GROIN, BP_TORSO))

--- a/code/modules/mob/living/carbon/human/human_organs.dm
+++ b/code/modules/mob/living/carbon/human/human_organs.dm
@@ -195,3 +195,11 @@
 	var/list/all_bits = internal_organs|organs
 	for(var/obj/item/organ/O in all_bits)
 		O.set_dna(dna)
+
+/mob/living/carbon/human/proc/set_gender(var/g)
+	if(g != gender)
+		gender = g
+	
+	if(dna.GetUIState(DNA_UI_GENDER) ^ gender == FEMALE) // XOR will catch both cases where they do not match
+		dna.SetUIState(DNA_UI_GENDER, gender == FEMALE)
+		sync_organ_dna(dna)

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -225,10 +225,7 @@ var/global/list/damage_icon_parts = list() //see UpdateDamageIcon()
 	//Create a new, blank icon for our mob to use.
 	var/icon/stand_icon = new(species.icon_template ? species.icon_template : 'icons/mob/human.dmi', icon_state = "blank")
 
-	var/g = "male"
-	if(gender == FEMALE)
-		g = "female"
-
+	var/g = (gender == MALE ? "male" : "female")
 	var/icon_key = "[species.get_race_key(src)][g][s_tone][r_skin][g_skin][b_skin]"
 	if(lip_style)
 		icon_key += "[lip_style]"


### PR DESCRIPTION
:cl:
bugfix: Fixes character setup not reflecting chosen biological sex
rscadd: Enterprising admins hoping to change a mob's gender, call the set_gender() proc on the mob with text "male" or "female" (No quotes), other options will default to male sprites.
/:cl:

Fixes #1810
![tested](https://puu.sh/H0LZ1/d826ec34cf.png)