### PR TITLE
Improves select_recipe.

### DIFF
--- a/code/_helpers/sorts/comparators.dm
+++ b/code/_helpers/sorts/comparators.dm
@@ -57,12 +57,6 @@
 	if (!.)
 		. = B[STAT_ENTRY_COUNT] - A[STAT_ENTRY_COUNT]
 
-// Compares complexity of recipes for use in cooking, etc. This is for telling which recipe to make, not for showing things to the player.
-/proc/cmp_recipe_complexity_dsc(datum/recipe/A, datum/recipe/B)
-	var/a_score = LAZYLEN(A.items) + LAZYLEN(A.reagents) + LAZYLEN(A.fruit)
-	var/b_score = LAZYLEN(B.items) + LAZYLEN(B.reagents) + LAZYLEN(B.fruit)
-	return b_score - a_score
-
 /proc/cmp_typepaths_asc(A, B)
 	return sorttext("[B]","[A]") 
 	

--- a/code/modules/food/recipe.dm
+++ b/code/modules/food/recipe.dm
@@ -314,20 +314,19 @@
 
 // When exact is false, extraneous ingredients are ignored
 // When exact is true, extraneous ingredients will fail the recipe
-// In both cases, the full complement of required inredients is still needed
+// In both cases, the full set of required ingredients is still needed
 /proc/select_recipe(var/list/datum/recipe/available_recipes, var/obj/obj as obj, var/exact)
 	var/list/datum/recipe/possible_recipes = list()
+	var/highest_count = 0
+	var/count = 0
 	for (var/datum/recipe/recipe in available_recipes)
 		if(!recipe.check_reagents(obj.reagents, exact) || !recipe.check_items(obj, exact)  || !recipe.check_fruit(obj, exact))
 			continue
-		possible_recipes |= recipe
-	if (!possible_recipes.len)
-		return null
-	else if (possible_recipes.len == 1)
-		return possible_recipes[1]
-	else //okay, let's select the most complicated recipe
-		sortTim(possible_recipes, /proc/cmp_recipe_complexity_dsc)
-		return possible_recipes[1]
+		// Taken from cmp_recipe_complexity_dsc, but is way faster.
+		count = LAZYLEN(recipe.items) + LAZYLEN(recipe.reagents) + LAZYLEN(recipe.fruit)
+		if(count >= highest_count)
+			highest_count = count
+			. = recipe
 
 // Both of these are just placeholders to allow special behavior for mob holders, but you can do other things in here later if you feel like it.
 /datum/recipe/proc/before_cook(obj/container) // Called Before the Microwave starts delays and cooking stuff

--- a/html/changelogs/MDP-recipecleanup.yml
+++ b/html/changelogs/MDP-recipecleanup.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: MoondancerPony
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - experiment: "Hopefully made cooking recipe selection/calculation much faster on the backend."


### PR DESCRIPTION
Removes the call to Timsort and the recipe comparator proc; uses a handrolled implementation of
`argmax(items + reagents + fruit)` instead. This will hopefully reduce the memory footprint of `select_recipe` as well as the amount of processing needed to select the optimal recipe; instead of O(n log n), it should be O(n).

Ceterum autem censeo Stellan Polaris esse delendam.