### PR TITLE
Fixes runtime in prison_break.dm, line 214

### DIFF
--- a/code/modules/gamemaster/event2/events/security/prison_break.dm
+++ b/code/modules/gamemaster/event2/events/security/prison_break.dm
@@ -211,7 +211,7 @@
 /datum/event2/event/prison_break/proc/flicker_area()
 	for(var/area/A in areas_to_break)
 		var/obj/machinery/power/apc/apc = A.get_apc()
-		if(apc.operating)	//If the apc's off, it's a little hard to overload the lights.
+		if(istype(apc) && apc.operating)	//If the apc's off, it's a little hard to overload the lights.
 			for(var/obj/machinery/light/L in A)
 				L.flicker(10)
 


### PR DESCRIPTION
Fixes #7996 
Issue was specifically that the second area in the virology prison break event, `/area/medical/virologyaccess`, isn't mapped in on the Southern Cross. Since there was no typecheck to enforce that it'd found a valid APC, it was trying to evaluate `null.operating` on an apc that didn't exist because the area in question wasn't mapped, and therefore _couldn't_ have an apc.