### PR TITLE
Diet/Allergy Rework & Refactor Pt2

### DIFF
--- a/code/__defines/species_languages.dm
+++ b/code/__defines/species_languages.dm
@@ -37,6 +37,13 @@
 #define COFFEE		0x200	// Mostly here for tajara.
 #define GENERIC		0x400	// Catchall for stuff that doesn't fall into the groups above. You shouldn't be allergic to this type, ever.
 
+// Allergen reactions
+#define AG_TOX_DMG	0x1	// the classic 
+#define AG_OXY_DMG	0x2	// intense airway reactions
+#define AG_EMOTE	0x4	// general emote reactions based on affect type
+#define AG_PAIN		0x8	// short-lived hurt
+#define AG_WEAKEN	0x10	// too weak to move, oof
+
 // Species spawn flags
 #define SPECIES_IS_WHITELISTED    0x1    // Must be whitelisted to play.
 #define SPECIES_IS_RESTRICTED     0x2    // Is not a core/normally playable species. (castes, mutantraces)

--- a/code/__defines/species_languages.dm
+++ b/code/__defines/species_languages.dm
@@ -36,7 +36,7 @@
 #define FUNGI		0x100	// Delicious shrooms.
 #define COFFEE		0x200	// Mostly here for tajara.
 #define GENERIC		0x400	// Catchall for stuff that doesn't fall into the groups above. You shouldn't be allergic to this type, ever.
-#define SUGARS		0x800	// Refined sugars, for unathi-like reactions
+#define SUGARS		0x800	// For unathi-like reactions
 
 // Allergen reactions
 #define AG_TOX_DMG	0x1	// the classic 

--- a/code/__defines/species_languages.dm
+++ b/code/__defines/species_languages.dm
@@ -36,6 +36,7 @@
 #define FUNGI		0x100	// Delicious shrooms.
 #define COFFEE		0x200	// Mostly here for tajara.
 #define GENERIC		0x400	// Catchall for stuff that doesn't fall into the groups above. You shouldn't be allergic to this type, ever.
+#define SUGARS		0x800	// Refined sugars, for unathi-like reactions
 
 // Allergen reactions
 #define AG_TOX_DMG	0x1	// the classic 
@@ -43,6 +44,8 @@
 #define AG_EMOTE	0x4	// general emote reactions based on affect type
 #define AG_PAIN		0x8	// short-lived hurt
 #define AG_WEAKEN	0x10	// too weak to move, oof
+#define AG_BLURRY	0x20	// blurred vision!
+#define AG_SLEEPY	0x40	// fatigue/exhaustion
 
 // Species spawn flags
 #define SPECIES_IS_WHITELISTED    0x1    // Must be whitelisted to play.

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -53,7 +53,7 @@
 
 	var/taste_sensitivity = TASTE_NORMAL							// How sensitive the species is to minute tastes.
 	var/allergens = null									// Things that will make this species very sick
-	var/allergen_reaction = AG_TOX_DMG|AG_OXY_DMG|AG_EMOTE|AG_PAIN|AG_WEAKEN		// What type of reactions will you have? These are all the options and are intended to approximate anaphylactic shock.
+	var/allergen_reaction = AG_TOX_DMG|AG_OXY_DMG|AG_EMOTE|AG_PAIN|AG_WEAKEN		// What type of reactions will you have? These the 'main' options and are intended to approximate anaphylactic shock at high doses.
 	var/allergen_damage_severity = 7.5							// How bad are reactions to the allergen? This is damage per unit, approximately.
 	var/allergen_disable_severity = 2.5							// Whilst this determines how long nonlethal effects last and how common emotes are.
 

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -51,9 +51,11 @@
 	var/hunger_factor = 0.05								// Multiplier for hunger.
 	var/active_regen_mult = 1								// Multiplier for 'Regenerate' power speed, in human_powers.dm
 
-	var/taste_sensitivity = TASTE_NORMAL					// How sensitive the species is to minute tastes.
-	var/allergens = null							// Things that will make this species very sick
-	var/allergen_severity = 0.5						// How bad are reactions to the allergen? This is raw toxin damage per metabolism tick, multiplied by the amount metabolized
+	var/taste_sensitivity = TASTE_NORMAL							// How sensitive the species is to minute tastes.
+	var/allergens = null									// Things that will make this species very sick
+	var/allergen_reaction = AG_TOX_DMG|AG_OXY_DMG|AG_EMOTE|AG_PAIN|AG_WEAKEN		// What type of reactions will you have? These are all the options and are intended to approximate anaphylactic shock.
+	var/allergen_damage_severity = 7.5							// How bad are reactions to the allergen? This is damage per unit, approximately.
+	var/allergen_disable_severity = 2.5							// Whilst this determines how long nonlethal effects last and how common emotes are.
 
 	var/min_age = 17
 	var/max_age = 70

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -54,8 +54,8 @@
 	var/taste_sensitivity = TASTE_NORMAL							// How sensitive the species is to minute tastes.
 	var/allergens = null									// Things that will make this species very sick
 	var/allergen_reaction = AG_TOX_DMG|AG_OXY_DMG|AG_EMOTE|AG_PAIN|AG_WEAKEN		// What type of reactions will you have? These the 'main' options and are intended to approximate anaphylactic shock at high doses.
-	var/allergen_damage_severity = 7.5							// How bad are reactions to the allergen? This is damage per unit, approximately.
-	var/allergen_disable_severity = 2.5							// Whilst this determines how long nonlethal effects last and how common emotes are.
+	var/allergen_damage_severity = 1.2							// How bad are reactions to the allergen? Touch with extreme caution.
+	var/allergen_disable_severity = 3							// Whilst this determines how long nonlethal effects last and how common emotes are.
 
 	var/min_age = 17
 	var/max_age = 70

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -162,24 +162,26 @@
 				affect_touch(M, alien, removed)
 	if(overdose && (volume > overdose * M?.species.chemOD_threshold) && (active_metab.metabolism_class != CHEM_TOUCH && !can_overdose_touch))
 		overdose(M, alien, removed)
-	if(M.species.allergens & allergen_type)	//uhoh, we can't handle this!		
+	if(M.species.allergens & allergen_type)	//uhoh, we can't handle this!	
+		var/damage_severity = M.species.allergen_damage_severity*allergen_factor
+		var/disable_severity = M.species.allergen_disable_severity*allergen_factor	
 		if(M.species.allergen_reaction & AG_TOX_DMG)
-			M.adjustToxLoss(M.species.allergen_damage_severity*allergen_factor)
+			M.adjustToxLoss(damage_severity)
 		if(M.species.allergen_reaction & AG_OXY_DMG)
-			M.adjustOxyLoss(M.species.allergen_damage_severity*allergen_factor)
-			if(prob(2.5*(M.species.allergen_disable_severity*allergen_factor)))
+			M.adjustOxyLoss(damage_severity)
+			if(prob(2.5*disable_severity))
 				M.emote(pick("cough","gasp","choke"))
 		if(M.species.allergen_reaction & AG_EMOTE)
-			if(prob(2.5*(M.species.allergen_disable_severity*allergen_factor)))	//this has a higher base chance, but not *too* high
+			if(prob(2.5*disable_severity))	//this has a higher base chance, but not *too* high
 				M.emote(pick("pale","shiver","twitch"))
 		if(M.species.allergen_reaction & AG_PAIN)
-			M.adjustHalLoss(M.species.allergen_disable_severity*allergen_factor)
+			M.adjustHalLoss(disable_severity)
 		if(M.species.allergen_reaction & AG_WEAKEN)
-			M.Weaken(M.species.allergen_disable_severity*allergen_factor)
+			M.Weaken(disable_severity)
 		if(M.species.allergen_reaction & AG_BLURRY)
-			M.eye_blurry = max(M.eye_blurry, M.species.allergen_disable_severity*allergen_factor)
+			M.eye_blurry = max(M.eye_blurry, disable_severity)
 		if(M.species.allergen_reaction & AG_SLEEPY)
-			M.drowsyness = max(M.drowsyness, M.species.allergen_disable_severity*allergen_factor)
+			M.drowsyness = max(M.drowsyness, disable_severity)
 	remove_self(removed)
 	return
 

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -25,6 +25,9 @@
 
 	var/affects_dead = 0	// Does this chem process inside a corpse?
 	var/affects_robots = 0	// Does this chem process inside a Synth?
+	
+	var/allergen_type = GENERIC	// What potential allergens does this contain?
+	var/allergen_factor = 1	// If the potential allergens are mixed and low-volume, they're a bit less dangerous. Needed for drinks because they're a single reagent compared to food which contains multiple seperate reagents.
 
 	var/cup_icon_state = null
 	var/cup_name = null
@@ -159,6 +162,24 @@
 				affect_touch(M, alien, removed)
 	if(overdose && (volume > overdose * M?.species.chemOD_threshold) && (active_metab.metabolism_class != CHEM_TOUCH && !can_overdose_touch))
 		overdose(M, alien, removed)
+	if(M.species.allergens & allergen_type)	//uhoh, we can't handle this!		
+		if(M.species.allergen_reaction & AG_TOX_DMG)
+			M.adjustToxLoss(M.species.allergen_damage_severity*allergen_factor)
+		if(M.species.allergen_reaction & AG_OXY_DMG)
+			M.adjustOxyLoss(M.species.allergen_damage_severity*allergen_factor)
+			if(prob(2.5*(M.species.allergen_disable_severity*allergen_factor)))
+				M.emote(pick("cough","gasp","choke"))
+		if(M.species.allergen_reaction & AG_EMOTE)
+			if(prob(2.5*(M.species.allergen_disable_severity*allergen_factor)))	//this has a higher base chance, but not *too* high
+				M.emote(pick("pale","shiver","twitch"))
+		if(M.species.allergen_reaction & AG_PAIN)
+			M.adjustHalLoss(M.species.allergen_disable_severity*allergen_factor)
+		if(M.species.allergen_reaction & AG_WEAKEN)
+			M.Weaken(M.species.allergen_disable_severity*allergen_factor)
+		if(M.species.allergen_reaction & AG_BLURRY)
+			M.eye_blurry = max(M.eye_blurry, M.species.allergen_disable_severity*allergen_factor)
+		if(M.species.allergen_reaction & AG_SLEEPY)
+			M.drowsyness = max(M.drowsyness, M.species.allergen_disable_severity*allergen_factor)
 	remove_self(removed)
 	return
 

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Dispenser.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Dispenser.dm
@@ -82,8 +82,6 @@
 
 	var/nutriment_factor = 0
 	var/strength = 10 // This is, essentially, units between stages - the lower, the stronger. Less fine tuning, more clarity.
-	var/allergen_type = GENERIC	// What potential allergens does this contain?
-	var/allergen_factor = 0.5	// If the potential allergens are mixed and low-volume, they're a bit less dangerous. Needed for drinks because they're a single reagent compared to food which contains multiple seperate reagents.
 	var/toxicity = 1
 
 	var/druggy = 0
@@ -93,6 +91,7 @@
 
 	glass_name = "ethanol"
 	glass_desc = "A well-known alcohol with a variety of applications."
+	allergen_factor = 0.5	//simulates mixed drinks containing less of the allergen, as they have only a single actual reagent unlike food
 
 /datum/reagent/ethanol/touch_mob(var/mob/living/L, var/amount)
 	if(istype(L))
@@ -141,27 +140,11 @@
 
 	if(halluci)
 		M.hallucination = max(M.hallucination, halluci*3)
-	
-	if(M.species.allergens & allergen_type)
-		if(M.species.allergen_reaction & AG_TOX_DMG)
-			M.adjustToxLoss(M.species.allergen_damage_severity*4)
-		if(M.species.allergen_reaction & AG_OXY_DMG)
-			M.adjustOxyLoss(M.species.allergen_damage_severity*4)			
-		if(M.species.allergen_reaction & AG_EMOTE)
-			if(prob(2*M.species.allergen_disable_severity))
-				M.emote("shiver","twitch")
-		if(M.species.allergen_reaction & AG_PAIN)
-			M.adjustHalLoss(M.species.allergen_disable_severity*8)
-		if(M.species.allergen_reaction & AG_WEAKEN)
-			M.Weaken(M.species.allergen_disable_severity*8)
-		if(M.species.allergen_reaction & AG_BLURRY)
-			M.eye_blurry = max(M.eye_blurry, M.species.allergen_disable_severity*4)
-		if(M.species.allergen_reaction & AG_SLEEPY)			
-			M.drowsyness = max(M.drowsyness, M.species.allergen_disable_severity*4)
 
 /datum/reagent/ethanol/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed)
 	if(issmall(M)) removed *= 2
-	M.adjust_nutrition(nutriment_factor * removed)
+	if(!(M.species.allergens & allergen_type))	//assuming it doesn't cause a horrible reaction, we get the nutrition effects
+		M.adjust_nutrition(nutriment_factor * removed)
 	var/strength_mod = 1 * M.species.alcohol_mod
 	if(alien == IS_SKRELL)
 		strength_mod *= 5
@@ -202,23 +185,6 @@
 
 	if(halluci)
 		M.hallucination = max(M.hallucination, halluci)
-	
-	if(M.species.allergens & allergen_type)
-		if(M.species.allergen_reaction & AG_TOX_DMG)
-			M.adjustToxLoss(M.species.allergen_damage_severity)
-		if(M.species.allergen_reaction & AG_OXY_DMG)
-			M.adjustOxyLoss(M.species.allergen_damage_severity)		
-		if(M.species.allergen_reaction & AG_EMOTE)
-			if(prob(4*M.species.allergen_disable_severity))	//keep in mind this a % chance to fire per tick of processing
-				M.emote("cough","vomit","gasp","choke","drool","pale")
-		if(M.species.allergen_reaction & AG_PAIN)
-			M.adjustHalLoss(M.species.allergen_disable_severity*4)
-		if(M.species.allergen_reaction & AG_WEAKEN)
-			M.Weaken(M.species.allergen_disable_severity*4)
-		if(M.species.allergen_reaction & AG_BLURRY)
-			M.eye_blurry = max(M.eye_blurry, M.species.allergen_disable_severity)
-		if(M.species.allergen_reaction & AG_SLEEPY)			
-			M.drowsyness = max(M.drowsyness, M.species.allergen_disable_severity)
 
 /datum/reagent/ethanol/touch_obj(var/obj/O)
 	if(istype(O, /obj/item/weapon/paper))

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Dispenser.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Dispenser.dm
@@ -154,6 +154,10 @@
 			M.adjustHalLoss(M.species.allergen_disable_severity*8)
 		if(M.species.allergen_reaction & AG_WEAKEN)
 			M.Weaken(M.species.allergen_disable_severity*8)
+		if(M.species.allergen_reaction & AG_BLURRY)
+			M.eye_blurry = max(M.eye_blurry, M.species.allergen_disable_severity*4)
+		if(M.species.allergen_reaction & AG_SLEEPY)			
+			M.drowsyness = max(M.drowsyness, M.species.allergen_disable_severity*4)
 
 /datum/reagent/ethanol/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed)
 	if(issmall(M)) removed *= 2
@@ -211,6 +215,10 @@
 			M.adjustHalLoss(M.species.allergen_disable_severity*4)
 		if(M.species.allergen_reaction & AG_WEAKEN)
 			M.Weaken(M.species.allergen_disable_severity*4)
+		if(M.species.allergen_reaction & AG_BLURRY)
+			M.eye_blurry = max(M.eye_blurry, M.species.allergen_disable_severity)
+		if(M.species.allergen_reaction & AG_SLEEPY)			
+			M.drowsyness = max(M.drowsyness, M.species.allergen_disable_severity)
 
 /datum/reagent/ethanol/touch_obj(var/obj/O)
 	if(istype(O, /obj/item/weapon/paper))

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Dispenser.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Dispenser.dm
@@ -143,7 +143,17 @@
 		M.hallucination = max(M.hallucination, halluci*3)
 	
 	if(M.species.allergens & allergen_type)
-		M.adjustToxLoss(((M.species.allergen_severity*allergen_factor)*4) * removed)
+		if(M.species.allergen_reaction & AG_TOX_DMG)
+			M.adjustToxLoss(M.species.allergen_damage_severity*4)
+		if(M.species.allergen_reaction & AG_OXY_DMG)
+			M.adjustOxyLoss(M.species.allergen_damage_severity*4)			
+		if(M.species.allergen_reaction & AG_EMOTE)
+			if(prob(2*M.species.allergen_disable_severity))
+				M.emote("shiver","twitch")
+		if(M.species.allergen_reaction & AG_PAIN)
+			M.adjustHalLoss(M.species.allergen_disable_severity*8)
+		if(M.species.allergen_reaction & AG_WEAKEN)
+			M.Weaken(M.species.allergen_disable_severity*8)
 
 /datum/reagent/ethanol/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed)
 	if(issmall(M)) removed *= 2
@@ -190,7 +200,17 @@
 		M.hallucination = max(M.hallucination, halluci)
 	
 	if(M.species.allergens & allergen_type)
-		M.adjustToxLoss((M.species.allergen_severity*allergen_factor) * removed)
+		if(M.species.allergen_reaction & AG_TOX_DMG)
+			M.adjustToxLoss(M.species.allergen_damage_severity)
+		if(M.species.allergen_reaction & AG_OXY_DMG)
+			M.adjustOxyLoss(M.species.allergen_damage_severity)		
+		if(M.species.allergen_reaction & AG_EMOTE)
+			if(prob(4*M.species.allergen_disable_severity))	//keep in mind this a % chance to fire per tick of processing
+				M.emote("cough","vomit","gasp","choke","drool","pale")
+		if(M.species.allergen_reaction & AG_PAIN)
+			M.adjustHalLoss(M.species.allergen_disable_severity*4)
+		if(M.species.allergen_reaction & AG_WEAKEN)
+			M.Weaken(M.species.allergen_disable_severity*4)
 
 /datum/reagent/ethanol/touch_obj(var/obj/O)
 	if(istype(O, /obj/item/weapon/paper))

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
@@ -42,7 +42,17 @@
 		M.adjustToxLoss(0.1 * removed)
 		return
 	if(M.species.allergens & allergen_type)
-		M.adjustToxLoss((M.species.allergen_severity*4) * removed)
+		if(M.species.allergen_reaction & AG_TOX_DMG)
+			M.adjustToxLoss(M.species.allergen_damage_severity*4)
+		if(M.species.allergen_reaction & AG_OXY_DMG)
+			M.adjustOxyLoss(M.species.allergen_damage_severity*4)			
+		if(M.species.allergen_reaction & AG_EMOTE)
+			if(prob(2*M.species.allergen_disable_severity))
+				M.emote("shiver","twitch")
+		if(M.species.allergen_reaction & AG_PAIN)
+			M.adjustHalLoss(M.species.allergen_disable_severity*8)
+		if(M.species.allergen_reaction & AG_WEAKEN)
+			M.Weaken(M.species.allergen_disable_severity*8)
 		return
 	affect_ingest(M, alien, removed)
 	..()
@@ -53,7 +63,17 @@
 		if(IS_UNATHI) removed *= 0.5
 	if(issmall(M)) removed *= 2 // Small bodymass, more effect from lower volume.
 	if(M.species.allergens & allergen_type)	//uhoh, we can't digest this!
-		M.adjustToxLoss(M.species.allergen_severity * removed)
+		if(M.species.allergen_reaction & AG_TOX_DMG)
+			M.adjustToxLoss(M.species.allergen_damage_severity)
+		if(M.species.allergen_reaction & AG_OXY_DMG)
+			M.adjustOxyLoss(M.species.allergen_damage_severity)		
+		if(M.species.allergen_reaction & AG_EMOTE)
+			if(prob(4*M.species.allergen_disable_severity))	//keep in mind this a % chance to fire per tick of processing
+				M.emote("cough","vomit","gasp","choke","drool","pale")
+		if(M.species.allergen_reaction & AG_PAIN)
+			M.adjustHalLoss(M.species.allergen_disable_severity*4)
+		if(M.species.allergen_reaction & AG_WEAKEN)
+			M.Weaken(M.species.allergen_disable_severity*4)
 	else	//delicious
 		M.heal_organ_damage(0.5 * removed, 0)
 		M.adjust_nutrition(nutriment_factor * removed)
@@ -868,12 +888,32 @@
 		strength_mod = 3
 	M.adjustToxLoss(removed * strength_mod) // Probably not a good idea; not very deadly though
 	if(M.species.allergens & allergen_type)	// Unless you're allergic, in which case...
-		M.adjustToxLoss(((M.species.allergen_severity*allergen_factor)*2) * removed)
+		if(M.species.allergen_reaction & AG_TOX_DMG)
+			M.adjustToxLoss((M.species.allergen_damage_severity*4)*allergen_factor)
+		if(M.species.allergen_reaction & AG_OXY_DMG)
+			M.adjustOxyLoss((M.species.allergen_damage_severity*4)*allergen_factor)			
+		if(M.species.allergen_reaction & AG_EMOTE)
+			if(prob(3*M.species.allergen_disable_severity))
+				M.emote("shiver","twitch")
+		if(M.species.allergen_reaction & AG_PAIN)
+			M.adjustHalLoss((M.species.allergen_disable_severity*8)*allergen_factor)
+		if(M.species.allergen_reaction & AG_WEAKEN)
+			M.Weaken((M.species.allergen_disable_severity*8)*allergen_factor)
 	return
 
 /datum/reagent/drink/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed)
 	if(M.species.allergens & allergen_type)
-		M.adjustToxLoss((M.species.allergen_severity*allergen_factor) * removed)
+		if(M.species.allergen_reaction & AG_TOX_DMG)
+			M.adjustToxLoss((M.species.allergen_damage_severity)*allergen_factor)
+		if(M.species.allergen_reaction & AG_OXY_DMG)
+			M.adjustOxyLoss((M.species.allergen_damage_severity)*allergen_factor)			
+		if(M.species.allergen_reaction & AG_EMOTE)
+			if(prob(2*M.species.allergen_disable_severity))	//keep in mind this a % chance to fire per tick of processing
+				M.emote("cough","vomit","gasp","choke","drool","pale")
+		if(M.species.allergen_reaction & AG_PAIN)
+			M.adjustHalLoss((M.species.allergen_disable_severity*4)*allergen_factor)
+		if(M.species.allergen_reaction & AG_WEAKEN)
+			M.Weaken((M.species.allergen_disable_severity*4)*allergen_factor)
 	else	//delicious
 		M.adjust_nutrition(nutrition * removed)
 	M.dizziness = max(0, M.dizziness + adj_dizzy)

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
@@ -9,7 +9,6 @@
 	metabolism = REM * 4
 	ingest_met = REM * 4
 	var/nutriment_factor = 30 // Per unit
-	var/allergen_type = GENERIC	// What potential allergens does this contain?
 	var/injectable = 0
 	color = "#664330"
 
@@ -41,23 +40,6 @@
 	if(!injectable && alien != IS_SLIME)
 		M.adjustToxLoss(0.1 * removed)
 		return
-	if(M.species.allergens & allergen_type)
-		if(M.species.allergen_reaction & AG_TOX_DMG)
-			M.adjustToxLoss(M.species.allergen_damage_severity*4)
-		if(M.species.allergen_reaction & AG_OXY_DMG)
-			M.adjustOxyLoss(M.species.allergen_damage_severity*4)			
-		if(M.species.allergen_reaction & AG_EMOTE)
-			if(prob(2*M.species.allergen_disable_severity))
-				M.emote("shiver","twitch")
-		if(M.species.allergen_reaction & AG_PAIN)
-			M.adjustHalLoss(M.species.allergen_disable_severity*8)
-		if(M.species.allergen_reaction & AG_WEAKEN)
-			M.Weaken(M.species.allergen_disable_severity*8)
-		if(M.species.allergen_reaction & AG_BLURRY)
-			M.eye_blurry = max(M.eye_blurry, M.species.allergen_disable_severity*4)
-		if(M.species.allergen_reaction & AG_SLEEPY)			
-			M.drowsyness = max(M.drowsyness, M.species.allergen_disable_severity*4)
-		return
 	affect_ingest(M, alien, removed)
 	..()
 
@@ -66,23 +48,7 @@
 		if(IS_DIONA) return
 		if(IS_UNATHI) removed *= 0.5
 	if(issmall(M)) removed *= 2 // Small bodymass, more effect from lower volume.
-	if(M.species.allergens & allergen_type)	//uhoh, we can't digest this!
-		if(M.species.allergen_reaction & AG_TOX_DMG)
-			M.adjustToxLoss(M.species.allergen_damage_severity)
-		if(M.species.allergen_reaction & AG_OXY_DMG)
-			M.adjustOxyLoss(M.species.allergen_damage_severity)		
-		if(M.species.allergen_reaction & AG_EMOTE)
-			if(prob(4*M.species.allergen_disable_severity))	//keep in mind this a % chance to fire per tick of processing
-				M.emote("cough","vomit","gasp","choke","drool","pale")
-		if(M.species.allergen_reaction & AG_PAIN)
-			M.adjustHalLoss(M.species.allergen_disable_severity*4)
-		if(M.species.allergen_reaction & AG_WEAKEN)
-			M.Weaken(M.species.allergen_disable_severity*4)
-		if(M.species.allergen_reaction & AG_BLURRY)
-			M.eye_blurry = max(M.eye_blurry, M.species.allergen_disable_severity)
-		if(M.species.allergen_reaction & AG_SLEEPY)			
-			M.drowsyness = max(M.drowsyness, M.species.allergen_disable_severity)
-	else	//delicious
+	if(!(M.species.allergens & allergen_type))	//assuming it doesn't cause a horrible reaction, we'll be ok!
 		M.heal_organ_damage(0.5 * removed, 0)
 		M.adjust_nutrition(nutriment_factor * removed)
 		M.add_chemical_effect(CE_BLOODRESTORE, 4 * removed)
@@ -887,42 +853,16 @@
 	var/adj_sleepy = 0
 	var/adj_temp = 0
 	var/water_based = TRUE
-	var/allergen_type = GENERIC	// What potential allergens does this contain?
-	var/allergen_factor = 1	// If the potential allergens are mixed and low-volume, they're a bit less dangerous. Needed for drinks because they're a single reagent compared to food which contains multiple seperate reagents.
 
 /datum/reagent/drink/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	var/strength_mod = 1
 	if(alien == IS_SLIME && water_based)
 		strength_mod = 3
 	M.adjustToxLoss(removed * strength_mod) // Probably not a good idea; not very deadly though
-	if(M.species.allergens & allergen_type)	// Unless you're allergic, in which case...
-		if(M.species.allergen_reaction & AG_TOX_DMG)
-			M.adjustToxLoss((M.species.allergen_damage_severity*4)*allergen_factor)
-		if(M.species.allergen_reaction & AG_OXY_DMG)
-			M.adjustOxyLoss((M.species.allergen_damage_severity*4)*allergen_factor)			
-		if(M.species.allergen_reaction & AG_EMOTE)
-			if(prob(3*M.species.allergen_disable_severity))
-				M.emote("shiver","twitch")
-		if(M.species.allergen_reaction & AG_PAIN)
-			M.adjustHalLoss((M.species.allergen_disable_severity*8)*allergen_factor)
-		if(M.species.allergen_reaction & AG_WEAKEN)
-			M.Weaken((M.species.allergen_disable_severity*8)*allergen_factor)
 	return
 
 /datum/reagent/drink/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed)
-	if(M.species.allergens & allergen_type)
-		if(M.species.allergen_reaction & AG_TOX_DMG)
-			M.adjustToxLoss((M.species.allergen_damage_severity)*allergen_factor)
-		if(M.species.allergen_reaction & AG_OXY_DMG)
-			M.adjustOxyLoss((M.species.allergen_damage_severity)*allergen_factor)			
-		if(M.species.allergen_reaction & AG_EMOTE)
-			if(prob(2*M.species.allergen_disable_severity))	//keep in mind this a % chance to fire per tick of processing
-				M.emote("cough","vomit","gasp","choke","drool","pale")
-		if(M.species.allergen_reaction & AG_PAIN)
-			M.adjustHalLoss((M.species.allergen_disable_severity*4)*allergen_factor)
-		if(M.species.allergen_reaction & AG_WEAKEN)
-			M.Weaken((M.species.allergen_disable_severity*4)*allergen_factor)
-	else	//delicious
+	if(!(M.species.allergens & allergen_type))
 		M.adjust_nutrition(nutrition * removed)
 	M.dizziness = max(0, M.dizziness + adj_dizzy)
 	M.drowsyness = max(0, M.drowsyness + adj_drowsy)

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
@@ -53,6 +53,10 @@
 			M.adjustHalLoss(M.species.allergen_disable_severity*8)
 		if(M.species.allergen_reaction & AG_WEAKEN)
 			M.Weaken(M.species.allergen_disable_severity*8)
+		if(M.species.allergen_reaction & AG_BLURRY)
+			M.eye_blurry = max(M.eye_blurry, M.species.allergen_disable_severity*4)
+		if(M.species.allergen_reaction & AG_SLEEPY)			
+			M.drowsyness = max(M.drowsyness, M.species.allergen_disable_severity*4)
 		return
 	affect_ingest(M, alien, removed)
 	..()
@@ -74,6 +78,10 @@
 			M.adjustHalLoss(M.species.allergen_disable_severity*4)
 		if(M.species.allergen_reaction & AG_WEAKEN)
 			M.Weaken(M.species.allergen_disable_severity*4)
+		if(M.species.allergen_reaction & AG_BLURRY)
+			M.eye_blurry = max(M.eye_blurry, M.species.allergen_disable_severity)
+		if(M.species.allergen_reaction & AG_SLEEPY)			
+			M.drowsyness = max(M.drowsyness, M.species.allergen_disable_severity)
 	else	//delicious
 		M.heal_organ_damage(0.5 * removed, 0)
 		M.adjust_nutrition(nutriment_factor * removed)


### PR DESCRIPTION
Refactors and builds on #7864 to allow for;
1) Purely lethal or purely nonlethal reactions
2) Differing severities for lethal/nonlethal reactions

I've moved the entire thing up to the /datum/reagent/ level where it probably should've been done in the first place to reduce code duplication. Thanks, past me!

__**IMPORTANT NOTICE:**__ this PR also adjusts the base amount of damage taken from allergens *quite significantly*. I suspect nobody ever actually *tested* the allergen reactions before my last PR, because the damage amount was barely a slap on the wrist. Now a few (~5) units of a reagent you're allergic to won't kill you outright, but it will be very, very bad for you and necessitate medical attention. Anything more than that will prove fatal within the span of a few minutes, but people can still save you if they're fairly quick in administering dylo/dex/carbon.

To put things in perspective, 5u of coffee will cause about 40-50 tox damage for a tajara, and if dylovene isn't administered immediately this will cause nasty liver damage over the long term. If they slam an entire cup of coffee they will probably explode*.

*Not literally. But they might if brute damage was a possible allergy reaction.

As always the values and reaction type can be tweaked on a per-species basis.

:cl:
tweak - allergies expanded again! Food allergies are also now actually dangerous.
/:cl: