### PR TITLE
Examining dark click catcher doesn't show turfs

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -355,5 +355,8 @@
 		var/list/P = params2list(params)
 		var/turf/T = screen_loc2turf(P["screen-loc"], get_turf(usr))
 		if(T)
+			if(modifiers["shift"])
+				usr.face_atom(T)
+				return 1
 			T.Click(location, control, params)
-	. = 1
+	return 1


### PR DESCRIPTION
Fixes #7890 
Tested, not really much to show when it doesn't output anything. I could make it call `face_atom()` so it still turns you, if people want that.