### PR TITLE
Voidsuit Balance Overhaul

### DIFF
--- a/code/datums/supplypacks/voidsuits.dm
+++ b/code/datums/supplypacks/voidsuits.dm
@@ -16,7 +16,7 @@
 			/obj/item/clothing/shoes/magboots = 2,
 			/obj/item/weapon/tank/oxygen = 2,
 			)
-	cost = 40
+	cost = 35
 	containertype = /obj/structure/closet/crate/secure/aether
 	containername = "Atmospheric voidsuit crate"
 	access = access_atmospherics
@@ -30,7 +30,7 @@
 			/obj/item/clothing/shoes/magboots = 2,
 			/obj/item/weapon/tank/oxygen = 2,
 			)
-	cost = 50
+	cost = 60
 	containertype = /obj/structure/closet/crate/secure/aether
 	containername = "Heavy Duty Atmospheric voidsuit crate"
 	access = access_atmospherics
@@ -44,7 +44,7 @@
 			/obj/item/clothing/shoes/magboots = 2,
 			/obj/item/weapon/tank/oxygen = 2
 			)
-	cost = 40
+	cost = 35
 	containertype = /obj/structure/closet/crate/secure/xion
 	containername = "Engineering voidsuit crate"
 	access = access_engine_equip
@@ -58,7 +58,7 @@
 			/obj/item/clothing/shoes/magboots = 2,
 			/obj/item/weapon/tank/oxygen = 2
 			)
-	cost = 40
+	cost = 35
 	containertype = /obj/structure/closet/crate/secure/xion
 	containername = "Engineering Construction voidsuit crate"
 	access = access_engine_equip
@@ -72,7 +72,7 @@
 			/obj/item/clothing/shoes/magboots = 2,
 			/obj/item/weapon/tank/oxygen = 2
 			)
-	cost = 45
+	cost = 35
 	containertype = /obj/structure/closet/crate/secure/xion
 	containername = "Engineering Hazmat voidsuit crate"
 	access = access_engine_equip
@@ -86,7 +86,7 @@
 			/obj/item/clothing/shoes/magboots = 2,
 			/obj/item/weapon/tank/oxygen = 2
 			)
-	cost = 50
+	cost = 60
 	containertype = /obj/structure/closet/crate/secure/xion
 	containername = "Reinforced Engineering voidsuit crate"
 	access = access_engine_equip
@@ -100,7 +100,7 @@
 			/obj/item/clothing/shoes/magboots = 2,
 			/obj/item/weapon/tank/oxygen = 2
 			)
-	cost = 40
+	cost = 35
 	containertype = /obj/structure/closet/crate/secure/veymed
 	containername = "Medical voidsuit crate"
 	access = access_medical_equip
@@ -114,7 +114,7 @@
 			/obj/item/clothing/shoes/magboots = 2,
 			/obj/item/weapon/tank/oxygen = 2
 			)
-	cost = 40
+	cost = 35
 	containertype = /obj/structure/closet/crate/secure/veymed
 	containername = "Medical EMT voidsuit crate"
 	access = access_medical_equip
@@ -128,7 +128,7 @@
 			/obj/item/clothing/shoes/magboots = 2,
 			/obj/item/weapon/tank/oxygen = 2
 			)
-	cost = 45
+	cost = 35
 	containertype = /obj/structure/closet/crate/secure/nanomed
 	containername = "Medical Biohazard voidsuit crate"
 	access = access_medical_equip
@@ -167,7 +167,7 @@
 			/obj/item/clothing/shoes/magboots = 2,
 			/obj/item/weapon/tank/oxygen = 2
 			)
-	cost = 40
+	cost = 35
 	containertype = /obj/structure/closet/crate/secure/heph
 	containername = "Security voidsuit crate"
 
@@ -207,7 +207,7 @@
 			/obj/item/clothing/mask/breath = 2,
 			/obj/item/weapon/tank/oxygen = 2
 			)
-	cost = 40
+	cost = 35
 	containertype = /obj/structure/closet/crate/secure/xion
 	containername = "Mining voidsuit crate"
 	access = access_mining
@@ -220,7 +220,7 @@
 			/obj/item/clothing/mask/breath = 2,
 			/obj/item/weapon/tank/oxygen = 2
 			)
-	cost = 50
+	cost = 60
 	containertype = /obj/structure/closet/crate/secure/grayson
 	containername = "Frontier Mining voidsuit crate"
 	access = access_mining

--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -1085,7 +1085,7 @@
 		if("Exploration")
 			parent_helmet = /obj/item/clothing/head/helmet/space/void/exploration
 			parent_suit = /obj/item/clothing/suit/space/void/exploration
-		if("Expedition Medic")
+		if("Field Medic")
 			parent_helmet = /obj/item/clothing/head/helmet/space/void/expedition_medical
 			parent_suit = /obj/item/clothing/suit/space/void/expedition_medical
 		if("Old Exploration")

--- a/code/modules/clothing/spacesuits/void/event.dm
+++ b/code/modules/clothing/spacesuits/void/event.dm
@@ -51,7 +51,7 @@
 	min_pressure_protection = 0  * ONE_ATMOSPHERE
 	max_pressure_protection = 15 * ONE_ATMOSPHERE
 	max_heat_protection_temperature = SPACE_SUIT_MAX_HEAT_PROTECTION_TEMPERATURE+10000
-	breach_threshold = 16 //These are kinda thicc
+	breach_threshold = 14 //These are kinda thicc
 	allowed = list(/obj/item/device/flashlight,
 			/obj/item/weapon/tank,
 			/obj/item/device/suit_cooling_unit,
@@ -125,7 +125,7 @@
 	item_state_slots = list(slot_r_hand_str = "sec_voidsuitTG", slot_l_hand_str = "sec_voidsuitTG")
 	slowdown = 1
 	armor = list(melee = 40, bullet = 35, laser = 35, energy = 5, bomb = 40, bio = 100, rad = 50)
-	breach_threshold = 16 //These are kinda thicc
+	breach_threshold = 14 //These are kinda thicc
 	resilience = 0.15 //Armored
 	siemens_coefficient = 0.8
 	allowed = list(/obj/item/weapon/gun,
@@ -163,7 +163,7 @@
 	item_state_slots = list(slot_r_hand_str = "sec_voidsuitTG", slot_l_hand_str = "sec_voidsuitTG")
 	slowdown = 1
 	armor = list(melee = 50, bullet = 45, laser = 45, energy = 10, bomb = 30, bio = 100, rad = 60)
-	breach_threshold = 20 //Extra Thicc
+	breach_threshold = 16 //Extra Thicc
 	resilience = 0.1 //Heavily Armored
 	siemens_coefficient = 0.7
 	allowed = list(/obj/item/weapon/gun,
@@ -277,7 +277,7 @@
 	item_state_slots = list(slot_r_hand_str = "sec_voidsuitTG", slot_l_hand_str = "sec_voidsuitTG")
 	slowdown = 1.5 //the tradeoff for being hot shit almost on par with a crimson suit is that it slows you down even more
 	armor = list(melee = 55, bullet = 45, laser = 45, energy = 25, bomb = 50, bio = 100, rad = 50)
-	breach_threshold = 20 //Extra Thicc
+	breach_threshold = 16 //Extra Thicc
 	resilience = 0.05 //Military Armor
 	siemens_coefficient = 0.6
 	allowed = list(/obj/item/weapon/gun,

--- a/code/modules/clothing/spacesuits/void/event.dm
+++ b/code/modules/clothing/spacesuits/void/event.dm
@@ -17,7 +17,6 @@
 	desc = "A refurbished early contact era voidsuit of human design. These things aren't especially good against modern weapons but they're sturdy, incredibly easy to come by, and there are lots of spare parts for repairs. Many old-timer spacers swear by these old things, even if new powered hardsuits have more features and better armor. This one is devoid of any identifying markings or rank indicators."
 	icon_state = "rig-vintagecrew"
 	item_state_slots = list(slot_r_hand_str = "sec_voidsuitTG", slot_l_hand_str = "sec_voidsuitTG")
-	slowdown = 0.5
 	armor = list(melee = 30, bullet = 15, laser = 15,energy = 5, bomb = 20, bio = 100, rad = 50)
 	allowed = list(/obj/item/device/flashlight,
 			/obj/item/weapon/tank,
@@ -40,7 +39,7 @@
 	armor = list(melee = 40, bullet = 20, laser = 20, energy = 5, bomb = 35, bio = 100, rad = 100)
 	min_pressure_protection = 0  * ONE_ATMOSPHERE
 	max_pressure_protection = 15 * ONE_ATMOSPHERE
-	max_heat_protection_temperature = FIRE_HELMET_MAX_HEAT_PROTECTION_TEMPERATURE
+	max_heat_protection_temperature = SPACE_SUIT_MAX_HEAT_PROTECTION_TEMPERATURE+10000
 
 /obj/item/clothing/suit/space/void/refurb/engineering
 	name = "vintage engineering voidsuit"
@@ -51,7 +50,8 @@
 	armor = list(melee = 40, bullet = 20, laser = 20, energy = 5, bomb = 35, bio = 100, rad = 100)
 	min_pressure_protection = 0  * ONE_ATMOSPHERE
 	max_pressure_protection = 15 * ONE_ATMOSPHERE
-	max_heat_protection_temperature = FIRESUIT_MAX_HEAT_PROTECTION_TEMPERATURE
+	max_heat_protection_temperature = SPACE_SUIT_MAX_HEAT_PROTECTION_TEMPERATURE+10000
+	breach_threshold = 16 //These are kinda thicc
 	allowed = list(/obj/item/device/flashlight,
 			/obj/item/weapon/tank,
 			/obj/item/device/suit_cooling_unit,
@@ -93,7 +93,6 @@
 	desc = "A refurbished early contact era voidsuit of human design. These things aren't especially good against modern weapons but they're sturdy, incredibly easy to come by, and there are lots of spare parts for repairs. Many old-timer spacers swear by these old things, even if new powered hardsuits have more features and better armor. The green and white markings indicate this as a medic's suit."
 	icon_state = "rig-vintagemedic"
 	item_state_slots = list(slot_r_hand_str = "sec_voidsuitTG", slot_l_hand_str = "sec_voidsuitTG")
-	slowdown = 0.5
 	armor = list(melee = 30, bullet = 15, laser = 15, energy = 5, bomb = 25, bio = 100, rad = 75)
 	allowed = list(/obj/item/device/flashlight,
 			/obj/item/weapon/tank,
@@ -117,6 +116,8 @@
 	icon_state = "rig0-vintagemarine"
 	item_state_slots = list(slot_r_hand_str = "syndicate-helm-black", slot_l_hand_str = "syndicate-helm-black")
 	armor = list(melee = 40, bullet = 35, laser = 35, energy = 5, bomb = 40, bio = 100, rad = 50)
+	breach_threshold = 16 //These are kinda thicc
+	resilience = 0.15 //Armored
 	siemens_coefficient = 0.8
 
 /obj/item/clothing/suit/space/void/refurb/marine
@@ -126,6 +127,8 @@
 	item_state_slots = list(slot_r_hand_str = "sec_voidsuitTG", slot_l_hand_str = "sec_voidsuitTG")
 	slowdown = 1
 	armor = list(melee = 40, bullet = 35, laser = 35, energy = 5, bomb = 40, bio = 100, rad = 50)
+	breach_threshold = 16 //These are kinda thicc
+	resilience = 0.15 //Armored
 	siemens_coefficient = 0.8
 	allowed = list(/obj/item/weapon/gun,
 			/obj/item/device/flashlight,
@@ -162,6 +165,8 @@
 	item_state_slots = list(slot_r_hand_str = "sec_voidsuitTG", slot_l_hand_str = "sec_voidsuitTG")
 	slowdown = 1
 	armor = list(melee = 50, bullet = 45, laser = 45, energy = 10, bomb = 30, bio = 100, rad = 60)
+	breach_threshold = 20 //Extra Thicc
+	resilience = 0.1 //Heavily Armored
 	siemens_coefficient = 0.7
 	allowed = list(/obj/item/weapon/gun,
 			/obj/item/device/flashlight,
@@ -201,7 +206,7 @@
 	desc = "A refurbished early contact era voidsuit of human design. These things aren't especially good against modern weapons but they're sturdy, incredibly easy to come by, and there are lots of spare parts for repairs. Many old-timer spacers swear by these old things, even if new powered hardsuits have more features and better armor. The royal blue markings indicate this is the pilot's variant; low protection but ultra-lightweight."
 	icon_state = "rig-vintagepilot"
 	item_state_slots = list(slot_r_hand_str = "sec_voidsuitTG", slot_l_hand_str = "sec_voidsuitTG")
-	slowdown = 0.25
+	slowdown = 0
 	armor = list(melee = 25, bullet = 20, laser = 20, energy = 5, bomb = 20, bio = 100, rad = 50)
 	siemens_coefficient = 0.9
 	allowed = list(/obj/item/device/flashlight,
@@ -232,7 +237,6 @@
 	desc = "A refurbished early contact era voidsuit of human design. These things aren't especially good against modern weapons but they're sturdy, incredibly easy to come by, and there are lots of spare parts for repairs. Many old-timer spacers swear by these old things, even if new powered hardsuits have more features and better armor. The purple markings indicate this as a scientist's suit. Keep your eyes open for ropes."
 	icon_state = "rig-vintagescientist"
 	item_state_slots = list(slot_r_hand_str = "sec_voidsuitTG", slot_l_hand_str = "sec_voidsuitTG")
-	slowdown = 0.5
 	armor = list(melee = 25, bullet = 10, laser = 10, energy = 50, bomb = 10, bio = 100, rad = 100)
 	siemens_coefficient = 0.8
 	allowed = list(/obj/item/device/flashlight,
@@ -275,6 +279,8 @@
 	item_state_slots = list(slot_r_hand_str = "sec_voidsuitTG", slot_l_hand_str = "sec_voidsuitTG")
 	slowdown = 1.5 //the tradeoff for being hot shit almost on par with a crimson suit is that it slows you down even more
 	armor = list(melee = 55, bullet = 45, laser = 45, energy = 25, bomb = 50, bio = 100, rad = 50)
+	breach_threshold = 20 //Extra Thicc
+	resilience = 0.05 //Military Armor
 	siemens_coefficient = 0.6
 	allowed = list(/obj/item/weapon/gun,
 			/obj/item/device/flashlight,

--- a/code/modules/clothing/spacesuits/void/event.dm
+++ b/code/modules/clothing/spacesuits/void/event.dm
@@ -116,8 +116,6 @@
 	icon_state = "rig0-vintagemarine"
 	item_state_slots = list(slot_r_hand_str = "syndicate-helm-black", slot_l_hand_str = "syndicate-helm-black")
 	armor = list(melee = 40, bullet = 35, laser = 35, energy = 5, bomb = 40, bio = 100, rad = 50)
-	breach_threshold = 16 //These are kinda thicc
-	resilience = 0.15 //Armored
 	siemens_coefficient = 0.8
 
 /obj/item/clothing/suit/space/void/refurb/marine

--- a/code/modules/clothing/spacesuits/void/merc.dm
+++ b/code/modules/clothing/spacesuits/void/merc.dm
@@ -18,7 +18,7 @@
 	armor = list(melee = 60, bullet = 50, laser = 30, energy = 15, bomb = 35, bio = 100, rad = 60)
 	allowed = list(/obj/item/device/flashlight,/obj/item/weapon/tank,/obj/item/device/suit_cooling_unit,/obj/item/weapon/gun,/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/weapon/melee/baton,/obj/item/weapon/melee/energy/sword,/obj/item/weapon/handcuffs)
 	siemens_coefficient = 0.6
-	breach_threshold = 20 //Extra Thicc
+	breach_threshold = 16 //Extra Thicc
 	resilience = 0.05 //Military Armor
 
 /obj/item/clothing/head/helmet/space/void/merc/fire
@@ -42,6 +42,5 @@
 	max_pressure_protection = 20* ONE_ATMOSPHERE
 	allowed = list(/obj/item/device/flashlight,/obj/item/weapon/tank,/obj/item/device/suit_cooling_unit,/obj/item/weapon/gun,/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/weapon/melee/baton,/obj/item/weapon/melee/energy/sword,/obj/item/weapon/handcuffs,/obj/item/weapon/material/twohanded/fireaxe,/obj/item/weapon/flamethrower)
 	siemens_coefficient = 0.7
-	breach_threshold = 24 //Super Extra Thicc
-	resilience = 0.05 //Military Armor
+	breach_threshold = 18 //Super Extra Thicc
 	slowdown = 1

--- a/code/modules/clothing/spacesuits/void/merc.dm
+++ b/code/modules/clothing/spacesuits/void/merc.dm
@@ -14,11 +14,12 @@
 	name = "blood-red voidsuit"
 	desc = "An advanced suit that protects against injuries during special operations. Property of Gorlex Marauders."
 	item_state_slots = list(slot_r_hand_str = "syndie_voidsuit", slot_l_hand_str = "syndie_voidsuit")
-	slowdown = 1
 	w_class = ITEMSIZE_NORMAL
 	armor = list(melee = 60, bullet = 50, laser = 30, energy = 15, bomb = 35, bio = 100, rad = 60)
 	allowed = list(/obj/item/device/flashlight,/obj/item/weapon/tank,/obj/item/device/suit_cooling_unit,/obj/item/weapon/gun,/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/weapon/melee/baton,/obj/item/weapon/melee/energy/sword,/obj/item/weapon/handcuffs)
 	siemens_coefficient = 0.6
+	breach_threshold = 20 //Extra Thicc
+	resilience = 0.05 //Military Armor
 
 /obj/item/clothing/head/helmet/space/void/merc/fire
 	icon_state = "rig0-firebug"
@@ -26,6 +27,8 @@
 	desc = "A blackened helmet that has had many of its protective plates coated in or replaced with high-grade thermal insulation, to protect against incineration. Property of Gorlex Marauders."
 	armor = list(melee = 40, bullet = 40, laser = 60, energy = 20, bomb = 50, bio = 100, rad = 50)
 	max_heat_protection_temperature = FIRE_HELMET_MAX_HEAT_PROTECTION_TEMPERATURE
+	min_pressure_protection = 0 * ONE_ATMOSPHERE
+	max_pressure_protection = 20* ONE_ATMOSPHERE
 	siemens_coefficient = 0.7
 	light_overlay = "helmet_light_fire"
 
@@ -33,7 +36,12 @@
 	icon_state = "rig-firebug"
 	name = "soot-covered voidsuit"
 	desc = "A blackened suit that has had many of its protective plates coated in or replaced with high-grade thermal insulation, to protect against incineration. Property of Gorlex Marauders."
-	armor = list(melee = 40, bullet = 40, laser = 60, energy = 20, bomb = 50, bio = 100, rad = 50)
+	armor = list(melee = 50, bullet = 40, laser = 60, energy = 20, bomb = 50, bio = 100, rad = 50)
 	max_heat_protection_temperature = FIRESUIT_MAX_HEAT_PROTECTION_TEMPERATURE
+	min_pressure_protection = 0 * ONE_ATMOSPHERE
+	max_pressure_protection = 20* ONE_ATMOSPHERE
 	allowed = list(/obj/item/device/flashlight,/obj/item/weapon/tank,/obj/item/device/suit_cooling_unit,/obj/item/weapon/gun,/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/weapon/melee/baton,/obj/item/weapon/melee/energy/sword,/obj/item/weapon/handcuffs,/obj/item/weapon/material/twohanded/fireaxe,/obj/item/weapon/flamethrower)
 	siemens_coefficient = 0.7
+	breach_threshold = 24 //Super Extra Thicc
+	resilience = 0.05 //Military Armor
+	slowdown = 1

--- a/code/modules/clothing/spacesuits/void/station.dm
+++ b/code/modules/clothing/spacesuits/void/station.dm
@@ -20,7 +20,7 @@
 	min_pressure_protection = 0  * ONE_ATMOSPHERE
 	max_pressure_protection = 15 * ONE_ATMOSPHERE
 	max_heat_protection_temperature = SPACE_SUIT_MAX_HEAT_PROTECTION_TEMPERATURE+5000
-	breach_threshold = 16 //These are kinda thicc
+	breach_threshold = 14 //These are kinda thicc
 	slowdown = 1
 
 //Engineering HAZMAT Voidsuit
@@ -118,7 +118,7 @@
 	item_state_slots = list(slot_r_hand_str = "mining_voidsuit", slot_l_hand_str = "mining_voidsuit")
 	allowed = list(/obj/item/device/flashlight,/obj/item/weapon/tank,/obj/item/device/suit_cooling_unit,/obj/item/weapon/pickaxe)
 	armor = list(melee = 50, bullet = 15, laser = 25, energy = 15, bomb = 55, bio = 100, rad = 50)
-	breach_threshold = 16 //These are kinda thicc
+	breach_threshold = 14 //These are kinda thicc
 	resilience = 0.15 //Armored
 	slowdown = 1
 
@@ -166,7 +166,7 @@
 	icon_state = "rig-medical_emt"
 	item_state_slots = list(slot_r_hand_str = "medical_voidsuit_emt", slot_l_hand_str = "medical_voidsuit_emt")
 	armor = list(melee = 40, bullet = 15, laser = 30, energy = 15, bomb = 35, bio = 100, rad = 50)
-	breach_threshold = 16 //These are kinda thicc
+	breach_threshold = 14 //These are kinda thicc
 
 //Medical Biohazard Voidsuit
 
@@ -189,7 +189,7 @@
 	max_heat_protection_temperature = FIRE_HELMET_MAX_HEAT_PROTECTION_TEMPERATURE
 	min_pressure_protection = 0  * ONE_ATMOSPHERE
 	max_pressure_protection = 15 * ONE_ATMOSPHERE
-	breach_threshold = 20 //Extra Thicc
+	breach_threshold = 16 //Extra Thicc
 	slowdown = 1.5
 
 //Medical Streamlined Voidsuit
@@ -283,7 +283,7 @@
 	armor = list(melee = 50, bullet = 25, laser = 25, energy = 15, bomb = 45, bio = 100, rad = 10)
 	allowed = list(/obj/item/weapon/gun,/obj/item/device/flashlight,/obj/item/weapon/tank,/obj/item/device/suit_cooling_unit,/obj/item/weapon/melee/baton)
 	siemens_coefficient = 0.7
-	breach_threshold = 16 //These are kinda thicc
+	breach_threshold = 14 //These are kinda thicc
 	resilience = 0.15 //Armored
 	slowdown = 1
 
@@ -301,7 +301,7 @@
 	desc = "A heavy-set and ominous looking crowd control suit. Fitted with state of the art shock absorbing materials, to disperse blunt force trauma."
 	icon_state = "rig-sec_riot"
 	armor = list(melee = 70, bullet = 15, laser = 15, energy = 15, bomb = 60, bio = 100, rad = 10)
-	breach_threshold = 20 //Extra Thicc
+	breach_threshold = 16 //Extra Thicc
 	resilience = 0.1 //Heavily Armored
 	item_state_slots = list(slot_r_hand_str = "sec_voidsuit_riot", slot_l_hand_str = "sec_voidsuit_riot")
 
@@ -317,7 +317,7 @@
 	name = "security EVA voidsuit"
 	desc = "A grey-black voidsuit with red highlights. A little tacky, but it offers better protection against modern firearms and radiation than standard-issue security voidsuits."
 	armor = list(melee = 40, bullet = 40, laser = 40, energy = 25, bomb = 40, bio = 100, rad = 50)
-	breach_threshold = 20 //Extra Thicc
+	breach_threshold = 16 //Extra Thicc
 	resilience = 0.1 //Heavily Armored
 	icon_state = "rig-secalt"
 	item_state_slots = list(slot_r_hand_str = "sec_voidsuitTG", slot_l_hand_str = "sec_voidsuitTG")
@@ -343,7 +343,7 @@
 	max_heat_protection_temperature = FIRESUIT_MAX_HEAT_PROTECTION_TEMPERATURE
 	min_pressure_protection = 0 * ONE_ATMOSPHERE
 	max_pressure_protection = 20* ONE_ATMOSPHERE
-	breach_threshold = 20 //Extra Thicc
+	breach_threshold = 16 //Extra Thicc
 	slowdown = 1.5
 
 //Atmospherics Surplus Voidsuit
@@ -380,7 +380,7 @@
 	armor = list(melee = 50, bullet = 15, laser = 35, energy = 25, bomb = 30, bio = 100, rad = 70)
 	allowed = list(/obj/item/device/flashlight,/obj/item/weapon/tank,/obj/item/device/suit_cooling_unit,/obj/item/stack/flag,/obj/item/device/healthanalyzer,/obj/item/device/gps,/obj/item/device/radio/beacon, \
 	/obj/item/weapon/shovel,/obj/item/ammo_magazine,/obj/item/weapon/gun)
-	breach_threshold = 16 //These are kinda thicc
+	breach_threshold = 14 //These are kinda thicc
 	resilience = 0.15 //Armored
 
 //SAR
@@ -402,7 +402,7 @@
 	armor = list(melee = 50, bullet = 15, laser = 25, energy = 15, bomb = 30, bio = 100, rad = 90)
 	allowed = list(/obj/item/device/flashlight,/obj/item/weapon/tank,/obj/item/device/suit_cooling_unit,/obj/item/stack/flag,/obj/item/device/healthanalyzer,/obj/item/device/gps,/obj/item/device/radio/beacon, \
 	/obj/item/weapon/shovel,/obj/item/ammo_magazine,/obj/item/weapon/gun,/obj/item/weapon/storage/firstaid,/obj/item/stack/medical)
-	breach_threshold = 16 //These are kinda thicc
+	breach_threshold = 14 //These are kinda thicc
 	resilience = 0.15 //Armored
 	max_heat_protection_temperature = SPACE_SUIT_MAX_HEAT_PROTECTION_TEMPERATURE+5000
 

--- a/code/modules/clothing/spacesuits/void/station.dm
+++ b/code/modules/clothing/spacesuits/void/station.dm
@@ -2,23 +2,26 @@
 //Engineering
 /obj/item/clothing/head/helmet/space/void/engineering
 	name = "engineering voidsuit helmet"
-	desc = "A special helmet designed for work in a hazardous, low-pressure environment. Has radiation shielding."
+	desc = "A special helmet designed for work in a hazardous, low-pressure environment. Has moderate radiation and pressure shielding."
 	icon_state = "rig0-engineering"
 	item_state_slots = list(slot_r_hand_str = "eng_helm", slot_l_hand_str = "eng_helm")
-	armor = list(melee = 40, bullet = 5, laser = 20, energy = 5, bomb = 35, bio = 100, rad = 80)
+	armor = list(melee = 30, bullet = 5, laser = 20, energy = 5, bomb = 35, bio = 100, rad = 70)
 	min_pressure_protection = 0  * ONE_ATMOSPHERE
 	max_pressure_protection = 15 * ONE_ATMOSPHERE
+	max_heat_protection_temperature = SPACE_SUIT_MAX_HEAT_PROTECTION_TEMPERATURE+5000
 
 /obj/item/clothing/suit/space/void/engineering
 	name = "engineering voidsuit"
-	desc = "A special suit that protects against hazardous, low pressure environments. Has radiation shielding."
+	desc = "A special suit that protects against hazardous, low pressure environments. Has moderate radiation and pressure shielding."
 	icon_state = "rig-engineering"
 	item_state_slots = list(slot_r_hand_str = "eng_voidsuit", slot_l_hand_str = "eng_voidsuit")
-	slowdown = 1
-	armor = list(melee = 40, bullet = 5, laser = 20, energy = 5, bomb = 35, bio = 100, rad = 80)
+	armor = list(melee = 30, bullet = 5, laser = 20, energy = 5, bomb = 35, bio = 100, rad = 70)
 	allowed = list(/obj/item/device/flashlight,/obj/item/weapon/tank,/obj/item/device/suit_cooling_unit,/obj/item/weapon/storage/bag/ore,/obj/item/device/t_scanner,/obj/item/weapon/pickaxe, /obj/item/weapon/rcd)
 	min_pressure_protection = 0  * ONE_ATMOSPHERE
 	max_pressure_protection = 15 * ONE_ATMOSPHERE
+	max_heat_protection_temperature = SPACE_SUIT_MAX_HEAT_PROTECTION_TEMPERATURE+5000
+	breach_threshold = 16 //These are kinda thicc
+	slowdown = 1
 
 //Engineering HAZMAT Voidsuit
 
@@ -27,26 +30,43 @@
 	desc = "A engineering helmet designed for work in a low-pressure environment. Extra radiation shielding appears to have been installed at the price of comfort."
 	icon_state = "rig0-engineering_rad"
 	item_state_slots = list(slot_r_hand_str = "eng_helm_rad", slot_l_hand_str = "eng_helm_rad")
-	armor = list(melee = 30, bullet = 5, laser = 20, energy = 5, bomb = 50, bio = 100, rad = 100)
+	armor = list(melee = 25, bullet = 5, laser = 20, energy = 5, bomb = 50, bio = 100, rad = 100)
+	min_pressure_protection = 0  * ONE_ATMOSPHERE
+	max_pressure_protection = 10 * ONE_ATMOSPHERE
+	max_heat_protection_temperature = SPACE_SUIT_MAX_HEAT_PROTECTION_TEMPERATURE
 
 /obj/item/clothing/suit/space/void/engineering/hazmat
 	name = "HAZMAT voidsuit"
 	desc = "A engineering voidsuit that protects against hazardous, low pressure environments. Has enhanced radiation shielding compared to regular engineering voidsuits."
 	icon_state = "rig-engineering_rad"
 	item_state_slots = list(slot_r_hand_str = "eng_voidsuit_rad", slot_l_hand_str = "eng_voidsuit_rad")
-	armor = list(melee = 30, bullet = 5, laser = 20, energy = 5, bomb = 50, bio = 100, rad = 100)
+	armor = list(melee = 25, bullet = 5, laser = 20, energy = 5, bomb = 50, bio = 100, rad = 100)
+	min_pressure_protection = 0  * ONE_ATMOSPHERE
+	max_pressure_protection = 10 * ONE_ATMOSPHERE
+	max_heat_protection_temperature = SPACE_SUIT_MAX_HEAT_PROTECTION_TEMPERATURE
 
 //Engineering Construction Voidsuit
 
 /obj/item/clothing/head/helmet/space/void/engineering/construction
 	name = "construction voidsuit helmet"
+	desc = "A special helmet designed for work in a hazardous, low-pressure environment. Exchanges radiation shielding for extra armor and maneuverability for field projects."
 	icon_state = "rig0-engineering_con"
 	item_state_slots = list(slot_r_hand_str = "eng_helm_con", slot_l_hand_str = "eng_helm_con")
+	armor = list(melee = 40, bullet = 15, laser = 25, energy = 15, bomb = 35, bio = 100, rad = 50)
+	min_pressure_protection = 0  * ONE_ATMOSPHERE
+	max_pressure_protection = 10 * ONE_ATMOSPHERE
+	max_heat_protection_temperature = SPACE_SUIT_MAX_HEAT_PROTECTION_TEMPERATURE
 
 /obj/item/clothing/suit/space/void/engineering/construction
-	name = "contstruction voidsuit"
+	name = "construction voidsuit"
+	desc = "A special suit that protects against hazardous, low pressure environments. Exchanges radiation shielding for extra armor and maneuverability for field projects."
 	icon_state = "rig-engineering_con"
 	item_state_slots = list(slot_r_hand_str = "eng_voidsuit_con", slot_l_hand_str = "eng_voidsuit_con")
+	armor = list(melee = 40, bullet = 15, laser = 25, energy = 15, bomb = 35, bio = 100, rad = 50)
+	min_pressure_protection = 0  * ONE_ATMOSPHERE
+	max_pressure_protection = 10 * ONE_ATMOSPHERE
+	max_heat_protection_temperature = SPACE_SUIT_MAX_HEAT_PROTECTION_TEMPERATURE
+	slowdown = 0.5
 
 //Engineering Surplus Voidsuits
 
@@ -54,14 +74,15 @@
 	name = "reinforced engineering voidsuit helmet"
 	desc = "A heavy, radiation-shielded voidsuit helmet with a surprisingly comfortable interior."
 	icon_state = "rig0-engineeringalt"
-	armor = list(melee = 40, bullet = 5, laser = 20,energy = 5, bomb = 45, bio = 100, rad = 100)
+	armor = list(melee = 50, bullet = 15, laser = 25, energy = 5, bomb = 45, bio = 100, rad = 100)
 	light_overlay = "helmet_light_dual"
 
 /obj/item/clothing/suit/space/void/engineering/alt
 	name = "reinforced engineering voidsuit"
 	desc = "A bulky industrial voidsuit. It's a few generations old, but a reliable design and radiation shielding make up for the lack of climate control."
 	icon_state = "rig-engineeringalt"
-	armor = list(melee = 40, bullet = 5, laser = 20,energy = 5, bomb = 45, bio = 100, rad = 100)
+	armor = list(melee = 50, bullet = 15, laser = 25, energy = 15, bomb = 45, bio = 100, rad = 100)
+	slowdown = 0.5
 
 /obj/item/clothing/head/helmet/space/void/engineering/salvage
 	name = "salvage voidsuit helmet"
@@ -71,14 +92,15 @@
 		slot_l_hand_str = "eng_helm",
 		slot_r_hand_str = "eng_helm",
 		)
-	armor = list(melee = 50, bullet = 10, laser = 30,energy = 15, bomb = 35, bio = 100, rad = 80)
+	armor = list(melee = 50, bullet = 15, laser = 25, energy = 15, bomb = 45, bio = 100, rad = 100)
 
 /obj/item/clothing/suit/space/void/engineering/salvage
 	name = "salvage voidsuit"
 	desc = "A hand-me-down salvage voidsuit. It has obviously had a lot of repair work done to its radiation shielding."
 	icon_state = "rig-engineeringsav"
-	armor = list(melee = 50, bullet = 10, laser = 30,energy = 15, bomb = 35, bio = 100, rad = 80)
+	armor = list(melee = 50, bullet = 15, laser = 25, energy = 15, bomb = 45, bio = 100, rad = 100)
 	allowed = list(/obj/item/device/flashlight,/obj/item/weapon/tank,/obj/item/device/suit_cooling_unit,/obj/item/weapon/storage/toolbox,/obj/item/weapon/storage/briefcase/inflatable,/obj/item/device/t_scanner,/obj/item/weapon/rcd)
+	slowdown = 0.5
 
 //Mining
 /obj/item/clothing/head/helmet/space/void/mining
@@ -86,7 +108,7 @@
 	desc = "A special helmet designed for work in a hazardous, low pressure environment. Has reinforced plating."
 	icon_state = "rig0-mining"
 	item_state_slots = list(slot_r_hand_str = "mining_helm", slot_l_hand_str = "mining_helm")
-	armor = list(melee = 50, bullet = 5, laser = 20, energy = 5, bomb = 55, bio = 100, rad = 20)
+	armor = list(melee = 50, bullet = 15, laser = 25, energy = 15, bomb = 55, bio = 100, rad = 50)
 	light_overlay = "helmet_light_dual"
 
 /obj/item/clothing/suit/space/void/mining
@@ -95,7 +117,10 @@
 	icon_state = "rig-mining"
 	item_state_slots = list(slot_r_hand_str = "mining_voidsuit", slot_l_hand_str = "mining_voidsuit")
 	allowed = list(/obj/item/device/flashlight,/obj/item/weapon/tank,/obj/item/device/suit_cooling_unit,/obj/item/weapon/pickaxe)
-	armor = list(melee = 50, bullet = 5, laser = 20, energy = 5, bomb = 55, bio = 100, rad = 20)
+	armor = list(melee = 50, bullet = 15, laser = 25, energy = 15, bomb = 55, bio = 100, rad = 50)
+	breach_threshold = 16 //These are kinda thicc
+	resilience = 0.15 //Armored
+	slowdown = 1
 
 //Mining Surplus Voidsuit
 
@@ -103,13 +128,12 @@
 	name = "frontier mining voidsuit helmet"
 	desc = "An armored cheap voidsuit helmet. Someone must have through they were pretty cool when they painted a mohawk on it."
 	icon_state = "rig0-miningalt"
-	armor = list(melee = 50, bullet = 15, laser = 20,energy = 5, bomb = 55, bio = 100, rad = 0)
 
 /obj/item/clothing/suit/space/void/mining/alt
 	icon_state = "rig-miningalt"
 	name = "frontier mining voidsuit"
 	desc = "A cheap prospecting voidsuit. What it lacks in comfort it makes up for in armor plating and street cred."
-	armor = list(melee = 50, bullet = 15, laser = 20,energy = 5, bomb = 55, bio = 100, rad = 0)
+	slowdown = 0.5
 
 //Medical
 /obj/item/clothing/head/helmet/space/void/medical
@@ -117,7 +141,7 @@
 	desc = "A special helmet designed for work in a hazardous, low pressure environment. Has minor radiation shielding."
 	icon_state = "rig0-medical"
 	item_state_slots = list(slot_r_hand_str = "medical_helm", slot_l_hand_str = "medical_helm")
-	armor = list(melee = 30, bullet = 5, laser = 20, energy = 5, bomb = 25, bio = 100, rad = 50)
+	armor = list(melee = 30, bullet = 5, laser = 20, energy = 5, bomb = 25, bio = 100, rad = 80)
 
 /obj/item/clothing/suit/space/void/medical
 	name = "medical voidsuit"
@@ -125,35 +149,48 @@
 	icon_state = "rig-medical"
 	item_state_slots = list(slot_r_hand_str = "medical_voidsuit", slot_l_hand_str = "medical_voidsuit")
 	allowed = list(/obj/item/device/flashlight,/obj/item/weapon/tank,/obj/item/device/suit_cooling_unit,/obj/item/weapon/storage/firstaid,/obj/item/device/healthanalyzer,/obj/item/stack/medical)
-	armor = list(melee = 30, bullet = 5, laser = 20, energy = 5, bomb = 25, bio = 100, rad = 50)
+	armor = list(melee = 30, bullet = 5, laser = 20, energy = 5, bomb = 25, bio = 100, rad = 80)
 
 //Medical EMT Voidsuit
 
 /obj/item/clothing/head/helmet/space/void/medical/emt
 	name = "emergency medical response voidsuit helmet"
+	desc = "A special helmet designed for work in a hazardous, low pressure environment. Exchanges radiation shielding for some additional protection."
 	icon_state = "rig0-medical_emt"
 	item_state_slots = list(slot_r_hand_str = "medical_helm_emt", slot_l_hand_str = "medical_helm_emt")
+	armor = list(melee = 40, bullet = 15, laser = 30, energy = 15, bomb = 35, bio = 100, rad = 50)
 
 /obj/item/clothing/suit/space/void/medical/emt
 	name = "emergency medical response voidsuit"
+	desc = "A special suit that protects against hazardous, low pressure environments. Exchanges radiation shielding for some additional protection."
 	icon_state = "rig-medical_emt"
 	item_state_slots = list(slot_r_hand_str = "medical_voidsuit_emt", slot_l_hand_str = "medical_voidsuit_emt")
+	armor = list(melee = 40, bullet = 15, laser = 30, energy = 15, bomb = 35, bio = 100, rad = 50)
+	breach_threshold = 16 //These are kinda thicc
 
 //Medical Biohazard Voidsuit
 
 /obj/item/clothing/head/helmet/space/void/medical/bio
 	name = "biohazard voidsuit helmet"
-	desc = "A special helmet that protects against hazardous environments. Has minor radiation shielding."
+	desc = "A special suit designed to protect the user in hazardous enviornments on the field. It feels heavier than the standard suit with extra protection around the joints."
 	icon_state = "rig0-medical_bio"
 	item_state_slots = list(slot_r_hand_str = "medical_helm_bio", slot_l_hand_str = "medical_helm_bio")
-	armor = list(melee = 45, bullet = 5, laser = 20, energy = 5, bomb = 15, bio = 100, rad = 75)
+	armor = list(melee = 55, bullet = 15, laser = 20, energy = 15, bomb = 15, bio = 100, rad = 75)
+	max_heat_protection_temperature = FIRE_HELMET_MAX_HEAT_PROTECTION_TEMPERATURE
+	min_pressure_protection = 0  * ONE_ATMOSPHERE
+	max_pressure_protection = 15 * ONE_ATMOSPHERE
 
 /obj/item/clothing/suit/space/void/medical/bio
 	name = "biohazard voidsuit"
-	desc = "A special suit that protects against hazardous, environments. It feels heavier than the standard suit with extra protection around the joints."
+	desc = "A special suit designed to protect the user in hazardous enviornments on the field. It feels heavier than the standard suit with extra protection around the joints."
 	icon_state = "rig-medical_bio"
 	item_state_slots = list(slot_r_hand_str = "medical_voidsuit_bio", slot_l_hand_str = "medical_voidsuit_bio")
-	armor = list(melee = 45, bullet = 5, laser = 20, energy = 5, bomb = 15, bio = 100, rad = 75)
+	armor = list(melee = 55, bullet = 15, laser = 20, energy = 15, bomb = 15, bio = 100, rad = 75)
+	max_heat_protection_temperature = FIRE_HELMET_MAX_HEAT_PROTECTION_TEMPERATURE
+	min_pressure_protection = 0  * ONE_ATMOSPHERE
+	max_pressure_protection = 15 * ONE_ATMOSPHERE
+	breach_threshold = 20 //Extra Thicc
+	slowdown = 1.5
 
 //Medical Streamlined Voidsuit
 /obj/item/clothing/head/helmet/space/void/medical/alt
@@ -234,7 +271,7 @@
 	desc = "A special helmet designed for work in a hazardous, low pressure environment. Has an additional layer of armor."
 	icon_state = "rig0-sec"
 	item_state_slots = list(slot_r_hand_str = "sec_helm", slot_l_hand_str = "sec_helm")
-	armor = list(melee = 50, bullet = 25, laser = 25, energy = 5, bomb = 45, bio = 100, rad = 10)
+	armor = list(melee = 50, bullet = 25, laser = 25, energy = 15, bomb = 45, bio = 100, rad = 10)
 	siemens_coefficient = 0.7
 	light_overlay = "helmet_light_dual"
 
@@ -243,9 +280,12 @@
 	desc = "A special suit that protects against hazardous, low pressure environments. Has an additional layer of armor."
 	icon_state = "rig-sec"
 	item_state_slots = list(slot_r_hand_str = "sec_voidsuit", slot_l_hand_str = "sec_voidsuit")
-	armor = list(melee = 50, bullet = 25, laser = 25, energy = 5, bomb = 45, bio = 100, rad = 10)
+	armor = list(melee = 50, bullet = 25, laser = 25, energy = 15, bomb = 45, bio = 100, rad = 10)
 	allowed = list(/obj/item/weapon/gun,/obj/item/device/flashlight,/obj/item/weapon/tank,/obj/item/device/suit_cooling_unit,/obj/item/weapon/melee/baton)
 	siemens_coefficient = 0.7
+	breach_threshold = 16 //These are kinda thicc
+	resilience = 0.15 //Armored
+	slowdown = 1
 
 //Security Crowd Control Voidsuit
 
@@ -253,28 +293,32 @@
 	name = "crowd control voidsuit helmet"
 	desc = "A heavy-set and ominous looking crowd control suit helmet. Fitted with state of the art shock absorbing materials, to disperse blunt force trauma."
 	icon_state = "rig0-sec_riot"
-	armor = list(melee = 70, bullet = 15, laser = 15, energy = 5, bomb = 40, bio = 100, rad = 10)
+	armor = list(melee = 70, bullet = 15, laser = 15, energy = 15, bomb = 60, bio = 100, rad = 10)
 	item_state_slots = list(slot_r_hand_str = "sec_helm_riot", slot_l_hand_str = "sec_helm_riot")
 
 /obj/item/clothing/suit/space/void/security/riot
 	name = "crowd control voidsuit"
 	desc = "A heavy-set and ominous looking crowd control suit. Fitted with state of the art shock absorbing materials, to disperse blunt force trauma."
 	icon_state = "rig-sec_riot"
-	armor = list(melee = 70, bullet = 15, laser = 15, energy = 5, bomb = 40, bio = 100, rad = 10)
+	armor = list(melee = 70, bullet = 15, laser = 15, energy = 15, bomb = 60, bio = 100, rad = 10)
+	breach_threshold = 20 //Extra Thicc
+	resilience = 0.1 //Heavily Armored
 	item_state_slots = list(slot_r_hand_str = "sec_voidsuit_riot", slot_l_hand_str = "sec_voidsuit_riot")
 
 //Security Surplus Voidsuit
 /obj/item/clothing/head/helmet/space/void/security/alt
 	name = "security EVA voidsuit helmet"
 	desc = "A grey-black voidsuit helmet with red highlights. A little tacky, but it offers better protection against modern firearms and radiation than standard-issue security voidsuit helmets."
-	armor = list(melee = 30, bullet = 40, laser = 40, energy = 25, bomb = 60, bio = 100, rad = 50)
+	armor = list(melee = 40, bullet = 40, laser = 40, energy = 25, bomb = 40, bio = 100, rad = 50)
 	icon_state = "rig0-secalt"
 	item_state_slots = list(slot_r_hand_str = "syndicate-helm-black", slot_l_hand_str = "syndicate-helm-black")
 
 /obj/item/clothing/suit/space/void/security/alt
 	name = "security EVA voidsuit"
 	desc = "A grey-black voidsuit with red highlights. A little tacky, but it offers better protection against modern firearms and radiation than standard-issue security voidsuits."
-	armor = list(melee = 30, bullet = 40, laser = 40, energy = 25, bomb = 60, bio = 100, rad = 50)
+	armor = list(melee = 40, bullet = 40, laser = 40, energy = 25, bomb = 40, bio = 100, rad = 50)
+	breach_threshold = 20 //Extra Thicc
+	resilience = 0.1 //Heavily Armored
 	icon_state = "rig-secalt"
 	item_state_slots = list(slot_r_hand_str = "sec_voidsuitTG", slot_l_hand_str = "sec_voidsuitTG")
 
@@ -299,6 +343,8 @@
 	max_heat_protection_temperature = FIRESUIT_MAX_HEAT_PROTECTION_TEMPERATURE
 	min_pressure_protection = 0 * ONE_ATMOSPHERE
 	max_pressure_protection = 20* ONE_ATMOSPHERE
+	breach_threshold = 20 //Extra Thicc
+	slowdown = 1.5
 
 //Atmospherics Surplus Voidsuit
 
@@ -306,16 +352,15 @@
 	desc = "A special voidsuit helmet designed for work in hazardous, low pressure environments.This one has been plated with an expensive heat and radiation resistant ceramic."
 	name = "heavy duty atmospherics voidsuit helmet"
 	icon_state = "rig0-atmosalt"
-	armor = list(melee = 20, bullet = 5, laser = 20,energy = 15, bomb = 45, bio = 100, rad = 50)
-	max_heat_protection_temperature = FIRE_HELMET_MAX_HEAT_PROTECTION_TEMPERATURE
+	armor = list(melee = 40, bullet = 5, laser = 20, energy = 5, bomb = 35, bio = 100, rad = 70)
 	light_overlay = "hardhat_light"
 
 /obj/item/clothing/suit/space/void/atmos/alt
 	desc = "A special suit that protects against hazardous, low pressure environments. Fits better than the standard atmospheric voidsuit while still rated to withstand extreme heat and even minor radiation."
 	icon_state = "rig-atmosalt"
 	name = "heavy duty atmos voidsuit"
-	armor = list(melee = 20, bullet = 5, laser = 20,energy = 15, bomb = 45, bio = 100, rad = 50)
-	max_heat_protection_temperature = FIRESUIT_MAX_HEAT_PROTECTION_TEMPERATURE
+	armor = list(melee = 40, bullet = 5, laser = 20, energy = 5, bomb = 35, bio = 100, rad = 70)
+	slowdown = 1
 
 //Exploration
 /obj/item/clothing/head/helmet/space/void/exploration
@@ -324,7 +369,7 @@
 	icon_state = "helm_explorer"
 	item_state = "helm_explorer"
 	item_state_slots = list(slot_r_hand_str = "syndicate-helm-black", slot_l_hand_str = "syndicate-helm-black")
-	armor = list(melee = 40, bullet = 15, laser = 25,energy = 35, bomb = 30, bio = 100, rad = 70)
+	armor = list(melee = 50, bullet = 15, laser = 35, energy = 25, bomb = 30, bio = 100, rad = 70)
 	light_overlay = "helmet_light_dual" //explorer_light
 
 /obj/item/clothing/suit/space/void/exploration
@@ -332,29 +377,34 @@
 	desc = "A hazard and radiation resistant voidsuit, featuring the Explorer emblem on its chest plate. Designed for exploring unknown planetary environments."
 	icon_state = "void_explorer"
 	item_state_slots = list(slot_r_hand_str = "skrell_suit_black", slot_l_hand_str = "skrell_suit_black")
-	armor = list(melee = 40, bullet = 15, laser = 25,energy = 35, bomb = 30, bio = 100, rad = 70)
+	armor = list(melee = 50, bullet = 15, laser = 35, energy = 25, bomb = 30, bio = 100, rad = 70)
 	allowed = list(/obj/item/device/flashlight,/obj/item/weapon/tank,/obj/item/device/suit_cooling_unit,/obj/item/stack/flag,/obj/item/device/healthanalyzer,/obj/item/device/gps,/obj/item/device/radio/beacon, \
 	/obj/item/weapon/shovel,/obj/item/ammo_magazine,/obj/item/weapon/gun)
+	breach_threshold = 16 //These are kinda thicc
+	resilience = 0.15 //Armored
 
 //SAR
 /obj/item/clothing/head/helmet/space/void/expedition_medical
-	name = "exploration medic\'s voidsuit helmet"
+	name = "field medic voidsuit helmet"
 	desc = "A radiation-resistant helmet made especially for exploring unknown planetary environments. Has a reinforced high-vis bubble style visor."
 	icon_state = "helm_exp_medic"
 	item_state = "helm_exp_medic"
 	item_state_slots = list(slot_r_hand_str = "syndicate-helm-black", slot_l_hand_str = "syndicate-helm-black")
-	armor = list(melee = 25, bullet = 10, laser = 20,energy = 30, bomb = 25, bio = 100, rad = 70)
+	armor = list(melee = 50, bullet = 15, laser = 25, energy = 15, bomb = 30, bio = 100, rad = 90)
 	light_overlay = "helmet_light_dual" //explorer_light
+	max_heat_protection_temperature = SPACE_SUIT_MAX_HEAT_PROTECTION_TEMPERATURE+5000
 
 /obj/item/clothing/suit/space/void/expedition_medical
-	name = "exploration medic\'s voidsuit"
+	name = "field medic voidsuit"
 	desc = "A hazard and radiation resistant voidsuit, featuring the Explorer emblem and a green cross on its chest plate. Seems to be a little lighter and more flexible than the regular explorer issue."
 	icon_state = "void_exp_medic"
-	slowdown = 0.75
 	item_state_slots = list(slot_r_hand_str = "skrell_suit_black", slot_l_hand_str = "skrell_suit_black")
-	armor = list(melee = 25, bullet = 10, laser = 20,energy = 30, bomb = 25, bio = 100, rad = 70)
+	armor = list(melee = 50, bullet = 15, laser = 25, energy = 15, bomb = 30, bio = 100, rad = 90)
 	allowed = list(/obj/item/device/flashlight,/obj/item/weapon/tank,/obj/item/device/suit_cooling_unit,/obj/item/stack/flag,/obj/item/device/healthanalyzer,/obj/item/device/gps,/obj/item/device/radio/beacon, \
 	/obj/item/weapon/shovel,/obj/item/ammo_magazine,/obj/item/weapon/gun,/obj/item/weapon/storage/firstaid,/obj/item/stack/medical)
+	breach_threshold = 16 //These are kinda thicc
+	resilience = 0.15 //Armored
+	max_heat_protection_temperature = SPACE_SUIT_MAX_HEAT_PROTECTION_TEMPERATURE+5000
 
 /obj/item/clothing/head/helmet/space/void/exploration/alt
 	desc = "A radiation-resistant helmet retrofitted for exploring unknown planetary environments."
@@ -374,8 +424,7 @@
 	icon_state = "rig0_pilot"
 	item_state = "pilot_helm"
 	item_state_slots = list(slot_r_hand_str = "atmos_helm", slot_l_hand_str = "atmos_helm")
-	armor = list(melee = 40, bullet = 5, laser = 20,energy = 5, bomb = 15, bio = 100, rad = 50)
-	max_heat_protection_temperature = FIRE_HELMET_MAX_HEAT_PROTECTION_TEMPERATURE
+	armor = list(melee = 40, bullet = 10, laser = 25, energy = 15, bomb = 25, bio = 100, rad = 60)
 	light_overlay = "helmet_light_dual"
 
 /obj/item/clothing/suit/space/void/pilot
@@ -383,8 +432,7 @@
 	icon_state = "rig-pilot"
 	item_state_slots = list(slot_r_hand_str = "atmos_voidsuit", slot_l_hand_str = "atmos_voidsuit")
 	name = "pilot voidsuit"
-	armor = list(melee = 40, bullet = 5, laser = 20,energy = 5, bomb = 15, bio = 100, rad = 50)
-	max_heat_protection_temperature = FIRESUIT_MAX_HEAT_PROTECTION_TEMPERATURE
+	armor = list(melee = 40, bullet = 10, laser = 25, energy = 15, bomb = 25, bio = 100, rad = 60)
 	allowed = list(/obj/item/device/flashlight,/obj/item/weapon/tank,/obj/item/device/suit_cooling_unit,/obj/item/weapon/storage/toolbox,/obj/item/weapon/storage/briefcase/inflatable)
 
 /obj/item/clothing/head/helmet/space/void/pilot/alt

--- a/code/modules/clothing/spacesuits/void/void.dm
+++ b/code/modules/clothing/spacesuits/void/void.dm
@@ -5,7 +5,7 @@
 	icon_state = "void"
 	item_state_slots = list(slot_r_hand_str = "syndicate", slot_l_hand_str = "syndicate")
 	heat_protection = HEAD
-	armor = list(melee = 40, bullet = 5, laser = 20,energy = 5, bomb = 35, bio = 100, rad = 20)
+	armor = list(melee = 30, bullet = 5, laser = 20,energy = 5, bomb = 35, bio = 100, rad = 20)
 	max_heat_protection_temperature = SPACE_SUIT_MAX_HEAT_PROTECTION_TEMPERATURE
 	min_pressure_protection = 0 * ONE_ATMOSPHERE
 	max_pressure_protection = 10 * ONE_ATMOSPHERE
@@ -35,8 +35,8 @@
 	icon_state = "void"
 	item_state_slots = list(slot_r_hand_str = "space_suit_syndicate", slot_l_hand_str = "space_suit_syndicate")
 	desc = "A high-tech dark red space suit. Used for AI satellite maintenance."
-	slowdown = 1
-	armor = list(melee = 40, bullet = 5, laser = 20,energy = 5, bomb = 35, bio = 100, rad = 20)
+	slowdown = 0.5
+	armor = list(melee = 30, bullet = 5, laser = 20,energy = 5, bomb = 35, bio = 100, rad = 20)
 	allowed = list(/obj/item/device/flashlight,/obj/item/weapon/tank,/obj/item/device/suit_cooling_unit)
 	heat_protection = UPPER_TORSO|LOWER_TORSO|LEGS|FEET|ARMS|HANDS
 	max_heat_protection_temperature = SPACE_SUIT_MAX_HEAT_PROTECTION_TEMPERATURE

--- a/code/modules/clothing/spacesuits/void/wizard.dm
+++ b/code/modules/clothing/spacesuits/void/wizard.dm
@@ -16,7 +16,6 @@
 	name = "gem-encrusted voidsuit"
 	desc = "A bizarre gem-encrusted suit that radiates magical energies."
 	item_state_slots = list(slot_r_hand_str = "wiz_voidsuit", slot_l_hand_str = "wiz_voidsuit")
-	slowdown = 1
 	w_class = ITEMSIZE_NORMAL
 	unacidable = 1
 	armor = list(melee = 40, bullet = 20, laser = 20,energy = 20, bomb = 35, bio = 100, rad = 60)


### PR DESCRIPTION
Overhauls the stats of voidsuits and tries to put them into niches. So far, I decided to go with a tier-based system.

Tier 1: Basic voidsuits available to the station and can be purchased from Cargo fairly cheaply (35 points).
Tier 1.5: These are slightly improved over Tier 1, but not as good as Tier 2. Currently, only the exploration/exploration medic voidsuits fit the bill.
Tier 2: These voidsuits are available to the station, but can only be purchased from Cargo at higher prices (60 points). Occasionally found as common loot on excursions (refurbished voidsuits).
Tier 2.5: Found as very rare loot. Nearly comparable with Merc voidsuits but not quite there.
Tier 3: Mercenary voidsuits. Can be found as extremely rare loot.

One of the key factors in this overhaul is that the slowdown on voidsuits was made granular. Instead of all voidsuits having a slowdown of 1 or 0, most voidsuits will have a slowdown of 0.5, while voidsuits that have really good protective attributes (such as security voidsuits) will move slower.

As well as this, most higher end voidsuits were given better breach threshhold and resilience values, because even the most heavily armored voidsuits were way too easy to pincushion for some reason.

On top of this, most voidsuits were given niches.

Engineering Voidsuit (Tier 1): Moderate radiation protection, Slightly better pressure/heat protection. Moves slow (Slowdown 1)
Hazmat Voidsuit (Tier 1): Perfect Rad Protection, but loses pressure/heat protection of engineering voidsuit. Also Slow.
Construction Voidsuit (Tier 1): Lighter than Engineering/Hazmat suits, but lacks either radiation protection or pressure/temp protection. Has a bit of extra armor, too. Mostly for field use.

Reinforced Engineering Voidsuit (Tier 2): Has good pressure/temp protections, perfect radiation protection, and moves pretty well.
Salvage Voidsuit (Tier 2): Same as above.

Mining (Tier 1): Fairly decent melee/bomb armor, and slightly harder to breach. Also mild radiation protection. Heavy.

Frontier Mining (Tier 2): Same as above, except lighter.

Medical (Tier 1): Normal weight, has some radiation protection, but otherwise unremarkable.
EMT (Tier 1): Exchanges radiation shielding for additional armor. Normal weight.
Biohazard (Tier 1): Highish melee protection and high atmos protection. Designed for EMTs in extremely hazardous enviornments.

Vay-med (Tier 2): Zero weight, still made of paper mache.

Security (Tier 1): Moderate protection all round, heavy weight.
Crowd Control (Tier 2): Focus on melee/bomb protection, 
Security EVA (Tier 2): Focus on Ballistics/Laser protection.

Atmospherics (Tier 1): Pretty much the same. Super High atmos/fire protection. Extremely slow. Extremely hard to breach.
Heavy Duty Atmospherics (Tier 2): Same as above, except lighter.

Exploration (Tier 1.5): Normal weight and armored, but skimps on ballistic armor. Not quite as armored as security voidsuits. Above average rad protection.

Field Medic (Tier 1.5): Loses some of the armor, but gains more rad protection and some heat/atmos protection.

Pilot (Tier 1): Some very light armor plating, minor rad protection, otherwise unremarkable.

Blood-red (Tier 3): Mostly the same, except extremely hard to breach now.

Soot-covered Voidsuit (Tier 3): Heavier than the blood-red, but also pressure and fireproof. Loses a very little bit of ballistic/melee protection for excellent laser protection.