### PR TITLE
Fixes mapped R-UST connections, removes debug logs

### DIFF
--- a/code/modules/power/fusion/core/core_control.dm
+++ b/code/modules/power/fusion/core/core_control.dm
@@ -6,7 +6,7 @@
 	icon_keyboard = "tech_key"
 	icon_screen = "core_control"
 
-//	var/id_tag
+	var/id_tag = ""
 	var/scan_range = 25
 	var/list/connected_devices = list()
 	var/obj/machinery/power/fusion_core/cur_viewed_device
@@ -15,6 +15,7 @@
 /obj/machinery/computer/fusion_core_control/New()
 	..()
 	monitor = new(src)
+	monitor.core_tag = id_tag
 
 /obj/machinery/computer/fusion_core_control/Destroy()
 	QDEL_NULL(monitor)

--- a/code/modules/power/fusion/fuel_assembly/fuel_control.dm
+++ b/code/modules/power/fusion/fuel_assembly/fuel_control.dm
@@ -13,6 +13,7 @@
 /obj/machinery/computer/fusion_fuel_control/New()
 	..()
 	monitor = new(src)
+	monitor.fuel_tag = id_tag
 
 /obj/machinery/computer/fusion_fuel_control/Destroy()
 	QDEL_NULL(monitor)

--- a/code/modules/power/fusion/gyrotron/gyrotron.dm
+++ b/code/modules/power/fusion/gyrotron/gyrotron.dm
@@ -23,17 +23,16 @@ GLOBAL_LIST_EMPTY(gyrotrons)
 
 /obj/machinery/power/emitter/gyrotron/Initialize()
 	GLOB.gyrotrons += src
-	update_active_power_usage(mega_energy * 50000)
 	default_apply_parts()
-	. = ..()
+	return ..()
 
 /obj/machinery/power/emitter/gyrotron/Destroy()
 	GLOB.gyrotrons -= src
 	return ..()
 
-/obj/machinery/power/emitter/gyrotron/process()
-	update_active_power_usage(mega_energy * 50000)
-	. = ..()
+/obj/machinery/power/emitter/gyrotron/proc/set_beam_power(var/new_power)
+	mega_energy = new_power
+	update_active_power_usage(mega_energy * initial(active_power_usage))
 
 /obj/machinery/power/emitter/gyrotron/get_rand_burst_delay()
 	return rate * 10

--- a/code/modules/power/fusion/gyrotron/gyrotron_control.dm
+++ b/code/modules/power/fusion/gyrotron/gyrotron_control.dm
@@ -14,6 +14,8 @@
 /obj/machinery/computer/gyrotron_control/New()
 	..()
 	monitor = new(src)
+	monitor.gyro_tag = id_tag
+	monitor.scan_range = scan_range
 
 /obj/machinery/computer/gyrotron_control/Destroy()
 	QDEL_NULL(monitor)

--- a/code/modules/tgui/modules/gyrotron_control.dm
+++ b/code/modules/tgui/modules/gyrotron_control.dm
@@ -3,57 +3,52 @@
 	tgui_id = "GyrotronControl"
 
 	var/gyro_tag = ""
+	var/scan_range = 25
 
 /datum/tgui_module/gyrotron_control/tgui_act(action, params)
 	if(..())
 		return TRUE
 
-	for(var/parameter in params)
-		to_world("[parameter] - [params[parameter]]")
+	// If the command requires a gyrotron, and we can't find it, we don't need to check any further
+	var/obj/machinery/power/emitter/gyrotron/G = null
+	if(params["gyro"])
+		G = locate(params["gyro"]) in GLOB.gyrotrons
+		if(!istype(G))
+			return FALSE
 
 	switch(action)
-		if("toggle_active")
-			var/obj/machinery/power/emitter/gyrotron/G = locate(params["gyro"])
-			if(!istype(G))
-				return 0
-			
-			G.activate(usr)
-
-			return 1
-
 		if("set_tag")
 			var/new_ident = sanitize_text(input("Enter a new ident tag.", "Gyrotron Control", gyro_tag) as null|text)
 			if(new_ident)
 				gyro_tag = new_ident
+			return TRUE
+
+		if("toggle_active")
+			G.activate(usr)
+			return TRUE
 
 		if("set_str")
-			var/obj/machinery/power/emitter/gyrotron/G = locate(params["gyro"])
-			if(!istype(G))
-				return 0
-
 			var/new_strength = params["str"]
-
-			G.mega_energy = new_strength
-
-			return 1
+			if(istext(new_strength))
+				new_strength = text2num(new_strength)
+			if(new_strength)
+				G.set_beam_power(new_strength)
+			return TRUE
 
 		if("set_rate")
-			var/obj/machinery/power/emitter/gyrotron/G = locate(params["gyro"])
-			if(!istype(G))
-				return 0
-
 			var/new_delay = params["rate"]
-
-			G.rate = new_delay
-
-			return 1
+			if(istext(new_delay))
+				new_delay = text2num(new_delay)
+			if(new_delay)
+				G.rate = new_delay
+			return TRUE
 
 /datum/tgui_module/gyrotron_control/tgui_data(mob/user)
 	var/list/data = list()
 	var/list/gyros = list()
 
 	for(var/obj/machinery/power/emitter/gyrotron/G in GLOB.gyrotrons)
-		if(G.id_tag == gyro_tag)
+		if(G.id_tag == gyro_tag)// && (get_dist(get_turf(G), get_turf(src)) <= scan_range))
 			gyros.Add(list(list(
 				"name" = G.name,
 				"active" = G.active,

--- a/code/modules/tgui/modules/rustcore_monitor.dm
+++ b/code/modules/tgui/modules/rustcore_monitor.dm
@@ -8,22 +8,19 @@
 	if(..())
 		return TRUE
 
-	for(var/parameter in params)
-		to_world("[parameter] - [params[parameter]]")
+	var/obj/machinery/power/fusion_core/C = null
+	if(params["core"])
+		C = locate(params["core"]) in GLOB.fusion_cores
+		if(!istype(C))
+			return FALSE
 
 	switch(action)
 		if("toggle_active")
-			var/obj/machinery/power/fusion_core/C = locate(params["core"])
-			if(!istype(C))
-				return FALSE
 			if(!C.Startup()) //Startup() whilst the device is active will return null.
 				C.Shutdown()
 			return TRUE
 
 		if("toggle_reactantdump")
-			var/obj/machinery/power/fusion_core/C = locate(params["core"])
-			if(!istype(C))
-				return FALSE
 			C.reactant_dump = !C.reactant_dump
 			return TRUE
 
@@ -31,16 +28,11 @@
 			var/new_ident = sanitize_text(input("Enter a new ident tag.", "Core Control", core_tag) as null|text)
 			if(new_ident)
 				core_tag = new_ident
+			return TRUE
 
 		if("set_fieldstr")
-			var/obj/machinery/power/fusion_core/C = locate(params["core"])
-			if(!istype(C))
-				return FALSE
-
 			var/new_strength = params["fieldstr"]
-
 			C.target_field_strength = new_strength
-
 			return TRUE
 
 /datum/tgui_module/rustcore_monitor/tgui_data(mob/user)
@@ -58,9 +50,6 @@
 						"name" = reagent,
 						"amount" = C.owned_field.dormant_reactant_quantities[reagent]
 						)))
-
-				for(var/list/reactant in reactants)
-					to_world("[reactant[1]] [reactant[2]]")
 
 			cores.Add(list(list(
 				"name" = C.name,

--- a/code/modules/tgui/modules/rustfuel_control.dm
+++ b/code/modules/tgui/modules/rustfuel_control.dm
@@ -8,12 +8,9 @@
 	if(..())
 		return TRUE
 
-	for(var/parameter in params)
-		to_world("[parameter] - [params[parameter]]")
-
 	switch(action)
 		if("toggle_active")
-			var/obj/machinery/fusion_fuel_injector/FI = locate(params["fuel"])
+			var/obj/machinery/fusion_fuel_injector/FI = locate(params["fuel"]) in GLOB.fuel_injectors
 			if(!istype(FI))
 				return FALSE
 


### PR DESCRIPTION
Fixes #8005 
DNM subject to further investigation of the conditions causing the runtime. I was unable to [reproduce it(.mp4)](https://puu.sh/HrY8l/56bfb40b47.mp4) on our live server and on a local test server running 1536. No other changes have been reported so I suspect it might be a byond version issue, but I'm waiting to hear more on that.

To get the consoles to automatically link up when mapped in, set their `id_tag` variables to the same value as is set on the [gyrotrons/fuel injectors/reactor cores].

Update: runtime has been sourced to missing input validation, and fixed. This has been tested, and the runtime no longer occurs.