### PR TITLE
Fixes access to cabin doors on shuttles 1,2

### DIFF
--- a/maps/southern_cross/southern_cross-1.dmm
+++ b/maps/southern_cross/southern_cross-1.dmm
@@ -4316,7 +4316,9 @@
 /turf/simulated/floor/tiled/monofloor,
 /area/hangar/one)
 "ajk" = (
-/obj/machinery/door/airlock/centcom,
+/obj/machinery/door/airlock/centcom{
+	req_one_access = list()
+	},
 /turf/simulated/shuttle/floor/black,
 /area/shuttle/shuttle1/start)
 "ajl" = (
@@ -18557,7 +18559,9 @@
 	},
 /area/hangar/two)
 "aKD" = (
-/obj/machinery/door/airlock/centcom,
+/obj/machinery/door/airlock/centcom{
+	req_one_access = list()
+	},
 /turf/simulated/shuttle/floor/black,
 /area/shuttle/shuttle2/start)
 "aKE" = (


### PR DESCRIPTION
Untested, but should be pretty straightforward. Not sure how or when that broke (Probably me updating map format to tgm? But that also makes no sense either?)
:cl:
fix - Shuttle cabins have normal access requirements and no longer only open for centcom access
/:cl: