### PR TITLE
Changes blueprints to use ChangeArea

### DIFF
--- a/code/game/objects/items/blueprints.dm
+++ b/code/game/objects/items/blueprints.dm
@@ -147,10 +147,8 @@ move an amendment</a> to the drawing.</p>
 
 
 /obj/item/blueprints/proc/move_turfs_to_area(var/list/turf/turfs, var/area/A)
-	A.contents.Add(turfs)
-		//oldarea.contents.Remove(usr.loc) // not needed
-		//T.loc = A //error: cannot change constant value
-
+	for(var/T in turfs)
+		ChangeArea(T, A)
 
 /obj/item/blueprints/proc/edit_area()
 	var/area/A = get_area()


### PR DESCRIPTION
This should fix a bug where using blueprints to set a livable area on turfs without dynamic lighting (such as space) prevents dynamic lighting from properly initializing on turfs in that area.