### PR TITLE
Makes mineral turf oretype list static

### DIFF
--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -40,7 +40,7 @@ var/list/mining_overlay_cache = list()
 	var/datum/artifact_find/artifact_find
 	var/ignore_mapgen
 
-	var/ore_types = list(
+	var/static/list/ore_types = list(
 		"hematite" = /obj/item/weapon/ore/iron,
 		"uranium" = /obj/item/weapon/ore/uranium,
 		"gold" = /obj/item/weapon/ore/gold,


### PR DESCRIPTION
`static` _is_ the right keyword here, right? Or is `global` more appropriate? I don't think this sort of thing really needs to go on GLOB because it's literally only referenced in one line.
It really doesn't need to be instantiated separately for every single mineral turf.