### PR TITLE
Non-mobs aren't allies

### DIFF
--- a/code/modules/ai/interfaces.dm
+++ b/code/modules/ai/interfaces.dm
@@ -52,7 +52,7 @@
 	return say(message)
 
 /mob/living/proc/IIsAlly(mob/living/L)
-	return src.faction == L.faction
+	return istype(L) && src.faction == L.faction
 
 /mob/living/simple_mob/IIsAlly(mob/living/L)
 	. = ..()


### PR DESCRIPTION
Fixes Runtime in interfaces.dm,55: undefined variable /obj/machinery/power/emitter/var/faction
   proc name: IIsAlly (/mob/living/proc/IIsAlly)