### PR TITLE
Fixes defib timers being 10 times as long compared to intended.

### DIFF
--- a/code/game/objects/items/devices/defib.dm
+++ b/code/game/objects/items/devices/defib.dm
@@ -503,8 +503,8 @@
 		return // Still no brain.
 
 	// If the brain'd `defib_timer` var gets below this number, brain damage will happen at a linear rate.
-	// This is measures in `Life()` ticks. E.g. 10 minute defib timer = 6000 world.time units = 3000 `Life()` ticks.
-	var/brain_damage_timer = ((config.defib_timer MINUTES) / 2) - ((config.defib_braindamage_timer MINUTES) / 2)
+	// This is measures in `Life()` ticks. E.g. 10 minute defib timer = 300 `Life()` ticks.				// Original math was VERY off. Life() tick occurs every ~2 seconds, not every 2 world.time ticks.
+	var/brain_damage_timer = ((config.defib_timer MINUTES) / 20) - ((config.defib_braindamage_timer MINUTES) / 20)
 
 	if(brain.defib_timer > brain_damage_timer)
 		return // They got revived before brain damage got a chance to set in.

--- a/code/modules/organs/internal/brain.dm
+++ b/code/modules/organs/internal/brain.dm
@@ -33,7 +33,7 @@ GLOBAL_LIST_BOILERPLATE(all_brain_organs, /obj/item/organ/internal/brain)
 	if(!owner || owner.stat == DEAD)
 		defib_timer = max(--defib_timer, 0)
 	else
-		defib_timer = min(++defib_timer, (config.defib_timer MINUTES) / 2)
+		defib_timer = min(++defib_timer, (config.defib_timer MINUTES) / 20)		// Time vars measure things in ticks. Life tick happens every ~2 seconds, therefore dividing by 20
 
 /obj/item/organ/internal/brain/proc/can_assist()
 	return can_assist
@@ -81,7 +81,7 @@ GLOBAL_LIST_BOILERPLATE(all_brain_organs, /obj/item/organ/internal/brain)
 /obj/item/organ/internal/brain/New()
 	..()
 	health = config.default_brain_health
-	defib_timer = (config.defib_timer MINUTES) / 2
+	defib_timer = (config.defib_timer MINUTES) / 20				// Time vars measure things in ticks. Life tick happens every ~2 seconds, therefore dividing by 20
 	spawn(5)
 		if(brainmob)
 			butcherable = FALSE


### PR DESCRIPTION
As title says. Math in the code assumed Life() ticks happen every two world.time ticks, but in actuality every 2 seconds (+- time dillation, lag, etc). And since every second is 10 world.time ticks... That meant that the defib timers were 10 times as generous as they were actually meant to be. Fixes that.