### PR TITLE
Fixes runtime in chunk.dm: line 91, I think?

### DIFF
--- a/code/modules/mob/freelook/chunk.dm
+++ b/code/modules/mob/freelook/chunk.dm
@@ -88,7 +88,7 @@
 
 	for(var/turf in visAdded)
 		var/turf/t = turf
-		if(t.obfuscations[obfuscation.type])
+		if(LAZYLEN(t.obfuscations) && t.obfuscations[obfuscation.type])
 			obscured -= t.obfuscations[obfuscation.type]
 			for(var/eye in seenby)
 				var/mob/observer/eye/m = eye


### PR DESCRIPTION
I have no idea how that didn't _always_ runtime because it's initialized to null on turfs and then if they need to obscure themselves they add the image. I also have no idea what the AI that triggered at least 20 of these runtimes in a single round was doing because this is a really deep part of the AI eye code, and the call stack on the runtime log was very unhelpful.

LAZYLEN should resolve the list being checked when null, the only other instance I can think of where this _could_ runtime is if the list were numerically indexed instead for some reason, but again, no idea how to reproduce it means no idea how to verify this works.