### PR TITLE
Fixes sif forest grass, adds overgrowth tiles

### DIFF
--- a/code/game/objects/items/stacks/tiles/fifty_spawner_tiles.dm
+++ b/code/game/objects/items/stacks/tiles/fifty_spawner_tiles.dm
@@ -8,6 +8,10 @@
 	name = "stack of sifgrass"
 	type_to_spawn = /obj/item/stack/tile/grass/sif
 
+/obj/fiftyspawner/grass/sif/forest
+	name = "stack of sifgrass"
+	type_to_spawn = /obj/item/stack/tile/grass/sif/forest
+
 /obj/fiftyspawner/wood
 	name = "stack of wood"
 	type_to_spawn = /obj/item/stack/tile/wood

--- a/code/game/objects/items/stacks/tiles/tile_types.dm
+++ b/code/game/objects/items/stacks/tiles/tile_types.dm
@@ -47,6 +47,11 @@
 	singular_name = "sivian grass floor tile"
 	desc = "A patch of grass like those that decorate the plains of Sif."
 
+/obj/item/stack/tile/grass/sif/forest
+	name = "sivian overgrowth tile"
+	singular_name = "sivian overgrowth floor tile"
+	desc = "A patch of dark overgrowth like those that decorate the plains of Sif."
+
 /*
  * Wood
  */

--- a/code/game/turfs/flooring/flooring.dm
+++ b/code/game/turfs/flooring/flooring.dm
@@ -148,6 +148,15 @@ var/list/flooring_types
 	icon_base = "grass_sif"
 	build_type = /obj/item/stack/tile/grass/sif
 	has_base_range = 1
+	
+/decl/flooring/grass/sif/forest
+	name = "thick growth"
+	desc = "A natural moss that has adapted to the sheer cold climate."
+	flags = TURF_REMOVE_SHOVEL
+	icon = 'icons/turf/outdoors.dmi'
+	icon_base = "grass_sif_dark"
+	build_type = /obj/item/stack/tile/grass/sif/forest
+	has_base_range = 1
 
 /decl/flooring/water
 	name = "water"

--- a/code/game/turfs/simulated/outdoors/grass.dm
+++ b/code/game/turfs/simulated/outdoors/grass.dm
@@ -85,6 +85,7 @@ var/list/grass_types = list(
 /turf/simulated/floor/outdoors/grass/sif/forest
 	name = "thick growth"
 	icon_state = "grass_sif_dark0"
+	initial_flooring = /decl/flooring/grass/sif/forest
 	edge_blending_priority = 5
 	tree_chance = 10
 	grass_chance = 1


### PR DESCRIPTION
Fixes grass/sif/forest to use the appropriate icons again after #7133 , adds a tile type for Sif forest turfs.

![image](https://user-images.githubusercontent.com/41974248/105651833-e9bbea80-5e85-11eb-9c87-287feb4116d9.png)
