### PR TITLE
Fixes animal type simplemobs runtiming on deletion

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -41,7 +41,7 @@
 			organs -= OR
 			qdel(OR)
 
-	if(LAZYLEN(internal_organs))
+	if(LAZYLEN(internal_organs) && !istype(src, /mob/living/simple_mob/animal))
 		internal_organs_by_name.Cut()
 		while(internal_organs.len)
 			var/obj/item/OR = internal_organs[1]


### PR DESCRIPTION
The code was trying to delete the actual organs while the animal mobs use that list for storing just typepaths to spawn when butchered.