### PR TITLE
Sheet Recipe Unexclusivity.

### DIFF
--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -163,7 +163,7 @@
 
 	if (recipe.time)
 		to_chat(user, "<span class='notice'>Building [recipe.title] ...</span>")
-		if (!do_after(user, recipe.time, exclusive = TRUE))
+		if (!do_after(user, recipe.time))
 			return
 
 	if (use(required))

--- a/polaris.dme
+++ b/polaris.dme
@@ -3141,7 +3141,7 @@
 #include "code\ZAS\Zone.dm"
 #include "interface\interface.dm"
 #include "interface\skin.dmf"
-#include "maps\southern_cross\southern_Cross.dm"
+#include "maps\southern_cross\southern_cross.dm"
 #include "maps\submaps\_helpers.dm"
 #include "maps\submaps\engine_submaps\engine.dm"
 #include "maps\submaps\engine_submaps\engine_areas.dm"


### PR DESCRIPTION
Exclusive does not exist. Seemingly un-needed?
Tested, spamming recipes failed to dupe objects.
🆑
fix - Sheet recipes with a duration time function again.
/🆑