### PR TITLE
Fixes manifest datacore failing to find job datums for alt titles

### DIFF
--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -316,7 +316,7 @@ var/global/list/PDA_Manifest = list()
 	if(H.mind && !player_is_antag(H.mind, only_offstation_roles = 1))
 		var/assignment = GetAssignment(H)
 		var/hidden
-		var/datum/job/J = SSjob.get_job(assignment)
+		var/datum/job/J = SSjob.get_job(H.mind.assigned_role)
 		hidden = J?.offmap_spawn
 
 		/* Note: Due to cached_character_icon, a number of emergent properties occur due to the initialization


### PR DESCRIPTION
I don't think this actually affects anything on Polaris, but it's causing bugs downstream