### PR TITLE
Adds optional area-based definition for outdoors-ness

### DIFF
--- a/code/__defines/turfs.dm
+++ b/code/__defines/turfs.dm
@@ -20,3 +20,9 @@
 #define isDiagonal(x)			(x == NORTHEAST || x == SOUTHEAST || x == NORTHWEST || x == SOUTHWEST)
 
 #define FOOTSTEP_SPRITE_AMT 2
+
+// Used to designate if a turf (or its area) should initialize as outdoors or not.
+#define OUTDOORS_YES		1	// This being 1 helps with backwards compatibility.
+#define OUTDOORS_NO			0	// Ditto.
+#define OUTDOORS_AREA		-1	// If a turf has this, it will defer to the area's settings on init.
+								// Note that after init, it will be either YES or NO.

--- a/code/controllers/subsystems/planets.dm
+++ b/code/controllers/subsystems/planets.dm
@@ -42,7 +42,7 @@ SUBSYSTEM_DEF(planets)
 			return
 		if(istype(T, /turf/unsimulated/wall/planetary))	
 			P.planet_walls += T
-		else if(istype(T, /turf/simulated) && T.outdoors)
+		else if(istype(T, /turf/simulated) && T.outdoors == OUTDOORS_YES)
 			P.planet_floors += T
 			T.vis_contents |= P.weather_holder.visuals
 			T.vis_contents |= P.weather_holder.special_visuals		

--- a/code/game/objects/effects/step_triggers.dm
+++ b/code/game/objects/effects/step_triggers.dm
@@ -215,7 +215,7 @@ var/global/list/tele_landmarks = list() // Terrible, but the alternative is loop
 			if(!istype(candidate) || istype(candidate, /turf/simulated/sky))
 				safety--
 				continue
-			else if(candidate && !candidate.outdoors)
+			else if(candidate && !candidate.outdoors == OUTDOORS_YES)
 				safety--
 				continue
 			else

--- a/code/game/turfs/simulated/floor_attackby.dm
+++ b/code/game/turfs/simulated/floor_attackby.dm
@@ -45,10 +45,10 @@
 				return
 
 		// Create a ceiling to shield from the weather
-		if(src.outdoors)
+		if(src.outdoors == OUTDOORS_YES)
 			for(var/dir in cardinal)
 				var/turf/A = get_step(src, dir)
-				if(A && !A.outdoors)
+				if(A && !A.outdoors == OUTDOORS_YES)
 					if(expended_tile || R.use(1))
 						make_indoors()
 						playsound(src, 'sound/weapons/Genhit.ogg', 50, 1)

--- a/code/game/turfs/simulated/lava.dm
+++ b/code/game/turfs/simulated/lava.dm
@@ -16,7 +16,7 @@
 	initial_flooring = /decl/flooring/lava // Defining this in case someone DOES step on lava and survive. Somehow.
 
 /turf/simulated/floor/lava/outdoors
-	outdoors = TRUE
+	outdoors = OUTDOORS_YES
 
 // For maximum pedantry.
 /turf/simulated/floor/lava/Initialize()

--- a/code/game/turfs/simulated/outdoors/outdoors.dm
+++ b/code/game/turfs/simulated/outdoors/outdoors.dm
@@ -5,7 +5,12 @@ var/list/turf_edge_cache = list()
 	// and if those adjacent turfs have a lower edge_blending_priority.
 	var/edge_blending_priority = 0
 	// Outdoors var determines if the game should consider the turf to be 'outdoors', which controls certain things such as weather effects.
-	var/outdoors = FALSE
+	var/outdoors = OUTDOORS_AREA
+
+/area
+	// If a turf's `outdoors` variable is set to `OUTDOORS_AREA`, 
+	// it will decide if it's outdoors or not when being initialized based on this var.
+	var/outdoors = OUTDOORS_NO
 
 /turf/simulated/floor/outdoors
 	name = "generic ground"
@@ -13,7 +18,7 @@ var/list/turf_edge_cache = list()
 	icon = 'icons/turf/outdoors.dmi'
 	icon_state = null
 	edge_blending_priority = 1
-	outdoors = TRUE					// This variable is used for weather effects.
+	outdoors = OUTDOORS_YES			// This variable is used for weather effects.
 	can_dirty = FALSE				// Looks hideous with dirt on it.
 	can_build_into_floor = TRUE
 
@@ -21,31 +26,46 @@ var/list/turf_edge_cache = list()
 	var/list/turf_layers = list(/turf/simulated/floor/outdoors/rocks)
 
 /turf/simulated/floor/Initialize(mapload)
-	if(outdoors)
+	if(should_be_outdoors())
 		SSplanets.addTurf(src)
 	. = ..()
 
 /turf/simulated/floor/Destroy()
-	if(outdoors)
+	if(should_be_outdoors())
 		SSplanets.removeTurf(src)
 	return ..()
 
+// Turfs can decide if they should be indoors or outdoors.
+// By default they choose based on their area's setting.
+// This helps cut down on ten billion `/outdoors` subtypes being needed.
+/turf/simulated/proc/should_be_outdoors()
+	switch(outdoors)
+		if(OUTDOORS_YES)
+			return TRUE
+		if(OUTDOORS_NO)
+			return FALSE
+		if(OUTDOORS_AREA)
+			var/area/A = loc
+			if(A.outdoors == OUTDOORS_YES)
+				return TRUE
+	return FALSE
+
 /turf/simulated/proc/make_outdoors()
-	if(outdoors)
+	if(outdoors == OUTDOORS_YES)
 		return
-	outdoors = TRUE
+	outdoors = OUTDOORS_YES
 	SSplanets.addTurf(src)
 
 /turf/simulated/proc/make_indoors()
-	if(!outdoors)
+	if(!outdoors == OUTDOORS_NO)
 		return
-	outdoors = FALSE
+	outdoors = OUTDOORS_NO
 	SSplanets.removeTurf(src)
 
 /turf/simulated/post_change()
 	..()
 	// If it was outdoors and still is, it will not get added twice when the planet controller gets around to putting it in.
-	if(outdoors)
+	if(outdoors == OUTDOORS_YES)
 		make_outdoors()
 	else
 		make_indoors()

--- a/code/game/turfs/simulated/outdoors/sky.dm
+++ b/code/game/turfs/simulated/outdoors/sky.dm
@@ -4,7 +4,7 @@
 	desc = "Hope you don't have a fear of heights."
 	icon = 'icons/turf/floors.dmi'
 	icon_state = "sky_slow"
-	outdoors = TRUE
+	outdoors = OUTDOORS_YES
 
 	// Assume there's a vacuum for the purposes of avoiding active edges at initialization, as well as ZAS fun if a window breaks.
 	oxygen = 0

--- a/code/game/turfs/simulated/wall_attacks.dm
+++ b/code/game/turfs/simulated/wall_attacks.dm
@@ -171,7 +171,7 @@
 				return
 
 		// Create a ceiling to shield from the weather
-		if(outdoors)
+		if(outdoors == OUTDOORS_YES)
 			if(expended_tile || R.use(1)) // Don't need to check adjacent turfs for a wall, we're building on one
 				make_indoors()
 				if(!expended_tile) // Would've already played a sound

--- a/code/game/turfs/simulated/water.dm
+++ b/code/game/turfs/simulated/water.dm
@@ -8,7 +8,7 @@
 	var/under_state = "rock"
 	edge_blending_priority = -1
 	movement_cost = 4
-	outdoors = TRUE
+	outdoors = OUTDOORS_YES
 
 	layer = WATER_FLOOR_LAYER
 
@@ -106,12 +106,12 @@
 	name = "pool"
 	desc = "Don't worry, it's not closed."
 	under_state = "pool"
-	outdoors = FALSE
+	outdoors = OUTDOORS_NO
 
 /turf/simulated/floor/water/deep/pool
 	name = "deep pool"
 	desc = "Don't worry, it's not closed."
-	outdoors = FALSE
+	outdoors = OUTDOORS_NO
 
 /mob/living/proc/can_breathe_water()
 	return FALSE

--- a/code/modules/admin/verbs/lightning_strike.dm
+++ b/code/modules/admin/verbs/lightning_strike.dm
@@ -40,13 +40,13 @@
 	for(var/obj/machinery/power/thing in range(LIGHTNING_REDIRECT_RANGE, T))
 		if(istype(thing, /obj/machinery/power/tesla_coil))
 			var/turf/simulated/coil_turf = get_turf(thing)
-			if(istype(coil_turf) && thing.anchored && coil_turf.outdoors)
+			if(istype(coil_turf) && thing.anchored && coil_turf.outdoors == OUTDOORS_YES)
 				coil = thing
 				break
 
 		if(istype(thing, /obj/machinery/power/grounding_rod))
 			var/turf/simulated/rod_turf = get_turf(thing)
-			if(istype(rod_turf) && thing.anchored && rod_turf.outdoors)
+			if(istype(rod_turf) && thing.anchored && rod_turf.outdoors == OUTDOORS_YES)
 				ground = thing
 
 	if(coil) // Coil gets highest priority.

--- a/code/modules/flufftext/look_up.dm
+++ b/code/modules/flufftext/look_up.dm
@@ -12,7 +12,7 @@
 		to_chat(usr, span("warning", "You appear to be in a place without any sort of concept of direction. You have bigger problems to worry about."))
 		return
 
-	if(!T.outdoors) // They're inside.
+	if(T.outdoors == OUTDOORS_NO) // They're inside.
 		to_chat(usr, "You see nothing interesting.")
 		return
 

--- a/code/modules/mining/fulton.dm
+++ b/code/modules/mining/fulton.dm
@@ -43,7 +43,7 @@ var/global/list/total_extraction_beacons = list()
 		return
 	if(!can_use_indoors)
 		var/turf/T = get_turf(A)
-		if(T && !T.outdoors)
+		if(T && T.outdoors == OUTDOORS_NO)
 			to_chat(user, "[src] can only be used on things that are outdoors!")
 			return
 	if(!flag)
@@ -146,7 +146,7 @@ var/global/list/total_extraction_beacons = list()
 
 /obj/item/fulton_core/attack_self(mob/user)
 	var/turf/T = get_turf(user)
-	var/outdoors = T.outdoors
+	var/outdoors = T.outdoors == OUTDOORS_YES
 	if(do_after(user,15,target = user) && !QDELETED(src) && outdoors)
 		new /obj/structure/extraction_point(get_turf(user))
 		qdel(src)

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -146,7 +146,7 @@
 			. += turf_move_cost
 
 	// Wind makes it easier or harder to move, depending on if you're with or against the wind.
-	if(T.outdoors && (T.z <= SSplanets.z_to_planet.len))
+	if((T.outdoors == OUTDOORS_YES) && (T.z <= SSplanets.z_to_planet.len))
 		var/datum/planet/P = SSplanets.z_to_planet[z]
 		if(P)
 			var/datum/weather_holder/WH = P.weather_holder

--- a/code/modules/planet/sif.dm
+++ b/code/modules/planet/sif.dm
@@ -299,7 +299,7 @@ var/datum/planet/sif/planet_sif = null
 	for(var/mob/living/L as anything in living_mob_list)
 		if(L.z in holder.our_planet.expected_z_levels)
 			var/turf/T = get_turf(L)
-			if(!T.outdoors)
+			if(T.outdoors == OUTDOORS_NO)
 				continue // They're indoors, so no need to rain on them.
 
 			// If they have an open umbrella, it'll guard from rain
@@ -352,7 +352,7 @@ var/datum/planet/sif/planet_sif = null
 	for(var/mob/living/L as anything in living_mob_list)
 		if(L.z in holder.our_planet.expected_z_levels)
 			var/turf/T = get_turf(L)
-			if(!T.outdoors)
+			if(T.outdoors == OUTDOORS_NO)
 				continue // They're indoors, so no need to rain on them.
 
 			// If they have an open umbrella, it'll guard from rain
@@ -410,7 +410,7 @@ var/datum/planet/sif/planet_sif = null
 	for(var/mob/living/carbon/H as anything in human_mob_list)
 		if(H.z in holder.our_planet.expected_z_levels)
 			var/turf/T = get_turf(H)
-			if(!T.outdoors)
+			if(T.outdoors == OUTDOORS_NO)
 				continue // They're indoors, so no need to pelt them with ice.
 
 			// If they have an open umbrella, it'll guard from hail
@@ -506,7 +506,7 @@ var/datum/planet/sif/planet_sif = null
 		var/mob/living/L = thing
 		if(L.z in holder.our_planet.expected_z_levels)
 			var/turf/T = get_turf(L)
-			if(!T.outdoors)
+			if(T.outdoors == OUTDOORS_NO)
 				continue // They're indoors, so no need to burn them with ash.
 
 			L.inflict_heat_damage(rand(1, 3))
@@ -544,7 +544,7 @@ var/datum/planet/sif/planet_sif = null
 		if(L.z in holder.our_planet.expected_z_levels)
 			irradiate_nearby_turf(L)
 			var/turf/T = get_turf(L)
-			if(!T.outdoors)
+			if(T.outdoors == OUTDOORS_NO)
 				continue // They're indoors, so no need to irradiate them with fallout.
 
 			L.rad_act(rand(direct_rad_low, direct_rad_high))
@@ -558,5 +558,5 @@ var/datum/planet/sif/planet_sif = null
 	var/turf/T = pick(turfs) // We get one try per tick.
 	if(!istype(T))
 		return
-	if(T.outdoors)
+	if(T.outdoors == OUTDOORS_YES)
 		SSradiation.radiate(T, rand(fallout_rad_low, fallout_rad_high))

--- a/code/modules/planet/weather.dm
+++ b/code/modules/planet/weather.dm
@@ -123,7 +123,7 @@
 	for(var/mob/M in player_list) // Don't need to care about clientless mobs.
 		if(M.z in our_planet.expected_z_levels)
 			var/turf/T = get_turf(M)
-			if(!T.outdoors)
+			if(T.outdoors == OUTDOORS_NO)
 				continue
 			to_chat(M, message)
 
@@ -200,7 +200,7 @@
 			// Otherwise they should hear some sounds, depending on if they're inside or not.
 			var/turf/T = get_turf(M)
 			if(istype(T))
-				if(T.outdoors) // Mob is currently outdoors.
+				if(T.outdoors == OUTDOORS_YES) // Mob is currently outdoors.
 					hear_outdoor_sounds(M, TRUE)
 					hear_indoor_sounds(M, FALSE)
 

--- a/maps/southern_cross/southern_cross_areas.dm
+++ b/maps/southern_cross/southern_cross_areas.dm
@@ -61,6 +61,7 @@
 	ambience = AMBIENCE_SIF
 	always_unpowered = TRUE
 	flags = AREA_FLAG_IS_NOT_PERSISTENT
+	outdoors = OUTDOORS_YES
 
 // The area near the outpost, so POIs don't show up right next to the outpost.
 /area/surface/outside/plains/outpost
@@ -163,10 +164,12 @@
 /area/surface/outpost/mining_main
 	name = "North Mining Outpost"
 	icon_state = "outpost_mine_main"
+	outdoors = OUTDOORS_NO
 
 /area/surface/outpost/mining_main/exterior
 	name = "North Mining Outpost Exterior"
 	icon_state = "outpost_mine_main"
+	outdoors = OUTDOORS_YES
 
 /area/surface/outpost/mining_main/crew_area
 	name = "North Mining Crew Area"
@@ -205,6 +208,7 @@
 
 /area/surface/outpost/research
 	icon_state = "outpost_research"
+	outdoors = OUTDOORS_NO
 
 /area/surface/outpost/research/xenoresearch
 	name = "\improper Xenoresearch"
@@ -291,6 +295,7 @@
 /area/surface/outpost/main
 	name = "\improper Main Outpost"
 	icon_state = "Sleep"
+	outdoors = OUTDOORS_NO
 
 /area/surface/outpost/main/gen_room
 	name = "\improper Main Outpost SMES"
@@ -371,6 +376,7 @@
 /area/outpost/mining_station
 	icon_state = "outpost_mine_main"
 	name = "Mining Station"
+	outdoors = OUTDOORS_NO
 
 /area/outpost/mining_station/dorms
 	name = "Mining Station Dormitory"

--- a/maps/southern_cross/turfs/outdoors.dm
+++ b/maps/southern_cross/turfs/outdoors.dm
@@ -24,19 +24,19 @@
 	oxygen		= MOLES_O2SIF
 	nitrogen	= MOLES_N2SIF
 	temperature	= TEMPERATURE_SIF
-	outdoors = TRUE
+	outdoors = OUTDOORS_YES
 
 /turf/simulated/floor/tiled/steel/sif/planetuse
 	oxygen		= MOLES_O2SIF
 	nitrogen	= MOLES_N2SIF
 	temperature	= TEMPERATURE_SIF
-	outdoors = TRUE
+	outdoors = OUTDOORS_YES
 
 /turf/simulated/floor/plating/sif/planetuse
 	oxygen		= MOLES_O2SIF
 	nitrogen	= MOLES_N2SIF
 	temperature	= TEMPERATURE_SIF
-	outdoors = TRUE
+	outdoors = OUTDOORS_YES
 
 /turf/simulated/floor/outdoors/snow/sif/planetuse
 	oxygen		= MOLES_O2SIF


### PR DESCRIPTION
This is mostly for the new map, but it might be helpful to have now and outside of the map PR.

This essentially converts the `outdoors` var on turfs from a binary value to a ternary, with init values being able to be 'yes', 'no', and a new option, 'area', which makes it outdoors or indoors based on what the area wants it to be, with a newly added value that can hold a 'yes' or 'no'.

The advantage is that this helps avoid ten thousand `/outdoors` subtypes for turfs (tho that ship has kinda sailed, but we can now get rid of those types and replace with the base one instead). It also helps avoid bugs with single turfs that are indoors when they're intended to be outdoors (or the other way around). It also helps cut down on map overrided turfs to set `outdoors` to 0 or 1.

It should be noted the turfs themselves have the final say on whether or not they're outdoors. If the value is 'yes' or 'no', the area's value is irrelevant. Also, the 'yes' value is 1, and the 'no' value is 0, which mirrors the binary system and thus this should be backwards compatible with current maps.

By default, turfs defer to the area. Also by default, areas default to being indoors. This is done since the majority of areas are indoors. Most outdoor areas are under a general outdoor area anyways, so it's easy to apply it.