### PR TITLE
SSpersistence tweaks

### DIFF
--- a/code/__defines/map.dm
+++ b/code/__defines/map.dm
@@ -7,6 +7,7 @@
 #define MAP_LEVEL_EMPTY			0x020 // Empty Z-levels that may be used for various things (currently used by bluespace jump)
 #define MAP_LEVEL_CONSOLES		0x040 // Z-levels available to various consoles, such as the crew monitor (when that gets coded in). Defaults to station_levels if unset.
 #define MAP_LEVEL_XENOARCH_EXEMPT 0x080	// Z-levels exempt from xenoarch digsite generation.
+#define MAP_LEVEL_PERSIST       0x100   // Z-levels where SSpersistence should persist between rounds
 
 // Misc map defines.
 #define SUBMAP_MAP_EDGE_PAD 15 // Automatically created submaps are forbidden from being this close to the main map's edge.

--- a/code/controllers/subsystems/persistence.dm
+++ b/code/controllers/subsystems/persistence.dm
@@ -32,8 +32,7 @@ SUBSYSTEM_DEF(persistence)
 	if(!A || (A.flags & AREA_FLAG_IS_NOT_PERSISTENT))
 		return
 
-//	if((!T.z in GLOB.using_map.station_levels) || !initialized)
-	if(!T.z in using_map.station_levels)
+	if(!(T.z in using_map.persist_levels))
 		return
 
 	if(!tracking_values[track_type])

--- a/code/modules/food/kitchen/smartfridge/engineering.dm
+++ b/code/modules/food/kitchen/smartfridge/engineering.dm
@@ -9,6 +9,9 @@
 /obj/machinery/smartfridge/sheets/persistent
 	persistent = /datum/persistent/storage/smartfridge/sheet_storage
 
+/obj/machinery/smartfridge/sheets/persistent_lossy
+	persistent = /datum/persistent/storage/smartfridge/sheet_storage/lossy
+
 /obj/machinery/smartfridge/sheets/accept_check(var/obj/item/O)
 	return istype(O, /obj/item/stack/material)
 

--- a/code/modules/food/kitchen/smartfridge/hydroponics.dm
+++ b/code/modules/food/kitchen/smartfridge/hydroponics.dm
@@ -1,5 +1,5 @@
 /obj/machinery/smartfridge/produce
-	name = "\improper SmartFridge"
+	name = "\improper Smart Produce Storage"
 	desc = "For storing all sorts of perishable foods!"
 	icon = 'icons/obj/vending.dmi'
 	icon_state = "fridge_food"
@@ -8,6 +8,9 @@
 
 /obj/machinery/smartfridge/produce/persistent
 	persistent = /datum/persistent/storage/smartfridge/produce
+
+/obj/machinery/smartfridge/produce/persistent_lossy
+	persistent = /datum/persistent/storage/smartfridge/produce/lossy
 
 /obj/machinery/smartfridge/produce/accept_check(var/obj/item/O as obj)
 	if(istype(O,/obj/item/weapon/reagent_containers/food/snacks/grown/) || istype(O,/obj/item/seeds/))

--- a/code/modules/food/kitchen/smartfridge/smartfridge.dm
+++ b/code/modules/food/kitchen/smartfridge/smartfridge.dm
@@ -13,7 +13,7 @@
 	idle_power_usage = 5
 	active_power_usage = 100
 	flags = NOREACT
-	var/global/max_n_of_items = 999 // Sorry but the BYOND infinite loop detector doesn't look things over 1000.
+	var/max_n_of_items = 999 // Sorry but the BYOND infinite loop detector doesn't look things over 1000.
 	var/list/item_records = list()
 	var/datum/stored_item/currently_vending = null	//What we're putting out of the machine.
 	var/stored_datum_type = /datum/stored_item
@@ -32,8 +32,8 @@
 	icon_base = "fridge_sci"
 	icon_contents = "chem"
 
-/obj/machinery/smartfridge/New()
-	..()
+/obj/machinery/smartfridge/Initialize()
+	. = ..()
 	if(persistent)
 		SSpersistence.track_value(src, persistent)
 	if(is_secure)

--- a/code/modules/persistence/datum/persistence_datum.dm
+++ b/code/modules/persistence/datum/persistence_datum.dm
@@ -5,13 +5,9 @@
 /datum/persistent
 	var/name = null
 	var/filename
-	var/tokens_per_line
 	var/entries_expire_at						// Set in rounds, this controls when the item is finally removed permanently regardless if cleaned or not.
 	var/entries_decay_at						// Set in rounds. This controls when item messages start getting scrambled.
 	var/entry_decay_weight = 0.5
-	var/file_entry_split_character = "\t"
-	var/file_entry_substitute_character = " "
-	var/file_line_split_character =  "\n"
 	var/has_admin_data
 
 /datum/persistent/New()
@@ -20,65 +16,57 @@
 
 /datum/persistent/proc/SetFilename()
 	if(name)
-		filename = "data/persistent/[lowertext(using_map.name)]-[lowertext(name)].txt"
+		filename = "data/persistent/[lowertext(using_map.name)]-[lowertext(name)].json"
 	if(!isnull(entries_decay_at) && !isnull(entries_expire_at))
 		entries_decay_at = round(entries_expire_at * entries_decay_at)
 
-// Reads in list of text tokens taken from file, generates labelled list of actual token values
-/datum/persistent/proc/LabelTokens(var/list/tokens)
-	var/list/labelled_tokens = list()
-	labelled_tokens["x"] = text2num(tokens[1])
-	labelled_tokens["y"] = text2num(tokens[2])
-	labelled_tokens["z"] = text2num(tokens[3])
-	labelled_tokens["age"] = text2num(tokens[4])
-	return labelled_tokens
-
-/datum/persistent/proc/GetValidTurf(var/turf/T, var/list/tokens)
-	if(T && CheckTurfContents(T, tokens))
+/datum/persistent/proc/GetValidTurf(var/turf/T, var/list/token)
+	if(T && CheckTurfContents(T, token))
 		return T
 
-/datum/persistent/proc/CheckTurfContents(var/turf/T, var/list/tokens)
+/datum/persistent/proc/CheckTurfContents(var/turf/T, var/list/token)
 	return TRUE
 
-/datum/persistent/proc/CheckTokenSanity(var/list/tokens)
+/datum/persistent/proc/CheckTokenSanity(var/list/token)
 	return ( \
-		!isnull(tokens["x"]) && \
-		!isnull(tokens["y"]) && \
-		!isnull(tokens["z"]) && \
-		!isnull(tokens["age"]) && \
-		tokens["age"] <= entries_expire_at \
+		!isnull(token["x"]) && \
+		!isnull(token["y"]) && \
+		!isnull(token["z"]) && \
+		!isnull(token["age"]) && \
+		token["age"] <= entries_expire_at \
 	)
 
 // Restores saved data to world
-/datum/persistent/proc/CreateEntryInstance(var/turf/creating, var/list/tokens)
+/datum/persistent/proc/CreateEntryInstance(var/turf/creating, var/list/token)
 	return
 
 /datum/persistent/proc/ProcessAndApplyTokens(var/list/tokens)
 
 	// If it's old enough we start to trim down any textual information and scramble strings.
-	if(tokens["message"] && !isnull(entries_decay_at) && !isnull(entry_decay_weight))
-		var/_n =       tokens["age"]
-		var/_message = tokens["message"]
-		if(_n >= entries_decay_at)
-			var/decayed_message = ""
-			for(var/i = 1 to length(_message))
-				var/char = copytext(_message, i, i + 1)
-				if(prob(round(_n * entry_decay_weight)))
-					if(prob(99))
-						decayed_message += pick(".",",","-","'","\\","/","\"",":",";")
-				else
-					decayed_message += char
-			_message = decayed_message
-		if(length(_message))
-			tokens["message"] = _message
-		else
-			return
+	for(var/list/token in tokens)
+		if(token["message"] && !isnull(entries_decay_at) && !isnull(entry_decay_weight))
+			var/_n =       token["age"]
+			var/_message = token["message"]
+			if(_n >= entries_decay_at)
+				var/decayed_message = ""
+				for(var/i = 1 to length(_message))
+					var/char = copytext(_message, i, i + 1)
+					if(prob(round(_n * entry_decay_weight)))
+						if(prob(99))
+							decayed_message += pick(".",",","-","'","\\","/","\"",":",";")
+					else
+						decayed_message += char
+				_message = decayed_message
+			if(length(_message))
+				token["message"] = _message
+			else
+				return
 
-	var/_z = tokens["z"]
-	if(_z in using_map.station_levels)
-		. = GetValidTurf(locate(tokens["x"], tokens["y"], _z), tokens)
-		if(.)
-			CreateEntryInstance(., tokens)
+		var/_z = token["z"]
+		if(_z in using_map.station_levels)
+			. = GetValidTurf(locate(token["x"], token["y"], _z), token)
+			if(.)
+				CreateEntryInstance(., token)
 
 /datum/persistent/proc/IsValidEntry(var/atom/entry)
 	if(!istype(entry))
@@ -99,46 +87,45 @@
 /datum/persistent/proc/CompileEntry(var/atom/entry)
 	var/turf/T = get_turf(entry)
 	return list(
-		T.x,
-		T.y,
-		T.z,
-		GetEntryAge(entry)
+		"x" = T.x,
+		"y" = T.y,
+		"z" = T.z,
+		"age" = GetEntryAge(entry)
 	)
 
 /datum/persistent/proc/Initialize()
 	if(fexists(filename))
-		for(var/entry_line in file2list(filename, file_line_split_character))
-			if(!entry_line)
-				continue
-			var/list/tokens = splittext(entry_line, file_entry_split_character)
-			if(LAZYLEN(tokens) < tokens_per_line)
-				continue
-			tokens = LabelTokens(tokens)
-			if(!CheckTokenSanity(tokens))
-				continue
-			ProcessAndApplyTokens(tokens)
+		var/list/tokens = json_decode(file2text(filename))
+		for(var/list/token in tokens)
+			if(!CheckTokenSanity(token))
+				tokens -= token
+		ProcessAndApplyTokens(tokens)
 
 /datum/persistent/proc/Shutdown()
 	if(fexists(filename))
 		fdel(filename)
-	var/write_file = file(filename)
+	
+	var/list/to_store = list()
 	for(var/thing in SSpersistence.tracking_values[type])
-		if(IsValidEntry(thing))
-			var/list/entry = CompileEntry(thing)
-			if(tokens_per_line == PERSISTENCE_VARIABLE_TOKEN_LENGTH || \
-					LAZYLEN(entry) == tokens_per_line)
-				for(var/i = 1 to LAZYLEN(entry))
-					if(istext(entry[i]))
-						entry[i] = replacetext(entry[i], file_entry_split_character, file_entry_substitute_character)
-				to_file(write_file, jointext(entry, file_entry_split_character))
+		if(!IsValidEntry(thing))
+			continue
+		to_store[++to_store.len] = CompileEntry(thing)
+
+	if(to_store.len)
+		to_file(file(filename), json_encode(to_store))
 
 /datum/persistent/proc/RemoveValue(var/atom/value)
 	qdel(value)
 
 /datum/persistent/proc/GetAdminSummary(var/mob/user, var/can_modify)
+	var/list/my_tracks = SSpersistence.tracking_values[type]
+	if(!my_tracks?.len)
+		return
+	
 	. = list("<tr><td colspan = 4><b>[capitalize(name)]</b></td></tr>")
 	. += "<tr><td colspan = 4><hr></td></tr>"
-	for(var/thing in SSpersistence.tracking_values[type])
+	
+	for(var/thing in my_tracks)
 		. += "<tr>[GetAdminDataStringFor(thing, can_modify, user)]</tr>"
 	. += "<tr><td colspan = 4><hr></td></tr>"
 

--- a/code/modules/persistence/effects/filth.dm
+++ b/code/modules/persistence/effects/filth.dm
@@ -1,26 +1,22 @@
 /datum/persistent/filth
 	name = "filth"
-	tokens_per_line = 5
-	entries_expire_at = 5
-
-/datum/persistent/filth/LabelTokens(var/list/tokens)
-	var/list/labelled_tokens = ..()
-	labelled_tokens["path"] = text2path(tokens[LAZYLEN(labelled_tokens)+1])
-	return labelled_tokens
+	entries_expire_at = 4 // 4 rounds, 24 hours.
 
 /datum/persistent/filth/IsValidEntry(var/atom/entry)
 	. = ..() && entry.invisibility == 0
 
-/datum/persistent/filth/CheckTokenSanity(var/list/tokens)
-	return ..() && ispath(tokens["path"])
+/datum/persistent/filth/CheckTokenSanity(var/list/token)
+	// byond's json implementation is "questionable", and uses types as keys and values without quotes sometimes even though they aren't valid json
+	token["path"] = istext(token["path"]) ? text2path(token["path"]) : token["path"]
+	return ..() && ispath(token["path"])
 
-/datum/persistent/filth/CheckTurfContents(var/turf/T, var/list/tokens)
-	var/_path = tokens["path"]
+/datum/persistent/filth/CheckTurfContents(var/turf/T, var/list/token)
+	var/_path = token["path"]
 	return (locate(_path) in T) ? FALSE : TRUE
 
-/datum/persistent/filth/CreateEntryInstance(var/turf/creating, var/list/tokens)
-	var/_path = tokens["path"]
-	new _path(creating, tokens["age"]+1)
+/datum/persistent/filth/CreateEntryInstance(var/turf/creating, var/list/token)
+	var/_path = token["path"]
+	new _path(creating, token["age"]+1)
 
 /datum/persistent/filth/GetEntryAge(var/atom/entry)
 	var/obj/effect/decal/cleanable/filth = entry
@@ -32,4 +28,4 @@
 
 /datum/persistent/filth/CompileEntry(var/atom/entry)
 	. = ..()
-	LAZYADD(., "[GetEntryPath(entry)]")
+	LAZYADDASSOC(., "path", "[GetEntryPath(entry)]")

--- a/code/modules/persistence/effects/graffiti.dm
+++ b/code/modules/persistence/effects/graffiti.dm
@@ -1,22 +1,14 @@
 /datum/persistent/graffiti
 	name = "graffiti"
-	tokens_per_line = 6
-	entries_expire_at = 50
+	entries_expire_at = 4 // This previously was at 50 rounds??? Over 10 days.
 	has_admin_data = TRUE
 
-/datum/persistent/graffiti/LabelTokens(var/list/tokens)
-	var/list/labelled_tokens = ..()
-	var/entries = LAZYLEN(labelled_tokens)
-	labelled_tokens["author"] =  tokens[entries+1]
-	labelled_tokens["message"] = tokens[entries+2]
-	return labelled_tokens
-
-/datum/persistent/graffiti/GetValidTurf(var/turf/T, var/list/tokens)
+/datum/persistent/graffiti/GetValidTurf(var/turf/T, var/list/token)
 	var/turf/checking_turf = ..()
 	if(istype(checking_turf) && checking_turf.can_engrave())
 		return checking_turf
 
-/datum/persistent/graffiti/CheckTurfContents(var/turf/T, var/list/tokens)
+/datum/persistent/graffiti/CheckTurfContents(var/turf/T, var/list/token)
 	var/too_much_graffiti = 0
 	for(var/obj/effect/decal/writing/W in .)
 		too_much_graffiti++
@@ -24,8 +16,10 @@
 			return FALSE
 	return TRUE
 
-/datum/persistent/graffiti/CreateEntryInstance(var/turf/creating, var/list/tokens)
-	new /obj/effect/decal/writing(creating, tokens["age"]+1, tokens["message"], tokens["author"])
+/datum/persistent/graffiti/CreateEntryInstance(var/turf/creating, var/list/token)
+	var/obj/effect/decal/writing/inst = new /obj/effect/decal/writing(creating, token["age"]+1, token["message"], token["author"])
+	if(token["icon_state"])
+		inst.icon_state = token["icon_state"]
 
 /datum/persistent/graffiti/IsValidEntry(var/atom/entry)
 	. = ..()
@@ -40,8 +34,9 @@
 /datum/persistent/graffiti/CompileEntry(var/atom/entry, var/write_file)
 	. = ..()
 	var/obj/effect/decal/writing/save_graffiti = entry
-	LAZYADD(., "[save_graffiti.author ? save_graffiti.author : "unknown"]")
-	LAZYADD(., "[save_graffiti.message]")
+	LAZYADDASSOC(., "author", "[save_graffiti.author ? save_graffiti.author : "unknown"]")
+	LAZYADDASSOC(., "message", "[save_graffiti.message]")
+	LAZYADDASSOC(., "icon_state", "[save_graffiti.icon_state]")
 
 /datum/persistent/graffiti/GetAdminDataStringFor(var/thing, var/can_modify, var/mob/user)
 	var/obj/effect/decal/writing/save_graffiti = thing

--- a/code/modules/persistence/effects/paper.dm
+++ b/code/modules/persistence/effects/paper.dm
@@ -1,32 +1,24 @@
 /datum/persistent/paper
 	name = "paper"
-	tokens_per_line = 7
 	entries_expire_at = 50
 	has_admin_data = TRUE
 	var/paper_type = /obj/item/weapon/paper
 	var/requires_noticeboard = TRUE
 
-/datum/persistent/paper/LabelTokens(var/list/tokens)
-	var/list/labelled_tokens = ..()
-	var/entries = LAZYLEN(labelled_tokens)
-	labelled_tokens["author"] =  tokens[entries+1]
-	labelled_tokens["message"] = tokens[entries+2]
-	labelled_tokens["title"] = tokens[entries+3]
-	return labelled_tokens
-
-/datum/persistent/paper/CheckTurfContents(var/turf/T, var/list/tokens)
+/datum/persistent/paper/CheckTurfContents(var/turf/T, var/list/token)
 	if(requires_noticeboard && !(locate(/obj/structure/noticeboard) in T))
 		new /obj/structure/noticeboard(T)
 	. = ..()
 
-/datum/persistent/paper/CreateEntryInstance(var/turf/creating, var/list/tokens)
+/datum/persistent/paper/CreateEntryInstance(var/turf/creating, var/list/token)
 	var/obj/structure/noticeboard/board = locate() in creating
 	if(requires_noticeboard && LAZYLEN(board.notices) >= board.max_notices)
 		return
 	var/obj/item/weapon/paper/paper = new paper_type(creating)
-	paper.info = tokens["message"]
-	paper.name = tokens["title"]
-	paper.last_modified_ckey = tokens["author"]
+	paper.info = token["message"]
+	paper.name = token["title"]
+	paper.last_modified_ckey = token["author"]
+	paper.age = token["age"]+1
 	if(requires_noticeboard)
 		board.add_paper(paper)
 	if(!paper.was_maploaded) // If we were created/loaded when the map was made, skip us!
@@ -40,9 +32,9 @@
 /datum/persistent/paper/CompileEntry(var/atom/entry, var/write_file)
 	. = ..()
 	var/obj/item/weapon/paper/paper = entry
-	LAZYADD(., "[paper.last_modified_ckey ? paper.last_modified_ckey : "unknown"]")
-	LAZYADD(., "[paper.info]")
-	LAZYADD(., "[paper.name]")
+	LAZYADDASSOC(., "author", "[paper.last_modified_ckey ? paper.last_modified_ckey : "unknown"]")
+	LAZYADDASSOC(., "message", "[paper.info]")
+	LAZYADDASSOC(., "name", "[paper.name]")
 
 /datum/persistent/paper/GetAdminDataStringFor(var/thing, var/can_modify, var/mob/user)
 	var/obj/item/weapon/paper/paper = thing

--- a/code/modules/persistence/effects/paper_sticky.dm
+++ b/code/modules/persistence/effects/paper_sticky.dm
@@ -2,27 +2,18 @@
 	name = "stickynotes"
 	paper_type = /obj/item/weapon/paper/sticky
 	requires_noticeboard = FALSE
-	tokens_per_line = 10
 
-/datum/persistent/paper/sticky/LabelTokens(var/list/tokens)
-	var/list/labelled_tokens = ..()
-	var/entries = LAZYLEN(labelled_tokens)
-	labelled_tokens["offset_x"] = tokens[entries+1]
-	labelled_tokens["offset_y"] = tokens[entries+2]
-	labelled_tokens["color"] =    tokens[entries+3]
-	return labelled_tokens
-
-/datum/persistent/paper/sticky/CreateEntryInstance(var/turf/creating, var/list/tokens)
+/datum/persistent/paper/sticky/CreateEntryInstance(var/turf/creating, var/list/token)
 	var/atom/paper = ..()
 	if(paper)
-		paper.pixel_x = text2num(tokens["offset_x"])
-		paper.pixel_y = text2num(tokens["offset_y"])
-		paper.color =   tokens["color"]
+		paper.pixel_x = token["offset_x"]
+		paper.pixel_y = token["offset_y"]
+		paper.color =   token["color"]
 	return paper
 
 /datum/persistent/paper/sticky/CompileEntry(var/atom/entry, var/write_file)
 	. = ..()
 	var/obj/item/weapon/paper/sticky/paper = entry
-	LAZYADD(., "[paper.pixel_x]")
-	LAZYADD(., "[paper.pixel_y]")
-	LAZYADD(., "[paper.color]")
+	LAZYADDASSOC(., "offset_x", paper.pixel_x)
+	LAZYADDASSOC(., "offset_y", paper.pixel_y)
+	LAZYADDASSOC(., "color", paper.color)

--- a/code/modules/persistence/storage/smartfridge.dm
+++ b/code/modules/persistence/storage/smartfridge.dm
@@ -6,9 +6,9 @@
 	for(var/datum/stored_item/I in entry.item_records)
 		.[I.item_path] = I.get_amount()
 
-/datum/persistent/storage/smartfridge/CreateEntryInstance(var/turf/creating, var/list/tokens)
+/datum/persistent/storage/smartfridge/CreateEntryInstance(var/turf/creating, var/list/token)
 	var/obj/machinery/smartfridge/S = find_specific_instance(creating)
-	var/list/L = generate_items(tokens["items"])
+	var/list/L = generate_items(token["items"])
 	for(var/atom/A in L)
 		if(S.accept_check(A))
 			S.stock(A)
@@ -20,7 +20,7 @@
 
 
 /datum/persistent/storage/smartfridge/sheet_storage
-	name = "sheet_storage"
+	name = "sheet storage"
 	max_storage = 50
 	store_per_type = TRUE
 	target_type = /obj/machinery/smartfridge/sheets
@@ -28,14 +28,15 @@
 	var/stacks_go_missing = FALSE // Variable rate depletion of stacks inter-round
 
 /datum/persistent/storage/smartfridge/sheet_storage/lossy
-	name = "sheet_storage_lossy"
+	name = "sheet storage lossy"
 	max_storage = 250
 	stacks_go_missing = TRUE
 
 /datum/persistent/storage/smartfridge/sheet_storage/generate_items(var/list/L)
 	. = list()
 	for(var/obj/item/stack/material/S as anything in L)
-		if(!ispath(S, /obj/item/stack/material))
+		var/real_path = istext(S) ? text2path(S) : S
+		if(!ispath(real_path, /obj/item/stack/material))
 			log_debug("Warning: Sheet_storage persistent datum tried to create [S]")
 			continue
 
@@ -45,7 +46,7 @@
 
 		var/count = L[S]
 
-		var/obj/item/stack/material/inst = S
+		var/obj/item/stack/material/inst = real_path
 		var/max_amount = initial(inst.max_amount)
 
 		// Delete some stacks if we want
@@ -59,43 +60,24 @@
 				if(10 to INFINITY)
 					count -= max_amount*3+fuzzy // 10+ stacks, lose 3 stacks
 			if(count <= 0)
-				qdel(inst)
 				continue
 		
 		while(count > 0)	
-			inst = new S
+			inst = new real_path
 			inst.amount = min(count, max_amount)
 			count -= inst.get_amount()
 			. += inst
 
 
 /datum/persistent/storage/smartfridge/produce
-	name = "fruit_storage"
+	name = "fruit storage"
 	max_storage = 50
 	store_per_type = FALSE
 	target_type = /obj/machinery/smartfridge/produce
 
 /datum/persistent/storage/smartfridge/produce/lossy
-	name = "fruit_storage_lossy"
+	name = "fruit storage lossy"
 	go_missing_chance = 12.5 // 10% loss between rounds
-
-/datum/persistent/storage/smartfridge/produce/assemble_token(var/T)
-	var/list/subtok = splittext(T, " ")
-	if(subtok.len != 2)
-		return null
-	
-	if(!istype(plant_controller)) // No seed controller means the fruit will come out all wonky if at all
-		return null
-
-	subtok[2] = text2num(subtok[2])
-
-	// Ensure we've found a token describing the quantity of a path
-	if(subtok.len != 2 || \
-			!istype(plant_controller.seeds[subtok[1]], /datum/seed) || \
-			!isnum(subtok[2]))
-		return null
-	
-	return subtok
 
 /datum/persistent/storage/smartfridge/produce/create_item(var/seedtype)
 	return new /obj/item/weapon/reagent_containers/food/snacks/grown(null, seedtype) // Smartfridge will be stock()ed with it, loc is unimportant

--- a/code/modules/persistence/storage/smartfridge.dm
+++ b/code/modules/persistence/storage/smartfridge.dm
@@ -25,6 +25,13 @@
 	store_per_type = TRUE
 	target_type = /obj/machinery/smartfridge/sheets
 
+	var/stacks_go_missing = FALSE // Variable rate depletion of stacks inter-round
+
+/datum/persistent/storage/smartfridge/sheet_storage/lossy
+	name = "sheet_storage_lossy"
+	max_storage = 250
+	stacks_go_missing = TRUE
+
 /datum/persistent/storage/smartfridge/sheet_storage/generate_items(var/list/L)
 	. = list()
 	for(var/obj/item/stack/material/S as anything in L)
@@ -32,13 +39,34 @@
 			log_debug("Warning: Sheet_storage persistent datum tried to create [S]")
 			continue
 
-		var/count = L[S]
-		while(count > 0)
-			S = new S
-			S.amount = min(count, S.get_max_amount())
-			count -= S.get_amount()
-			. += S
+		// Skip entire stack if we hit the chance
+		if(prob(go_missing_chance))
+			continue
 
+		var/count = L[S]
+
+		var/obj/item/stack/material/inst = S
+		var/max_amount = initial(inst.max_amount)
+
+		// Delete some stacks if we want
+		if(stacks_go_missing)
+			var/fuzzy = rand(-5,5)
+			switch(count / max_amount)
+				if(0 to 1)
+					count -= 10+fuzzy // 1 stack or less, lose 10
+				if(1 to 10)
+					count -= max_amount+fuzzy // 1 to 10 stacks, lose a stack
+				if(10 to INFINITY)
+					count -= max_amount*3+fuzzy // 10+ stacks, lose 3 stacks
+			if(count <= 0)
+				qdel(inst)
+				continue
+		
+		while(count > 0)	
+			inst = new S
+			inst.amount = min(count, max_amount)
+			count -= inst.get_amount()
+			. += inst
 
 
 /datum/persistent/storage/smartfridge/produce
@@ -46,6 +74,10 @@
 	max_storage = 50
 	store_per_type = FALSE
 	target_type = /obj/machinery/smartfridge/produce
+
+/datum/persistent/storage/smartfridge/produce/lossy
+	name = "fruit_storage_lossy"
+	go_missing_chance = 12.5 // 10% loss between rounds
 
 /datum/persistent/storage/smartfridge/produce/assemble_token(var/T)
 	var/list/subtok = splittext(T, " ")
@@ -74,6 +106,8 @@
 
 	. = list()
 	for(var/datum/stored_item/I in entry.item_records)
+		if(prob(go_missing_chance))
+			continue
 		if(LAZYLEN(I.instances))
 			var/obj/item/weapon/reagent_containers/food/snacks/grown/G = I.instances[1]
 			if(!istype(G))

--- a/code/modules/persistence/storage/storage.dm
+++ b/code/modules/persistence/storage/storage.dm
@@ -1,12 +1,18 @@
 /datum/persistent/storage
 	entries_expire_at = 1
+	
+	// Don't use these for storage persistence. If someone takes some sheets out and puts them back in mixed in with
+	// new sheets, how do you know the age of the stack? If you want sheets to 'decay', see go_missing_chance
 	entries_decay_at = 0
 	entry_decay_weight = 0
+	// // // //
+
 	tokens_per_line = PERSISTENCE_VARIABLE_TOKEN_LENGTH
-	
 	var/max_storage = 0
 	var/store_per_type = FALSE // If true, will store up to max_storage for each type stored
 	var/target_type = null // Path of the thing that this expects to put stuff into
+
+	var/go_missing_chance = 0 // Chance an item will fail to be spawned in from persistence and need to be restocked
 
 /datum/persistent/storage/SetFilename()
 	if(name)
@@ -26,7 +32,7 @@
 		return null
 	
 	subtok[1] = text2path(subtok[1])
-	subtok[2] = text2num( subtok[2])
+	subtok[2] = text2num(subtok[2])
 
 	// Ensure we've found a token describing the quantity of a path
 	if(subtok.len != 2 || \
@@ -73,6 +79,8 @@
 	. = list()
 	for(var/path in L)
 		for(var/i in 1 to L[path])
+			if(prob(go_missing_chance))
+				continue
 			var/atom/A = create_item(path)
 			if(!QDELETED(A))
 				. += A

--- a/code/modules/persistence/storage/storage.dm
+++ b/code/modules/persistence/storage/storage.dm
@@ -1,5 +1,7 @@
 /datum/persistent/storage
+	name = "storage"
 	entries_expire_at = 1
+	has_admin_data = TRUE
 	
 	// Don't use these for storage persistence. If someone takes some sheets out and puts them back in mixed in with
 	// new sheets, how do you know the age of the stack? If you want sheets to 'decay', see go_missing_chance
@@ -7,7 +9,6 @@
 	entry_decay_weight = 0
 	// // // //
 
-	tokens_per_line = PERSISTENCE_VARIABLE_TOKEN_LENGTH
 	var/max_storage = 0
 	var/store_per_type = FALSE // If true, will store up to max_storage for each type stored
 	var/target_type = null // Path of the thing that this expects to put stuff into
@@ -16,31 +17,7 @@
 
 /datum/persistent/storage/SetFilename()
 	if(name)
-		filename = "data/persistent/storage/[lowertext(using_map.name)]-[lowertext(name)].txt"
-
-/datum/persistent/storage/LabelTokens(var/list/tokens)
-	. = ..()
-	.["items"] = list()
-	for(var/T in tokens)
-		var/list/L = assemble_token(T)
-		if(LAZYLEN(L))
-			.["items"][L[1]] = text2num(L[2])
-
-/datum/persistent/storage/proc/assemble_token(var/T)
-	var/list/subtok = splittext(T, " ")
-	if(subtok.len != 2)
-		return null
-	
-	subtok[1] = text2path(subtok[1])
-	subtok[2] = text2num(subtok[2])
-
-	// Ensure we've found a token describing the quantity of a path
-	if(subtok.len != 2 || \
-			!ispath(subtok[1]) || \
-			!isnum(subtok[2]))
-		return null
-	
-	return subtok
+		filename = "data/persistent/storage/[lowertext(using_map.name)]-[lowertext(name)].json"
 
 /datum/persistent/storage/IsValidEntry(var/atom/entry)
 	return ..() && istype(entry, target_type)
@@ -58,9 +35,8 @@
 		if(!store_per_type)
 			stored = max(stored - item_list[item], 0) 
 	
-	for(var/item in storage_list)
-		. += "[item] [storage_list[item]]"
-
+	LAZYADDASSOC(., "items", storage_list)
+	
 // Usage: returns list with structure:
 //  list(
 //      [type1] = [stored_quantity],
@@ -72,18 +48,27 @@
 /datum/persistent/storage/proc/find_specific_instance(var/turf/T)
 	return locate(target_type) in T
 
-/datum/persistent/storage/CheckTurfContents(var/turf/T, var/list/tokens)
+/datum/persistent/storage/CheckTurfContents(var/turf/T, var/list/token)
 	return istype(find_specific_instance(T), target_type)
 
 /datum/persistent/storage/proc/generate_items(var/list/L)
 	. = list()
 	for(var/path in L)
+		// byond's json implementation is "questionable", and uses types as keys and values without quotes sometimes even though they aren't valid json
+		var/real_path = istext(path) ? text2path(path) : path
 		for(var/i in 1 to L[path])
 			if(prob(go_missing_chance))
 				continue
-			var/atom/A = create_item(path)
+			var/atom/A = create_item(real_path)
 			if(!QDELETED(A))
 				. += A
 
 /datum/persistent/storage/proc/create_item(var/path)
 	return new path()
+
+/datum/persistent/storage/GetAdminDataStringFor(var/thing, var/can_modify, var/mob/user)
+	var/atom/T = thing
+	if(!istype(T))
+		return "<td><Missing entry><td>"
+	else
+		. = "<td colspan = 2>[T.name]</td><td>[T.x],[T.y],[T.z]</td><td>"

--- a/maps/~map_system/maps.dm
+++ b/maps/~map_system/maps.dm
@@ -33,6 +33,7 @@ var/list/all_maps = list()
 	var/static/list/player_levels = list()  // Z-levels a character can typically reach
 	var/static/list/sealed_levels = list()  // Z-levels that don't allow random transit at edge
 	var/static/list/xenoarch_exempt_levels = list()	//Z-levels exempt from xenoarch finds and digsites spawning.
+	var/static/list/persist_levels = list() // Z-levels where SSpersistence should persist between rounds. Defaults to station_levels if unset.
 	var/static/list/empty_levels = null     // Empty Z-levels that may be used for various things (currently used by bluespace jump)
 	// End Static Lists
 
@@ -116,8 +117,10 @@ var/list/all_maps = list()
 	if(zlevel_datum_type)
 		for(var/type in subtypesof(zlevel_datum_type))
 			new type(src)
-	if(!map_levels)
+	if(!map_levels?.len)
 		map_levels = station_levels.Copy()
+	if(!persist_levels?.len)
+		persist_levels = station_levels.Copy()
 	if(!allowed_jobs || !allowed_jobs.len)
 		allowed_jobs = subtypesof(/datum/job)
 	if(default_skybox) //Type was specified
@@ -276,6 +279,7 @@ var/list/all_maps = list()
 	if(flags & MAP_LEVEL_PLAYER) map.player_levels += z
 	if(flags & MAP_LEVEL_SEALED) map.sealed_levels += z
 	if(flags & MAP_LEVEL_XENOARCH_EXEMPT) map.xenoarch_exempt_levels += z
+	if(flags & MAP_LEVEL_PERSIST) map.persist_levels += z
 	if(flags & MAP_LEVEL_EMPTY)
 		if(!map.empty_levels) map.empty_levels = list()
 		map.empty_levels += z

--- a/polaris.dme
+++ b/polaris.dme
@@ -56,7 +56,6 @@
 #include "code\__defines\objects.dm"
 #include "code\__defines\overmap.dm"
 #include "code\__defines\pda.dm"
-#include "code\__defines\persistence.dm"
 #include "code\__defines\planets.dm"
 #include "code\__defines\preferences.dm"
 #include "code\__defines\process_scheduler.dm"


### PR DESCRIPTION
- Convert output files to JSON instead of tab-delimited
- Adds MAP_LEVEL_PERSIST to allow specific maps to be persisted (if set on none, it will use station_levels)
- Adds a couple of 'lossy' sheet storage options (will not affect your existing ones)
- Fixes sticky notes and paper not aging at all
- Adds some small admin info lines for storage persistence (just coordinates and name)

More tangental:
- Converts smartfridge max storage var to not be a global so different types can have different values. Of all the vars to make global... this one? Really?
- Convert smartfridge New() to Initialize() due to how it was interacting with the timing of SSpersistence. It should be Init anyway.

FYI semantically a "token" is now a JS object literal loaded from the file. Previously it appeared to mean "cell" in the tsv file, or have mixed meanings in various places. I'm also not 100% sure it would persist more than one smartfridge before now? Maybe it would, I dunno. It does now.