### PR TITLE
ripleys autoscoop ore in an aoe

### DIFF
--- a/code/game/mecha/working/ripley.dm
+++ b/code/game/mecha/working/ripley.dm
@@ -25,6 +25,19 @@
 	icon_scale_x = 1.2
 	icon_scale_y = 1.2
 
+/obj/mecha/working/ripley/Move()
+	. = ..()
+	if(.)
+		collect_ore()
+
+/obj/mecha/working/ripley/proc/collect_ore()
+	if(locate(/obj/item/mecha_parts/mecha_equipment/tool/hydraulic_clamp) in equipment)
+		var/obj/structure/ore_box/ore_box = locate(/obj/structure/ore_box) in cargo
+		if(ore_box)
+			for(var/obj/item/weapon/ore/ore in range(1, src))
+				if(ore.Adjacent(src) && ((get_dir(src, ore) & dir) || ore.loc == loc)) //we can reach it and it's in front of us? grab it!
+					ore.forceMove(ore_box)
+
 /obj/mecha/working/ripley/Destroy()
 	for(var/atom/movable/A in src.cargo)
 		A.loc = loc


### PR DESCRIPTION
note:
to autoscoop ore, the ripley will need
- a hydraulic clamp
- an ore box in the cargo hold

otherwise, well, it's kind of self-explanatory

why it's good:
as it is now, if you run over a pile of stray ore (or sand) while in a ripley and with a mining satchel in your pocket:
the ore will go into your pocket, and not your ripley, or the ore box inside
this is annoying to me so here's a "fix" pr for a very small thing