### PR TITLE
clamps decon_mod between 0 and 1

### DIFF
--- a/code/modules/research/destructive_analyzer.dm
+++ b/code/modules/research/destructive_analyzer.dm
@@ -25,7 +25,7 @@ Note: Must be placed within 3 tiles of the R&D Console
 	var/T = 0
 	for(var/obj/item/weapon/stock_parts/S in component_parts)
 		T += S.rating
-	T =* 0.1
+	T *= 0.1
 	decon_mod = clamp(T, 0, 1)
 
 /obj/machinery/r_n_d/destructive_analyzer/update_icon()

--- a/code/modules/research/destructive_analyzer.dm
+++ b/code/modules/research/destructive_analyzer.dm
@@ -25,7 +25,8 @@ Note: Must be placed within 3 tiles of the R&D Console
 	var/T = 0
 	for(var/obj/item/weapon/stock_parts/S in component_parts)
 		T += S.rating
-	decon_mod = T * 0.1
+	T =* 0.1
+	decon_mod = clamp(T, 0, 1)
 
 /obj/machinery/r_n_d/destructive_analyzer/update_icon()
 	if(panel_open)


### PR DESCRIPTION
turns out if you have tier 4 parts or above, you can get a decon mod above 1, meaning you get more materials from deconstructing things than it costs to have them. this is especially useful with sheets