### PR TITLE
Adds whitelist system for ear/tail genemods/augments

### DIFF
--- a/code/modules/mob/new_player/sprite_accessories_ear.dm
+++ b/code/modules/mob/new_player/sprite_accessories_ear.dm
@@ -30,7 +30,7 @@
 	icon_state = "ears_plain"
 	do_colouration = 1
 	color_blend_mode = ICON_MULTIPLY
-	species_allowed = list(SPECIES_TAJ, SPECIES_EVENT1, SPECIES_EVENT2, SPECIES_EVENT3)
+	species_allowed = list(SPECIES_HUMAN, SPECIES_HUMAN_VATBORN, SPECIES_TAJ, SPECIES_EVENT1, SPECIES_EVENT2, SPECIES_EVENT3)
 	extra_overlay = "ears_plain-inner"
 
 /datum/sprite_accessory/ears/taj_ears_tall
@@ -250,6 +250,7 @@
 	do_colouration = 1
 	color_blend_mode = ICON_MULTIPLY
 	extra_overlay = "kittyinner"
+	species_allowed = list(SPECIES_HUMAN, SPECIES_HUMAN_VATBORN, SPECIES_EVENT1, SPECIES_EVENT2, SPECIES_EVENT3)
 
 /datum/sprite_accessory/ears/bunnyhc
 	name = "bunny, colorable"


### PR DESCRIPTION
Species-specific mods will continue to be available to anyone that can select that species (tesh ears, variant taj ears, etc).
The whitelist exists to allow characters access to a more expanded set of ears/tails, and restrict people just memeing the system. Specific choices subject to people saying "Hey that looks dumb".
Will discuss this further with staff, but I may restrict the extra options per-species, such that say, unathi, cannot have teddybear ears.
Details of the whitelist application to be discussed at a later date.