### PR TITLE
Planetside crew appears on manifest

### DIFF
--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -275,6 +275,7 @@ var/global/list/PDA_Manifest = list()
 		list("cat" = "Medical", "elems" = med),
 		list("cat" = "Science", "elems" = sci),
 		list("cat" = "Cargo", "elems" = car),
+		list("cat" = "Planetside", "elems" = pla),
 		list("cat" = "Civilian", "elems" = civ),
 		list("cat" = "Silicon", "elems" = bot),
 		list("cat" = "Miscellaneous", "elems" = misc)
@@ -318,7 +319,7 @@ var/global/list/PDA_Manifest = list()
 		var/datum/job/J = SSjob.get_job(assignment)
 		hidden = J?.offmap_spawn
 
-		/* Note: Due to cached_character_icon, a number of emergent properties occur due to the initialization 
+		/* Note: Due to cached_character_icon, a number of emergent properties occur due to the initialization
 		* order of readied-up vs latejoiners. Namely, latejoiners will get a uniform in their datacore picture, but readied-up will
 		* not. This is due to the fact that SSticker calls data_core.manifest_inject() inside of ticker/proc/create_characters(),
 		* but does not equip them until ticker/proc/equip_characters(), which is called later. So, this proc is literally called before


### PR DESCRIPTION
Amidst the changes, planetside crew category was forgotten on the PDA.

fixes #7859 

![image](https://user-images.githubusercontent.com/26665154/107198856-43123680-69bb-11eb-83fd-98ddccb54959.png)
![image](https://user-images.githubusercontent.com/26665154/107198874-49081780-69bb-11eb-83e8-a1131e5603dc.png)
