### PR TITLE
Fixes VChat HTML export text colours.

### DIFF
--- a/code/modules/vchat/css/ss13styles.css
+++ b/code/modules/vchat/css/ss13styles.css
@@ -120,8 +120,8 @@ body.inverted {
 
 /* Miscellaneous */
 .name					{font-weight: bold;}
-.say					{}
-.emote					{}
+.say					{color: #000000;}
+.emote					{color: #000000;}
 .alert					{color: #ff0000;}
 h1.alert, h2.alert		{color: #000000;}
 

--- a/code/modules/vchat/css/ss13styles.css
+++ b/code/modules/vchat/css/ss13styles.css
@@ -121,7 +121,9 @@ body.inverted {
 /* Miscellaneous */
 .name					{font-weight: bold;}
 .say					{color: #000000;}
+.inverted .say				{color: #FFFFFF;}
 .emote					{color: #000000;}
+.inverted .emote			{color: #FFFFFF;}
 .alert					{color: #ff0000;}
 h1.alert, h2.alert		{color: #000000;}
 
@@ -210,6 +212,7 @@ img.icon.bigicon		{max-height: 32px;}
 .debug_error					{color:#FF0000; font-weight:bold}
 .debug_warning					{color:#FF0000;}
 .debug_info						{color:#000000;}
+.inverted .debug_info				{color: #FFFFFF;}
 .debug_debug					{color:#0000FF;}
 .debug_trace					{color:#888888;}
 

--- a/code/modules/vchat/css/ss13styles.css
+++ b/code/modules/vchat/css/ss13styles.css
@@ -209,7 +209,7 @@ img.icon.bigicon		{max-height: 32px;}
 /* Debug Logs */
 .debug_error					{color:#FF0000; font-weight:bold}
 .debug_warning					{color:#FF0000;}
-.debug_info						{}
+.debug_info						{color:#000000;}
 .debug_debug					{color:#0000FF;}
 .debug_trace					{color:#888888;}
 


### PR DESCRIPTION
Previously, HTML export of VChat logs did not set the colour of 'say' actions and emotes. This meant that instead of being black, the text would adopt the colour of whatever previous radio channel was used.
![image](https://user-images.githubusercontent.com/10407111/108124584-5e450c00-7075-11eb-8959-e20b14ac7abb.png)
This fixes that for `say`, `emote`, and `debug_info` messages, which did not previously have defined colours. 