### PR TITLE
Makes manifest preserve original position of Custom jobs

### DIFF
--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -310,7 +310,6 @@ var/global/list/PDA_Manifest = list()
 			break
 		else
 			var/list/alttitles = get_alternate_titles(J.title)
-			if(!J)	continue
 			if(assignment in alttitles)
 				real_title = J.title
 				break

--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -288,7 +288,7 @@ var/global/list/PDA_Manifest = list()
 			manifest_inject(H)
 		return
 
-/datum/datacore/proc/manifest_modify(var/name, var/assignment)
+/datum/datacore/proc/manifest_modify(var/name, var/assignment, var/rank)
 	ResetPDAManifest()
 	var/datum/data/record/foundrecord
 	var/real_title = assignment
@@ -302,11 +302,18 @@ var/global/list/PDA_Manifest = list()
 	var/list/all_jobs = get_job_datums()
 
 	for(var/datum/job/J in all_jobs)
-		var/list/alttitles = get_alternate_titles(J.title)
-		if(!J)	continue
-		if(assignment in alttitles)
-			real_title = J.title
+		if(J.title == rank)					//If we have a rank, just default to using that.
+			real_title = rank
 			break
+		else if(J.title == assignment)
+			real_title = rank
+			break
+		else
+			var/list/alttitles = get_alternate_titles(J.title)
+			if(!J)	continue
+			if(assignment in alttitles)
+				real_title = J.title
+				break
 
 	if(foundrecord)
 		foundrecord.fields["rank"] = assignment

--- a/code/game/machinery/computer/card.dm
+++ b/code/game/machinery/computer/card.dm
@@ -153,7 +153,7 @@
 	switch(href_list["choice"])
 		if ("modify")
 			if (modify)
-				data_core.manifest_modify(modify.registered_name, modify.assignment)
+				data_core.manifest_modify(modify.registered_name, modify.assignment, modify.rank)
 				modify.name = text("[modify.registered_name]'s ID Card ([modify.assignment])")
 				if(ishuman(usr))
 					modify.forceMove(get_turf(src))

--- a/code/modules/tgui/modules/ntos-only/cardmod.dm
+++ b/code/modules/tgui/modules/ntos-only/cardmod.dm
@@ -167,7 +167,7 @@
 		if("modify")
 			if(computer && computer.card_slot)
 				if(id_card)
-					data_core.manifest_modify(id_card.registered_name, id_card.assignment)
+					data_core.manifest_modify(id_card.registered_name, id_card.assignment, id_card.rank)
 				computer.proc_eject_id(usr)
 			. = TRUE
 		if("terminate")


### PR DESCRIPTION
Title. Screw all modifications out of the general alt-titles throwing the position down to Miscellaneous.