### PR TITLE
Adds admin verb to hopefully fix database connection failures

### DIFF
--- a/code/modules/admin/admin_verb_lists.dm
+++ b/code/modules/admin/admin_verb_lists.dm
@@ -185,7 +185,8 @@ var/list/admin_verbs_server = list(
 	/client/proc/panicbunker,
 	/client/proc/paranoia_logging,
 	/client/proc/ip_reputation,
-	/client/proc/debug_global_variables
+	/client/proc/debug_global_variables,
+	/client/proc/dbcon_fix
 	)
 
 var/list/admin_verbs_debug = list(

--- a/code/modules/admin/verbs/dbcon_fix.dm
+++ b/code/modules/admin/verbs/dbcon_fix.dm
@@ -1,0 +1,39 @@
+// Will hoepfully fix the database when it breaks
+// Use case: if the server is left in the lobby for long enough,  players that join will see player_age = 0, restricting them from all age-locked jobs.
+/client/proc/dbcon_fix()
+	set name = "Fix Database Connection"
+	set category = "Server"
+	set desc = "Experimental: Will hopefully perform a one-button fix for a database connection that has timed out."
+
+	if(!check_rights(R_ADMIN|R_DEBUG|R_FUN))
+		to_chat(src, "You must be an admin to do this.")
+		return FALSE
+
+	log_admin("Attempting to fix database connection")
+	if(dbcon.IsConnected())
+		dbcon.Disconnect()
+	else
+		log_admin("Database already disconnected")
+	
+	establish_db_connection()
+	var/errno = dbcon.ErrorMsg()
+	if(errno)
+		log_admin("Database connection returned error message `[errno]`. Aborting.")
+		return FALSE
+	if(!dbcon.IsConnected())
+		log_admin("Database could not be reconnected! Aborting.")
+		return FALSE
+	log_admin("Database reconnected. Fixing player ages...")	
+
+	var/num = 0
+	for(var/client/C in GLOB.clients)
+		C.log_client_to_db()
+		errno = dbcon.ErrorMsg()
+		if(errno)
+			log_admin("Database connection returned error message `[errno]` after adjusting player ages for [num] players. [C] was being updated when the error struck. Aborting.")
+			return FALSE
+		if(C.player_age)
+			num++
+	
+	log_admin("Successfully updated non-0 player age for [num] clients.")
+	return FALSE

--- a/polaris.dme
+++ b/polaris.dme
@@ -1420,6 +1420,7 @@
 #include "code\modules\admin\verbs\check_customitem_activity.dm"
 #include "code\modules\admin\verbs\cinematic.dm"
 #include "code\modules\admin\verbs\custom_event.dm"
+#include "code\modules\admin\verbs\dbcon_fix.dm"
 #include "code\modules\admin\verbs\deadsay.dm"
 #include "code\modules\admin\verbs\debug.dm"
 #include "code\modules\admin\verbs\diagnostics.dm"


### PR DESCRIPTION
Will be tested live on the server if/when the issue happens again and someone remembers to test this.
Has lots of output to try and determine what actually goes wrong with it.

> `view-global-variables`
> > Select `dbcon`
> > > Call Proc `Disconnect`, no parameters
> 
> `Advanced-ProcCall`, proc is NOT owned by something, `/proc/establish_database_connection`, no parameters
> `SDQL2-query` "CALL log_client_to_db() ON /mob WHERE client MAP client"