### PR TITLE
Fixed/generalized loadout implants.

### DIFF
--- a/code/_helpers/_global_objects.dm
+++ b/code/_helpers/_global_objects.dm
@@ -1,1 +1,2 @@
 var/datum/gear_tweak/color/gear_tweak_free_color_choice = new()
+var/datum/gear_tweak/implant_location/gear_tweak_implant_location = new()

--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -386,7 +386,7 @@ var/global/datum/controller/occupations/job_master
 
 					// Implants get special treatment
 					if(G.slot == "implant")
-						var/obj/item/weapon/implant/I = G.spawn_item(H)
+						var/obj/item/weapon/implant/I = G.spawn_item(H, H.client.prefs.gear[G.display_name])
 						I.invisibility = 100
 						I.implant_loadout(H)
 						continue

--- a/code/game/objects/items/weapons/implants/implantdud.dm
+++ b/code/game/objects/items/weapons/implants/implantdud.dm
@@ -4,18 +4,6 @@
 	icon = 'icons/obj/device.dmi'
 	icon_state = "implant"
 	initialize_loc = BP_HEAD
-	var/roundstart = TRUE
 
 /obj/item/weapon/implant/dud/torso
-	name = "unknown implant"
-	desc = "A small device with small connector wires."
-	icon = 'icons/obj/device.dmi'
-	icon_state = "implant"
 	initialize_loc = BP_TORSO
-
-/obj/item/weapon/implant/dud/old
-	name = "old implant"
-	desc = "A small device with small connector wires."
-	icon = 'icons/obj/device.dmi'
-	icon_state = "implant"
-	roundstart = FALSE

--- a/code/modules/client/preference_setup/loadout/gear_tweaks.dm
+++ b/code/modules/client/preference_setup/loadout/gear_tweaks.dm
@@ -1,3 +1,5 @@
+#define LOADOUT_BAN_STRING "Custom loadout"
+
 /datum/gear_tweak/proc/get_contents(var/metadata)
 	return
 
@@ -165,7 +167,7 @@ var/datum/gear_tweak/custom_name/gear_tweak_free_name = new()
 	return ""
 
 /datum/gear_tweak/custom_name/get_metadata(var/user, var/metadata)
-	if(jobban_isbanned(user, "Custom loadout"))
+	if(jobban_isbanned(user, LOADOUT_BAN_STRING))
 		to_chat(user, SPAN_WARNING("You are banned from using custom loadout names/descriptions."))
 		return
 	if(valid_custom_names)
@@ -196,7 +198,7 @@ var/datum/gear_tweak/custom_desc/gear_tweak_free_desc = new()
 	return ""
 
 /datum/gear_tweak/custom_desc/get_metadata(var/user, var/metadata)
-	if(jobban_isbanned(user, "Custom loadout"))
+	if(jobban_isbanned(user, LOADOUT_BAN_STRING))
 		to_chat(user, SPAN_WARNING("You are banned from using custom loadout names/descriptions."))
 		return
 	if(valid_custom_desc)
@@ -507,3 +509,46 @@ var/datum/gear_tweak/custom_desc/gear_tweak_free_desc = new()
 		var/t = ValidTeslaLinks[metadata[7]]
 		I.tesla_link = new t(I)
 	I.update_verbs()
+
+/datum/gear_tweak/implant_location
+	var/static/list/bodypart_names_to_tokens = list(
+		"left hand" =  BP_L_HAND,
+		"left arm" =   BP_L_ARM,
+		"right hand" = BP_R_HAND,
+		"right arm" =  BP_R_ARM,
+		"left foot" =  BP_L_FOOT,
+		"left leg" =   BP_L_LEG,
+		"right foot" = BP_R_FOOT,
+		"right leg" =  BP_R_LEG,
+		"lower body" = BP_GROIN,
+		"upper body" = BP_TORSO,
+		"head" =       BP_HEAD
+	)
+	var/static/list/bodypart_tokens_to_names = list(
+		BP_LEFT_HAND =  "left hand",
+		BP_LEFT_ARM =   "left arm",
+		BP_RIGHT_HAND = "right hand",
+		BP_RIGHT_ARM =  "right arm",
+		BP_LEFT_FOOT =  "left foot",
+		BP_LEFT_LEG =   "left leg",
+		BP_RIGHT_FOOT = "right foot",
+		BP_RIGHT_LEG =  "right leg",
+		BP_GROIN =      "lower body",
+		BP_TORSO =      "upper body",
+		BP_HEAD =       "head"
+	)
+
+/datum/gear_tweak/implant_location/get_default()
+	return BP_TORSO
+
+/datum/gear_tweak/implant_location/tweak_item(var/obj/item/weapon/implant/I, var/metadata)
+	if(istype(I))
+		I.initialize_loc = bodypart_names_to_tokens[metadata] || BP_TORSO
+
+/datum/gear_tweak/implant_location/get_contents(var/metadata)
+	return "Location: [metadata]"
+
+/datum/gear_tweak/implant_location/get_metadata(var/user, var/metadata)
+	return (input(user, "Select a bodypart for the implant to be implanted inside.", "Implant Location", metadata || "upper body") as null|anything in bodypart_names_to_tokens) || bodypart_tokens_to_names[BP_TORSO]
+
+#undef LOADOUT_BAN_STRING

--- a/code/modules/client/preference_setup/loadout/loadout_cyberware.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_cyberware.dm
@@ -1,0 +1,56 @@
+/datum/gear/utility/implant
+	display_name = "implant, neural assistance web"
+	description = "A complex web implanted into the subject, medically in order to compensate for neurological disease."
+	path = /obj/item/weapon/implant/neural
+	slot = "implant"
+	exploitable = 1
+	sort_category = "Cyberware"
+	cost = 6
+
+/datum/gear/utility/implant/tracking
+	display_name = "implant, tracking"
+	path = /obj/item/weapon/implant/tracking/weak
+	cost = 10
+
+// Remove these after generic implant has been in for awhile and everyone has had a reasonable period to copy their old descs.
+/datum/gear/utility/implant/dud1
+	display_name = "implant, head"
+	description = "An implant with no obvious purpose (DEPRECATED, USE GENERIC IMPLANT)."
+	path = /obj/item/weapon/implant/dud
+	cost = 1
+/datum/gear/utility/implant/dud2
+	display_name = "implant, torso"
+	description = "An implant with no obvious purpose (DEPRECATED, USE GENERIC IMPLANT)."
+	path = /obj/item/weapon/implant/dud/torso
+	cost = 1
+// End removal marker.
+
+/datum/gear/utility/implant/generic
+	display_name = "implant, generic, primary"
+	description = "An implant with no obvious purpose."
+	path = /obj/item/weapon/implant
+	cost = 1
+
+/datum/gear/utility/implant/generic/second
+	display_name = "implant, generic, secondary"
+
+/datum/gear/utility/implant/generic/third
+	display_name = "implant, generic, tertiary"
+
+/datum/gear/utility/implant/generic/New()
+	..()
+	gear_tweaks += global.gear_tweak_implant_location
+
+/datum/gear/utility/implant/language
+	cost = 2
+	exploitable = 0
+
+/datum/gear/utility/implant/language/eal
+	display_name = "vocal synthesizer, EAL"
+	description = "A surgically implanted vocal synthesizer which allows the owner to speak EAL, if they know it."
+	path = /obj/item/weapon/implant/language/eal
+
+/datum/gear/utility/implant/language/skrellian
+	display_name = "vocal synthesizer, Skrellian"
+	description = "A surgically implanted vocal synthesizer which allows the owner to speak Common Skrellian, if they know it."
+	path = /obj/item/weapon/implant/language/skrellian

--- a/code/modules/client/preference_setup/loadout/loadout_utility.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_utility.dm
@@ -113,47 +113,6 @@
 	display_name = "cell, device"
 	path = /obj/item/weapon/cell/device
 
-/datum/gear/utility/implant
-	slot = "implant"
-	exploitable = 1
-
-/datum/gear/utility/implant/tracking
-	display_name = "implant, tracking"
-	path = /obj/item/weapon/implant/tracking/weak
-	cost = 10
-
-/datum/gear/utility/implant/neural
-	display_name = "implant, neural assistance web"
-	description = "A complex web implanted into the subject, medically in order to compensate for neurological disease."
-	path = /obj/item/weapon/implant/neural
-	cost = 6
-
-/datum/gear/utility/implant/dud1
-	display_name = "implant, head"
-	description = "An implant with no obvious purpose."
-	path = /obj/item/weapon/implant/dud
-	cost = 1
-
-/datum/gear/utility/implant/dud2
-	display_name = "implant, torso"
-	description = "An implant with no obvious purpose."
-	path = /obj/item/weapon/implant/dud/torso
-	cost = 1
-
-/datum/gear/utility/implant/language
-	cost = 2
-	exploitable = 0
-
-/datum/gear/utility/implant/language/eal
-	display_name = "vocal synthesizer, EAL"
-	description = "A surgically implanted vocal synthesizer which allows the owner to speak EAL, if they know it."
-	path = /obj/item/weapon/implant/language/eal
-
-/datum/gear/utility/implant/language/skrellian
-	display_name = "vocal synthesizer, Skrellian"
-	description = "A surgically implanted vocal synthesizer which allows the owner to speak Common Skrellian, if they know it."
-	path = /obj/item/weapon/implant/language/skrellian
-
 /datum/gear/utility/pen
 	display_name = "Fountain Pen"
 	path = /obj/item/weapon/pen/fountain

--- a/polaris.dme
+++ b/polaris.dme
@@ -1562,6 +1562,7 @@
 #include "code\modules\client\preference_setup\loadout\loadout.dm"
 #include "code\modules\client\preference_setup\loadout\loadout_accessories.dm"
 #include "code\modules\client\preference_setup\loadout\loadout_cosmetics.dm"
+#include "code\modules\client\preference_setup\loadout\loadout_cyberware.dm"
 #include "code\modules\client\preference_setup\loadout\loadout_ears.dm"
 #include "code\modules\client\preference_setup\loadout\loadout_eyes.dm"
 #include "code\modules\client\preference_setup\loadout\loadout_general.dm"


### PR DESCRIPTION
- Moves implants to a Cyberware category in loadout.
- Adds generic implant loadout + tweak to allow people to select a bodypart.
- Fixed metadata passing to early implant spawn proc.

I've left the dud implants and loadout options in so people get a chance to save their old descs and copy them over, but they are redundant now.