### PR TITLE
QoL Door Closing

### DIFF
--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -66,6 +66,16 @@
 	return 1
 
 /turf/attack_hand(mob/user)
+	//QOL feature, clicking on turf can toogle doors
+	var/obj/machinery/door/airlock/AL = locate(/obj/machinery/door/airlock) in src.contents
+	if(AL)
+		AL.attack_hand(user)
+		return TRUE
+	var/obj/machinery/door/firedoor/FD = locate(/obj/machinery/door/firedoor) in src.contents
+	if(FD)
+		FD.attack_hand(user)
+		return TRUE
+
 	if(!(user.canmove) || user.restrained() || !(user.pulling))
 		return 0
 	if(user.pulling.anchored || !isturf(user.pulling.loc))


### PR DESCRIPTION
Clicking on the tile (with an empty hand) of an airlock or firelock, will cause you to click on the air/firelock instead.

This way, you can close airlocks and/or firelocks easier, just by clicking the tile that the open door is on.

Airlocks take priority over firelocks.

:cl:
add: QoL feature that lets you close doors/firelocks while they're open, simply by clicking on the tile. (Airlocks take priority over firelocks, so if you need to close a firelock that's on the same tile as an airlock, you'll have to click on the pixels.)
/:cl: