### PR TITLE
Allows removing omni filters/mixers at any pressure (same as non-omni)

### DIFF
--- a/code/ATMOSPHERICS/components/omni_devices/omni_base.dm
+++ b/code/ATMOSPHERICS/components/omni_devices/omni_base.dm
@@ -96,15 +96,6 @@
 			"You hear a ratchet.")
 		deconstruct()
 
-/obj/machinery/atmospherics/omni/can_unwrench()
-	var/int_pressure = 0
-	for(var/datum/omni_port/P in ports)
-		int_pressure += P.air.return_pressure()
-	var/datum/gas_mixture/env_air = loc.return_air()
-	if((int_pressure - env_air.return_pressure()) > 2*ONE_ATMOSPHERE)
-		return 0
-	return 1
-
 /obj/machinery/atmospherics/omni/attack_hand(user as mob)
 	if(..())
 		return


### PR DESCRIPTION
🆑
tweak - Omni filters and mixers can now be removed regardless of pressure, just like their non-omni versions.
/🆑
Tested.