### PR TITLE
Adds an advanced version of the mining drill scanner.

### DIFF
--- a/code/game/objects/structures/loot_piles.dm
+++ b/code/game/objects/structures/loot_piles.dm
@@ -376,6 +376,7 @@ Loot piles can be depleted, if loot_depleted is turned on.  Note that players wh
 		/obj/item/weapon/tool/wrench,
 		/obj/item/weapon/tool/screwdriver,
 		/obj/item/weapon/tool/wirecutters,
+		/obj/item/weapon/mining_scanner/advanced,
 		/obj/item/device/multitool,
 		/obj/item/mecha_parts/mecha_equipment/generator,
 		/obj/item/mecha_parts/mecha_equipment/tool/cable_layer,

--- a/code/modules/mining/drilling/scanner.dm
+++ b/code/modules/mining/drilling/scanner.dm
@@ -7,6 +7,8 @@
 	origin_tech = list(TECH_MAGNET = 1, TECH_ENGINEERING = 1)
 	matter = list(DEFAULT_WALL_MATERIAL = 150)
 	var/scan_time = 2 SECONDS
+	var/range = 2
+	var/exact = FALSE
 
 /obj/item/weapon/mining_scanner/attack_self(mob/user as mob)
 	to_chat(user, "<span class='notice'>You begin sweeping \the [src] about, scanning for metal deposits.</span>")
@@ -17,7 +19,7 @@
 
 	ScanTurf(get_turf(user), user)
 
-/obj/item/weapon/mining_scanner/proc/ScanTurf(var/atom/target, var/mob/user, var/exact = FALSE)
+/obj/item/weapon/mining_scanner/proc/ScanTurf(var/atom/target, var/mob/user)
 	var/list/metals = list(
 		"surface minerals" = 0,
 		"industrial metals" = 0,
@@ -30,7 +32,7 @@
 
 	var/turf/Turf = get_turf(target)
 
-	for(var/turf/simulated/T in range(2, Turf))
+	for(var/turf/simulated/T in range(range, Turf))
 
 		if(!T.has_resources)
 			continue
@@ -66,3 +68,23 @@
 		message += "<br><span class='notice'>- [result] of [ore_type].</span>"
 
 	to_chat(user, message)
+
+/obj/item/weapon/mining_scanner/advanced
+	name = "advanced ore detector"
+	desc = "An advanced device used to locate ore deep underground."
+	description_info = "This scanner has variable range, you can use the Set Scanner Range verb, or alt+click the device. Drills dig in 5x5."
+	origin_tech = list(TECH_MAGNET = 4, TECH_ENGINEERING = 4)
+	matter = list(DEFAULT_WALL_MATERIAL = 150)
+	scan_time = 0.5 SECONDS
+	exact = TRUE
+
+/obj/item/weapon/mining_scanner/advanced/AltClick(mob/user)
+	change_size()
+
+/obj/item/weapon/mining_scanner/advanced/verb/change_size()
+	set name = "Set Scanner Range"
+	set category = "Object"
+	var/custom_range = input("Scanner Range","Pick a range to scan. ") as null|anything in list(0,1,2,3,4,5,6,7)
+	if(custom_range)
+		range = custom_range
+		to_chat(usr, "<span class='notice'>Scanner will now look up to [range] tile(s) away.</span>")

--- a/code/modules/research/designs/mining_toys.dm
+++ b/code/modules/research/designs/mining_toys.dm
@@ -48,3 +48,10 @@
 	materials = list(DEFAULT_WALL_MATERIAL = 1000,"glass" = 1000, MAT_COPPER = 50)
 	build_path = /obj/item/device/depth_scanner
 	sort_string = "FBAAA"
+
+/datum/design/item/weapon/mining/mining_scanner
+	id = "mining_scanner"
+	req_tech = list(TECH_MAGNET = 3, TECH_ENGINEERING = 4, TECH_BLUESPACE = 1)
+	materials = list(DEFAULT_WALL_MATERIAL = 1000,"glass" = 500, MAT_COPPER = 250)
+	build_path = /obj/item/weapon/mining_scanner/advanced
+	sort_string = "FBAAB"


### PR DESCRIPTION
Advanced scanner can adjust it's scan range and shows exact numbers of ore.
Can scan up to 7 tiles away (whole screen), 4 times faster than normal scanner.

Can be made in R&D at Magnets 3, Engi 4, Bluespace 1, for 1000 steel, 500 glass and 250 copper.
Also added to technical loot piles.
:cl:
adds: Adds advanced mineral scanner that can adjust its scan range and shows exact numbers of ore, available through R&D
/:cl: