### PR TITLE
Makes explorer a subordinate of science

### DIFF
--- a/maps/southern_cross/items/encryptionkey_sc.dm
+++ b/maps/southern_cross/items/encryptionkey_sc.dm
@@ -6,7 +6,7 @@
 /obj/item/device/encryptionkey/explorer
 	name = "explorer radio encryption key"
 	icon_state = "com_cypherkey"
-	channels = list("Explorer" = 1)
+	channels = list("Explorer" = 1, "Science" = 1)
 
 /obj/item/device/encryptionkey/sar
 	name = "sar's encryption key"

--- a/maps/southern_cross/southern_cross_jobs.dm
+++ b/maps/southern_cross/southern_cross_jobs.dm
@@ -75,16 +75,16 @@ var/const/access_explorer = 43
 /datum/job/explorer
 	title = "Explorer"
 	flag = EXPLORER
-	departments = list(DEPARTMENT_PLANET)
-	department_flag = CIVILIAN
+	departments = list(DEPARTMENT_RESEARCH, DEPARTMENT_PLANET)
+	department_flag = MEDSCI
 	faction = "Station"
 	total_positions = 4
 	spawn_positions = 4
-	supervisors = "the Head of Personnel"
-	selection_color = "#515151"
+	supervisors = "the Research Director"
+	selection_color =  "#633D63"
 	economic_modifier = 4
-	access = list(access_explorer)
-	minimal_access = list(access_explorer)
+	access = list(access_explorer, access_research)
+	minimal_access = list(access_explorer, access_research)
 
 	outfit_type = /decl/hierarchy/outfit/job/explorer2
 	job_description = "An Explorer searches for interesting things on the surface of Sif, and returns them to the station."


### PR DESCRIPTION
Tested (access changes also tested):
![png](https://puu.sh/H4eHC/f6b2f7db32.png)
Page layout is a little lopsided now but I don't feel like fucking w/ it, could probably move engi over to the second column to balance things out pretty well.
:cl:
tweak - Explorers are now officially part of Research, and subordinate to the Research Director
rscadd - Explorers have access to science radio channel, and science hallways/maintenance.
/:cl: