### PR TITLE
Fixes context-menu examine expanding incorrect target

### DIFF
--- a/code/_helpers/view.dm
+++ b/code/_helpers/view.dm
@@ -10,3 +10,7 @@
 		viewX = text2num(viewrangelist[1])
 		viewY = text2num(viewrangelist[2])
 	return list(viewX, viewY)
+
+// Used to get `atom/O as obj|mob|turf in view()` to match against strings containing apostrophes immediately after substrings that match to other objects. Somehow. - Ater
+/proc/_validate_atom(atom/A)
+	return view()

--- a/code/modules/admin/admin_tools.dm
+++ b/code/modules/admin/admin_tools.dm
@@ -58,8 +58,3 @@
 
 
 	feedback_add_details("admin_verb","PDL") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
-
-
-// Used to get `atom/O as obj|mob|turf in view()` to match against strings containing apostrophes immediately after substrings that match to other objects. Somehow. - Ater
-/proc/admin_atom_validate(atom/A)
-	return view()

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -609,7 +609,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 	message_admins("[key_name_admin(src)] has created a command report", 1)
 	feedback_add_details("admin_verb","CCR") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
-/client/proc/cmd_admin_delete(atom/O as obj|mob|turf in admin_atom_validate(O)) // I don't understand precisely how this fixes the string matching against a substring, but it does - Ater
+/client/proc/cmd_admin_delete(atom/O as obj|mob|turf in _validate_atom(O)) // I don't understand precisely how this fixes the string matching against a substring, but it does - Ater
 	set category = "Admin"
 	set name = "Delete"
 

--- a/code/modules/examine/examine.dm
+++ b/code/modules/examine/examine.dm
@@ -76,10 +76,24 @@
 			stat(null,"<font color='#8A0808'><b>[description_holders["antag"]]</b></font>") //Red, malicious antag-related text
 
 //override examinate verb to update description holders when things are examined
-/mob/examinate(atom/A as mob|obj|turf in view())
-	if(..())
+//mob verbs are faster than object verbs. See http://www.byond.com/forum/?post=1326139&page=2#comment8198716 for why this isn't atom/verb/examine()
+/mob/verb/examinate(atom/A as mob|obj|turf in _validate_atom(A))
+	set name = "Examine"
+	set category = "IC"
+
+	if((is_blind(src) || usr.stat) && !isobserver(src))
+		to_chat(src, "<span class='notice'>Something is there but you can't see it.</span>")
 		return 1
 
+	//Could be gone by the time they finally pick something
+	if(!A)
+		return 1
+
+	face_atom(A)
+	var/list/results = A.examine(src)
+	if(!results || !results.len)
+		results = list("You were unable to examine that. Tell a developer!")
+	to_chat(src, jointext(results, "<br>"))
 	update_examine_panel(A)
 
 /mob/proc/update_examine_panel(var/atom/A)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -193,25 +193,6 @@
 				client.eye = loc
 		return TRUE
 
-//mob verbs are faster than object verbs. See http://www.byond.com/forum/?post=1326139&page=2#comment8198716 for why this isn't atom/verb/examine()
-/mob/verb/examinate(atom/A as mob|obj|turf in view())
-	set name = "Examine"
-	set category = "IC"
-
-	if((is_blind(src) || usr.stat) && !isobserver(src))
-		to_chat(src, "<span class='notice'>Something is there but you can't see it.</span>")
-		return 1
-
-	//Could be gone by the time they finally pick something
-	if(!A)
-		return 1
-
-	face_atom(A)
-	var/list/results = A.examine(src)
-	if(!results || !results.len)
-		results = list("You were unable to examine that. Tell a developer!")
-	to_chat(src, jointext(results, "<br>"))
-
 /mob/verb/pointed(atom/A as mob|obj|turf in view())
 	set name = "Point To"
 	set category = "Object"


### PR DESCRIPTION
Fixes #7901 
Uses exactly the same fix as for admin-delete, and I genericized the proc name because it'll probably need to be used elsewhere too.
Tested, shift-click examine doesn't produce the `validating` line because it provides the atom clicked upon directly to the verb, context-menu examine (right click menu) _does_ generate the `validating` line because it has to expand the string name of the object into a reference
![.png](https://puu.sh/Hnb8N/f97e39cc39.png)

This took longer than it should have (A matter of 30m or so) because someone at some point made a shell call to the verb to update the examine panel instead of just... adding that function to the verb. Or moving the definition of the verb to the `examine` modules directory. Someone shall get the bonk, for they have messed with the honk.