### PR TITLE
Makes roundstart webhook not metagame.

### DIFF
--- a/code/modules/webhooks/webhook_roundstart.dm
+++ b/code/modules/webhooks/webhook_roundstart.dm
@@ -4,7 +4,7 @@
 // Data expects a "url" field pointing to the current hosted server and port to connect on.
 /decl/webhook/roundstart/get_message(var/list/data)
 	. = ..()
-	var/desc = "Gamemode: **[SSticker.mode.name]**\n"
+	var/desc = "Gamemode: **[global.master_mode]**\n"
 	desc += "Players: **[global.player_list.len]**"
 	if(data && data["url"])
 		desc += "\nAddress: <[data["url"]]>"


### PR DESCRIPTION
If the round is Secret, it won't spoil the real roundtype in the webhook message sent to Discord.
Roundend still says the real roundtype.