### PR TITLE
Fixes despawn cryopods gib-killing the occupant

### DIFF
--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -380,6 +380,8 @@
 
 	//Drop all items into the pod.
 	for(var/obj/item/W in to_despawn)
+		if(istype(W,/obj/item/organ))
+			continue
 		to_despawn.drop_from_inventory(W)
 		W.forceMove(src)
 


### PR DESCRIPTION
_Haha completely harmless machine go brrrrr_

Fixes despawn cryopods tearing the occupant into little pieces and making them croak audibly before despawning them.