### PR TITLE
phoron bore stock parts now affect range, along with other bits

### DIFF
--- a/code/modules/projectiles/projectile/magnetic.dm
+++ b/code/modules/projectiles/projectile/magnetic.dm
@@ -161,6 +161,10 @@
 	irradiate = 20
 	range = 6
 
+/obj/item/projectile/bullet/magnetic/bore/Initialize(loc, range_mod) // i'm gonna be real honest i dunno how this works but it does
+	. = ..()
+	range += range_mod
+
 /obj/item/projectile/bullet/magnetic/bore/get_structure_damage()
 	return damage * 3 //made for boring holes
 


### PR DESCRIPTION
phoron bores:
- examining them now shows if there's a manipulator loaded, and how much material it will consume per shot
(if there isn't, a "manipulator missing" message is shown instead)
- fired phorogenic blasts can now gain a **!!RANGE BUFF!!** depending on the rating of the stock parts (capacitor, manipulator) loaded in
- bores no longer display their ammo count twice
- closes #7779. by fixing it

phoron bore range buff mechanic:
- requires both a manipulator and a capacitor to be loaded in
- adds the rating of the capacitor AND manipulator to the range of the blast
(this can get rather Quirky, even with conventional T3 parts)

i'm open to changing the range buff mechanic to average the capacitor and manipulator ratings, rounding up, but until i'm told otherwise it's staying as is