### PR TITLE
Fixes synthetic var not getting cleared between loaded chars

### DIFF
--- a/code/modules/client/preference_setup/general/03_body.dm
+++ b/code/modules/client/preference_setup/general/03_body.dm
@@ -339,6 +339,7 @@ var/global/list/valid_bloodtypes = list("A+", "A-", "B+", "B-", "AB+", "AB-", "O
 	character.set_gender(pref.biological_gender)
 
 	// Destroy/cyborgize organs and limbs.
+	character.synthetic = null //Clear the existing var.
 	for(var/name in list(BP_HEAD, BP_L_HAND, BP_R_HAND, BP_L_ARM, BP_R_ARM, BP_L_FOOT, BP_R_FOOT, BP_L_LEG, BP_R_LEG, BP_GROIN, BP_TORSO))
 		var/status = pref.organ_data[name]
 		var/obj/item/organ/external/O = character.organs_by_name[name]


### PR DESCRIPTION
Fixes synthetic var not getting cleared when loading character slots. Due to the char setup mannequin mob's nature of being a single same mob just getting its properties loaded from save slots, loading/making a synth character would permanently mess up the var for all non-synth chars on the roster and cause issues with synth-related settings because there was nothing in the code to clear the var.