### PR TITLE
Makes wrenches only anchor lockers if they're open

### DIFF
--- a/code/game/objects/structures/crates_lockers/__closets.dm
+++ b/code/game/objects/structures/crates_lockers/__closets.dm
@@ -272,7 +272,7 @@
 				anchored = !anchored
 				return
 		else
-			to_chat(user, "<span class='notice'>You can't reach the anchoring bolts when \the door is closed!</span>")
+			to_chat(user, "<span class='notice'>You can't reach the anchoring bolts when the door is closed!</span>")
 	else if(opened)
 		if(istype(W, /obj/item/weapon/grab))
 			var/obj/item/weapon/grab/G = W

--- a/code/game/objects/structures/crates_lockers/__closets.dm
+++ b/code/game/objects/structures/crates_lockers/__closets.dm
@@ -272,7 +272,7 @@
 				anchored = !anchored
 				return
 		else
-			to_chat(user, "<span class='notice'>You can't reach the anchoring bolts when \the [src] is closed!")
+			to_chat(user, "<span class='notice'>You can't reach the anchoring bolts when \the door is closed!</span>")
 	else if(opened)
 		if(istype(W, /obj/item/weapon/grab))
 			var/obj/item/weapon/grab/G = W

--- a/code/game/objects/structures/crates_lockers/__closets.dm
+++ b/code/game/objects/structures/crates_lockers/__closets.dm
@@ -260,7 +260,20 @@
 	return
 
 /obj/structure/closet/attackby(obj/item/weapon/W as obj, mob/user as mob)
-	if(opened)
+	if(W.is_wrench())
+		if(opened)
+			if(anchored)
+				user.visible_message("\The [user] begins unsecuring \the [src] from the floor.", "You start unsecuring \the [src] from the floor.")
+			else
+				user.visible_message("\The [user] begins securing \the [src] to the floor.", "You start securing \the [src] to the floor.")
+			if(do_after(user, 20 * W.toolspeed))
+				if(!src) return
+				to_chat(user, "<span class='notice'>You [anchored? "un" : ""]secured \the [src]!</span>")
+				anchored = !anchored
+				return
+		else
+			to_chat(user, "<span class='notice'>You can't reach the anchoring bolts when \the [src] is closed!")
+	else if(opened)
 		if(istype(W, /obj/item/weapon/grab))
 			var/obj/item/weapon/grab/G = W
 			MouseDrop_T(G.affecting, user)      //act like they were dragged onto the closet
@@ -316,17 +329,6 @@
 				update_icon()
 				for(var/mob/M in viewers(src))
 					M.show_message("<span class='warning'>[src] has been [sealed?"sealed":"unsealed"] by [user.name].</span>", 3)
-	else if(W.is_wrench())
-		if(sealed)
-			if(anchored)
-				user.visible_message("\The [user] begins unsecuring \the [src] from the floor.", "You start unsecuring \the [src] from the floor.")
-			else
-				user.visible_message("\The [user] begins securing \the [src] to the floor.", "You start securing \the [src] to the floor.")
-			playsound(src, W.usesound, 50)
-			if(do_after(user, 20 * W.toolspeed))
-				if(!src) return
-				to_chat(user, "<span class='notice'>You [anchored? "un" : ""]secured \the [src]!</span>")
-				anchored = !anchored
 	else
 		attack_hand(user)
 	return

--- a/code/game/objects/structures/crates_lockers/closets/secure/secure_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/secure_closets.dm
@@ -66,7 +66,7 @@
 				anchored = !anchored
 				return
 		else
-			to_chat(user, "<span class='notice'>You can't reach the anchoring bolts when \the [src] is closed!")
+			to_chat(user, "<span class='notice'>You can't reach the anchoring bolts when the door is closed!</span>")
 	else if(opened)
 		if(istype(W, /obj/item/weapon/storage/laundry_basket))
 			return ..(W,user)

--- a/code/game/objects/structures/crates_lockers/closets/secure/secure_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/secure_closets.dm
@@ -54,7 +54,20 @@
 		to_chat(user, "<span class='notice'>Access Denied</span>")
 
 /obj/structure/closet/secure_closet/attackby(obj/item/weapon/W as obj, mob/user as mob)
-	if(opened)
+	if(W.is_wrench())
+		if(opened)
+			if(anchored)
+				user.visible_message("\The [user] begins unsecuring \the [src] from the floor.", "You start unsecuring \the [src] from the floor.")
+			else
+				user.visible_message("\The [user] begins securing \the [src] to the floor.", "You start securing \the [src] to the floor.")
+			if(do_after(user, 20 * W.toolspeed))
+				if(!src) return
+				to_chat(user, "<span class='notice'>You [anchored? "un" : ""]secured \the [src]!</span>")
+				anchored = !anchored
+				return
+		else
+			to_chat(user, "<span class='notice'>You can't reach the anchoring bolts when \the [src] is closed!")
+	else if(opened)
 		if(istype(W, /obj/item/weapon/storage/laundry_basket))
 			return ..(W,user)
 		if(istype(W, /obj/item/weapon/grab))
@@ -77,17 +90,6 @@
 			spark_system.start()
 			playsound(src, 'sound/weapons/blade1.ogg', 50, 1)
 			playsound(src, "sparks", 50, 1)
-	else if(W.is_wrench())
-		if(sealed)
-			if(anchored)
-				user.visible_message("\The [user] begins unsecuring \the [src] from the floor.", "You start unsecuring \the [src] from the floor.")
-			else
-				user.visible_message("\The [user] begins securing \the [src] to the floor.", "You start securing \the [src] to the floor.")
-			if(do_after(user, 20 * W.toolspeed))
-				if(!src) return
-				to_chat(user, "<span class='notice'>You [anchored? "un" : ""]secured \the [src]!</span>")
-				anchored = !anchored
-				return
 	else if(istype(W,/obj/item/weapon/packageWrap) || istype(W,/obj/item/weapon/weldingtool))
 		return ..(W,user)
 	else


### PR DESCRIPTION
It doesn't make sense to me that lockers can only be anchored if they're welded shut.
So I've made it that a locker has to be open in order to be (un)bolted down.

:cl:
tweak: Lockers can now only be (un)wrenched if the door is open.
/:cl: