### PR TITLE
Telecrystals are only stored on the mind

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -55,6 +55,9 @@
 
 	var/rev_cooldown = 0
 	var/tcrystals = 0
+	var/list/purchase_log = new
+	var/used_TC = 0
+
 
 	// the world.time since the mob has been brigged, or -1 if not at all
 	var/brigged_since = -1
@@ -73,7 +76,7 @@
 
 /datum/mind/New(var/key)
 	src.key = key
-
+	purchase_log = list()
 	..()
 
 /datum/mind/proc/transfer_to(mob/living/new_character)

--- a/code/datums/uplink/badassery.dm
+++ b/code/datums/uplink/badassery.dm
@@ -22,18 +22,18 @@
 	desc = "Buys you one random item."
 
 /datum/uplink_item/item/badassery/random_one/buy(var/obj/item/device/uplink/U, var/mob/user)
-	var/datum/uplink_item/item = default_uplink_selection.get_random_item(user.mind)
+	var/datum/uplink_item/item = default_uplink_selection.get_random_item((user ? user.mind.tcrystals : DEFAULT_TELECRYSTAL_AMOUNT), U)
 	return item.buy(U, user)
 
-/datum/uplink_item/item/badassery/random_one/can_buy(var/obj/item/device/uplink/U, var/datum/mind/M)
-	return default_uplink_selection.get_random_item(M.tcrystals, U) != null
+/datum/uplink_item/item/badassery/random_one/can_buy(var/obj/item/device/uplink/U, var/telecrystals)
+	return default_uplink_selection.get_random_item(telecrystals, U) != null
 
 /datum/uplink_item/item/badassery/random_many
 	name = "Random Items"
 	desc = "Buys you as many random items you can afford. Convenient packaging NOT included."
 
-/datum/uplink_item/item/badassery/random_many/cost(obj/item/device/uplink/U, mob/M)
-	return max(1, M.mind.tcrystals)
+/datum/uplink_item/item/badassery/random_many/cost(obj/item/device/uplink/U, var/telecrystals)
+	return max(1, telecrystals)
 
 /datum/uplink_item/item/badassery/random_many/get_goods(var/obj/item/device/uplink/U, var/loc, var/mob/M)
 	var/list/bought_items = list()
@@ -47,7 +47,7 @@
 
 /datum/uplink_item/item/badassery/random_many/purchase_log(obj/item/device/uplink/U)
 	feedback_add_details("traitor_uplink_items_bought", "[src]")
-	log_and_message_admins("used \the [U.loc] to buy \a [src]")
+	log_and_message_admins("used \the [U.loc] to buy \a [src] at random")
 
 /****************
 * Surplus Crate *

--- a/code/datums/uplink/badassery.dm
+++ b/code/datums/uplink/badassery.dm
@@ -22,22 +22,22 @@
 	desc = "Buys you one random item."
 
 /datum/uplink_item/item/badassery/random_one/buy(var/obj/item/device/uplink/U, var/mob/user)
-	var/datum/uplink_item/item = default_uplink_selection.get_random_item(U.uses)
+	var/datum/uplink_item/item = default_uplink_selection.get_random_item(user.mind)
 	return item.buy(U, user)
 
-/datum/uplink_item/item/badassery/random_one/can_buy(obj/item/device/uplink/U)
-	return default_uplink_selection.get_random_item(U.uses, U) != null
+/datum/uplink_item/item/badassery/random_one/can_buy(var/obj/item/device/uplink/U, var/datum/mind/M)
+	return default_uplink_selection.get_random_item(M.tcrystals, U) != null
 
 /datum/uplink_item/item/badassery/random_many
 	name = "Random Items"
 	desc = "Buys you as many random items you can afford. Convenient packaging NOT included."
 
-/datum/uplink_item/item/badassery/random_many/cost(var/telecrystals)
-	return max(1, telecrystals)
+/datum/uplink_item/item/badassery/random_many/cost(obj/item/device/uplink/U, mob/M)
+	return max(1, M.mind.tcrystals)
 
-/datum/uplink_item/item/badassery/random_many/get_goods(var/obj/item/device/uplink/U, var/loc)
+/datum/uplink_item/item/badassery/random_many/get_goods(var/obj/item/device/uplink/U, var/loc, var/mob/M)
 	var/list/bought_items = list()
-	for(var/datum/uplink_item/UI in get_random_uplink_items(U, U.uses, loc))
+	for(var/datum/uplink_item/UI in get_random_uplink_items(U, M.mind.tcrystals, loc))
 		UI.purchase_log(U)
 		var/obj/item/I = UI.get_goods(U, loc)
 		if(istype(I))

--- a/code/datums/uplink/telecrystals.dm
+++ b/code/datums/uplink/telecrystals.dm
@@ -5,8 +5,8 @@
 	category = /datum/uplink_category/telecrystals
 	blacklisted = 1
 
-/datum/uplink_item/item/telecrystal/get_goods(var/obj/item/device/uplink/U, var/loc)
-	return new /obj/item/stack/telecrystal(loc, cost(U.uses))
+/datum/uplink_item/item/telecrystal/get_goods(var/obj/item/device/uplink/U, var/loc, var/datum/mind/M)
+	return new /obj/item/stack/telecrystal(loc, cost(U, M))
 
 /datum/uplink_item/item/telecrystal/one
 	name = "Telecrystal - 01"
@@ -35,5 +35,5 @@
 /datum/uplink_item/item/telecrystal/all
 	name = "Telecrystals - Empty Uplink"
 
-/datum/uplink_item/item/telecrystal/all/cost(var/telecrystals)
-	return max(1, telecrystals)
+/datum/uplink_item/item/telecrystal/all/cost(obj/item/device/uplink/U, mob/M)
+	return max(1, M.mind.tcrystals)

--- a/code/datums/uplink/telecrystals.dm
+++ b/code/datums/uplink/telecrystals.dm
@@ -5,8 +5,8 @@
 	category = /datum/uplink_category/telecrystals
 	blacklisted = 1
 
-/datum/uplink_item/item/telecrystal/get_goods(var/obj/item/device/uplink/U, var/loc, var/datum/mind/M)
-	return new /obj/item/stack/telecrystal(loc, cost(U, M))
+/datum/uplink_item/item/telecrystal/get_goods(var/obj/item/device/uplink/U, var/loc, var/mob/M)
+	return new /obj/item/stack/telecrystal(loc, cost(U, M.mind.tcrystals))
 
 /datum/uplink_item/item/telecrystal/one
 	name = "Telecrystal - 01"

--- a/code/datums/uplink/uplink_categories.dm
+++ b/code/datums/uplink/uplink_categories.dm
@@ -6,12 +6,6 @@
 	..()
 	items = list()
 
-/datum/uplink_category/proc/can_view(obj/item/device/uplink/U)
-	for(var/datum/uplink_item/item in items)
-		if(item.can_view(U))
-			return 1
-	return 0
-
 datum/uplink_category/ammunition
 	name = "Ammunition"
 

--- a/code/datums/uplink/uplink_items.dm
+++ b/code/datums/uplink/uplink_items.dm
@@ -51,7 +51,7 @@ var/datum/uplink/uplink = new()
 	if(!can_buy(U, user.mind))
 		return
 
-	if(U.tgui_status(user, GLOB.tgui_inventory_state) != STATUS_INTERACTIVE)
+	if(U.tgui_status(user, GLOB.tgui_deep_inventory_state) != STATUS_INTERACTIVE)
 		return
 
 	var/cost = cost(U, user)

--- a/code/datums/uplink/uplink_items.dm
+++ b/code/datums/uplink/uplink_items.dm
@@ -31,7 +31,7 @@ var/datum/uplink/uplink = new()
 	var/item_cost = 0
 	var/datum/uplink_category/category		// Item category
 	var/list/datum/antagonist/antag_roles	// Antag roles this item is displayed to. If empty, display to all.
-	var/blacklisted = 0
+	var/blacklisted = FALSE
 
 /datum/uplink_item/item
 	var/path = null
@@ -48,50 +48,34 @@ var/datum/uplink/uplink = new()
 	if(!extra_args)
 		return
 
-	if(!can_buy(U))
+	if(!can_buy(U, user.mind))
 		return
 
-	if(U.CanUseTopic(user, inventory_state) != STATUS_INTERACTIVE)
+	if(U.tgui_status(user, GLOB.tgui_inventory_state) != STATUS_INTERACTIVE)
 		return
 
-	var/cost = cost(U.uses, U)
+	var/cost = cost(U, user)
 
 	var/goods = get_goods(U, get_turf(user), user, extra_args)
 	if(!goods)
 		return
 
-	purchase_log(U)
+	purchase_log(user)
 	user.mind.tcrystals -= cost
-	U.used_TC += cost
+	user.mind.used_TC += cost
 	return goods
 
 // Any additional arguments you wish to send to the get_goods
 /datum/uplink_item/proc/extra_args(var/mob/user)
-	return 1
+	return TRUE
 
-/datum/uplink_item/proc/can_buy(obj/item/device/uplink/U)
-	if(cost(U.uses, U) > U.uses)
-		return 0
+/datum/uplink_item/proc/can_buy(var/obj/item/device/uplink/U, var/datum/mind/M)
+	if(cost(U, M.tcrystals) > M.tcrystals)
+		return FALSE
 
-	return can_view(U)
+	return TRUE
 
-/datum/uplink_item/proc/can_view(obj/item/device/uplink/U)
-	// Making the assumption that if no uplink was supplied, then we don't care about antag roles
-	if(!U || !antag_roles.len)
-		return 1
-
-	// With no owner, there's no need to check antag status.
-	if(!U.uplink_owner)
-		return 0
-
-	for(var/antag_role in antag_roles)
-		var/datum/antagonist/antag = all_antag_types[antag_role]
-		if(!isnull(antag))
-			if(antag.is_antagonist(U.uplink_owner))
-				return 1
-	return 0
-
-/datum/uplink_item/proc/cost(var/telecrystals, obj/item/device/uplink/U)
+/datum/uplink_item/proc/cost(obj/item/device/uplink/U, mob/M)
 	. = item_cost
 	if(U)
 		. = U.get_item_cost(src, .)
@@ -100,19 +84,19 @@ var/datum/uplink/uplink = new()
 	return desc
 
 // get_goods does not necessarily return physical objects, it is simply a way to acquire the uplink item without paying
-/datum/uplink_item/proc/get_goods(var/obj/item/device/uplink/U, var/loc)
-	return 0
+/datum/uplink_item/proc/get_goods(var/obj/item/device/uplink/U, var/loc, mob/user)
+	return FALSE
 
 /datum/uplink_item/proc/log_icon()
 	return
 
-/datum/uplink_item/proc/purchase_log(obj/item/device/uplink/U)
+/datum/uplink_item/proc/purchase_log(mob/M)
 	feedback_add_details("traitor_uplink_items_bought", "[src]")
-	log_and_message_admins("used \the [U.loc] to buy \a [src]")
-	U.purchase_log[src] = U.purchase_log[src] + 1
+	log_and_message_admins("\the [M] bought \a [src] through the uplink")
+	M.mind.purchase_log[src] += 1
 
 datum/uplink_item/dd_SortValue()
-	return cost(INFINITY)
+	return cost()
 
 /********************************
 *                           	*
@@ -133,7 +117,7 @@ datum/uplink_item/dd_SortValue()
 		A.put_in_any_hand_if_possible(I)
 	return I
 
-/datum/uplink_item/item/get_goods(var/obj/item/device/uplink/U, var/loc)
+/datum/uplink_item/item/get_goods(var/obj/item/device/uplink/U, var/loc, var/mob/user)
 	var/obj/item/I = new path(loc)
 	return I
 
@@ -208,7 +192,7 @@ datum/uplink_item/dd_SortValue()
 
 /proc/get_surplus_items(var/obj/item/device/uplink/U, var/remaining_TC, var/loc)
 	var/list/bought_items = list()
-	var/override = 1
+	var/override = TRUE
 	while(remaining_TC)
 		var/datum/uplink_item/I = all_uplink_selection.get_random_item(remaining_TC, U, bought_items, override)
 		if(!I)

--- a/code/datums/uplink/uplink_items.dm
+++ b/code/datums/uplink/uplink_items.dm
@@ -48,13 +48,13 @@ var/datum/uplink/uplink = new()
 	if(!extra_args)
 		return
 
-	if(!can_buy(U, user.mind))
+	if(!can_buy(U, user.mind.tcrystals))
 		return
 
 	if(U.tgui_status(user, GLOB.tgui_deep_inventory_state) != STATUS_INTERACTIVE)
 		return
 
-	var/cost = cost(U, user)
+	var/cost = cost(U, user.mind.tcrystals)
 
 	var/goods = get_goods(U, get_turf(user), user, extra_args)
 	if(!goods)
@@ -69,8 +69,8 @@ var/datum/uplink/uplink = new()
 /datum/uplink_item/proc/extra_args(var/mob/user)
 	return TRUE
 
-/datum/uplink_item/proc/can_buy(var/obj/item/device/uplink/U, var/datum/mind/M)
-	if(cost(U, M.tcrystals) > M.tcrystals)
+/datum/uplink_item/proc/can_buy(var/obj/item/device/uplink/U, var/telecrystals)
+	if(cost(U, telecrystals) > telecrystals)
 		return FALSE
 
 	return TRUE
@@ -96,7 +96,7 @@ var/datum/uplink/uplink = new()
 	M.mind.purchase_log[src] += 1
 
 datum/uplink_item/dd_SortValue()
-	return cost()
+	return item_cost
 
 /********************************
 *                           	*

--- a/code/game/antagonist/antagonist_print.dm
+++ b/code/game/antagonist/antagonist_print.dm
@@ -1,7 +1,7 @@
 /datum/antagonist/proc/print_player_summary()
 
 	if(!current_antagonists.len)
-		return 0
+		return FALSE
 
 	var/text = "<br><br><font size = 2><b>The [current_antagonists.len == 1 ? "[role_text] was" : "[role_text_plural] were"]:</b></font>"
 	for(var/datum/mind/P in current_antagonists)
@@ -21,7 +21,7 @@
 				else
 					text += "<font color='red'>Fail.</font>"
 					feedback_add_details(feedback_tag,"[O.type]|FAIL")
-					failed = 1
+					failed = TRUE
 				num++
 				if(failed)
 					text += "<br><font color='red'><B>The [role_text] has failed.</B></font>"
@@ -32,7 +32,7 @@
 		text += "<BR><FONT size = 2>Their objectives were:</FONT>"
 		var/num = 1
 		for(var/datum/objective/O in global_objectives)
-			text += print_objective(O, num, 1)
+			text += print_objective(O, num, TRUE)
 			num++
 
 	// Display the results.
@@ -68,14 +68,14 @@
 /datum/antagonist/proc/print_player_full(var/datum/mind/ply)
 	var/text = print_player_lite(ply)
 
-	var/TC_uses = 0
-	var/uplink_true = 0
+	var/TC_uses = FALSE
+	var/uplink_true = FALSE
 	var/purchases = ""
-	for(var/obj/item/device/uplink/H in world_uplinks)
-		if(H && H.uplink_owner && H.uplink_owner == ply)
-			TC_uses += H.used_TC
-			uplink_true = 1
-			purchases += get_uplink_purchases(H)
+	for(var/mob/M in player_list)
+		if(M.mind && M.mind.used_TC)
+			TC_uses += M.mind.used_TC
+			uplink_true = TRUE
+			purchases += get_uplink_purchases(M.mind)
 	if(uplink_true)
 		text += " (used [TC_uses] TC)"
 		if(purchases)
@@ -83,18 +83,8 @@
 
 	return text
 
-/proc/print_ownerless_uplinks()
-	var/has_printed = 0
-	for(var/obj/item/device/uplink/H in world_uplinks)
-		if(isnull(H.uplink_owner) && H.used_TC)
-			if(!has_printed)
-				has_printed = 1
-				to_world("<b>Ownerless Uplinks</b>")
-			to_world("[H.loc] (used [H.used_TC] TC)")
-			to_world(get_uplink_purchases(H))
-
-/proc/get_uplink_purchases(var/obj/item/device/uplink/H)
+/proc/get_uplink_purchases(var/datum/mind/M)
 	var/list/refined_log = new()
-	for(var/datum/uplink_item/UI in H.purchase_log)
-		refined_log.Add("[H.purchase_log[UI]]x[UI.log_icon()][UI.name]")
+	for(var/datum/uplink_item/UI in M.purchase_log)
+		refined_log.Add("[M.purchase_log[UI]]x[UI.log_icon()][UI.name]")
 	. = english_list(refined_log, nothing_text = "")

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -292,7 +292,6 @@ var/global/list/additional_antag_types = list()
 			antag.check_victory()
 			antag.print_player_summary()
 		sleep(10)
-		print_ownerless_uplinks()
 
 	var/clients = 0
 	var/surviving_humans = 0

--- a/code/game/objects/items/devices/uplink.dm
+++ b/code/game/objects/items/devices/uplink.dm
@@ -233,5 +233,5 @@
 	traitor_frequency = 1445
 
 /obj/item/device/radio/headset/uplink/New()
-	..(loc)
+	..()
 	hidden_uplink = new(src)

--- a/code/game/objects/items/devices/uplink.dm
+++ b/code/game/objects/items/devices/uplink.dm
@@ -1,5 +1,3 @@
-GLOBAL_LIST_BOILERPLATE(world_uplinks, /obj/item/device/uplink)
-
 // I placed this here because of how relevant it is.
 // You place this in your uplinkable item to check if an uplink is active or not.
 // If it is, it will display the uplink menu and return 1, else it'll return false.
@@ -14,29 +12,19 @@ GLOBAL_LIST_BOILERPLATE(world_uplinks, /obj/item/device/uplink)
 
 /obj/item/device/uplink
 	var/welcome = "Welcome, Operative"	// Welcoming menu message
-	var/uses 							// Numbers of crystals
 	var/list/ItemsCategory				// List of categories with lists of items
 	var/list/ItemsReference				// List of references with an associated item
 	var/list/nanoui_items				// List of items for NanoUI use
 	var/faction = ""					//Antag faction holder.
 
-	var/list/purchase_log = new
-	var/datum/mind/uplink_owner = null
-	var/used_TC = 0
 	var/offer_time = 10 MINUTES			//The time increment per discount offered
 	var/next_offer_time
 	var/datum/uplink_item/discount_item	//The item to be discounted
 	var/discount_amount					//The amount as a percent the item will be discounted by
 	var/compact_mode = FALSE
 
-/obj/item/device/uplink/Initialize(var/mapload, var/datum/mind/owner = null, var/telecrystals = DEFAULT_TELECRYSTAL_AMOUNT)
+/obj/item/device/uplink/Initialize(var/mapload)
 	. = ..()
-	uplink_owner = owner
-	purchase_log = list()
-	if(owner)
-		uses = owner.tcrystals
-	else
-		uses = telecrystals
 	addtimer(CALLBACK(src, .proc/next_offer), offer_time) //It seems like only the /hidden type actually makes use of this...
 
 /obj/item/device/uplink/get_item_cost(var/item_type, var/item_cost)
@@ -85,7 +73,7 @@ GLOBAL_LIST_BOILERPLATE(world_uplinks, /obj/item/device/uplink)
 /obj/item/device/uplink/hidden/proc/trigger(mob/user as mob)
 	if(!active)
 		toggle()
-	interact(user)
+	tgui_interact(user)
 
 // Checks to see if the value meets the target. Like a frequency being a traitor_frequency, in order to unlock a headset.
 // If true, it accesses trigger() and returns 1. If it fails, it returns false. Use this to see if you need to close the
@@ -126,7 +114,7 @@ GLOBAL_LIST_BOILERPLATE(world_uplinks, /obj/item/device/uplink)
 
 	var/list/data = ..()
 
-	data["telecrystals"] = uses
+	data["telecrystals"] = user.mind.tcrystals
 	data["lockable"] = TRUE
 	data["compactMode"] = compact_mode
 
@@ -176,22 +164,19 @@ GLOBAL_LIST_BOILERPLATE(world_uplinks, /obj/item/device/uplink)
 
 	data["categories"] = list()
 	for(var/datum/uplink_category/category in uplink.categories)
-		if(category.can_view(src))
-			var/list/cat = list(
+		var/list/cat = list(
 				"name" = category.name,
 				"items" = (category == selected_cat ? list() : null)
 			)
-			for(var/datum/uplink_item/item in category.items)
-				if(!item.can_view(src))
-					continue
-				var/cost = item.cost(uses, src) || "???"
-				cat["items"] += list(list(
-					"name" = item.name,
-					"cost" = cost,
-					"desc" = item.description(),
-					"ref" = REF(item),
-				))
-			data["categories"] += list(cat)
+		for(var/datum/uplink_item/item in category.items)
+			var/cost = item.cost(src, user) || "???"
+			cat["items"] += list(list(
+				"name" = item.name,
+				"cost" = cost,
+				"desc" = item.description(),
+				"ref" = REF(item),
+			))
+		data["categories"] += list(cat)
 
 	return data
 
@@ -227,9 +212,9 @@ GLOBAL_LIST_BOILERPLATE(world_uplinks, /obj/item/device/uplink)
 //
 // Includes normal radio uplink, multitool uplink,
 // implant uplink (not the implant tool) and a preset headset uplink.
-/obj/item/device/radio/uplink/New(atom/loc, datum/mind/target_mind, telecrystals)
-	..(loc)
-	hidden_uplink = new(src, target_mind, telecrystals)
+/obj/item/device/radio/uplink/New()
+	..()
+	hidden_uplink = new(src)
 	icon_state = "radio"
 
 /obj/item/device/radio/uplink/attack_self(mob/user as mob)
@@ -237,6 +222,7 @@ GLOBAL_LIST_BOILERPLATE(world_uplinks, /obj/item/device/uplink)
 		hidden_uplink.trigger(user)
 
 /obj/item/device/multitool/uplink/New()
+	..()
 	hidden_uplink = new(src)
 
 /obj/item/device/multitool/uplink/attack_self(mob/user as mob)
@@ -247,6 +233,5 @@ GLOBAL_LIST_BOILERPLATE(world_uplinks, /obj/item/device/uplink)
 	traitor_frequency = 1445
 
 /obj/item/device/radio/headset/uplink/New()
-	..()
+	..(loc)
 	hidden_uplink = new(src)
-	hidden_uplink.uses = DEFAULT_TELECRYSTAL_AMOUNT

--- a/code/game/objects/items/devices/uplink.dm
+++ b/code/game/objects/items/devices/uplink.dm
@@ -81,8 +81,8 @@
 /obj/item/device/uplink/hidden/proc/check_trigger(mob/user as mob, var/value, var/target)
 	if(value == target)
 		trigger(user)
-		return 1
-	return 0
+		return TRUE
+	return FALSE
 
 // Legacy
 /obj/item/device/uplink/hidden/interact(mob/user)
@@ -95,7 +95,7 @@
 	return loc
 
 /obj/item/device/uplink/hidden/tgui_state(mob/user)
-	return GLOB.tgui_inventory_state
+	return GLOB.tgui_deep_inventory_state
 
 /obj/item/device/uplink/hidden/tgui_interact(mob/user, datum/tgui/ui, datum/tgui/parent_ui)
 	if(!active)

--- a/code/game/objects/items/devices/uplink_random_lists.dm
+++ b/code/game/objects/items/devices/uplink_random_lists.dm
@@ -22,7 +22,7 @@ var/datum/uplink_random_selection/all_uplink_selection = new/datum/uplink_random
 	items = list()
 	all_items = list()
 
-/datum/uplink_random_selection/proc/get_random_item(var/datum/mind/M, obj/item/device/uplink/U, var/list/bought_items, var/items_override = 0)
+/datum/uplink_random_selection/proc/get_random_item(var/telecrystals, obj/item/device/uplink/U, var/list/bought_items, var/items_override = 0)
 	var/const/attempts = 50
 
 	for(var/i = 0; i < attempts; i++)
@@ -34,11 +34,11 @@ var/datum/uplink_random_selection/all_uplink_selection = new/datum/uplink_random
 		if(!prob(RI.keep_probability))
 			continue
 		var/datum/uplink_item/I = uplink.items_assoc[RI.uplink_item]
-		if(I.cost(M.tcrystals, U) > M.tcrystals)
+		if(I.cost(U) > telecrystals)
 			continue
 		if(bought_items && (I in bought_items) && !prob(RI.reselect_probability))
 			continue
-		if(U && !I.can_buy(U, M))
+		if(U && !I.can_buy(U, telecrystals))
 			continue
 		return I
 

--- a/code/game/objects/items/devices/uplink_random_lists.dm
+++ b/code/game/objects/items/devices/uplink_random_lists.dm
@@ -22,7 +22,7 @@ var/datum/uplink_random_selection/all_uplink_selection = new/datum/uplink_random
 	items = list()
 	all_items = list()
 
-/datum/uplink_random_selection/proc/get_random_item(var/telecrystals, obj/item/device/uplink/U, var/list/bought_items, var/items_override = 0)
+/datum/uplink_random_selection/proc/get_random_item(var/datum/mind/M, obj/item/device/uplink/U, var/list/bought_items, var/items_override = 0)
 	var/const/attempts = 50
 
 	for(var/i = 0; i < attempts; i++)
@@ -34,11 +34,11 @@ var/datum/uplink_random_selection/all_uplink_selection = new/datum/uplink_random
 		if(!prob(RI.keep_probability))
 			continue
 		var/datum/uplink_item/I = uplink.items_assoc[RI.uplink_item]
-		if(I.cost(telecrystals, U) > telecrystals)
+		if(I.cost(M.tcrystals, U) > M.tcrystals)
 			continue
 		if(bought_items && (I in bought_items) && !prob(RI.reselect_probability))
 			continue
-		if(U && !I.can_buy(U))
+		if(U && !I.can_buy(U, M))
 			continue
 		return I
 

--- a/code/modules/pda/cart.dm
+++ b/code/modules/pda/cart.dm
@@ -307,5 +307,4 @@ var/list/civilian_cartridges = list(
 	name = "F.R.A.M.E. cartridge"
 	icon_state = "cart"
 	charges = 5
-	var/telecrystals = 0
 	messenger_plugins = list(new/datum/data/pda/messenger_plugin/virus/frame)

--- a/code/modules/pda/messenger_plugins.dm
+++ b/code/modules/pda/messenger_plugins.dm
@@ -85,7 +85,4 @@
 			P.lock_code = lock_code
 		// else
 			// P.hidden_uplink.hidden_crystals += P.hidden_uplink.uses //Temporarially hide the PDA's crystals, so you can't steal telecrystals.
-		var/obj/item/weapon/cartridge/frame/parent_cart = pda.cartridge
-		P.hidden_uplink.uses = parent_cart.telecrystals
-		parent_cart.telecrystals = 0
 		P.hidden_uplink.active = TRUE


### PR DESCRIPTION
Refactors telecrystals away from being stored on the uplink, because that was only half-done at some point in the indeterminate past and the code was really janky. This shouldn't change any actual mechanics from the _intended_ usage, but I have logged the fixes I'm aware of below.
Fixes #6005

:cl:
bugfix Fixes an issue where uplinks wouldn't see the correct number of telecrystals, preventing users from purchasing anything with them.
bugfix Fixes another issue where uplinks would check cost against the uplink's telecrystals but charge them to the user's mind, even if that user was another player, resulting in telecrystals not being correctly deducted and even becoming negative.
bugfix Fixes *another* issue where the uplink was trying to check a nanoui verb, when it uses tgui, resulting in it being impossible to actually purchase anything at all.
bugfix Fixes uplink implants to work at all.
/:cl:

Tested:
![test](https://puu.sh/HfCLn/7cd92dd2eb.png)
[Uplink implant test(mp4)](https://puu.sh/HfDZT/fafd349896.mp4)