### PR TITLE
Fixes infinite loop following cooking error

### DIFF
--- a/code/modules/food/recipe.dm
+++ b/code/modules/food/recipe.dm
@@ -198,7 +198,8 @@
 
 		else if(istype(container, /obj/item/weapon/reagent_containers/cooking_container))
 			var/obj/item/weapon/reagent_containers/cooking_container/CC = container
-			container.clear()
+			CC.clear()
+
 		container.visible_message(SPAN_WARNING("[container] inexplicably spills, and its contents are lost!"))
 
 		return

--- a/code/modules/food/recipe.dm
+++ b/code/modules/food/recipe.dm
@@ -194,11 +194,13 @@
 		log_runtime(EXCEPTION("<span class='danger'>Recipe [type] is defined without a result, please bug report this.</span>"))
 		if(istype(container, /obj/machinery/microwave))
 			var/obj/machinery/microwave/M = container
-			M.fail()
+			M.dispose(FALSE)
+
 		else if(istype(container, /obj/item/weapon/reagent_containers/cooking_container))
 			var/obj/item/weapon/reagent_containers/cooking_container/CC = container
 			container.clear()
-			container.visible_message(SPAN_WARNING("[container] inexplicably spills, and its contents are lost!"))
+		container.visible_message(SPAN_WARNING("[container] inexplicably spills, and its contents are lost!"))
+
 		return
 
 
@@ -331,4 +333,3 @@
 
 
 /datum/recipe/proc/after_cook(obj/container) // Called When the Microwave is finished.
-

--- a/code/modules/food/recipe.dm
+++ b/code/modules/food/recipe.dm
@@ -192,6 +192,13 @@
 /datum/recipe/proc/make_food(var/obj/container as obj)
 	if(!result)
 		log_runtime(EXCEPTION("<span class='danger'>Recipe [type] is defined without a result, please bug report this.</span>"))
+		if(istype(container, /obj/machinery/microwave))
+			var/obj/machinery/microwave/M = container
+			M.fail()
+		else if(istype(container, /obj/item/weapon/reagent_containers/cooking_container))
+			var/obj/item/weapon/reagent_containers/cooking_container/CC = container
+			container.clear()
+			container.visible_message(SPAN_WARNING("[container] inexplicably spills, and its contents are lost!"))
 		return
 
 


### PR DESCRIPTION
```
		while (select_recipe(available_recipes,C) == recipe)
			var/list/TR = list()
			TR += recipe.make_food(C)
```
This would never consume reagents due to an early return, meaning it would never terminate from the while loop. Clearing the reagents is an easy fix for something that will hopefully never happen, and avoids locking the server up if it does.
Also makes such failures obvious.
TODO: Unit test for recipes without results.