### PR TITLE
Optimizes SSplanets initialization

### DIFF
--- a/code/__defines/subsystems.dm
+++ b/code/__defines/subsystems.dm
@@ -57,6 +57,7 @@ var/global/list/runlevel_flags = list(RUNLEVEL_LOBBY, RUNLEVEL_SETUP, RUNLEVEL_G
 #define INIT_ORDER_SKYBOX		30
 #define INIT_ORDER_MAPPING		25
 #define INIT_ORDER_DECALS		20
+#define INIT_ORDER_PLANETS		18
 #define INIT_ORDER_JOB			17
 #define INIT_ORDER_ALARM		16 // Must initialize before atoms.
 #define INIT_ORDER_ATOMS		15
@@ -67,7 +68,6 @@ var/global/list/runlevel_flags = list(RUNLEVEL_LOBBY, RUNLEVEL_SETUP, RUNLEVEL_G
 #define INIT_ORDER_LIGHTING		0
 #define INIT_ORDER_AIR			-1
 #define INIT_ORDER_ASSETS		-3
-#define INIT_ORDER_PLANETS		-4
 #define INIT_ORDER_HOLOMAPS		-5
 #define INIT_ORDER_NIGHTSHIFT	-6
 #define INIT_ORDER_OVERLAY		-7

--- a/code/game/turfs/simulated/outdoors/outdoors.dm
+++ b/code/game/turfs/simulated/outdoors/outdoors.dm
@@ -31,10 +31,14 @@ var/list/turf_edge_cache = list()
 	return ..()
 
 /turf/simulated/proc/make_outdoors()
+	if(outdoors)
+		return
 	outdoors = TRUE
 	SSplanets.addTurf(src)
 
 /turf/simulated/proc/make_indoors()
+	if(!outdoors)
+		return
 	outdoors = FALSE
 	SSplanets.removeTurf(src)
 

--- a/code/modules/planet/sif.dm
+++ b/code/modules/planet/sif.dm
@@ -216,15 +216,17 @@ var/datum/planet/sif/planet_sif = null
 	outdoor_sounds_type = /datum/looping_sound/weather/outside_snow
 	indoor_sounds_type = /datum/looping_sound/weather/inside_snow
 
+/*
 /datum/weather/sif/snow/process_effects()
 	..()
-	for(var/turf/simulated/floor/outdoors/snow/S in SSplanets.new_outdoor_turfs) //This didn't make any sense before SSplanets, either
+	for(var/turf/simulated/floor/outdoors/snow/S as anything in SSplanets.new_outdoor_turfs) //This didn't make any sense before SSplanets, either
 		if(S.z in holder.our_planet.expected_z_levels)
 			for(var/dir_checked in cardinal)
 				var/turf/simulated/floor/T = get_step(S, dir_checked)
 				if(istype(T))
 					if(istype(T, /turf/simulated/floor/outdoors) && prob(33))
 						T.chill()
+*/
 
 /datum/weather/sif/blizzard
 	name = "blizzard"
@@ -249,15 +251,17 @@ var/datum/planet/sif/planet_sif = null
 	outdoor_sounds_type = /datum/looping_sound/weather/outside_blizzard
 	indoor_sounds_type = /datum/looping_sound/weather/inside_blizzard
 
+/*
 /datum/weather/sif/blizzard/process_effects()
 	..()
-	for(var/turf/simulated/floor/outdoors/snow/S in SSplanets.new_outdoor_turfs) //This didn't make any sense before SSplanets, either
+	for(var/turf/simulated/floor/outdoors/snow/S as anything in SSplanets.new_outdoor_turfs) //This didn't make any sense before SSplanets, either
 		if(S.z in holder.our_planet.expected_z_levels)
 			for(var/dir_checked in cardinal)
 				var/turf/simulated/floor/T = get_step(S, dir_checked)
 				if(istype(T))
 					if(istype(T, /turf/simulated/floor/outdoors) && prob(50))
 						T.chill()
+*/
 
 /datum/weather/sif/rain
 	name = "rain"
@@ -283,25 +287,21 @@ var/datum/planet/sif/planet_sif = null
 
 /datum/weather/sif/rain/process_effects()
 	..()
-	for(var/mob/living/L in living_mob_list)
+	for(var/mob/living/L as anything in living_mob_list)
 		if(L.z in holder.our_planet.expected_z_levels)
 			var/turf/T = get_turf(L)
 			if(!T.outdoors)
 				continue // They're indoors, so no need to rain on them.
 
 			// If they have an open umbrella, it'll guard from rain
-			if(istype(L.get_active_hand(), /obj/item/weapon/melee/umbrella))
-				var/obj/item/weapon/melee/umbrella/U = L.get_active_hand()
-				if(U.open)
-					if(show_message)
-						to_chat(L, "<span class='notice'>Rain patters softly onto your umbrella.</span>")
-					continue
-			else if(istype(L.get_inactive_hand(), /obj/item/weapon/melee/umbrella))
-				var/obj/item/weapon/melee/umbrella/U = L.get_inactive_hand()
-				if(U.open)
-					if(show_message)
-						to_chat(L, "<span class='notice'>Rain patters softly onto your umbrella.</span>")
-					continue
+			var/obj/item/weapon/melee/umbrella/U = L.get_active_hand()
+			if(!istype(U) || !U.open)
+				U = L.get_inactive_hand()
+
+			if(istype(U) && U.open)
+				if(show_message)
+					to_chat(L, "<span class='notice'>Rain patters softly onto your umbrella.</span>")
+				continue
 
 			L.water_act(1)
 			if(show_message)
@@ -340,24 +340,21 @@ var/datum/planet/sif/planet_sif = null
 
 /datum/weather/sif/storm/process_effects()
 	..()
-	for(var/mob/living/L in living_mob_list)
+	for(var/mob/living/L as anything in living_mob_list)
 		if(L.z in holder.our_planet.expected_z_levels)
 			var/turf/T = get_turf(L)
 			if(!T.outdoors)
 				continue // They're indoors, so no need to rain on them.
+
 			// If they have an open umbrella, it'll guard from rain
-			if(istype(L.get_active_hand(), /obj/item/weapon/melee/umbrella))
-				var/obj/item/weapon/melee/umbrella/U = L.get_active_hand()
-				if(U.open)
-					if(show_message)
-						to_chat(L, "<span class='notice'>Rain showers loudly onto your umbrella!</span>")
-					continue
-			else if(istype(L.get_inactive_hand(), /obj/item/weapon/melee/umbrella))
-				var/obj/item/weapon/melee/umbrella/U = L.get_inactive_hand()
-				if(U.open)
-					if(show_message)
-						to_chat(L, "<span class='notice'>Rain showers loudly onto your umbrella!</span>")
-					continue
+			var/obj/item/weapon/melee/umbrella/U = L.get_active_hand()
+			if(!istype(U) || !U.open)
+				U = L.get_inactive_hand()
+
+			if(istype(U) && U.open)
+				if(show_message)
+					to_chat(L, "<span class='notice'>Rain showers loudly onto your umbrella!</span>")
+				continue
 
 
 			L.water_act(2)
@@ -401,20 +398,18 @@ var/datum/planet/sif/planet_sif = null
 
 /datum/weather/sif/hail/process_effects()
 	..()
-	for(var/humie in human_mob_list)
-		var/mob/living/carbon/human/H = humie
+	for(var/mob/living/carbon/H as anything in human_mob_list)
 		if(H.z in holder.our_planet.expected_z_levels)
 			var/turf/T = get_turf(H)
 			if(!T.outdoors)
 				continue // They're indoors, so no need to pelt them with ice.
 
 			// If they have an open umbrella, it'll guard from hail
-			var/obj/item/weapon/melee/umbrella/U
-			if(istype(H.get_active_hand(), /obj/item/weapon/melee/umbrella))
-				U = H.get_active_hand()
-			else if(istype(H.get_inactive_hand(), /obj/item/weapon/melee/umbrella))
+			var/obj/item/weapon/melee/umbrella/U = H.get_active_hand()
+			if(!istype(U) || !U.open)
 				U = H.get_inactive_hand()
-			if(U && U.open)
+
+			if(istype(U) && U.open)
 				if(show_message)
 					to_chat(H, "<span class='notice'>Hail patters onto your umbrella.</span>")
 				continue


### PR DESCRIPTION
Initialization on a local test server dropped from ~110s to ~71s
Tested, and lighting and weather still work. I did simplify the logic on umbrellas in the rain, and I commented out the snow/blizzard logic that was _intended_ to make turfs snowy, but which I suspect wasn't working because iterating over all planet turfs every 2 seconds would have generated _enormous_ amounts of lag. I've ideas for a cleaner solution using automata (cave generation).

Removed SSplanets' list of planet turfs/walls because that was completely unused and wasted a huge amount of time and space (~20s initialization different).
Switched planet datum's turf addition/removal to use += after thoroughly tracking the cases where it was triggered (On initializations, on post_change() (Happens through ChangeTurf and similar), and happens when roofing tiles are used on outdoor turfs), added some safeguards to require updates, and added a nice angry comment to warn people off of abusing it.

Planets has to initialize before atoms in order for the planets to exist when the turfs initialize and try to add themselves to those planets, so init order was adjust accordingly.
Sprinkled in a few `as anythings` where the lists as defined could only contain one type, which should hopefully boost runtime performance a little bit as well.