### PR TITLE
ANOTHER Event manager TGUI fix

### DIFF
--- a/code/modules/tgui/states/default.dm
+++ b/code/modules/tgui/states/default.dm
@@ -74,6 +74,6 @@ GLOBAL_DATUM_INIT(tgui_default_state, /datum/tgui_state/default, new)
 		return ..()
 
 /mob/observer/dead/default_can_use_tgui_topic()
-	if(check_rights(R_ADMIN, 0, src))
+	if(check_rights(R_ADMIN|R_EVENT, 0, src))
 		return STATUS_INTERACTIVE				// Admins are more equal
 	return STATUS_UPDATE						// Ghosts can view updates

--- a/code/modules/tgui/states/observer.dm
+++ b/code/modules/tgui/states/observer.dm
@@ -9,7 +9,7 @@ GLOBAL_DATUM_INIT(tgui_observer_state, /datum/tgui_state/observer_state, new)
 /datum/tgui_state/observer_state/can_use_topic(src_object, mob/user)
 	if(isobserver(user))
 		return STATUS_INTERACTIVE
-	if(check_rights(R_ADMIN, 0, src))
+	if(check_rights(R_ADMIN|R_EVENT, 0, src))
 		return STATUS_INTERACTIVE
 	return STATUS_CLOSE
 


### PR DESCRIPTION
Guess what, TGUI does not in fact use its own master admin-interact check like half of the time, and checks for R_ADMIN in a bunch of other places instead. Added R_EVENT to THOSE too.