### PR TITLE
Fixed 'Hardsuit Modules' tab verbs

### DIFF
--- a/code/modules/clothing/spacesuits/rig/modules/modules.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/modules.dm
@@ -265,12 +265,18 @@
 
 /stat_rig_module/Click()
 	if(CanUse())
-		var/list/href_list = list(
-							"interact_module" = module.holder.installed_modules.Find(module),
-							"module_mode" = module_mode
-							)
-		AddHref(href_list)
-		module.holder.Topic(usr, href_list)
+		switch(module_mode)
+			if("select")
+				module.holder.selected_module = module
+			if("engage")
+				module.engage()
+			if("toggle")
+				if(module.active)
+					module.deactivate()
+				else
+					module.activate()
+			if("select_charge_type")
+				module.charge_selected = module.charges[module.charges.Find(module.charge_selected)]
 
 /stat_rig_module/DblClick()
 	return Click()


### PR DESCRIPTION
Fixes the module-use quick-access verbs specifically on the "Hardsuit Modules" tab not working (You had to go through the TGUI menus specifically, or the more cumbersome 'Activate Module' verb under 'Hardsuit' tab. The verbs on the modules tab just didn't call shit.)

It relied on going through a Topic() interface proc which was removed by the switch to TGUI, so this just does the previous functionality then and there on the verb click.

Fixes #7875 