### PR TITLE
Adds unit test for invalid recipes

### DIFF
--- a/code/unit_tests/recipe_tests.dm
+++ b/code/unit_tests/recipe_tests.dm
@@ -5,7 +5,7 @@
 	var/failed = FALSE
 	for(var/datum/recipe/R in subtypesof(/datum/recipe))
 		var/our_result = initial(R.result)
-		var/our_amount = initial(R.result_amount)
+		var/our_amount = initial(R.result_quantity)
 		if(!our_result)
 			log_unit_test("[R]: Recipes - Missing result.")
 			failed = TRUE

--- a/code/unit_tests/recipe_tests.dm
+++ b/code/unit_tests/recipe_tests.dm
@@ -1,0 +1,29 @@
+/datum/unit_test/recipe_test_shall_have_valid_result_and_quantity
+	name = "RECIPES: Recipes shall have valid result and result_quantity definitions"
+
+/datum/unit_test/recipe_test_shall_have_valid_result_and_quantity/start_test()
+	var/failed = FALSE
+	for(var/datum/recipe/R in subtypesof(/datum/recipe))
+		var/our_result = initial(R.result)
+		var/our_amount = initial(R.result_amount)
+		if(!our_result)
+			log_unit_test("[R]: Recipes - Missing result type.")
+			failed = TRUE
+		else if(!ispath(our_result, /atom/movable)
+			log_unit_test("[R]: Recipes - Improper result type; [our_result] is not an obj or mob.")
+			failed = TRUE
+		if(isnull(our_amount))
+			log_unit_test("[R]: Recipes - result_quantity must be set.")
+			failed = TRUE
+		if(initial(R.result_amount) <= 0)
+			log_unit_test("[R]: Recipes - result_quantity must be greater than zero.")
+			failed = TRUE
+		else if(!ISINTEGER(initial(R.result_amount)))
+			log_unit_test("[R]: Recipes - result_quantity must be an integer.")
+			failed = TRUE
+
+	if(failed)
+		fail("One or more /datum/recipe subtypes had invalid results or result_quantity definitions.")
+	else
+		pass("All /datum/recipe subtypes had correct settings.")
+	return TRUE

--- a/code/unit_tests/recipe_tests.dm
+++ b/code/unit_tests/recipe_tests.dm
@@ -9,7 +9,7 @@
 		if(!our_result)
 			log_unit_test("[R]: Recipes - Missing result.")
 			failed = TRUE
-		else if(!ispath(our_result, /atom/movable)
+		else if(!ispath(our_result, /atom/movable))
 			log_unit_test("[R]: Recipes - Improper result; [our_result] is not an obj or mob.")
 			failed = TRUE
 		if(isnull(our_amount))
@@ -18,7 +18,7 @@
 		if(our_amount <= 0)
 			log_unit_test("[R]: Recipes - result_quantity must be greater than zero.")
 			failed = TRUE
-		else if(!ISINTEGER(our_amount)
+		else if(!ISINTEGER(our_amount))
 			log_unit_test("[R]: Recipes - result_quantity must be an integer.")
 			failed = TRUE
 

--- a/code/unit_tests/recipe_tests.dm
+++ b/code/unit_tests/recipe_tests.dm
@@ -7,18 +7,18 @@
 		var/our_result = initial(R.result)
 		var/our_amount = initial(R.result_amount)
 		if(!our_result)
-			log_unit_test("[R]: Recipes - Missing result type.")
+			log_unit_test("[R]: Recipes - Missing result.")
 			failed = TRUE
 		else if(!ispath(our_result, /atom/movable)
-			log_unit_test("[R]: Recipes - Improper result type; [our_result] is not an obj or mob.")
+			log_unit_test("[R]: Recipes - Improper result; [our_result] is not an obj or mob.")
 			failed = TRUE
 		if(isnull(our_amount))
 			log_unit_test("[R]: Recipes - result_quantity must be set.")
 			failed = TRUE
-		if(initial(R.result_amount) <= 0)
+		if(our_amount <= 0)
 			log_unit_test("[R]: Recipes - result_quantity must be greater than zero.")
 			failed = TRUE
-		else if(!ISINTEGER(initial(R.result_amount)))
+		else if(!ISINTEGER(our_amount)
 			log_unit_test("[R]: Recipes - result_quantity must be an integer.")
 			failed = TRUE
 

--- a/polaris.dme
+++ b/polaris.dme
@@ -3227,6 +3227,7 @@
 #include "code\unit_tests\loadout_tests.dm"
 #include "code\unit_tests\map_tests.dm"
 #include "code\unit_tests\mob_tests.dm"
+#include "code\unit_tests\recipe_tests.dm"
 #include "code\unit_tests\research_tests.dm"
 #include "code\unit_tests\sqlite_tests.dm"
 #include "code\unit_tests\subsystem_tests.dm"


### PR DESCRIPTION
Checks for:
- Missing result type
- Result type is not /atom/movable (mob or obj)
- Result quantity unset
- Quantity less than or equal to zero
- Quantity is not an integer