### PR TITLE
Closet appearance decls correctly use the repository

### DIFF
--- a/code/_helpers/global_lists.dm
+++ b/code/_helpers/global_lists.dm
@@ -25,9 +25,6 @@ var/global/list/joblist = list()					//list of all jobstypes, minus borg and AI
 
 var/list/mannequins_
 
-// Closets have magic appearances
-GLOBAL_LIST_EMPTY(closet_appearances)
-
 // Times that players are allowed to respawn ("ckey" = world.time)
 GLOBAL_LIST_EMPTY(respawn_timers)
 
@@ -217,9 +214,6 @@ var/global/list/string_slot_flags = list(
 	paths = typesof(/datum/alloy)-/datum/alloy
 	for(var/alloytype in paths)
 		GLOB.alloy_data += new alloytype()
-
-	//Closet appearances
-	GLOB.closet_appearances = decls_repository.get_decls_of_type(/decl/closet_appearance)
 
 	paths = typesof(/datum/sprite_accessory/ears) - /datum/sprite_accessory/ears
 	for(var/path in paths)

--- a/code/datums/repositories/decls.dm
+++ b/code/datums/repositories/decls.dm
@@ -14,8 +14,7 @@
 //     III. Thou shalt not write a decl that relies on arguments supplied to New().
 //     IV.  Thou shalt not call Initialize() on a /decl.
 
-var/repository/decls/decls_repository // Initialiozed in /datum/global_init/New()
-
+var/repository/decls/decls_repository = new()
 /repository/decls
 	var/list/fetched_decls
 	var/list/fetched_decl_types

--- a/code/game/objects/structures/crates_lockers/__closets.dm
+++ b/code/game/objects/structures/crates_lockers/__closets.dm
@@ -59,7 +59,7 @@
 			storage_capacity = content_size + 5
 
 	if(ispath(closet_appearance))
-		var/decl/closet_appearance/app = GLOB.closet_appearances[closet_appearance]
+		var/decl/closet_appearance/app = decls_repository.get_decl(closet_appearance)
 		if(app)
 			icon = app.icon
 			color = null

--- a/code/game/objects/structures/crates_lockers/__closets.dm
+++ b/code/game/objects/structures/crates_lockers/__closets.dm
@@ -59,7 +59,7 @@
 			storage_capacity = content_size + 5
 
 	if(ispath(closet_appearance))
-		var/decl/closet_appearance/app = decls_repository.get_decl(closet_appearance)
+		var/decl/closet_appearance/app = GET_DECL(closet_appearance)
 		if(app)
 			icon = app.icon
 			color = null

--- a/code/global_init.dm
+++ b/code/global_init.dm
@@ -21,7 +21,6 @@ var/global/datum/global_init/init = new ()
 	error_log = file("[log_path]-error.log")
 	debug_log = file("[log_path]-debug.log")
 	debug_log << "[log_end]\n[log_end]\nStarting up. [time_stamp()][log_end]\n---------------------[log_end]"
-	decls_repository = new()	
 	load_configuration()
 	makeDatumRefLists()
 


### PR DESCRIPTION
Tested, doesn't break everything:
![dreamseeker_2021-06-20_23-53-01](https://user-images.githubusercontent.com/8475252/122726659-4d222c80-d21a-11eb-8b2b-7ee0021be2fc.png)

Moves decl repo init back out of global init