### PR TITLE
Fixes Resist Button

### DIFF
--- a/code/__defines/mobs.dm
+++ b/code/__defines/mobs.dm
@@ -441,3 +441,5 @@
 #define FAKE_INVIS_ALPHA_THRESHOLD 127 // If something's alpha var is at or below this number, certain things will pretend it is invisible.
 
 #define DEATHGASP_NO_MESSAGE "no message"
+
+#define RESIST_COOLDOWN		2 SECONDS

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -619,8 +619,8 @@
 	set name = "Resist"
 	set category = "IC"
 
-	if(!incapacitated(INCAPACITATION_KNOCKOUT) && checkClickCooldown())
-		setClickCooldown(20)
+	if(!incapacitated(INCAPACITATION_KNOCKOUT) && (last_resist_time + RESIST_COOLDOWN < world.time))
+		last_resist_time = world.time
 		resist_grab()
 		if(!weakened)
 			process_resist()

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -80,3 +80,4 @@
 
 	var/inventory_panel_type = /datum/inventory_panel
 	var/datum/inventory_panel/inventory_panel
+	var/last_resist_time = 0 // world.time of the most recent resist that wasn't on cooldown.


### PR DESCRIPTION
Resist button now works again. It broke due to clicking the hud element giving a very brief amount of click cooldown, the resist code seeing your click was on cooldown, and thinking you're spamming resist and not doing anything. That's why other methods to resist, like typing the verb or using the hotkey, didn't have that problem, as click code didn't get involved.
To fix this, resist cooldown is now independent from click cooldown. Mashing resist 200 times in a second still only counts as 1 resist attempt.
As a bonus, you'll no longer be disallowed from clicking on anything else for two seconds after using the button to unbuckle yourself.