### PR TITLE
Random spawner refactor.

### DIFF
--- a/code/game/objects/random/_random.dm
+++ b/code/game/objects/random/_random.dm
@@ -9,25 +9,36 @@
 // creates a new object and deletes itself
 /obj/random/Initialize()
 	..()
-	if (!prob(spawn_nothing_percentage))
-		spawn_item()
+	if(!prob(spawn_nothing_percentage))
+		try_spawn_item()
 	return INITIALIZE_HINT_QDEL
+
+/obj/random/proc/try_spawn_item()
+	var/atom/result = spawn_item()
+	if(istype(result) && !QDELETED(result))
+		apply_adjustments(result)
+	else if(islist(result))
+		for(var/atom/A in result)
+			if(!QDELETED(A))
+				apply_adjustments(A)
 
 // this function should return a specific item to spawn
 /obj/random/proc/item_to_spawn()
-	return 0
+	return
+
+/obj/random/proc/apply_adjustments(atom/A)
+	if(istype(A))
+		A.pixel_x = pixel_x
+		A.pixel_y = pixel_y
+		A.set_dir(dir)
 
 /obj/random/drop_location()
-	return drop_get_turf? get_turf(src) : ..()
+	return drop_get_turf ? get_turf(src) : ..()
 
 // creates the random item
 /obj/random/proc/spawn_item()
 	var/build_path = item_to_spawn()
-
-	var/atom/A = new build_path(drop_location())
-	if(pixel_x || pixel_y)
-		A.pixel_x = pixel_x
-		A.pixel_y = pixel_y
+	return new build_path(drop_location())
 
 var/list/random_junk_
 var/list/random_useful_
@@ -82,7 +93,7 @@ var/list/random_useful_
 /obj/random/multiple/spawn_item()
 	var/list/things_to_make = item_to_spawn()
 	for(var/new_type in things_to_make)
-		new new_type(src.loc)
+		LAZYADD(., new new_type(src.loc))
 
 /*
 //	Multi Point Spawn


### PR DESCRIPTION
Allows mapped random object spawners to set `dir` on the result.