### PR TITLE
Makes xenowear species WL check for species instead of ckey

### DIFF
--- a/code/modules/client/preference_setup/loadout/loadout.dm
+++ b/code/modules/client/preference_setup/loadout/loadout.dm
@@ -66,7 +66,7 @@ var/list/gear_datums = list()
 	for(var/gear_name in gear_datums)
 		var/datum/gear/G = gear_datums[gear_name]
 
-		if(G.whitelisted && !is_alien_whitelisted(preference_mob, GLOB.all_species[G.whitelisted]))
+		if(G.whitelisted != pref.species)
 			continue
 		if(max_cost && G.cost > max_cost)
 			continue


### PR DESCRIPTION
Makes loadout xenowear species whitelists check the selected species of the character instead of just whether or not the client key is whitelisted for the species regardless of what the character's species is.