### PR TITLE
Stair tweaks

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -450,8 +450,10 @@
 		minor_dir = dx
 		minor_dist = dist_x
 
+	range = min(dist_x + dist_y, range)
+
 	while(src && target && src.throwing && istype(src.loc, /turf) \
-		  && ((abs(target.x - src.x)+abs(target.y - src.y) > 0 && dist_travelled < (dist_x + dist_y)) \
+		  && ((abs(target.x - src.x)+abs(target.y - src.y) > 0 && dist_travelled < range) \
 		  	   || (a && a.has_gravity == 0) \
 			   || istype(src.loc, /turf/space)))
 		// only stop when we've gone the whole distance (or max throw range) and are on a non-space tile, or hit something, or hit the end of the map, or someone picks it up

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -451,7 +451,7 @@
 		minor_dist = dist_x
 
 	while(src && target && src.throwing && istype(src.loc, /turf) \
-		  && ((abs(target.x - src.x)+abs(target.y - src.y) > 0 && dist_travelled < range) \
+		  && ((abs(target.x - src.x)+abs(target.y - src.y) > 0 && dist_travelled < (dist_x + dist_y)) \
 		  	   || (a && a.has_gravity == 0) \
 			   || istype(src.loc, /turf/space)))
 		// only stop when we've gone the whole distance (or max throw range) and are on a non-space tile, or hit something, or hit the end of the map, or someone picks it up

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -291,6 +291,8 @@
 				if(AM == src)
 					continue
 				AM.Uncrossed(src)
+				if(loc != destination) // Uncrossed() triggered a separate movement
+					return
 
 			// Information about turf and z-levels for source and dest collected
 			var/turf/oldturf = get_turf(oldloc)
@@ -315,6 +317,8 @@
 				if(AM == src)
 					continue
 				AM.Crossed(src, oldloc)
+				if(loc != destination) // Crossed triggered a separate movement
+					return
 
 			// Call our thingy to inform everyone we moved
 			Moved(oldloc, NONE, TRUE)

--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -40,10 +40,7 @@
 			return TRUE
 
 /atom/movable/proc/has_buckled_mobs()
-	if(!buckled_mobs)
-		return FALSE
-	if(buckled_mobs.len)
-		return TRUE
+	return LAZYLEN(buckled_mobs)
 
 /atom/movable/Destroy()
 	unbuckle_all_mobs()

--- a/code/modules/multiz/stairs.dm
+++ b/code/modules/multiz/stairs.dm
@@ -196,6 +196,9 @@
 	return TRUE
 
 /obj/structure/stairs/bottom/instant_stairs(var/atom/movable/AM)
+	if(isobserver(AM)) // Ghosts have their own methods for going up and down
+		return
+
 	if(isliving(AM))
 		var/mob/living/L = AM
 	
@@ -436,6 +439,9 @@
 	return TRUE
 
 /obj/structure/stairs/top/instant_stairs(var/atom/movable/AM)
+	if(isobserver(AM)) // Ghosts have their own methods for going up and down
+		return
+
 	if(isliving(AM))
 		var/mob/living/L = AM
 

--- a/code/modules/multiz/stairs.dm
+++ b/code/modules/multiz/stairs.dm
@@ -61,6 +61,9 @@
 /obj/structure/stairs/proc/use_stairs(var/atom/movable/AM, var/atom/oldloc)
 	return
 
+/obj/structure/stairs/proc/instant_stairs(var/atom/movable/AM)
+	return
+
 //////////////////////////////////////////////////////////////////////
 // Bottom piece that you step ontor //////////////////////////////////
 //////////////////////////////////////////////////////////////////////
@@ -133,7 +136,11 @@
 	return FALSE
 
 /obj/structure/stairs/bottom/Crossed(var/atom/movable/AM, var/atom/oldloc)
-	use_stairs(AM, oldloc)
+	if(isliving(AM))
+		var/mob/living/L = AM
+		if(L.has_AI())
+			use_stairs(AM, oldloc)
+	..()
 
 /obj/structure/stairs/bottom/use_stairs(var/atom/movable/AM, var/atom/oldloc)	
 	// If we're coming from the top of the stairs, don't trap us in an infinite staircase
@@ -147,7 +154,9 @@
 	if(AM.pulledby) // Animating the movement of pulled things is handled when the puller goes up the stairs
 		return
 	
-	var/animation_delay = STAIR_MOVE_DELAY // Default value
+	if(AM.has_buckled_mobs()) // Similarly, the rider entering the turf will bring along whatever they're buckled to
+		return
+
 	var/list/atom/movable/pulling = list() // Will also include grabbed mobs
 	if(isliving(AM))
 		var/mob/living/L = AM
@@ -155,8 +164,8 @@
 		if(L.grabbed_by.len) // Same as pulledby, whoever's holding you will keep you from going down stairs.
 			return
 
-		// If the object has a measurable movement delay, use that
-		animation_delay = L.movement_delay()
+		if(L.buckled)
+			pulling |= L.buckled
 
 		// If the object is pulling or grabbing anything, we'll want to move those too. A grab chain may be disrupted in doing so.
 		if(L.pulling && !L.pulling.anchored)
@@ -167,71 +176,49 @@
 	// If the stairs aren't broken, go up.
 	if(check_integrity())
 		AM.dir = src.dir
-		// Animate moving onto M
-		switch(src.dir)
-			if(NORTH)
-				animate(AM, AM.pixel_y += 32, time = animation_delay)
-			if(SOUTH)
-				animate(AM, AM.pixel_y += -32, time = animation_delay)
-			if(EAST)
-				animate(AM, AM.pixel_x += 32, time = animation_delay)
-			if(WEST)
-				animate(AM, AM.pixel_x += -32, time = animation_delay)
 
 		// Bring the pulled/grabbed object(s) along behind us
 		for(var/atom/movable/P in pulling)
 			P.forceMove(get_turf(src)) // They will move onto the turf but won't get past the check earlier in crossed. Aligns animation more cleanly
-			switch(src.dir)
-				if(NORTH)
-					animate(P, P.pixel_y += 32, time = animation_delay)
-				if(SOUTH)
-					animate(P, P.pixel_y += -32, time = animation_delay)
-				if(EAST)
-					animate(P, P.pixel_x += 32, time = animation_delay)
-				if(WEST)
-					animate(P, P.pixel_x += -32, time = animation_delay)
 
 
-		// Go up the stairs
-		spawn(animation_delay)
-			// Move to Top
-			AM.forceMove(get_turf(top))
-
-			// Animate moving from O to T
-			switch(src.dir)
-				if(NORTH)
-					AM.pixel_y -= 64
-					animate(AM, AM.pixel_y += 32, time = animation_delay)//, easing = SINE_EASING | EASE_OUT)
-				if(SOUTH)
-					AM.pixel_y -= -64
-					animate(AM, AM.pixel_y += -32, time = animation_delay)//, easing = SINE_EASING | EASE_OUT)
-				if(EAST)
-					AM.pixel_x -= 64
-					animate(AM, AM.pixel_x += 32, time = animation_delay)//, easing = SINE_EASING | EASE_OUT)
-				if(WEST)
-					AM.pixel_x -= -64
-					animate(AM, AM.pixel_x += -32, time = animation_delay)//, easing = SINE_EASING | EASE_OUT)
+		// Move to Top
+		AM.forceMove(get_turf(top))
 		
-		
-			// If something is being pulled, bring it along directly to avoid the mob being torn away from it due to movement delays
-			for(var/atom/movable/P in pulling)
-				spawn(animation_delay)
-					switch(src.dir)
-						if(NORTH)
-							P.pixel_y -= 32
-						if(SOUTH)
-							P.pixel_y -= -32
-						if(EAST)
-							P.pixel_x -= 32
-						if(WEST)
-							P.pixel_x -= -32
-					P.forceMove(get_turf(top)) // Just bring it along directly, no fussing with animation timing
-					if(isliving(P))
-						var/mob/living/L = P
-						if(L.client)
-							L.client.Process_Grab() // Update any miscellanous grabs, possibly break grab-chains
+		// If something is being pulled, bring it along directly to avoid the mob being torn away from it due to movement delays
+		for(var/atom/movable/P in pulling)
+			P.forceMove(get_turf(top)) // Just bring it along directly, no fussing with animation timing
+			if(isliving(P))
+				var/mob/living/L = P
+				if(L.client)
+					L.client.Process_Grab() // Update any miscellanous grabs, possibly break grab-chains
 
 	return TRUE
+
+/obj/structure/stairs/bottom/instant_stairs(var/atom/movable/AM)
+	if(isliving(AM))
+		var/mob/living/L = AM
+	
+		if(L.grabbed_by.len) // Same as pulledby, whoever's holding you will keep you from going down stairs.
+			return
+		
+		if(L.has_buckled_mobs())
+			return
+
+		if(L.buckled)
+			L.buckled.forceMove(get_turf(top))
+		
+		// If the object is pulling or grabbing anything, we'll want to move those too. A grab chain may be disrupted in doing so.
+		if(L.pulling && !L.pulling.anchored)
+			L.pulling.forceMove(get_turf(top))
+
+		for(var/obj/item/weapon/grab/G in list(L.l_hand, L.r_hand))
+			G.affecting.forceMove(get_turf(top))
+		
+		if(L.client)
+			L.client.Process_Grab()
+
+	AM.forceMove(get_turf(top))
 
 //////////////////////////////////////////////////////////////////////
 // Middle piece that you are animated onto/off of ////////////////////
@@ -318,7 +305,7 @@
 
 /obj/structure/stairs/middle/Bumped(mob/user)
 	if(check_integrity() && bottom && (bottom in get_turf(user))) // Bottom must be enforced because the middle stairs don't actually need the bottom
-		user.forceMove(get_turf(top))
+		bottom.instant_stairs(user)
 
 //////////////////////////////////////////////////////////////////////
 // Top piece that you step onto //////////////////////////////////////
@@ -391,8 +378,11 @@
 	return
 
 /obj/structure/stairs/top/Crossed(var/atom/movable/AM, var/atom/oldloc)
-	use_stairs(AM, oldloc)
-	. = ..()
+	if(isliving(AM))
+		var/mob/living/L = AM
+		if(L.has_AI())
+			use_stairs(AM, oldloc)
+	..()
 
 /obj/structure/stairs/top/use_stairs(var/atom/movable/AM, var/atom/oldloc)
 	// If we're coming from the bottom of the stairs, don't trap us in an infinite staircase
@@ -405,8 +395,10 @@
 	
 	if(AM.pulledby) // Animating the movement of pulled things is handled when the puller goes up the stairs
 		return
+	
+	if(AM.has_buckled_mobs()) // Similarly, the rider entering the turf will bring along whatever they're buckled to
+		return
 
-	var/animation_delay = STAIR_MOVE_DELAY // Default value
 	var/list/atom/movable/pulling = list() // Will also include grabbed mobs
 	if(isliving(AM))
 		var/mob/living/L = AM
@@ -414,8 +406,8 @@
 		if(L.grabbed_by.len) // Same as pulledby, whoever's holding you will keep you from going down stairs.
 			return
 
-		// If the object has a measurable movement delay, use that
-		animation_delay = L.movement_delay()
+		if(L.buckled)
+			pulling |= L.buckled
 
 		// If the object is pulling or grabbing anything, we'll want to move those too. A grab chain may be disrupted in doing so.
 		if(L.pulling && !L.pulling.anchored)
@@ -426,71 +418,47 @@
 	// If the stairs aren't broken, go up.
 	if(check_integrity())
 		AM.dir = turn(src.dir, 180)
-		// Animate moving onto M
-		switch(src.dir)
-			if(NORTH)
-				animate(AM, AM.pixel_y -= 32, time = animation_delay) // Incrementing/decrementing to preserve prior values
-			if(SOUTH)
-				animate(AM, AM.pixel_y -= -32, time = animation_delay)
-			if(EAST)
-				animate(AM, AM.pixel_x -= 32, time = animation_delay)
-			if(WEST)
-				animate(AM, AM.pixel_x -= -32, time = animation_delay)
-
 		// Bring the pulled/grabbed object(s) along behind us
 		for(var/atom/movable/P in pulling)
 			P.forceMove(get_turf(src)) // They will move onto the turf but won't get past the check earlier in crossed. Aligns animation more cleanly
-			switch(src.dir)
-				if(NORTH)
-					animate(P, P.pixel_y -= 32, time = animation_delay)
-				if(SOUTH)
-					animate(P, P.pixel_y -= -32, time = animation_delay)
-				if(EAST)
-					animate(P, P.pixel_x -= 32, time = animation_delay)
-				if(WEST)
-					animate(P, P.pixel_x -= -32, time = animation_delay)
 
-		// Go up the stairs
-		spawn(animation_delay)
-			// Move to Top
-			AM.forceMove(get_turf(bottom))
-
-			// Animate moving from O to T
-			switch(src.dir)
-				if(NORTH)
-					AM.pixel_y += 64
-					animate(AM, AM.pixel_y -= 32, time = animation_delay)//, easing = SINE_EASING | EASE_OUT)
-				if(SOUTH)
-					AM.pixel_y += -64
-					animate(AM, AM.pixel_y -= -32, time = animation_delay)//, easing = SINE_EASING | EASE_OUT)
-				if(EAST)
-					AM.pixel_x += 64
-					animate(AM, AM.pixel_x -= 32, time = animation_delay)//, easing = SINE_EASING | EASE_OUT)
-				if(WEST)
-					AM.pixel_x += -64
-					animate(AM, AM.pixel_x -= -32, time = animation_delay)//, easing = SINE_EASING | EASE_OUT)
+		// Move to Top
+		AM.forceMove(get_turf(bottom))
 		
-		
-			// If something is being pulled, bring it along directly to avoid the mob being torn away from it due to movement delays
-			for(var/atom/movable/P in pulling)
-				spawn(animation_delay)
-					switch(src.dir)
-						if(NORTH)
-							P.pixel_y += 32
-						if(SOUTH)
-							P.pixel_y += -32
-						if(EAST)
-							P.pixel_x += 32
-						if(WEST)
-							P.pixel_x += -32
-					P.forceMove(get_turf(bottom)) // Just bring it along directly, no fussing with animation timing
-					if(isliving(P))
-						var/mob/living/L = P
-						if(L.client)
-							L.client.Process_Grab() // Update any miscellanous grabs, possibly break grab-chains
+		// If something is being pulled, bring it along directly to avoid the mob being torn away from it due to movement delays
+		for(var/atom/movable/P in pulling)
+			P.forceMove(get_turf(bottom)) // Just bring it along directly, no fussing with animation timing
+			if(isliving(P))
+				var/mob/living/L = P
+				if(L.client)
+					L.client.Process_Grab() // Update any miscellanous grabs, possibly break grab-chains
 
 	return TRUE
 
+/obj/structure/stairs/top/instant_stairs(var/atom/movable/AM)
+	if(isliving(AM))
+		var/mob/living/L = AM
+
+		if(L.grabbed_by.len) // Same as pulledby, whoever's holding you will keep you from going down stairs.
+			return
+		
+		if(L.has_buckled_mobs())
+			return
+		
+		if(L.buckled)
+			L.buckled.forceMove(get_turf(bottom))
+		
+		// If the object is pulling or grabbing anything, we'll want to move those too. A grab chain may be disrupted in doing so.
+		if(L.pulling && !L.pulling.anchored)
+			L.pulling.forceMove(get_turf(bottom))
+
+		for(var/obj/item/weapon/grab/G in list(L.l_hand, L.r_hand))
+			G.affecting.forceMove(get_turf(bottom))
+		
+		if(L.client)
+			L.client.Process_Grab()
+
+	AM.forceMove(get_turf(bottom))
 
 // Mapping pieces, placed at the bottommost part of the stairs
 /obj/structure/stairs/spawner

--- a/code/modules/multiz/turf.dm
+++ b/code/modules/multiz/turf.dm
@@ -52,13 +52,6 @@
 
 /turf/simulated/open/Entered(var/atom/movable/mover, var/atom/oldloc)
 	..()
-
-	// Going down stairs from the topstair piece
-	var/obj/structure/stairs/top/T = locate(/obj/structure/stairs/top) in oldloc
-	if(T && mover.dir == turn(T.dir, 180) && T.check_integrity())
-		T.instant_stairs(mover)
-		return
-
 	mover.fall()
 
 /turf/simulated/open/proc/BelowOpenUpdated(turf/T, atom/movable/AM, old_loc)

--- a/code/modules/multiz/turf.dm
+++ b/code/modules/multiz/turf.dm
@@ -56,7 +56,7 @@
 	// Going down stairs from the topstair piece
 	var/obj/structure/stairs/top/T = locate(/obj/structure/stairs/top) in oldloc
 	if(T && mover.dir == turn(T.dir, 180) && T.check_integrity())
-		T.use_stairs(mover, oldloc)
+		T.instant_stairs(mover)
 		return
 
 	mover.fall()

--- a/maps/example/example-2.dmm
+++ b/maps/example/example-2.dmm
@@ -562,7 +562,7 @@ i
 i
 c
 E
-E
+i
 i
 c
 a

--- a/maps/southern_cross/southern_cross-1.dmm
+++ b/maps/southern_cross/southern_cross-1.dmm
@@ -72438,7 +72438,7 @@
 /area/quartermaster/lockerroom)
 "cFQ" = (
 /obj/structure/railing,
-/turf/simulated/open,
+/turf/simulated/floor/tiled,
 /area/quartermaster/lockerroom)
 "cFR" = (
 /obj/structure/railing,
@@ -114178,6 +114178,24 @@
 /obj/machinery/computer/ship/sensors,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/seconddeck/ascenter)
+"eAB" = (
+/obj/structure/railing,
+/turf/simulated/floor/tiled,
+/area/hallway/primary/seconddeck/aft)
+"ioU" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/thirddeck/central)
+"oJY" = (
+/obj/structure/railing,
+/turf/simulated/floor/tiled,
+/area/hallway/secondary/eva_hallway)
+"pel" = (
+/obj/structure/railing,
+/turf/simulated/floor/tiled,
+/area/rnd/research)
 "twa" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/door/airlock/glass_external{
@@ -114195,6 +114213,12 @@
 /obj/effect/landmark/engine_loader,
 /turf/space,
 /area/space)
+"vTW" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/seconddeck/stairwell)
 
 (1,1,1) = {"
 aaa
@@ -211221,7 +211245,7 @@ cqx
 cso
 cuc
 cvE
-cxE
+vTW
 cxE
 cqx
 dVz
@@ -211506,7 +211530,7 @@ ddu
 cYq
 deu
 ddA
-dfg
+eAB
 dfJ
 dgh
 dia
@@ -213754,7 +213778,7 @@ ebo
 bkq
 bkq
 bqr
-bri
+oJY
 btP
 buT
 bvY
@@ -223277,7 +223301,7 @@ bEn
 eby
 ebD
 bBr
-ebK
+pel
 bMb
 bOc
 bPA
@@ -277272,7 +277296,7 @@ dML
 dVB
 dNE
 dOd
-dOd
+ioU
 dPi
 dPA
 dQc


### PR DESCRIPTION
Fixes #7934 , at least as far as I can understand/reproduce the issues listed. Lighting issues are a mapping issue, mostly because I don't want to go rooting through lighting code right now, and that solves it (Just replace the open_space under the top stair piece with an actual tile).

Player-controlled mobs will now transition up/down stairs by moving in the direction of the stairs (i.e., to go up, you step from the bottom-most stair into the middle stair). Works similar to old stairs, but the transition is in the visual middle.

Buckled things are brought with the mob, works similar to pulled objects.
Throwing things up/down stairs won't hurl them to the max range once they're up there, but instead the distance the user actually tried to throw it.

AI-piloted mobs will use the ""new"" interaction where they simply have to step on the stair turfs to transition, in keeping with the original goal of reworking stairs such that they are a destination that a mob can path to in order to move between z-levels, rather than a boundary which a mob must move from to perform the transition.