### PR TITLE
Updates uplink uses to owner tcrystals more often

### DIFF
--- a/code/game/objects/items/devices/uplink.dm
+++ b/code/game/objects/items/devices/uplink.dm
@@ -126,6 +126,8 @@ GLOBAL_LIST_BOILERPLATE(world_uplinks, /obj/item/device/uplink)
 
 	var/list/data = ..()
 
+	if(owner)
+		uses = owner.tcrystals
 	data["telecrystals"] = uses
 	data["lockable"] = TRUE
 	data["compactMode"] = compact_mode


### PR DESCRIPTION
Untested, fix should be straightforward: Bug observed was that uplink `uses` var was set to 0 despite having an owner with non-0 telecrystals, code shows that it's only updated `uses` on initialization to whatever the owner has (Iff set at init!). Buying items also does not appear to pass updates back to the uplink, so I made it poll for owner telecrystals on `tgui_data()` to ensure more reliable fetching of the amount.
:cl:
fix Uplinks get the correct number of telecrystals for their owners again
/:cl: