### PR TITLE
Adds Respawn to allow ghosts to return to lobby so admins stop disabling respawn instead because SOMEONE, SOMEWHERE IS WRONG

### DIFF
--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -907,3 +907,8 @@ mob/observer/dead/MayRespawn(var/feedback = 0)
 	to_chat(src, "<span class='ghostalert'><a href=?src=[REF(src)];reenter=1>(Click to re-enter)</a></span>")
 	if(sound)
 		SEND_SOUND(src, sound(sound))
+
+/mob/observer/dead/verb/respawn()
+	set name = "Respawn"
+	set category = "Ghost"
+	src.abandon_mob()


### PR DESCRIPTION
Tin
:cl:
rscadd - Adds a "Respawn" verb that you can use to return to the lobby. Works exactly like "Return to menu" except it's intelligently named and won't trick admins into disabling respawn.
/:cl:

In case anyone is wondering, the bug is that the usage of return to menu is misleading for people who've learned the game on respawn and have access to the "toggle respawn" verb. Confusing usage is bad usage.