### PR TITLE
Technomancer Bugfixes

### DIFF
--- a/code/game/gamemodes/technomancer/instability.dm
+++ b/code/game/gamemodes/technomancer/instability.dm
@@ -273,6 +273,7 @@
 			var/outgoing_instability = (amount) * ( 1 / (radius**2) )
 
 			L.receive_radiated_instability(outgoing_instability)
+			src.adjust_instability(-outgoing_instability) //This should prevent feedback loops
 
 // This should only be used for EXTERNAL sources of instability, such as from someone or something glowing.
 /mob/living/proc/receive_radiated_instability(amount)

--- a/code/game/gamemodes/technomancer/spells/illusion.dm
+++ b/code/game/gamemodes/technomancer/spells/illusion.dm
@@ -33,6 +33,7 @@
 			if(pay_energy(500))
 				illusion = new(T)
 				illusion.copy_appearance(copied)
+				illusion.copy_overlays(copied, TRUE)
 				to_chat(user, "<span class='notice'>An illusion of \the [copied] is made on \the [T].</span>")
 				user << 'sound/effects/pop.ogg'
 				return 1

--- a/code/modules/mob/living/simple_mob/subtypes/illusion/illusion.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/illusion/illusion.dm
@@ -33,7 +33,7 @@
 	appearance = thing_to_copy.appearance
 	copying = thing_to_copy
 	density = thing_to_copy.density // So you can't bump into objects that aren't supposed to be dense.
-	catalogue_data = thing_to_copy.catalogue_data.Copy()
+	catalogue_data = thing_to_copy.get_catalogue_data()
 	catalogue_delay = thing_to_copy.catalogue_delay
 	return TRUE
 


### PR DESCRIPTION
🆑
fix: Technomancer Illusions now properly copy carbonmob appearances
fix: Technomancer illusions now copy cataloguer data without runtiming
fix: Instability radiation now radiates and does not generate additional instability out of nothing (This might need a review?)
/🆑