### PR TITLE
Adds config option to control loadout whitelist strictness

### DIFF
--- a/code/__defines/misc.dm
+++ b/code/__defines/misc.dm
@@ -436,3 +436,7 @@ GLOBAL_LIST_INIT(all_volume_channels, list(
 #define NTOS_EMAIL_NEWMESSAGE		2
 
 #define GET_DECL(D) (ispath(D, /decl) ? (decls_repository.fetched_decls[D] || decls_repository.get_decl(D)) : null)
+
+#define LOADOUT_WHITELIST_OFF    0
+#define LOADOUT_WHITELIST_LAX    1
+#define LOADOUT_WHITELIST_STRICT 2

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -286,6 +286,9 @@ var/list/gamemode_cache = list()
 	// whether or not to use the nightshift subsystem to perform lighting changes
 	var/static/enable_night_shifts = FALSE
 
+	// How strictly the loadout enforces object species whitelists
+	var/loadout_whitelist = LOADOUT_WHITELIST_LAX
+
 /datum/configuration/New()
 	var/list/L = typesof(/datum/game_mode) - /datum/game_mode
 	for (var/T in L)
@@ -997,7 +1000,10 @@ var/list/gamemode_cache = list()
 
 				if("use_loyalty_implants")
 					config.use_loyalty_implants = 1
-
+				
+				if("loadout_whitelist")
+					config.loadout_whitelist = text2num(value)
+				
 				else
 					log_misc("Unknown setting in configuration: '[name]'")
 

--- a/code/modules/client/preference_setup/loadout/loadout.dm
+++ b/code/modules/client/preference_setup/loadout/loadout.dm
@@ -62,12 +62,14 @@ var/list/gear_datums = list()
 
 /datum/category_item/player_setup_item/loadout/proc/valid_gear_choices(var/max_cost)
 	. = list()
-	var/mob/preference_mob = preference_mob()
 	for(var/gear_name in gear_datums)
 		var/datum/gear/G = gear_datums[gear_name]
 
-		if(G.whitelisted != pref.species)
-			continue
+		if(G.whitelisted && config.loadout_whitelist != LOADOUT_WHITELIST_OFF)
+			if(config.loadout_whitelist == LOADOUT_WHITELIST_STRICT && G.whitelisted != pref.species)
+				continue
+			if(config.loadout_whitelist == LOADOUT_WHITELIST_LAX && !is_alien_whitelisted(preference_mob(), GLOB.all_species[G.whitelisted]))	
+				continue
 		if(max_cost && G.cost > max_cost)
 			continue
 		. += gear_name

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -539,3 +539,7 @@ ALLOW_URL_LINKS
 
 # Control which submaps are loaded for the Dynamic Engine system
 ENGINE_MAP Supermatter Engine,Edison's Bane
+
+# Controls how strictly the species whitelists on loadout entries are enforced
+# Possible values: 0 (Off), 1 (Lax, user must be whitelisted for the species), 2 (Strict, user must be the species)
+LOADOUT_WHITELIST 1


### PR DESCRIPTION
Tweak of #8047 incorporating [VOREStation/10213](https://github.com/VOREStation/VOREStation/pull/10213) (Which added a null check for the whitelist var)
Config values are 0, 1, 2 corresponding to no whitelist (What Vore did with it), the behaviour prior to 8047, and the behaviour implemented by 8047