### PR TITLE
Removes transform from speech bubbles when speaker is scaled at less than 2x.

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -604,7 +604,7 @@
 			speech_bubble_hearers += M.client
 
 	if(length(speech_bubble_hearers))
-		var/image/I = image('icons/mob/talk.dmi', src, "[bubble_icon][say_test(message)]", FLY_LAYER)
+		var/image/I = generate_speech_bubble(src, "[bubble_icon][say_test(message)]", FLY_LAYER)
 		I.appearance_flags = APPEARANCE_UI_IGNORE_ALPHA
 		INVOKE_ASYNC(GLOBAL_PROC, /.proc/flick_overlay, I, speech_bubble_hearers, 30)
 

--- a/code/modules/mob/living/carbon/brain/brain.dm
+++ b/code/modules/mob/living/carbon/brain/brain.dm
@@ -53,9 +53,7 @@
 		return
 
 	if(!typing_indicator)
-		typing_indicator = new
-		typing_indicator.icon = 'icons/mob/talk.dmi'
-		typing_indicator.icon_state = "[speech_bubble_appearance()]_typing"
+		init_typing_indicator("[speech_bubble_appearance()]_typing")
 
 	if(state && !typing)
 		loc.add_overlay(typing_indicator, TRUE)

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -292,7 +292,7 @@ proc/get_radio_key_from_channel(var/channel)
 	//The 'post-say' static speech bubble
 	var/speech_bubble_test = say_test(message)
 	var/speech_type = speech_bubble_appearance()
-	var/image/speech_bubble = image('icons/mob/talk.dmi',src,"[speech_type][speech_bubble_test]")
+	var/image/speech_bubble = generate_speech_bubble(src, "[speech_type][speech_bubble_test]")
 	var/sb_alpha = 255
 	var/atom/loc_before_turf = src
 	while(loc_before_turf && !isturf(loc_before_turf.loc))
@@ -310,7 +310,7 @@ proc/get_radio_key_from_channel(var/channel)
 		var/turf/ST = get_turf(above)
 		if(ST)
 			var/list/results = get_mobs_and_objs_in_view_fast(ST, world.view)
-			var/image/z_speech_bubble = image('icons/mob/talk.dmi', above, "h[speech_bubble_test]")
+			var/image/z_speech_bubble = generate_speech_bubble(above, "h[speech_bubble_test]")
 			images_to_clients[z_speech_bubble] = list()
 			for(var/item in results["mobs"])
 				if(item != above && !(item in listening))

--- a/code/modules/mob/living/voice/voice.dm
+++ b/code/modules/mob/living/voice/voice.dm
@@ -109,7 +109,7 @@
 	if(comm)
 		var/speech_bubble_test = say_test(message)
 		var/speech_type = speech_bubble_appearance()
-		var/image/speech_bubble = image('icons/mob/talk.dmi',comm,"[speech_type][speech_bubble_test]")
+		var/image/speech_bubble = generate_speech_bubble(comm, "[speech_type][speech_bubble_test]")
 		spawn(30)
 			qdel(speech_bubble)
 

--- a/code/modules/mob/typing_indicator.dm
+++ b/code/modules/mob/typing_indicator.dm
@@ -1,15 +1,20 @@
 /mob/proc/set_typing_indicator(var/state) //Leaving this here for mobs.
 
 	if(!is_preference_enabled(/datum/client_preference/show_typing_indicator))
-		cut_overlay(typing_indicator, TRUE)
+		if(typing_indicator)
+			cut_overlay(typing_indicator, TRUE)
 		return
 
 	if(!typing_indicator)
 		typing_indicator = new
 		typing_indicator.icon = 'icons/mob/talk.dmi'
 		typing_indicator.icon_state = "[speech_bubble_appearance()]_typing"
+		typing_indicator.appearance_flags |= (RESET_COLOR|RESET_TRANSFORM)
 
 	if(state && !typing)
+		typing_indicator.pixel_z = world.icon_size * (get_icon_scale_x()-1)
+		typing_indicator.pixel_w = world.icon_size * (get_icon_scale_y()-1)
+		to_world(json_encode(typing_indicator.transform?.vars))
 		add_overlay(typing_indicator, TRUE)
 		typing = TRUE
 	else if(typing)

--- a/code/modules/mob/typing_indicator.dm
+++ b/code/modules/mob/typing_indicator.dm
@@ -1,3 +1,19 @@
+/proc/generate_speech_bubble(var/bubble_loc, var/speech_state, var/set_layer = FLOAT_LAYER)
+	var/image/I = image('icons/mob/talk.dmi', bubble_loc, speech_state, set_layer)
+	I.appearance_flags |= (KEEP_APART|RESET_COLOR|PIXEL_SCALE)
+	if(istype(bubble_loc, /atom/movable))
+		var/atom/movable/AM = bubble_loc
+		var/x_scale = AM.get_icon_scale_x()
+		if(abs(x_scale) < 2) // reset transform on bubbles, except for the Very Large
+			I.pixel_z = (AM.icon_expected_height * (x_scale-1))
+			I.appearance_flags |= RESET_TRANSFORM
+	return I
+
+/mob/proc/init_typing_indicator(var/set_state = "typing")
+	typing_indicator = new
+	typing_indicator.appearance = generate_speech_bubble(null, set_state)
+	typing_indicator.appearance_flags |= (KEEP_APART|RESET_COLOR|RESET_TRANSFORM|PIXEL_SCALE)
+
 /mob/proc/set_typing_indicator(var/state) //Leaving this here for mobs.
 
 	if(!is_preference_enabled(/datum/client_preference/show_typing_indicator))
@@ -6,15 +22,9 @@
 		return
 
 	if(!typing_indicator)
-		typing_indicator = new
-		typing_indicator.icon = 'icons/mob/talk.dmi'
-		typing_indicator.icon_state = "[speech_bubble_appearance()]_typing"
-		typing_indicator.appearance_flags |= (RESET_COLOR|RESET_TRANSFORM)
+		init_typing_indicator("[speech_bubble_appearance()]_typing")
 
 	if(state && !typing)
-		typing_indicator.pixel_z = world.icon_size * (get_icon_scale_x()-1)
-		typing_indicator.pixel_w = world.icon_size * (get_icon_scale_y()-1)
-		to_world(json_encode(typing_indicator.transform?.vars))
 		add_overlay(typing_indicator, TRUE)
 		typing = TRUE
 	else if(typing)

--- a/code/modules/multiz/zshadow.dm
+++ b/code/modules/multiz/zshadow.dm
@@ -121,9 +121,7 @@
 
 /mob/zshadow/set_typing_indicator(var/state)
 	if(!typing_indicator)
-		typing_indicator = new
-		typing_indicator.icon = 'icons/mob/talk.dmi' // Looks better on the right with job icons.
-		typing_indicator.icon_state = "typing"
+		init_typing_indicator("typing")
 	if(state && !typing)
 		overlays += typing_indicator
 		typing = 1


### PR DESCRIPTION
Supersized mobs will get the old speechbubble behavior, smaller scaling levels like those you expect to see on a regular crewmember are offset on the y-axis but not scaled, preventing blur or weird munging.