### PR TITLE
Updates respawn_character some more

### DIFF
--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -507,6 +507,8 @@ Traitors and the like can also be revived with the previous role mostly intact.
 	if(equipment)
 		if(charjob)
 			job_master.EquipRank(new_character, charjob, 1)
+			new_character.mind.assigned_role = charjob
+			new_character.mind.role_alt_title = job_master.GetPlayerAltTitle(new_character, charjob)
 		equip_custom_items(new_character)
 
 	//If desired, add records.
@@ -514,7 +516,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 		data_core.manifest_inject(new_character)
 
 	//A redraw for good measure
-	new_character.update_icons_all()
+	new_character.regenerate_icons()
 
 	//If we're announcing their arrival
 	if(announce)

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -113,15 +113,6 @@ var/global/list/damage_icon_parts = list() //see UpdateDamageIcon()
 	//Do any species specific layering updates, such as when hiding.
 	update_icon_special()
 
-/mob/living/carbon/human/update_icons_layers()
-	crash_with("CANARY: Old human update_icons_layers was called.")
-
-/mob/living/carbon/human/update_icons_all()
-	crash_with("CANARY: Old human update_icons_all was called.")
-
-/mob/living/carbon/human/update_icons_huds()
-	crash_with("CANARY: Old human update_icons_huds was called.")
-
 /mob/living/carbon/human/update_transform()
 	// First, get the correct size.
 	var/desired_scale_x = icon_scale_x

--- a/code/modules/mob/update_icons.dm
+++ b/code/modules/mob/update_icons.dm
@@ -9,16 +9,7 @@
 	return
 
 // Obsolete
-/mob/proc/update_icons_layers()
-	return
-
-/mob/proc/update_icons_huds()
-	return
-
 /mob/proc/update_icons_body()
-	return
-
-/mob/proc/update_icons_all()
 	return
 // End obsolete
 


### PR DESCRIPTION
- Fixes Spawned characters not having their job title set properly
- Fixes depreciated proc being called, replaces with closest equivalent: regenerate_icons()
- Deletes a bunch of old, unused procs