### PR TITLE
Spear Recalibration

### DIFF
--- a/code/game/objects/items/weapons/material/twohanded.dm
+++ b/code/game/objects/items/weapons/material/twohanded.dm
@@ -149,9 +149,9 @@
 	force = 10
 	w_class = ITEMSIZE_LARGE
 	slot_flags = SLOT_BACK
-	force_divisor = 0.5 			// 15 when wielded with hardness 30 (glass)
-	unwielded_force_divisor = 0.375
-	thrown_force_divisor = 1.5 		// 22.5 when thrown with weight 15 (glass)
+	force_divisor = 0.3 			// 30 force with a durasteel spear, 24 with plasteel.
+	unwielded_force_divisor = 0.375 // One-handing it does 11.25 damage with durasteel, 9 for plasteel.
+	thrown_force_divisor = 1.5 		// 33.75 throwing force when throwing a durasteel spear, 27 with plasteel. Throwforce uses one-handed damage.
 	throw_speed = 3
 	edge = 0
 	sharp = 1
@@ -163,6 +163,7 @@
 	fragile = 1	//It's a haphazard thing of glass, wire, and steel
 	reach = 2 // Spears are long.
 	attackspeed = 14
+	slowdown = 1 // Spears are also long, bulky, and heavy, so this might help reduce them from being godly to kite with.
 
 /obj/item/weapon/material/twohanded/riding_crop
 	name = "riding crop"


### PR DESCRIPTION
People were complaining that spears were op, so have a balance PR with too much overthinking included.

### Changes
This PR changes spears in the following way:
- Spear damage values have been balanced around durasteel (100% strength) and plasteel (80% strength). The comments previous imply the numbers were balanced around glass, which if true might account for the wonky numbers previously there.
- `force_divisor` reduced from 0.5 to 0.3. 
  - This effectively reduces spear damage by 40%.
  - This makes durasteel spears do 30 damage, from 50.
  - Plasteel spears now do 24 damage, from 40.
  - Somewhat unintuitively, this also scales the one-handed and thrown damage, without needing to touch the related variables, by roughly 40%.
  - One-Handed Damage:
    - One-handing a durasteel spear does 11 damage, down from 18.
    - A plasteel spear one-handed does 9 damage, down from 15.
    - It no longer eclipses the stunbaton/other 1h 15 force weapons.
  - Thrown Damage:
    - Thrown durasteel spears now do 16 damage, down from 27.
    - Thrown plasteel spears now do 13 damage, down from 22.
    - This can be adjusted if there is a desire to have throwing be part of the spear's niche (again), however be wary of pneumatic cannons.
- Carrying a spear now slows the holder by 1, equivalent to wearing a dufflebag.

### Rationale
This is being done in order to try to tune spears, while still preserving their identity as a weapon that can make attacks at a longer range compared to standard melee weapons. Spears being able to attack from a small distance away is a somewhat common ability in various roguelikes such as Dungeon Crawl Stone Soup and Cata DDA.

I feel that reaching attacks is beneficial to have on Polaris, and that the reaching attack is integral to the identity of the spear as a weapon, yet it's also incredibly potent for reasons detailed later in this ~~essay~~ PR, thus more measures are presumably needed beyond just a damage adjustment. For that, I've chosen adding some slowdown to the spear, to try to make the weapon feel more of a situational weapon as opposed to just the best choice in 9 out of 10 situations. The goal is also to make it less attractive as an option for kiting forever, but instead be a good choice for when fighting among other people (can attack 'over' your friends), or when defending a fortified position (can attack over certain fortifications like tables).


### Numbers
Spears are a rather big outlier, but they're not alone, as you'll see below. The true OPness is in fireaxes imo.
|Name                                      |Damage | Attack Speed | DPS* | Armor Pen | Hands |
| ------------------------------------- |------------| -----------------|--------|---------------|----------|
| Durasteel Spear (Current)      | **50**      | 1.4s               | 35.71|0                |2           |
| Plasteel Spear (Current)         | 40          | 1.4s              | 28.57|0                 |2           |
| Durasteel Spear (Proposed)   | 30          | 1.4s              | 17.14|0                 |2           |
| Plasteel Spear (Proposed)      | 24          | 1.4s              | 21.42|0                 |2           |
| Durasteel Baseball Bat            | 30          | 0.8s              | 37.5|0                  |2           |
| Plasteel Baseball Bat              | 25          | 0.8s              | 31.25|0                 |2           |
| Fireaxe                                   | 42          | 0.8s              | **52.5**|0              |2           |
| Energy Sword                         | 30          | 0.8s              | 37.5|50                 |1           |
| Stunbaton                               | 15          | 0.8s              | 18.75|0                 |1           |

### *A Note on DPS
In my opinion, 'DPS' is a useful metric to know, but it's also not one to rely on too heavily, since most fights don't involve two people running up to each other and clicking each other until one of them goes horizontal. Instead, one or both sides will try to maneuver around, in order to protect themselves, to get an advantage over their opponent, and to avoid their opponent from getting one. Doing that tends to hurt DPS (especially for melee), since it implies not being able have 100% uptime for attacking.

The result is that weapons with a longer delay between attacks tend to not be disadvantaged too hard by a longer attack delay, and instead the base damage becomes more important, because the delay can be filled by maneuvering or otherwise protecting yourself in some form (hiding in cover, kiting a spider, etc). This is especially potent if one side has the ability to out-maneuver the other side (they are very fast, opponent is trapped somewhere, etc), and thus be able to dictate the pace of the fight, hence why speed is very valuable in fighting. This is typically the case in fights against simplemobs and most blobs, since players generally can engage and disengage at will, provided that they are healthy and otherwise not slowed down or incapacitated in some way.

In that situation, the initial damage is generally more important than the DPS, since attacks are more sporadic. Slow but high damage hits also tend to be more impactful, in terms of causing conditions such as broken bones or IB. Spears are often used in that kind of fight, and excel at it due to the ability to attack from two tiles away, as well as having very high damage. The range especially makes tactics such as kiting very attractive, if the person doing it has a higher speed than their opponent, which for simplemobs and blobs, is generally true, as the attacker can attack with no risk coming to them (assuming their opponent does not have a ranged attack themselves).

The changes in this PR will hopefully help by reducing the raw damage from each hit, and the slowdown reducing the viability to endless kiting.