### PR TITLE
Autoinjectors are Autoinjectors

### DIFF
--- a/code/modules/identification/identification.dm
+++ b/code/modules/identification/identification.dm
@@ -117,7 +117,7 @@
 /datum/identification/hypo
 	naming_lists = list(
 		list("unidentified", "unknown", "unmarked", "blank", "refilled", "custom", "modified", "questionable", "suspicious"),
-		list("hypospray", "autoinjector")
+		list("autoinjector")
 	)
 	unidentified_desc = "An autoinjector that does not give any indication towards what is inside. \
 	The case is also sealed tight and the liquids contained cannot be removed except by injecting it into someone. \


### PR DESCRIPTION
Unidentified Autoinjectors are not hyposprays stop calling them hyposprays.