### PR TITLE
Makes drag-drop bodyjacking not break aghost bonds

### DIFF
--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -1424,6 +1424,11 @@ proc/admin_notice(var/message, var/rights)
 		return 1
 	if(tomob.client) //No need to ghostize if there is no client
 		tomob.ghostize(0)
+	if(frommob.mind && frommob.mind.current) //Preserve teleop for original body when adminghosting.
+		var/mob/body = frommob.mind.current
+		if(body)
+			if(body.teleop)
+				body.teleop = tomob
 	message_admins("<span class='adminnotice'>[key_name_admin(usr)] has put [frommob.ckey] in control of [tomob.name].</span>")
 	log_admin("[key_name(usr)] stuffed [frommob.ckey] into [tomob.name].")
 	feedback_add_details("admin_verb","CGD")


### PR DESCRIPTION
Possessing mobs by drag-dropping your aghost into the mob now transfers your original body's spirit link into the possessed mob and thus prevents your original body from getting knocked out when your ghost disappears into the new body.