### PR TITLE
Fixes some fluff weirdness with Virgo-ported prosthetics

### DIFF
--- a/code/modules/organs/robolimbs.dm
+++ b/code/modules/organs/robolimbs.dm
@@ -406,6 +406,7 @@ var/const/standard_monitor_styles = "blank=ipc_blank;\
 	company = "Zeng-Hu"
 	desc = "This limb has a rubbery fleshtone covering with visible seams."
 	icon = 'icons/mob/human_races/cyberlimbs/zenghu/zenghu_main.dmi'
+	species_alternates = list(SPECIES_TAJ = "Zeng-Hu - Tajaran")
 	unavailable_to_build = 1
 	skin_tone = 1
 

--- a/code/modules/organs/robolimbs_custom.dm
+++ b/code/modules/organs/robolimbs_custom.dm
@@ -7,49 +7,53 @@
 
 // verkister : Rahwoof Boop
 /datum/robolimb/eggnerdltd
-	company = "Eggnerd Prototyping Ltd."
-	desc = "This limb has a slight salvaged handicraft vibe to it. The CE-marking on it is definitely not the standardized one, it looks more like a hand-written sharpie monogram."
+	company = "Uesseka Prototyping Ltd."
+	desc = "This limb seems meticulously hand-crafted, and distinctly Unathi in design."
 	icon = 'icons/mob/human_races/cyberlimbs/_fluff_vr/rahboop.dmi'
+	species_cannot_use = list(SPECIES_TESHARI, SPECIES_PROMETHEAN, SPECIES_DIONA, SPECIES_HUMAN, SPECIES_VOX, SPECIES_HUMAN_VATBORN, SPECIES_TAJ, SPECIES_SKRELL, SPECIES_ZADDAT)
+	species_alternates = list(SPECIES_HUMAN = "NanoTrasen")
+	suggested_species = SPECIES_UNATHI
 	blood_color = "#5e280d"
 	includes_tail = 1
 	unavailable_to_build = 1
 
-/obj/item/weapon/disk/limb/eggnerdltd
-	company = "Eggnerd Prototyping Ltd."
-//	icon = 'icons/obj/items_vr.dmi'
-//	icon_state = "verkdisk"
+/obj/item/weapon/disk/limb/uesseka
+	company = "Uesseka Prototyping Ltd."
 
-//////////////// General VS-only ones /////////////////
-/datum/robolimb/talon //They're buildable by default due to being extremely basic.
-	company = "Talon LLC"
-	desc = "This metallic limb is sleek and featuresless apart from some exposed motors"
+/datum/robolimb/nanotrasen_metro
+	company = "NanoTrasen - Metro"
+	desc = "This metallic limb is sleek and featuresless apart from some exposed motors around the joints."
 	icon = 'icons/mob/human_races/cyberlimbs/talon/talon_main.dmi' //Sprited by: Viveret
 
-/obj/item/weapon/disk/limb/talon
-	company = "Talon LLC"
+/obj/item/weapon/disk/limb/nanotrasen_metro
+	company = "NanoTrasen - Metro"
+	catalogue_data = list(/datum/category_item/catalogue/information/organization/nanotrasen)
 
-/datum/robolimb/zenghu_taj //This wasn't indented. At all. It's a miracle this didn't break literally everything.
+
+/datum/robolimb/zenghu_taj
 	company = "Zeng-Hu - Tajaran"
-	desc = "This limb has a rubbery fleshtone covering with visible seams."
+	desc = "This limb has a rubbery covering with basic faux fur and visible seams."
 	icon = 'icons/mob/human_races/cyberlimbs/zenghu/zenghu_taj.dmi'
+	species_cannot_use = list(SPECIES_TESHARI, SPECIES_PROMETHEAN, SPECIES_DIONA, SPECIES_HUMAN, SPECIES_VOX, SPECIES_HUMAN_VATBORN, SPECIES_UNATHI, SPECIES_SKRELL, SPECIES_ZADDAT)
+	suggested_species = SPECIES_TAJ
 	unavailable_to_build = 1
 	parts = list(BP_HEAD)
 
-/datum/robolimb/eggnerdltdred
-	company = "Eggnerd Prototyping Ltd. (Red)"
-	desc = "A slightly more refined limb variant from Eggnerd Prototyping. Its got red plating instead of orange."
+/datum/robolimb/uessekared
+	company = "Uesseka Prototyping Ltd. - Red"
+	desc = "This limb seems meticulously hand-crafted, and distinctly Unathi in design. This one's red!"
 	icon = 'icons/mob/human_races/cyberlimbs/rahboopred/rahboopred.dmi'
+	species_cannot_use = list(SPECIES_TESHARI, SPECIES_PROMETHEAN, SPECIES_DIONA, SPECIES_HUMAN, SPECIES_VOX, SPECIES_HUMAN_VATBORN, SPECIES_TAJ, SPECIES_SKRELL, SPECIES_ZADDAT)
+	species_alternates = list(SPECIES_HUMAN = "NanoTrasen")
+	suggested_species = SPECIES_UNATHI
 	blood_color = "#5e280d"
 	includes_tail = 1
 	unavailable_to_build = 1
 
-/obj/item/weapon/disk/limb/eggnerdltdred
-	company = "Eggnerd Prototyping Ltd. (Red)"
-//	icon = 'icons/obj/items_vr.dmi'
-//	icon_state = "verkdisk"
+/obj/item/weapon/disk/limb/uessekared
+	company = "Uesseka Prototyping Ltd. (Red)"
 
-
-//Darkside Incorperated synthetic augmentation list! Many current most used fuzzy and notsofuzzy races made into synths here.
+//Downstream realistic-fluffies for adminbus:
 
 /datum/robolimb/dsi_tajaran
 	company = "DSI - Tajaran"


### PR DESCRIPTION
Zeng-Hu Tajaran Heads weren't tagged as being for Taj. Is now + acts as default option when taj pick Zeng-Hu.
Eggnerd Unathi-prosthetics were available to Everybody. Made Unathi-only. (Also, refluffed the name)
Talon LLC doesn't exist in our lore but was made a 'default' option on prosfabs. Changed to a NanoTrasen own-brand ultra-cheapo 'lifelike' model named Metro(polis, geddit).