### PR TITLE
[Bugfix] Maybe Fix Cleanbots

### DIFF
--- a/code/modules/mob/living/bot/cleanbot.dm
+++ b/code/modules/mob/living/bot/cleanbot.dm
@@ -14,7 +14,6 @@
 	var/cleaning = 0
 	var/wet_floors = 0
 	var/spray_blood = 0
-	var/blood = 1
 	var/list/target_types = list()
 
 /mob/living/bot/cleanbot/New()
@@ -164,8 +163,7 @@
 	data["on"] = on
 	data["open"] = open
 	data["locked"] = locked
-	
-	data["blood"] = blood
+
 	data["patrol"] = will_patrol
 	data["vocal"] = vocal
 
@@ -184,10 +182,6 @@ mob/living/bot/cleanbot/tgui_act(action, list/params, datum/tgui/ui, datum/tgui_
 				turn_off()
 			else
 				turn_on()
-			. = TRUE
-		if("blood")
-			blood = !blood
-			get_targets()
 			. = TRUE
 		if("patrol")
 			will_patrol = !will_patrol
@@ -216,18 +210,7 @@ mob/living/bot/cleanbot/tgui_act(action, list/params, datum/tgui/ui, datum/tgui_
 		return 1
 
 /mob/living/bot/cleanbot/proc/get_targets()
-	target_types = list()
-
-	target_types += /obj/effect/decal/cleanable/blood/oil
-	target_types += /obj/effect/decal/cleanable/vomit
-	target_types += /obj/effect/decal/cleanable/crayon
-	target_types += /obj/effect/decal/cleanable/liquid_fuel
-	target_types += /obj/effect/decal/cleanable/mucus
-	target_types += /obj/effect/decal/cleanable/dirt
-	target_types += /obj/effect/decal/cleanable/filth
-
-	if(blood)
-		target_types += /obj/effect/decal/cleanable/blood
+	target_types = list(/obj/effect/decal/cleanable)
 
 /* Assembly */
 

--- a/code/modules/mob/living/bot/edCLNbot.dm
+++ b/code/modules/mob/living/bot/edCLNbot.dm
@@ -14,7 +14,6 @@
 
 	vocal = 1
 	cleaning = 0
-	blood = 0
 	var/red_switch = 0
 	var/blue_switch = 0
 	var/green_switch = 0


### PR DESCRIPTION
Removes blood stuff, since it's already a cleanable, which is what a cleanbot is to clean, anything cleanable. Also effectively removes anything in the target_types list, replace with the base cleanable obj path so it cleans any children of cleanable. Tested, spawned stuff, it cleaned pie splatter, cobwebs, etc.

The way this was before, if there was still a cleanable that wasn't listed in target_types, the bot would get stuck forever without the un-included cleanable showing up in their target.

🆑 
bugfix - Cleanbots no longer get stuck trying to clean something not in its target list
/🆑 

Edit for clarification: only removed the targeting stuff for blood. The gib splattering effect from emagged cleanbot has not been removed with this PR.