### PR TITLE
The Personal Computer Unit

### DIFF
--- a/code/game/machinery/computer/atmos_control.dm
+++ b/code/game/machinery/computer/atmos_control.dm
@@ -19,7 +19,7 @@
 	..()
 
 /obj/machinery/computer/atmoscontrol/laptop //[TO DO] Change name to PCU and update mapdata to include replacement computers
-	name = "/improper Atmospherics PCU"
+	name = "\improper Atmospherics PCU"
 	desc = "A personal computer unit. It seems to have only the Atmosphereics Control program installed."
 	icon_screen = "pcu_atmo"
 	icon_state = "pcu"

--- a/code/game/machinery/computer/atmos_control.dm
+++ b/code/game/machinery/computer/atmos_control.dm
@@ -18,12 +18,12 @@
 /obj/machinery/computer/atmoscontrol/New()
 	..()
 
-/obj/machinery/computer/atmoscontrol/laptop
-	name = "Atmospherics Laptop"
-	desc = "A cheap laptop."
-	icon_screen = "medlaptop"
-	icon_state = "laptop"
-	icon_keyboard = "laptop_key"
+/obj/machinery/computer/atmoscontrol/laptop //[TO DO] Change name to PCU and update mapdata to include replacement computers
+	name = "/improper Atmospherics PCU"
+	desc = "A personal computer unit. It seems to have only the Atmosphereics Control program installed."
+	icon_screen = "pcu_atmo"
+	icon_state = "pcu"
+	icon_keyboard = "pcu_key"
 	density = 0
 
 /obj/machinery/computer/atmoscontrol/attack_ai(var/mob/user as mob)

--- a/code/game/machinery/computer/medical.dm
+++ b/code/game/machinery/computer/medical.dm
@@ -494,7 +494,7 @@
 
 
 /obj/machinery/computer/med_data/laptop //[TO DO] Change name to PCU and update mapdata to include replacement computers
-	name = "/improper Medical PCU"
+	name = "\improper Medical PCU"
 	desc = "A personal computer unit. It seems to have only the medical records program installed."
 	icon_state = "pcu"
 	icon_keyboard = "pcu_key"

--- a/code/game/machinery/computer/medical.dm
+++ b/code/game/machinery/computer/medical.dm
@@ -494,7 +494,7 @@
 
 
 /obj/machinery/computer/med_data/laptop //[TO DO] Change name to PCU and update mapdata to include replacement computers
-	name = "Medical PCU"
+	name = "/improper Medical PCU"
 	desc = "A personal computer unit. It seems to have only the medical records program installed."
 	icon_state = "pcu"
 	icon_keyboard = "pcu_key"

--- a/code/game/machinery/computer/medical.dm
+++ b/code/game/machinery/computer/medical.dm
@@ -493,13 +493,13 @@
 	..(severity)
 
 
-/obj/machinery/computer/med_data/laptop
-	name = "Medical Laptop"
-	desc = "A cheap laptop. It seems to have only the medical records program."
-	icon_state = "laptop"
-	icon_keyboard = "laptop_key"
-	icon_screen = "medlaptop"
-	circuit = /obj/item/weapon/circuitboard/med_data/laptop
+/obj/machinery/computer/med_data/laptop //[TO DO] Change name to PCU and update mapdata to include replacement computers
+	name = "Medical PCU"
+	desc = "A personal computer unit. It seems to have only the medical records program installed."
+	icon_state = "pcu"
+	icon_keyboard = "pcu_key"
+	icon_screen = "pcu_generic"
+	circuit = /obj/item/weapon/circuitboard/med_data/pcu
 	density = 0
 
 #undef FIELD

--- a/code/game/machinery/computer/skills.dm
+++ b/code/game/machinery/computer/skills.dm
@@ -7,7 +7,7 @@
 #define FIELD(N, V, E) list(field = N, value = V, edit = E)
 
 /obj/machinery/computer/skills//TODO:SANITY //[TO DO] Change name to PCU and update mapdata to include replacement computers
-	name = "/improper employment records PCU"
+	name = "\improper employment records PCU"
 	desc = "A personal computer unit that's used to view, edit and maintain employment records."
 	icon_state = "pcu"
 	icon_keyboard = "pcu_key"

--- a/code/game/machinery/computer/skills.dm
+++ b/code/game/machinery/computer/skills.dm
@@ -6,12 +6,12 @@
 
 #define FIELD(N, V, E) list(field = N, value = V, edit = E)
 
-/obj/machinery/computer/skills//TODO:SANITY
-	name = "employment records console"
-	desc = "Used to view, edit and maintain employment records."
-	icon_state = "laptop"
-	icon_keyboard = "laptop_key"
-	icon_screen = "medlaptop"
+/obj/machinery/computer/skills//TODO:SANITY //[TO DO] Change name to PCU and update mapdata to include replacement computers
+	name = "/improper employment records PCU"
+	desc = "A personal computer unit that's used to view, edit and maintain employment records."
+	icon_state = "pcu"
+	icon_keyboard = "pcu_key"
+	icon_screen = "pcu_generic"
 	light_color = "#00b000"
 	req_one_access = list(access_heads)
 	circuit = /obj/item/weapon/circuitboard/skills
@@ -175,7 +175,7 @@
 				screen = GENERAL_RECORD_LIST
 		else
 			. = FALSE
-	
+
 	if(.)
 		return
 

--- a/code/game/objects/items/weapons/circuitboards/computer/computer.dm
+++ b/code/game/objects/items/weapons/circuitboards/computer/computer.dm
@@ -21,8 +21,8 @@
 	name = T_BOARD("medical records console")
 	build_path = /obj/machinery/computer/med_data
 
-/obj/item/weapon/circuitboard/med_data/laptop
-	name = T_BOARD("medical records laptop")
+/obj/item/weapon/circuitboard/med_data/pcu
+	name = T_BOARD("medical records PCU")
 	build_path = /obj/machinery/computer/med_data/laptop
 
 /obj/item/weapon/circuitboard/scan_consolenew


### PR DESCRIPTION
Adds the new Personal Computer Unit (PCU) to the game to replace the static laptops in atmos, command, and medical. I always thought that the static laptops made no sense considering that there is already a portable laptop in the game - one that looks vastly different from the static one. So to replace the black brick that is the static laptop I dug through the code and found the 'personal' salvage computer in salvageable.dmi which I made rotateable. I hope this will be a more "makes sense" version of what is currently in the game. It's certainly better than a generic black box with a screen and buttons.

Pictures of the new computer are found below:

![Test3](https://user-images.githubusercontent.com/609886/111529972-28a94680-8739-11eb-924d-e1f6bfba97eb.png)

![rotate_showcase](https://user-images.githubusercontent.com/609886/111529981-2b0ba080-8739-11eb-81ca-63527594e0eb.png)
