### PR TITLE
Added unit test to ensure emote key uniqueness.

### DIFF
--- a/code/modules/emotes/definitions/audible.dm
+++ b/code/modules/emotes/definitions/audible.dm
@@ -12,7 +12,7 @@
 		emote_message_radio_synthetic = emote_message_synthetic_3p
 
 /decl/emote/audible/deathgasp_alien
-	key = "deathgasp"
+	key = "adeathgasp"
 	emote_message_3p = "lets out a waning guttural screech, green blood bubbling from its maw."
 
 /decl/emote/audible/whimper
@@ -29,7 +29,7 @@
 	emote_message_3p = "scretches."
 
 /decl/emote/audible/choke
-	key ="choke"
+	key = "choke"
 	emote_message_3p = "chokes."
 	conscious = FALSE
 
@@ -63,7 +63,7 @@
 	emote_message_3p = "boops."
 
 /decl/emote/audible/beep
-	key = "beep"
+	key = "bbeep"
 	emote_message_3p = "You beep."
 	emote_message_3p = "beeps."
 	emote_sound = 'sound/machines/twobeep.ogg'
@@ -133,18 +133,18 @@
 	emote_message_3p = "grunts."
 
 /decl/emote/audible/bug_hiss
-	key ="hiss"
+	key = "bhiss"
 	emote_message_3p_target = "hisses at TARGET."
 	emote_message_3p = "hisses."
 	emote_sound = 'sound/voice/BugHiss.ogg'
 
 /decl/emote/audible/bug_buzz
-	key ="buzz"
+	key = "bbuzz"
 	emote_message_3p = "buzzes its wings."
 	emote_sound = 'sound/voice/BugBuzz.ogg'
 
 /decl/emote/audible/bug_chitter
-	key ="chitter"
+	key = "chitter"
 	emote_message_3p = "chitters."
 	emote_sound = 'sound/voice/Bug.ogg'
 
@@ -213,7 +213,7 @@
 	emote_sound = 'sound/voice/teshsqueak.ogg' // Copyright CC BY 3.0 InspectorJ (freesound.org) for the source audio.
 
 /decl/emote/audible/teshchirp
-	key = "chirp"
+	key = "tchirp"
 	emote_message_1p = "You chirp!"
 	emote_message_3p = "chirps!"
 	emote_message_1p_target = "You chirp at TARGET!"

--- a/code/modules/emotes/definitions/slimes.dm
+++ b/code/modules/emotes/definitions/slimes.dm
@@ -12,21 +12,21 @@
 	return ..() && isslime(user)
 
 /decl/emote/slime/pout
-	key = "pout"
+	key = "mpout"
 	mood = "pout"
 
 /decl/emote/slime/sad
-	key = "sad"
+	key = "msad"
 	mood = "sad"
 
 /decl/emote/slime/angry
-	key = "angry"
+	key = "mangry"
 	mood = "angry"
 
 /decl/emote/slime/frown
-	key = "frown"
+	key = "mfrown"
 	mood = "mischevous"
 
 /decl/emote/slime/smile
-	key = "smile"
+	key = "msmile"
 	mood = ":3"

--- a/code/modules/emotes/definitions/visible.dm
+++ b/code/modules/emotes/definitions/visible.dm
@@ -1,5 +1,5 @@
 /decl/emote/visible
-	key ="tail"
+	key = "tail"
 	emote_message_3p = "waves USER_THEIR tail."
 	message_type = VISIBLE_MESSAGE
 
@@ -9,48 +9,48 @@
 	emote_message_3p = "scratches."
 
 /decl/emote/visible/drool
-	key ="drool"
+	key = "drool"
 	emote_message_3p = "drools."
 	conscious = FALSE
 
 /decl/emote/visible/nod
-	key ="nod"
+	key = "nod"
 	emote_message_3p_target = "nods USER_THEIR head at TARGET."
 	emote_message_3p = "nods USER_THEIR head."
 
 /decl/emote/visible/sway
-	key ="sway"
+	key = "sways"
 	emote_message_3p = "sways around dizzily."
 
 /decl/emote/visible/sulk
-	key ="sulk"
+	key = "sulk"
 	emote_message_3p = "sulks down sadly."
 
 /decl/emote/visible/dance
-	key ="dance"
+	key = "dance"
 	check_restraints = TRUE
 	emote_message_3p = "dances around happily."
 
 /decl/emote/visible/roll
-	key ="roll"
+	key = "roll"
 	check_restraints = TRUE
 	emote_message_3p = "rolls."
 
 /decl/emote/visible/shake
-	key ="shake"
+	key = "shake"
 	emote_message_3p = "shakes USER_THEIR head."
 
 /decl/emote/visible/jump
-	key ="jump"
+	key = "jump"
 	emote_message_3p = "jumps!"
 
 /decl/emote/visible/shiver
-	key ="shiver"
+	key = "shiver"
 	emote_message_3p = "shivers."
 	conscious = FALSE
 
 /decl/emote/visible/collapse
-	key ="collapse"
+	key = "collapse"
 	emote_message_3p = "collapses!"
 
 /decl/emote/visible/collapse/do_extra(var/mob/user)
@@ -216,7 +216,7 @@
 	emote_message_3p = "vibrates!"
 
 /decl/emote/visible/deathgasp_robot
-	key = "deathgasp"
+	key = "rdeathgasp"
 	emote_message_3p = "shudders violently for a moment, then becomes motionless, USER_THEIR eyes slowly darkening."
 
 /decl/emote/visible/handshake

--- a/code/modules/emotes/emote_mob.dm
+++ b/code/modules/emotes/emote_mob.dm
@@ -71,7 +71,7 @@
 		return
 
 	if(!use_emote.mob_can_use(src))
-		to_chat(src, SPAN_WARNING("You cannot use the emote '[act]'. Type <b>say *help</b> for  a list of usable emotes."))
+		to_chat(src, SPAN_WARNING("You cannot use the emote '[act]'. Type <b>say *help</b> for a list of usable emotes."))
 		return
 
 	if(m_type != use_emote.message_type && use_emote.conscious && stat != CONSCIOUS)

--- a/code/unit_tests/decl_tests.dm
+++ b/code/unit_tests/decl_tests.dm
@@ -1,0 +1,26 @@
+/datum/unit_test/emotes_shall_have_unique_keys
+	name = "DECLS: Emotes Shall Have Unique Keys"
+
+/datum/unit_test/emotes_shall_have_unique_keys/start_test()
+
+	var/list/keys = list()
+	var/list/duplicates = list()
+
+	var/list/all_emotes = decls_repository.get_decls_of_subtype(/decl/emote)
+	for(var/etype in all_emotes)
+		var/decl/emote/emote = all_emotes[etype]
+		if(!emote.key)
+			continue
+		if(emote.key in keys)
+			if(!duplicates[emote.key])
+				duplicates[emote.key] = list() 
+			duplicates[emote.key] += etype
+		else
+			keys += emote.key
+
+	if(length(duplicates))
+		fail("[length(duplicates)] emote\s had overlapping keys: [english_list(duplicates)].")
+	else
+		pass("All emotes had unique keys.")
+
+	return TRUE

--- a/polaris.dme
+++ b/polaris.dme
@@ -3223,6 +3223,7 @@
 #include "code\modules\xenobio\machinery\processor.dm"
 #include "code\modules\xgm\xgm_gas_data.dm"
 #include "code\modules\xgm\xgm_gas_mixture.dm"
+#include "code\unit_tests\decl_tests.dm"
 #include "code\unit_tests\language_tests.dm"
 #include "code\unit_tests\loadout_tests.dm"
 #include "code\unit_tests\map_tests.dm"


### PR DESCRIPTION
Fixes https://github.com/VOREStation/VOREStation/issues/10556. Surprisingly annoying bug to chase down.
:cl:
tweak: Several premotes (ex. 'say *fart') have had their keys changed to be unique - if an emote doesn't work, please check 'say *help' before reporting it as a bug.
/:cl: