### PR TITLE
Refactors utensils to use weakrefs

### DIFF
--- a/code/game/objects/items/weapons/material/kitchen.dm
+++ b/code/game/objects/items/weapons/material/kitchen.dm
@@ -16,7 +16,6 @@
 	force_divisor = 0.1 // 6 when wielded with hardness 60 (steel)
 	thrown_force_divisor = 0.25 // 5 when thrown with weight 20 (steel)
 	var/weakref/loaded //Weakref for currently loaded food object.
-	var/scoop_food = TRUE
 
 /obj/item/weapon/material/kitchen/utensil/New()
 	..()
@@ -51,14 +50,14 @@
 		reagents.trans_to_mob(M, reagents.total_volume, CHEM_INGEST)
 		if(eaten)	
 			if(M == user)
-				if(!M.can_eat(loaded))
+				if(!M.can_eat(eaten))
 					return
-				M.visible_message(SPAN_NOTICE("\The [user] eats some [loaded] from \the [src]."))
+				M.visible_message(SPAN_NOTICE("\The [user] eats some of \the [eaten] with \the [src]."))
 			else
 				user.visible_message(SPAN_WARNING("\The [user] begins to feed \the [M]!"))
 				if(!(M.can_force_feed(user, loaded) && do_mob(user, M, 5 SECONDS)))
 					return
-				M.visible_message(SPAN_NOTICE("\The [user] feeds some [loaded] to \the [M] with \the [src]."))
+				M.visible_message(SPAN_NOTICE("\The [user] feeds some of \the [eaten] to \the [M] with \the [src]."))
 			playsound(src,'sound/items/eatfood.ogg', rand(10,40), 1)
 		update_icon()
 		return

--- a/code/game/objects/items/weapons/material/kitchen.dm
+++ b/code/game/objects/items/weapons/material/kitchen.dm
@@ -11,12 +11,12 @@
 	thrown_force_divisor = 1
 	origin_tech = list(TECH_MATERIAL = 1)
 	attack_verb = list("attacked", "stabbed", "poked")
-	sharp = 1
-	edge = 1
+	sharp = TRUE
+	edge = TRUE
 	force_divisor = 0.1 // 6 when wielded with hardness 60 (steel)
 	thrown_force_divisor = 0.25 // 5 when thrown with weight 20 (steel)
-	var/loaded      //Descriptive string for currently loaded food object.
-	var/scoop_food = 1
+	var/weakref/loaded //Weakref for currently loaded food object.
+	var/scoop_food = TRUE
 
 /obj/item/weapon/material/kitchen/utensil/New()
 	..()
@@ -24,6 +24,15 @@
 		src.pixel_y = rand(0, 4)
 	create_reagents(5)
 	return
+
+/obj/item/weapon/material/kitchen/utensil/update_icon()
+	. = ..()
+	cut_overlays()
+	var/obj/item/weapon/reagent_containers/food/snacks/eaten = loaded?.resolve()
+	if(eaten)
+		var/image/I = new(icon, "loadedfood")
+		I.color = eaten.filling_color
+		add_overlay(I)
 
 /obj/item/weapon/material/kitchen/utensil/attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob)
 	if(!istype(M))
@@ -37,30 +46,32 @@
 		else
 			return ..()
 
-	if (reagents.total_volume > 0)
+	if (loaded && reagents.total_volume > 0)
+		var/atom/movable/eaten = loaded?.resolve()
 		reagents.trans_to_mob(M, reagents.total_volume, CHEM_INGEST)
-		if(M == user)
-			if(!M.can_eat(loaded))
-				return
-			M.visible_message("<span class='notice'>\The [user] eats some [loaded] from \the [src].</span>")
-		else
-			user.visible_message("<span class='warning'>\The [user] begins to feed \the [M]!</span>")
-			if(!(M.can_force_feed(user, loaded) && do_mob(user, M, 5 SECONDS)))
-				return
-			M.visible_message("<span class='notice'>\The [user] feeds some [loaded] to \the [M] with \the [src].</span>")
-		playsound(src,'sound/items/eatfood.ogg', rand(10,40), 1)
-		overlays.Cut()
+		if(eaten)	
+			if(M == user)
+				if(!M.can_eat(loaded))
+					return
+				M.visible_message(SPAN_NOTICE("\The [user] eats some [loaded] from \the [src]."))
+			else
+				user.visible_message(SPAN_WARNING("\The [user] begins to feed \the [M]!"))
+				if(!(M.can_force_feed(user, loaded) && do_mob(user, M, 5 SECONDS)))
+					return
+				M.visible_message(SPAN_NOTICE("\The [user] feeds some [loaded] to \the [M] with \the [src]."))
+			playsound(src,'sound/items/eatfood.ogg', rand(10,40), 1)
+		update_icon()
 		return
 	else
-		to_chat(user, "<span class='warning'>You don't have anything on \the [src].</span>")	//if we have help intent and no food scooped up DON'T STAB OURSELVES WITH THE FORK
+		to_chat(user, SPAN_WARNING("You don't have anything on \the [src]."))	//if we have help intent and no food scooped up DON'T STAB OURSELVES WITH THE FORK
 		return
 
 /obj/item/weapon/material/kitchen/utensil/fork
 	name = "fork"
 	desc = "It's a fork. Sure is pointy."
 	icon_state = "fork"
-	sharp = 1
-	edge = 0
+	sharp = TRUE
+	edge = FALSE
 
 /obj/item/weapon/material/kitchen/utensil/fork/plastic
 	default_material = "plastic"
@@ -70,8 +81,8 @@
 	desc = "It's a spoon. You can see your own upside-down face in it."
 	icon_state = "spoon"
 	attack_verb = list("attacked", "poked")
-	edge = 0
-	sharp = 0
+	edge = FALSE
+	sharp = FALSE
 	force_divisor = 0.1 //2 when wielded with weight 20 (steel)
 
 /obj/item/weapon/material/kitchen/utensil/spoon/plastic

--- a/code/game/objects/items/weapons/material/kitchen.dm
+++ b/code/game/objects/items/weapons/material/kitchen.dm
@@ -55,7 +55,7 @@
 				M.visible_message(SPAN_NOTICE("\The [user] eats some of \the [eaten] with \the [src]."))
 			else
 				user.visible_message(SPAN_WARNING("\The [user] begins to feed \the [M]!"))
-				if(!(M.can_force_feed(user, loaded) && do_mob(user, M, 5 SECONDS)))
+				if(!(M.can_force_feed(user, eaten) && do_mob(user, M, 5 SECONDS)))
 					return
 				M.visible_message(SPAN_NOTICE("\The [user] feeds some of \the [eaten] to \the [M] with \the [src]."))
 			playsound(src,'sound/items/eatfood.ogg', rand(10,40), 1)

--- a/code/modules/food/food/snacks.dm
+++ b/code/modules/food/food/snacks.dm
@@ -173,12 +173,7 @@
 				"<font color='blue'>You scoop up some [src] with \the [U]!</font>" \
 			)
 
-			src.bitecount++
-			U.overlays.Cut()
-			U.loaded = "[src]"
-			var/image/I = new(U.icon, "loadedfood")
-			I.color = src.filling_color
-			U.overlays += I
+			bitecount++
 
 			reagents.trans_to_obj(U, min(reagents.total_volume,5))
 

--- a/code/modules/food/food/snacks.dm
+++ b/code/modules/food/food/snacks.dm
@@ -160,26 +160,25 @@
 	// Eating with forks
 	if(istype(W,/obj/item/weapon/material/kitchen/utensil))
 		var/obj/item/weapon/material/kitchen/utensil/U = W
-		if(U.scoop_food)
-			if(!U.reagents)
-				U.create_reagents(5)
+		if(!U.reagents)
+			U.create_reagents(5)
 
-			if (U.reagents.total_volume > 0)
-				to_chat(user, "<font color='red'>You already have something on your [U].</font>")
-				return
-
-			user.visible_message( \
-				"[user] scoops up some [src] with \the [U]!", \
-				"<font color='blue'>You scoop up some [src] with \the [U]!</font>" \
-			)
-
-			bitecount++
-
-			reagents.trans_to_obj(U, min(reagents.total_volume,5))
-
-			if (reagents.total_volume <= 0)
-				qdel(src)
+		if (U.reagents.total_volume > 0)
+			to_chat(user, "<font color='red'>You already have something on your [U].</font>")
 			return
+
+		user.visible_message( \
+			"[user] scoops up some [src] with \the [U]!", \
+			"<font color='blue'>You scoop up some [src] with \the [U]!</font>" \
+		)
+
+		bitecount++
+
+		reagents.trans_to_obj(U, min(reagents.total_volume,5))
+
+		if (reagents.total_volume <= 0)
+			qdel(src)
+		return
 
 	if (is_sliceable())
 		//these are used to allow hiding edge items in food that is not on a table/tray

--- a/html/changelogs/MDP-utensilsrefactor.yml
+++ b/html/changelogs/MDP-utensilsrefactor.yml
@@ -1,0 +1,37 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: MoondancerPony
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Foods will no longer have improper grammar and capitalisation when eaten with utensils."
+  - tweak: "Refactors utensils to use weakrefs rather than stored strings; also does a bunch of code cleanup."


### PR DESCRIPTION
This should prevent stuff like `"MarinaGryphon eats some The eggs benedict from the fork."`
It was originally because `loaded = "[src]"`; references in string interpolation are automatically expanded to "\the [src]" which then expands to "[src.name]" or "the [src.name]", depending on if something is a proper noun. There IS one exception: If the reference is at the start of a string, it'll have `\The` inserted instead of `\the`, which leads to the aforementioned issue.

Also replaces span tags with span macros and uses boolean macros for boolean values.

Ceterum autem censeo Stellae Polaris esse delendam.