### PR TITLE
Small cleanup from init PR.

### DIFF
--- a/code/modules/nano/nanoui.dm
+++ b/code/modules/nano/nanoui.dm
@@ -404,7 +404,7 @@ nanoui is used to open and update nano browser uis
 	// An attempted fix to UIs sometimes locking up spamming runtime errors due to src_object being null for whatever reason.
 	// This hard-deletes the UI, preventing the device that uses the UI from being locked up permanently.
 	if(!src_object)
-		qdel(src)
+		del(src)
 
 	var/window_size = ""
 	if (width && height)

--- a/code/modules/organs/internal/augment.dm
+++ b/code/modules/organs/internal/augment.dm
@@ -31,7 +31,7 @@
 	var/last_activate = null
 
 /obj/item/organ/internal/augment/Initialize()
-	. ..()
+	. = ..()
 	setup_radial_icon()
 	if(integrated_object_type)
 		integrated_object = new integrated_object_type(src)


### PR DESCRIPTION
- qdel => harddel is not equivalent and NanoUI needs to hard del and return early there I suspect.
- No idea how `. ..()` even compiled.