### PR TITLE
Autolathes don't spam debug on first use

### DIFF
--- a/code/datums/autolathe/autolathe.dm
+++ b/code/datums/autolathe/autolathe.dm
@@ -7,7 +7,7 @@ var/datum/category_collection/autolathe/autolathe_recipes
 		I = new path()
 
 	if(!I)	// Something has gone horribly wrong, or right.
-		log_debug("[name] created an Autolathe design without an assigned path. This is expected for only the Material Sheet generation.")
+		log_debug("[name] created an Autolathe design without an assigned path.")
 		return
 
 	if(I.matter && !resources)
@@ -82,22 +82,12 @@ var/datum/category_collection/autolathe/autolathe_recipes
 		if(istype(M, /datum/material/alienalloy))
 			continue
 
-		var/obj/item/stack/material/Mat = new M.stack_type()
-
-		if(Mat.name in items_by_name)
-			qdel(Mat)
+		var/obj/item/stack/material/S = M.stack_type
+		if(initial(S.name) in items_by_name)
 			continue
 
-		var/datum/category_item/autolathe/materials/WorkDat = new(src)
+		var/datum/category_item/autolathe/materials/WorkDat = new(src, M)
 
-		WorkDat.name = "[Mat.name]"
-		WorkDat.resources = Mat.matter.Copy()
-		WorkDat.is_stack = TRUE
-		WorkDat.no_scale = TRUE
-		WorkDat.max_stack = Mat.max_amount
-		WorkDat.path = M.stack_type
-
-		qdel(Mat)
 
 		items |= WorkDat
 		items_by_name[WorkDat.name] = WorkDat

--- a/code/datums/autolathe/materials.dm
+++ b/code/datums/autolathe/materials.dm
@@ -1,38 +1,23 @@
-
-/datum/category_item/autolathe/materials/metal
-	name = "steel sheets"
-	path =/obj/item/stack/material/steel
+/datum/category_item/autolathe/materials
 	is_stack = TRUE
-	no_scale = TRUE //prevents material duplication exploits
+	no_scale = TRUE // Prevents material duplaction exploits
 
-/datum/category_item/autolathe/materials/glass
-	name = "glass sheets"
-	path =/obj/item/stack/material/glass
-	is_stack = TRUE
-	no_scale = TRUE //prevents material duplication exploits
+/datum/category_item/autolathe/materials/New(var/loc, var/mat)
+	if(istype(mat, /obj/item/stack/material))
+		var/obj/item/stack/material/M = mat
+		name = M.name
+		resources = M.matter.Copy()
+		max_stack = M.max_amount
+		path = M.type
+	else if(istype(mat, /datum/material))
+		var/datum/material/M = mat
+		var/obj/item/stack/material/S = M.stack_type
+		name = initial(S.name)
+		resources = M.get_matter()
+		max_stack = initial(S.max_amount)
+		path = S
+	. = ..()
 
-/datum/category_item/autolathe/materials/rglass
-	name = "reinforced glass sheets"
-	path =/obj/item/stack/material/glass/reinforced
-	is_stack = TRUE
-	no_scale = TRUE //prevents material duplication exploits
-
-/datum/category_item/autolathe/materials/rods
+/datum/category_item/autolathe/materials/rods // Not strictly a material, so they need their own define
 	name = "metal rods"
 	path =/obj/item/stack/rods
-	is_stack = TRUE
-	no_scale = TRUE //prevents material duplication exploits
-
-/datum/category_item/autolathe/materials/plasteel
-	name = "plasteel sheets"
-	path =/obj/item/stack/material/plasteel
-	is_stack = TRUE
-	no_scale = TRUE //prevents material duplication exploits
-	resources = list(MAT_PLASTEEL = 2000)
-
-/datum/category_item/autolathe/materials/plastic
-	name = "plastic sheets"
-	path =/obj/item/stack/material/plastic
-	is_stack = TRUE
-	no_scale = TRUE //prevents material duplication exploits
-	resources = list(MAT_PLASTIC = 2000)

--- a/code/modules/materials/materials.dm
+++ b/code/modules/materials/materials.dm
@@ -53,9 +53,10 @@ var/list/name_to_material
 /proc/populate_material_list(force_remake=0)
 	if(name_to_material && !force_remake) return // Already set up!
 	name_to_material = list()
-	for(var/type in typesof(/datum/material) - /datum/material)
+	for(var/type in subtypesof(/datum/material))
 		var/datum/material/new_mineral = new type
 		if(!new_mineral.name)
+			qdel(new_mineral)
 			continue
 		name_to_material[lowertext(new_mineral.name)] = new_mineral
 	return 1


### PR DESCRIPTION
Tested with steel, glass, plastic, and plasteel in the autolathe:
![.png](https://puu.sh/HtLP7/60bc2e9fa7.png)

Steel rods are weird, and they still need to have a specific category_item definition, but everything else is generated automatically, and only displayed if the required materials are inside of the autolathe. This also means that plasteel (And probably other alloys, like durasteel) can be manufactured in the autolathe if you just insert all of the basic materials.

No debug spam was created during tests.