### PR TITLE
Makes slimes not reproduce in unlimited stacks

### DIFF
--- a/code/modules/mob/living/simple_mob/subtypes/slime/xenobio/xenobio.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/slime/xenobio/xenobio.dm
@@ -201,7 +201,7 @@
 				if(T.density) // No walls.
 					continue
 				for(var/atom/movable/AM in T)
-					if(AM.density)
+					if(AM.density || istype(AM, /mob/living/simple_mob/slime))
 						free = FALSE
 						break
 


### PR DESCRIPTION
Xenobio slimes will now count other slimes as taking space instead of reproducing uncontrollably in astronomical stacks per tile when not confined in a 2x1 tile cell.