### PR TITLE
stops armour plate and armour plate inserts having the same name, and…

### DIFF
--- a/code/game/objects/items/weapons/material/material_armor.dm
+++ b/code/game/objects/items/weapons/material/material_armor.dm
@@ -288,7 +288,9 @@ Protectiveness | Armor %
 
 /obj/item/weapon/material/armor_plating/insert
 	unbreakable = FALSE
-
+	name = "plate insert"
+	desc = "used to craft armor plates for a plate carrier. Trim with a welder for light armor or add a second for heavy armor"
+	
 /obj/item/weapon/material/armor_plating/attackby(var/obj/O, mob/user)
 	if(istype(O, /obj/item/stack/cable_coil))
 		var/obj/item/stack/cable_coil/S = O


### PR DESCRIPTION
… examine text as each other

armour plate and armour plate inserts have the same sprite, name, and examine text in game. I can fix two of  three things. You need to do stuff with amour plate inserts to make it fit in a plate carrier wile amour plate just will never fit