### PR TITLE
Reverts recipe changes from Industrial Expansion

### DIFF
--- a/code/game/objects/items/devices/communicator/communicator.dm
+++ b/code/game/objects/items/devices/communicator/communicator.dm
@@ -27,7 +27,7 @@ var/global/list/obj/item/device/communicator/all_communicators = list()
 	show_messages = 1
 
 	origin_tech = list(TECH_ENGINEERING = 2, TECH_MAGNET = 2, TECH_BLUESPACE = 2, TECH_DATA = 2)
-	matter = list(DEFAULT_WALL_MATERIAL = 30,"glass" = 10, MAT_COPPER = 10)
+	matter = list(DEFAULT_WALL_MATERIAL = 30,"glass" = 10)
 
 	var/video_range = 4
 	var/obj/machinery/camera/communicator/video_source	// Their camera
@@ -131,10 +131,10 @@ var/global/list/obj/item/device/communicator/all_communicators = list()
 // Description: Shows all the voice mobs inside the device, and their status.
 /obj/item/device/communicator/examine(mob/user)
 	. = ..()
-
+	
 	for(var/mob/living/voice/voice in contents)
 		. += "<span class='notice'>On the screen, you can see a image feed of [voice].</span>"
-
+		
 		if(voice && voice.key)
 			switch(voice.stat)
 				if(CONSCIOUS)

--- a/code/game/objects/items/devices/laserpointer.dm
+++ b/code/game/objects/items/devices/laserpointer.dm
@@ -6,7 +6,7 @@
 	item_state = "pen"
 	var/pointer_icon_state
 	slot_flags = SLOT_BELT
-	matter = list("glass" = 500,"metal" = 500, MAT_COPPER = 10)
+	matter = list("glass" = 500,"metal" = 500)
 	w_class = 2 //Increased to 2, because diodes are w_class 2. Conservation of matter.
 	origin_tech = list(TECH_MAGNET = 2, TECH_COMBAT = 1)
 	var/turf/pointer_loc

--- a/code/game/objects/items/devices/multitool.dm
+++ b/code/game/objects/items/devices/multitool.dm
@@ -17,7 +17,7 @@
 	drop_sound = 'sound/items/drop/multitool.ogg'
 	pickup_sound = 'sound/items/pickup/multitool.ogg'
 
-	matter = list(DEFAULT_WALL_MATERIAL = 50,"glass" = 20, MAT_COPPER = 10)
+	matter = list(DEFAULT_WALL_MATERIAL = 50,"glass" = 20)
 
 	var/mode_index = 1
 	var/toolmode = MULTITOOL_MODE_STANDARD
@@ -29,7 +29,6 @@
 	var/obj/machinery/connectable	//Used to connect machinery.
 	var/weakref_wiring //Used to store weak references for integrated circuitry. This is now the Omnitool.
 	toolspeed = 1
-	tool_qualities = list(TOOL_MULTITOOL)
 
 /obj/item/device/multitool/attack_self(mob/living/user)
 	var/choice = alert("What do you want to do with \the [src]?","Multitool Menu", "Switch Mode", "Clear Buffers", "Cancel")
@@ -65,6 +64,9 @@
 	accepting_refs = (toolmode == MULTITOOL_MODE_INTCIRCUITS)
 
 	return
+
+/obj/item/device/multitool/is_multitool()
+	return TRUE
 
 /obj/item/device/multitool/cyborg
 	name = "multitool"

--- a/code/game/objects/items/devices/radio/electropack.dm
+++ b/code/game/objects/items/devices/radio/electropack.dm
@@ -11,7 +11,7 @@
 	slot_flags = SLOT_BACK
 	w_class = ITEMSIZE_HUGE
 
-	matter = list(DEFAULT_WALL_MATERIAL = 10000,"glass" = 2500, MAT_COPPER = 1550)
+	matter = list(DEFAULT_WALL_MATERIAL = 10000,"glass" = 2500)
 
 	var/code = 2
 

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -58,7 +58,7 @@ var/global/list/default_medbay_channels = list(
 	var/bs_tx_preload_id
 	var/bs_rx_preload_id
 
-	matter = list("glass" = 25, DEFAULT_WALL_MATERIAL = 75, MAT_COPPER = 15)
+	matter = list("glass" = 25,DEFAULT_WALL_MATERIAL = 75)
 	var/const/FREQ_LISTENING = 1
 	var/list/internal_channels
 

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -20,7 +20,7 @@ HALOGEN COUNTER	- Radcount on mobs
 	w_class = ITEMSIZE_SMALL
 	throw_speed = 5
 	throw_range = 10
-	matter = list(DEFAULT_WALL_MATERIAL = 200, MAT_COPPER = 25)
+	matter = list(DEFAULT_WALL_MATERIAL = 200)
 	origin_tech = list(TECH_MAGNET = 1, TECH_BIO = 1)
 	var/mode = 1;
 	var/advscan = 0

--- a/code/game/objects/items/weapons/circuitboards/circuitboard.dm
+++ b/code/game/objects/items/weapons/circuitboards/circuitboard.dm
@@ -23,8 +23,6 @@
 	drop_sound = 'sound/items/drop/device.ogg'
 	pickup_sound = 'sound/items/pickup/device.ogg'
 
-	matter = list(DEFAULT_WALL_MATERIAL = 50, "glass" = 50, MAT_COPPER = 100)
-
 //Called when the circuitboard is used to contruct a new machine.
 /obj/item/weapon/circuitboard/proc/construct(var/obj/machinery/M)
 	if(istype(M, build_path))

--- a/code/game/objects/items/weapons/circuitboards/frame.dm
+++ b/code/game/objects/items/weapons/circuitboards/frame.dm
@@ -10,37 +10,37 @@
 	name = T_BOARD("guestpass console")
 	build_path = /obj/machinery/computer/guestpass
 	board_type = new /datum/frame/frame_types/guest_pass_console
-	matter = list(DEFAULT_WALL_MATERIAL = 50, "glass" = 50, MAT_COPPER = 100)
+	matter = list(DEFAULT_WALL_MATERIAL = 50, "glass" = 50)
 
 /obj/item/weapon/circuitboard/status_display
 	name = T_BOARD("status display")
 	build_path = /obj/machinery/status_display
 	board_type = new /datum/frame/frame_types/display
-	matter = list(DEFAULT_WALL_MATERIAL = 50, "glass" = 50, MAT_COPPER = 100)
+	matter = list(DEFAULT_WALL_MATERIAL = 50, "glass" = 50)
 
 /obj/item/weapon/circuitboard/ai_status_display
 	name = T_BOARD("ai status display")
 	build_path = /obj/machinery/ai_status_display
 	board_type = new /datum/frame/frame_types/display
-	matter = list(DEFAULT_WALL_MATERIAL = 50, "glass" = 50, MAT_COPPER = 100)
+	matter = list(DEFAULT_WALL_MATERIAL = 50, "glass" = 50)
 
 /obj/item/weapon/circuitboard/newscaster
 	name = T_BOARD("newscaster")
 	build_path = /obj/machinery/newscaster
 	board_type = new /datum/frame/frame_types/newscaster
-	matter = list(DEFAULT_WALL_MATERIAL = 50, "glass" = 50, MAT_COPPER = 100)
+	matter = list(DEFAULT_WALL_MATERIAL = 50, "glass" = 50)
 
 /obj/item/weapon/circuitboard/atm
 	name = T_BOARD("atm")
 	build_path = /obj/machinery/atm
 	board_type = new /datum/frame/frame_types/atm
-	matter = list(DEFAULT_WALL_MATERIAL = 50, "glass" = 50, MAT_COPPER = 100)
+	matter = list(DEFAULT_WALL_MATERIAL = 50, "glass" = 50)
 
 /obj/item/weapon/circuitboard/request
 	name = T_BOARD("request console")
 	build_path = /obj/machinery/requests_console
 	board_type = new /datum/frame/frame_types/supply_request_console
-	matter = list(DEFAULT_WALL_MATERIAL = 50, "glass" = 50, MAT_COPPER = 100)
+	matter = list(DEFAULT_WALL_MATERIAL = 50, "glass" = 50)
 
 //Alarm
 
@@ -48,25 +48,25 @@
 	name = T_BOARD("fire alarm")
 	build_path = /obj/machinery/firealarm
 	board_type = new /datum/frame/frame_types/fire_alarm
-	matter = list(DEFAULT_WALL_MATERIAL = 50, "glass" = 50, MAT_COPPER = 100)
+	matter = list(DEFAULT_WALL_MATERIAL = 50, "glass" = 50)
 
 /obj/item/weapon/circuitboard/airalarm
 	name = T_BOARD("air alarm")
 	build_path = /obj/machinery/alarm
 	board_type = new /datum/frame/frame_types/air_alarm
-	matter = list(DEFAULT_WALL_MATERIAL = 50, "glass" = 50, MAT_COPPER = 100)
+	matter = list(DEFAULT_WALL_MATERIAL = 50, "glass" = 50)
 
 /obj/item/weapon/circuitboard/intercom
 	name = T_BOARD("intercom")
 	build_path = /obj/item/device/radio/intercom
 	board_type = new /datum/frame/frame_types/intercom
-	matter = list(DEFAULT_WALL_MATERIAL = 50, "glass" = 50, MAT_COPPER = 100)
+	matter = list(DEFAULT_WALL_MATERIAL = 50, "glass" = 50)
 
 /obj/item/weapon/circuitboard/keycard_auth
 	name = T_BOARD("keycard authenticator")
 	build_path = /obj/machinery/keycard_auth
 	board_type = new /datum/frame/frame_types/keycard_authenticator
-	matter = list(DEFAULT_WALL_MATERIAL = 50, "glass" = 50, MAT_COPPER = 100)
+	matter = list(DEFAULT_WALL_MATERIAL = 50, "glass" = 50)
 
 //Computer
 
@@ -74,7 +74,7 @@
 	name = T_BOARD("holopad")
 	build_path = /obj/machinery/hologram/holopad
 	board_type = new /datum/frame/frame_types/holopad
-	matter = list(DEFAULT_WALL_MATERIAL = 50, "glass" = 50, MAT_COPPER = 100)
+	matter = list(DEFAULT_WALL_MATERIAL = 50, "glass" = 50)
 
 /obj/item/weapon/circuitboard/scanner_console
 	name = T_BOARD("body scanner console")
@@ -94,7 +94,7 @@
 	name = T_BOARD("photocopier")
 	build_path = /obj/machinery/photocopier
 	board_type = new /datum/frame/frame_types/photocopier
-	matter = list(DEFAULT_WALL_MATERIAL = 50, "glass" = 50, MAT_COPPER = 100)
+	matter = list(DEFAULT_WALL_MATERIAL = 50, "glass" = 50)
 	req_components = list(
 							/obj/item/weapon/stock_parts/scanning_module = 1,
 							/obj/item/weapon/stock_parts/motor = 1,
@@ -105,7 +105,7 @@
 	name = T_BOARD("fax")
 	build_path = /obj/machinery/photocopier/faxmachine
 	board_type = new /datum/frame/frame_types/fax
-	matter = list(DEFAULT_WALL_MATERIAL = 50, "glass" = 50, MAT_COPPER = 100)
+	matter = list(DEFAULT_WALL_MATERIAL = 50, "glass" = 50)
 	req_components = list(
 							/obj/item/weapon/stock_parts/scanning_module = 1,
 							/obj/item/weapon/stock_parts/motor = 1,
@@ -116,7 +116,6 @@
 	name = T_BOARD("conveyor")
 	build_path = /obj/machinery/conveyor
 	board_type = new /datum/frame/frame_types/conveyor
-	matter = list(DEFAULT_WALL_MATERIAL = 50, "glass" = 50, MAT_COPPER = 100)
 	req_components = list(
 							/obj/item/weapon/stock_parts/gear = 2,
 							/obj/item/weapon/stock_parts/motor = 2,
@@ -126,7 +125,6 @@
 	name = T_BOARD("recharger")
 	build_path = /obj/machinery/recharger
 	board_type = new /datum/frame/frame_types/recharger
-	matter = list(DEFAULT_WALL_MATERIAL = 50, "glass" = 50, MAT_COPPER = 100)
 	req_components = list(
 							/obj/item/weapon/stock_parts/capacitor = 1,
 							/obj/item/stack/cable_coil = 5)
@@ -140,7 +138,6 @@
 	name = T_BOARD("heavy-duty cell charger")
 	build_path = /obj/machinery/cell_charger
 	board_type = new /datum/frame/frame_types/cell_charger
-	matter = list(DEFAULT_WALL_MATERIAL = 50, "glass" = 50, MAT_COPPER = 100)
 	req_components = list(
 							/obj/item/weapon/stock_parts/capacitor = 1,
 							/obj/item/stack/cable_coil = 5)
@@ -149,7 +146,7 @@
 	name = T_BOARD("washing machine")
 	build_path = /obj/machinery/washing_machine
 	board_type = new /datum/frame/frame_types/washing_machine
-	matter = list(DEFAULT_WALL_MATERIAL = 50, "glass" = 50, MAT_COPPER = 100)
+	matter = list(DEFAULT_WALL_MATERIAL = 50, "glass" = 50)
 	req_components = list(
 							/obj/item/weapon/stock_parts/motor = 1,
 							/obj/item/weapon/stock_parts/gear = 2)
@@ -158,7 +155,6 @@
 	name = T_BOARD("reagent grinder")
 	build_path = /obj/machinery/reagentgrinder
 	board_type = new /datum/frame/frame_types/grinder
-	matter = list(DEFAULT_WALL_MATERIAL = 50, "glass" = 50, MAT_COPPER = 100)
 	req_components = list(
 							/obj/item/weapon/stock_parts/motor = 1,
 							/obj/item/weapon/stock_parts/gear = 1,
@@ -167,7 +163,6 @@
 /obj/item/weapon/circuitboard/distiller
 	build_path = /obj/machinery/portable_atmospherics/powered/reagent_distillery
 	board_type = new /datum/frame/frame_types/reagent_distillery
-	matter = list(DEFAULT_WALL_MATERIAL = 50, "glass" = 50, MAT_COPPER = 100)
 	req_components = list(
 							/obj/item/weapon/stock_parts/capacitor = 1,
 							/obj/item/weapon/stock_parts/micro_laser = 1,
@@ -178,7 +173,6 @@
 	name = T_BOARD("teleporter hub")
 	build_path = /obj/machinery/teleport/hub
 	board_type = "teleporter_hub"
-	matter = list(DEFAULT_WALL_MATERIAL = 50, "glass" = 50, MAT_GOLD = 100)
 //	origin_tech = list(TECH_DATA = 2, TECH_BLUESPACE = 4)
 	req_components = list(
 							/obj/item/weapon/stock_parts/scanning_module = 4,
@@ -189,7 +183,6 @@
 	name = T_BOARD("teleporter station")
 	build_path = /obj/machinery/teleport/station
 	board_type = "teleporter_station"
-	matter = list(DEFAULT_WALL_MATERIAL = 50, "glass" = 50, MAT_GOLD = 100)
 //	origin_tech = list(TECH_DATA = 2, TECH_BLUESPACE = 3)
 	req_components = list(
 							/obj/item/weapon/stock_parts/console_screen = 1,
@@ -201,7 +194,6 @@
 	build_path = /obj/machinery/bodyscanner
 	board_type = new /datum/frame/frame_types/medical_pod
 	origin_tech = list(TECH_MAGNET = 2, TECH_BIO = 2)
-	matter = list(DEFAULT_WALL_MATERIAL = 50, "glass" = 50, MAT_COPPER = 100)
 	req_components = list(
 							/obj/item/weapon/stock_parts/scanning_module = 3,
 							/obj/item/stack/material/glass/reinforced = 2)
@@ -210,7 +202,6 @@
 	name = T_BOARD("sleeper")
 	build_path = /obj/machinery/sleeper
 	board_type = new /datum/frame/frame_types/medical_pod
-	matter = list(DEFAULT_WALL_MATERIAL = 50, "glass" = 50, MAT_COPPER = 100)
 	origin_tech = list(TECH_MAGNET = 2, TECH_BIO = 2)
 	req_components = list(
 							/obj/item/weapon/stock_parts/manipulator = 1,
@@ -223,7 +214,6 @@
 	name = T_BOARD("VR sleeper")
 	build_path = /obj/machinery/vr_sleeper
 	board_type = new /datum/frame/frame_types/medical_pod
-	matter = list(DEFAULT_WALL_MATERIAL = 50, "glass" = 50, MAT_GOLD = 100)
 	origin_tech = list(TECH_MAGNET = 2, TECH_BIO = 2)
 	req_components = list(
 							/obj/item/weapon/stock_parts/scanning_module = 1,
@@ -233,7 +223,6 @@
 	name = T_BOARD("dna analyzer")
 	build_path = /obj/machinery/dnaforensics
 	board_type = new /datum/frame/frame_types/dna_analyzer
-	matter = list(DEFAULT_WALL_MATERIAL = 50, "glass" = 50, MAT_GOLD = 100)
 	origin_tech = list(TECH_MAGNET = 4, TECH_BIO = 2, TECH_DATA = 2)
 	req_components = list(
 							/obj/item/weapon/stock_parts/scanning_module = 2,
@@ -244,7 +233,6 @@
 	name = T_BOARD("mass driver")
 	build_path = /obj/machinery/mass_driver
 	board_type = new /datum/frame/frame_types/mass_driver
-	matter = list(DEFAULT_WALL_MATERIAL = 50, "glass" = 50, MAT_GOLD = 100)
 	req_components = list(
 							/obj/item/weapon/stock_parts/gear = 2,
 							/obj/item/weapon/stock_parts/motor = 2,

--- a/code/game/objects/items/weapons/circuitboards/mecha.dm
+++ b/code/game/objects/items/weapons/circuitboards/mecha.dm
@@ -8,7 +8,6 @@
 	icon = 'icons/obj/module.dmi'
 	icon_state = "std_mod"
 	board_type = "other"
-	matter = list(DEFAULT_WALL_MATERIAL = 50, "glass" = 50, MAT_COPPER = 100)
 
 /obj/item/weapon/circuitboard/mecha/ripley
 		origin_tech = list(TECH_DATA = 3)

--- a/code/modules/assembly/igniter.dm
+++ b/code/modules/assembly/igniter.dm
@@ -3,7 +3,7 @@
 	desc = "A small electronic device able to ignite combustable substances."
 	icon_state = "igniter"
 	origin_tech = list(TECH_MAGNET = 1)
-	matter = list(DEFAULT_WALL_MATERIAL = 500, "glass" = 50, MAT_COPPER = 10, "waste" = 10)
+	matter = list(DEFAULT_WALL_MATERIAL = 500, "glass" = 50, "waste" = 10)
 
 	secured = 1
 	wires = WIRE_RECEIVE

--- a/code/modules/assembly/infrared.dm
+++ b/code/modules/assembly/infrared.dm
@@ -5,7 +5,7 @@
 	desc = "Emits a visible or invisible beam and is triggered when the beam is interrupted."
 	icon_state = "infrared"
 	origin_tech = list(TECH_MAGNET = 2)
-	matter = list(DEFAULT_WALL_MATERIAL = 1000, "glass" = 500, MAT_COPPER = 10, "waste" = 100)
+	matter = list(DEFAULT_WALL_MATERIAL = 1000, "glass" = 500, "waste" = 100)
 
 	wires = WIRE_PULSE
 

--- a/code/modules/assembly/proximity.dm
+++ b/code/modules/assembly/proximity.dm
@@ -3,7 +3,7 @@
 	desc = "Used for scanning and alerting when someone enters a certain proximity."
 	icon_state = "prox"
 	origin_tech = list(TECH_MAGNET = 1)
-	matter = list(DEFAULT_WALL_MATERIAL = 800, "glass" = 200, MAT_COPPER = 10, "waste" = 50)
+	matter = list(DEFAULT_WALL_MATERIAL = 800, "glass" = 200, "waste" = 50)
 	wires = WIRE_PULSE
 
 	secured = 0

--- a/code/modules/assembly/signaler.dm
+++ b/code/modules/assembly/signaler.dm
@@ -4,7 +4,7 @@
 	icon_state = "signaller"
 	item_state = "signaler"
 	origin_tech = list(TECH_MAGNET = 1)
-	matter = list(DEFAULT_WALL_MATERIAL = 1000, "glass" = 200, MAT_COPPER = 10, "waste" = 100)
+	matter = list(DEFAULT_WALL_MATERIAL = 1000, "glass" = 200, "waste" = 100)
 	wires = WIRE_RECEIVE | WIRE_PULSE | WIRE_RADIO_PULSE | WIRE_RADIO_RECEIVE
 
 	secured = TRUE

--- a/code/modules/assembly/timer.dm
+++ b/code/modules/assembly/timer.dm
@@ -3,7 +3,7 @@
 	desc = "Used to time things. Works well with contraptions which has to count down. Tick tock."
 	icon_state = "timer"
 	origin_tech = list(TECH_MAGNET = 1)
-	matter = list(DEFAULT_WALL_MATERIAL = 500, "glass" = 50, MAT_COPPER = 10, "waste" = 10)
+	matter = list(DEFAULT_WALL_MATERIAL = 500, "glass" = 50, "waste" = 10)
 
 	wires = WIRE_PULSE
 

--- a/code/modules/assembly/voice.dm
+++ b/code/modules/assembly/voice.dm
@@ -3,7 +3,7 @@
 	desc = "A small electronic device able to record a voice sample, and send a signal when that sample is repeated."
 	icon_state = "voice"
 	origin_tech = list(TECH_MAGNET = 1)
-	matter = list(DEFAULT_WALL_MATERIAL = 500, "glass" = 50, MAT_COPPER = 10, "waste" = 10)
+	matter = list(DEFAULT_WALL_MATERIAL = 500, "glass" = 50, "waste" = 10)
 	var/listening = 0
 	var/recorded	//the activation message
 

--- a/code/modules/projectiles/ammunition/rounds.dm
+++ b/code/modules/projectiles/ammunition/rounds.dm
@@ -300,15 +300,14 @@
 	icon_state = "lcasing"
 	caliber = "14.5mm"
 	projectile_type = /obj/item/projectile/bullet/rifle/a145
-	matter = list(MAT_TITANIUM = 2500, MAT_URANIUM = 1000, MAT_PLASTEEL = 1500)
+	matter = list(DEFAULT_WALL_MATERIAL = 1250)
 
 /obj/item/ammo_casing/a145/highvel
 	desc = "A 14.5mm sabot shell."
 	projectile_type = /obj/item/projectile/bullet/rifle/a145
-	matter = list(MAT_TITANIUM = 2500, MAT_PLASTEEL = 1500)
 
 /obj/item/ammo_casing/a145/spent/Initialize()
-	. = ..()
+	..()
 	expend()
 
 /*

--- a/code/modules/research/designs/HUDs.dm
+++ b/code/modules/research/designs/HUDs.dm
@@ -1,7 +1,7 @@
 // HUDs
 
 /datum/design/item/hud
-	materials = list(DEFAULT_WALL_MATERIAL = 50, "glass" = 50, MAT_COPPER = 10)
+	materials = list(DEFAULT_WALL_MATERIAL = 50, "glass" = 50)
 
 /datum/design/item/hud/AssembleDesignName()
 	..()
@@ -42,6 +42,6 @@
 	name = "graviton visor"
 	id = "graviton_goggles"
 	req_tech = list(TECH_MAGNET = 5, TECH_ENGINEERING = 3, TECH_BLUESPACE = 3, TECH_PHORON = 3)
-	materials = list(MAT_PLASTEEL = 2000, "glass" = 3000, MAT_PHORON = 1500, MAT_COPPER = 10)
+	materials = list(MAT_PLASTEEL = 2000, "glass" = 3000, MAT_PHORON = 1500)
 	build_path = /obj/item/clothing/glasses/graviton
 	sort_string = "EAAAE"

--- a/code/modules/research/designs/ai_holders.dm
+++ b/code/modules/research/designs/ai_holders.dm
@@ -8,7 +8,7 @@
 	id = "mmi"
 	req_tech = list(TECH_DATA = 2, TECH_BIO = 3)
 	build_type = PROTOLATHE | PROSFAB
-	materials = list(DEFAULT_WALL_MATERIAL = 1000, "glass" = 500, MAT_COPPER = 200)
+	materials = list(DEFAULT_WALL_MATERIAL = 1000, "glass" = 500)
 	build_path = /obj/item/device/mmi
 	category = "Misc"
 	sort_string = "SAAAA"
@@ -18,7 +18,7 @@
 	id = "posibrain"
 	req_tech = list(TECH_ENGINEERING = 4, TECH_MATERIAL = 6, TECH_BLUESPACE = 2, TECH_DATA = 4)
 	build_type = PROTOLATHE | PROSFAB
-	materials = list(MAT_TITANIUM = 2000, "glass" = 1000, "silver" = 500, "gold" = 500, "phoron" = 500, MAT_DIAMOND = 100)
+	materials = list(DEFAULT_WALL_MATERIAL = 2000, "glass" = 1000, "silver" = 1000, "gold" = 500, "phoron" = 500, "diamond" = 100)
 	build_path = /obj/item/device/mmi/digital/posibrain
 	category = "Misc"
 	sort_string = "SAAAB"
@@ -28,7 +28,7 @@
 	id = "dronebrain"
 	req_tech = list(TECH_ENGINEERING = 4, TECH_MATERIAL = 5, TECH_DATA = 4)
 	build_type = PROTOLATHE | PROSFAB
-	materials = list(DEFAULT_WALL_MATERIAL = 2000, "glass" = 1000, "silver" = 1000, "gold" = 500, MAT_COPPER = 100)
+	materials = list(DEFAULT_WALL_MATERIAL = 2000, "glass" = 1000, "silver" = 1000, "gold" = 500)
 	build_path = /obj/item/device/mmi/digital/robot
 	category = "Misc"
 	sort_string = "SAAAC"
@@ -37,7 +37,7 @@
 	name = "'pAI', personal artificial intelligence device"
 	id = "paicard"
 	req_tech = list(TECH_DATA = 2)
-	materials = list("glass" = 500, DEFAULT_WALL_MATERIAL = 500, MAT_COPPER = 250)
+	materials = list("glass" = 500, DEFAULT_WALL_MATERIAL = 500)
 	build_path = /obj/item/device/paicard
 	sort_string = "SBAAA"
 
@@ -46,6 +46,6 @@
 	desc = "Allows for the construction of an intelliCore."
 	id = "intellicore"
 	req_tech = list(TECH_DATA = 4, TECH_MATERIAL = 4)
-	materials = list(MAT_TITANIUM = 2500, MAT_ALUMINIUM = 500, "glass" = 500, "gold" = 200)
+	materials = list("glass" = 1000, "gold" = 200)
 	build_path = /obj/item/device/aicard
 	sort_string = "SCAAA"

--- a/code/modules/research/designs/bag_of_holding.dm
+++ b/code/modules/research/designs/bag_of_holding.dm
@@ -9,7 +9,7 @@
 	desc = "Using localized pockets of bluespace this bag prototype offers incredible storage capacity with the contents weighting nothing. It's a shame the bag itself is pretty heavy."
 	id = "bag_holding"
 	req_tech = list(TECH_BLUESPACE = 4, TECH_MATERIAL = 6)
-	materials = list(MAT_TITANIUM = 2000, "gold" = 1000, "diamond" = 1500, "uranium" = 250)
+	materials = list("gold" = 3000, "diamond" = 1500, "uranium" = 250)
 	build_path = /obj/item/weapon/storage/backpack/holding
 	sort_string = "QAAAA"
 
@@ -18,6 +18,6 @@
 	desc = "A minaturized prototype of the popular Bag of Holding, the Dufflebag of Holding is, functionally, identical to the bag of holding, but comes in a more stylish and compact form."
 	id = "dufflebag_holding"
 	req_tech = list(TECH_BLUESPACE = 4, TECH_MATERIAL = 6)
-	materials = list(MAT_TITANIUM = 2000, "gold" = 1000, "diamond" = 1500, "uranium" = 250)
+	materials = list("gold" = 3000, "diamond" = 1500, "uranium" = 250)
 	build_path = /obj/item/weapon/storage/backpack/holding/duffle
 	sort_string = "QAAAB"

--- a/code/modules/research/designs/bio_devices.dm
+++ b/code/modules/research/designs/bio_devices.dm
@@ -1,5 +1,5 @@
 /datum/design/item/biotech
-	materials = list(DEFAULT_WALL_MATERIAL = 30, "glass" = 20, MAT_COPPER = 10)
+	materials = list(DEFAULT_WALL_MATERIAL = 30, "glass" = 20)
 
 /datum/design/item/biotech/AssembleDesignName()
 	..()
@@ -39,7 +39,7 @@
 	desc = "A hand-held scanner able to diagnose robotic injuries."
 	id = "robot_scanner"
 	req_tech = list(TECH_MAGNET = 3, TECH_BIO = 2, TECH_ENGINEERING = 3)
-	materials = list(DEFAULT_WALL_MATERIAL = 500, "glass" = 200, MAT_COPPER = 20)
+	materials = list(DEFAULT_WALL_MATERIAL = 500, "glass" = 200)
 	build_path = /obj/item/device/robotanalyzer
 	sort_string = "JAACA"
 
@@ -47,7 +47,7 @@
 	desc = "A tube of paste containing swarms of repair nanites. Very effective in repairing robotic machinery."
 	id = "nanopaste"
 	req_tech = list(TECH_MATERIAL = 4, TECH_ENGINEERING = 3)
-	materials = list(DEFAULT_WALL_MATERIAL = 7000, "glass" = 7000, MAT_COPPER = 15)
+	materials = list(DEFAULT_WALL_MATERIAL = 7000, "glass" = 7000)
 	build_path = /obj/item/stack/nanopaste
 	sort_string = "JAACB"
 
@@ -55,7 +55,7 @@
 	desc = "A device capable of quickly scanning all relevant data about a plant."
 	id = "plant_analyzer"
 	req_tech = list(TECH_MAGNET = 2, TECH_BIO = 2)
-	materials = list(DEFAULT_WALL_MATERIAL = 500, "glass" = 500, MAT_COPPER = 10)
+	materials = list(DEFAULT_WALL_MATERIAL = 500, "glass" = 500)
 	build_path = /obj/item/device/analyzer/plant_analyzer
 	sort_string = "JAADA"
 

--- a/code/modules/research/designs/circuits/ai_modules.dm
+++ b/code/modules/research/designs/circuits/ai_modules.dm
@@ -1,6 +1,6 @@
 /datum/design/aimodule
 	build_type = IMPRINTER
-	materials = list("glass" = 1800, MAT_COPPER = 200, "gold" = 100)
+	materials = list("glass" = 2000, "gold" = 100)
 
 /datum/design/aimodule/AssembleDesignName()
 	name = "AI module design ([name])"

--- a/code/modules/research/designs/circuits/circuits.dm
+++ b/code/modules/research/designs/circuits/circuits.dm
@@ -5,7 +5,7 @@ CIRCUITS BELOW
 /datum/design/circuit
 	build_type = IMPRINTER
 	req_tech = list(TECH_DATA = 2)
-	materials = list("glass" = 1850, MAT_COPPER = 150)
+	materials = list("glass" = 2000)
 	chemicals = list("sacid" = 20)
 	time = 5
 
@@ -493,7 +493,7 @@ CIRCUITS BELOW
 	name = "'Durand' central control"
 	id = "durand_main"
 	req_tech = list(TECH_DATA = 4)
-	materials = list("glass" = 2000, MAT_GRAPHITE = 1250, MAT_COPPER = 100)
+	materials = list("glass" = 2000, MAT_GRAPHITE = 1250)
 	chemicals = list("sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/mecha/durand/main
 	sort_string = "NAADA"
@@ -502,7 +502,7 @@ CIRCUITS BELOW
 	name = "'Durand' peripherals control"
 	id = "durand_peri"
 	req_tech = list(TECH_DATA = 4)
-	materials = list("glass" = 2000, MAT_GRAPHITE = 1250, MAT_COPPER = 100)
+	materials = list("glass" = 2000, MAT_GRAPHITE = 1250)
 	chemicals = list("sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/mecha/durand/peripherals
 	sort_string = "NAADB"
@@ -511,7 +511,7 @@ CIRCUITS BELOW
 	name = "'Durand' weapon control and targeting"
 	id = "durand_targ"
 	req_tech = list(TECH_DATA = 4, TECH_COMBAT = 2)
-	materials = list("glass" = 2000, MAT_GRAPHITE = 1250, MAT_COPPER = 100)
+	materials = list("glass" = 2000, MAT_GRAPHITE = 1250)
 	chemicals = list("sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/mecha/durand/targeting
 	sort_string = "NAADC"
@@ -578,7 +578,7 @@ CIRCUITS BELOW
 
 /datum/design/circuit/shield
 	req_tech = list(TECH_BLUESPACE = 4, TECH_PHORON = 3)
-	materials = list("glass" = 2000, MAT_COPPER = 100, "gold" = 1000)
+	materials = list("glass" = 2000, "gold" = 1000)
 
 /datum/design/circuit/shield/AssembleDesignName()
 	name = "Shield generator circuit design ([name])"
@@ -662,19 +662,6 @@ CIRCUITS BELOW
 	build_path = /obj/item/weapon/circuitboard/microwave/advanced
 	sort_string = "HACAA"
 
-/datum/design/circuit/pointdefense
-	name = "point defense battery"
-	id = "pointdefense"
-	req_tech = list(TECH_DATA = 2, TECH_ENGINEERING = 3, TECH_COMBAT = 4)
-	build_path = /obj/item/weapon/circuitboard/pointdefense
-	sort_string = "OAABA"
-
-/datum/design/circuit/pointdefense_control
-	name = "point defense control"
-	id = "pointdefense_control"
-	req_tech = list(TECH_DATA = 4, TECH_ENGINEERING = 3, TECH_COMBAT = 2)
-	build_path = /obj/item/weapon/circuitboard/pointdefense_control
-	sort_string = "OAABB"
 
 /* I have no idea how this was even running before, but it doesn't seem to be necessary.
 ///////////////////////////////////

--- a/code/modules/research/designs/circuits/disks.dm
+++ b/code/modules/research/designs/circuits/disks.dm
@@ -2,7 +2,7 @@
 /datum/design/circuit/disk
 	build_type = IMPRINTER
 	req_tech = list(TECH_DATA = 3)
-	materials = list(MAT_PLASTIC = 2000, MAT_GLASS = 1000, MAT_COPPER = 150)
+	materials = list(MAT_PLASTIC = 2000, MAT_GLASS = 1000)
 	chemicals = list("pacid" = 10)
 	time = 5
 

--- a/code/modules/research/designs/engineering.dm
+++ b/code/modules/research/designs/engineering.dm
@@ -9,7 +9,7 @@
 	desc = "A welding tool that generate fuel for itself."
 	id = "expwelder"
 	req_tech = list(TECH_ENGINEERING = 4, TECH_PHORON = 3, TECH_MATERIAL = 4)
-	materials = list(DEFAULT_WALL_MATERIAL = 70, "glass" = 120, "phoron" = 100, MAT_COPPER = 10)
+	materials = list(DEFAULT_WALL_MATERIAL = 70, "glass" = 120, "phoron" = 100)
 	build_path = /obj/item/weapon/weldingtool/experimental
 	sort_string = "NAAAA"
 
@@ -18,7 +18,7 @@
 	desc = "A simple powered hand drill."
 	id = "handdrill"
 	req_tech = list(TECH_ENGINEERING = 3, TECH_MATERIAL = 2)
-	materials = list(MAT_ALUMINIUM = 300, "silver" = 100, MAT_COPPER = 10)
+	materials = list(DEFAULT_WALL_MATERIAL = 300, "silver" = 100)
 	build_path = /obj/item/weapon/tool/screwdriver/power
 	sort_string = "NAAAB"
 
@@ -27,7 +27,7 @@
 	desc = "A set of jaws of life, compressed through the magic of science."
 	id = "jawslife"
 	req_tech = list(TECH_ENGINEERING = 3, TECH_MATERIAL = 2)
-	materials = list(MAT_ALUMINIUM = 300, MAT_TITANIUM = 100, MAT_COPPER = 10)
+	materials = list(DEFAULT_WALL_MATERIAL = 300, "silver" = 100)
 	build_path = /obj/item/weapon/tool/crowbar/power
 	sort_string = "NAAAC"
 
@@ -42,7 +42,7 @@
 	desc = "A terahertz-ray emitter and scanner used to detect underfloor objects such as cables and pipes."
 	id = "tscanner"
 	req_tech = list(TECH_MAGNET = 2, TECH_ENGINEERING = 2, TECH_MATERIAL = 2)
-	materials = list(DEFAULT_WALL_MATERIAL = 200, MAT_COPPER = 10)
+	materials = list(DEFAULT_WALL_MATERIAL = 200)
 	build_path = /obj/item/device/t_scanner
 	sort_string = "NBAAA"
 
@@ -51,7 +51,7 @@
 	desc = "An upgraded version of the terahertz-ray emitter and scanner used to detect underfloor objects such as cables and pipes."
 	id = "upgradedtscanner"
 	req_tech = list(TECH_MAGNET = 3, TECH_ENGINEERING = 4, TECH_MATERIAL = 2)
-	materials = list(DEFAULT_WALL_MATERIAL = 500, "phoron" = 150, MAT_COPPER = 10)
+	materials = list(DEFAULT_WALL_MATERIAL = 500, "phoron" = 150)
 	build_path = /obj/item/device/t_scanner/upgraded
 	sort_string = "NBAAB"
 
@@ -60,7 +60,7 @@
 	desc = "An advanced version of the terahertz-ray emitter and scanner used to detect underfloor objects such as cables and pipes."
 	id = "advancedtscanner"
 	req_tech = list(TECH_MAGNET = 6, TECH_ENGINEERING = 6, TECH_MATERIAL = 6)
-	materials = list(MAT_ALUMINIUM = 1250, "phoron" = 500, "silver" = 50)
+	materials = list(DEFAULT_WALL_MATERIAL = 1250, "phoron" = 500, "silver" = 50)
 	build_path = /obj/item/device/t_scanner/advanced
 	sort_string = "NBAAC"
 
@@ -69,6 +69,6 @@
 	desc = "A hand-held environmental scanner which reports current gas levels."
 	id = "atmosanalyzer"
 	req_tech = list(TECH_ENGINEERING = 2)
-	materials = list(DEFAULT_WALL_MATERIAL = 200, "glass" = 100, MAT_COPPER = 10)
+	materials = list(DEFAULT_WALL_MATERIAL = 200, "glass" = 100)
 	build_path = /obj/item/device/analyzer
 	sort_string = "NBABA"

--- a/code/modules/research/designs/implants.dm
+++ b/code/modules/research/designs/implants.dm
@@ -1,7 +1,7 @@
 // Implants
 
 /datum/design/item/implant
-	materials = list(DEFAULT_WALL_MATERIAL = 50, "glass" = 50, MAT_COPPER = 5)
+	materials = list(DEFAULT_WALL_MATERIAL = 50, "glass" = 50)
 
 /datum/design/item/implant/AssembleDesignName()
 	..()
@@ -17,7 +17,6 @@
 /datum/design/item/implant/freedom
 	name = "freedom"
 	id = "implant_free"
-	req_tech = list(TECH_MATERIAL = 3, TECH_ILLEGAL = 2, TECH_BIO = 3)
+	req_tech = list(TECH_ILLEGAL = 2, TECH_BIO = 3)
 	build_path = /obj/item/weapon/implantcase/freedom
 	sort_string = "MFAAB"
-	materials = list(MAT_TITANIUM = 50, "glass" = 50, MAT_COPPER = 5)

--- a/code/modules/research/designs/locator_devices.dm
+++ b/code/modules/research/designs/locator_devices.dm
@@ -2,7 +2,7 @@
 
 /datum/design/item/gps
 	req_tech = list(TECH_MATERIAL = 2, TECH_DATA = 2, TECH_BLUESPACE = 2)
-	materials = list(DEFAULT_WALL_MATERIAL = 500, MAT_COPPER = 5)
+	materials = list(DEFAULT_WALL_MATERIAL = 500)
 
 /datum/design/item/gps/AssembleDesignName()
 	..()
@@ -67,7 +67,7 @@
 	desc = "Used to scan and locate signals on a particular frequency."
 	id = "beacon_locator"
 	req_tech = list(TECH_MAGNET = 3, TECH_ENGINEERING = 2, TECH_BLUESPACE = 3)
-	materials = list(DEFAULT_WALL_MATERIAL = 1000,"glass" = 500, MAT_COPPER = 150)
+	materials = list(DEFAULT_WALL_MATERIAL = 1000,"glass" = 500)
 	build_path = /obj/item/device/beacon_locator
 	sort_string = "DBAAA"
 
@@ -75,6 +75,6 @@
 	name = "Bluespace tracking beacon"
 	id = "beacon"
 	req_tech = list(TECH_BLUESPACE = 1)
-	materials = list (DEFAULT_WALL_MATERIAL = 20, "glass" = 10, MAT_COPPER = 5)
+	materials = list (DEFAULT_WALL_MATERIAL = 20, "glass" = 10)
 	build_path = /obj/item/device/radio/beacon
 	sort_string = "DBABA"

--- a/code/modules/research/designs/medical.dm
+++ b/code/modules/research/designs/medical.dm
@@ -12,7 +12,7 @@
 	desc = "A scalpel augmented with a directed laser, for more precise cutting without blood entering the field. This one looks basic and could be improved."
 	id = "scalpel_laser1"
 	req_tech = list(TECH_BIO = 2, TECH_MATERIAL = 2, TECH_MAGNET = 2)
-	materials = list(DEFAULT_WALL_MATERIAL = 12500, "glass" = 7500, MAT_COPPER = 120)
+	materials = list(DEFAULT_WALL_MATERIAL = 12500, "glass" = 7500)
 	build_path = /obj/item/weapon/surgical/scalpel/laser1
 	sort_string = "KAAAA"
 
@@ -75,7 +75,7 @@
 	desc = "A hand-held body scanner able to distinguish vital signs of the subject."
 	id = "medical_analyzer"
 	req_tech = list(TECH_MAGNET = 2, TECH_BIO = 2)
-	materials = list(DEFAULT_WALL_MATERIAL = 500, "glass" = 500, MAT_COPPER = 20)
+	materials = list(DEFAULT_WALL_MATERIAL = 500, "glass" = 500)
 	build_path = /obj/item/device/healthanalyzer
 	sort_string = "KBAAA"
 
@@ -93,6 +93,6 @@
 	desc = "A more advanced version of the regular roller bed, with inbuilt surgical stabilisers and an improved folding system."
 	id = "roller_bed"
 	req_tech = list(TECH_BIO = 3, TECH_MATERIAL = 3, TECH_MAGNET = 3)
-	materials = list(DEFAULT_WALL_MATERIAL = 4000, "glass" = 2000, "phoron" = 2000, MAT_COPPER = 100)
+	materials = list(DEFAULT_WALL_MATERIAL = 4000, "glass" = 2000, "phoron" = 2000)
 	build_path = /obj/item/roller/adv
 	sort_string = "KCAAA"

--- a/code/modules/research/designs/mining_toys.dm
+++ b/code/modules/research/designs/mining_toys.dm
@@ -7,14 +7,14 @@
 /datum/design/item/weapon/mining/drill
 	id = "drill"
 	req_tech = list(TECH_MATERIAL = 2, TECH_POWER = 3, TECH_ENGINEERING = 2)
-	materials = list(DEFAULT_WALL_MATERIAL = 6000, "glass" = 1000, MAT_COPPER = 10) //expensive, but no need for miners.
+	materials = list(DEFAULT_WALL_MATERIAL = 6000, "glass" = 1000) //expensive, but no need for miners.
 	build_path = /obj/item/weapon/pickaxe/drill
 	sort_string = "FAAAA"
 
 /datum/design/item/weapon/mining/jackhammer
 	id = "jackhammer"
 	req_tech = list(TECH_MATERIAL = 3, TECH_POWER = 2, TECH_ENGINEERING = 2)
-	materials = list(DEFAULT_WALL_MATERIAL = 2000, "glass" = 500, "silver" = 500, MAT_COPPER = 20)
+	materials = list(DEFAULT_WALL_MATERIAL = 2000, "glass" = 500, "silver" = 500)
 	build_path = /obj/item/weapon/pickaxe/jackhammer
 	sort_string = "FAAAB"
 
@@ -28,14 +28,14 @@
 /datum/design/item/weapon/mining/pick_diamond
 	id = "pick_diamond"
 	req_tech = list(TECH_MATERIAL = 6)
-	materials = list(MAT_WOOD = 2000, "diamond" = 3000)
+	materials = list("diamond" = 3000)
 	build_path = /obj/item/weapon/pickaxe/diamond
 	sort_string = "FAAAD"
 
 /datum/design/item/weapon/mining/drill_diamond
 	id = "drill_diamond"
 	req_tech = list(TECH_MATERIAL = 6, TECH_POWER = 4, TECH_ENGINEERING = 4)
-	materials = list(MAT_ALUMINIUM = 2000, DEFAULT_WALL_MATERIAL = 1000, "glass" = 500, "diamond" = 2000, MAT_COPPER = 50)
+	materials = list(DEFAULT_WALL_MATERIAL = 3000, "glass" = 1000, "diamond" = 2000)
 	build_path = /obj/item/weapon/pickaxe/diamonddrill
 	sort_string = "FAAAE"
 
@@ -45,13 +45,6 @@
 	desc = "Used to check spatial depth and density of rock outcroppings."
 	id = "depth_scanner"
 	req_tech = list(TECH_MAGNET = 2, TECH_ENGINEERING = 2, TECH_BLUESPACE = 2)
-	materials = list(DEFAULT_WALL_MATERIAL = 1000,"glass" = 1000, MAT_COPPER = 50)
+	materials = list(DEFAULT_WALL_MATERIAL = 1000,"glass" = 1000)
 	build_path = /obj/item/device/depth_scanner
 	sort_string = "FBAAA"
-
-/datum/design/item/weapon/mining/mining_scanner
-	id = "mining_scanner"
-	req_tech = list(TECH_MAGNET = 3, TECH_ENGINEERING = 4, TECH_BLUESPACE = 1)
-	materials = list(DEFAULT_WALL_MATERIAL = 1000,"glass" = 500, MAT_COPPER = 250)
-	build_path = /obj/item/weapon/mining_scanner/advanced
-	sort_string = "FBAAB"

--- a/code/modules/research/designs/misc.dm
+++ b/code/modules/research/designs/misc.dm
@@ -8,7 +8,7 @@
 	name = "Communicator"
 	id = "communicator"
 	req_tech = list(TECH_DATA = 2, TECH_MAGNET = 2)
-	materials = list(DEFAULT_WALL_MATERIAL = 500, "glass" = 500, MAT_COPPER = 50)
+	materials = list(DEFAULT_WALL_MATERIAL = 500, "glass" = 500)
 	build_path = /obj/item/device/communicator
 	sort_string = "TAAAA"
 
@@ -17,7 +17,7 @@ datum/design/item/general/laserpointer
 	desc = "Don't shine it in your eyes!"
 	id = "laser_pointer"
 	req_tech = list(TECH_MAGNET = 3)
-	materials = list(DEFAULT_WALL_MATERIAL = 100, "glass" = 50, MAT_COPPER = 10)
+	materials = list(DEFAULT_WALL_MATERIAL = 100, "glass" = 50)
 	build_path = /obj/item/device/laser_pointer
 	sort_string = "TAABA"
 
@@ -25,7 +25,7 @@ datum/design/item/general/laserpointer
 	name = "handheld translator"
 	id = "translator"
 	req_tech = list(TECH_DATA = 3, TECH_ENGINEERING = 3)
-	materials = list(DEFAULT_WALL_MATERIAL = 3000, "glass" = 3000, MAT_COPPER = 50)
+	materials = list(DEFAULT_WALL_MATERIAL = 3000, "glass" = 3000)
 	build_path = /obj/item/device/universal_translator
 	sort_string = "TAACA"
 
@@ -33,7 +33,7 @@ datum/design/item/general/laserpointer
 	name = "earpiece translator"
 	id = "ear_translator"
 	req_tech = list(TECH_DATA = 5, TECH_ENGINEERING = 5)	//It's been hella miniaturized.
-	materials = list(DEFAULT_WALL_MATERIAL = 2000, "glass" = 2000, "gold" = 1000, MAT_COPPER = 50)
+	materials = list(DEFAULT_WALL_MATERIAL = 2000, "glass" = 2000, "gold" = 1000)
 	build_path = /obj/item/device/universal_translator/ear
 	sort_string = "TAACB"
 
@@ -51,7 +51,7 @@ datum/design/item/general/laserpointer
 	desc = "Allows for deciphering the binary channel on-the-fly."
 	id = "binaryencrypt"
 	req_tech = list(TECH_ILLEGAL = 2)
-	materials = list(DEFAULT_WALL_MATERIAL = 300, "glass" = 300, MAT_COPPER = 30)
+	materials = list(DEFAULT_WALL_MATERIAL = 300, "glass" = 300)
 	build_path = /obj/item/device/encryptionkey/binary
 	sort_string = "TBAAA"
 
@@ -60,7 +60,7 @@ datum/design/item/general/laserpointer
 	desc = "A kit of dangerous, high-tech equipment with changeable looks."
 	id = "chameleon"
 	req_tech = list(TECH_ILLEGAL = 2)
-	materials = list(MAT_PLASTIC = 500, MAT_COPPER = 500, DEFAULT_WALL_MATERIAL = 500)
+	materials = list(DEFAULT_WALL_MATERIAL = 500)
 	build_path = /obj/item/weapon/storage/box/syndie_kit/chameleon
 	sort_string = "TBAAB"
 

--- a/code/modules/research/designs/modular_computer.dm
+++ b/code/modules/research/designs/modular_computer.dm
@@ -9,14 +9,14 @@
 	name = "basic hard drive"
 	id = "hdd_basic"
 	req_tech = list(TECH_DATA = 1, TECH_ENGINEERING = 1)
-	materials = list(DEFAULT_WALL_MATERIAL = 2000, "glass" = 100, MAT_COPPER = 50)
+	materials = list(DEFAULT_WALL_MATERIAL = 2000, "glass" = 100)
 	build_path = /obj/item/weapon/computer_hardware/hard_drive/
 	sort_string = "VAAAA"
 
 /datum/design/item/modularcomponent/disk/advanced
 	name = "advanced hard drive"
 	id = "hdd_advanced"
-	materials = list(DEFAULT_WALL_MATERIAL = 4000, "glass" = 200, MAT_COPPER = 50)
+	materials = list(DEFAULT_WALL_MATERIAL = 4000, "glass" = 200)
 	build_path = /obj/item/weapon/computer_hardware/hard_drive/advanced
 	sort_string = "VAAAB"
 
@@ -24,7 +24,7 @@
 	name = "super hard drive"
 	id = "hdd_super"
 	req_tech = list(TECH_DATA = 3, TECH_ENGINEERING = 3)
-	materials = list(DEFAULT_WALL_MATERIAL = 8000, "glass" = 400, MAT_COPPER = 50)
+	materials = list(DEFAULT_WALL_MATERIAL = 8000, "glass" = 400)
 	build_path = /obj/item/weapon/computer_hardware/hard_drive/super
 	sort_string = "VAAAC"
 
@@ -32,7 +32,7 @@
 	name = "cluster hard drive"
 	id = "hdd_cluster"
 	req_tech = list(TECH_DATA = 4, TECH_ENGINEERING = 4)
-	materials = list(DEFAULT_WALL_MATERIAL = 16000, "glass" = 800, MAT_COPPER = 40)
+	materials = list(DEFAULT_WALL_MATERIAL = 16000, "glass" = 800)
 	build_path = /obj/item/weapon/computer_hardware/hard_drive/cluster
 	sort_string = "VAAAD"
 
@@ -40,7 +40,7 @@
 	name = "small hard drive"
 	id = "hdd_small"
 	req_tech = list(TECH_DATA = 2, TECH_ENGINEERING = 2)
-	materials = list(DEFAULT_WALL_MATERIAL = 4000, "glass" = 200, MAT_COPPER = 30)
+	materials = list(DEFAULT_WALL_MATERIAL = 4000, "glass" = 200)
 	build_path = /obj/item/weapon/computer_hardware/hard_drive/small
 	sort_string = "VAAAE"
 
@@ -48,7 +48,7 @@
 	name = "micro hard drive"
 	id = "hdd_micro"
 	req_tech = list(TECH_DATA = 1, TECH_ENGINEERING = 1)
-	materials = list(DEFAULT_WALL_MATERIAL = 2000, "glass" = 100, MAT_COPPER = 20)
+	materials = list(DEFAULT_WALL_MATERIAL = 2000, "glass" = 100)
 	build_path = /obj/item/weapon/computer_hardware/hard_drive/micro
 	sort_string = "VAAAF"
 
@@ -58,7 +58,7 @@
 	name = "basic network card"
 	id = "netcard_basic"
 	req_tech = list(TECH_DATA = 2, TECH_ENGINEERING = 1)
-	materials = list(DEFAULT_WALL_MATERIAL = 500, "glass" = 100, MAT_COPPER = 10)
+	materials = list(DEFAULT_WALL_MATERIAL = 500, "glass" = 100)
 	build_path = /obj/item/weapon/computer_hardware/network_card
 	sort_string = "VBAAA"
 
@@ -66,7 +66,7 @@
 	name = "advanced network card"
 	id = "netcard_advanced"
 	req_tech = list(TECH_DATA = 4, TECH_ENGINEERING = 2)
-	materials = list(DEFAULT_WALL_MATERIAL = 1000, "glass" = 200, MAT_COPPER = 10)
+	materials = list(DEFAULT_WALL_MATERIAL = 1000, "glass" = 200)
 	build_path = /obj/item/weapon/computer_hardware/network_card/advanced
 	sort_string = "VBAAB"
 
@@ -74,7 +74,7 @@
 	name = "wired network card"
 	id = "netcard_wired"
 	req_tech = list(TECH_DATA = 5, TECH_ENGINEERING = 3)
-	materials = list(DEFAULT_WALL_MATERIAL = 5000, "glass" = 400, MAT_COPPER = 10)
+	materials = list(DEFAULT_WALL_MATERIAL = 5000, "glass" = 400)
 	build_path = /obj/item/weapon/computer_hardware/network_card/wired
 	sort_string = "VBAAC"
 
@@ -84,7 +84,7 @@
 	name = "standard battery module"
 	id = "bat_normal"
 	req_tech = list(TECH_POWER = 1, TECH_ENGINEERING = 1)
-	materials = list(DEFAULT_WALL_MATERIAL = 2000, MAT_COPPER = 10)
+	materials = list(DEFAULT_WALL_MATERIAL = 2000)
 	build_path = /obj/item/weapon/computer_hardware/battery_module
 	sort_string = "VCAAA"
 
@@ -92,7 +92,7 @@
 	name = "advanced battery module"
 	id = "bat_advanced"
 	req_tech = list(TECH_POWER = 2, TECH_ENGINEERING = 2)
-	materials = list(DEFAULT_WALL_MATERIAL = 4000, MAT_COPPER = 10)
+	materials = list(DEFAULT_WALL_MATERIAL = 4000)
 	build_path = /obj/item/weapon/computer_hardware/battery_module/advanced
 	sort_string = "VCAAB"
 
@@ -100,7 +100,7 @@
 	name = "super battery module"
 	id = "bat_super"
 	req_tech = list(TECH_POWER = 3, TECH_ENGINEERING = 3)
-	materials = list(DEFAULT_WALL_MATERIAL = 8000, MAT_COPPER = 10)
+	materials = list(DEFAULT_WALL_MATERIAL = 8000)
 	build_path = /obj/item/weapon/computer_hardware/battery_module/super
 	sort_string = "VCAAC"
 
@@ -108,7 +108,7 @@
 	name = "ultra battery module"
 	id = "bat_ultra"
 	req_tech = list(TECH_POWER = 5, TECH_ENGINEERING = 4)
-	materials = list(DEFAULT_WALL_MATERIAL = 16000, MAT_COPPER = 10)
+	materials = list(DEFAULT_WALL_MATERIAL = 16000)
 	build_path = /obj/item/weapon/computer_hardware/battery_module/ultra
 	sort_string = "VCAAD"
 
@@ -116,7 +116,7 @@
 	name = "nano battery module"
 	id = "bat_nano"
 	req_tech = list(TECH_POWER = 1, TECH_ENGINEERING = 1)
-	materials = list(DEFAULT_WALL_MATERIAL = 2000, MAT_COPPER = 10)
+	materials = list(DEFAULT_WALL_MATERIAL = 2000)
 	build_path = /obj/item/weapon/computer_hardware/battery_module/nano
 	sort_string = "VCAAE"
 
@@ -124,7 +124,7 @@
 	name = "micro battery module"
 	id = "bat_micro"
 	req_tech = list(TECH_POWER = 2, TECH_ENGINEERING = 2)
-	materials = list(DEFAULT_WALL_MATERIAL = 4000, MAT_COPPER = 10)
+	materials = list(DEFAULT_WALL_MATERIAL = 4000)
 	build_path = /obj/item/weapon/computer_hardware/battery_module/micro
 	sort_string = "VCAAF"
 
@@ -134,7 +134,7 @@
 	name = "computer processor unit"
 	id = "cpu_normal"
 	req_tech = list(TECH_DATA = 3, TECH_ENGINEERING = 2)
-	materials = list(DEFAULT_WALL_MATERIAL = 8000, MAT_COPPER = 10)
+	materials = list(DEFAULT_WALL_MATERIAL = 8000)
 	build_path = /obj/item/weapon/computer_hardware/processor_unit
 	sort_string = "VDAAA"
 
@@ -142,7 +142,7 @@
 	name = "computer microprocessor unit"
 	id = "cpu_small"
 	req_tech = list(TECH_DATA = 2, TECH_ENGINEERING = 2)
-	materials = list(DEFAULT_WALL_MATERIAL = 4000, MAT_COPPER = 10)
+	materials = list(DEFAULT_WALL_MATERIAL = 4000)
 	build_path = /obj/item/weapon/computer_hardware/processor_unit/small
 	sort_string = "VDAAB"
 
@@ -150,7 +150,7 @@
 	name = "computer photonic processor unit"
 	id = "pcpu_normal"
 	req_tech = list(TECH_DATA = 5, TECH_ENGINEERING = 4)
-	materials = list(DEFAULT_WALL_MATERIAL = 32000, glass = 8000, MAT_COPPER = 10)
+	materials = list(DEFAULT_WALL_MATERIAL = 32000, glass = 8000)
 	build_path = /obj/item/weapon/computer_hardware/processor_unit/photonic
 	sort_string = "VDAAC"
 
@@ -158,7 +158,7 @@
 	name = "computer photonic microprocessor unit"
 	id = "pcpu_small"
 	req_tech = list(TECH_DATA = 4, TECH_ENGINEERING = 3)
-	materials = list(DEFAULT_WALL_MATERIAL = 16000, glass = 4000, MAT_COPPER = 10)
+	materials = list(DEFAULT_WALL_MATERIAL = 16000, glass = 4000)
 	build_path = /obj/item/weapon/computer_hardware/processor_unit/photonic/small
 	sort_string = "VDAAD"
 
@@ -168,7 +168,7 @@
 	name = "RFID card slot"
 	id = "cardslot"
 	req_tech = list(TECH_DATA = 2)
-	materials = list(DEFAULT_WALL_MATERIAL = 3000, MAT_COPPER = 10)
+	materials = list(DEFAULT_WALL_MATERIAL = 3000)
 	build_path = /obj/item/weapon/computer_hardware/card_slot
 	sort_string = "VEAAA"
 
@@ -176,7 +176,7 @@
 	name = "nano printer"
 	id = "nanoprinter"
 	req_tech = list(TECH_DATA = 2, TECH_ENGINEERING = 2)
-	materials = list(DEFAULT_WALL_MATERIAL = 3000, MAT_COPPER = 10)
+	materials = list(DEFAULT_WALL_MATERIAL = 3000)
 	build_path = /obj/item/weapon/computer_hardware/nano_printer
 	sort_string = "VEAAB"
 
@@ -184,7 +184,7 @@
 	name = "tesla link"
 	id = "teslalink"
 	req_tech = list(TECH_DATA = 2, TECH_POWER = 3, TECH_ENGINEERING = 2)
-	materials = list(DEFAULT_WALL_MATERIAL = 10000, MAT_PHORON = 350, MAT_GOLD = 500)
+	materials = list(DEFAULT_WALL_MATERIAL = 10000)
 	build_path = /obj/item/weapon/computer_hardware/tesla_link
 	sort_string = "VEAAC"
 
@@ -198,7 +198,7 @@
 	name = "basic data crystal"
 	id = "portadrive_basic"
 	req_tech = list(TECH_DATA = 1)
-	materials = list("glass" = 8000, MAT_COPPER = 10)
+	materials = list("glass" = 8000)
 	build_path = /obj/item/weapon/computer_hardware/hard_drive/portable
 	sort_string = "VFAAA"
 
@@ -206,7 +206,7 @@
 	name = "advanced data crystal"
 	id = "portadrive_advanced"
 	req_tech = list(TECH_DATA = 2)
-	materials = list("glass" = 16000, MAT_COPPER = 20)
+	materials = list("glass" = 16000)
 	build_path = /obj/item/weapon/computer_hardware/hard_drive/portable/advanced
 	sort_string = "VFAAB"
 
@@ -214,6 +214,6 @@
 	name = "super data crystal"
 	id = "portadrive_super"
 	req_tech = list(TECH_DATA = 4)
-	materials = list("glass" = 32000, MAT_COPPER = 60)
+	materials = list("glass" = 32000)
 	build_path = /obj/item/weapon/computer_hardware/hard_drive/portable/super
 	sort_string = "VFAAC"

--- a/code/modules/research/designs/pdas.dm
+++ b/code/modules/research/designs/pdas.dm
@@ -5,7 +5,7 @@
 	desc = "Cheaper than whiny non-digital assistants."
 	id = "pda"
 	req_tech = list(TECH_ENGINEERING = 2, TECH_POWER = 3)
-	materials = list(DEFAULT_WALL_MATERIAL = 50, "glass" = 50, MAT_COPPER = 10)
+	materials = list(DEFAULT_WALL_MATERIAL = 50, "glass" = 50)
 	build_path = /obj/item/device/pda
 	sort_string = "WAAAA"
 

--- a/code/modules/research/designs/power_cells.dm
+++ b/code/modules/research/designs/power_cells.dm
@@ -20,7 +20,7 @@
 	build_type = PROTOLATHE | MECHFAB
 	id = "basic_cell"
 	req_tech = list(TECH_POWER = 1)
-	materials = list(DEFAULT_WALL_MATERIAL = 700, "glass" = 50, MAT_COPPER = 15)
+	materials = list(DEFAULT_WALL_MATERIAL = 700, "glass" = 50)
 	build_path = /obj/item/weapon/cell
 	category = "Misc"
 	sort_string = "BAAAA"
@@ -30,7 +30,7 @@
 	build_type = PROTOLATHE | MECHFAB
 	id = "high_cell"
 	req_tech = list(TECH_POWER = 2)
-	materials = list(DEFAULT_WALL_MATERIAL = 700, "glass" = 60, MAT_COPPER = 15)
+	materials = list(DEFAULT_WALL_MATERIAL = 700, "glass" = 60)
 	build_path = /obj/item/weapon/cell/high
 	category = "Misc"
 	sort_string = "BAAAB"
@@ -39,7 +39,7 @@
 	name = "super-capacity"
 	id = "super_cell"
 	req_tech = list(TECH_POWER = 3, TECH_MATERIAL = 2)
-	materials = list(DEFAULT_WALL_MATERIAL = 700, "glass" = 70, MAT_COPPER = 15)
+	materials = list(DEFAULT_WALL_MATERIAL = 700, "glass" = 70)
 	build_path = /obj/item/weapon/cell/super
 	category = "Misc"
 	sort_string = "BAAAC"
@@ -57,7 +57,7 @@
 	name = "device"
 	build_type = PROTOLATHE
 	id = "device"
-	materials = list(DEFAULT_WALL_MATERIAL = 350, "glass" = 25, MAT_COPPER = 5)
+	materials = list(DEFAULT_WALL_MATERIAL = 350, "glass" = 25)
 	build_path = /obj/item/weapon/cell/device
 	category = "Misc"
 	sort_string = "BAABA"
@@ -66,7 +66,7 @@
 	name = "weapon"
 	build_type = PROTOLATHE
 	id = "weapon"
-	materials = list(DEFAULT_WALL_MATERIAL = 700, "glass" = 50, MAT_COPPER = 15)
+	materials = list(DEFAULT_WALL_MATERIAL = 700, "glass" = 50)
 	build_path = /obj/item/weapon/cell/device/weapon
 	category = "Misc"
 	sort_string = "BAABB"

--- a/code/modules/research/designs/stock_parts.dm
+++ b/code/modules/research/designs/stock_parts.dm
@@ -40,14 +40,14 @@
 /datum/design/item/stock_part/hyper_matter_bin
 	id = "hyper_matter_bin"
 	req_tech = list(TECH_MATERIAL = 6, TECH_ARCANE = 2)
-	materials = list(MAT_ALUMINIUM = 200, MAT_VERDANTIUM = 60, MAT_TITANIUM = 75)
+	materials = list(DEFAULT_WALL_MATERIAL = 200, MAT_VERDANTIUM = 60, MAT_DURASTEEL = 75)
 	build_path = /obj/item/weapon/stock_parts/matter_bin/hyper
 	sort_string = "AAAAD"
 
 /datum/design/item/stock_part/omni_matter_bin
 	id = "omni_matter_bin"
 	req_tech = list(TECH_MATERIAL = 7, TECH_PRECURSOR = 2)
-	materials = list(MAT_TITANIUM = 2000, MAT_PLASTEEL = 100, MAT_MORPHIUM = 100, MAT_DURASTEEL = 100)
+	materials = list(DEFAULT_WALL_MATERIAL = 2000, MAT_PLASTEEL = 100, MAT_MORPHIUM = 100, MAT_DURASTEEL = 100)
 	build_path = /obj/item/weapon/stock_parts/matter_bin/omni
 	sort_string = "AAAAE"
 
@@ -77,14 +77,14 @@
 /datum/design/item/stock_part/hyper_mani
 	id = "hyper_mani"
 	req_tech = list(TECH_MATERIAL = 6, TECH_DATA = 3, TECH_ARCANE = 2)
-	materials = list(MAT_ALUMINIUM = 200, MAT_VERDANTIUM = 50, MAT_TITANIUM = 50)
+	materials = list(DEFAULT_WALL_MATERIAL = 200, MAT_VERDANTIUM = 50, MAT_DURASTEEL = 50)
 	build_path = /obj/item/weapon/stock_parts/manipulator/hyper
 	sort_string = "AAABD"
 
 /datum/design/item/stock_part/omni_mani
 	id = "omni_mani"
 	req_tech = list(TECH_MATERIAL = 7, TECH_DATA = 4, TECH_PRECURSOR = 2)
-	materials = list(MAT_ALUMINIUM = 2000, MAT_PLASTEEL = 500, MAT_MORPHIUM = 100, MAT_DURASTEEL = 100)
+	materials = list(DEFAULT_WALL_MATERIAL = 2000, MAT_PLASTEEL = 500, MAT_MORPHIUM = 100, MAT_DURASTEEL = 100)
 	build_path = /obj/item/weapon/stock_parts/manipulator/omni
 	sort_string = "AAABE"
 
@@ -93,14 +93,14 @@
 /datum/design/item/stock_part/basic_capacitor
 	id = "basic_capacitor"
 	req_tech = list(TECH_POWER = 1)
-	materials = list(DEFAULT_WALL_MATERIAL = 50, "glass" = 50, MAT_COPPER = 10)
+	materials = list(DEFAULT_WALL_MATERIAL = 50, "glass" = 50)
 	build_path = /obj/item/weapon/stock_parts/capacitor
 	sort_string = "AAACA"
 
 /datum/design/item/stock_part/adv_capacitor
 	id = "adv_capacitor"
 	req_tech = list(TECH_POWER = 3)
-	materials = list(DEFAULT_WALL_MATERIAL = 50, "glass" = 50, MAT_COPPER = 10)
+	materials = list(DEFAULT_WALL_MATERIAL = 50, "glass" = 50)
 	build_path = /obj/item/weapon/stock_parts/capacitor/adv
 	sort_string = "AAACB"
 
@@ -114,7 +114,7 @@
 /datum/design/item/stock_part/hyper_capacitor
 	id = "hyper_capacitor"
 	req_tech = list(TECH_POWER = 6, TECH_MATERIAL = 5, TECH_BLUESPACE = 1, TECH_ARCANE = 1)
-	materials = list(MAT_ALUMINIUM = 200, MAT_GLASS = 100, MAT_VERDANTIUM = 30, MAT_TITANIUM = 25)
+	materials = list(DEFAULT_WALL_MATERIAL = 200, MAT_GLASS = 100, MAT_VERDANTIUM = 30, MAT_DURASTEEL = 25)
 	build_path = /obj/item/weapon/stock_parts/capacitor/hyper
 	sort_string = "AAACD"
 
@@ -130,14 +130,14 @@
 /datum/design/item/stock_part/basic_sensor
 	id = "basic_sensor"
 	req_tech = list(TECH_MAGNET = 1)
-	materials = list(DEFAULT_WALL_MATERIAL = 50, "glass" = 20, MAT_COPPER = 10)
+	materials = list(DEFAULT_WALL_MATERIAL = 50, "glass" = 20)
 	build_path = /obj/item/weapon/stock_parts/scanning_module
 	sort_string = "AAADA"
 
 /datum/design/item/stock_part/adv_sensor
 	id = "adv_sensor"
 	req_tech = list(TECH_MAGNET = 3)
-	materials = list(DEFAULT_WALL_MATERIAL = 50, "glass" = 20, MAT_COPPER = 10)
+	materials = list(DEFAULT_WALL_MATERIAL = 50, "glass" = 20)
 	build_path = /obj/item/weapon/stock_parts/scanning_module/adv
 	sort_string = "AAADB"
 
@@ -151,14 +151,14 @@
 /datum/design/item/stock_part/hyper_sensor
 	id = "hyper_sensor"
 	req_tech = list(TECH_MAGNET = 6, TECH_MATERIAL = 4, TECH_ARCANE = 1)
-	materials = list(MAT_ALUMINIUM = 50, MAT_GLASS = 20, MAT_SILVER = 50, MAT_VERDANTIUM = 40, MAT_TITANIUM = 50)
+	materials = list(DEFAULT_WALL_MATERIAL = 50, MAT_GLASS = 20, MAT_SILVER = 50, MAT_VERDANTIUM = 40, MAT_DURASTEEL = 50)
 	build_path = /obj/item/weapon/stock_parts/scanning_module/hyper
 	sort_string = "AAADD"
 
 /datum/design/item/stock_part/omni_sensor
 	id = "omni_sensor"
 	req_tech = list(TECH_MAGNET = 7, TECH_MATERIAL = 5, TECH_PRECURSOR = 1)
-	materials = list(MAT_ALUMINIUM = 1000, MAT_TITANIUM = 500, MAT_GLASS = 750, MAT_SILVER = 500, MAT_MORPHIUM = 60, MAT_DURASTEEL = 100)
+	materials = list(DEFAULT_WALL_MATERIAL = 1000, MAT_PLASTEEL = 500, MAT_GLASS = 750, MAT_SILVER = 500, MAT_MORPHIUM = 60, MAT_DURASTEEL = 100)
 	build_path = /obj/item/weapon/stock_parts/scanning_module/omni
 	sort_string = "AAADE"
 
@@ -188,14 +188,14 @@
 /datum/design/item/stock_part/hyper_micro_laser
 	id = "hyper_micro_laser"
 	req_tech = list(TECH_MAGNET = 6, TECH_MATERIAL = 6, TECH_ARCANE = 2)
-	materials = list(MAT_ALUMINIUM = 200, MAT_GLASS = 20, MAT_URANIUM = 30, MAT_VERDANTIUM = 50, MAT_TITANIUM = 100)
+	materials = list(DEFAULT_WALL_MATERIAL = 200, MAT_GLASS = 20, MAT_URANIUM = 30, MAT_VERDANTIUM = 50, MAT_DURASTEEL = 100)
 	build_path = /obj/item/weapon/stock_parts/micro_laser/hyper
 	sort_string = "AAAED"
 
 /datum/design/item/stock_part/omni_micro_laser
 	id = "omni_micro_laser"
 	req_tech = list(TECH_MAGNET = 7, TECH_MATERIAL = 7, TECH_PRECURSOR = 2)
-	materials = list(MAT_TITANIUM = 2000, MAT_GLASS = 500, MAT_URANIUM = 2000, MAT_MORPHIUM = 50, MAT_DURASTEEL = 100)
+	materials = list(DEFAULT_WALL_MATERIAL = 2000, MAT_GLASS = 500, MAT_URANIUM = 2000, MAT_MORPHIUM = 50, MAT_DURASTEEL = 100)
 	build_path = /obj/item/weapon/stock_parts/micro_laser/omni
 	sort_string = "AAAEE"
 

--- a/code/modules/research/designs/weapons.dm
+++ b/code/modules/research/designs/weapons.dm
@@ -22,21 +22,21 @@
 /datum/design/item/weapon/energy/stunrevolver
 	id = "stunrevolver"
 	req_tech = list(TECH_COMBAT = 3, TECH_MATERIAL = 3, TECH_POWER = 2)
-	materials = list(DEFAULT_WALL_MATERIAL = 4000, MAT_COPPER = 30)
+	materials = list(DEFAULT_WALL_MATERIAL = 4000)
 	build_path = /obj/item/weapon/gun/energy/stunrevolver
 	sort_string = "MAAAA"
 
 /datum/design/item/weapon/energy/nuclear_gun
 	id = "nuclear_gun"
 	req_tech = list(TECH_COMBAT = 3, TECH_MATERIAL = 5, TECH_POWER = 3)
-	materials = list(DEFAULT_WALL_MATERIAL = 5000, "glass" = 1000, "uranium" = 500, MAT_COPPER = 50)
+	materials = list(DEFAULT_WALL_MATERIAL = 5000, "glass" = 1000, "uranium" = 500)
 	build_path = /obj/item/weapon/gun/energy/gun/nuclear
 	sort_string = "MAAAB"
 
 /datum/design/item/weapon/energy/phoronpistol
 	id = "ppistol"
 	req_tech = list(TECH_COMBAT = 5, TECH_PHORON = 4)
-	materials = list(DEFAULT_WALL_MATERIAL = 5000, "glass" = 1000, "phoron" = 3000, MAT_COPPER = 50)
+	materials = list(DEFAULT_WALL_MATERIAL = 5000, "glass" = 1000, "phoron" = 3000)
 	build_path = /obj/item/weapon/gun/energy/toxgun
 	sort_string = "MAAAC"
 
@@ -44,14 +44,14 @@
 	desc = "The lasing medium of this prototype is enclosed in a tube lined with uranium-235 and subjected to high neutron flux in a nuclear reactor core."
 	id = "lasercannon"
 	req_tech = list(TECH_COMBAT = 4, TECH_MATERIAL = 3, TECH_POWER = 3)
-	materials = list(MAT_TITANIUM = 5000, MAT_BOROSILICATE = 1000, "diamond" = 2000, MAT_COPPER = 50)
+	materials = list(DEFAULT_WALL_MATERIAL = 10000, "glass" = 1000, "diamond" = 2000)
 	build_path = /obj/item/weapon/gun/energy/lasercannon
 	sort_string = "MAAAD"
 
 /datum/design/item/weapon/energy/decloner
 	id = "decloner"
 	req_tech = list(TECH_COMBAT = 8, TECH_MATERIAL = 7, TECH_BIO = 5, TECH_POWER = 6)
-	materials = list(MAT_TITANIUM = 2750, "gold" = 5000,"uranium" = 10000)
+	materials = list("gold" = 5000,"uranium" = 10000)
 	build_path = /obj/item/weapon/gun/energy/decloner
 	sort_string = "MAAAE"
 
@@ -59,14 +59,14 @@
 	desc = "A gun that shoots high-powered glass-encased energy temperature bullets."
 	id = "temp_gun"
 	req_tech = list(TECH_COMBAT = 3, TECH_MATERIAL = 4, TECH_POWER = 3, TECH_MAGNET = 2)
-	materials = list(MAT_ALUMINIUM = 5000, "glass" = 500, "silver" = 3000)
+	materials = list(DEFAULT_WALL_MATERIAL = 5000, "glass" = 500, "silver" = 3000)
 	build_path = /obj/item/weapon/gun/energy/temperature
 	sort_string = "MAAAF"
 
 /datum/design/item/weapon/energy/flora_gun
 	id = "flora_gun"
 	req_tech = list(TECH_MATERIAL = 2, TECH_BIO = 3, TECH_POWER = 3)
-	materials = list(MAT_ALUMINIUM = 2000, "glass" = 500, "uranium" = 500)
+	materials = list(DEFAULT_WALL_MATERIAL = 2000, "glass" = 500, "uranium" = 500)
 	build_path = /obj/item/weapon/gun/energy/floragun
 	sort_string = "MAAAG"
 
@@ -117,15 +117,6 @@
 	build_path = /obj/item/weapon/storage/box/empshells
 	sort_string = "MABBC"
 
-/datum/design/item/weapon/ballistic/ammo/ptrshell
-	name = "14.5mm shell"
-	desc = "A dense-core projectile fired from a small cannon."
-	id = "ptrshell"
-	req_tech = list(TECH_COMBAT = 7, TECH_ILLEGAL = 4)
-	materials = list(MAT_TITANIUM = 4000, MAT_URANIUM = 500, MAT_PLASTEEL = 500)
-	build_path = /obj/item/ammo_casing/a145
-	sort_string = "MABBD"
-
 // Phase weapons
 
 /datum/design/item/weapon/phase/AssembleDesignName()
@@ -135,14 +126,14 @@
 /datum/design/item/weapon/phase/phase_pistol
 	id = "phasepistol"
 	req_tech = list(TECH_COMBAT = 3, TECH_MATERIAL = 2, TECH_POWER = 2)
-	materials = list(DEFAULT_WALL_MATERIAL = 4000, MAT_COPPER = 30)
+	materials = list(DEFAULT_WALL_MATERIAL = 4000)
 	build_path = /obj/item/weapon/gun/energy/phasegun/pistol
 	sort_string = "MACAA"
 
 /datum/design/item/weapon/phase/phase_carbine
 	id = "phasecarbine"
 	req_tech = list(TECH_COMBAT = 4, TECH_MATERIAL = 2, TECH_POWER = 2)
-	materials = list(DEFAULT_WALL_MATERIAL = 6000, "glass" = 1500, MAT_COPPER = 40)
+	materials = list(DEFAULT_WALL_MATERIAL = 6000, "glass" = 1500)
 	build_path = /obj/item/weapon/gun/energy/phasegun
 	sort_string = "MACAB"
 
@@ -165,7 +156,7 @@
 /datum/design/item/weapon/rapidsyringe
 	id = "rapidsyringe"
 	req_tech = list(TECH_COMBAT = 3, TECH_MATERIAL = 3, TECH_ENGINEERING = 3, TECH_BIO = 2)
-	materials = list(DEFAULT_WALL_MATERIAL = 5000, "glass" = 1000, MAT_COPPER = 20)
+	materials = list(DEFAULT_WALL_MATERIAL = 5000, "glass" = 1000)
 	build_path = /obj/item/weapon/gun/launcher/syringe/rapid
 	sort_string = "MADAA"
 
@@ -181,7 +172,7 @@
 	desc = "An advanced chem spraying device."
 	id = "chemsprayer"
 	req_tech = list(TECH_MATERIAL = 3, TECH_ENGINEERING = 3, TECH_BIO = 2)
-	materials = list(DEFAULT_WALL_MATERIAL = 5000, "glass" = 1000, MAT_COPPER = 30)
+	materials = list(DEFAULT_WALL_MATERIAL = 5000, "glass" = 1000)
 	build_path = /obj/item/weapon/reagent_containers/spray/chemsprayer
 	sort_string = "MADAC"
 

--- a/code/modules/research/designs/xenoarch_toys.dm
+++ b/code/modules/research/designs/xenoarch_toys.dm
@@ -9,7 +9,7 @@
 	id = "ano_scanner"
 	desc = "Aids in triangulation of exotic particles."
 	req_tech = list(TECH_BLUESPACE = 3, TECH_MAGNET = 3)
-	materials = list(DEFAULT_WALL_MATERIAL = 10000,"glass" = 5000, MAT_COPPER = 20)
+	materials = list(DEFAULT_WALL_MATERIAL = 10000,"glass" = 5000)
 	build_path = /obj/item/device/ano_scanner
 	sort_string = "GAAAA"
 
@@ -18,7 +18,7 @@
 	id = "xenoarch_multitool"
 	req_tech = list(TECH_MAGNET = 3, TECH_ENGINEERING = 3, TECH_BLUESPACE = 3)
 	build_path = /obj/item/device/xenoarch_multi_tool
-	materials = list(DEFAULT_WALL_MATERIAL = 2000, "glass" = 1000, "uranium" = 500, "phoron" = 500, MAT_COPPER = 40)
+	materials = list(DEFAULT_WALL_MATERIAL = 2000, "glass" = 1000, "uranium" = 500, "phoron" = 500)
 	sort_string = "GAAAB"
 
 /datum/design/item/weapon/xenoarch/excavationdrill
@@ -26,6 +26,6 @@
 	id = "excavationdrill"
 	req_tech = list(TECH_MATERIAL = 3, TECH_POWER = 2, TECH_ENGINEERING = 2, TECH_BLUESPACE = 3)
 	build_type = PROTOLATHE
-	materials = list(DEFAULT_WALL_MATERIAL = 4000, "glass" = 4000, MAT_COPPER = 30)
+	materials = list(DEFAULT_WALL_MATERIAL = 4000, "glass" = 4000)
 	build_path = /obj/item/weapon/pickaxe/excavationdrill
 	sort_string = "GAAAC"

--- a/code/modules/research/designs/xenobio_toys.dm
+++ b/code/modules/research/designs/xenobio_toys.dm
@@ -7,14 +7,14 @@
 /datum/design/item/weapon/xenobio/slimebaton
 	id = "slimebaton"
 	req_tech = list(TECH_MATERIAL = 2, TECH_BIO = 2, TECH_POWER = 3, TECH_COMBAT = 3)
-	materials = list(DEFAULT_WALL_MATERIAL = 5000, MAT_COPPER = 30)
+	materials = list(DEFAULT_WALL_MATERIAL = 5000)
 	build_path = /obj/item/weapon/melee/baton/slime
 	sort_string = "HAAAA"
 
 /datum/design/item/weapon/xenobio/slimetaser
 	id = "slimetaser"
 	req_tech = list(TECH_MATERIAL = 3, TECH_BIO = 3, TECH_POWER = 4, TECH_COMBAT = 4)
-	materials = list(DEFAULT_WALL_MATERIAL = 5000, MAT_COPPER = 40)
+	materials = list(DEFAULT_WALL_MATERIAL = 5000)
 	build_path = /obj/item/weapon/gun/energy/taser/xeno
 	sort_string = "HAAAB"
 
@@ -25,6 +25,6 @@
 	desc = "A hand-held body scanner able to learn information about slimes."
 	id = "slime_scanner"
 	req_tech = list(TECH_MAGNET = 2, TECH_BIO = 2)
-	materials = list(DEFAULT_WALL_MATERIAL = 500, "glass" = 500, MAT_COPPER = 30)
+	materials = list(DEFAULT_WALL_MATERIAL = 500, "glass" = 500)
 	build_path = /obj/item/device/slime_scanner
 	sort_string = "HBAAA"

--- a/code/modules/research/mechfab_designs.dm
+++ b/code/modules/research/mechfab_designs.dm
@@ -357,13 +357,11 @@
 	name = "PBT \"Pacifier\" Mounted Taser"
 	id = "mech_taser"
 	build_path = /obj/item/mecha_parts/mecha_equipment/weapon/energy/taser
-	materials = list(DEFAULT_WALL_MATERIAL = 6500, MAT_COPPER = 1000)
 
 /datum/design/item/mecha/rigged_taser
 	name = "Jury-Rigged Taser"
 	id = "mech_taser-r"
 	build_path = /obj/item/mecha_parts/mecha_equipment/weapon/energy/taser/rigged
-	materials = list(DEFAULT_WALL_MATERIAL = 6500, MAT_COPPER = 200)
 
 /datum/design/item/mecha/shocker
 	name = "Exosuit Electrifier"
@@ -568,7 +566,7 @@
 	desc = "Automated repair droid, exosuits' best companion. BEEP BOOP"
 	id = "mech_repair_droid"
 	req_tech = list(TECH_MAGNET = 3, TECH_DATA = 3, TECH_ENGINEERING = 3)
-	materials = list(DEFAULT_WALL_MATERIAL = 7500, "gold" = 750, "silver" = 1500, MAT_ALUMINIUM = 3750)
+	materials = list(DEFAULT_WALL_MATERIAL = 7500, "gold" = 750, "silver" = 1500, "glass" = 3750)
 	build_path = /obj/item/mecha_parts/mecha_equipment/repair_droid
 
 /datum/design/item/mecha/combat_shield
@@ -592,7 +590,7 @@
 	desc = "Deploys a small medical drone capable of patching small wounds in order to stabilize nearby patients."
 	id = "mech_med_droid"
 	req_tech = list(TECH_PHORON = 3, TECH_MAGNET = 6, TECH_BIO = 5, TECH_DATA = 4, TECH_ARCANE = 1)
-	materials = list(DEFAULT_WALL_MATERIAL = 8000, MAT_GOLD = 2000, MAT_ALUMINIUM = 3750, MAT_VERDANTIUM = 2500, MAT_GLASS = 3000)
+	materials = list(DEFAULT_WALL_MATERIAL = 8000, MAT_GOLD = 2000, MAT_SILVER = 3000, MAT_VERDANTIUM = 2500, MAT_GLASS = 3000)
 	build_path = /obj/item/mecha_parts/mecha_equipment/crisis_drone
 
 /datum/design/item/mecha/rad_drone
@@ -600,7 +598,7 @@
 	desc = "Deploys a small hazmat drone capable of purging minor radiation damage in order to stabilize nearby patients."
 	id = "mech_rad_droid"
 	req_tech = list(TECH_PHORON = 4, TECH_MAGNET = 5, TECH_BIO = 6, TECH_DATA = 4, TECH_ARCANE = 1)
-	materials = list(DEFAULT_WALL_MATERIAL = 8000, MAT_GOLD = 2000, MAT_ALUMINIUM = 2500, MAT_URANIUM = 1000, MAT_VERDANTIUM = 1000, MAT_GLASS = 3000)
+	materials = list(DEFAULT_WALL_MATERIAL = 8000, MAT_GOLD = 2000, MAT_URANIUM = 3000, MAT_VERDANTIUM = 2500, MAT_GLASS = 3000)
 	build_path = /obj/item/mecha_parts/mecha_equipment/crisis_drone/rad
 
 /datum/design/item/mecha/medanalyzer
@@ -608,7 +606,7 @@
 	desc = "An advanced mech-mounted device that is not quite as powerful as a stationary body scanner, though still suitably powerful."
 	id = "mech_med_analyzer"
 	req_tech = list(TECH_PHORON = 4, TECH_MAGNET = 5, TECH_BIO = 5, TECH_DATA = 4)
-	materials = list(MAT_ALUMINIUM = 4500, MAT_GOLD = 2000, MAT_URANIUM = 3000, MAT_GLASS = 3000)
+	materials = list(MAT_PLASTEEL = 4500, MAT_GOLD = 2000, MAT_URANIUM = 3000, MAT_GLASS = 3000)
 	build_path = /obj/item/mecha_parts/mecha_equipment/tool/powertool/medanalyzer
 
 /datum/design/item/mecha/jetpack
@@ -617,7 +615,7 @@
 	id = "mech_jetpack"
 	req_tech = list(TECH_ENGINEERING = 3, TECH_MAGNET = 4) //One less magnet than the actual got-damn teleporter.
 	build_path = /obj/item/mecha_parts/mecha_equipment/tool/jetpack
-	materials = list(MAT_ALUMINIUM = 7500, "silver" = 300, "glass" = 600)
+	materials = list(DEFAULT_WALL_MATERIAL = 7500, "silver" = 300, "glass" = 600)
 
 /datum/design/item/mecha/phoron_generator
 	desc = "Phoron Reactor"
@@ -662,7 +660,7 @@
 	desc = "A heavy duty bore. Bigger, better, stronger than the core sampler, but not quite as good as a large drill."
 	id = "mech_ground_drill"
 	req_tech = list(TECH_MATERIAL = 4, TECH_ENGINEERING = 2, TECH_PHORON = 1)
-	materials = list(MAT_ALUMINIUM = 5000, "silver" = 3000, DEFAULT_WALL_MATERIAL = 2000)
+	materials = list(DEFAULT_WALL_MATERIAL = 7000, "silver" = 3000, "phoron" = 2000)
 	build_path = /obj/item/mecha_parts/mecha_equipment/tool/drill/bore
 
 /datum/design/item/mecha/orescanner
@@ -670,7 +668,7 @@
 	desc = "A hefty device used to scan for subterranean veins of ore."
 	id = "mech_ore_scanner"
 	req_tech = list(TECH_MATERIAL = 2, TECH_MAGNET = 2, TECH_POWER = 2)
-	materials = list(MAT_ALUMINIUM = 3000, MAT_COPPER = 1000, "glass" = 1000)
+	materials = list(DEFAULT_WALL_MATERIAL = 4000, "glass" = 1000)
 	build_path = /obj/item/mecha_parts/mecha_equipment/tool/orescanner
 
 /datum/design/item/mecha/advorescanner
@@ -678,7 +676,7 @@
 	desc = "A hefty device used to scan for the exact volumes of subterranean veins of ore."
 	id = "mech_ore_scanner_adv"
 	req_tech = list(TECH_MATERIAL = 5, TECH_MAGNET = 4, TECH_POWER = 4, TECH_BLUESPACE = 2)
-	materials = list(MAT_ALUMINIUM = 5000, "osmium" = 3000, "silver" = 1000)
+	materials = list(DEFAULT_WALL_MATERIAL = 5000, "osmium" = 3000, "silver" = 1000)
 	build_path = /obj/item/mecha_parts/mecha_equipment/tool/orescanner/advanced
 
 /datum/design/item/mecha/runningboard
@@ -750,7 +748,7 @@
 	desc = "Exosuit-held nuclear reactor. Converts uranium and everyone's health to energy."
 	id = "mech_generator_nuclear"
 	req_tech = list(TECH_POWER= 3, TECH_ENGINEERING = 3, TECH_MATERIAL = 3)
-	materials = list(MAT_ALUMINIUM = 7500, "silver" = 375, MAT_LEAD = 1250)
+	materials = list(DEFAULT_WALL_MATERIAL = 7500, "silver" = 375, "glass" = 750)
 	build_path = /obj/item/mecha_parts/mecha_equipment/generator/nuclear
 
 /datum/design/item/mecha/speedboost_ripley
@@ -758,7 +756,7 @@
 	desc = "System enhancements and overdrives to make a mech's legs move faster."
 	id = "mech_speedboost_ripley"
 	req_tech = list( TECH_POWER = 5, TECH_MATERIAL = 4, TECH_ENGINEERING = 4)
-	materials = list(DEFAULT_WALL_MATERIAL = 10000, MAT_ALUMINIUM = 1000, "gold" = 1000)
+	materials = list(DEFAULT_WALL_MATERIAL = 10000, "silver" = 1000, "gold" = 1000)
 	build_path = /obj/item/mecha_parts/mecha_equipment/speedboost
 
 /datum/design/item/synthetic_flash
@@ -784,7 +782,7 @@
 	desc = "A space-bike's un-assembled frame."
 	id = "vehicle_chassis_spacebike"
 	req_tech = list(TECH_MATERIAL = 5, TECH_ENGINEERING = 6, TECH_BLUESPACE = 3, TECH_PHORON = 3)
-	materials = list(MAT_ALUMINIUM = 9000, "silver" = 3000, "phoron" = 3000, "osmium" = 1000)
+	materials = list(DEFAULT_WALL_MATERIAL = 12000, "silver" = 3000, "phoron" = 3000, "osmium" = 1000)
 	build_path = /obj/item/weapon/vehicle_assembly/spacebike
 
 /datum/design/item/mechfab/vehicle/quadbike_chassis
@@ -926,7 +924,7 @@
 	desc = "A compact cleaning-foam grenade system for a hardsuit."
 	id = "rig_grenade_cleanfoam"
 	req_tech = list(TECH_MATERIAL = 3, TECH_ENGINEERING = 3, TECH_BIO = 2, TECH_POWER = 2)
-	materials = list(MAT_ALUMINIUM = 2000, MAT_GLASS = 1000, MAT_GRAPHITE = 1500, MAT_PLASTIC = 750)
+	materials = list(MAT_PLASTEEL = 2000, MAT_GLASS = 1000, MAT_GRAPHITE = 1500, MAT_PLASTIC = 750)
 	build_path = /obj/item/rig_module/cleaner_launcher
 
 /datum/design/item/mechfab/rigsuit/taser
@@ -934,7 +932,7 @@
 	desc = "A compact taser system for a hardsuit."
 	id = "rig_gun_taser"
 	req_tech = list(TECH_MATERIAL = 5, TECH_ENGINEERING = 3, TECH_MAGNET = 2, TECH_POWER = 3, TECH_COMBAT = 2)
-	materials = list(MAT_ALUMINIUM = 2000, MAT_GRAPHITE = 1500, MAT_PLASTIC = 500)
+	materials = list(MAT_PLASTEEL = 2000, MAT_GRAPHITE = 1500, MAT_PLASTIC = 500)
 	build_path = /obj/item/rig_module/mounted/taser
 
 /datum/design/item/mechfab/rigsuit/egun
@@ -958,7 +956,7 @@
 	desc = "A compact overclocking system for a hardsuit."
 	id = "rig_component_sprinter"
 	req_tech = list(TECH_MATERIAL = 5, TECH_ENGINEERING = 5, TECH_BIO = 4, TECH_POWER = 4)
-	materials = list(MAT_ALUMINIUM = 2000, MAT_GRAPHITE = 1500, MAT_PLASTIC = 500, MAT_VERDANTIUM = 1000)
+	materials = list(MAT_PLASTEEL = 2000, MAT_GRAPHITE = 1500, MAT_PLASTIC = 500, MAT_VERDANTIUM = 1000)
 	build_path = /obj/item/rig_module/sprinter
 
 /datum/design/item/mechfab/rigsuit/meson
@@ -966,7 +964,7 @@
 	desc = "A compact meson visor for a hardsuit."
 	id = "rig_component_meson"
 	req_tech = list(TECH_MATERIAL = 4, TECH_ENGINEERING = 5, TECH_MAGNET = 3, TECH_POWER = 4)
-	materials = list(MAT_ALUMINIUM = 2000, MAT_GRAPHITE = 1500, MAT_OSMIUM = 500)
+	materials = list(MAT_PLASTEEL = 2000, MAT_GRAPHITE = 1500, MAT_OSMIUM = 500)
 	build_path = /obj/item/rig_module/vision/meson
 
 /datum/design/item/mechfab/rigsuit/material
@@ -974,7 +972,7 @@
 	desc = "A compact material visor for a hardsuit."
 	id = "rig_component_material"
 	req_tech = list(TECH_MATERIAL = 4, TECH_ENGINEERING = 5, TECH_MAGNET = 3, TECH_POWER = 4)
-	materials = list(MAT_ALUMINIUM = 2000, MAT_GRAPHITE = 1500, MAT_OSMIUM = 500)
+	materials = list(MAT_PLASTEEL = 2000, MAT_GRAPHITE = 1500, MAT_OSMIUM = 500)
 	build_path = /obj/item/rig_module/vision/material
 
 /datum/design/item/mechfab/rigsuit/nvg
@@ -982,7 +980,7 @@
 	desc = "A compact night-vision visor for a hardsuit."
 	id = "rig_component_nvg"
 	req_tech = list(TECH_MATERIAL = 5, TECH_ENGINEERING = 6, TECH_MAGNET = 4, TECH_POWER = 5)
-	materials = list(MAT_ALUMINIUM = 2000, MAT_GRAPHITE = 1500, MAT_OSMIUM = 500, MAT_URANIUM = 1000)
+	materials = list(MAT_PLASTEEL = 2000, MAT_GRAPHITE = 1500, MAT_OSMIUM = 500, MAT_URANIUM = 1000)
 	build_path = /obj/item/rig_module/vision/nvg
 
 /datum/design/item/mechfab/rigsuit/sechud
@@ -990,7 +988,7 @@
 	desc = "A compact security visor for a hardsuit."
 	id = "rig_component_sechud"
 	req_tech = list(TECH_MATERIAL = 4, TECH_ENGINEERING = 3, TECH_MAGNET = 3, TECH_POWER = 2)
-	materials = list(MAT_ALUMINIUM = 2000, MAT_GRAPHITE = 1500, MAT_PLASTIC = 500, MAT_SILVER = 500)
+	materials = list(MAT_PLASTEEL = 2000, MAT_GRAPHITE = 1500, MAT_PLASTIC = 500, MAT_SILVER = 500)
 	build_path = /obj/item/rig_module/vision/sechud
 
 /datum/design/item/mechfab/rigsuit/medhud
@@ -998,7 +996,7 @@
 	desc = "A compact medical visor for a hardsuit."
 	id = "rig_component_medhud"
 	req_tech = list(TECH_MATERIAL = 4, TECH_ENGINEERING = 3, TECH_MAGNET = 3, TECH_BIO = 2)
-	materials = list(MAT_ALUMINIUM = 2000, MAT_GRAPHITE = 1500, MAT_PLASTIC = 500, MAT_SILVER = 500)
+	materials = list(MAT_PLASTEEL = 2000, MAT_GRAPHITE = 1500, MAT_PLASTIC = 500, MAT_SILVER = 500)
 	build_path = /obj/item/rig_module/vision/medhud
 
 /datum/design/item/mechfab/rigsuit/voice
@@ -1030,7 +1028,7 @@
 	desc = "A compact chemical injector network for a hardsuit."
 	id = "rig_component_chemicals"
 	req_tech = list(TECH_MATERIAL = 5, TECH_ENGINEERING = 5, TECH_MAGNET = 5, TECH_BIO = 4)
-	materials = list(MAT_ALUMINIUM = 3000, MAT_GRAPHITE = 2000, MAT_PLASTIC = 3500, MAT_SILVER = 1750, MAT_GOLD = 1250)
+	materials = list(MAT_PLASTEEL = 3000, MAT_GRAPHITE = 2000, MAT_PLASTIC = 3500, MAT_SILVER = 1750, MAT_GOLD = 1250)
 	build_path = /obj/item/rig_module/chem_dispenser/injector/advanced/empty
 
 /datum/design/item/mechfab/rigsuit/teleporter
@@ -1047,7 +1045,7 @@
 	build_path = /obj/item/device/uav
 	time = 20
 	req_tech = list(TECH_MATERIAL = 6, TECH_ENGINEERING = 5, TECH_PHORON = 3, TECH_MAGNET = 4, TECH_POWER = 6)
-	materials = list(MAT_ALUMINIUM = 5000, "glass" = 6000, MAT_COPPER = 4000)
+	materials = list(DEFAULT_WALL_MATERIAL = 10000, "glass" = 6000, "silver" = 4000)
 
 // Exosuit Internals
 
@@ -1069,7 +1067,7 @@
 	category = "Exosuit Internals"
 	id = "exo_int_armor_lightweight"
 	req_tech = list(TECH_MATERIAL = 2, TECH_ENGINEERING = 3)
-	materials = list(MAT_ALUMINIUM = 5000, MAT_PLASTIC = 3000)
+	materials = list(DEFAULT_WALL_MATERIAL = 5000, MAT_PLASTIC = 3000)
 	build_path = /obj/item/mecha_parts/component/armor/lightweight
 
 /datum/design/item/mechfab/exointernal/reinf_armor


### PR DESCRIPTION
Blanket revert of recipe changes by #7811 
Part 2 of, and afaict fixes #7885

These changes weren't sufficiently discussed, and have been met with widespread disapproval at the increased complexity, tedium, and reliance upon mining. Sufficient quantities of copper, titanium, and aluminum were not mapped in to accompany these changes, meaning cargo, engineering, and research are far more reliant upon mining to do various pieces of their jobs.

Recipes may later be changed to use these new materials, but not before more serious consideration of how accessible the materials for those recipes should be.