### PR TITLE
Taking cell out of a standing drill now attempts to put it in your hands.

### DIFF
--- a/code/modules/mining/drilling/drill.dm
+++ b/code/modules/mining/drilling/drill.dm
@@ -192,7 +192,7 @@
 
 	if (panel_open && cell && user.Adjacent(src))
 		to_chat(user, "You take out \the [cell].")
-		cell.forceMove(get_turf(user))
+		user.put_in_hands(cell)
 		component_parts -= cell
 		cell = null
 		return


### PR DESCRIPTION
Spite-Filled Fixes FTW.

Taking a power cell out of a standing drill now attempts to put it in your hand, instead of putting it under you.