### PR TITLE
Replaces DEFAULT_WALL_MATERIAL with MAT_STEEL, where applicable

### DIFF
--- a/code/__defines/materials.dm
+++ b/code/__defines/materials.dm
@@ -1,6 +1,3 @@
-#define DEFAULT_TABLE_MATERIAL "plastic"
-#define DEFAULT_WALL_MATERIAL "steel"
-
 #define MAT_IRON			"iron"
 #define MAT_MARBLE			"marble"
 #define MAT_STEEL			"steel"
@@ -46,6 +43,9 @@
 #define MAT_PAINITE			"painite"
 #define MAT_BOROSILICATE	"borosilicate glass"
 #define MAT_SANDSTONE		"sandstone"
+
+#define DEFAULT_TABLE_MATERIAL MAT_PLASTIC
+#define DEFAULT_WALL_MATERIAL MAT_STEEL
 
 #define SHARD_SHARD "shard"
 #define SHARD_SHRAPNEL "shrapnel"

--- a/code/datums/autolathe/arms.dm
+++ b/code/datums/autolathe/arms.dm
@@ -74,13 +74,13 @@
 	name = "pistol magazine (.45 armor piercing)"
 	path =/obj/item/ammo_magazine/m45/ap
 	hidden = 1
-	resources = list(DEFAULT_WALL_MATERIAL = 500, MAT_PLASTEEL = 300)
+	resources = list(MAT_STEEL = 500, MAT_PLASTEEL = 300)
 
 /datum/category_item/autolathe/arms/pistol_45hp
 	name = "pistol magazine (.45 hollowpoint)"
 	path =/obj/item/ammo_magazine/m45/hp
 	hidden = 1
-	resources = list(DEFAULT_WALL_MATERIAL = 500, MAT_PLASTIC = 200)
+	resources = list(MAT_STEEL = 500, MAT_PLASTIC = 200)
 
 /datum/category_item/autolathe/arms/pistol_45uzi
 	name = "uzi magazine (.45)"

--- a/code/datums/autolathe/devices.dm
+++ b/code/datums/autolathe/devices.dm
@@ -30,7 +30,7 @@
 	name = "barbed wire"
 	path = /obj/item/weapon/material/barbedwire
 	hidden = 1
-	resources = list(DEFAULT_WALL_MATERIAL = 10000)
+	resources = list(MAT_STEEL = 10000)
 
 /datum/category_item/autolathe/devices/electropack
 	name = "electropack"

--- a/code/datums/autolathe/general.dm
+++ b/code/datums/autolathe/general.dm
@@ -126,7 +126,7 @@
 /datum/category_item/autolathe/general/idcard
 	name = "ID Card"
 	path = /obj/item/weapon/card/id
-	resources = list(DEFAULT_WALL_MATERIAL = 100, MAT_GLASS = 100, MAT_PLASTIC = 300)
+	resources = list(MAT_STEEL = 100, MAT_GLASS = 100, MAT_PLASTIC = 300)
 	man_rating = 2
 
 /datum/category_item/autolathe/general/handcuffs

--- a/code/datums/autolathe/tools.dm
+++ b/code/datums/autolathe/tools.dm
@@ -56,6 +56,6 @@
 /datum/category_item/autolathe/tools/spraynozzle
 	name = "spray nozzle"
 	path = /obj/item/weapon/reagent_containers/spray
-	resources = list(MAT_PLASTIC = 5000, DEFAULT_WALL_MATERIAL = 2000)
+	resources = list(MAT_PLASTIC = 5000, MAT_STEEL = 2000)
 	hidden = 1
 	man_rating = 2

--- a/code/defines/obj/weapon.dm
+++ b/code/defines/obj/weapon.dm
@@ -150,7 +150,7 @@
 	w_class = ITEMSIZE_SMALL
 	throw_speed = 4
 	throw_range = 20
-	matter = list(DEFAULT_WALL_MATERIAL = 100)
+	matter = list(MAT_STEEL = 100)
 	origin_tech = list(TECH_MAGNET = 1)
 	drop_sound = 'sound/items/drop/device.ogg'
 	pickup_sound = 'sound/items/pickup/device.ogg'
@@ -215,7 +215,7 @@
 	icon_state = "power_mod"
 	item_state = "std_mod"
 	desc = "Heavy-duty switching circuits for power control."
-	matter = list(DEFAULT_WALL_MATERIAL = 50, "glass" = 50)
+	matter = list(MAT_STEEL = 50, "glass" = 50)
 
 /obj/item/weapon/module/id_auth
 	name = "\improper ID authentication module"
@@ -385,7 +385,7 @@
 	desc = "A basic capacitor used in the construction of a variety of devices."
 	icon_state = "capacitor"
 	origin_tech = list(TECH_POWER = 1)
-	matter = list(DEFAULT_WALL_MATERIAL = 50,"glass" = 50)
+	matter = list(MAT_STEEL = 50,"glass" = 50)
 
 	var/charge = 0
 	var/max_charge = 1000
@@ -410,28 +410,28 @@
 	desc = "A compact, high resolution scanning module used in the construction of certain devices."
 	icon_state = "scan_module"
 	origin_tech = list(TECH_MAGNET = 1)
-	matter = list(DEFAULT_WALL_MATERIAL = 50,"glass" = 20)
+	matter = list(MAT_STEEL = 50,"glass" = 20)
 
 /obj/item/weapon/stock_parts/manipulator
 	name = "micro-manipulator"
 	desc = "A tiny little manipulator used in the construction of certain devices."
 	icon_state = "micro_mani"
 	origin_tech = list(TECH_MATERIAL = 1, TECH_DATA = 1)
-	matter = list(DEFAULT_WALL_MATERIAL = 30)
+	matter = list(MAT_STEEL = 30)
 
 /obj/item/weapon/stock_parts/micro_laser
 	name = "micro-laser"
 	desc = "A tiny laser used in certain devices."
 	icon_state = "micro_laser"
 	origin_tech = list(TECH_MAGNET = 1)
-	matter = list(DEFAULT_WALL_MATERIAL = 10,"glass" = 20)
+	matter = list(MAT_STEEL = 10,"glass" = 20)
 
 /obj/item/weapon/stock_parts/matter_bin
 	name = "matter bin"
 	desc = "A container for hold compressed matter awaiting re-construction."
 	icon_state = "matter_bin"
 	origin_tech = list(TECH_MATERIAL = 1)
-	matter = list(DEFAULT_WALL_MATERIAL = 80)
+	matter = list(MAT_STEEL = 80)
 
 //Rank 2
 
@@ -441,7 +441,7 @@
 	icon_state = "capacitor_adv"
 	origin_tech = list(TECH_POWER = 3)
 	rating = 2
-	matter = list(DEFAULT_WALL_MATERIAL = 50,"glass" = 50)
+	matter = list(MAT_STEEL = 50,"glass" = 50)
 
 /obj/item/weapon/stock_parts/scanning_module/adv
 	name = "advanced scanning module"
@@ -449,7 +449,7 @@
 	icon_state = "scan_module_adv"
 	origin_tech = list(TECH_MAGNET = 3)
 	rating = 2
-	matter = list(DEFAULT_WALL_MATERIAL = 50,"glass" = 20)
+	matter = list(MAT_STEEL = 50,"glass" = 20)
 
 /obj/item/weapon/stock_parts/manipulator/nano
 	name = "nano-manipulator"
@@ -457,7 +457,7 @@
 	icon_state = "nano_mani"
 	origin_tech = list(TECH_MATERIAL = 3, TECH_DATA = 2)
 	rating = 2
-	matter = list(DEFAULT_WALL_MATERIAL = 30)
+	matter = list(MAT_STEEL = 30)
 
 /obj/item/weapon/stock_parts/micro_laser/high
 	name = "high-power micro-laser"
@@ -465,7 +465,7 @@
 	icon_state = "high_micro_laser"
 	origin_tech = list(TECH_MAGNET = 3)
 	rating = 2
-	matter = list(DEFAULT_WALL_MATERIAL = 10,"glass" = 20)
+	matter = list(MAT_STEEL = 10,"glass" = 20)
 
 /obj/item/weapon/stock_parts/matter_bin/adv
 	name = "advanced matter bin"
@@ -473,7 +473,7 @@
 	icon_state = "advanced_matter_bin"
 	origin_tech = list(TECH_MATERIAL = 3)
 	rating = 2
-	matter = list(DEFAULT_WALL_MATERIAL = 80)
+	matter = list(MAT_STEEL = 80)
 
 //Rating 3
 
@@ -483,7 +483,7 @@
 	icon_state = "capacitor_super"
 	origin_tech = list(TECH_POWER = 5, TECH_MATERIAL = 4)
 	rating = 3
-	matter = list(DEFAULT_WALL_MATERIAL = 50,"glass" = 50)
+	matter = list(MAT_STEEL = 50,"glass" = 50)
 
 /obj/item/weapon/stock_parts/scanning_module/phasic
 	name = "phasic scanning module"
@@ -491,7 +491,7 @@
 	icon_state = "scan_module_phasic"
 	origin_tech = list(TECH_MAGNET = 5)
 	rating = 3
-	matter = list(DEFAULT_WALL_MATERIAL = 50,"glass" = 20)
+	matter = list(MAT_STEEL = 50,"glass" = 20)
 
 /obj/item/weapon/stock_parts/manipulator/pico
 	name = "pico-manipulator"
@@ -499,7 +499,7 @@
 	icon_state = "pico_mani"
 	origin_tech = list(TECH_MATERIAL = 5, TECH_DATA = 2)
 	rating = 3
-	matter = list(DEFAULT_WALL_MATERIAL = 30)
+	matter = list(MAT_STEEL = 30)
 
 /obj/item/weapon/stock_parts/micro_laser/ultra
 	name = "ultra-high-power micro-laser"
@@ -507,7 +507,7 @@
 	desc = "A tiny laser used in certain devices."
 	origin_tech = list(TECH_MAGNET = 5)
 	rating = 3
-	matter = list(DEFAULT_WALL_MATERIAL = 10,"glass" = 20)
+	matter = list(MAT_STEEL = 10,"glass" = 20)
 
 /obj/item/weapon/stock_parts/matter_bin/super
 	name = "super matter bin"
@@ -515,7 +515,7 @@
 	icon_state = "super_matter_bin"
 	origin_tech = list(TECH_MATERIAL = 5)
 	rating = 3
-	matter = list(DEFAULT_WALL_MATERIAL = 80)
+	matter = list(MAT_STEEL = 80)
 
 // Rating 4 - Anomaly
 
@@ -525,7 +525,7 @@
 	icon_state = "capacitor_hyper"
 	origin_tech = list(TECH_POWER = 6, TECH_MATERIAL = 5, TECH_BLUESPACE = 1, TECH_ARCANE = 1)
 	rating = 4
-	matter = list(DEFAULT_WALL_MATERIAL = 80, MAT_GLASS = 40)
+	matter = list(MAT_STEEL = 80, MAT_GLASS = 40)
 
 /obj/item/weapon/stock_parts/scanning_module/hyper
 	name = "quantum scanning module"
@@ -533,7 +533,7 @@
 	icon_state = "scan_module_hyper"
 	origin_tech = list(TECH_MAGNET = 6, TECH_BLUESPACE = 1, TECH_ARCANE = 1)
 	rating = 4
-	matter = list(DEFAULT_WALL_MATERIAL = 100,"glass" = 40)
+	matter = list(MAT_STEEL = 100,"glass" = 40)
 
 /obj/item/weapon/stock_parts/manipulator/hyper
 	name = "planck-manipulator"
@@ -541,7 +541,7 @@
 	icon_state = "hyper_mani"
 	origin_tech = list(TECH_MATERIAL = 6, TECH_DATA = 3, TECH_ARCANE = 1)
 	rating = 4
-	matter = list(DEFAULT_WALL_MATERIAL = 30)
+	matter = list(MAT_STEEL = 30)
 
 /obj/item/weapon/stock_parts/micro_laser/hyper
 	name = "hyper-power micro-laser"
@@ -549,7 +549,7 @@
 	desc = "A tiny laser used in certain devices."
 	origin_tech = list(TECH_MAGNET = 6, TECH_ARCANE = 1)
 	rating = 4
-	matter = list(DEFAULT_WALL_MATERIAL = 30, MAT_GLASS = 40)
+	matter = list(MAT_STEEL = 30, MAT_GLASS = 40)
 
 /obj/item/weapon/stock_parts/matter_bin/hyper
 	name = "hyper matter bin"
@@ -557,7 +557,7 @@
 	icon_state = "hyper_matter_bin"
 	origin_tech = list(TECH_MATERIAL = 6, TECH_ARCANE = 1)
 	rating = 4
-	matter = list(DEFAULT_WALL_MATERIAL = 100)
+	matter = list(MAT_STEEL = 100)
 
 // Rating 5 - Precursor
 
@@ -567,7 +567,7 @@
 	icon_state = "capacitor_omni"
 	origin_tech = list(TECH_POWER = 7, TECH_MATERIAL = 6, TECH_BLUESPACE = 3, TECH_PRECURSOR  = 1)
 	rating = 5
-	matter = list(DEFAULT_WALL_MATERIAL = 80, MAT_GLASS = 40)
+	matter = list(MAT_STEEL = 80, MAT_GLASS = 40)
 
 /obj/item/weapon/stock_parts/scanning_module/omni
 	name = "omni-scanning module"
@@ -575,7 +575,7 @@
 	icon_state = "scan_module_omni"
 	origin_tech = list(TECH_MAGNET = 7, TECH_BLUESPACE = 3, TECH_PRECURSOR = 1)
 	rating = 5
-	matter = list(DEFAULT_WALL_MATERIAL = 100,"glass" = 40)
+	matter = list(MAT_STEEL = 100,"glass" = 40)
 
 /obj/item/weapon/stock_parts/manipulator/omni
 	name = "omni-manipulator"
@@ -583,7 +583,7 @@
 	icon_state = "omni_mani"
 	origin_tech = list(TECH_MATERIAL = 7, TECH_DATA = 4, TECH_PRECURSOR  = 1)
 	rating = 5
-	matter = list(DEFAULT_WALL_MATERIAL = 30)
+	matter = list(MAT_STEEL = 30)
 
 /obj/item/weapon/stock_parts/micro_laser/omni
 	name = "omni-power micro-laser"
@@ -591,7 +591,7 @@
 	desc = "A strange laser used in certain devices."
 	origin_tech = list(TECH_MAGNET = 7, TECH_PRECURSOR  = 1)
 	rating = 5
-	matter = list(DEFAULT_WALL_MATERIAL = 30, MAT_GLASS = 40)
+	matter = list(MAT_STEEL = 30, MAT_GLASS = 40)
 
 /obj/item/weapon/stock_parts/matter_bin/omni
 	name = "omni-matter bin"
@@ -599,7 +599,7 @@
 	icon_state = "omni_matter_bin"
 	origin_tech = list(TECH_MATERIAL = 7, TECH_PRECURSOR  = 1)
 	rating = 5
-	matter = list(DEFAULT_WALL_MATERIAL = 100)
+	matter = list(MAT_STEEL = 100)
 
 
 // Subspace stock parts
@@ -609,35 +609,35 @@
 	icon_state = "subspace_ansible"
 	desc = "A compact module capable of sensing extradimensional activity."
 	origin_tech = list(TECH_DATA = 3, TECH_MAGNET = 5 ,TECH_MATERIAL = 4, TECH_BLUESPACE = 2)
-	matter = list(DEFAULT_WALL_MATERIAL = 30,"glass" = 10)
+	matter = list(MAT_STEEL = 30,"glass" = 10)
 
 /obj/item/weapon/stock_parts/subspace/sub_filter
 	name = "hyperwave filter"
 	icon_state = "hyperwave_filter"
 	desc = "A tiny device capable of filtering and converting super-intense radiowaves."
 	origin_tech = list(TECH_DATA = 4, TECH_MAGNET = 2)
-	matter = list(DEFAULT_WALL_MATERIAL = 30,"glass" = 10)
+	matter = list(MAT_STEEL = 30,"glass" = 10)
 
 /obj/item/weapon/stock_parts/subspace/amplifier
 	name = "subspace amplifier"
 	icon_state = "subspace_amplifier"
 	desc = "A compact micro-machine capable of amplifying weak subspace transmissions."
 	origin_tech = list(TECH_DATA = 3, TECH_MAGNET = 4, TECH_MATERIAL = 4, TECH_BLUESPACE = 2)
-	matter = list(DEFAULT_WALL_MATERIAL = 30,"glass" = 10)
+	matter = list(MAT_STEEL = 30,"glass" = 10)
 
 /obj/item/weapon/stock_parts/subspace/treatment
 	name = "subspace treatment disk"
 	icon_state = "treatment_disk"
 	desc = "A compact micro-machine capable of stretching out hyper-compressed radio waves."
 	origin_tech = list(TECH_DATA = 3, TECH_MAGNET = 2, TECH_MATERIAL = 5, TECH_BLUESPACE = 2)
-	matter = list(DEFAULT_WALL_MATERIAL = 30,"glass" = 10)
+	matter = list(MAT_STEEL = 30,"glass" = 10)
 
 /obj/item/weapon/stock_parts/subspace/analyzer
 	name = "subspace wavelength analyzer"
 	icon_state = "wavelength_analyzer"
 	desc = "A sophisticated analyzer capable of analyzing cryptic subspace wavelengths."
 	origin_tech = list(TECH_DATA = 3, TECH_MAGNET = 4, TECH_MATERIAL = 4, TECH_BLUESPACE = 2)
-	matter = list(DEFAULT_WALL_MATERIAL = 30,"glass" = 10)
+	matter = list(MAT_STEEL = 30,"glass" = 10)
 
 /obj/item/weapon/stock_parts/subspace/crystal
 	name = "ansible crystal"
@@ -651,7 +651,7 @@
 	icon_state = "subspace_transmitter"
 	desc = "A large piece of equipment used to open a window into the subspace dimension."
 	origin_tech = list(TECH_MAGNET = 5, TECH_MATERIAL = 5, TECH_BLUESPACE = 3)
-	matter = list(DEFAULT_WALL_MATERIAL = 50)
+	matter = list(MAT_STEEL = 50)
 
 /obj/item/weapon/ectoplasm
 	name = "ectoplasm"
@@ -675,7 +675,7 @@
 	icon = 'icons/obj/stock_parts.dmi'
 	icon_state = "gear"
 	origin_tech = list(TECH_ENGINEERING = 1)
-	matter = list(DEFAULT_WALL_MATERIAL = 50)
+	matter = list(MAT_STEEL = 50)
 
 /obj/item/weapon/stock_parts/motor
 	name = "motor"
@@ -683,7 +683,7 @@
 	icon = 'icons/obj/stock_parts.dmi'
 	icon_state = "motor"
 	origin_tech = list(TECH_ENGINEERING = 1)
-	matter = list(DEFAULT_WALL_MATERIAL = 60, "glass" = 10)
+	matter = list(MAT_STEEL = 60, "glass" = 10)
 
 /obj/item/weapon/stock_parts/spring
 	name = "spring"
@@ -691,4 +691,4 @@
 	icon = 'icons/obj/stock_parts.dmi'
 	icon_state = "spring"
 	origin_tech = list(TECH_ENGINEERING = 1)
-	matter = list(DEFAULT_WALL_MATERIAL = 40)
+	matter = list(MAT_STEEL = 40)

--- a/code/game/gamemodes/nuclear/pinpointer.dm
+++ b/code/game/gamemodes/nuclear/pinpointer.dm
@@ -7,7 +7,7 @@
 	item_state = "electronic"
 	throw_speed = 4
 	throw_range = 20
-	matter = list(DEFAULT_WALL_MATERIAL = 500)
+	matter = list(MAT_STEEL = 500)
 	preserve_item = 1
 	var/obj/item/weapon/disk/nuclear/the_disk = null
 	var/active = 0

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -728,7 +728,7 @@ var/global/list/all_objectives = list()
 /datum/objective/heist/salvage/choose_target()
 	switch(rand(1,8))
 		if(1)
-			target = DEFAULT_WALL_MATERIAL
+			target = MAT_STEEL
 			target_amount = 300
 		if(2)
 			target = "glass"

--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -12,8 +12,8 @@
 
 	circuit = /obj/item/weapon/circuitboard/autolathe
 	var/datum/category_collection/autolathe/machine_recipes
-	var/list/stored_material =  list(DEFAULT_WALL_MATERIAL = 0, MAT_GLASS = 0, MAT_PLASTEEL = 0, MAT_PLASTIC = 0)
-	var/list/storage_capacity = list(DEFAULT_WALL_MATERIAL = 0, MAT_GLASS = 0, MAT_PLASTEEL = 0, MAT_PLASTIC = 0)
+	var/list/stored_material =  list(MAT_STEEL = 0, MAT_GLASS = 0, MAT_PLASTEEL = 0, MAT_PLASTIC = 0)
+	var/list/storage_capacity = list(MAT_STEEL = 0, MAT_GLASS = 0, MAT_PLASTEEL = 0, MAT_PLASTIC = 0)
 	var/datum/category_group/autolathe/current_category
 
 	var/hacked = 0
@@ -75,7 +75,7 @@
 		var/list/material_bottom = list("<tr>")
 
 		for(var/material in stored_material)
-			if(material != DEFAULT_WALL_MATERIAL && material != MAT_GLASS) // Don't show the Extras unless people care enough to put them in.
+			if(material != MAT_STEEL && material != MAT_GLASS) // Don't show the Extras unless people care enough to put them in.
 				if(stored_material[material] <= 0)
 					continue
 			material_top += "<td width = '25%' align = center><b>[material]</b></td>"
@@ -175,7 +175,7 @@
 			to_chat(user, "\The [speedloader] is too hazardous to put back into the autolathe while there's ammunition inside of it!")
 			return
 		else
-			speedloader.matter = list(DEFAULT_WALL_MATERIAL = 75) // It's just a hunk of scrap metal now.
+			speedloader.matter = list(MAT_STEEL = 75) // It's just a hunk of scrap metal now.
 	if(istype(O,/obj/item/ammo_magazine)) // This was just for immersion consistency with above.
 		var/obj/item/ammo_magazine/mag = O
 		if(mag.stored_ammo)

--- a/code/game/machinery/bioprinter.dm
+++ b/code/game/machinery/bioprinter.dm
@@ -333,7 +333,7 @@
 	circuit = /obj/item/weapon/circuitboard/roboprinter
 
 	var/matter_amount_per_sheet = 10
-	var/matter_type = DEFAULT_WALL_MATERIAL
+	var/matter_type = MAT_STEEL
 
 /obj/machinery/organ_printer/robot/full/New()
 	. = ..()

--- a/code/game/machinery/camera/camera_assembly.dm
+++ b/code/game/machinery/camera/camera_assembly.dm
@@ -6,7 +6,7 @@
 	w_class = ITEMSIZE_SMALL
 	anchored = 0
 
-	matter = list(DEFAULT_WALL_MATERIAL = 700,"glass" = 300)
+	matter = list(MAT_STEEL = 700,"glass" = 300)
 
 	//	Motion, EMP-Proof, X-Ray
 	var/list/obj/item/possible_upgrades = list(/obj/item/device/assembly/prox_sensor, /obj/item/stack/material/osmium, /obj/item/weapon/stock_parts/scanning_module)

--- a/code/game/machinery/fire_alarm.dm
+++ b/code/game/machinery/fire_alarm.dm
@@ -173,7 +173,7 @@ Just a object used in constructing fire alarms
 	icon_state = "door_electronics"
 	desc = "A circuit. It has a label on it, it says \"Can handle heat levels up to 40 degrees celsius!\""
 	w_class = ITEMSIZE_SMALL
-	matter = list(DEFAULT_WALL_MATERIAL = 50, "glass" = 50)
+	matter = list(MAT_STEEL = 50, "glass" = 50)
 */
 /obj/machinery/partyalarm
 	name = "\improper PARTY BUTTON"

--- a/code/game/machinery/pipe/pipelayer.dm
+++ b/code/game/machinery/pipe/pipelayer.dm
@@ -62,8 +62,8 @@
 		var/answer = alert(user, "Do you want to eject all the metal in \the [src]?", , "Yes","No")
 		if(answer == "Yes")
 			var/amount_ejected = eject_metal()
-			user.visible_message("<span class='notice'>[user] removes [amount_ejected] sheet\s of [DEFAULT_WALL_MATERIAL] from the \the [src].</span>",
-				"<span class='notice'>You remove [amount_ejected] sheet\s of [DEFAULT_WALL_MATERIAL] from \the [src].</span>")
+			user.visible_message("<span class='notice'>[user] removes [amount_ejected] sheet\s of [MAT_STEEL] from the \the [src].</span>",
+				"<span class='notice'>You remove [amount_ejected] sheet\s of [MAT_STEEL] from \the [src].</span>")
 		return
 	if(!metal && !on)
 		to_chat(user, "<span class='warning'>\The [src] doesn't work without metal.</span>")
@@ -92,8 +92,8 @@
 		return
 	if(istype(W, /obj/item/pipe))
 		// NOTE - We must check for matter, otherwise the (free) pipe dispenser can be used to get infinite steel.
-		if(!W.matter || W.matter[DEFAULT_WALL_MATERIAL] < pipe_cost * SHEET_MATERIAL_AMOUNT)
-			to_chat(user, "<span class='warning'>\The [W] doesn't contain enough [DEFAULT_WALL_MATERIAL] to recycle.</span>")
+		if(!W.matter || W.matter[MAT_STEEL] < pipe_cost * SHEET_MATERIAL_AMOUNT)
+			to_chat(user, "<span class='warning'>\The [W] doesn't contain enough [MAT_STEEL] to recycle.</span>")
 		else if(metal + pipe_cost > max_metal)
 			to_chat(user, "<span class='notice'>\The [src] is full.</span>")
 		else
@@ -102,7 +102,7 @@
 			to_chat(user, "<span class='notice'>You recycle \the [W].</span>")
 			qdel(W)
 		return
-	if(istype(W, /obj/item/stack/material) && W.get_material_name() == DEFAULT_WALL_MATERIAL)
+	if(istype(W, /obj/item/stack/material) && W.get_material_name() == MAT_STEEL)
 		var/result = load_metal(W)
 		if(isnull(result))
 			to_chat(user, "<span class='warning'>Unable to load [W] - no metal found.</span>")
@@ -145,7 +145,7 @@
 /obj/machinery/pipelayer/proc/eject_metal()
 	var/amount_ejected = 0
 	while (metal >= 1)
-		var/datum/material/M = get_material_by_name(DEFAULT_WALL_MATERIAL)
+		var/datum/material/M = get_material_by_name(MAT_STEEL)
 		var/obj/item/stack/material/S = new M.stack_type(get_turf(src))
 		S.amount = min(metal, S.max_amount)
 		metal -= S.amount
@@ -177,7 +177,7 @@
 	var/obj/item/pipe/P = new pi_type(w_turf, p_type, p_dir)
 	P.setPipingLayer(p_layer)
 	// We used metal to make these, so should be reclaimable!
-	P.matter = list(DEFAULT_WALL_MATERIAL = pipe_cost * SHEET_MATERIAL_AMOUNT)
+	P.matter = list(MAT_STEEL = pipe_cost * SHEET_MATERIAL_AMOUNT)
 	P.attackby(W , src)
 
 	return 1

--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -983,7 +983,7 @@
 				return
 
 		if(1)
-			if(istype(I, /obj/item/stack/material) && I.get_material_name() == DEFAULT_WALL_MATERIAL)
+			if(istype(I, /obj/item/stack/material) && I.get_material_name() == MAT_STEEL)
 				var/obj/item/stack/M = I
 				if(M.use(2))
 					to_chat(user, "<span class='notice'>You add some metal armor to the interior frame.</span>")
@@ -1069,7 +1069,7 @@
 			//attack_hand() removes the prox sensor
 
 		if(6)
-			if(istype(I, /obj/item/stack/material) && I.get_material_name() == DEFAULT_WALL_MATERIAL)
+			if(istype(I, /obj/item/stack/material) && I.get_material_name() == MAT_STEEL)
 				var/obj/item/stack/M = I
 				if(M.use(2))
 					to_chat(user, "<span class='notice'>You add some metal armor to the exterior frame.</span>")

--- a/code/game/machinery/robot_fabricator.dm
+++ b/code/game/machinery/robot_fabricator.dm
@@ -12,7 +12,7 @@
 	active_power_usage = 10000
 
 /obj/machinery/robotic_fabricator/attackby(var/obj/item/O as obj, var/mob/user as mob)
-	if(istype(O, /obj/item/stack/material) && O.get_material_name() == DEFAULT_WALL_MATERIAL)
+	if(istype(O, /obj/item/stack/material) && O.get_material_name() == MAT_STEEL)
 		var/obj/item/stack/M = O
 		if(metal_amount < 150000.0)
 			var/count = 0
@@ -22,7 +22,7 @@
 					if(!M.get_amount())
 						return
 					while(metal_amount < 150000 && M.amount)
-						metal_amount += O.matter[DEFAULT_WALL_MATERIAL] /*O:height * O:width * O:length * 100000.0*/
+						metal_amount += O.matter[MAT_STEEL] /*O:height * O:width * O:length * 100000.0*/
 						M.use(1)
 						count++
 

--- a/code/game/mecha/mech_fabricator.dm
+++ b/code/game/mecha/mech_fabricator.dm
@@ -13,7 +13,7 @@
 
 	var/speed = 1
 	var/mat_efficiency = 1
-	var/list/materials = list(DEFAULT_WALL_MATERIAL = 0, "glass" = 0, "plastic" = 0, MAT_GRAPHITE = 0, MAT_PLASTEEL = 0, "gold" = 0, "silver" = 0, MAT_LEAD = 0, "osmium" = 0, "diamond" = 0, MAT_DURASTEEL = 0, "phoron" = 0, "uranium" = 0, MAT_VERDANTIUM = 0, MAT_MORPHIUM = 0, MAT_METALHYDROGEN = 0, MAT_SUPERMATTER = 0)
+	var/list/materials = list(MAT_STEEL = 0, "glass" = 0, "plastic" = 0, MAT_GRAPHITE = 0, MAT_PLASTEEL = 0, "gold" = 0, "silver" = 0, MAT_LEAD = 0, "osmium" = 0, "diamond" = 0, MAT_DURASTEEL = 0, "phoron" = 0, "uranium" = 0, MAT_VERDANTIUM = 0, MAT_MORPHIUM = 0, MAT_METALHYDROGEN = 0, MAT_SUPERMATTER = 0)
 	var/list/hidden_materials = list(MAT_PLASTEEL, MAT_DURASTEEL, MAT_GRAPHITE, MAT_VERDANTIUM, MAT_MORPHIUM, MAT_METALHYDROGEN, MAT_SUPERMATTER)
 	var/res_max_amount = 200000
 

--- a/code/game/mecha/mech_prosthetics.dm
+++ b/code/game/mecha/mech_prosthetics.dm
@@ -13,7 +13,7 @@
 
 	var/speed = 1
 	var/mat_efficiency = 1
-	var/list/materials = list(DEFAULT_WALL_MATERIAL = 0, "glass" = 0, "plastic" = 0, MAT_GRAPHITE = 0, MAT_PLASTEEL = 0, "gold" = 0, "silver" = 0, MAT_LEAD = 0, "osmium" = 0, "diamond" = 0, MAT_DURASTEEL = 0, "phoron" = 0, "uranium" = 0, MAT_VERDANTIUM = 0, MAT_MORPHIUM = 0)
+	var/list/materials = list(MAT_STEEL = 0, "glass" = 0, "plastic" = 0, MAT_GRAPHITE = 0, MAT_PLASTEEL = 0, "gold" = 0, "silver" = 0, MAT_LEAD = 0, "osmium" = 0, "diamond" = 0, MAT_DURASTEEL = 0, "phoron" = 0, "uranium" = 0, MAT_VERDANTIUM = 0, MAT_MORPHIUM = 0)
 	var/list/hidden_materials = list(MAT_DURASTEEL, MAT_GRAPHITE, MAT_VERDANTIUM, MAT_MORPHIUM)
 	var/res_max_amount = 200000
 

--- a/code/game/mecha/mecha_parts.dm
+++ b/code/game/mecha/mecha_parts.dm
@@ -211,42 +211,42 @@
 	name="Phazon Torso"
 	icon_state = "phazon_harness"
 	//construction_time = 300
-	//construction_cost = list(DEFAULT_WALL_MATERIAL=35000,"glass"=10000,"phoron"=20000)
+	//construction_cost = list(MAT_STEEL=35000,"glass"=10000,"phoron"=20000)
 	origin_tech = list(TECH_DATA = 5, TECH_MATERIAL = 7, TECH_BLUESPACE = 6, TECH_POWER = 6)
 
 /obj/item/mecha_parts/part/phazon_head
 	name="Phazon Head"
 	icon_state = "phazon_head"
 	//construction_time = 200
-	//construction_cost = list(DEFAULT_WALL_MATERIAL=15000,"glass"=5000,"phoron"=10000)
+	//construction_cost = list(MAT_STEEL=15000,"glass"=5000,"phoron"=10000)
 	origin_tech = list(TECH_DATA = 4, TECH_MATERIAL = 5, TECH_MAGNET = 6)
 
 /obj/item/mecha_parts/part/phazon_left_arm
 	name="Phazon Left Arm"
 	icon_state = "phazon_l_arm"
 	//construction_time = 200
-	//construction_cost = list(DEFAULT_WALL_MATERIAL=20000,"phoron"=10000)
+	//construction_cost = list(MAT_STEEL=20000,"phoron"=10000)
 	origin_tech = list(TECH_MATERIAL = 5, TECH_BLUESPACE = 2, TECH_MAGNET = 2)
 
 /obj/item/mecha_parts/part/phazon_right_arm
 	name="Phazon Right Arm"
 	icon_state = "phazon_r_arm"
 	//construction_time = 200
-	//construction_cost = list(DEFAULT_WALL_MATERIAL=20000,"phoron"=10000)
+	//construction_cost = list(MAT_STEEL=20000,"phoron"=10000)
 	origin_tech = list(TECH_MATERIAL = 5, TECH_BLUESPACE = 2, TECH_MAGNET = 2)
 
 /obj/item/mecha_parts/part/phazon_left_leg
 	name="Phazon Left Leg"
 	icon_state = "phazon_l_leg"
 	//construction_time = 200
-	//construction_cost = list(DEFAULT_WALL_MATERIAL=20000,"phoron"=10000)
+	//construction_cost = list(MAT_STEEL=20000,"phoron"=10000)
 	origin_tech = list(TECH_MATERIAL = 5, TECH_BLUESPACE = 3, TECH_MAGNET = 3)
 
 /obj/item/mecha_parts/part/phazon_right_leg
 	name="Phazon Right Leg"
 	icon_state = "phazon_r_leg"
 	//construction_time = 200
-	//construction_cost = list(DEFAULT_WALL_MATERIAL=20000,"phoron"=10000)
+	//construction_cost = list(MAT_STEEL=20000,"phoron"=10000)
 	origin_tech = list(TECH_MATERIAL = 5, TECH_BLUESPACE = 3, TECH_MAGNET = 3)
 
 ///////// Odysseus
@@ -299,7 +299,7 @@
 	icon_state = "odysseus_armour"
 	origin_tech = list(TECH_MATERIAL = 3, TECH_ENGINEERING = 3)
 	construction_time = 200
-	construction_cost = list(DEFAULT_WALL_MATERIAL=15000)*/
+	construction_cost = list(MAT_STEEL=15000)*/
 
 ////////// Janus
 

--- a/code/game/objects/items/devices/communicator/communicator.dm
+++ b/code/game/objects/items/devices/communicator/communicator.dm
@@ -27,7 +27,7 @@ var/global/list/obj/item/device/communicator/all_communicators = list()
 	show_messages = 1
 
 	origin_tech = list(TECH_ENGINEERING = 2, TECH_MAGNET = 2, TECH_BLUESPACE = 2, TECH_DATA = 2)
-	matter = list(DEFAULT_WALL_MATERIAL = 30,"glass" = 10)
+	matter = list(MAT_STEEL = 30,"glass" = 10)
 
 	var/video_range = 4
 	var/obj/machinery/camera/communicator/video_source	// Their camera

--- a/code/game/objects/items/devices/debugger.dm
+++ b/code/game/objects/items/devices/debugger.dm
@@ -16,7 +16,7 @@
 	throw_speed = 3
 	desc = "You can use this on airlocks or APCs to try to hack them without cutting wires."
 
-	matter = list(DEFAULT_WALL_MATERIAL = 50,"glass" = 20)
+	matter = list(MAT_STEEL = 50,"glass" = 20)
 
 	origin_tech = list(TECH_MAGNET = 1, TECH_ENGINEERING = 1)
 	var/obj/machinery/telecomms/buffer // simple machine buffer for device linkage

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -5,7 +5,7 @@
 	icon_state = "flashlight"
 	w_class = ITEMSIZE_SMALL
 	slot_flags = SLOT_BELT
-	matter = list(DEFAULT_WALL_MATERIAL = 50,"glass" = 20)
+	matter = list(MAT_STEEL = 50,"glass" = 20)
 	action_button_name = "Toggle Flashlight"
 	var/on = 0
 	var/brightness_on = 4 //luminosity when on
@@ -275,7 +275,7 @@
 	slot_flags = SLOT_BELT
 	w_class = ITEMSIZE_SMALL
 	attack_verb = list ("smacked", "thwacked", "thunked")
-	matter = list(DEFAULT_WALL_MATERIAL = 200,"glass" = 50)
+	matter = list(MAT_STEEL = 200,"glass" = 50)
 	hitsound = "swing_hit"
 
 /obj/item/device/flashlight/drone

--- a/code/game/objects/items/devices/gps.dm
+++ b/code/game/objects/items/devices/gps.dm
@@ -8,7 +8,7 @@ var/list/GPS_list = list()
 	w_class = ITEMSIZE_TINY
 	slot_flags = SLOT_BELT
 	origin_tech = list(TECH_MATERIAL = 2, TECH_BLUESPACE = 2, TECH_MAGNET = 1)
-	matter = list(DEFAULT_WALL_MATERIAL = 500)
+	matter = list(MAT_STEEL = 500)
 
 	var/gps_tag = "GEN0"
 	var/emped = FALSE

--- a/code/game/objects/items/devices/multitool.dm
+++ b/code/game/objects/items/devices/multitool.dm
@@ -17,7 +17,7 @@
 	drop_sound = 'sound/items/drop/multitool.ogg'
 	pickup_sound = 'sound/items/pickup/multitool.ogg'
 
-	matter = list(DEFAULT_WALL_MATERIAL = 50,"glass" = 20)
+	matter = list(MAT_STEEL = 50,"glass" = 20)
 
 	var/mode_index = 1
 	var/toolmode = MULTITOOL_MODE_STANDARD

--- a/code/game/objects/items/devices/powersink.dm
+++ b/code/game/objects/items/devices/powersink.dm
@@ -9,7 +9,7 @@
 	throw_speed = 1
 	throw_range = 2
 
-	matter = list(DEFAULT_WALL_MATERIAL = 750,"waste" = 750)
+	matter = list(MAT_STEEL = 750,"waste" = 750)
 
 	origin_tech = list(TECH_POWER = 3, TECH_ILLEGAL = 5)
 	var/drain_rate = 1500000		// amount of power to drain per tick

--- a/code/game/objects/items/devices/radio/electropack.dm
+++ b/code/game/objects/items/devices/radio/electropack.dm
@@ -11,7 +11,7 @@
 	slot_flags = SLOT_BACK
 	w_class = ITEMSIZE_HUGE
 
-	matter = list(DEFAULT_WALL_MATERIAL = 10000,"glass" = 2500)
+	matter = list(MAT_STEEL = 10000,"glass" = 2500)
 
 	var/code = 2
 

--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -4,7 +4,7 @@
 	var/radio_desc = ""
 	icon_state = "headset"
 	item_state = null //To remove the radio's state
-	matter = list(DEFAULT_WALL_MATERIAL = 75)
+	matter = list(MAT_STEEL = 75)
 	subspace_transmission = 1
 	canhear_range = 0 // can't hear headsets from very far away
 	slot_flags = SLOT_EARS

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -58,7 +58,7 @@ var/global/list/default_medbay_channels = list(
 	var/bs_tx_preload_id
 	var/bs_rx_preload_id
 
-	matter = list("glass" = 25,DEFAULT_WALL_MATERIAL = 75)
+	matter = list("glass" = 25,MAT_STEEL = 75)
 	var/const/FREQ_LISTENING = 1
 	var/list/internal_channels
 

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -20,7 +20,7 @@ HALOGEN COUNTER	- Radcount on mobs
 	w_class = ITEMSIZE_SMALL
 	throw_speed = 5
 	throw_range = 10
-	matter = list(DEFAULT_WALL_MATERIAL = 200)
+	matter = list(MAT_STEEL = 200)
 	origin_tech = list(TECH_MAGNET = 1, TECH_BIO = 1)
 	var/mode = 1;
 	var/advscan = 0
@@ -331,7 +331,7 @@ HALOGEN COUNTER	- Radcount on mobs
 	throw_speed = 4
 	throw_range = 20
 
-	matter = list(DEFAULT_WALL_MATERIAL = 30,"glass" = 20)
+	matter = list(MAT_STEEL = 30,"glass" = 20)
 
 	origin_tech = list(TECH_MAGNET = 1, TECH_ENGINEERING = 1)
 
@@ -369,7 +369,7 @@ HALOGEN COUNTER	- Radcount on mobs
 	throw_speed = 4
 	throw_range = 20
 
-	matter = list(DEFAULT_WALL_MATERIAL = 30,"glass" = 20)
+	matter = list(MAT_STEEL = 30,"glass" = 20)
 
 	origin_tech = list(TECH_MAGNET = 2, TECH_BIO = 2)
 	var/details = 0
@@ -429,7 +429,7 @@ HALOGEN COUNTER	- Radcount on mobs
 	throwforce = 5
 	throw_speed = 4
 	throw_range = 20
-	matter = list(DEFAULT_WALL_MATERIAL = 30,"glass" = 20)
+	matter = list(MAT_STEEL = 30,"glass" = 20)
 
 	origin_tech = list(TECH_MAGNET = 2, TECH_BIO = 2)
 	var/details = 0
@@ -475,7 +475,7 @@ HALOGEN COUNTER	- Radcount on mobs
 	throwforce = 0
 	throw_speed = 3
 	throw_range = 7
-	matter = list(DEFAULT_WALL_MATERIAL = 30,"glass" = 20)
+	matter = list(MAT_STEEL = 30,"glass" = 20)
 
 /obj/item/device/slime_scanner/attack(mob/living/M as mob, mob/living/user as mob)
 	if(!istype(M, /mob/living/simple_mob/slime/xenobio))

--- a/code/game/objects/items/devices/t_scanner.dm
+++ b/code/game/objects/items/devices/t_scanner.dm
@@ -7,7 +7,7 @@
 	item_state = "t-ray"
 	slot_flags = SLOT_BELT
 	w_class = ITEMSIZE_SMALL
-	matter = list(DEFAULT_WALL_MATERIAL = 150)
+	matter = list(MAT_STEEL = 150)
 	origin_tech = list(TECH_MAGNET = 1, TECH_ENGINEERING = 1)
 
 	var/scan_range = 1
@@ -135,14 +135,14 @@
 /obj/item/device/t_scanner/upgraded
 	name = "Upgraded T-ray Scanner"
 	desc = "An upgraded version of the terahertz-ray emitter and scanner used to detect underfloor objects such as cables and pipes."
-	matter = list(DEFAULT_WALL_MATERIAL = 500, PHORON = 150)
+	matter = list(MAT_STEEL = 500, PHORON = 150)
 	origin_tech = list(TECH_MAGNET = 4, TECH_ENGINEERING = 5)
 	scan_range = 3
 
 /obj/item/device/t_scanner/advanced
 	name = "Advanced T-ray Scanner"
 	desc = "An advanced version of the terahertz-ray emitter and scanner used to detect underfloor objects such as cables and pipes."
-	matter = list(DEFAULT_WALL_MATERIAL = 1500, PHORON = 200, SILVER = 250)
+	matter = list(MAT_STEEL = 1500, PHORON = 200, SILVER = 250)
 	origin_tech = list(TECH_MAGNET = 7, TECH_ENGINEERING = 7, TECH_MATERIAL = 6)
 	scan_range = 7
 

--- a/code/game/objects/items/devices/taperecorder.dm
+++ b/code/game/objects/items/devices/taperecorder.dm
@@ -5,7 +5,7 @@
 	item_state = "analyzer"
 	w_class = ITEMSIZE_SMALL
 
-	matter = list(DEFAULT_WALL_MATERIAL = 60,"glass" = 30)
+	matter = list(MAT_STEEL = 60,"glass" = 30)
 
 	var/emagged = 0.0
 	var/recording = 0.0
@@ -361,7 +361,7 @@
 	icon_state = "tape_white"
 	item_state = "analyzer"
 	w_class = ITEMSIZE_TINY
-	matter = list(DEFAULT_WALL_MATERIAL=20, "glass"=5)
+	matter = list(MAT_STEEL=20, "glass"=5)
 	force = 1
 	throwforce = 0
 	var/max_capacity = 1800

--- a/code/game/objects/items/robot/robot_parts.dm
+++ b/code/game/objects/items/robot/robot_parts.dm
@@ -100,7 +100,7 @@
 
 /obj/item/robot_parts/robot_suit/attackby(obj/item/W as obj, mob/user as mob)
 	..()
-	if(istype(W, /obj/item/stack/material) && W.get_material_name() == DEFAULT_WALL_MATERIAL && !l_arm && !r_arm && !l_leg && !r_leg && !chest && !head)
+	if(istype(W, /obj/item/stack/material) && W.get_material_name() == MAT_STEEL && !l_arm && !r_arm && !l_leg && !r_leg && !chest && !head)
 		var/obj/item/stack/material/M = W
 		if (M.use(1))
 			var/obj/item/weapon/secbot_assembly/ed209_assembly/B = new /obj/item/weapon/secbot_assembly/ed209_assembly

--- a/code/game/objects/items/weapons/RCD.dm
+++ b/code/game/objects/items/weapons/RCD.dm
@@ -14,7 +14,7 @@
 	throw_range = 5
 	w_class = ITEMSIZE_NORMAL
 	origin_tech = list(TECH_ENGINEERING = 4, TECH_MATERIAL = 2)
-	matter = list(DEFAULT_WALL_MATERIAL = 50000)
+	matter = list(MAT_STEEL = 50000)
 	preserve_item = TRUE // RCDs are pretty important.
 	var/datum/effect/effect/system/spark_spread/spark_system
 	var/stored_matter = 0

--- a/code/game/objects/items/weapons/canes.dm
+++ b/code/game/objects/items/weapons/canes.dm
@@ -10,7 +10,7 @@
 	force = 5.0
 	throwforce = 7.0
 	w_class = ITEMSIZE_NORMAL
-	matter = list(DEFAULT_WALL_MATERIAL = 50)
+	matter = list(MAT_STEEL = 50)
 	attack_verb = list("bludgeoned", "whacked", "disciplined", "thrashed")
 
 /obj/item/weapon/cane/crutch

--- a/code/game/objects/items/weapons/circuitboards/computer/camera_monitor.dm
+++ b/code/game/objects/items/weapons/circuitboards/computer/camera_monitor.dm
@@ -36,7 +36,7 @@
 	name = T_BOARD("entertainment camera monitor")
 	build_path = /obj/machinery/computer/security/telescreen/entertainment
 	board_type = new /datum/frame/frame_types/display
-	matter = list(DEFAULT_WALL_MATERIAL = 50, "glass" = 50)
+	matter = list(MAT_STEEL = 50, "glass" = 50)
 
 /obj/item/weapon/circuitboard/security/telescreen/entertainment/New()
 	..()

--- a/code/game/objects/items/weapons/circuitboards/frame.dm
+++ b/code/game/objects/items/weapons/circuitboards/frame.dm
@@ -10,37 +10,37 @@
 	name = T_BOARD("guestpass console")
 	build_path = /obj/machinery/computer/guestpass
 	board_type = new /datum/frame/frame_types/guest_pass_console
-	matter = list(DEFAULT_WALL_MATERIAL = 50, "glass" = 50)
+	matter = list(MAT_STEEL = 50, "glass" = 50)
 
 /obj/item/weapon/circuitboard/status_display
 	name = T_BOARD("status display")
 	build_path = /obj/machinery/status_display
 	board_type = new /datum/frame/frame_types/display
-	matter = list(DEFAULT_WALL_MATERIAL = 50, "glass" = 50)
+	matter = list(MAT_STEEL = 50, "glass" = 50)
 
 /obj/item/weapon/circuitboard/ai_status_display
 	name = T_BOARD("ai status display")
 	build_path = /obj/machinery/ai_status_display
 	board_type = new /datum/frame/frame_types/display
-	matter = list(DEFAULT_WALL_MATERIAL = 50, "glass" = 50)
+	matter = list(MAT_STEEL = 50, "glass" = 50)
 
 /obj/item/weapon/circuitboard/newscaster
 	name = T_BOARD("newscaster")
 	build_path = /obj/machinery/newscaster
 	board_type = new /datum/frame/frame_types/newscaster
-	matter = list(DEFAULT_WALL_MATERIAL = 50, "glass" = 50)
+	matter = list(MAT_STEEL = 50, "glass" = 50)
 
 /obj/item/weapon/circuitboard/atm
 	name = T_BOARD("atm")
 	build_path = /obj/machinery/atm
 	board_type = new /datum/frame/frame_types/atm
-	matter = list(DEFAULT_WALL_MATERIAL = 50, "glass" = 50)
+	matter = list(MAT_STEEL = 50, "glass" = 50)
 
 /obj/item/weapon/circuitboard/request
 	name = T_BOARD("request console")
 	build_path = /obj/machinery/requests_console
 	board_type = new /datum/frame/frame_types/supply_request_console
-	matter = list(DEFAULT_WALL_MATERIAL = 50, "glass" = 50)
+	matter = list(MAT_STEEL = 50, "glass" = 50)
 
 //Alarm
 
@@ -48,31 +48,31 @@
 	name = T_BOARD("fire alarm")
 	build_path = /obj/machinery/firealarm
 	board_type = new /datum/frame/frame_types/fire_alarm
-	matter = list(DEFAULT_WALL_MATERIAL = 50, "glass" = 50)
+	matter = list(MAT_STEEL = 50, "glass" = 50)
 
 /obj/item/weapon/circuitboard/airalarm
 	name = T_BOARD("air alarm")
 	build_path = /obj/machinery/alarm
 	board_type = new /datum/frame/frame_types/air_alarm
-	matter = list(DEFAULT_WALL_MATERIAL = 50, "glass" = 50)
+	matter = list(MAT_STEEL = 50, "glass" = 50)
 
 /obj/item/weapon/circuitboard/intercom
 	name = T_BOARD("intercom")
 	build_path = /obj/item/device/radio/intercom
 	board_type = new /datum/frame/frame_types/intercom
-	matter = list(DEFAULT_WALL_MATERIAL = 50, "glass" = 50)
+	matter = list(MAT_STEEL = 50, "glass" = 50)
 
 /obj/item/weapon/circuitboard/keycard_auth
 	name = T_BOARD("keycard authenticator")
 	build_path = /obj/machinery/keycard_auth
 	board_type = new /datum/frame/frame_types/keycard_authenticator
-	matter = list(DEFAULT_WALL_MATERIAL = 50, "glass" = 50)
+	matter = list(MAT_STEEL = 50, "glass" = 50)
 
 /obj/item/weapon/circuitboard/geiger
 	name = T_BOARD("geiger counter")
 	build_path = /obj/item/device/geiger/wall
 	board_type = new /datum/frame/frame_types/geiger
-	matter = list(DEFAULT_WALL_MATERIAL = 50, "glass" = 50)
+	matter = list(MAT_STEEL = 50, "glass" = 50)
 
 //Computer
 
@@ -80,7 +80,7 @@
 	name = T_BOARD("holopad")
 	build_path = /obj/machinery/hologram/holopad
 	board_type = new /datum/frame/frame_types/holopad
-	matter = list(DEFAULT_WALL_MATERIAL = 50, "glass" = 50)
+	matter = list(MAT_STEEL = 50, "glass" = 50)
 
 /obj/item/weapon/circuitboard/scanner_console
 	name = T_BOARD("body scanner console")
@@ -100,7 +100,7 @@
 	name = T_BOARD("photocopier")
 	build_path = /obj/machinery/photocopier
 	board_type = new /datum/frame/frame_types/photocopier
-	matter = list(DEFAULT_WALL_MATERIAL = 50, "glass" = 50)
+	matter = list(MAT_STEEL = 50, "glass" = 50)
 	req_components = list(
 							/obj/item/weapon/stock_parts/scanning_module = 1,
 							/obj/item/weapon/stock_parts/motor = 1,
@@ -111,7 +111,7 @@
 	name = T_BOARD("fax")
 	build_path = /obj/machinery/photocopier/faxmachine
 	board_type = new /datum/frame/frame_types/fax
-	matter = list(DEFAULT_WALL_MATERIAL = 50, "glass" = 50)
+	matter = list(MAT_STEEL = 50, "glass" = 50)
 	req_components = list(
 							/obj/item/weapon/stock_parts/scanning_module = 1,
 							/obj/item/weapon/stock_parts/motor = 1,
@@ -152,7 +152,7 @@
 	name = T_BOARD("washing machine")
 	build_path = /obj/machinery/washing_machine
 	board_type = new /datum/frame/frame_types/washing_machine
-	matter = list(DEFAULT_WALL_MATERIAL = 50, "glass" = 50)
+	matter = list(MAT_STEEL = 50, "glass" = 50)
 	req_components = list(
 							/obj/item/weapon/stock_parts/motor = 1,
 							/obj/item/weapon/stock_parts/gear = 2)

--- a/code/game/objects/items/weapons/circuitboards/machinery/engineering.dm
+++ b/code/game/objects/items/weapons/circuitboards/machinery/engineering.dm
@@ -6,7 +6,7 @@
 	name = T_BOARD("pipe layer")
 	build_path = /obj/machinery/pipelayer
 	board_type = new /datum/frame/frame_types/machine
-	matter = list(DEFAULT_WALL_MATERIAL = 50, "glass" = 50)
+	matter = list(MAT_STEEL = 50, "glass" = 50)
 	req_components = list(
 							/obj/item/weapon/stock_parts/motor = 1,
 							/obj/item/weapon/stock_parts/gear = 1,

--- a/code/game/objects/items/weapons/circuitboards/machinery/kitchen_appliances.dm
+++ b/code/game/objects/items/weapons/circuitboards/machinery/kitchen_appliances.dm
@@ -4,7 +4,7 @@
 	build_path = /obj/machinery/microwave
 	board_type = new /datum/frame/frame_types/microwave
 	contain_parts = 0
-	matter = list(DEFAULT_WALL_MATERIAL = 50, "glass" = 50)
+	matter = list(MAT_STEEL = 50, "glass" = 50)
 	req_components = list(
 							/obj/item/weapon/stock_parts/console_screen = 1,
 							/obj/item/weapon/stock_parts/capacitor = 3, // Original Capacitor count was 1
@@ -17,7 +17,7 @@
 	desc = "The circuitboard for an oven."
 	build_path = /obj/machinery/appliance/cooker/oven
 	board_type = new /datum/frame/frame_types/oven
-	matter = list(DEFAULT_WALL_MATERIAL = 50, "glass" = 50)
+	matter = list(MAT_STEEL = 50, "glass" = 50)
 	req_components = list(
 							/obj/item/weapon/stock_parts/capacitor = 3,
 							/obj/item/weapon/stock_parts/scanning_module = 1,
@@ -67,7 +67,7 @@
 	name = T_BOARD("deluxe microwave")
 	build_path = /obj/machinery/microwave/advanced
 	board_type = new /datum/frame/frame_types/microwave
-	matter = list(DEFAULT_WALL_MATERIAL = 50, "glass" = 50)
+	matter = list(MAT_STEEL = 50, "glass" = 50)
 	req_components = list(
 							/obj/item/weapon/stock_parts/console_screen = 1,
 							/obj/item/weapon/stock_parts/motor = 1,

--- a/code/game/objects/items/weapons/circuitboards/machinery/papershredder.dm
+++ b/code/game/objects/items/weapons/circuitboards/machinery/papershredder.dm
@@ -6,7 +6,7 @@
 	name = T_BOARD("papershredder")
 	build_path = /obj/machinery/papershredder
 	board_type = new /datum/frame/frame_types/machine
-	matter = list(DEFAULT_WALL_MATERIAL = 50, "glass" = 50)
+	matter = list(MAT_STEEL = 50, "glass" = 50)
 	req_components = list(
 							/obj/item/weapon/stock_parts/motor = 1,
 							/obj/item/weapon/stock_parts/gear = 2,

--- a/code/game/objects/items/weapons/extinguisher.dm
+++ b/code/game/objects/items/weapons/extinguisher.dm
@@ -10,7 +10,7 @@
 	throw_speed = 2
 	throw_range = 10
 	force = 10
-	matter = list(DEFAULT_WALL_MATERIAL = 90)
+	matter = list(MAT_STEEL = 90)
 	attack_verb = list("slammed", "whacked", "bashed", "thunked", "battered", "bludgeoned", "thrashed")
 	drop_sound = 'sound/items/drop/gascan.ogg'
 	pickup_sound = 'sound/items/pickup/gascan.ogg'

--- a/code/game/objects/items/weapons/flamethrower.dm
+++ b/code/game/objects/items/weapons/flamethrower.dm
@@ -14,7 +14,7 @@
 	throw_range = 5
 	w_class = ITEMSIZE_NORMAL
 	origin_tech = list(TECH_COMBAT = 1, TECH_PHORON = 1)
-	matter = list(DEFAULT_WALL_MATERIAL = 500)
+	matter = list(MAT_STEEL = 500)
 	var/status = 0
 	var/throw_amount = 100
 	var/lit = 0	//on or off

--- a/code/game/objects/items/weapons/handcuffs.dm
+++ b/code/game/objects/items/weapons/handcuffs.dm
@@ -10,7 +10,7 @@
 	throw_speed = 2
 	throw_range = 5
 	origin_tech = list(TECH_MATERIAL = 1)
-	matter = list(DEFAULT_WALL_MATERIAL = 500)
+	matter = list(MAT_STEEL = 500)
 	drop_sound = 'sound/items/drop/accessory.ogg'
 	pickup_sound = 'sound/items/pickup/accessory.ogg'
 	var/elastic

--- a/code/game/objects/items/weapons/implants/implanter.dm
+++ b/code/game/objects/items/weapons/implants/implanter.dm
@@ -6,7 +6,7 @@
 	throw_speed = 1
 	throw_range = 5
 	w_class = ITEMSIZE_SMALL
-	matter = list(DEFAULT_WALL_MATERIAL = 1000, "glass" = 1000)
+	matter = list(MAT_STEEL = 1000, "glass" = 1000)
 	var/obj/item/weapon/implant/imp = null
 	var/active = 1
 

--- a/code/game/objects/items/weapons/material/knives.dm
+++ b/code/game/objects/items/weapons/material/knives.dm
@@ -64,7 +64,7 @@
 	sharp = 1
 	edge = 1
 	force_divisor = 0.15 // 9 when wielded with hardness 60 (steel)
-	matter = list(DEFAULT_WALL_MATERIAL = 12000)
+	matter = list(MAT_STEEL = 12000)
 	origin_tech = list(TECH_MATERIAL = 1)
 	attack_verb = list("slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
 	drop_sound = 'sound/items/drop/knife.ogg'

--- a/code/game/objects/items/weapons/material/material_armor.dm
+++ b/code/game/objects/items/weapons/material/material_armor.dm
@@ -201,7 +201,7 @@ Protectiveness | Armor %
 
 /obj/item/clothing/suit/armor/material
 	name = "armor"
-	default_material = DEFAULT_WALL_MATERIAL
+	default_material = MAT_STEEL
 
 /obj/item/clothing/suit/armor/material/makeshift
 	name = "sheet armor"
@@ -401,7 +401,7 @@ Protectiveness | Armor %
 /obj/item/clothing/head/helmet/material
 	name = "helmet"
 	flags_inv = HIDEEARS|HIDEEYES|BLOCKHAIR
-	default_material = DEFAULT_WALL_MATERIAL
+	default_material = MAT_STEEL
 
 /obj/item/clothing/head/helmet/material/makeshift
 	name = "bucket"

--- a/code/game/objects/items/weapons/material/material_weapons.dm
+++ b/code/game/objects/items/weapons/material/material_weapons.dm
@@ -23,7 +23,7 @@
 	var/force_divisor = 0.5
 	var/thrown_force_divisor = 0.5
 	var/dulled_divisor = 0.5	//Just drops the damage by half
-	var/default_material = DEFAULT_WALL_MATERIAL
+	var/default_material = MAT_STEEL
 	var/datum/material/material
 	var/drops_debris = 1
 

--- a/code/game/objects/items/weapons/paint.dm
+++ b/code/game/objects/items/weapons/paint.dm
@@ -9,7 +9,7 @@ var/global/list/cached_icons = list()
 	icon = 'icons/obj/items.dmi'
 	icon_state = "paint_neutral"
 	item_state = "paintcan"
-	matter = list(DEFAULT_WALL_MATERIAL = 200)
+	matter = list(MAT_STEEL = 200)
 	w_class = ITEMSIZE_NORMAL
 	amount_per_transfer_from_this = 10
 	possible_transfer_amounts = list(10,20,30,60)

--- a/code/game/objects/items/weapons/shields.dm
+++ b/code/game/objects/items/weapons/shields.dm
@@ -68,7 +68,7 @@
 	throw_range = 4
 	w_class = ITEMSIZE_LARGE
 	origin_tech = list(TECH_MATERIAL = 2)
-	matter = list("glass" = 7500, DEFAULT_WALL_MATERIAL = 1000)
+	matter = list("glass" = 7500, MAT_STEEL = 1000)
 	attack_verb = list("shoved", "bashed")
 	var/cooldown = 0 //shield bash cooldown. based on world.time
 

--- a/code/game/objects/items/weapons/surgery_tools.dm
+++ b/code/game/objects/items/weapons/surgery_tools.dm
@@ -30,7 +30,7 @@
 	name = "retractor"
 	desc = "Retracts stuff."
 	icon_state = "retractor"
-	matter = list(DEFAULT_WALL_MATERIAL = 10000, "glass" = 5000)
+	matter = list(MAT_STEEL = 10000, "glass" = 5000)
 	origin_tech = list(TECH_MATERIAL = 1, TECH_BIO = 1)
 	drop_sound = 'sound/items/drop/scrap.ogg'
 
@@ -41,7 +41,7 @@
 	name = "hemostat"
 	desc = "You think you have seen this before."
 	icon_state = "hemostat"
-	matter = list(DEFAULT_WALL_MATERIAL = 5000, "glass" = 2500)
+	matter = list(MAT_STEEL = 5000, "glass" = 2500)
 	origin_tech = list(TECH_MATERIAL = 1, TECH_BIO = 1)
 	attack_verb = list("attacked", "pinched")
 	drop_sound = 'sound/items/drop/scrap.ogg'
@@ -53,7 +53,7 @@
 	name = "cautery"
 	desc = "This stops bleeding."
 	icon_state = "cautery"
-	matter = list(DEFAULT_WALL_MATERIAL = 5000, "glass" = 2500)
+	matter = list(MAT_STEEL = 5000, "glass" = 2500)
 	origin_tech = list(TECH_MATERIAL = 1, TECH_BIO = 1)
 	attack_verb = list("burnt")
 	drop_sound = 'sound/items/drop/scrap.ogg'
@@ -66,7 +66,7 @@
 	desc = "You can drill using this item. You dig?"
 	icon_state = "drill"
 	hitsound = 'sound/weapons/circsawhit.ogg'
-	matter = list(DEFAULT_WALL_MATERIAL = 15000, "glass" = 10000)
+	matter = list(MAT_STEEL = 15000, "glass" = 10000)
 	force = 15.0
 	w_class = ITEMSIZE_NORMAL
 	origin_tech = list(TECH_MATERIAL = 1, TECH_BIO = 1)
@@ -95,7 +95,7 @@
 	throw_speed = 3
 	throw_range = 5
 	origin_tech = list(TECH_MATERIAL = 1, TECH_BIO = 1)
-	matter = list(DEFAULT_WALL_MATERIAL = 10000, "glass" = 5000)
+	matter = list(MAT_STEEL = 10000, "glass" = 5000)
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
 	drop_sound = 'sound/items/drop/knife.ogg'
 
@@ -159,7 +159,7 @@
 	throw_speed = 3
 	throw_range = 5
 	origin_tech = list(TECH_MATERIAL = 1, TECH_BIO = 1)
-	matter = list(DEFAULT_WALL_MATERIAL = 20000,"glass" = 10000)
+	matter = list(MAT_STEEL = 20000,"glass" = 10000)
 	attack_verb = list("attacked", "slashed", "sawed", "cut")
 	sharp = 1
 	edge = 1
@@ -173,7 +173,7 @@
 	damtype = SEARING
 	w_class = ITEMSIZE_LARGE
 	origin_tech = list(TECH_BIO = 4, TECH_MATERIAL = 6, TECH_MAGNET = 6)
-	matter = list(DEFAULT_WALL_MATERIAL = 12500)
+	matter = list(MAT_STEEL = 12500)
 	attack_verb = list("attacked", "slashed", "seared", "cut")
 	toolspeed = 0.75
 

--- a/code/game/objects/items/weapons/teleportation.dm
+++ b/code/game/objects/items/weapons/teleportation.dm
@@ -21,7 +21,7 @@
 	throw_speed = 4
 	throw_range = 20
 	origin_tech = list(TECH_MAGNET = 1)
-	matter = list(DEFAULT_WALL_MATERIAL = 400)
+	matter = list(MAT_STEEL = 400)
 
 /obj/item/weapon/locator/attack_self(mob/user as mob)
 	user.set_machine(src)
@@ -127,7 +127,7 @@ Frequency:
 	throw_speed = 3
 	throw_range = 5
 	origin_tech = list(TECH_MAGNET = 1, TECH_BLUESPACE = 3)
-	matter = list(DEFAULT_WALL_MATERIAL = 10000)
+	matter = list(MAT_STEEL = 10000)
 	preserve_item = 1
 
 /obj/item/weapon/hand_tele/attack_self(mob/user as mob)

--- a/code/game/objects/items/weapons/tools/crowbar.dm
+++ b/code/game/objects/items/weapons/tools/crowbar.dm
@@ -14,7 +14,7 @@
 	item_state = "crowbar"
 	w_class = ITEMSIZE_SMALL
 	origin_tech = list(TECH_ENGINEERING = 1)
-	matter = list(DEFAULT_WALL_MATERIAL = 50)
+	matter = list(MAT_STEEL = 50)
 	attack_verb = list("attacked", "bashed", "battered", "bludgeoned", "whacked")
 	usesound = 'sound/items/crowbar.ogg'
 	drop_sound = 'sound/items/drop/crowbar.ogg'

--- a/code/game/objects/items/weapons/tools/screwdriver.dm
+++ b/code/game/objects/items/weapons/tools/screwdriver.dm
@@ -17,7 +17,7 @@
 	usesound = 'sound/items/screwdriver.ogg'
 	drop_sound = 'sound/items/drop/screwdriver.ogg'
 	pickup_sound = 'sound/items/pickup/screwdriver.ogg'
-	matter = list(DEFAULT_WALL_MATERIAL = 75)
+	matter = list(MAT_STEEL = 75)
 	attack_verb = list("stabbed")
 	sharp  = 1
 	toolspeed = 1
@@ -116,7 +116,7 @@
 	desc = "A simple powered hand drill. It's fitted with a screw bit."
 	icon_state = "drill_screw"
 	item_state = "drill"
-	matter = list(DEFAULT_WALL_MATERIAL = 150, MAT_SILVER = 50)
+	matter = list(MAT_STEEL = 150, MAT_SILVER = 50)
 	origin_tech = list(TECH_MATERIAL = 2, TECH_ENGINEERING = 2)
 	slot_flags = SLOT_BELT
 	force = 8

--- a/code/game/objects/items/weapons/tools/weldingtool.dm
+++ b/code/game/objects/items/weapons/tools/weldingtool.dm
@@ -17,7 +17,7 @@
 	w_class = ITEMSIZE_SMALL
 
 	//Cost to make in the autolathe
-	matter = list(DEFAULT_WALL_MATERIAL = 70, "glass" = 30)
+	matter = list(MAT_STEEL = 70, "glass" = 30)
 
 	//R&D tech level
 	origin_tech = list(TECH_ENGINEERING = 1)
@@ -361,7 +361,7 @@
 	icon_state = "indwelder"
 	max_fuel = 40
 	origin_tech = list(TECH_ENGINEERING = 2, TECH_PHORON = 2)
-	matter = list(DEFAULT_WALL_MATERIAL = 70, "glass" = 60)
+	matter = list(MAT_STEEL = 70, "glass" = 60)
 
 /obj/item/weapon/weldingtool/largetank/cyborg
 	name = "integrated welding tool"
@@ -375,7 +375,7 @@
 	max_fuel = 80
 	w_class = ITEMSIZE_NORMAL
 	origin_tech = list(TECH_ENGINEERING = 3)
-	matter = list(DEFAULT_WALL_MATERIAL = 70, "glass" = 120)
+	matter = list(MAT_STEEL = 70, "glass" = 120)
 
 /obj/item/weapon/weldingtool/mini
 	name = "emergency welding tool"
@@ -437,7 +437,7 @@
 	max_fuel = 40
 	w_class = ITEMSIZE_NORMAL
 	origin_tech = list(TECH_ENGINEERING = 4, TECH_PHORON = 3)
-	matter = list(DEFAULT_WALL_MATERIAL = 70, "glass" = 120)
+	matter = list(MAT_STEEL = 70, "glass" = 120)
 	toolspeed = 0.5
 	change_icons = 0
 	flame_intensity = 3

--- a/code/game/objects/items/weapons/tools/wirecutters.dm
+++ b/code/game/objects/items/weapons/tools/wirecutters.dm
@@ -13,7 +13,7 @@
 	throw_range = 9
 	w_class = ITEMSIZE_SMALL
 	origin_tech = list(TECH_MATERIAL = 1, TECH_ENGINEERING = 1)
-	matter = list(DEFAULT_WALL_MATERIAL = 80)
+	matter = list(MAT_STEEL = 80)
 	attack_verb = list("pinched", "nipped")
 	hitsound = 'sound/items/wirecutter.ogg'
 	usesound = 'sound/items/wirecutter.ogg'

--- a/code/game/objects/items/weapons/tools/wrench.dm
+++ b/code/game/objects/items/weapons/tools/wrench.dm
@@ -11,7 +11,7 @@
 	throwforce = 7
 	w_class = ITEMSIZE_SMALL
 	origin_tech = list(TECH_MATERIAL = 1, TECH_ENGINEERING = 1)
-	matter = list(DEFAULT_WALL_MATERIAL = 150)
+	matter = list(MAT_STEEL = 150)
 	attack_verb = list("bashed", "battered", "bludgeoned", "whacked")
 	usesound = 'sound/items/ratchet.ogg'
 	toolspeed = 1
@@ -73,7 +73,7 @@
 	icon_state = "drill_bolt"
 	item_state = "drill"
 	usesound = 'sound/items/drill_use.ogg'
-	matter = list(DEFAULT_WALL_MATERIAL = 150, MAT_SILVER = 50)
+	matter = list(MAT_STEEL = 150, MAT_SILVER = 50)
 	origin_tech = list(TECH_MATERIAL = 2, TECH_ENGINEERING = 2)
 	force = 8
 	w_class = ITEMSIZE_SMALL

--- a/code/game/objects/items/weapons/traps.dm
+++ b/code/game/objects/items/weapons/traps.dm
@@ -17,7 +17,7 @@
 	throwforce = 0
 	w_class = ITEMSIZE_NORMAL
 	origin_tech = list(TECH_MATERIAL = 1)
-	matter = list(DEFAULT_WALL_MATERIAL = 18750)
+	matter = list(MAT_STEEL = 18750)
 	var/deployed = 0
 	var/camo_net = FALSE
 	var/stun_length = 0.25 SECONDS

--- a/code/game/objects/items/weapons/trays.dm
+++ b/code/game/objects/items/weapons/trays.dm
@@ -11,7 +11,7 @@
 	throw_speed = 1
 	throw_range = 5
 	w_class = ITEMSIZE_NORMAL
-	matter = list(DEFAULT_WALL_MATERIAL = 3000)
+	matter = list(MAT_STEEL = 3000)
 	var/list/carrying = list() // List of things on the tray. - Doohl
 	var/max_carry = 10
 	drop_sound = 'sound/items/trayhit1.ogg'

--- a/code/modules/assembly/assembly.dm
+++ b/code/modules/assembly/assembly.dm
@@ -4,7 +4,7 @@
 	icon = 'icons/obj/assemblies/new_assemblies.dmi'
 	icon_state = ""
 	w_class = ITEMSIZE_SMALL
-	matter = list(DEFAULT_WALL_MATERIAL = 100)
+	matter = list(MAT_STEEL = 100)
 	throwforce = 2
 	throw_speed = 3
 	throw_range = 10

--- a/code/modules/assembly/igniter.dm
+++ b/code/modules/assembly/igniter.dm
@@ -3,7 +3,7 @@
 	desc = "A small electronic device able to ignite combustable substances."
 	icon_state = "igniter"
 	origin_tech = list(TECH_MAGNET = 1)
-	matter = list(DEFAULT_WALL_MATERIAL = 500, "glass" = 50, "waste" = 10)
+	matter = list(MAT_STEEL = 500, "glass" = 50, "waste" = 10)
 
 	secured = 1
 	wires = WIRE_RECEIVE

--- a/code/modules/assembly/infrared.dm
+++ b/code/modules/assembly/infrared.dm
@@ -5,7 +5,7 @@
 	desc = "Emits a visible or invisible beam and is triggered when the beam is interrupted."
 	icon_state = "infrared"
 	origin_tech = list(TECH_MAGNET = 2)
-	matter = list(DEFAULT_WALL_MATERIAL = 1000, "glass" = 500, "waste" = 100)
+	matter = list(MAT_STEEL = 1000, "glass" = 500, "waste" = 100)
 
 	wires = WIRE_PULSE
 

--- a/code/modules/assembly/mousetrap.dm
+++ b/code/modules/assembly/mousetrap.dm
@@ -3,7 +3,7 @@
 	desc = "A handy little spring-loaded trap for catching pesty rodents."
 	icon_state = "mousetrap"
 	origin_tech = list(TECH_COMBAT = 1)
-	matter = list(DEFAULT_WALL_MATERIAL = 100, "waste" = 10)
+	matter = list(MAT_STEEL = 100, "waste" = 10)
 	var/armed = 0
 
 

--- a/code/modules/assembly/proximity.dm
+++ b/code/modules/assembly/proximity.dm
@@ -3,7 +3,7 @@
 	desc = "Used for scanning and alerting when someone enters a certain proximity."
 	icon_state = "prox"
 	origin_tech = list(TECH_MAGNET = 1)
-	matter = list(DEFAULT_WALL_MATERIAL = 800, "glass" = 200, "waste" = 50)
+	matter = list(MAT_STEEL = 800, "glass" = 200, "waste" = 50)
 	wires = WIRE_PULSE
 
 	secured = 0

--- a/code/modules/assembly/signaler.dm
+++ b/code/modules/assembly/signaler.dm
@@ -4,7 +4,7 @@
 	icon_state = "signaller"
 	item_state = "signaler"
 	origin_tech = list(TECH_MAGNET = 1)
-	matter = list(DEFAULT_WALL_MATERIAL = 1000, "glass" = 200, "waste" = 100)
+	matter = list(MAT_STEEL = 1000, "glass" = 200, "waste" = 100)
 	wires = WIRE_RECEIVE | WIRE_PULSE | WIRE_RADIO_PULSE | WIRE_RADIO_RECEIVE
 
 	secured = TRUE

--- a/code/modules/assembly/timer.dm
+++ b/code/modules/assembly/timer.dm
@@ -3,7 +3,7 @@
 	desc = "Used to time things. Works well with contraptions which has to count down. Tick tock."
 	icon_state = "timer"
 	origin_tech = list(TECH_MAGNET = 1)
-	matter = list(DEFAULT_WALL_MATERIAL = 500, "glass" = 50, "waste" = 10)
+	matter = list(MAT_STEEL = 500, "glass" = 50, "waste" = 10)
 
 	wires = WIRE_PULSE
 

--- a/code/modules/assembly/voice.dm
+++ b/code/modules/assembly/voice.dm
@@ -3,7 +3,7 @@
 	desc = "A small electronic device able to record a voice sample, and send a signal when that sample is repeated."
 	icon_state = "voice"
 	origin_tech = list(TECH_MAGNET = 1)
-	matter = list(DEFAULT_WALL_MATERIAL = 500, "glass" = 50, "waste" = 10)
+	matter = list(MAT_STEEL = 500, "glass" = 50, "waste" = 10)
 	var/listening = 0
 	var/recorded	//the activation message
 

--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -342,7 +342,7 @@ BLIND     // can't see anything
 	icon_state = "welding-g"
 	item_state_slots = list(slot_r_hand_str = "welding-g", slot_l_hand_str = "welding-g")
 	action_button_name = "Flip Welding Goggles"
-	matter = list(DEFAULT_WALL_MATERIAL = 1500, "glass" = 1000)
+	matter = list(MAT_STEEL = 1500, "glass" = 1000)
 	item_flags = AIRTIGHT
 	var/up = 0
 	flash_protection = FLASH_PROTECTION_MAJOR

--- a/code/modules/clothing/gloves/miscellaneous.dm
+++ b/code/modules/clothing/gloves/miscellaneous.dm
@@ -125,7 +125,7 @@
 	name = "knuckle dusters"
 	desc = "A pair of brass knuckles. Generally used to enhance the user's punches."
 	icon_state = "knuckledusters"
-	matter = list(DEFAULT_WALL_MATERIAL = 500)
+	matter = list(MAT_STEEL = 500)
 	attack_verb = list("punched", "beaten", "struck")
 	flags = THICKMATERIAL	// Stops rings from increasing hit strength
 	siemens_coefficient = 1

--- a/code/modules/clothing/head/misc.dm
+++ b/code/modules/clothing/head/misc.dm
@@ -42,7 +42,7 @@
 	name = "magnetic 'pin'"
 	addblends = null
 	desc = "Finally, a hair pin even a Morpheus chassis can use."
-	matter = list(DEFAULT_WALL_MATERIAL = 10)
+	matter = list(MAT_STEEL = 10)
 
 /obj/item/clothing/head/pin/flower
 	name = "red flower pin"

--- a/code/modules/clothing/head/misc_special.dm
+++ b/code/modules/clothing/head/misc_special.dm
@@ -18,7 +18,7 @@
 	desc = "A head-mounted face cover designed to protect the wearer completely from space-arc eye."
 	icon_state = "welding"
 	item_state_slots = list(slot_r_hand_str = "welding", slot_l_hand_str = "welding")
-	matter = list(DEFAULT_WALL_MATERIAL = 3000, "glass" = 1000)
+	matter = list(MAT_STEEL = 3000, "glass" = 1000)
 	var/up = 0
 	armor = list(melee = 10, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 0, rad = 0)
 	flags_inv = (HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE)

--- a/code/modules/clothing/rings/material.dm
+++ b/code/modules/clothing/rings/material.dm
@@ -7,7 +7,7 @@
 /obj/item/clothing/gloves/ring/material/New(var/newloc, var/new_material)
 	..(newloc)
 	if(!new_material)
-		new_material = DEFAULT_WALL_MATERIAL
+		new_material = MAT_STEEL
 	material = get_material_by_name(new_material)
 	if(!istype(material))
 		qdel(src)

--- a/code/modules/clothing/spacesuits/breaches.dm
+++ b/code/modules/clothing/spacesuits/breaches.dm
@@ -181,9 +181,9 @@ var/global/list/breach_burn_descriptors = list(
 	if(istype(W,/obj/item/stack/material))
 		var/repair_power = 0
 		switch(W.get_material_name())
-			if(DEFAULT_WALL_MATERIAL)
+			if(MAT_STEEL)
 				repair_power = 2
-			if("plastic")
+			if(MAT_PLASTIC)
 				repair_power = 1
 
 		if(!repair_power)

--- a/code/modules/clothing/spacesuits/rig/modules/modules.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/modules.dm
@@ -13,7 +13,7 @@
 	desc = "It looks pretty sciency."
 	icon = 'icons/obj/rig_modules.dmi'
 	icon_state = "module"
-	matter = list(DEFAULT_WALL_MATERIAL = 20000, "plastic" = 30000, "glass" = 5000)
+	matter = list(MAT_STEEL = 20000, "plastic" = 30000, "glass" = 5000)
 
 	var/damage = 0
 	var/obj/item/weapon/rig/holder

--- a/code/modules/clothing/under/accessories/accessory.dm
+++ b/code/modules/clothing/under/accessories/accessory.dm
@@ -378,7 +378,7 @@
 /obj/item/clothing/accessory/bracelet/material/New(var/newloc, var/new_material)
 	..(newloc)
 	if(!new_material)
-		new_material = DEFAULT_WALL_MATERIAL
+		new_material = MAT_STEEL
 	material = get_material_by_name(new_material)
 	if(!istype(material))
 		qdel(src)

--- a/code/modules/detectivework/tools/uvlight.dm
+++ b/code/modules/detectivework/tools/uvlight.dm
@@ -6,7 +6,7 @@
 	w_class = ITEMSIZE_SMALL
 	item_state = "electronic"
 	action_button_name = "Toggle UV light"
-	matter = list(DEFAULT_WALL_MATERIAL = 150)
+	matter = list(MAT_STEEL = 150)
 	origin_tech = list(TECH_MAGNET = 1, TECH_ENGINEERING = 1)
 
 	var/list/scanned = list()

--- a/code/modules/economy/mint.dm
+++ b/code/modules/economy/mint.dm
@@ -15,7 +15,7 @@
 	var/amt_uranium = 0
 	var/newCoins = 0   //how many coins the machine made in it's last load
 	var/processing = 0
-	var/chosen = DEFAULT_WALL_MATERIAL //which material will be used to make coins
+	var/chosen = MAT_STEEL //which material will be used to make coins
 	var/coinsToProduce = 10
 
 
@@ -50,7 +50,7 @@
 			amt_phoron += 100 * O.get_amount()
 		if("uranium")
 			amt_uranium += 100 * O.get_amount()
-		if(DEFAULT_WALL_MATERIAL)
+		if(MAT_STEEL)
 			amt_iron += 100 * O.get_amount()
 		else
 			processed = 0
@@ -79,7 +79,7 @@
 	else
 		dat += text("<A href='?src=\ref[src];choose=silver'>Choose</A>")
 	dat += text("<br><font color='#555555'><b>Iron inserted: </b>[amt_iron]</font> ")
-	if (chosen == DEFAULT_WALL_MATERIAL)
+	if (chosen == MAT_STEEL)
 		dat += text("chosen")
 	else
 		dat += text("<A href='?src=\ref[src];choose=metal'>Choose</A>")
@@ -131,7 +131,7 @@
 			icon_state = "coinpress1"
 			var/obj/item/weapon/moneybag/M
 			switch(chosen)
-				if(DEFAULT_WALL_MATERIAL)
+				if(MAT_STEEL)
 					while(amt_iron > 0 && coinsToProduce > 0)
 						if (locate(/obj/item/weapon/moneybag,output.loc))
 							M = locate(/obj/item/weapon/moneybag,output.loc)

--- a/code/modules/integrated_electronics/core/printer.dm
+++ b/code/modules/integrated_electronics/core/printer.dm
@@ -36,7 +36,7 @@
 /obj/item/device/integrated_circuit_printer/attackby(var/obj/item/O, var/mob/user)
 	if(istype(O,/obj/item/stack/material))
 		var/obj/item/stack/material/stack = O
-		if(stack.material.name == DEFAULT_WALL_MATERIAL)
+		if(stack.material.name == MAT_STEEL)
 			if(debug)
 				to_chat(user, span("warning", "\The [src] does not need any material."))
 				return

--- a/code/modules/materials/materials/glass.dm
+++ b/code/modules/materials/materials/glass.dm
@@ -106,7 +106,7 @@
 	hardness = 40
 	weight = 30
 	stack_origin_tech = list(TECH_MATERIAL = 2)
-	composite_material = list(DEFAULT_WALL_MATERIAL = SHEET_MATERIAL_AMOUNT / 2, "glass" = SHEET_MATERIAL_AMOUNT)
+	composite_material = list(MAT_STEEL = SHEET_MATERIAL_AMOUNT / 2, "glass" = SHEET_MATERIAL_AMOUNT)
 	window_options = list("One Direction" = 1, "Full Window" = 4, "Windoor" = 2)
 	created_window = /obj/structure/window/reinforced
 	created_fulltile_window = /obj/structure/window/reinforced/full
@@ -139,5 +139,5 @@
 	hardness = 40
 	weight = 30
 	stack_origin_tech = list(TECH_MATERIAL = 2)
-	composite_material = list(DEFAULT_WALL_MATERIAL = SHEET_MATERIAL_AMOUNT / 2, "borosilicate glass" = SHEET_MATERIAL_AMOUNT)
+	composite_material = list(MAT_STEEL = SHEET_MATERIAL_AMOUNT / 2, "borosilicate glass" = SHEET_MATERIAL_AMOUNT)
 	rod_product = null

--- a/code/modules/materials/materials/holographic.dm
+++ b/code/modules/materials/materials/holographic.dm
@@ -1,17 +1,17 @@
 /datum/material/steel/holographic
-	name = "holo" + DEFAULT_WALL_MATERIAL
-	display_name = DEFAULT_WALL_MATERIAL
+	name = "holo" + MAT_STEEL
+	display_name = MAT_STEEL
 	stack_type = null
 	shard_type = SHARD_NONE
 
 /datum/material/plastic/holographic
-	name = "holoplastic"
+	name = "holo" + MAT_PLASTIC
 	display_name = "plastic"
 	stack_type = null
 	shard_type = SHARD_NONE
 
 /datum/material/wood/holographic
-	name = "holowood"
+	name = "holo" + MAT_WOOD
 	display_name = "wood"
 	stack_type = null
 	shard_type = SHARD_NONE

--- a/code/modules/materials/materials/metals/plasteel.dm
+++ b/code/modules/materials/materials/metals/plasteel.dm
@@ -12,7 +12,7 @@
 	protectiveness = 20 // 50%
 	conductivity = 13 // For the purposes of balance.
 	stack_origin_tech = list(TECH_MATERIAL = 2)
-	composite_material = list(DEFAULT_WALL_MATERIAL = SHEET_MATERIAL_AMOUNT, "platinum" = SHEET_MATERIAL_AMOUNT) //todo
+	composite_material = list(MAT_STEEL = SHEET_MATERIAL_AMOUNT, "platinum" = SHEET_MATERIAL_AMOUNT) //todo
 	supply_conversion_value = 6
 
 /datum/material/plasteel/generate_recipes()

--- a/code/modules/materials/materials/metals/steel.dm
+++ b/code/modules/materials/materials/metals/steel.dm
@@ -1,5 +1,5 @@
 /datum/material/steel
-	name = DEFAULT_WALL_MATERIAL
+	name = MAT_STEEL
 	stack_type = /obj/item/stack/material/steel
 	integrity = 150
 	conductivity = 11 // Assuming this is carbon steel, it would actually be slightly less conductive than iron, but lets ignore that.

--- a/code/modules/materials/sheets/metals/metal.dm
+++ b/code/modules/materials/sheets/metals/metal.dm
@@ -1,7 +1,7 @@
 /obj/item/stack/material/steel
-	name = DEFAULT_WALL_MATERIAL
+	name = MAT_STEEL
 	icon_state = "sheet-refined"
-	default_type = DEFAULT_WALL_MATERIAL
+	default_type = MAT_STEEL
 	no_variants = FALSE
 	apply_colour = TRUE
 

--- a/code/modules/materials/sheets/metals/rods.dm
+++ b/code/modules/materials/sheets/metals/rods.dm
@@ -10,7 +10,7 @@
 	throw_range = 20
 	drop_sound = 'sound/items/drop/metalweapon.ogg'
 	pickup_sound = 'sound/items/pickup/metalweapon.ogg'
-	matter = list(DEFAULT_WALL_MATERIAL = SHEET_MATERIAL_AMOUNT / 2)
+	matter = list(MAT_STEEL = SHEET_MATERIAL_AMOUNT / 2)
 	max_amount = 60
 	attack_verb = list("hit", "bludgeoned", "whacked")
 

--- a/code/modules/mining/alloys.dm
+++ b/code/modules/mining/alloys.dm
@@ -30,7 +30,7 @@
 	product = /obj/item/stack/material/plasteel
 
 /datum/alloy/steel
-	metaltag = DEFAULT_WALL_MATERIAL
+	metaltag = MAT_STEEL
 	requires = list(
 		"carbon" = 1,
 		"hematite" = 1

--- a/code/modules/mining/drilling/scanner.dm
+++ b/code/modules/mining/drilling/scanner.dm
@@ -5,7 +5,7 @@
 	icon_state = "deep_scan_device"
 	item_state = "electronic"
 	origin_tech = list(TECH_MAGNET = 1, TECH_ENGINEERING = 1)
-	matter = list(DEFAULT_WALL_MATERIAL = 150)
+	matter = list(MAT_STEEL = 150)
 	var/scan_time = 2 SECONDS
 	var/range = 2
 	var/exact = FALSE
@@ -74,7 +74,7 @@
 	desc = "An advanced device used to locate ore deep underground."
 	description_info = "This scanner has variable range, you can use the Set Scanner Range verb, or alt+click the device. Drills dig in 5x5."
 	origin_tech = list(TECH_MAGNET = 4, TECH_ENGINEERING = 4)
-	matter = list(DEFAULT_WALL_MATERIAL = 150)
+	matter = list(MAT_STEEL = 150)
 	scan_time = 0.5 SECONDS
 	exact = TRUE
 

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -19,7 +19,7 @@
 	icon_state = "pickaxe"
 	item_state = "jackhammer"
 	w_class = ITEMSIZE_LARGE
-	matter = list(DEFAULT_WALL_MATERIAL = 3750)
+	matter = list(MAT_STEEL = 3750)
 	var/digspeed = 40 //moving the delay to an item var so R&D can make improved picks. --NEO
 	var/sand_dig = FALSE // does this thing dig sand?
 	origin_tech = list(TECH_MATERIAL = 1, TECH_ENGINEERING = 1)
@@ -122,7 +122,7 @@
 	item_state = "shovel"
 	w_class = ITEMSIZE_NORMAL
 	origin_tech = list(TECH_MATERIAL = 1, TECH_ENGINEERING = 1)
-	matter = list(DEFAULT_WALL_MATERIAL = 50)
+	matter = list(MAT_STEEL = 50)
 	attack_verb = list("bashed", "bludgeoned", "thrashed", "whacked")
 	sharp = 0
 	edge = 1

--- a/code/modules/mob/living/bot/floorbot.dm
+++ b/code/modules/mob/living/bot/floorbot.dm
@@ -207,7 +207,7 @@
 
 	if(emagged && istype(A, /turf/simulated/floor))
 		var/turf/simulated/floor/F = A
-		busy = 1
+		busy = TRUE
 		update_icons()
 		if(F.flooring)
 			visible_message("<span class='warning'>\The [src] begins to tear the floor tile from the floor!</span>")
@@ -220,7 +220,7 @@
 				F.ReplaceWithLattice()
 				addTiles(1)
 		target = null
-		busy = 0
+		busy = FALSE
 		update_icons()
 	else if(istype(A, /turf/space) || istype(A, /turf/simulated/mineral/floor))
 		var/building = 2
@@ -228,7 +228,7 @@
 			building = 1
 		if(amount < building)
 			return
-		busy = 1
+		busy = TRUE
 		update_icons()
 		visible_message("<span class='notice'>\The [src] begins to repair the hole.</span>")
 		if(do_after(src, 50))
@@ -240,22 +240,22 @@
 					I = new /obj/item/stack/rods(src)
 				A.attackby(I, src)
 		target = null
-		busy = 0
+		busy = FALSE
 		update_icons()
 	else if(istype(A, /turf/simulated/floor))
 		var/turf/simulated/floor/F = A
 		if(F.broken || F.burnt)
-			busy = 1
+			busy = TRUE
 			update_icons()
 			visible_message("<span class='notice'>\The [src] begins to remove the broken floor.</span>")
 			if(do_after(src, 50, F))
 				if(F.broken || F.burnt)
 					F.make_plating()
 			target = null
-			busy = 0
+			busy = FALSE
 			update_icons()
 		else if(!F.flooring && amount)
-			busy = 1
+			busy = TRUE
 			update_icons()
 			visible_message("<span class='notice'>\The [src] begins to improve the floor.</span>")
 			if(do_after(src, 50))
@@ -263,12 +263,12 @@
 					F.set_flooring(get_flooring_data(floor_build_type))
 					addTiles(-1)
 			target = null
-			busy = 0
+			busy = FALSE
 			update_icons()
 	else if(istype(A, /obj/item/stack/tile/floor) && amount < maxAmount)
 		var/obj/item/stack/tile/floor/T = A
 		visible_message("<span class='notice'>\The [src] begins to collect tiles.</span>")
-		busy = 1
+		busy = TRUE
 		update_icons()
 		if(do_after(src, 20))
 			if(T)
@@ -276,18 +276,20 @@
 				T.use(eaten)
 				addTiles(eaten)
 		target = null
-		busy = 0
+		busy = FALSE
 		update_icons()
-	else if(istype(A, /obj/item/stack/material) && amount + 4 <= maxAmount)
+	else if(istype(A, /obj/item/stack/material))
 		var/obj/item/stack/material/M = A
-		if(M.get_material_name() == DEFAULT_WALL_MATERIAL)
+		if(M.get_material_name() == MAT_STEEL)
 			visible_message("<span class='notice'>\The [src] begins to make tiles.</span>")
-			busy = 1
-			update_icons()
-			if(do_after(50))
-				if(M)
-					M.use(1)
-					addTiles(4)
+			while(amount + 4 <= maxAmount))
+				busy = TRUE
+				update_icons()
+				if(do_after(50))
+					if(M)
+						M.use(1)
+						addTiles(4)
+			busy = FALSE
 
 /mob/living/bot/floorbot/explode()
 	turn_off()

--- a/code/modules/mob/living/bot/floorbot.dm
+++ b/code/modules/mob/living/bot/floorbot.dm
@@ -280,12 +280,12 @@
 		update_icons()
 	else if(istype(A, /obj/item/stack/material))
 		var/obj/item/stack/material/M = A
-		if(M.get_material_name() == MAT_STEEL)
+		if(M.get_material_name() == DEFAULT_WALL_MATERIAL)
 			visible_message("<span class='notice'>\The [src] begins to make tiles.</span>")
-			while(amount + 4 <= maxAmount))
+			while(amount + 4 <= maxAmount)
 				busy = TRUE
 				update_icons()
-				if(do_after(50))
+				if(do_after(5 SECONDS))
 					if(M)
 						M.use(1)
 						addTiles(4)

--- a/code/modules/mob/living/silicon/robot/analyzer.dm
+++ b/code/modules/mob/living/silicon/robot/analyzer.dm
@@ -12,7 +12,7 @@
 	throw_speed = 5
 	throw_range = 10
 	origin_tech = list(TECH_MAGNET = 2, TECH_BIO = 1, TECH_ENGINEERING = 2)
-	matter = list(DEFAULT_WALL_MATERIAL = 500, "glass" = 200)
+	matter = list(MAT_STEEL = 500, "glass" = 200)
 	var/mode = 1;
 
 /obj/item/device/robotanalyzer/attack(mob/living/M as mob, mob/living/user as mob)

--- a/code/modules/mob/living/silicon/robot/component.dm
+++ b/code/modules/mob/living/silicon/robot/component.dm
@@ -212,7 +212,7 @@
 	name = "broken component"
 	icon = 'icons/obj/robot_component.dmi'
 	icon_state = "broken"
-	matter = list(DEFAULT_WALL_MATERIAL = 1000)
+	matter = list(MAT_STEEL = 1000)
 
 /obj/item/broken_device/random
 	var/list/possible_icons = list("binradio_broken",

--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -20,7 +20,7 @@
 	w_class = ITEMSIZE_TINY
 	throw_speed = 7
 	throw_range = 15
-	matter = list(DEFAULT_WALL_MATERIAL = 10)
+	matter = list(MAT_STEEL = 10)
 	var/colour = "black"	//what colour the ink is!
 	pressure_resistance = 2
 	drop_sound = 'sound/items/drop/accessory.ogg'

--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -128,7 +128,7 @@ var/global/photo_count = 0
 	item_state = "camera"
 	w_class = ITEMSIZE_SMALL
 	slot_flags = SLOT_BELT
-	matter = list(DEFAULT_WALL_MATERIAL = 2000)
+	matter = list(MAT_STEEL = 2000)
 	var/pictures_max = 10
 	var/pictures_left = 10
 	var/on = 1

--- a/code/modules/paperwork/stamps.dm
+++ b/code/modules/paperwork/stamps.dm
@@ -9,7 +9,7 @@
 	slot_flags = SLOT_HOLSTER
 	throw_speed = 7
 	throw_range = 15
-	matter = list(DEFAULT_WALL_MATERIAL = 60)
+	matter = list(MAT_STEEL = 60)
 	pressure_resistance = 2
 	attack_verb = list("stamped")
 	drop_sound = 'sound/items/drop/device.ogg'

--- a/code/modules/power/antimatter/shielding.dm
+++ b/code/modules/power/antimatter/shielding.dm
@@ -194,7 +194,7 @@
 	throwforce = 5
 	throw_speed = 1
 	throw_range = 2
-	matter = list(DEFAULT_WALL_MATERIAL = 100, "waste" = 2000)
+	matter = list(MAT_STEEL = 100, "waste" = 2000)
 
 /obj/item/device/am_shielding_container/attackby(var/obj/item/I, var/mob/user)
 	if(istype(I, /obj/item/device/multitool) && istype(src.loc,/turf))

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -503,7 +503,7 @@ var/list/possible_cable_coil_colours = list(
 	w_class = ITEMSIZE_SMALL
 	throw_speed = 2
 	throw_range = 5
-	matter = list(DEFAULT_WALL_MATERIAL = 50, "glass" = 20)
+	matter = list(MAT_STEEL = 50, "glass" = 20)
 	slot_flags = SLOT_BELT
 	item_state = "coil"
 	attack_verb = list("whipped", "lashed", "disciplined", "flogged")
@@ -951,7 +951,7 @@ var/list/possible_cable_coil_colours = list(
 	w_class = ITEMSIZE_SMALL
 	throw_speed = 2
 	throw_range = 5
-	matter = list(DEFAULT_WALL_MATERIAL = 50, "glass" = 20)
+	matter = list(MAT_STEEL = 50, "glass" = 20)
 	slot_flags = SLOT_BELT
 	attack_verb = list("whipped", "lashed", "disciplined", "flogged")
 	stacktype = null

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -24,7 +24,7 @@
 	var/charge_amount = 25 // How much power to give, if self_recharge is true.  The number is in absolute cell charge, as it gets divided by CELLRATE later.
 	var/last_use = 0 // A tracker for use in self-charging
 	var/charge_delay = 0 // How long it takes for the cell to start recharging after last use
-	matter = list(DEFAULT_WALL_MATERIAL = 700, "glass" = 50)
+	matter = list(MAT_STEEL = 700, "glass" = 50)
 	drop_sound = 'sound/items/drop/component.ogg'
 	pickup_sound = 'sound/items/pickup/component.ogg'
 

--- a/code/modules/power/cells/esoteric_cells.dm
+++ b/code/modules/power/cells/esoteric_cells.dm
@@ -5,7 +5,7 @@
 	origin_tech = list(TECH_POWER = 2)
 	icon_state = "spikecell"
 	maxcharge = 10000
-	matter = list(DEFAULT_WALL_MATERIAL = 1000, MAT_GLASS = 80, MAT_SILVER = 100)
+	matter = list(MAT_STEEL = 1000, MAT_GLASS = 80, MAT_SILVER = 100)
 	self_recharge = TRUE
 	charge_amount = 150
 

--- a/code/modules/power/cells/power_cells.dm
+++ b/code/modules/power/cells/power_cells.dm
@@ -3,7 +3,7 @@
 	desc = "You can't top the plasma top." //TOTALLY TRADEMARK INFRINGEMENT
 	origin_tech = list(TECH_POWER = 0)
 	maxcharge = 500
-	matter = list(DEFAULT_WALL_MATERIAL = 700, "glass" = 40)
+	matter = list(MAT_STEEL = 700, "glass" = 40)
 
 /obj/item/weapon/cell/crap/empty/New()
 	..()
@@ -13,7 +13,7 @@
 	name = "security borg rechargable D battery"
 	origin_tech = list(TECH_POWER = 0)
 	maxcharge = 600	//600 max charge / 100 charge per shot = six shots
-	matter = list(DEFAULT_WALL_MATERIAL = 700, "glass" = 40)
+	matter = list(MAT_STEEL = 700, "glass" = 40)
 
 /obj/item/weapon/cell/secborg/empty/New()
 	..()
@@ -24,14 +24,14 @@
 	name = "heavy-duty power cell"
 	origin_tech = list(TECH_POWER = 1)
 	maxcharge = 5000
-	matter = list(DEFAULT_WALL_MATERIAL = 700, "glass" = 50)
+	matter = list(MAT_STEEL = 700, "glass" = 50)
 
 /obj/item/weapon/cell/high
 	name = "high-capacity power cell"
 	origin_tech = list(TECH_POWER = 2)
 	icon_state = "hcell"
 	maxcharge = 10000
-	matter = list(DEFAULT_WALL_MATERIAL = 700, "glass" = 60)
+	matter = list(MAT_STEEL = 700, "glass" = 60)
 
 /obj/item/weapon/cell/high/empty/New()
 	..()
@@ -43,7 +43,7 @@
 	origin_tech = list(TECH_POWER = 5)
 	icon_state = "scell"
 	maxcharge = 20000
-	matter = list(DEFAULT_WALL_MATERIAL = 700, "glass" = 70)
+	matter = list(MAT_STEEL = 700, "glass" = 70)
 
 /obj/item/weapon/cell/super/empty/New()
 	..()
@@ -55,7 +55,7 @@
 	origin_tech = list(TECH_POWER = 6)
 	icon_state = "hpcell"
 	maxcharge = 30000
-	matter = list(DEFAULT_WALL_MATERIAL = 700, "glass" = 80)
+	matter = list(MAT_STEEL = 700, "glass" = 80)
 
 /obj/item/weapon/cell/hyper/empty/New()
 	..()
@@ -72,7 +72,7 @@
 	icon_state = "icell"
 	origin_tech =  null
 	maxcharge = 30000 //determines how badly mobs get shocked
-	matter = list(DEFAULT_WALL_MATERIAL = 700, "glass" = 80)
+	matter = list(MAT_STEEL = 700, "glass" = 80)
 
 /obj/item/weapon/cell/infinite/check_charge()
 	return 1

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -843,7 +843,7 @@ var/global/list/light_type_cache = list()
 	var/status = 0		// LIGHT_OK, LIGHT_BURNED or LIGHT_BROKEN
 	var/base_state
 	var/switchcount = 0	// number of times switched
-	matter = list(DEFAULT_WALL_MATERIAL = 60)
+	matter = list(MAT_STEEL = 60)
 	var/rigged = 0		// true if rigged to explode
 	var/broken_chance = 2
 

--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -207,7 +207,7 @@
 					to_chat(user, "<span class='warning'>You need more welding fuel to complete this task.</span>")
 		return
 
-	if(istype(W, /obj/item/stack/material) && W.get_material_name() == DEFAULT_WALL_MATERIAL)
+	if(istype(W, /obj/item/stack/material) && W.get_material_name() == MAT_STEEL)
 		var/amt = CEILING(( initial(integrity) - integrity)/10, 1)
 		if(!amt)
 			to_chat(user, "<span class='notice'>\The [src] is already fully repaired.</span>")

--- a/code/modules/power/tesla/telsa_construction.dm
+++ b/code/modules/power/tesla/telsa_construction.dm
@@ -23,7 +23,7 @@
 	name = T_BOARD("grounding rod")
 	build_path = /obj/machinery/power/grounding_rod
 	board_type = new /datum/frame/frame_types/machine
-	matter = list(DEFAULT_WALL_MATERIAL = 50, "glass" = 50)
+	matter = list(MAT_STEEL = 50, "glass" = 50)
 	req_components = list()
 
 /datum/category_item/autolathe/engineering/grounding_rod

--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -102,7 +102,7 @@
 	icon = 'icons/obj/ammo.dmi'
 	slot_flags = SLOT_BELT
 	item_state = "syringe_kit"
-	matter = list(DEFAULT_WALL_MATERIAL = 500)
+	matter = list(MAT_STEEL = 500)
 	throwforce = 5
 	w_class = ITEMSIZE_SMALL
 	throw_speed = 4

--- a/code/modules/projectiles/ammunition/magazines.dm
+++ b/code/modules/projectiles/ammunition/magazines.dm
@@ -32,7 +32,7 @@
 	icon_state = "38"
 	caliber = ".357"
 	ammo_type = /obj/item/ammo_casing/a357
-	matter = list(DEFAULT_WALL_MATERIAL = 1260)
+	matter = list(MAT_STEEL = 1260)
 	max_ammo = 6
 	multiple_sprites = 1
 
@@ -43,7 +43,7 @@
 	desc = "A speedloader for .38 revolvers."
 	icon_state = "38"
 	caliber = ".38"
-	matter = list(DEFAULT_WALL_MATERIAL = 360)
+	matter = list(MAT_STEEL = 360)
 	ammo_type = /obj/item/ammo_casing/a38
 	max_ammo = 6
 	multiple_sprites = 1
@@ -64,7 +64,7 @@
 	icon_state = "45"
 	mag_type = MAGAZINE
 	ammo_type = /obj/item/ammo_casing/a45
-	matter = list(DEFAULT_WALL_MATERIAL = 525) //metal costs are very roughly based around 1 .45 casing = 75 metal
+	matter = list(MAT_STEEL = 525) //metal costs are very roughly based around 1 .45 casing = 75 metal
 	caliber = ".45"
 	max_ammo = 7
 	multiple_sprites = 1
@@ -101,7 +101,7 @@
 	icon_state = "uzi45"
 	mag_type = MAGAZINE
 	ammo_type = /obj/item/ammo_casing/a45
-	matter = list(DEFAULT_WALL_MATERIAL = 1200)
+	matter = list(MAT_STEEL = 1200)
 	caliber = ".45"
 	max_ammo = 16
 	multiple_sprites = 1
@@ -114,7 +114,7 @@
 	icon_state = "tommy-mag"
 	mag_type = MAGAZINE
 	ammo_type = /obj/item/ammo_casing/a45
-	matter = list(DEFAULT_WALL_MATERIAL = 1500)
+	matter = list(MAT_STEEL = 1500)
 	caliber = ".45"
 	max_ammo = 20
 
@@ -131,7 +131,7 @@
 	w_class = ITEMSIZE_NORMAL // Bulky ammo doesn't fit in your pockets!
 	mag_type = MAGAZINE
 	ammo_type = /obj/item/ammo_casing/a45
-	matter = list(DEFAULT_WALL_MATERIAL = 3750)
+	matter = list(MAT_STEEL = 3750)
 	caliber = ".45"
 	max_ammo = 50
 
@@ -148,7 +148,7 @@
 	desc = "A stripper clip for reloading .45 rounds into magazines."
 	caliber = ".45"
 	ammo_type = /obj/item/ammo_casing/a45
-	matter = list(DEFAULT_WALL_MATERIAL = 675) // metal costs very roughly based around one .45 casing = 75 metal
+	matter = list(MAT_STEEL = 675) // metal costs very roughly based around one .45 casing = 75 metal
 	max_ammo = 9
 	multiple_sprites = 1
 
@@ -168,7 +168,7 @@
 	name = "speedloader (.45)"
 	icon_state = "45s"
 	ammo_type = /obj/item/ammo_casing/a45
-	matter = list(DEFAULT_WALL_MATERIAL = 525) //metal costs are very roughly based around 1 .45 casing = 75 metal
+	matter = list(MAT_STEEL = 525) //metal costs are very roughly based around 1 .45 casing = 75 metal
 	caliber = ".45"
 	max_ammo = 7
 	multiple_sprites = 1
@@ -214,7 +214,7 @@
 	icon_state = "9x19p_fullsize"
 	origin_tech = list(TECH_COMBAT = 2)
 	mag_type = MAGAZINE
-	matter = list(DEFAULT_WALL_MATERIAL = 600)
+	matter = list(MAT_STEEL = 600)
 	caliber = "9mm"
 	ammo_type = /obj/item/ammo_casing/a9mm
 	max_ammo = 10
@@ -250,7 +250,7 @@
 	icon_state = "9x19p"
 	origin_tech = list(TECH_COMBAT = 2)
 	mag_type = MAGAZINE
-	matter = list(DEFAULT_WALL_MATERIAL = 480)
+	matter = list(MAT_STEEL = 480)
 	caliber = "9mm"
 	ammo_type = /obj/item/ammo_casing/a9mm
 	max_ammo = 8
@@ -277,7 +277,7 @@
 	icon_state = "9mmt"
 	mag_type = MAGAZINE
 	ammo_type = /obj/item/ammo_casing/a9mm
-	matter = list(DEFAULT_WALL_MATERIAL = 1200)
+	matter = list(MAT_STEEL = 1200)
 	caliber = "9mm"
 	max_ammo = 20
 	multiple_sprites = 1
@@ -300,14 +300,14 @@
 /obj/item/ammo_magazine/m9mmt/ap
 	name = "top mounted magazine (9mm armor piercing)"
 	ammo_type = /obj/item/ammo_casing/a9mm/ap
-	matter = list(DEFAULT_WALL_MATERIAL = 1000, MAT_PLASTEEL = 2000)
+	matter = list(MAT_STEEL = 1000, MAT_PLASTEEL = 2000)
 
 /obj/item/ammo_magazine/m9mmp90
 	name = "large capacity top mounted magazine (9mm armor-piercing)"
 	icon_state = "p90"
 	mag_type = MAGAZINE
 	ammo_type = /obj/item/ammo_casing/a9mm/ap
-	matter = list(DEFAULT_WALL_MATERIAL = 3000)
+	matter = list(MAT_STEEL = 3000)
 	caliber = "9mm"
 	max_ammo = 50
 	multiple_sprites = 1
@@ -321,7 +321,7 @@
 	desc = "A stripper clip for reloading 9mm rounds into magazines."
 	caliber = "9mm"
 	ammo_type = /obj/item/ammo_casing/a9mm
-	matter = list(DEFAULT_WALL_MATERIAL = 540) // metal costs are very roughly based around one 9mm casing = 60 metal
+	matter = list(MAT_STEEL = 540) // metal costs are very roughly based around one 9mm casing = 60 metal
 	max_ammo = 9
 	multiple_sprites = 1
 
@@ -342,7 +342,7 @@
 	icon_state = "S9mm"
 	mag_type = MAGAZINE
 	ammo_type = /obj/item/ammo_casing/a9mm
-	matter = list(DEFAULT_WALL_MATERIAL = 1200)
+	matter = list(MAT_STEEL = 1200)
 	caliber = "9mm"
 	max_ammo = 21
 	origin_tech = list(TECH_COMBAT = 2, TECH_ILLEGAL = 1)
@@ -352,7 +352,7 @@
 	desc = "A high capacity double stack magazine made specially for the Advanced SMG. Filled with 21 9mm armor piercing bullets."
 	icon_state = "S9mm"
 	ammo_type = /obj/item/ammo_casing/a9mm/ap
-	matter = list(DEFAULT_WALL_MATERIAL = 2000)
+	matter = list(MAT_STEEL = 2000)
 
 /obj/item/ammo_magazine/m9mmR/saber/empty
 	initial_ammo = 0
@@ -365,7 +365,7 @@
 	origin_tech = list(TECH_COMBAT = 2)
 	mag_type = MAGAZINE
 	caliber = "10mm"
-	matter = list(DEFAULT_WALL_MATERIAL = 1500)
+	matter = list(MAT_STEEL = 1500)
 	ammo_type = /obj/item/ammo_casing/a10mm
 	max_ammo = 20
 	multiple_sprites = 1
@@ -379,7 +379,7 @@
 	desc = "A stripper clip for reloading 5mm rounds into magazines."
 	caliber = "10mm"
 	ammo_type = /obj/item/ammo_casing/a10mm
-	matter = list(DEFAULT_WALL_MATERIAL = 675) // metal costs are very roughly based around one 10mm casing = 75 metal
+	matter = list(MAT_STEEL = 675) // metal costs are very roughly based around one 10mm casing = 75 metal
 	max_ammo = 9
 	multiple_sprites = 1
 
@@ -395,14 +395,14 @@
 	origin_tech = list(TECH_COMBAT = 2)
 	mag_type = MAGAZINE
 	caliber = "5.45mm"
-	matter = list(DEFAULT_WALL_MATERIAL = 1800)
+	matter = list(MAT_STEEL = 1800)
 	ammo_type = /obj/item/ammo_casing/a545
 	max_ammo = 20
 	multiple_sprites = 1
 
 /obj/item/ammo_magazine/m545/ext
 	name = "extended magazine (5.45mm)"
-	matter = list(DEFAULT_WALL_MATERIAL = 2700)
+	matter = list(MAT_STEEL = 2700)
 	max_ammo = 30
 
 /obj/item/ammo_magazine/m545/empty
@@ -438,7 +438,7 @@
 /obj/item/ammo_magazine/m545/small
 	name = "reduced magazine (5.45mm)"
 	icon_state = "m545-small"
-	matter = list(DEFAULT_WALL_MATERIAL = 900)
+	matter = list(MAT_STEEL = 900)
 	max_ammo = 10
 
 /obj/item/ammo_magazine/m545/small/empty
@@ -461,7 +461,7 @@
 	icon_state = "clip_rifle"
 	caliber = "5.45mm"
 	ammo_type = /obj/item/ammo_casing/a545
-	matter = list(DEFAULT_WALL_MATERIAL = 450) // metal costs are very roughly based around one 10mm casing = 180 metal
+	matter = list(MAT_STEEL = 450) // metal costs are very roughly based around one 10mm casing = 180 metal
 	max_ammo = 5
 	multiple_sprites = 1
 
@@ -483,7 +483,7 @@
 	origin_tech = list(TECH_COMBAT = 2)
 	mag_type = MAGAZINE
 	caliber = "5.45mm"
-	matter = list(DEFAULT_WALL_MATERIAL = 10000)
+	matter = list(MAT_STEEL = 10000)
 	ammo_type = /obj/item/ammo_casing/a545
 	w_class = ITEMSIZE_NORMAL // This should NOT fit in your pocket!!
 	max_ammo = 50
@@ -508,7 +508,7 @@
 	origin_tech = list(TECH_COMBAT = 2)
 	mag_type = MAGAZINE
 	caliber = ".44"
-	matter = list(DEFAULT_WALL_MATERIAL = 1260)
+	matter = list(MAT_STEEL = 1260)
 	ammo_type = /obj/item/ammo_casing/a44
 	max_ammo = 7
 	multiple_sprites = 1
@@ -522,7 +522,7 @@
 	desc = "A stripper clip for reloading .44 rounds into magazines."
 	caliber = ".44"
 	ammo_type = /obj/item/ammo_casing/a44
-	matter = list(DEFAULT_WALL_MATERIAL = 1620) // metal costs are very roughly based around one .50 casing = 180 metal
+	matter = list(MAT_STEEL = 1620) // metal costs are very roughly based around one .50 casing = 180 metal
 	max_ammo = 9
 	multiple_sprites = 1
 
@@ -530,7 +530,7 @@
 	name = "speedloader (.44)"
 	icon_state = "44"
 	ammo_type = /obj/item/ammo_casing/a44
-	matter = list(DEFAULT_WALL_MATERIAL = 1260) //metal costs are very roughly based around 1 .45 casing = 75 metal
+	matter = list(MAT_STEEL = 1260) //metal costs are very roughly based around 1 .45 casing = 75 metal
 	caliber = ".44"
 	max_ammo = 6
 	multiple_sprites = 1
@@ -555,7 +555,7 @@
 	icon_state = "m762-small"
 	mag_type = MAGAZINE
 	caliber = "7.62mm"
-	matter = list(DEFAULT_WALL_MATERIAL = 2000)
+	matter = list(MAT_STEEL = 2000)
 	ammo_type = /obj/item/ammo_casing/a762
 	max_ammo = 10
 	multiple_sprites = 1
@@ -572,7 +572,7 @@
 	icon_state = "m762"
 	mag_type = MAGAZINE
 	caliber = "7.62mm"
-	matter = list(DEFAULT_WALL_MATERIAL = 4000)
+	matter = list(MAT_STEEL = 4000)
 	ammo_type = /obj/item/ammo_casing/a762
 	max_ammo = 20
 	multiple_sprites = 1
@@ -589,7 +589,7 @@
 	icon_state = "gclip"
 	mag_type = MAGAZINE
 	caliber = "7.62mm"
-	matter = list(DEFAULT_WALL_MATERIAL = 1600)
+	matter = list(MAT_STEEL = 1600)
 	ammo_type = /obj/item/ammo_casing/a762
 	max_ammo = 8
 	multiple_sprites = 1
@@ -606,7 +606,7 @@
 	icon_state = "clip_rifle"
 	caliber = "7.62mm"
 	ammo_type = /obj/item/ammo_casing/a762
-	matter = list(DEFAULT_WALL_MATERIAL = 1000) // metal costs are very roughly based around one 7.62 casing = 200 metal
+	matter = list(MAT_STEEL = 1000) // metal costs are very roughly based around one 7.62 casing = 200 metal
 	max_ammo = 5
 	multiple_sprites = 1
 
@@ -627,7 +627,7 @@
 	icon_state = "SVD"
 	mag_type = MAGAZINE
 	caliber = "7.62mm"
-	matter = list(DEFAULT_WALL_MATERIAL = 2000)
+	matter = list(MAT_STEEL = 2000)
 	ammo_type = /obj/item/ammo_casing/a762
 	max_ammo = 10
 	multiple_sprites = 1
@@ -646,7 +646,7 @@
 	icon_state = "ashot-mag"
 	mag_type = MAGAZINE
 	caliber = "12g"
-	matter = list(DEFAULT_WALL_MATERIAL = 13000)
+	matter = list(MAT_STEEL = 13000)
 	ammo_type = /obj/item/ammo_casing/a12g
 	max_ammo = 24
 	multiple_sprites = 1
@@ -672,7 +672,7 @@
 	desc = "A color-coded metal clip for holding and quickly loading shotgun shells. This one is loaded with slugs."
 	caliber = "12g"
 	ammo_type = /obj/item/ammo_casing/a12g
-	matter = list(DEFAULT_WALL_MATERIAL = 1070) // slugs shells x2 + 350 metal for the clip itself.
+	matter = list(MAT_STEEL = 1070) // slugs shells x2 + 350 metal for the clip itself.
 	max_ammo = 2
 	multiple_sprites = 1
 
@@ -681,14 +681,14 @@
 	icon_state = "12gclipshell"
 	desc = "A color-coded metal clip for holding and quickly loading shotgun shells. This one is loaded with buckshot."
 	ammo_type = /obj/item/ammo_casing/a12g/pellet
-	matter = list(DEFAULT_WALL_MATERIAL = 1070) // buckshot and slugs cost the same
+	matter = list(MAT_STEEL = 1070) // buckshot and slugs cost the same
 
 /obj/item/ammo_magazine/clip/c12g/beanbag
 	name = "ammo clip (12g beanbag)"
 	icon_state = "12gclipbean"
 	desc = "A color-coded metal clip for holding and quickly loading shotgun shells. This one is loaded with beanbags."
 	ammo_type = /obj/item/ammo_casing/a12g/beanbag
-	matter = list(DEFAULT_WALL_MATERIAL = 710) //beanbags x2 + 350 metal
+	matter = list(MAT_STEEL = 710) //beanbags x2 + 350 metal
 
 ///////// .75 Gyrojet /////////
 
@@ -712,6 +712,6 @@
 	caliber = "caps"
 	color = "#FF0000"
 	ammo_type = /obj/item/ammo_casing/cap
-	matter = list(DEFAULT_WALL_MATERIAL = 600)
+	matter = list(MAT_STEEL = 600)
 	max_ammo = 7
 	multiple_sprites = 1

--- a/code/modules/projectiles/ammunition/magnetic.dm
+++ b/code/modules/projectiles/ammunition/magnetic.dm
@@ -4,7 +4,7 @@
 	icon = 'icons/obj/ammo.dmi'
 	icon_state = "caseless-mag"
 	w_class = ITEMSIZE_SMALL
-	matter = list(DEFAULT_WALL_MATERIAL = 1800)
+	matter = list(MAT_STEEL = 1800)
 	origin_tech = list(TECH_COMBAT = 1)
 	var/remaining = 9
 	preserve_item = 1

--- a/code/modules/projectiles/ammunition/rounds.dm
+++ b/code/modules/projectiles/ammunition/rounds.dm
@@ -27,7 +27,7 @@
 	desc = "A .357 bullet casing."
 	caliber = ".357"
 	projectile_type = /obj/item/projectile/bullet/pistol/strong
-	matter = list(DEFAULT_WALL_MATERIAL = 210)
+	matter = list(MAT_STEEL = 210)
 
 /*
  * .38
@@ -37,7 +37,7 @@
 	desc = "A .38 bullet casing."
 	caliber = ".38"
 	projectile_type = /obj/item/projectile/bullet/pistol
-	matter = list(DEFAULT_WALL_MATERIAL = 60)
+	matter = list(MAT_STEEL = 60)
 
 /obj/item/ammo_casing/a38/rubber
 	desc = "A .38 rubber bullet casing."
@@ -49,7 +49,7 @@
 	desc = "A .38 bullet casing fitted with a single-use ion pulse generator."
 	icon_state = "empcasing"
 	projectile_type = /obj/item/projectile/ion/small
-	matter = list(DEFAULT_WALL_MATERIAL = 130, "uranium" = 100)
+	matter = list(MAT_STEEL = 130, "uranium" = 100)
 
 /*
  * .44
@@ -59,18 +59,18 @@
 	desc = "A .44 bullet casing."
 	caliber = ".44"
 	projectile_type = /obj/item/projectile/bullet/pistol/strong
-	matter = list(DEFAULT_WALL_MATERIAL = 210)
+	matter = list(MAT_STEEL = 210)
 
 /obj/item/ammo_casing/a44/rubber
 	icon_state = "r-casing"
 	desc = "A .44 rubber bullet casing."
 	projectile_type = /obj/item/projectile/bullet/pistol/rubber/strong
-	matter = list(DEFAULT_WALL_MATERIAL = 60)
+	matter = list(MAT_STEEL = 60)
 
 /obj/item/ammo_casing/a44/rifle
 	desc = "A proprietary Hedberg-Hammarstrom .44 bullet casing designed for use in revolving rifles."
 	projectile_type = /obj/item/projectile/bullet/rifle/a44rifle
-	matter = list(DEFAULT_WALL_MATERIAL = 210)
+	matter = list(MAT_STEEL = 210)
 
 /*
  * .75 (aka Gyrojet Rockets, aka admin abuse)
@@ -80,7 +80,7 @@
 	desc = "A .75 gyrojet rocket sheathe."
 	caliber = ".75"
 	projectile_type = /obj/item/projectile/bullet/gyro
-	matter = list(DEFAULT_WALL_MATERIAL = 4000)
+	matter = list(MAT_STEEL = 4000)
 
 /*
  * 9mm
@@ -90,12 +90,12 @@
 	desc = "A 9mm bullet casing."
 	caliber = "9mm"
 	projectile_type = /obj/item/projectile/bullet/pistol
-	matter = list(DEFAULT_WALL_MATERIAL = 60)
+	matter = list(MAT_STEEL = 60)
 
 /obj/item/ammo_casing/a9mm/ap
 	desc = "A 9mm armor-piercing bullet casing."
 	projectile_type = /obj/item/projectile/bullet/pistol/ap
-	matter = list(DEFAULT_WALL_MATERIAL = 80)
+	matter = list(MAT_STEEL = 80)
 
 /obj/item/ammo_casing/a9mm/hp
 	desc = "A 9mm hollow-point bullet casing."
@@ -125,43 +125,43 @@
 	desc = "A .45 bullet casing."
 	caliber = ".45"
 	projectile_type = /obj/item/projectile/bullet/pistol/medium
-	matter = list(DEFAULT_WALL_MATERIAL = 75)
+	matter = list(MAT_STEEL = 75)
 
 /obj/item/ammo_casing/a45/ap
 	desc = "A .45 Armor-Piercing bullet casing."
 	icon_state = "r-casing"
 	projectile_type = /obj/item/projectile/bullet/pistol/medium/ap
-	matter = list(DEFAULT_WALL_MATERIAL = 50, MAT_PLASTEEL = 25)
+	matter = list(MAT_STEEL = 50, MAT_PLASTEEL = 25)
 
 /obj/item/ammo_casing/a45/practice
 	desc = "A .45 practice bullet casing."
 	icon_state = "r-casing"
 	projectile_type = /obj/item/projectile/bullet/practice
-	matter = list(DEFAULT_WALL_MATERIAL = 60)
+	matter = list(MAT_STEEL = 60)
 
 /obj/item/ammo_casing/a45/rubber
 	desc = "A .45 rubber bullet casing."
 	icon_state = "r-casing"
 	projectile_type = /obj/item/projectile/bullet/pistol/rubber
-	matter = list(DEFAULT_WALL_MATERIAL = 60)
+	matter = list(MAT_STEEL = 60)
 
 /obj/item/ammo_casing/a45/flash
 	desc = "A .45 flash shell casing."
 	icon_state = "r-casing"
 	projectile_type = /obj/item/projectile/energy/flash
-	matter = list(DEFAULT_WALL_MATERIAL = 60)
+	matter = list(MAT_STEEL = 60)
 
 /obj/item/ammo_casing/a45/emp
 	name = ".45 haywire round"
 	desc = "A .45 bullet casing fitted with a single-use ion pulse generator."
 	projectile_type = /obj/item/projectile/ion/small
 	icon_state = "empcasing"
-	matter = list(DEFAULT_WALL_MATERIAL = 130, "uranium" = 100)
+	matter = list(MAT_STEEL = 130, "uranium" = 100)
 
 /obj/item/ammo_casing/a45/hp
 	desc = "A .45 hollow-point bullet casing."
 	projectile_type = /obj/item/projectile/bullet/pistol/medium/hp
-	matter = list(DEFAULT_WALL_MATERIAL = 60, MAT_PLASTIC = 15)
+	matter = list(MAT_STEEL = 60, MAT_PLASTIC = 15)
 
 /*
  * 10mm
@@ -171,14 +171,14 @@
 	desc = "A 10mm bullet casing."
 	caliber = "10mm"
 	projectile_type = /obj/item/projectile/bullet/pistol/medium
-	matter = list(DEFAULT_WALL_MATERIAL = 75)
+	matter = list(MAT_STEEL = 75)
 
 /obj/item/ammo_casing/a10mm/emp
 	name = "10mm haywire round"
 	desc = "A 10mm bullet casing fitted with a single-use ion pulse generator."
 	projectile_type = /obj/item/projectile/ion/small
 	icon_state = "empcasing"
-	matter = list(DEFAULT_WALL_MATERIAL = 130, "uranium" = 100)
+	matter = list(MAT_STEEL = 130, "uranium" = 100)
 
 /*
  * 12g (aka shotgun ammo)
@@ -190,7 +190,7 @@
 	icon_state = "slshell"
 	caliber = "12g"
 	projectile_type = /obj/item/projectile/bullet/shotgun
-	matter = list(DEFAULT_WALL_MATERIAL = 360)
+	matter = list(MAT_STEEL = 360)
 
 /obj/item/ammo_casing/a12g/pellet
 	name = "shotgun shell"
@@ -203,21 +203,21 @@
 	desc = "A blank shell."
 	icon_state = "blshell"
 	projectile_type = /obj/item/projectile/bullet/blank
-	matter = list(DEFAULT_WALL_MATERIAL = 90)
+	matter = list(MAT_STEEL = 90)
 
 /obj/item/ammo_casing/a12g/practice
 	name = "shotgun shell"
 	desc = "A practice shell."
 	icon_state = "pshell"
 	projectile_type = /obj/item/projectile/bullet/practice
-	matter = list(DEFAULT_WALL_MATERIAL = 90)
+	matter = list(MAT_STEEL = 90)
 
 /obj/item/ammo_casing/a12g/beanbag
 	name = "beanbag shell"
 	desc = "A beanbag shell."
 	icon_state = "bshell"
 	projectile_type = /obj/item/projectile/bullet/shotgun/beanbag
-	matter = list(DEFAULT_WALL_MATERIAL = 180)
+	matter = list(MAT_STEEL = 180)
 
 //Can stun in one hit if aimed at the head, but
 //is blocked by clothing that stops tasers and is vulnerable to EMP
@@ -226,7 +226,7 @@
 	desc = "A 12 gauge taser cartridge."
 	icon_state = "stunshell"
 	projectile_type = /obj/item/projectile/energy/electrode/stunshot
-	matter = list(DEFAULT_WALL_MATERIAL = 360, "glass" = 720)
+	matter = list(MAT_STEEL = 360, "glass" = 720)
 
 /obj/item/ammo_casing/a12g/stunshell/emp_act(severity)
 	if(prob(100/severity)) BB = null
@@ -238,7 +238,7 @@
 	desc = "A chemical shell used to signal distress or provide illumination."
 	icon_state = "fshell"
 	projectile_type = /obj/item/projectile/energy/flash/flare
-	matter = list(DEFAULT_WALL_MATERIAL = 90, "glass" = 90)
+	matter = list(MAT_STEEL = 90, "glass" = 90)
 
 /obj/item/ammo_casing/a12g/emp
 	name = "ion shell"
@@ -246,7 +246,7 @@
 	icon_state = "empshell"
 	projectile_type = /obj/item/projectile/ion
 //	projectile_type = /obj/item/projectile/bullet/shotgun/ion
-	matter = list(DEFAULT_WALL_MATERIAL = 360, "uranium" = 240)
+	matter = list(MAT_STEEL = 360, "uranium" = 240)
 
 /obj/item/ammo_casing/a12g/flechette
 	name = "shotgun flechette"
@@ -254,7 +254,7 @@
 	icon_state = "slshell"
 	caliber = "12g"
 	projectile_type = /obj/item/projectile/scatter/flechette
-	matter = list(DEFAULT_WALL_MATERIAL = 360, MAT_PLASTEEL = 100)
+	matter = list(MAT_STEEL = 360, MAT_PLASTEEL = 100)
 
 /*
  * 7.62mm
@@ -265,23 +265,23 @@
 	caliber = "7.62mm"
 	icon_state = "rifle-casing"
 	projectile_type = /obj/item/projectile/bullet/rifle/a762
-	matter = list(DEFAULT_WALL_MATERIAL = 200)
+	matter = list(MAT_STEEL = 200)
 
 /obj/item/ammo_casing/a762/ap
 	desc = "A 7.62mm armor-piercing bullet casing."
 	projectile_type = /obj/item/projectile/bullet/rifle/a762/ap
-	matter = list(DEFAULT_WALL_MATERIAL = 300)
+	matter = list(MAT_STEEL = 300)
 
 /obj/item/ammo_casing/a762/practice
 	desc = "A 7.62mm practice bullet casing."
 	icon_state = "rifle-casing" // Need to make an icon for these
 	projectile_type = /obj/item/projectile/bullet/practice
-	matter = list(DEFAULT_WALL_MATERIAL = 90)
+	matter = list(MAT_STEEL = 90)
 
 /obj/item/ammo_casing/a762/blank
 	desc = "A blank 7.62mm bullet casing."
 	projectile_type = /obj/item/projectile/bullet/blank
-	matter = list(DEFAULT_WALL_MATERIAL = 90)
+	matter = list(MAT_STEEL = 90)
 
 /obj/item/ammo_casing/a762/hp
 	desc = "A 7.62mm hollow-point bullet casing."
@@ -300,7 +300,7 @@
 	icon_state = "lcasing"
 	caliber = "14.5mm"
 	projectile_type = /obj/item/projectile/bullet/rifle/a145
-	matter = list(DEFAULT_WALL_MATERIAL = 1250)
+	matter = list(MAT_STEEL = 1250)
 
 /obj/item/ammo_casing/a145/highvel
 	desc = "A 14.5mm sabot shell."
@@ -319,23 +319,23 @@
 	caliber = "5.45mm"
 	icon_state = "rifle-casing"
 	projectile_type = /obj/item/projectile/bullet/rifle/a545
-	matter = list(DEFAULT_WALL_MATERIAL = 180)
+	matter = list(MAT_STEEL = 180)
 
 /obj/item/ammo_casing/a545/ap
 	desc = "A 5.45mm armor-piercing bullet casing."
 	projectile_type = /obj/item/projectile/bullet/rifle/a545/ap
-	matter = list(DEFAULT_WALL_MATERIAL = 270)
+	matter = list(MAT_STEEL = 270)
 
 /obj/item/ammo_casing/a545/practice
 	desc = "A 5.45mm practice bullet casing."
 	icon_state = "rifle-casing" // Need to make an icon for these
 	projectile_type = /obj/item/projectile/bullet/practice
-	matter = list(DEFAULT_WALL_MATERIAL = 90)
+	matter = list(MAT_STEEL = 90)
 
 /obj/item/ammo_casing/a545/blank
 	desc = "A blank 5.45mm bullet casing."
 	projectile_type = /obj/item/projectile/bullet/blank
-	matter = list(DEFAULT_WALL_MATERIAL = 90)
+	matter = list(MAT_STEEL = 90)
 
 /obj/item/ammo_casing/a545/hp
 	desc = "A 5.45mm hollow-point bullet casing."
@@ -354,7 +354,7 @@
 	caliber = "5mm caseless"
 	icon_state = "casing" // Placeholder. Should probably be purple.
 	projectile_type = /obj/item/projectile/bullet/pistol // Close enough to be comparable.
-	matter = list(DEFAULT_WALL_MATERIAL = 180)
+	matter = list(MAT_STEEL = 180)
 	caseless = 1
 
 /obj/item/ammo_casing/a5mmcaseless/stun
@@ -371,7 +371,7 @@
 	icon_state = "rocketshell"
 	projectile_type = /obj/item/projectile/bullet/srmrocket
 	caliber = "rocket"
-	matter = list(DEFAULT_WALL_MATERIAL = 10000)
+	matter = list(MAT_STEEL = 10000)
 
 /obj/item/ammo_casing/cap
 	name = "cap"
@@ -380,7 +380,7 @@
 	icon_state = "r-casing"
 	color = "#FF0000"
 	projectile_type = /obj/item/projectile/bullet/pistol/cap
-	matter = list(DEFAULT_WALL_MATERIAL = 85)
+	matter = list(MAT_STEEL = 85)
 
 /obj/item/ammo_casing/spent // For simple hostile mobs only, so they don't cough up usable bullets when firing. This is for literally nothing else.
 	icon_state = "s-casing-spent"

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -39,7 +39,7 @@
 	icon_state = "detective"
 	item_state = "gun"
 	slot_flags = SLOT_BELT|SLOT_HOLSTER
-	matter = list(DEFAULT_WALL_MATERIAL = 2000)
+	matter = list(MAT_STEEL = 2000)
 	w_class = ITEMSIZE_NORMAL
 	throwforce = 5
 	throw_speed = 4

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -11,7 +11,7 @@
 	w_class = ITEMSIZE_LARGE
 	force = 10
 	origin_tech = list(TECH_COMBAT = 3, TECH_MAGNET = 2)
-	matter = list(DEFAULT_WALL_MATERIAL = 2000)
+	matter = list(MAT_STEEL = 2000)
 	projectile_type = /obj/item/projectile/beam/midlaser
 	one_handed_penalty = 30
 
@@ -77,7 +77,7 @@
 	w_class = ITEMSIZE_LARGE
 	force = 15
 	origin_tech = list(TECH_COMBAT = 3, TECH_MAGNET = 2)
-	matter = list(DEFAULT_WALL_MATERIAL = 2000)
+	matter = list(MAT_STEEL = 2000)
 	projectile_type = /obj/item/projectile/beam/mininglaser
 	one_handed_penalty = 30
 
@@ -284,7 +284,7 @@
 	item_state = "laser"
 	desc = "Standard issue weapon of the Imperial Guard"
 	origin_tech = list(TECH_COMBAT = 1, TECH_MAGNET = 2)
-	matter = list(DEFAULT_WALL_MATERIAL = 2000)
+	matter = list(MAT_STEEL = 2000)
 	projectile_type = /obj/item/projectile/beam/lasertag/blue
 	cell_type = /obj/item/weapon/cell/device/weapon/recharge
 	battery_lock = 1

--- a/code/modules/projectiles/guns/energy/stun.dm
+++ b/code/modules/projectiles/guns/energy/stun.dm
@@ -48,7 +48,7 @@
 	w_class = ITEMSIZE_SMALL
 	item_state = "crossbow"
 	origin_tech = list(TECH_COMBAT = 2, TECH_MAGNET = 2, TECH_ILLEGAL = 5)
-	matter = list(DEFAULT_WALL_MATERIAL = 2000)
+	matter = list(MAT_STEEL = 2000)
 	slot_flags = SLOT_BELT | SLOT_HOLSTER
 	silenced = 1
 	projectile_type = /obj/item/projectile/energy/bolt
@@ -66,7 +66,7 @@
 	desc = "A weapon favored by mercenary infiltration teams."
 	w_class = ITEMSIZE_LARGE
 	force = 10
-	matter = list(DEFAULT_WALL_MATERIAL = 200000)
+	matter = list(MAT_STEEL = 200000)
 	slot_flags = SLOT_BELT
 	projectile_type = /obj/item/projectile/energy/bolt/large
 

--- a/code/modules/projectiles/guns/launcher/grenade_launcher.dm
+++ b/code/modules/projectiles/guns/launcher/grenade_launcher.dm
@@ -15,7 +15,7 @@
 	var/obj/item/weapon/grenade/chambered
 	var/list/grenades = new/list()
 	var/max_grenades = 5 //holds this + one in the chamber
-	matter = list(DEFAULT_WALL_MATERIAL = 2000)
+	matter = list(MAT_STEEL = 2000)
 
 //revolves the magazine, allowing players to choose between multiple grenade types
 /obj/item/weapon/gun/launcher/grenade/proc/pump(mob/M as mob)

--- a/code/modules/projectiles/guns/launcher/pneumatic.dm
+++ b/code/modules/projectiles/guns/launcher/pneumatic.dm
@@ -172,7 +172,7 @@
 			buildstate++
 			update_icon()
 			return
-	else if(istype(W,/obj/item/stack/material) && W.get_material_name() == DEFAULT_WALL_MATERIAL)
+	else if(istype(W,/obj/item/stack/material) && W.get_material_name() == MAT_STEEL)
 		if(buildstate == 2)
 			var/obj/item/stack/material/M = W
 			if(M.use(5))

--- a/code/modules/projectiles/guns/launcher/syringe_gun.dm
+++ b/code/modules/projectiles/guns/launcher/syringe_gun.dm
@@ -4,7 +4,7 @@
 	icon = 'icons/obj/ammo.dmi'
 	icon_state = "syringe-cartridge"
 	var/icon_flight = "syringe-cartridge-flight" //so it doesn't look so weird when shot
-	matter = list(DEFAULT_WALL_MATERIAL = 125, "glass" = 375)
+	matter = list(MAT_STEEL = 125, "glass" = 375)
 	slot_flags = SLOT_BELT | SLOT_EARS
 	throwforce = 3
 	force = 3
@@ -68,7 +68,7 @@
 	item_state = "syringegun"
 	w_class = ITEMSIZE_NORMAL
 	force = 7
-	matter = list(DEFAULT_WALL_MATERIAL = 2000)
+	matter = list(MAT_STEEL = 2000)
 	slot_flags = SLOT_BELT
 
 	fire_sound = 'sound/weapons/empty.ogg'

--- a/code/modules/projectiles/guns/magnetic/magnetic_construction.dm
+++ b/code/modules/projectiles/guns/magnetic/magnetic_construction.dm
@@ -12,7 +12,7 @@
 	if(istype(thing, /obj/item/stack/material) && construction_stage == 1)
 		var/obj/item/stack/material/reinforcing = thing
 		var/datum/material/reinforcing_with = reinforcing.get_material()
-		if(reinforcing_with.name == DEFAULT_WALL_MATERIAL) // Steel
+		if(reinforcing_with.name == MAT_STEEL) // Steel
 			if(reinforcing.get_amount() < 5)
 				to_chat(user, "<span class='warning'>You need at least 5 [reinforcing.singular_name]\s for this task.</span>")
 				return

--- a/code/modules/projectiles/guns/projectile.dm
+++ b/code/modules/projectiles/guns/projectile.dm
@@ -8,7 +8,7 @@
 	icon_state = "revolver"
 	origin_tech = list(TECH_COMBAT = 2, TECH_MATERIAL = 2)
 	w_class = ITEMSIZE_NORMAL
-	matter = list(DEFAULT_WALL_MATERIAL = 1000)
+	matter = list(MAT_STEEL = 1000)
 	recoil = 1
 	projectile_type = /obj/item/projectile/bullet/pistol/strong	//Only used for chameleon guns
 

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -259,7 +259,7 @@
 	icon_state = "bucket"
 	item_state = "bucket"
 	center_of_mass = list("x" = 16,"y" = 10)
-	matter = list(DEFAULT_WALL_MATERIAL = 200)
+	matter = list(MAT_STEEL = 200)
 	w_class = ITEMSIZE_NORMAL
 	amount_per_transfer_from_this = 20
 	possible_transfer_amounts = list(10,20,30,60,120)
@@ -283,7 +283,7 @@
 		user.drop_from_inventory(src)
 		qdel(src)
 		return
-	else if(istype(D, /obj/item/stack/material) && D.get_material_name() == DEFAULT_WALL_MATERIAL)
+	else if(istype(D, /obj/item/stack/material) && D.get_material_name() == MAT_STEEL)
 		var/obj/item/stack/material/M = D
 		if (M.use(1))
 			var/obj/item/weapon/secbot_assembly/edCLN_assembly/B = new /obj/item/weapon/secbot_assembly/edCLN_assembly

--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -6,7 +6,7 @@
 	item_state = "cleaner"
 	center_of_mass = list("x" = 16,"y" = 10)
 	flags = OPENCONTAINER|NOBLUDGEON
-	matter = list("glass" = 300, DEFAULT_WALL_MATERIAL = 300)
+	matter = list("glass" = 300, MAT_STEEL = 300)
 	slot_flags = SLOT_BELT
 	throwforce = 3
 	w_class = ITEMSIZE_SMALL

--- a/code/modules/recycling/disposal-construction.dm
+++ b/code/modules/recycling/disposal-construction.dm
@@ -10,7 +10,7 @@
 	anchored = 0
 	density = 0
 	pressure_resistance = 5*ONE_ATMOSPHERE
-	matter = list(DEFAULT_WALL_MATERIAL = 1850)
+	matter = list(MAT_STEEL = 1850)
 	level = 2
 	var/sortType = ""
 	var/ptype = 0

--- a/code/modules/research/circuitprinter.dm
+++ b/code/modules/research/circuitprinter.dm
@@ -16,7 +16,7 @@ using metal and glass, it uses glass and reagents (usually sulphuric acid).
 	var/mat_efficiency = 1
 	var/speed = 1
 
-	materials = list(DEFAULT_WALL_MATERIAL = 0, "glass" = 0, MAT_PLASTEEL = 0, "plastic" = 0, MAT_GRAPHITE = 0, "gold" = 0, "silver" = 0, "osmium" = 0, MAT_LEAD = 0, "phoron" = 0, "uranium" = 0, "diamond" = 0, MAT_DURASTEEL = 0, MAT_VERDANTIUM = 0, MAT_MORPHIUM = 0, MAT_METALHYDROGEN = 0, MAT_SUPERMATTER = 0)
+	materials = list(MAT_STEEL = 0, "glass" = 0, MAT_PLASTEEL = 0, "plastic" = 0, MAT_GRAPHITE = 0, "gold" = 0, "silver" = 0, "osmium" = 0, MAT_LEAD = 0, "phoron" = 0, "uranium" = 0, "diamond" = 0, MAT_DURASTEEL = 0, MAT_VERDANTIUM = 0, MAT_MORPHIUM = 0, MAT_METALHYDROGEN = 0, MAT_SUPERMATTER = 0)
 
 	hidden_materials = list(MAT_PLASTEEL, MAT_DURASTEEL, MAT_GRAPHITE, MAT_VERDANTIUM, MAT_MORPHIUM, MAT_METALHYDROGEN, MAT_SUPERMATTER)
 

--- a/code/modules/research/designs/HUDs.dm
+++ b/code/modules/research/designs/HUDs.dm
@@ -1,7 +1,7 @@
 // HUDs
 
 /datum/design/item/hud
-	materials = list(DEFAULT_WALL_MATERIAL = 50, "glass" = 50)
+	materials = list(MAT_STEEL = 50, "glass" = 50)
 
 /datum/design/item/hud/AssembleDesignName()
 	..()

--- a/code/modules/research/designs/ai_holders.dm
+++ b/code/modules/research/designs/ai_holders.dm
@@ -8,7 +8,7 @@
 	id = "mmi"
 	req_tech = list(TECH_DATA = 2, TECH_BIO = 3)
 	build_type = PROTOLATHE | PROSFAB
-	materials = list(DEFAULT_WALL_MATERIAL = 1000, "glass" = 500)
+	materials = list(MAT_STEEL = 1000, "glass" = 500)
 	build_path = /obj/item/device/mmi
 	category = "Misc"
 	sort_string = "SAAAA"
@@ -18,7 +18,7 @@
 	id = "posibrain"
 	req_tech = list(TECH_ENGINEERING = 4, TECH_MATERIAL = 6, TECH_BLUESPACE = 2, TECH_DATA = 4)
 	build_type = PROTOLATHE | PROSFAB
-	materials = list(DEFAULT_WALL_MATERIAL = 2000, "glass" = 1000, "silver" = 1000, "gold" = 500, "phoron" = 500, "diamond" = 100)
+	materials = list(MAT_STEEL = 2000, "glass" = 1000, "silver" = 1000, "gold" = 500, "phoron" = 500, "diamond" = 100)
 	build_path = /obj/item/device/mmi/digital/posibrain
 	category = "Misc"
 	sort_string = "SAAAB"
@@ -28,7 +28,7 @@
 	id = "dronebrain"
 	req_tech = list(TECH_ENGINEERING = 4, TECH_MATERIAL = 5, TECH_DATA = 4)
 	build_type = PROTOLATHE | PROSFAB
-	materials = list(DEFAULT_WALL_MATERIAL = 2000, "glass" = 1000, "silver" = 1000, "gold" = 500)
+	materials = list(MAT_STEEL = 2000, "glass" = 1000, "silver" = 1000, "gold" = 500)
 	build_path = /obj/item/device/mmi/digital/robot
 	category = "Misc"
 	sort_string = "SAAAC"
@@ -37,7 +37,7 @@
 	name = "'pAI', personal artificial intelligence device"
 	id = "paicard"
 	req_tech = list(TECH_DATA = 2)
-	materials = list("glass" = 500, DEFAULT_WALL_MATERIAL = 500)
+	materials = list("glass" = 500, MAT_STEEL = 500)
 	build_path = /obj/item/device/paicard
 	sort_string = "SBAAA"
 

--- a/code/modules/research/designs/beakers.dm
+++ b/code/modules/research/designs/beakers.dm
@@ -8,7 +8,7 @@
 	desc = "A cryostasis beaker that allows for chemical storage without reactions. Can hold up to 50 units."
 	id = "splitbeaker"
 	req_tech = list(TECH_MATERIAL = 2)
-	materials = list(DEFAULT_WALL_MATERIAL = 3000)
+	materials = list(MAT_STEEL = 3000)
 	build_path = /obj/item/weapon/reagent_containers/glass/beaker/noreact
 	sort_string = "IAAAA"
 
@@ -17,6 +17,6 @@
 	desc = "A bluespace beaker, powered by experimental bluespace technology and Element Cuban combined with the Compound Pete. Can hold up to 300 units."
 	id = "bluespacebeaker"
 	req_tech = list(TECH_BLUESPACE = 2, TECH_MATERIAL = 6)
-	materials = list(DEFAULT_WALL_MATERIAL = 3000, "phoron" = 3000, "diamond" = 500)
+	materials = list(MAT_STEEL = 3000, "phoron" = 3000, "diamond" = 500)
 	build_path = /obj/item/weapon/reagent_containers/glass/beaker/bluespace
 	sort_string = "IAAAB"

--- a/code/modules/research/designs/bio_devices.dm
+++ b/code/modules/research/designs/bio_devices.dm
@@ -1,5 +1,5 @@
 /datum/design/item/biotech
-	materials = list(DEFAULT_WALL_MATERIAL = 30, "glass" = 20)
+	materials = list(MAT_STEEL = 30, "glass" = 20)
 
 /datum/design/item/biotech/AssembleDesignName()
 	..()
@@ -39,7 +39,7 @@
 	desc = "A hand-held scanner able to diagnose robotic injuries."
 	id = "robot_scanner"
 	req_tech = list(TECH_MAGNET = 3, TECH_BIO = 2, TECH_ENGINEERING = 3)
-	materials = list(DEFAULT_WALL_MATERIAL = 500, "glass" = 200)
+	materials = list(MAT_STEEL = 500, "glass" = 200)
 	build_path = /obj/item/device/robotanalyzer
 	sort_string = "JAACA"
 
@@ -47,7 +47,7 @@
 	desc = "A tube of paste containing swarms of repair nanites. Very effective in repairing robotic machinery."
 	id = "nanopaste"
 	req_tech = list(TECH_MATERIAL = 4, TECH_ENGINEERING = 3)
-	materials = list(DEFAULT_WALL_MATERIAL = 7000, "glass" = 7000)
+	materials = list(MAT_STEEL = 7000, "glass" = 7000)
 	build_path = /obj/item/stack/nanopaste
 	sort_string = "JAACB"
 
@@ -55,7 +55,7 @@
 	desc = "A device capable of quickly scanning all relevant data about a plant."
 	id = "plant_analyzer"
 	req_tech = list(TECH_MAGNET = 2, TECH_BIO = 2)
-	materials = list(DEFAULT_WALL_MATERIAL = 500, "glass" = 500)
+	materials = list(MAT_STEEL = 500, "glass" = 500)
 	build_path = /obj/item/device/analyzer/plant_analyzer
 	sort_string = "JAADA"
 

--- a/code/modules/research/designs/circuit_assembly.dm
+++ b/code/modules/research/designs/circuit_assembly.dm
@@ -9,7 +9,7 @@
 	desc = "A portable(ish) printer for modular machines."
 	id = "ic_printer"
 	req_tech = list(TECH_MATERIAL = 3, TECH_ENGINEERING = 4, TECH_DATA = 5)
-	materials = list(DEFAULT_WALL_MATERIAL = 10000)
+	materials = list(MAT_STEEL = 10000)
 	build_path = /obj/item/device/integrated_circuit_printer
 	sort_string = "UAAAA"
 
@@ -18,7 +18,7 @@
 	desc = "Allows the integrated circuit printer to create advanced circuits"
 	id = "ic_printer_upgrade_adv"
 	req_tech = list(TECH_ENGINEERING = 3, TECH_DATA = 4)
-	materials = list(DEFAULT_WALL_MATERIAL = 2000)
+	materials = list(MAT_STEEL = 2000)
 	build_path = /obj/item/weapon/disk/integrated_circuit/upgrade/advanced
 	sort_string = "UBAAA"
 
@@ -26,7 +26,7 @@
 	name = "Custom wirer tool"
 	id = "wirer"
 	req_tech = list(TECH_MATERIAL = 2, TECH_ENGINEERING = 2)
-	materials = list(DEFAULT_WALL_MATERIAL = 5000, "glass" = 2500)
+	materials = list(MAT_STEEL = 5000, "glass" = 2500)
 	build_path = /obj/item/device/integrated_electronics/wirer
 	sort_string = "UCAAA"
 
@@ -34,7 +34,7 @@
 	name = "Custom circuit debugger tool"
 	id = "debugger"
 	req_tech = list(TECH_MATERIAL = 2, TECH_ENGINEERING = 2)
-	materials = list(DEFAULT_WALL_MATERIAL = 5000, "glass" = 2500)
+	materials = list(MAT_STEEL = 5000, "glass" = 2500)
 	build_path = /obj/item/device/integrated_electronics/debugger
 	sort_string = "UCBBB"
 
@@ -49,7 +49,7 @@
 	desc = "A customizable assembly for simple, small devices."
 	id = "assembly-small"
 	req_tech = list(TECH_MATERIAL = 3, TECH_ENGINEERING = 2, TECH_POWER = 2)
-	materials = list(DEFAULT_WALL_MATERIAL = 10000)
+	materials = list(MAT_STEEL = 10000)
 	build_path = /obj/item/device/electronic_assembly
 	sort_string = "UDAAA"
 
@@ -58,7 +58,7 @@
 	desc = "A customizable assembly suited for more ambitious mechanisms."
 	id = "assembly-medium"
 	req_tech = list(TECH_MATERIAL = 4, TECH_ENGINEERING = 3, TECH_POWER = 3)
-	materials = list(DEFAULT_WALL_MATERIAL = 20000)
+	materials = list(MAT_STEEL = 20000)
 	build_path = /obj/item/device/electronic_assembly/medium
 	sort_string = "UDAAB"
 
@@ -67,7 +67,7 @@
 	desc = "A customizable assembly for large machines."
 	id = "assembly-large"
 	req_tech = list(TECH_MATERIAL = 5, TECH_ENGINEERING = 4, TECH_POWER = 4)
-	materials = list(DEFAULT_WALL_MATERIAL = 40000)
+	materials = list(MAT_STEEL = 40000)
 	build_path = /obj/item/device/electronic_assembly/large
 	sort_string = "UDAAC"
 
@@ -76,7 +76,7 @@
 	desc = "A customizable assembly optimized for autonomous devices."
 	id = "assembly-drone"
 	req_tech = list(TECH_MATERIAL = 4, TECH_ENGINEERING = 4, TECH_POWER = 4)
-	materials = list(DEFAULT_WALL_MATERIAL = 30000)
+	materials = list(MAT_STEEL = 30000)
 	build_path = /obj/item/device/electronic_assembly/drone
 	sort_string = "UDAAD"
 
@@ -85,7 +85,7 @@
 	desc = "An customizable assembly designed to interface with other devices."
 	id = "assembly-device"
 	req_tech = list(TECH_MATERIAL = 2, TECH_ENGINEERING = 2, TECH_POWER = 2)
-	materials = list(DEFAULT_WALL_MATERIAL = 5000)
+	materials = list(MAT_STEEL = 5000)
 	build_path = /obj/item/device/assembly/electronic_assembly
 	sort_string = "UDAAE"
 
@@ -94,6 +94,6 @@
 	desc = "An customizable assembly for very small devices, implanted into living entities."
 	id = "assembly-implant"
 	req_tech = list(TECH_MATERIAL = 5, TECH_ENGINEERING = 4, TECH_POWER = 3, TECH_BIO = 5)
-	materials = list(DEFAULT_WALL_MATERIAL = 2000)
+	materials = list(MAT_STEEL = 2000)
 	build_path = /obj/item/weapon/implant/integrated_circuit
 	sort_string = "UDAAF"

--- a/code/modules/research/designs/engineering.dm
+++ b/code/modules/research/designs/engineering.dm
@@ -9,7 +9,7 @@
 	desc = "A welding tool that generate fuel for itself."
 	id = "expwelder"
 	req_tech = list(TECH_ENGINEERING = 4, TECH_PHORON = 3, TECH_MATERIAL = 4)
-	materials = list(DEFAULT_WALL_MATERIAL = 70, "glass" = 120, "phoron" = 100)
+	materials = list(MAT_STEEL = 70, "glass" = 120, "phoron" = 100)
 	build_path = /obj/item/weapon/weldingtool/experimental
 	sort_string = "NAAAA"
 
@@ -18,7 +18,7 @@
 	desc = "A simple powered hand drill."
 	id = "handdrill"
 	req_tech = list(TECH_ENGINEERING = 3, TECH_MATERIAL = 2)
-	materials = list(DEFAULT_WALL_MATERIAL = 300, "silver" = 100)
+	materials = list(MAT_STEEL = 300, "silver" = 100)
 	build_path = /obj/item/weapon/tool/screwdriver/power
 	sort_string = "NAAAB"
 
@@ -27,7 +27,7 @@
 	desc = "A set of jaws of life, compressed through the magic of science."
 	id = "jawslife"
 	req_tech = list(TECH_ENGINEERING = 3, TECH_MATERIAL = 2)
-	materials = list(DEFAULT_WALL_MATERIAL = 300, "silver" = 100)
+	materials = list(MAT_STEEL = 300, "silver" = 100)
 	build_path = /obj/item/weapon/tool/crowbar/power
 	sort_string = "NAAAC"
 
@@ -42,7 +42,7 @@
 	desc = "A terahertz-ray emitter and scanner used to detect underfloor objects such as cables and pipes."
 	id = "tscanner"
 	req_tech = list(TECH_MAGNET = 2, TECH_ENGINEERING = 2, TECH_MATERIAL = 2)
-	materials = list(DEFAULT_WALL_MATERIAL = 200)
+	materials = list(MAT_STEEL = 200)
 	build_path = /obj/item/device/t_scanner
 	sort_string = "NBAAA"
 
@@ -51,7 +51,7 @@
 	desc = "An upgraded version of the terahertz-ray emitter and scanner used to detect underfloor objects such as cables and pipes."
 	id = "upgradedtscanner"
 	req_tech = list(TECH_MAGNET = 3, TECH_ENGINEERING = 4, TECH_MATERIAL = 2)
-	materials = list(DEFAULT_WALL_MATERIAL = 500, "phoron" = 150)
+	materials = list(MAT_STEEL = 500, "phoron" = 150)
 	build_path = /obj/item/device/t_scanner/upgraded
 	sort_string = "NBAAB"
 
@@ -60,7 +60,7 @@
 	desc = "An advanced version of the terahertz-ray emitter and scanner used to detect underfloor objects such as cables and pipes."
 	id = "advancedtscanner"
 	req_tech = list(TECH_MAGNET = 6, TECH_ENGINEERING = 6, TECH_MATERIAL = 6)
-	materials = list(DEFAULT_WALL_MATERIAL = 1250, "phoron" = 500, "silver" = 50)
+	materials = list(MAT_STEEL = 1250, "phoron" = 500, "silver" = 50)
 	build_path = /obj/item/device/t_scanner/advanced
 	sort_string = "NBAAC"
 
@@ -69,6 +69,6 @@
 	desc = "A hand-held environmental scanner which reports current gas levels."
 	id = "atmosanalyzer"
 	req_tech = list(TECH_ENGINEERING = 2)
-	materials = list(DEFAULT_WALL_MATERIAL = 200, "glass" = 100)
+	materials = list(MAT_STEEL = 200, "glass" = 100)
 	build_path = /obj/item/device/analyzer
 	sort_string = "NBABA"

--- a/code/modules/research/designs/implants.dm
+++ b/code/modules/research/designs/implants.dm
@@ -1,7 +1,7 @@
 // Implants
 
 /datum/design/item/implant
-	materials = list(DEFAULT_WALL_MATERIAL = 50, "glass" = 50)
+	materials = list(MAT_STEEL = 50, "glass" = 50)
 
 /datum/design/item/implant/AssembleDesignName()
 	..()

--- a/code/modules/research/designs/locator_devices.dm
+++ b/code/modules/research/designs/locator_devices.dm
@@ -2,7 +2,7 @@
 
 /datum/design/item/gps
 	req_tech = list(TECH_MATERIAL = 2, TECH_DATA = 2, TECH_BLUESPACE = 2)
-	materials = list(DEFAULT_WALL_MATERIAL = 500)
+	materials = list(MAT_STEEL = 500)
 
 /datum/design/item/gps/AssembleDesignName()
 	..()
@@ -67,7 +67,7 @@
 	desc = "Used to scan and locate signals on a particular frequency."
 	id = "beacon_locator"
 	req_tech = list(TECH_MAGNET = 3, TECH_ENGINEERING = 2, TECH_BLUESPACE = 3)
-	materials = list(DEFAULT_WALL_MATERIAL = 1000,"glass" = 500)
+	materials = list(MAT_STEEL = 1000,"glass" = 500)
 	build_path = /obj/item/device/beacon_locator
 	sort_string = "DBAAA"
 
@@ -75,6 +75,6 @@
 	name = "Bluespace tracking beacon"
 	id = "beacon"
 	req_tech = list(TECH_BLUESPACE = 1)
-	materials = list (DEFAULT_WALL_MATERIAL = 20, "glass" = 10)
+	materials = list (MAT_STEEL = 20, "glass" = 10)
 	build_path = /obj/item/device/radio/beacon
 	sort_string = "DBABA"

--- a/code/modules/research/designs/medical.dm
+++ b/code/modules/research/designs/medical.dm
@@ -1,5 +1,5 @@
 /datum/design/item/medical
-	materials = list(DEFAULT_WALL_MATERIAL = 30, "glass" = 20)
+	materials = list(MAT_STEEL = 30, "glass" = 20)
 
 /datum/design/item/medical/AssembleDesignName()
 	..()
@@ -12,7 +12,7 @@
 	desc = "A scalpel augmented with a directed laser, for more precise cutting without blood entering the field. This one looks basic and could be improved."
 	id = "scalpel_laser1"
 	req_tech = list(TECH_BIO = 2, TECH_MATERIAL = 2, TECH_MAGNET = 2)
-	materials = list(DEFAULT_WALL_MATERIAL = 12500, "glass" = 7500)
+	materials = list(MAT_STEEL = 12500, "glass" = 7500)
 	build_path = /obj/item/weapon/surgical/scalpel/laser1
 	sort_string = "KAAAA"
 
@@ -21,7 +21,7 @@
 	desc = "A scalpel augmented with a directed laser, for more precise cutting without blood entering the field. This one looks somewhat advanced."
 	id = "scalpel_laser2"
 	req_tech = list(TECH_BIO = 3, TECH_MATERIAL = 4, TECH_MAGNET = 4)
-	materials = list(DEFAULT_WALL_MATERIAL = 12500, "glass" = 7500, "silver" = 2500)
+	materials = list(MAT_STEEL = 12500, "glass" = 7500, "silver" = 2500)
 	build_path = /obj/item/weapon/surgical/scalpel/laser2
 	sort_string = "KAAAB"
 
@@ -30,7 +30,7 @@
 	desc = "A scalpel augmented with a directed laser, for more precise cutting without blood entering the field. This one looks to be the pinnacle of precision energy cutlery!"
 	id = "scalpel_laser3"
 	req_tech = list(TECH_BIO = 4, TECH_MATERIAL = 6, TECH_MAGNET = 5)
-	materials = list(DEFAULT_WALL_MATERIAL = 12500, "glass" = 7500, "silver" = 2000, "gold" = 1500)
+	materials = list(MAT_STEEL = 12500, "glass" = 7500, "silver" = 2000, "gold" = 1500)
 	build_path = /obj/item/weapon/surgical/scalpel/laser3
 	sort_string = "KAAAC"
 
@@ -39,7 +39,7 @@
 	desc = "A true extension of the surgeon's body, this marvel instantly and completely prepares an incision allowing for the immediate commencement of therapeutic steps."
 	id = "scalpel_manager"
 	req_tech = list(TECH_BIO = 4, TECH_MATERIAL = 7, TECH_MAGNET = 5, TECH_DATA = 4)
-	materials = list (DEFAULT_WALL_MATERIAL = 12500, "glass" = 7500, "silver" = 1500, "gold" = 1500, "diamond" = 750)
+	materials = list (MAT_STEEL = 12500, "glass" = 7500, "silver" = 1500, "gold" = 1500, "diamond" = 750)
 	build_path = /obj/item/weapon/surgical/scalpel/manager
 	sort_string = "KAAAD"
 
@@ -48,7 +48,7 @@
 	desc = "A strange development following the I.M.S., this heavy tool can split and open, or close and shut, intentional holes in bones."
 	id = "advanced_saw"
 	req_tech = list(TECH_BIO = 4, TECH_MATERIAL = 7, TECH_MAGNET = 6, TECH_DATA = 5)
-	materials = list (DEFAULT_WALL_MATERIAL = 12500, MAT_PLASTIC = 800, "silver" = 1500, "gold" = 1500, MAT_OSMIUM = 1000)
+	materials = list (MAT_STEEL = 12500, MAT_PLASTIC = 800, "silver" = 1500, "gold" = 1500, MAT_OSMIUM = 1000)
 	build_path = /obj/item/weapon/surgical/circular_saw/manager
 	sort_string = "KAAAE"
 
@@ -57,7 +57,7 @@
 	desc = "A modern and horrifying take on an ancient practice, this tool is capable of rapidly removing an organ from a hopefully willing patient, without damaging it."
 	id = "organ_ripper"
 	req_tech = list(TECH_BIO = 3, TECH_MATERIAL = 5, TECH_MAGNET = 4, TECH_ILLEGAL = 3)
-	materials = list (DEFAULT_WALL_MATERIAL = 12500, MAT_PLASTIC = 8000, MAT_OSMIUM = 2500)
+	materials = list (MAT_STEEL = 12500, MAT_PLASTIC = 8000, MAT_OSMIUM = 2500)
 	build_path = /obj/item/weapon/surgical/scalpel/ripper
 	sort_string = "KAAAF"
 
@@ -66,7 +66,7 @@
 	desc = "A miracle of modern science, this tool rapidly knits together bone, without the need for bone gel."
 	id = "bone_clamp"
 	req_tech = list(TECH_BIO = 4, TECH_MATERIAL = 5, TECH_MAGNET = 4, TECH_DATA = 4)
-	materials = list (DEFAULT_WALL_MATERIAL = 12500, "glass" = 7500, "silver" = 2500)
+	materials = list (MAT_STEEL = 12500, "glass" = 7500, "silver" = 2500)
 	build_path = /obj/item/weapon/surgical/bone_clamp
 	sort_string = "KAABA"
 
@@ -75,7 +75,7 @@
 	desc = "A hand-held body scanner able to distinguish vital signs of the subject."
 	id = "medical_analyzer"
 	req_tech = list(TECH_MAGNET = 2, TECH_BIO = 2)
-	materials = list(DEFAULT_WALL_MATERIAL = 500, "glass" = 500)
+	materials = list(MAT_STEEL = 500, "glass" = 500)
 	build_path = /obj/item/device/healthanalyzer
 	sort_string = "KBAAA"
 
@@ -84,7 +84,7 @@
 	desc = "A prototype version of the regular health analyzer, able to distinguish the location of more serious injuries as well as accurately determine radiation levels."
 	id = "improved_analyzer"
 	req_tech = list(TECH_MAGNET = 5, TECH_BIO = 6)
-	materials = list(DEFAULT_WALL_MATERIAL = 2000, "glass" = 1000, "silver" = 1000, "gold" = 1500)
+	materials = list(MAT_STEEL = 2000, "glass" = 1000, "silver" = 1000, "gold" = 1500)
 	build_path = /obj/item/device/healthanalyzer/improved
 	sort_string = "KBAAB"
 
@@ -93,6 +93,6 @@
 	desc = "A more advanced version of the regular roller bed, with inbuilt surgical stabilisers and an improved folding system."
 	id = "roller_bed"
 	req_tech = list(TECH_BIO = 3, TECH_MATERIAL = 3, TECH_MAGNET = 3)
-	materials = list(DEFAULT_WALL_MATERIAL = 4000, "glass" = 2000, "phoron" = 2000)
+	materials = list(MAT_STEEL = 4000, "glass" = 2000, "phoron" = 2000)
 	build_path = /obj/item/roller/adv
 	sort_string = "KCAAA"

--- a/code/modules/research/designs/mining_toys.dm
+++ b/code/modules/research/designs/mining_toys.dm
@@ -7,21 +7,21 @@
 /datum/design/item/weapon/mining/drill
 	id = "drill"
 	req_tech = list(TECH_MATERIAL = 2, TECH_POWER = 3, TECH_ENGINEERING = 2)
-	materials = list(DEFAULT_WALL_MATERIAL = 6000, "glass" = 1000) //expensive, but no need for miners.
+	materials = list(MAT_STEEL = 6000, "glass" = 1000) //expensive, but no need for miners.
 	build_path = /obj/item/weapon/pickaxe/drill
 	sort_string = "FAAAA"
 
 /datum/design/item/weapon/mining/jackhammer
 	id = "jackhammer"
 	req_tech = list(TECH_MATERIAL = 3, TECH_POWER = 2, TECH_ENGINEERING = 2)
-	materials = list(DEFAULT_WALL_MATERIAL = 2000, "glass" = 500, "silver" = 500)
+	materials = list(MAT_STEEL = 2000, "glass" = 500, "silver" = 500)
 	build_path = /obj/item/weapon/pickaxe/jackhammer
 	sort_string = "FAAAB"
 
 /datum/design/item/weapon/mining/plasmacutter
 	id = "plasmacutter"
 	req_tech = list(TECH_MATERIAL = 4, TECH_PHORON = 3, TECH_ENGINEERING = 3)
-	materials = list(DEFAULT_WALL_MATERIAL = 1500, "glass" = 500, "gold" = 500, "phoron" = 500)
+	materials = list(MAT_STEEL = 1500, "glass" = 500, "gold" = 500, "phoron" = 500)
 	build_path = /obj/item/weapon/pickaxe/plasmacutter
 	sort_string = "FAAAC"
 
@@ -35,7 +35,7 @@
 /datum/design/item/weapon/mining/drill_diamond
 	id = "drill_diamond"
 	req_tech = list(TECH_MATERIAL = 6, TECH_POWER = 4, TECH_ENGINEERING = 4)
-	materials = list(DEFAULT_WALL_MATERIAL = 3000, "glass" = 1000, "diamond" = 2000)
+	materials = list(MAT_STEEL = 3000, "glass" = 1000, "diamond" = 2000)
 	build_path = /obj/item/weapon/pickaxe/diamonddrill
 	sort_string = "FAAAE"
 
@@ -45,6 +45,6 @@
 	desc = "Used to check spatial depth and density of rock outcroppings."
 	id = "depth_scanner"
 	req_tech = list(TECH_MAGNET = 2, TECH_ENGINEERING = 2, TECH_BLUESPACE = 2)
-	materials = list(DEFAULT_WALL_MATERIAL = 1000,"glass" = 1000)
+	materials = list(MAT_STEEL = 1000,"glass" = 1000)
 	build_path = /obj/item/device/depth_scanner
 	sort_string = "FBAAA"

--- a/code/modules/research/designs/misc.dm
+++ b/code/modules/research/designs/misc.dm
@@ -8,7 +8,7 @@
 	name = "Communicator"
 	id = "communicator"
 	req_tech = list(TECH_DATA = 2, TECH_MAGNET = 2)
-	materials = list(DEFAULT_WALL_MATERIAL = 500, "glass" = 500)
+	materials = list(MAT_STEEL = 500, "glass" = 500)
 	build_path = /obj/item/device/communicator
 	sort_string = "TAAAA"
 
@@ -17,7 +17,7 @@
 	desc = "Don't shine it in your eyes!"
 	id = "laser_pointer"
 	req_tech = list(TECH_MAGNET = 3)
-	materials = list(DEFAULT_WALL_MATERIAL = 100, "glass" = 50)
+	materials = list(MAT_STEEL = 100, "glass" = 50)
 	build_path = /obj/item/device/laser_pointer
 	sort_string = "TAABA"
 
@@ -25,7 +25,7 @@
 	name = "handheld translator"
 	id = "translator"
 	req_tech = list(TECH_DATA = 3, TECH_ENGINEERING = 3)
-	materials = list(DEFAULT_WALL_MATERIAL = 3000, "glass" = 3000)
+	materials = list(MAT_STEEL = 3000, "glass" = 3000)
 	build_path = /obj/item/device/universal_translator
 	sort_string = "TAACA"
 
@@ -33,7 +33,7 @@
 	name = "earpiece translator"
 	id = "ear_translator"
 	req_tech = list(TECH_DATA = 5, TECH_ENGINEERING = 5)	//It's been hella miniaturized.
-	materials = list(DEFAULT_WALL_MATERIAL = 2000, "glass" = 2000, "gold" = 1000)
+	materials = list(MAT_STEEL = 2000, "glass" = 2000, "gold" = 1000)
 	build_path = /obj/item/device/universal_translator/ear
 	sort_string = "TAACB"
 
@@ -42,7 +42,7 @@
 	desc = "A device to automatically replace lights. Refill with working lightbulbs."
 	id = "light_replacer"
 	req_tech = list(TECH_MAGNET = 3, TECH_MATERIAL = 4)
-	materials = list(DEFAULT_WALL_MATERIAL = 1500, "silver" = 150, "glass" = 3000)
+	materials = list(MAT_STEEL = 1500, "silver" = 150, "glass" = 3000)
 	build_path = /obj/item/device/lightreplacer
 	sort_string = "TAADA"
 
@@ -51,7 +51,7 @@
 	desc = "Allows for deciphering the binary channel on-the-fly."
 	id = "binaryencrypt"
 	req_tech = list(TECH_ILLEGAL = 2)
-	materials = list(DEFAULT_WALL_MATERIAL = 300, "glass" = 300)
+	materials = list(MAT_STEEL = 300, "glass" = 300)
 	build_path = /obj/item/device/encryptionkey/binary
 	sort_string = "TBAAA"
 
@@ -60,7 +60,7 @@
 	desc = "A kit of dangerous, high-tech equipment with changeable looks."
 	id = "chameleon"
 	req_tech = list(TECH_ILLEGAL = 2)
-	materials = list(DEFAULT_WALL_MATERIAL = 500)
+	materials = list(MAT_STEEL = 500)
 	build_path = /obj/item/weapon/storage/box/syndie_kit/chameleon
 	sort_string = "TBAAB"
 
@@ -69,6 +69,6 @@
 	desc = "A marker that can be detected by shuttle landing systems."
 	id = "bsflare"
 	req_tech = list(TECH_DATA = 3, TECH_BLUESPACE = 4)
-	materials = list(DEFAULT_WALL_MATERIAL = 4000, MAT_GLASS = 2000, MAT_SILVER = 2000)
+	materials = list(MAT_STEEL = 4000, MAT_GLASS = 2000, MAT_SILVER = 2000)
 	build_path = /obj/item/device/spaceflare
 	sort_string = "TBAAC"

--- a/code/modules/research/designs/modular_computer.dm
+++ b/code/modules/research/designs/modular_computer.dm
@@ -9,14 +9,14 @@
 	name = "basic hard drive"
 	id = "hdd_basic"
 	req_tech = list(TECH_DATA = 1, TECH_ENGINEERING = 1)
-	materials = list(DEFAULT_WALL_MATERIAL = 2000, "glass" = 100)
+	materials = list(MAT_STEEL = 2000, "glass" = 100)
 	build_path = /obj/item/weapon/computer_hardware/hard_drive/
 	sort_string = "VAAAA"
 
 /datum/design/item/modularcomponent/disk/advanced
 	name = "advanced hard drive"
 	id = "hdd_advanced"
-	materials = list(DEFAULT_WALL_MATERIAL = 4000, "glass" = 200)
+	materials = list(MAT_STEEL = 4000, "glass" = 200)
 	build_path = /obj/item/weapon/computer_hardware/hard_drive/advanced
 	sort_string = "VAAAB"
 
@@ -24,7 +24,7 @@
 	name = "super hard drive"
 	id = "hdd_super"
 	req_tech = list(TECH_DATA = 3, TECH_ENGINEERING = 3)
-	materials = list(DEFAULT_WALL_MATERIAL = 8000, "glass" = 400)
+	materials = list(MAT_STEEL = 8000, "glass" = 400)
 	build_path = /obj/item/weapon/computer_hardware/hard_drive/super
 	sort_string = "VAAAC"
 
@@ -32,7 +32,7 @@
 	name = "cluster hard drive"
 	id = "hdd_cluster"
 	req_tech = list(TECH_DATA = 4, TECH_ENGINEERING = 4)
-	materials = list(DEFAULT_WALL_MATERIAL = 16000, "glass" = 800)
+	materials = list(MAT_STEEL = 16000, "glass" = 800)
 	build_path = /obj/item/weapon/computer_hardware/hard_drive/cluster
 	sort_string = "VAAAD"
 
@@ -40,7 +40,7 @@
 	name = "small hard drive"
 	id = "hdd_small"
 	req_tech = list(TECH_DATA = 2, TECH_ENGINEERING = 2)
-	materials = list(DEFAULT_WALL_MATERIAL = 4000, "glass" = 200)
+	materials = list(MAT_STEEL = 4000, "glass" = 200)
 	build_path = /obj/item/weapon/computer_hardware/hard_drive/small
 	sort_string = "VAAAE"
 
@@ -48,7 +48,7 @@
 	name = "micro hard drive"
 	id = "hdd_micro"
 	req_tech = list(TECH_DATA = 1, TECH_ENGINEERING = 1)
-	materials = list(DEFAULT_WALL_MATERIAL = 2000, "glass" = 100)
+	materials = list(MAT_STEEL = 2000, "glass" = 100)
 	build_path = /obj/item/weapon/computer_hardware/hard_drive/micro
 	sort_string = "VAAAF"
 
@@ -58,7 +58,7 @@
 	name = "basic network card"
 	id = "netcard_basic"
 	req_tech = list(TECH_DATA = 2, TECH_ENGINEERING = 1)
-	materials = list(DEFAULT_WALL_MATERIAL = 500, "glass" = 100)
+	materials = list(MAT_STEEL = 500, "glass" = 100)
 	build_path = /obj/item/weapon/computer_hardware/network_card
 	sort_string = "VBAAA"
 
@@ -66,7 +66,7 @@
 	name = "advanced network card"
 	id = "netcard_advanced"
 	req_tech = list(TECH_DATA = 4, TECH_ENGINEERING = 2)
-	materials = list(DEFAULT_WALL_MATERIAL = 1000, "glass" = 200)
+	materials = list(MAT_STEEL = 1000, "glass" = 200)
 	build_path = /obj/item/weapon/computer_hardware/network_card/advanced
 	sort_string = "VBAAB"
 
@@ -74,7 +74,7 @@
 	name = "wired network card"
 	id = "netcard_wired"
 	req_tech = list(TECH_DATA = 5, TECH_ENGINEERING = 3)
-	materials = list(DEFAULT_WALL_MATERIAL = 5000, "glass" = 400)
+	materials = list(MAT_STEEL = 5000, "glass" = 400)
 	build_path = /obj/item/weapon/computer_hardware/network_card/wired
 	sort_string = "VBAAC"
 
@@ -84,7 +84,7 @@
 	name = "standard battery module"
 	id = "bat_normal"
 	req_tech = list(TECH_POWER = 1, TECH_ENGINEERING = 1)
-	materials = list(DEFAULT_WALL_MATERIAL = 2000)
+	materials = list(MAT_STEEL = 2000)
 	build_path = /obj/item/weapon/computer_hardware/battery_module
 	sort_string = "VCAAA"
 
@@ -92,7 +92,7 @@
 	name = "advanced battery module"
 	id = "bat_advanced"
 	req_tech = list(TECH_POWER = 2, TECH_ENGINEERING = 2)
-	materials = list(DEFAULT_WALL_MATERIAL = 4000)
+	materials = list(MAT_STEEL = 4000)
 	build_path = /obj/item/weapon/computer_hardware/battery_module/advanced
 	sort_string = "VCAAB"
 
@@ -100,7 +100,7 @@
 	name = "super battery module"
 	id = "bat_super"
 	req_tech = list(TECH_POWER = 3, TECH_ENGINEERING = 3)
-	materials = list(DEFAULT_WALL_MATERIAL = 8000)
+	materials = list(MAT_STEEL = 8000)
 	build_path = /obj/item/weapon/computer_hardware/battery_module/super
 	sort_string = "VCAAC"
 
@@ -108,7 +108,7 @@
 	name = "ultra battery module"
 	id = "bat_ultra"
 	req_tech = list(TECH_POWER = 5, TECH_ENGINEERING = 4)
-	materials = list(DEFAULT_WALL_MATERIAL = 16000)
+	materials = list(MAT_STEEL = 16000)
 	build_path = /obj/item/weapon/computer_hardware/battery_module/ultra
 	sort_string = "VCAAD"
 
@@ -116,7 +116,7 @@
 	name = "nano battery module"
 	id = "bat_nano"
 	req_tech = list(TECH_POWER = 1, TECH_ENGINEERING = 1)
-	materials = list(DEFAULT_WALL_MATERIAL = 2000)
+	materials = list(MAT_STEEL = 2000)
 	build_path = /obj/item/weapon/computer_hardware/battery_module/nano
 	sort_string = "VCAAE"
 
@@ -124,7 +124,7 @@
 	name = "micro battery module"
 	id = "bat_micro"
 	req_tech = list(TECH_POWER = 2, TECH_ENGINEERING = 2)
-	materials = list(DEFAULT_WALL_MATERIAL = 4000)
+	materials = list(MAT_STEEL = 4000)
 	build_path = /obj/item/weapon/computer_hardware/battery_module/micro
 	sort_string = "VCAAF"
 
@@ -134,7 +134,7 @@
 	name = "computer processor unit"
 	id = "cpu_normal"
 	req_tech = list(TECH_DATA = 3, TECH_ENGINEERING = 2)
-	materials = list(DEFAULT_WALL_MATERIAL = 8000)
+	materials = list(MAT_STEEL = 8000)
 	build_path = /obj/item/weapon/computer_hardware/processor_unit
 	sort_string = "VDAAA"
 
@@ -142,7 +142,7 @@
 	name = "computer microprocessor unit"
 	id = "cpu_small"
 	req_tech = list(TECH_DATA = 2, TECH_ENGINEERING = 2)
-	materials = list(DEFAULT_WALL_MATERIAL = 4000)
+	materials = list(MAT_STEEL = 4000)
 	build_path = /obj/item/weapon/computer_hardware/processor_unit/small
 	sort_string = "VDAAB"
 
@@ -150,7 +150,7 @@
 	name = "computer photonic processor unit"
 	id = "pcpu_normal"
 	req_tech = list(TECH_DATA = 5, TECH_ENGINEERING = 4)
-	materials = list(DEFAULT_WALL_MATERIAL = 32000, glass = 8000)
+	materials = list(MAT_STEEL = 32000, glass = 8000)
 	build_path = /obj/item/weapon/computer_hardware/processor_unit/photonic
 	sort_string = "VDAAC"
 
@@ -158,7 +158,7 @@
 	name = "computer photonic microprocessor unit"
 	id = "pcpu_small"
 	req_tech = list(TECH_DATA = 4, TECH_ENGINEERING = 3)
-	materials = list(DEFAULT_WALL_MATERIAL = 16000, glass = 4000)
+	materials = list(MAT_STEEL = 16000, glass = 4000)
 	build_path = /obj/item/weapon/computer_hardware/processor_unit/photonic/small
 	sort_string = "VDAAD"
 
@@ -168,7 +168,7 @@
 	name = "RFID card slot"
 	id = "cardslot"
 	req_tech = list(TECH_DATA = 2)
-	materials = list(DEFAULT_WALL_MATERIAL = 3000)
+	materials = list(MAT_STEEL = 3000)
 	build_path = /obj/item/weapon/computer_hardware/card_slot
 	sort_string = "VEAAA"
 
@@ -176,7 +176,7 @@
 	name = "nano printer"
 	id = "nanoprinter"
 	req_tech = list(TECH_DATA = 2, TECH_ENGINEERING = 2)
-	materials = list(DEFAULT_WALL_MATERIAL = 3000)
+	materials = list(MAT_STEEL = 3000)
 	build_path = /obj/item/weapon/computer_hardware/nano_printer
 	sort_string = "VEAAB"
 
@@ -184,7 +184,7 @@
 	name = "tesla link"
 	id = "teslalink"
 	req_tech = list(TECH_DATA = 2, TECH_POWER = 3, TECH_ENGINEERING = 2)
-	materials = list(DEFAULT_WALL_MATERIAL = 10000)
+	materials = list(MAT_STEEL = 10000)
 	build_path = /obj/item/weapon/computer_hardware/tesla_link
 	sort_string = "VEAAC"
 

--- a/code/modules/research/designs/pdas.dm
+++ b/code/modules/research/designs/pdas.dm
@@ -5,7 +5,7 @@
 	desc = "Cheaper than whiny non-digital assistants."
 	id = "pda"
 	req_tech = list(TECH_ENGINEERING = 2, TECH_POWER = 3)
-	materials = list(DEFAULT_WALL_MATERIAL = 50, "glass" = 50)
+	materials = list(MAT_STEEL = 50, "glass" = 50)
 	build_path = /obj/item/device/pda
 	sort_string = "WAAAA"
 
@@ -13,7 +13,7 @@
 
 /datum/design/item/pda_cartridge
 	req_tech = list(TECH_ENGINEERING = 2, TECH_POWER = 3)
-	materials = list(DEFAULT_WALL_MATERIAL = 50, "glass" = 50)
+	materials = list(MAT_STEEL = 50, "glass" = 50)
 
 /datum/design/item/pda_cartridge/AssembleDesignName()
 	..()

--- a/code/modules/research/designs/power_cells.dm
+++ b/code/modules/research/designs/power_cells.dm
@@ -20,7 +20,7 @@
 	build_type = PROTOLATHE | MECHFAB
 	id = "basic_cell"
 	req_tech = list(TECH_POWER = 1)
-	materials = list(DEFAULT_WALL_MATERIAL = 700, "glass" = 50)
+	materials = list(MAT_STEEL = 700, "glass" = 50)
 	build_path = /obj/item/weapon/cell
 	category = "Misc"
 	sort_string = "BAAAA"
@@ -30,7 +30,7 @@
 	build_type = PROTOLATHE | MECHFAB
 	id = "high_cell"
 	req_tech = list(TECH_POWER = 2)
-	materials = list(DEFAULT_WALL_MATERIAL = 700, "glass" = 60)
+	materials = list(MAT_STEEL = 700, "glass" = 60)
 	build_path = /obj/item/weapon/cell/high
 	category = "Misc"
 	sort_string = "BAAAB"
@@ -39,7 +39,7 @@
 	name = "super-capacity"
 	id = "super_cell"
 	req_tech = list(TECH_POWER = 3, TECH_MATERIAL = 2)
-	materials = list(DEFAULT_WALL_MATERIAL = 700, "glass" = 70)
+	materials = list(MAT_STEEL = 700, "glass" = 70)
 	build_path = /obj/item/weapon/cell/super
 	category = "Misc"
 	sort_string = "BAAAC"
@@ -48,7 +48,7 @@
 	name = "hyper-capacity"
 	id = "hyper_cell"
 	req_tech = list(TECH_POWER = 5, TECH_MATERIAL = 4)
-	materials = list(DEFAULT_WALL_MATERIAL = 400, "gold" = 150, "silver" = 150, "glass" = 70)
+	materials = list(MAT_STEEL = 400, "gold" = 150, "silver" = 150, "glass" = 70)
 	build_path = /obj/item/weapon/cell/hyper
 	category = "Misc"
 	sort_string = "BAAAD"
@@ -57,7 +57,7 @@
 	name = "device"
 	build_type = PROTOLATHE
 	id = "device"
-	materials = list(DEFAULT_WALL_MATERIAL = 350, "glass" = 25)
+	materials = list(MAT_STEEL = 350, "glass" = 25)
 	build_path = /obj/item/weapon/cell/device
 	category = "Misc"
 	sort_string = "BAABA"
@@ -66,7 +66,7 @@
 	name = "weapon"
 	build_type = PROTOLATHE
 	id = "weapon"
-	materials = list(DEFAULT_WALL_MATERIAL = 700, "glass" = 50)
+	materials = list(MAT_STEEL = 700, "glass" = 50)
 	build_path = /obj/item/weapon/cell/device/weapon
 	category = "Misc"
 	sort_string = "BAABB"

--- a/code/modules/research/designs/stock_parts.dm
+++ b/code/modules/research/designs/stock_parts.dm
@@ -19,35 +19,35 @@
 /datum/design/item/stock_part/basic_matter_bin
 	id = "basic_matter_bin"
 	req_tech = list(TECH_MATERIAL = 1)
-	materials = list(DEFAULT_WALL_MATERIAL = 80)
+	materials = list(MAT_STEEL = 80)
 	build_path = /obj/item/weapon/stock_parts/matter_bin
 	sort_string = "AAAAA"
 
 /datum/design/item/stock_part/adv_matter_bin
 	id = "adv_matter_bin"
 	req_tech = list(TECH_MATERIAL = 3)
-	materials = list(DEFAULT_WALL_MATERIAL = 80)
+	materials = list(MAT_STEEL = 80)
 	build_path = /obj/item/weapon/stock_parts/matter_bin/adv
 	sort_string = "AAAAB"
 
 /datum/design/item/stock_part/super_matter_bin
 	id = "super_matter_bin"
 	req_tech = list(TECH_MATERIAL = 5)
-	materials = list(DEFAULT_WALL_MATERIAL = 80)
+	materials = list(MAT_STEEL = 80)
 	build_path = /obj/item/weapon/stock_parts/matter_bin/super
 	sort_string = "AAAAC"
 
 /datum/design/item/stock_part/hyper_matter_bin
 	id = "hyper_matter_bin"
 	req_tech = list(TECH_MATERIAL = 6, TECH_ARCANE = 2)
-	materials = list(DEFAULT_WALL_MATERIAL = 200, MAT_VERDANTIUM = 60, MAT_DURASTEEL = 75)
+	materials = list(MAT_STEEL = 200, MAT_VERDANTIUM = 60, MAT_DURASTEEL = 75)
 	build_path = /obj/item/weapon/stock_parts/matter_bin/hyper
 	sort_string = "AAAAD"
 
 /datum/design/item/stock_part/omni_matter_bin
 	id = "omni_matter_bin"
 	req_tech = list(TECH_MATERIAL = 7, TECH_PRECURSOR = 2)
-	materials = list(DEFAULT_WALL_MATERIAL = 2000, MAT_PLASTEEL = 100, MAT_MORPHIUM = 100, MAT_DURASTEEL = 100)
+	materials = list(MAT_STEEL = 2000, MAT_PLASTEEL = 100, MAT_MORPHIUM = 100, MAT_DURASTEEL = 100)
 	build_path = /obj/item/weapon/stock_parts/matter_bin/omni
 	sort_string = "AAAAE"
 
@@ -56,35 +56,35 @@
 /datum/design/item/stock_part/micro_mani
 	id = "micro_mani"
 	req_tech = list(TECH_MATERIAL = 1, TECH_DATA = 1)
-	materials = list(DEFAULT_WALL_MATERIAL = 30)
+	materials = list(MAT_STEEL = 30)
 	build_path = /obj/item/weapon/stock_parts/manipulator
 	sort_string = "AAABA"
 
 /datum/design/item/stock_part/nano_mani
 	id = "nano_mani"
 	req_tech = list(TECH_MATERIAL = 3, TECH_DATA = 2)
-	materials = list(DEFAULT_WALL_MATERIAL = 30)
+	materials = list(MAT_STEEL = 30)
 	build_path = /obj/item/weapon/stock_parts/manipulator/nano
 	sort_string = "AAABB"
 
 /datum/design/item/stock_part/pico_mani
 	id = "pico_mani"
 	req_tech = list(TECH_MATERIAL = 5, TECH_DATA = 2)
-	materials = list(DEFAULT_WALL_MATERIAL = 30)
+	materials = list(MAT_STEEL = 30)
 	build_path = /obj/item/weapon/stock_parts/manipulator/pico
 	sort_string = "AAABC"
 
 /datum/design/item/stock_part/hyper_mani
 	id = "hyper_mani"
 	req_tech = list(TECH_MATERIAL = 6, TECH_DATA = 3, TECH_ARCANE = 2)
-	materials = list(DEFAULT_WALL_MATERIAL = 200, MAT_VERDANTIUM = 50, MAT_DURASTEEL = 50)
+	materials = list(MAT_STEEL = 200, MAT_VERDANTIUM = 50, MAT_DURASTEEL = 50)
 	build_path = /obj/item/weapon/stock_parts/manipulator/hyper
 	sort_string = "AAABD"
 
 /datum/design/item/stock_part/omni_mani
 	id = "omni_mani"
 	req_tech = list(TECH_MATERIAL = 7, TECH_DATA = 4, TECH_PRECURSOR = 2)
-	materials = list(DEFAULT_WALL_MATERIAL = 2000, MAT_PLASTEEL = 500, MAT_MORPHIUM = 100, MAT_DURASTEEL = 100)
+	materials = list(MAT_STEEL = 2000, MAT_PLASTEEL = 500, MAT_MORPHIUM = 100, MAT_DURASTEEL = 100)
 	build_path = /obj/item/weapon/stock_parts/manipulator/omni
 	sort_string = "AAABE"
 
@@ -93,35 +93,35 @@
 /datum/design/item/stock_part/basic_capacitor
 	id = "basic_capacitor"
 	req_tech = list(TECH_POWER = 1)
-	materials = list(DEFAULT_WALL_MATERIAL = 50, "glass" = 50)
+	materials = list(MAT_STEEL = 50, "glass" = 50)
 	build_path = /obj/item/weapon/stock_parts/capacitor
 	sort_string = "AAACA"
 
 /datum/design/item/stock_part/adv_capacitor
 	id = "adv_capacitor"
 	req_tech = list(TECH_POWER = 3)
-	materials = list(DEFAULT_WALL_MATERIAL = 50, "glass" = 50)
+	materials = list(MAT_STEEL = 50, "glass" = 50)
 	build_path = /obj/item/weapon/stock_parts/capacitor/adv
 	sort_string = "AAACB"
 
 /datum/design/item/stock_part/super_capacitor
 	id = "super_capacitor"
 	req_tech = list(TECH_POWER = 5, TECH_MATERIAL = 4)
-	materials = list(DEFAULT_WALL_MATERIAL = 50, "glass" = 50, "gold" = 20)
+	materials = list(MAT_STEEL = 50, "glass" = 50, "gold" = 20)
 	build_path = /obj/item/weapon/stock_parts/capacitor/super
 	sort_string = "AAACC"
 
 /datum/design/item/stock_part/hyper_capacitor
 	id = "hyper_capacitor"
 	req_tech = list(TECH_POWER = 6, TECH_MATERIAL = 5, TECH_BLUESPACE = 1, TECH_ARCANE = 1)
-	materials = list(DEFAULT_WALL_MATERIAL = 200, MAT_GLASS = 100, MAT_VERDANTIUM = 30, MAT_DURASTEEL = 25)
+	materials = list(MAT_STEEL = 200, MAT_GLASS = 100, MAT_VERDANTIUM = 30, MAT_DURASTEEL = 25)
 	build_path = /obj/item/weapon/stock_parts/capacitor/hyper
 	sort_string = "AAACD"
 
 /datum/design/item/stock_part/omni_capacitor
 	id = "omni_capacitor"
 	req_tech = list(TECH_POWER = 7, TECH_MATERIAL = 6, TECH_BLUESPACE = 3, TECH_PRECURSOR = 1)
-	materials = list(DEFAULT_WALL_MATERIAL = 2000, MAT_DIAMOND = 1000, MAT_GLASS = 1000, MAT_MORPHIUM = 100, MAT_DURASTEEL = 100)
+	materials = list(MAT_STEEL = 2000, MAT_DIAMOND = 1000, MAT_GLASS = 1000, MAT_MORPHIUM = 100, MAT_DURASTEEL = 100)
 	build_path = /obj/item/weapon/stock_parts/capacitor/omni
 	sort_string = "AAACE"
 
@@ -130,35 +130,35 @@
 /datum/design/item/stock_part/basic_sensor
 	id = "basic_sensor"
 	req_tech = list(TECH_MAGNET = 1)
-	materials = list(DEFAULT_WALL_MATERIAL = 50, "glass" = 20)
+	materials = list(MAT_STEEL = 50, "glass" = 20)
 	build_path = /obj/item/weapon/stock_parts/scanning_module
 	sort_string = "AAADA"
 
 /datum/design/item/stock_part/adv_sensor
 	id = "adv_sensor"
 	req_tech = list(TECH_MAGNET = 3)
-	materials = list(DEFAULT_WALL_MATERIAL = 50, "glass" = 20)
+	materials = list(MAT_STEEL = 50, "glass" = 20)
 	build_path = /obj/item/weapon/stock_parts/scanning_module/adv
 	sort_string = "AAADB"
 
 /datum/design/item/stock_part/phasic_sensor
 	id = "phasic_sensor"
 	req_tech = list(TECH_MAGNET = 5, TECH_MATERIAL = 3)
-	materials = list(DEFAULT_WALL_MATERIAL = 50, "glass" = 20, "silver" = 10)
+	materials = list(MAT_STEEL = 50, "glass" = 20, "silver" = 10)
 	build_path = /obj/item/weapon/stock_parts/scanning_module/phasic
 	sort_string = "AAADC"
 
 /datum/design/item/stock_part/hyper_sensor
 	id = "hyper_sensor"
 	req_tech = list(TECH_MAGNET = 6, TECH_MATERIAL = 4, TECH_ARCANE = 1)
-	materials = list(DEFAULT_WALL_MATERIAL = 50, MAT_GLASS = 20, MAT_SILVER = 50, MAT_VERDANTIUM = 40, MAT_DURASTEEL = 50)
+	materials = list(MAT_STEEL = 50, MAT_GLASS = 20, MAT_SILVER = 50, MAT_VERDANTIUM = 40, MAT_DURASTEEL = 50)
 	build_path = /obj/item/weapon/stock_parts/scanning_module/hyper
 	sort_string = "AAADD"
 
 /datum/design/item/stock_part/omni_sensor
 	id = "omni_sensor"
 	req_tech = list(TECH_MAGNET = 7, TECH_MATERIAL = 5, TECH_PRECURSOR = 1)
-	materials = list(DEFAULT_WALL_MATERIAL = 1000, MAT_PLASTEEL = 500, MAT_GLASS = 750, MAT_SILVER = 500, MAT_MORPHIUM = 60, MAT_DURASTEEL = 100)
+	materials = list(MAT_STEEL = 1000, MAT_PLASTEEL = 500, MAT_GLASS = 750, MAT_SILVER = 500, MAT_MORPHIUM = 60, MAT_DURASTEEL = 100)
 	build_path = /obj/item/weapon/stock_parts/scanning_module/omni
 	sort_string = "AAADE"
 
@@ -167,35 +167,35 @@
 /datum/design/item/stock_part/basic_micro_laser
 	id = "basic_micro_laser"
 	req_tech = list(TECH_MAGNET = 1)
-	materials = list(DEFAULT_WALL_MATERIAL = 10, "glass" = 20)
+	materials = list(MAT_STEEL = 10, "glass" = 20)
 	build_path = /obj/item/weapon/stock_parts/micro_laser
 	sort_string = "AAAEA"
 
 /datum/design/item/stock_part/high_micro_laser
 	id = "high_micro_laser"
 	req_tech = list(TECH_MAGNET = 3)
-	materials = list(DEFAULT_WALL_MATERIAL = 10, "glass" = 20)
+	materials = list(MAT_STEEL = 10, "glass" = 20)
 	build_path = /obj/item/weapon/stock_parts/micro_laser/high
 	sort_string = "AAAEB"
 
 /datum/design/item/stock_part/ultra_micro_laser
 	id = "ultra_micro_laser"
 	req_tech = list(TECH_MAGNET = 5, TECH_MATERIAL = 5)
-	materials = list(DEFAULT_WALL_MATERIAL = 10, "glass" = 20, "uranium" = 10)
+	materials = list(MAT_STEEL = 10, "glass" = 20, "uranium" = 10)
 	build_path = /obj/item/weapon/stock_parts/micro_laser/ultra
 	sort_string = "AAAEC"
 
 /datum/design/item/stock_part/hyper_micro_laser
 	id = "hyper_micro_laser"
 	req_tech = list(TECH_MAGNET = 6, TECH_MATERIAL = 6, TECH_ARCANE = 2)
-	materials = list(DEFAULT_WALL_MATERIAL = 200, MAT_GLASS = 20, MAT_URANIUM = 30, MAT_VERDANTIUM = 50, MAT_DURASTEEL = 100)
+	materials = list(MAT_STEEL = 200, MAT_GLASS = 20, MAT_URANIUM = 30, MAT_VERDANTIUM = 50, MAT_DURASTEEL = 100)
 	build_path = /obj/item/weapon/stock_parts/micro_laser/hyper
 	sort_string = "AAAED"
 
 /datum/design/item/stock_part/omni_micro_laser
 	id = "omni_micro_laser"
 	req_tech = list(TECH_MAGNET = 7, TECH_MATERIAL = 7, TECH_PRECURSOR = 2)
-	materials = list(DEFAULT_WALL_MATERIAL = 2000, MAT_GLASS = 500, MAT_URANIUM = 2000, MAT_MORPHIUM = 50, MAT_DURASTEEL = 100)
+	materials = list(MAT_STEEL = 2000, MAT_GLASS = 500, MAT_URANIUM = 2000, MAT_MORPHIUM = 50, MAT_DURASTEEL = 100)
 	build_path = /obj/item/weapon/stock_parts/micro_laser/omni
 	sort_string = "AAAEE"
 
@@ -207,7 +207,7 @@
 	desc = "Special mechanical module made to store, sort, and apply standard machine parts."
 	id = "rped"
 	req_tech = list(TECH_ENGINEERING = 3, TECH_MATERIAL = 3)
-	materials = list(DEFAULT_WALL_MATERIAL = 15000, "glass" = 5000)
+	materials = list(MAT_STEEL = 15000, "glass" = 5000)
 	build_path = /obj/item/weapon/storage/part_replacer
 	sort_string = "ABAAA"
 
@@ -216,6 +216,6 @@
 	desc = "Special mechanical module made to store, sort, and apply standard machine parts.  This one has a greatly upgraded storage capacity."
 	id = "arped"
 	req_tech = list(TECH_ENGINEERING = 5, TECH_MATERIAL = 5)
-	materials = list(DEFAULT_WALL_MATERIAL = 30000, "glass" = 10000)
+	materials = list(MAT_STEEL = 30000, "glass" = 10000)
 	build_path = /obj/item/weapon/storage/part_replacer/adv
 	sort_string = "ABAAB"

--- a/code/modules/research/designs/subspace_parts.dm
+++ b/code/modules/research/designs/subspace_parts.dm
@@ -7,35 +7,35 @@
 /datum/design/item/stock_part/subspace/subspace_ansible
 	id = "s-ansible"
 	req_tech = list(TECH_DATA = 3, TECH_MAGNET = 4, TECH_MATERIAL = 4, TECH_BLUESPACE = 2)
-	materials = list(DEFAULT_WALL_MATERIAL = 80, "silver" = 20)
+	materials = list(MAT_STEEL = 80, "silver" = 20)
 	build_path = /obj/item/weapon/stock_parts/subspace/ansible
 	sort_string = "RAAAA"
 
 /datum/design/item/stock_part/subspace/hyperwave_filter
 	id = "s-filter"
 	req_tech = list(TECH_DATA = 3, TECH_MAGNET = 3)
-	materials = list(DEFAULT_WALL_MATERIAL = 40, "silver" = 10)
+	materials = list(MAT_STEEL = 40, "silver" = 10)
 	build_path = /obj/item/weapon/stock_parts/subspace/sub_filter
 	sort_string = "RAAAB"
 
 /datum/design/item/stock_part/subspace/subspace_amplifier
 	id = "s-amplifier"
 	req_tech = list(TECH_DATA = 3, TECH_MAGNET = 4, TECH_MATERIAL = 4, TECH_BLUESPACE = 2)
-	materials = list(DEFAULT_WALL_MATERIAL = 10, "gold" = 30, "uranium" = 15)
+	materials = list(MAT_STEEL = 10, "gold" = 30, "uranium" = 15)
 	build_path = /obj/item/weapon/stock_parts/subspace/amplifier
 	sort_string = "RAAAC"
 
 /datum/design/item/stock_part/subspace/subspace_treatment
 	id = "s-treatment"
 	req_tech = list(TECH_DATA = 3, TECH_MAGNET = 2, TECH_MATERIAL = 4, TECH_BLUESPACE = 2)
-	materials = list(DEFAULT_WALL_MATERIAL = 10, "silver" = 20)
+	materials = list(MAT_STEEL = 10, "silver" = 20)
 	build_path = /obj/item/weapon/stock_parts/subspace/treatment
 	sort_string = "RAAAD"
 
 /datum/design/item/stock_part/subspace/subspace_analyzer
 	id = "s-analyzer"
 	req_tech = list(TECH_DATA = 3, TECH_MAGNET = 4, TECH_MATERIAL = 4, TECH_BLUESPACE = 2)
-	materials = list(DEFAULT_WALL_MATERIAL = 10, "gold" = 15)
+	materials = list(MAT_STEEL = 10, "gold" = 15)
 	build_path = /obj/item/weapon/stock_parts/subspace/analyzer
 	sort_string = "RAAAE"
 

--- a/code/modules/research/designs/tech_disks.dm
+++ b/code/modules/research/designs/tech_disks.dm
@@ -7,7 +7,7 @@
 	desc = "Produce additional disks for storing device designs."
 	id = "design_disk"
 	req_tech = list(TECH_DATA = 1)
-	materials = list(DEFAULT_WALL_MATERIAL = 30, "glass" = 10)
+	materials = list(MAT_STEEL = 30, "glass" = 10)
 	build_path = /obj/item/weapon/disk/design_disk
 	sort_string = "CAAAA"
 
@@ -16,6 +16,6 @@
 	desc = "Produce additional disks for storing technology data."
 	id = "tech_disk"
 	req_tech = list(TECH_DATA = 1)
-	materials = list(DEFAULT_WALL_MATERIAL = 30, "glass" = 10)
+	materials = list(MAT_STEEL = 30, "glass" = 10)
 	build_path = /obj/item/weapon/disk/tech_disk
 	sort_string = "CAAAB"

--- a/code/modules/research/designs/uncommented.dm
+++ b/code/modules/research/designs/uncommented.dm
@@ -10,7 +10,7 @@
 	name = "loyalty"
 	id = "implant_loyal"
 	req_tech = list(TECH_MATERIAL = 2, TECH_BIO = 3)
-	materials = list(DEFAULT_WALL_MATERIAL = 7000, "glass" = 7000)
+	materials = list(MAT_STEEL = 7000, "glass" = 7000)
 	build_path = /obj/item/weapon/implantcase/loyalty"
 
 /datum/design/rust_core_control

--- a/code/modules/research/designs/weapons.dm
+++ b/code/modules/research/designs/weapons.dm
@@ -22,21 +22,21 @@
 /datum/design/item/weapon/energy/stunrevolver
 	id = "stunrevolver"
 	req_tech = list(TECH_COMBAT = 3, TECH_MATERIAL = 3, TECH_POWER = 2)
-	materials = list(DEFAULT_WALL_MATERIAL = 4000)
+	materials = list(MAT_STEEL = 4000)
 	build_path = /obj/item/weapon/gun/energy/stunrevolver
 	sort_string = "MAAAA"
 
 /datum/design/item/weapon/energy/nuclear_gun
 	id = "nuclear_gun"
 	req_tech = list(TECH_COMBAT = 3, TECH_MATERIAL = 5, TECH_POWER = 3)
-	materials = list(DEFAULT_WALL_MATERIAL = 5000, "glass" = 1000, "uranium" = 500)
+	materials = list(MAT_STEEL = 5000, "glass" = 1000, "uranium" = 500)
 	build_path = /obj/item/weapon/gun/energy/gun/nuclear
 	sort_string = "MAAAB"
 
 /datum/design/item/weapon/energy/phoronpistol
 	id = "ppistol"
 	req_tech = list(TECH_COMBAT = 5, TECH_PHORON = 4)
-	materials = list(DEFAULT_WALL_MATERIAL = 5000, "glass" = 1000, "phoron" = 3000)
+	materials = list(MAT_STEEL = 5000, "glass" = 1000, "phoron" = 3000)
 	build_path = /obj/item/weapon/gun/energy/toxgun
 	sort_string = "MAAAC"
 
@@ -44,7 +44,7 @@
 	desc = "The lasing medium of this prototype is enclosed in a tube lined with uranium-235 and subjected to high neutron flux in a nuclear reactor core."
 	id = "lasercannon"
 	req_tech = list(TECH_COMBAT = 4, TECH_MATERIAL = 3, TECH_POWER = 3)
-	materials = list(DEFAULT_WALL_MATERIAL = 10000, "glass" = 1000, "diamond" = 2000)
+	materials = list(MAT_STEEL = 10000, "glass" = 1000, "diamond" = 2000)
 	build_path = /obj/item/weapon/gun/energy/lasercannon
 	sort_string = "MAAAD"
 
@@ -59,14 +59,14 @@
 	desc = "A gun that shoots high-powered glass-encased energy temperature bullets."
 	id = "temp_gun"
 	req_tech = list(TECH_COMBAT = 3, TECH_MATERIAL = 4, TECH_POWER = 3, TECH_MAGNET = 2)
-	materials = list(DEFAULT_WALL_MATERIAL = 5000, "glass" = 500, "silver" = 3000)
+	materials = list(MAT_STEEL = 5000, "glass" = 500, "silver" = 3000)
 	build_path = /obj/item/weapon/gun/energy/temperature
 	sort_string = "MAAAF"
 
 /datum/design/item/weapon/energy/flora_gun
 	id = "flora_gun"
 	req_tech = list(TECH_MATERIAL = 2, TECH_BIO = 3, TECH_POWER = 3)
-	materials = list(DEFAULT_WALL_MATERIAL = 2000, "glass" = 500, "uranium" = 500)
+	materials = list(MAT_STEEL = 2000, "glass" = 500, "uranium" = 500)
 	build_path = /obj/item/weapon/gun/energy/floragun
 	sort_string = "MAAAG"
 
@@ -80,7 +80,7 @@
 	id = "smg"
 	desc = "An advanced 9mm SMG with a reflective laser optic."
 	req_tech = list(TECH_COMBAT = 4, TECH_MATERIAL = 3)
-	materials = list(DEFAULT_WALL_MATERIAL = 8000, "silver" = 2000, "diamond" = 1000)
+	materials = list(MAT_STEEL = 8000, "silver" = 2000, "diamond" = 1000)
 	build_path = /obj/item/weapon/gun/projectile/automatic/advanced_smg
 	sort_string = "MABAA"
 
@@ -95,7 +95,7 @@
 	id = "ammo_9mm"
 	desc = "A 21 round magazine for an advanced 9mm SMG."
 	req_tech = list(TECH_COMBAT = 4, TECH_MATERIAL = 3)
-	materials = list(DEFAULT_WALL_MATERIAL = 3750, "silver" = 100) // Requires silver for proprietary magazines! Or something.
+	materials = list(MAT_STEEL = 3750, "silver" = 100) // Requires silver for proprietary magazines! Or something.
 	build_path = /obj/item/ammo_magazine/m9mmAdvanced
 	sort_string = "MABBA"
 
@@ -104,7 +104,7 @@
 	desc = "A stunning shell for a shotgun."
 	id = "stunshell"
 	req_tech = list(TECH_COMBAT = 3, TECH_MATERIAL = 3)
-	materials = list(DEFAULT_WALL_MATERIAL = 4000)
+	materials = list(MAT_STEEL = 4000)
 	build_path = /obj/item/weapon/storage/box/stunshells
 	sort_string = "MABBB"
 
@@ -113,7 +113,7 @@
 	desc = "An electromagnetic shell for a shotgun."
 	id = "empshell"
 	req_tech = list(TECH_COMBAT = 4, TECH_MAGNET = 3)
-	materials = list(DEFAULT_WALL_MATERIAL = 4000, MAT_URANIUM = 1000)
+	materials = list(MAT_STEEL = 4000, MAT_URANIUM = 1000)
 	build_path = /obj/item/weapon/storage/box/empshells
 	sort_string = "MABBC"
 
@@ -126,28 +126,28 @@
 /datum/design/item/weapon/phase/phase_pistol
 	id = "phasepistol"
 	req_tech = list(TECH_COMBAT = 3, TECH_MATERIAL = 2, TECH_POWER = 2)
-	materials = list(DEFAULT_WALL_MATERIAL = 4000)
+	materials = list(MAT_STEEL = 4000)
 	build_path = /obj/item/weapon/gun/energy/phasegun/pistol
 	sort_string = "MACAA"
 
 /datum/design/item/weapon/phase/phase_carbine
 	id = "phasecarbine"
 	req_tech = list(TECH_COMBAT = 4, TECH_MATERIAL = 2, TECH_POWER = 2)
-	materials = list(DEFAULT_WALL_MATERIAL = 6000, "glass" = 1500)
+	materials = list(MAT_STEEL = 6000, "glass" = 1500)
 	build_path = /obj/item/weapon/gun/energy/phasegun
 	sort_string = "MACAB"
 
 /datum/design/item/weapon/phase/phase_rifle
 	id = "phaserifle"
 	req_tech = list(TECH_COMBAT = 4, TECH_MATERIAL = 3, TECH_POWER = 3)
-	materials = list(DEFAULT_WALL_MATERIAL = 7000, "glass" = 2000, "silver" = 500)
+	materials = list(MAT_STEEL = 7000, "glass" = 2000, "silver" = 500)
 	build_path = /obj/item/weapon/gun/energy/phasegun/rifle
 	sort_string = "MACAC"
 
 /datum/design/item/weapon/phase/phase_cannon
 	id = "phasecannon"
 	req_tech = list(TECH_COMBAT = 4, TECH_MATERIAL = 4, TECH_POWER = 4)
-	materials = list(DEFAULT_WALL_MATERIAL = 10000, "glass" = 2000, "silver" = 1000, "diamond" = 750)
+	materials = list(MAT_STEEL = 10000, "glass" = 2000, "silver" = 1000, "diamond" = 750)
 	build_path = /obj/item/weapon/gun/energy/phasegun/cannon
 	sort_string = "MACAD"
 
@@ -156,7 +156,7 @@
 /datum/design/item/weapon/rapidsyringe
 	id = "rapidsyringe"
 	req_tech = list(TECH_COMBAT = 3, TECH_MATERIAL = 3, TECH_ENGINEERING = 3, TECH_BIO = 2)
-	materials = list(DEFAULT_WALL_MATERIAL = 5000, "glass" = 1000)
+	materials = list(MAT_STEEL = 5000, "glass" = 1000)
 	build_path = /obj/item/weapon/gun/launcher/syringe/rapid
 	sort_string = "MADAA"
 
@@ -164,7 +164,7 @@
 	desc = "A gun that fires small hollow chemical-payload darts."
 	id = "dartgun_r"
 	req_tech = list(TECH_COMBAT = 6, TECH_MATERIAL = 4, TECH_BIO = 4, TECH_MAGNET = 3, TECH_ILLEGAL = 1)
-	materials = list(DEFAULT_WALL_MATERIAL = 5000, "gold" = 5000, "silver" = 2500, "glass" = 750)
+	materials = list(MAT_STEEL = 5000, "gold" = 5000, "silver" = 2500, "glass" = 750)
 	build_path = /obj/item/weapon/gun/projectile/dartgun/research
 	sort_string = "MADAB"
 
@@ -172,14 +172,14 @@
 	desc = "An advanced chem spraying device."
 	id = "chemsprayer"
 	req_tech = list(TECH_MATERIAL = 3, TECH_ENGINEERING = 3, TECH_BIO = 2)
-	materials = list(DEFAULT_WALL_MATERIAL = 5000, "glass" = 1000)
+	materials = list(MAT_STEEL = 5000, "glass" = 1000)
 	build_path = /obj/item/weapon/reagent_containers/spray/chemsprayer
 	sort_string = "MADAC"
 
 /datum/design/item/weapon/fuelrod
 	id = "fuelrod_gun"
 	req_tech = list(TECH_COMBAT = 6, TECH_MATERIAL = 4, TECH_PHORON = 4, TECH_ILLEGAL = 5, TECH_MAGNET = 5)
-	materials = list(DEFAULT_WALL_MATERIAL = 10000, "glass" = 2000, "gold" = 500, "silver" = 500, "uranium" = 1000, "phoron" = 3000, "diamond" = 1000)
+	materials = list(MAT_STEEL = 10000, "glass" = 2000, "gold" = 500, "silver" = 500, "uranium" = 1000, "phoron" = 3000, "diamond" = 1000)
 	build_path = /obj/item/weapon/gun/magnetic/fuelrod
 	sort_string = "MADAD"
 
@@ -188,35 +188,35 @@
 /datum/design/item/weapon/ammo/dartgunmag_small
 	id = "dartgun_mag_s"
 	req_tech = list(TECH_COMBAT = 6, TECH_MATERIAL = 2, TECH_BIO = 2, TECH_MAGNET = 1, TECH_ILLEGAL = 1)
-	materials = list(DEFAULT_WALL_MATERIAL = 300, "gold" = 100, "silver" = 100, "glass" = 300)
+	materials = list(MAT_STEEL = 300, "gold" = 100, "silver" = 100, "glass" = 300)
 	build_path = /obj/item/ammo_magazine/chemdart/small
 	sort_string = "MADBA"
 
 /datum/design/item/weapon/ammo/dartgun_ammo_small
 	id = "dartgun_ammo_s"
 	req_tech = list(TECH_COMBAT = 6, TECH_MATERIAL = 2, TECH_BIO = 2, TECH_MAGNET = 1, TECH_ILLEGAL = 1)
-	materials = list(DEFAULT_WALL_MATERIAL = 50, "gold" = 30, "silver" = 30, "glass" = 50)
+	materials = list(MAT_STEEL = 50, "gold" = 30, "silver" = 30, "glass" = 50)
 	build_path = /obj/item/ammo_casing/chemdart/small
 	sort_string = "MADBB"
 
 /datum/design/item/weapon/ammo/dartgunmag_med
 	id = "dartgun_mag_m"
 	req_tech = list(TECH_COMBAT = 7, TECH_MATERIAL = 2, TECH_BIO = 2, TECH_MAGNET = 1, TECH_ILLEGAL = 1)
-	materials = list(DEFAULT_WALL_MATERIAL = 500, "gold" = 150, "silver" = 150, "diamond" = 200, "glass" = 400)
+	materials = list(MAT_STEEL = 500, "gold" = 150, "silver" = 150, "diamond" = 200, "glass" = 400)
 	build_path = /obj/item/ammo_magazine/chemdart
 	sort_string = "MADBC"
 
 /datum/design/item/weapon/ammo/dartgun_ammo_med
 	id = "dartgun_ammo_m"
 	req_tech = list(TECH_COMBAT = 7, TECH_MATERIAL = 2, TECH_BIO = 2, TECH_MAGNET = 1, TECH_ILLEGAL = 1)
-	materials = list(DEFAULT_WALL_MATERIAL = 80, "gold" = 40, "silver" = 40, "glass" = 60)
+	materials = list(MAT_STEEL = 80, "gold" = 40, "silver" = 40, "glass" = 60)
 	build_path = /obj/item/ammo_casing/chemdart
 	sort_string = "MADBD"
 
 /datum/design/item/weapon/ammo/flechette
 	id = "magnetic_ammo"
 	req_tech = list(TECH_COMBAT = 4, TECH_MATERIAL = 4, TECH_MAGNET = 4)
-	materials = list(DEFAULT_WALL_MATERIAL = 500, "gold" = 300, "glass" = 150, MAT_PHORON = 100)
+	materials = list(MAT_STEEL = 500, "gold" = 300, "glass" = 150, MAT_PHORON = 100)
 	build_path = /obj/item/weapon/magnetic_ammo
 	sort_string = "MADBE"
 
@@ -250,6 +250,6 @@
 /datum/design/item/weapon/grenade/large_grenade
 	id = "large_Grenade"
 	req_tech = list(TECH_COMBAT = 3, TECH_MATERIAL = 2)
-	materials = list(DEFAULT_WALL_MATERIAL = 3000)
+	materials = list(MAT_STEEL = 3000)
 	build_path = /obj/item/weapon/grenade/chem_grenade/large
 	sort_string = "MCAAA"

--- a/code/modules/research/designs/xenoarch_toys.dm
+++ b/code/modules/research/designs/xenoarch_toys.dm
@@ -9,7 +9,7 @@
 	id = "ano_scanner"
 	desc = "Aids in triangulation of exotic particles."
 	req_tech = list(TECH_BLUESPACE = 3, TECH_MAGNET = 3)
-	materials = list(DEFAULT_WALL_MATERIAL = 10000,"glass" = 5000)
+	materials = list(MAT_STEEL = 10000,"glass" = 5000)
 	build_path = /obj/item/device/ano_scanner
 	sort_string = "GAAAA"
 
@@ -18,7 +18,7 @@
 	id = "xenoarch_multitool"
 	req_tech = list(TECH_MAGNET = 3, TECH_ENGINEERING = 3, TECH_BLUESPACE = 3)
 	build_path = /obj/item/device/xenoarch_multi_tool
-	materials = list(DEFAULT_WALL_MATERIAL = 2000, "glass" = 1000, "uranium" = 500, "phoron" = 500)
+	materials = list(MAT_STEEL = 2000, "glass" = 1000, "uranium" = 500, "phoron" = 500)
 	sort_string = "GAAAB"
 
 /datum/design/item/weapon/xenoarch/excavationdrill
@@ -26,6 +26,6 @@
 	id = "excavationdrill"
 	req_tech = list(TECH_MATERIAL = 3, TECH_POWER = 2, TECH_ENGINEERING = 2, TECH_BLUESPACE = 3)
 	build_type = PROTOLATHE
-	materials = list(DEFAULT_WALL_MATERIAL = 4000, "glass" = 4000)
+	materials = list(MAT_STEEL = 4000, "glass" = 4000)
 	build_path = /obj/item/weapon/pickaxe/excavationdrill
 	sort_string = "GAAAC"

--- a/code/modules/research/designs/xenobio_toys.dm
+++ b/code/modules/research/designs/xenobio_toys.dm
@@ -7,14 +7,14 @@
 /datum/design/item/weapon/xenobio/slimebaton
 	id = "slimebaton"
 	req_tech = list(TECH_MATERIAL = 2, TECH_BIO = 2, TECH_POWER = 3, TECH_COMBAT = 3)
-	materials = list(DEFAULT_WALL_MATERIAL = 5000)
+	materials = list(MAT_STEEL = 5000)
 	build_path = /obj/item/weapon/melee/baton/slime
 	sort_string = "HAAAA"
 
 /datum/design/item/weapon/xenobio/slimetaser
 	id = "slimetaser"
 	req_tech = list(TECH_MATERIAL = 3, TECH_BIO = 3, TECH_POWER = 4, TECH_COMBAT = 4)
-	materials = list(DEFAULT_WALL_MATERIAL = 5000)
+	materials = list(MAT_STEEL = 5000)
 	build_path = /obj/item/weapon/gun/energy/taser/xeno
 	sort_string = "HAAAB"
 
@@ -25,6 +25,6 @@
 	desc = "A hand-held body scanner able to learn information about slimes."
 	id = "slime_scanner"
 	req_tech = list(TECH_MAGNET = 2, TECH_BIO = 2)
-	materials = list(DEFAULT_WALL_MATERIAL = 500, "glass" = 500)
+	materials = list(MAT_STEEL = 500, "glass" = 500)
 	build_path = /obj/item/device/slime_scanner
 	sort_string = "HBAAA"

--- a/code/modules/research/mechfab_designs.dm
+++ b/code/modules/research/mechfab_designs.dm
@@ -11,7 +11,7 @@
 	id = "ripley_chassis"
 	build_path = /obj/item/mecha_parts/chassis/ripley
 	time = 10
-	materials = list(DEFAULT_WALL_MATERIAL = 15000)
+	materials = list(MAT_STEEL = 15000)
 
 /datum/design/item/mechfab/ripley/chassis/firefighter
 	name = "Firefigher Chassis"
@@ -23,35 +23,35 @@
 	id = "ripley_torso"
 	build_path = /obj/item/mecha_parts/part/ripley_torso
 	time = 20
-	materials = list(DEFAULT_WALL_MATERIAL = 30000, "glass" = 11250)
+	materials = list(MAT_STEEL = 30000, "glass" = 11250)
 
 /datum/design/item/mechfab/ripley/left_arm
 	name = "Ripley Left Arm"
 	id = "ripley_left_arm"
 	build_path = /obj/item/mecha_parts/part/ripley_left_arm
 	time = 15
-	materials = list(DEFAULT_WALL_MATERIAL = 18750)
+	materials = list(MAT_STEEL = 18750)
 
 /datum/design/item/mechfab/ripley/right_arm
 	name = "Ripley Right Arm"
 	id = "ripley_right_arm"
 	build_path = /obj/item/mecha_parts/part/ripley_right_arm
 	time = 15
-	materials = list(DEFAULT_WALL_MATERIAL = 18750)
+	materials = list(MAT_STEEL = 18750)
 
 /datum/design/item/mechfab/ripley/left_leg
 	name = "Ripley Left Leg"
 	id = "ripley_left_leg"
 	build_path = /obj/item/mecha_parts/part/ripley_left_leg
 	time = 15
-	materials = list(DEFAULT_WALL_MATERIAL = 22500)
+	materials = list(MAT_STEEL = 22500)
 
 /datum/design/item/mechfab/ripley/right_leg
 	name = "Ripley Right Leg"
 	id = "ripley_right_leg"
 	build_path = /obj/item/mecha_parts/part/ripley_right_leg
 	time = 15
-	materials = list(DEFAULT_WALL_MATERIAL = 22500)
+	materials = list(MAT_STEEL = 22500)
 
 /datum/design/item/mechfab/odysseus
 	category = "Odysseus"
@@ -61,49 +61,49 @@
 	id = "odysseus_chassis"
 	build_path = /obj/item/mecha_parts/chassis/odysseus
 	time = 10
-	materials = list(DEFAULT_WALL_MATERIAL = 15000)
+	materials = list(MAT_STEEL = 15000)
 
 /datum/design/item/mechfab/odysseus/torso
 	name = "Odysseus Torso"
 	id = "odysseus_torso"
 	build_path = /obj/item/mecha_parts/part/odysseus_torso
 	time = 18
-	materials = list(DEFAULT_WALL_MATERIAL = 18750)
+	materials = list(MAT_STEEL = 18750)
 
 /datum/design/item/mechfab/odysseus/head
 	name = "Odysseus Head"
 	id = "odysseus_head"
 	build_path = /obj/item/mecha_parts/part/odysseus_head
 	time = 10
-	materials = list(DEFAULT_WALL_MATERIAL = 1500, "glass" = 7500)
+	materials = list(MAT_STEEL = 1500, "glass" = 7500)
 
 /datum/design/item/mechfab/odysseus/left_arm
 	name = "Odysseus Left Arm"
 	id = "odysseus_left_arm"
 	build_path = /obj/item/mecha_parts/part/odysseus_left_arm
 	time = 12
-	materials = list(DEFAULT_WALL_MATERIAL = 7500)
+	materials = list(MAT_STEEL = 7500)
 
 /datum/design/item/mechfab/odysseus/right_arm
 	name = "Odysseus Right Arm"
 	id = "odysseus_right_arm"
 	build_path = /obj/item/mecha_parts/part/odysseus_right_arm
 	time = 12
-	materials = list(DEFAULT_WALL_MATERIAL = 7500)
+	materials = list(MAT_STEEL = 7500)
 
 /datum/design/item/mechfab/odysseus/left_leg
 	name = "Odysseus Left Leg"
 	id = "odysseus_left_leg"
 	build_path = /obj/item/mecha_parts/part/odysseus_left_leg
 	time = 13
-	materials = list(DEFAULT_WALL_MATERIAL = 11250)
+	materials = list(MAT_STEEL = 11250)
 
 /datum/design/item/mechfab/odysseus/right_leg
 	name = "Odysseus Right Leg"
 	id = "odysseus_right_leg"
 	build_path = /obj/item/mecha_parts/part/odysseus_right_leg
 	time = 13
-	materials = list(DEFAULT_WALL_MATERIAL = 11250)
+	materials = list(MAT_STEEL = 11250)
 
 /datum/design/item/mechfab/gygax
 	category = "Gygax"
@@ -112,63 +112,63 @@
 	name = "Serenity Chassis"
 	id = "serenity_chassis"
 	build_path = /obj/item/mecha_parts/chassis/serenity
-	materials = list(DEFAULT_WALL_MATERIAL = 18750, "phoron" = 4000)
+	materials = list(MAT_STEEL = 18750, "phoron" = 4000)
 
 /datum/design/item/mechfab/gygax/chassis
 	name = "Gygax Chassis"
 	id = "gygax_chassis"
 	build_path = /obj/item/mecha_parts/chassis/gygax
 	time = 10
-	materials = list(DEFAULT_WALL_MATERIAL = 18750)
+	materials = list(MAT_STEEL = 18750)
 
 /datum/design/item/mechfab/gygax/torso
 	name = "Gygax Torso"
 	id = "gygax_torso"
 	build_path = /obj/item/mecha_parts/part/gygax_torso
 	time = 30
-	materials = list(DEFAULT_WALL_MATERIAL = 37500, "glass" = 15000)
+	materials = list(MAT_STEEL = 37500, "glass" = 15000)
 
 /datum/design/item/mechfab/gygax/head
 	name = "Gygax Head"
 	id = "gygax_head"
 	build_path = /obj/item/mecha_parts/part/gygax_head
 	time = 20
-	materials = list(DEFAULT_WALL_MATERIAL = 15000, "glass" = 7500)
+	materials = list(MAT_STEEL = 15000, "glass" = 7500)
 
 /datum/design/item/mechfab/gygax/left_arm
 	name = "Gygax Left Arm"
 	id = "gygax_left_arm"
 	build_path = /obj/item/mecha_parts/part/gygax_left_arm
 	time = 20
-	materials = list(DEFAULT_WALL_MATERIAL = 22500)
+	materials = list(MAT_STEEL = 22500)
 
 /datum/design/item/mechfab/gygax/right_arm
 	name = "Gygax Right Arm"
 	id = "gygax_right_arm"
 	build_path = /obj/item/mecha_parts/part/gygax_right_arm
 	time = 20
-	materials = list(DEFAULT_WALL_MATERIAL = 22500)
+	materials = list(MAT_STEEL = 22500)
 
 /datum/design/item/mechfab/gygax/left_leg
 	name = "Gygax Left Leg"
 	id = "gygax_left_leg"
 	build_path = /obj/item/mecha_parts/part/gygax_left_leg
 	time = 20
-	materials = list(DEFAULT_WALL_MATERIAL = 26250)
+	materials = list(MAT_STEEL = 26250)
 
 /datum/design/item/mechfab/gygax/right_leg
 	name = "Gygax Right Leg"
 	id = "gygax_right_leg"
 	build_path = /obj/item/mecha_parts/part/gygax_right_leg
 	time = 20
-	materials = list(DEFAULT_WALL_MATERIAL = 26250)
+	materials = list(MAT_STEEL = 26250)
 
 /datum/design/item/mechfab/gygax/armour
 	name = "Gygax Armour Plates"
 	id = "gygax_armour"
 	build_path = /obj/item/mecha_parts/part/gygax_armour
 	time = 60
-	materials = list(DEFAULT_WALL_MATERIAL = 37500, "diamond" = 7500)
+	materials = list(MAT_STEEL = 37500, "diamond" = 7500)
 
 /datum/design/item/mechfab/durand
 	category = "Durand"
@@ -178,56 +178,56 @@
 	id = "durand_chassis"
 	build_path = /obj/item/mecha_parts/chassis/durand
 	time = 20
-	materials = list(DEFAULT_WALL_MATERIAL = 18750, MAT_PLASTEEL = 20000)
+	materials = list(MAT_STEEL = 18750, MAT_PLASTEEL = 20000)
 
 /datum/design/item/mechfab/durand/torso
 	name = "Durand Torso"
 	id = "durand_torso"
 	build_path = /obj/item/mecha_parts/part/durand_torso
 	time = 30
-	materials = list(DEFAULT_WALL_MATERIAL = 41250, MAT_PLASTEEL = 15000, "silver" = 7500)
+	materials = list(MAT_STEEL = 41250, MAT_PLASTEEL = 15000, "silver" = 7500)
 
 /datum/design/item/mechfab/durand/head
 	name = "Durand Head"
 	id = "durand_head"
 	build_path = /obj/item/mecha_parts/part/durand_head
 	time = 20
-	materials = list(DEFAULT_WALL_MATERIAL = 18750, "glass" = 7500, "silver" = 2250)
+	materials = list(MAT_STEEL = 18750, "glass" = 7500, "silver" = 2250)
 
 /datum/design/item/mechfab/durand/left_arm
 	name = "Durand Left Arm"
 	id = "durand_left_arm"
 	build_path = /obj/item/mecha_parts/part/durand_left_arm
 	time = 20
-	materials = list(DEFAULT_WALL_MATERIAL = 26250, "silver" = 2250)
+	materials = list(MAT_STEEL = 26250, "silver" = 2250)
 
 /datum/design/item/mechfab/durand/right_arm
 	name = "Durand Right Arm"
 	id = "durand_right_arm"
 	build_path = /obj/item/mecha_parts/part/durand_right_arm
 	time = 20
-	materials = list(DEFAULT_WALL_MATERIAL = 26250, "silver" = 2250)
+	materials = list(MAT_STEEL = 26250, "silver" = 2250)
 
 /datum/design/item/mechfab/durand/left_leg
 	name = "Durand Left Leg"
 	id = "durand_left_leg"
 	build_path = /obj/item/mecha_parts/part/durand_left_leg
 	time = 20
-	materials = list(DEFAULT_WALL_MATERIAL = 30000, "silver" = 2250)
+	materials = list(MAT_STEEL = 30000, "silver" = 2250)
 
 /datum/design/item/mechfab/durand/right_leg
 	name = "Durand Right Leg"
 	id = "durand_right_leg"
 	build_path = /obj/item/mecha_parts/part/durand_right_leg
 	time = 20
-	materials = list(DEFAULT_WALL_MATERIAL = 30000, "silver" = 2250)
+	materials = list(MAT_STEEL = 30000, "silver" = 2250)
 
 /datum/design/item/mechfab/durand/armour
 	name = "Durand Armour Plates"
 	id = "durand_armour"
 	build_path = /obj/item/mecha_parts/part/durand_armour
 	time = 60
-	materials = list(DEFAULT_WALL_MATERIAL = 27500, MAT_PLASTEEL = 10000, "uranium" = 7500)
+	materials = list(MAT_STEEL = 27500, MAT_PLASTEEL = 10000, "uranium" = 7500)
 
 /datum/design/item/mechfab/janus
 	category = "Janus"
@@ -246,42 +246,42 @@
 	id = "janus_torso"
 	build_path = /obj/item/mecha_parts/part/janus_torso
 	time = 300
-	materials = list(DEFAULT_WALL_MATERIAL = 30000, MAT_DURASTEEL = 8000, MAT_MORPHIUM = 10000, MAT_GOLD = 5000, MAT_VERDANTIUM = 5000)
+	materials = list(MAT_STEEL = 30000, MAT_DURASTEEL = 8000, MAT_MORPHIUM = 10000, MAT_GOLD = 5000, MAT_VERDANTIUM = 5000)
 
 /datum/design/item/mechfab/janus/head
 	name = "Imperion Head"
 	id = "janus_head"
 	build_path = /obj/item/mecha_parts/part/janus_head
 	time = 200
-	materials = list(DEFAULT_WALL_MATERIAL = 30000, MAT_DURASTEEL = 2000, MAT_MORPHIUM = 6000, MAT_GOLD = 5000)
+	materials = list(MAT_STEEL = 30000, MAT_DURASTEEL = 2000, MAT_MORPHIUM = 6000, MAT_GOLD = 5000)
 
 /datum/design/item/mechfab/janus/left_arm
 	name = "Prototype Gygax Left Arm"
 	id = "janus_left_arm"
 	build_path = /obj/item/mecha_parts/part/janus_left_arm
 	time = 200
-	materials = list(DEFAULT_WALL_MATERIAL = 30000, MAT_METALHYDROGEN = 3000, MAT_DURASTEEL = 2000, MAT_MORPHIUM = 3000, MAT_GOLD = 5000, MAT_DIAMOND = 7000)
+	materials = list(MAT_STEEL = 30000, MAT_METALHYDROGEN = 3000, MAT_DURASTEEL = 2000, MAT_MORPHIUM = 3000, MAT_GOLD = 5000, MAT_DIAMOND = 7000)
 
 /datum/design/item/mechfab/janus/right_arm
 	name = "Prototype Gygax Right Arm"
 	id = "janus_right_arm"
 	build_path = /obj/item/mecha_parts/part/janus_right_arm
 	time = 200
-	materials = list(DEFAULT_WALL_MATERIAL = 30000, MAT_METALHYDROGEN = 3000, MAT_DURASTEEL = 2000, MAT_MORPHIUM = 3000, MAT_GOLD = 5000, MAT_DIAMOND = 7000)
+	materials = list(MAT_STEEL = 30000, MAT_METALHYDROGEN = 3000, MAT_DURASTEEL = 2000, MAT_MORPHIUM = 3000, MAT_GOLD = 5000, MAT_DIAMOND = 7000)
 
 /datum/design/item/mechfab/janus/left_leg
 	name = "Prototype Durand Left Leg"
 	id = "janus_left_leg"
 	build_path = /obj/item/mecha_parts/part/janus_left_leg
 	time = 200
-	materials = list(DEFAULT_WALL_MATERIAL = 30000, MAT_METALHYDROGEN = 3000, MAT_DURASTEEL = 2000, MAT_MORPHIUM = 3000, MAT_GOLD = 5000, MAT_URANIUM = 7000)
+	materials = list(MAT_STEEL = 30000, MAT_METALHYDROGEN = 3000, MAT_DURASTEEL = 2000, MAT_MORPHIUM = 3000, MAT_GOLD = 5000, MAT_URANIUM = 7000)
 
 /datum/design/item/mechfab/janus/right_leg
 	name = "Prototype Durand Right Leg"
 	id = "janus_right_leg"
 	build_path = /obj/item/mecha_parts/part/janus_right_leg
 	time = 200
-	materials = list(DEFAULT_WALL_MATERIAL = 30000, MAT_METALHYDROGEN = 3000, MAT_DURASTEEL = 2000, MAT_MORPHIUM = 3000, MAT_GOLD = 5000, MAT_URANIUM = 7000)
+	materials = list(MAT_STEEL = 30000, MAT_METALHYDROGEN = 3000, MAT_DURASTEEL = 2000, MAT_MORPHIUM = 3000, MAT_GOLD = 5000, MAT_URANIUM = 7000)
 
 /datum/design/item/mechfab/janus/phase_coil
 	name = "Janus Phase Coil"
@@ -294,7 +294,7 @@
 	build_type = MECHFAB
 	category = "Exosuit Equipment"
 	time = 10
-	materials = list(DEFAULT_WALL_MATERIAL = 7500)
+	materials = list(MAT_STEEL = 7500)
 
 /datum/design/item/mecha/AssembleDesignDesc()
 	if(!desc)
@@ -304,7 +304,7 @@
 	name = "Exosuit Tracking Beacon"
 	id = "mech_tracker"
 	time = 5
-	materials = list(DEFAULT_WALL_MATERIAL = 375)
+	materials = list(MAT_STEEL = 375)
 	build_path = /obj/item/mecha_parts/mecha_tracking
 
 /datum/design/item/mecha/hydraulic_clamp
@@ -326,32 +326,32 @@
 	name = "Cable Layer"
 	id = "mech_cable_layer"
 	build_path = /obj/item/mecha_parts/mecha_equipment/tool/cable_layer
-	materials = list(DEFAULT_WALL_MATERIAL = 7500, "plastic" = 1000)
+	materials = list(MAT_STEEL = 7500, "plastic" = 1000)
 
 /datum/design/item/mecha/flaregun
 	name = "Flare Launcher"
 	id = "mecha_flare_gun"
 	build_path = /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack/flare
-	materials = list(DEFAULT_WALL_MATERIAL = 9375)
+	materials = list(MAT_STEEL = 9375)
 
 /datum/design/item/mecha/sleeper
 	name = "Sleeper"
 	id = "mech_sleeper"
 	build_path = /obj/item/mecha_parts/mecha_equipment/tool/sleeper
-	materials = list(DEFAULT_WALL_MATERIAL = 3750, "glass" = 7500)
+	materials = list(MAT_STEEL = 3750, "glass" = 7500)
 
 /datum/design/item/mecha/syringe_gun
 	name = "Syringe Gun"
 	id = "mech_syringe_gun"
 	build_path = /obj/item/mecha_parts/mecha_equipment/tool/syringe_gun
 	time = 20
-	materials = list(DEFAULT_WALL_MATERIAL = 2250, "glass" = 1500)
+	materials = list(MAT_STEEL = 2250, "glass" = 1500)
 
 /datum/design/item/mecha/passenger
 	name = "Passenger Compartment"
 	id = "mech_passenger"
 	build_path = /obj/item/mecha_parts/mecha_equipment/tool/passenger
-	materials = list(DEFAULT_WALL_MATERIAL = 3750, "glass" = 3750)
+	materials = list(MAT_STEEL = 3750, "glass" = 3750)
 
 /datum/design/item/mecha/taser
 	name = "PBT \"Pacifier\" Mounted Taser"
@@ -369,7 +369,7 @@
 	id = "mech_shocker"
 	req_tech = list(TECH_COMBAT = 3, TECH_POWER = 6, TECH_MAGNET = 1)
 	build_path = /obj/item/mecha_parts/mecha_equipment/shocker
-	materials = list(DEFAULT_WALL_MATERIAL = 3500, "gold" = 750, "glass" = 1000)
+	materials = list(MAT_STEEL = 3500, "gold" = 750, "glass" = 1000)
 
 /datum/design/item/mecha/lmg
 	name = "Ultra AC 2"
@@ -383,7 +383,7 @@
 
 /datum/design/item/mecha/weapon
 	req_tech = list(TECH_COMBAT = 3)
-	materials = list(DEFAULT_WALL_MATERIAL = 8000, "glass" = 2000)
+	materials = list(MAT_STEEL = 8000, "glass" = 2000)
 
 // *** Weapon modules
 /datum/design/item/mecha/weapon/scattershot
@@ -391,21 +391,21 @@
 	id = "mech_scattershot"
 	req_tech = list(TECH_COMBAT = 4)
 	build_path = /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/scattershot
-	materials = list(DEFAULT_WALL_MATERIAL = 8000, "glass" = 3000, "plastic" = 2000, "silver" = 2500)
+	materials = list(MAT_STEEL = 8000, "glass" = 3000, "plastic" = 2000, "silver" = 2500)
 
 /datum/design/item/mecha/weapon/rigged_scattershot
 	name = "Jury-Rigged Shrapnel Cannon"
 	id = "mech_scattershot-r"
 	req_tech = list(TECH_COMBAT = 4)
 	build_path = /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/scattershot/rigged
-	materials = list(DEFAULT_WALL_MATERIAL = 7000, "glass" = 2000, "plastic" = 2000, "silver" = 2000)
+	materials = list(MAT_STEEL = 7000, "glass" = 2000, "plastic" = 2000, "silver" = 2000)
 
 /datum/design/item/mecha/weapon/laser
 	name = "CH-PS \"Immolator\" Laser"
 	id = "mech_laser"
 	req_tech = list(TECH_COMBAT = 3, TECH_MAGNET = 3)
 	build_path = /obj/item/mecha_parts/mecha_equipment/weapon/energy/laser
-	materials = list(DEFAULT_WALL_MATERIAL = 8000, "glass" = 3000, "plastic" = 2000)
+	materials = list(MAT_STEEL = 8000, "glass" = 3000, "plastic" = 2000)
 
 /datum/design/item/mecha/weapon/laser_rigged
 	name = "Jury-Rigged Welder-Laser"
@@ -419,70 +419,70 @@
 	id = "mech_laser_heavy"
 	req_tech = list(TECH_COMBAT = 4, TECH_MAGNET = 4)
 	build_path = /obj/item/mecha_parts/mecha_equipment/weapon/energy/laser/heavy
-	materials = list(DEFAULT_WALL_MATERIAL = 10000, "glass" = 3000, "diamond" = 2000, "osmium" = 5000, "plastic" = 2000)
+	materials = list(MAT_STEEL = 10000, "glass" = 3000, "diamond" = 2000, "osmium" = 5000, "plastic" = 2000)
 
 /datum/design/item/mecha/weapon/rigged_laser_heavy
 	name = "Jury-Rigged Emitter Cannon"
 	id = "mech_laser_heavy-r"
 	req_tech = list(TECH_COMBAT = 4, TECH_MAGNET = 4, TECH_PHORON = 3, TECH_ILLEGAL = 1)
 	build_path = /obj/item/mecha_parts/mecha_equipment/weapon/energy/laser/heavy/rigged
-	materials = list(DEFAULT_WALL_MATERIAL = 8000, "glass" = 4000, "diamond" = 1500, "osmium" = 4000, "plastic" = 2000)
+	materials = list(MAT_STEEL = 8000, "glass" = 4000, "diamond" = 1500, "osmium" = 4000, "plastic" = 2000)
 
 /datum/design/item/mecha/weapon/laser_xray
 	name = "CH-XS \"Penetrator\" Laser"
 	id = "mech_laser_xray"
 	req_tech = list(TECH_MATERIAL = 3, TECH_COMBAT = 3, TECH_PHORON = 3, TECH_POWER = 4)
 	build_path = /obj/item/mecha_parts/mecha_equipment/weapon/energy/laser/xray
-	materials = list(DEFAULT_WALL_MATERIAL = 9000, "glass" = 3000, "phoron" = 1000, "silver" = 1500, "gold" = 2500, "plastic" = 2000)
+	materials = list(MAT_STEEL = 9000, "glass" = 3000, "phoron" = 1000, "silver" = 1500, "gold" = 2500, "plastic" = 2000)
 
 /datum/design/item/mecha/weapon/rigged_laser_xray
 	name = "Jury-Rigged Xray Rifle"
 	id = "mech_laser_xray-r"
 	req_tech = list(TECH_MATERIAL = 3, TECH_COMBAT = 3, TECH_PHORON = 3, TECH_POWER = 4)
 	build_path = /obj/item/mecha_parts/mecha_equipment/weapon/energy/laser/xray/rigged
-	materials = list(DEFAULT_WALL_MATERIAL = 8500, "glass" = 2500, "phoron" = 1000, "silver" = 1250, "gold" = 2000, "plastic" = 2000)
+	materials = list(MAT_STEEL = 8500, "glass" = 2500, "phoron" = 1000, "silver" = 1250, "gold" = 2000, "plastic" = 2000)
 
 /datum/design/item/mecha/weapon/phase
 	name = "NT-PE \"Scorpio\" Phase-Emitter"
 	id = "mech_phase"
 	req_tech = list(TECH_MATERIAL = 1, TECH_COMBAT = 2, TECH_MAGNET = 2)
 	build_path = /obj/item/mecha_parts/mecha_equipment/weapon/energy/phase
-	materials = list(DEFAULT_WALL_MATERIAL = 6000, "glass" = 3000, "plastic" = 3000)
+	materials = list(MAT_STEEL = 6000, "glass" = 3000, "plastic" = 3000)
 
 /datum/design/item/mecha/weapon/ion
 	name = "MK-IV Ion Heavy Cannon"
 	id = "mech_ion"
 	req_tech = list(TECH_COMBAT = 4, TECH_MAGNET = 4)
 	build_path = /obj/item/mecha_parts/mecha_equipment/weapon/energy/ion
-	materials = list(DEFAULT_WALL_MATERIAL = 15000, "uranium" = 2000, "silver" = 2000, "osmium" = 4500, "plastic" = 2000)
+	materials = list(MAT_STEEL = 15000, "uranium" = 2000, "silver" = 2000, "osmium" = 4500, "plastic" = 2000)
 
 /datum/design/item/mecha/weapon/rigged_ion
 	name = "Jury-Rigged Ion Cannon"
 	id = "mech_ion-r"
 	req_tech = list(TECH_COMBAT = 4, TECH_MAGNET = 4)
 	build_path = /obj/item/mecha_parts/mecha_equipment/weapon/energy/ion/rigged
-	materials = list(DEFAULT_WALL_MATERIAL = 13000, "uranium" = 1000, "silver" = 1000, "osmium" = 3000, "plastic" = 2000)
+	materials = list(MAT_STEEL = 13000, "uranium" = 1000, "silver" = 1000, "osmium" = 3000, "plastic" = 2000)
 
 /datum/design/item/mecha/weapon/grenade_launcher
 	name = "SGL-6 Grenade Launcher"
 	id = "mech_grenade_launcher"
 	req_tech = list(TECH_COMBAT = 3)
 	build_path = /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack/grenade
-	materials = list(DEFAULT_WALL_MATERIAL = 7000, "gold" = 2000, "plastic" = 3000)
+	materials = list(MAT_STEEL = 7000, "gold" = 2000, "plastic" = 3000)
 
 /datum/design/item/mecha/weapon/rigged_grenade_launcher
 	name = "Jury-Rigged Pneumatic Flashlauncher"
 	id = "mech_grenade_launcher-rig"
 	req_tech = list(TECH_COMBAT = 3)
 	build_path = /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack/grenade/rigged
-	materials = list(DEFAULT_WALL_MATERIAL = 5000, "gold" = 2000, "plastic" = 2000)
+	materials = list(MAT_STEEL = 5000, "gold" = 2000, "plastic" = 2000)
 
 /datum/design/item/mecha/weapon/clusterbang_launcher
 	name = "SOP-6 Grenade Launcher"
 	desc = "A weapon that violates the Geneva Convention at 6 rounds per minute."
 	id = "clusterbang_launcher"
 	req_tech = list(TECH_COMBAT= 5, TECH_MATERIAL = 5, TECH_ILLEGAL = 3)
-	materials = list(DEFAULT_WALL_MATERIAL = 15000, "gold" = 4500, "uranium" = 4500)
+	materials = list(MAT_STEEL = 15000, "gold" = 4500, "uranium" = 4500)
 	build_path = /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack/grenade/clusterbang/limited
 
 /datum/design/item/mecha/weapon/conc_grenade_launcher
@@ -490,21 +490,21 @@
 	id = "mech_grenade_launcher_conc"
 	req_tech = list(TECH_COMBAT = 3, TECH_MATERIAL = 4, TECH_ILLEGAL = 1)
 	build_path = /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack/grenade/concussion
-	materials = list(DEFAULT_WALL_MATERIAL = 9000, "gold" = 1000, "osmium" = 1000, "plastic" = 3000)
+	materials = list(MAT_STEEL = 9000, "gold" = 1000, "osmium" = 1000, "plastic" = 3000)
 
 /datum/design/item/mecha/weapon/frag_grenade_launcher
 	name = "HEP-MI 6 Grenade Launcher"
 	id = "mech_grenade_launcher_frag"
 	req_tech = list(TECH_COMBAT = 4, TECH_ENGINEERING = 2, TECH_MATERIAL = 3, TECH_ILLEGAL = 2)
 	build_path = /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack/grenade/frag/mini
-	materials = list(DEFAULT_WALL_MATERIAL = 10000, "gold" = 2500, "uranium" = 3000, "osmium" = 3000, "plastic" = 3000)
+	materials = list(MAT_STEEL = 10000, "gold" = 2500, "uranium" = 3000, "osmium" = 3000, "plastic" = 3000)
 
 /datum/design/item/mecha/weapon/flamer
 	name = "CR-3 Mark 8 Flamethrower"
 	desc = "A weapon that violates the CCWC at two hundred gallons per minute."
 	id = "mech_flamer_full"
 	req_tech = list(TECH_MATERIAL = 4, TECH_COMBAT = 6, TECH_PHORON = 4, TECH_ILLEGAL = 4)
-	materials = list(DEFAULT_WALL_MATERIAL = 10000, "gold" = 2000, "uranium" = 3000, "phoron" = 8000)
+	materials = list(MAT_STEEL = 10000, "gold" = 2000, "uranium" = 3000, "phoron" = 8000)
 	build_path = /obj/item/mecha_parts/mecha_equipment/weapon/energy/flamer
 
 /datum/design/item/mecha/weapon/flamer_rigged
@@ -512,7 +512,7 @@
 	desc = "A weapon that accidentally violates the CCWC at one hundred gallons per minute."
 	id = "mech_flamer_rigged"
 	req_tech = list(TECH_MATERIAL = 3, TECH_COMBAT = 3, TECH_PHORON = 3, TECH_ILLEGAL = 2)
-	materials = list(DEFAULT_WALL_MATERIAL = 8000, "gold" = 1500, "silver" = 1500, "uranium" = 2000, "phoron" = 6000)
+	materials = list(MAT_STEEL = 8000, "gold" = 1500, "silver" = 1500, "uranium" = 2000, "phoron" = 6000)
 	build_path = /obj/item/mecha_parts/mecha_equipment/weapon/energy/flamer/rigged
 
 /datum/design/item/mecha/weapon/flame_mg
@@ -520,7 +520,7 @@
 	desc = "A weapon that violates the CCWC at sixty rounds a minute."
 	id = "mech_lmg_flamer"
 	req_tech = list(TECH_MATERIAL = 4, TECH_COMBAT = 5, TECH_PHORON = 2, TECH_ILLEGAL = 1)
-	materials = list(DEFAULT_WALL_MATERIAL = 8000, "gold" = 2000, "silver" = 1750, "uranium" = 1500, "phoron" = 4000)
+	materials = list(MAT_STEEL = 8000, "gold" = 2000, "silver" = 1750, "uranium" = 1500, "phoron" = 4000)
 	build_path = /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/incendiary
 
 // *** Nonweapon modules
@@ -550,7 +550,7 @@
 	desc = "An exosuit-mounted rapid construction device."
 	id = "mech_rcd"
 	time = 120
-	materials = list(DEFAULT_WALL_MATERIAL = 20000, "plastic" = 10000, "phoron" = 18750, "silver" = 15000, "gold" = 15000)
+	materials = list(MAT_STEEL = 20000, "plastic" = 10000, "phoron" = 18750, "silver" = 15000, "gold" = 15000)
 	req_tech = list(TECH_MATERIAL = 4, TECH_BLUESPACE = 3, TECH_MAGNET = 4, TECH_POWER = 4, TECH_ENGINEERING = 4)
 	build_path = /obj/item/mecha_parts/mecha_equipment/tool/rcd
 
@@ -566,7 +566,7 @@
 	desc = "Automated repair droid, exosuits' best companion. BEEP BOOP"
 	id = "mech_repair_droid"
 	req_tech = list(TECH_MAGNET = 3, TECH_DATA = 3, TECH_ENGINEERING = 3)
-	materials = list(DEFAULT_WALL_MATERIAL = 7500, "gold" = 750, "silver" = 1500, "glass" = 3750)
+	materials = list(MAT_STEEL = 7500, "gold" = 750, "silver" = 1500, "glass" = 3750)
 	build_path = /obj/item/mecha_parts/mecha_equipment/repair_droid
 
 /* These are way too OP to be buildable
@@ -575,7 +575,7 @@
 	desc = "Linear shield projector. Deploys a large, familiar, and rectangular shield in one direction at a time."
 	id = "mech_shield_droid"
 	req_tech = list(TECH_PHORON = 3, TECH_MAGNET = 6, TECH_ILLEGAL = 4)
-	materials = list(DEFAULT_WALL_MATERIAL = 8000, "gold" = 2000, "silver" = 3000, "phoron" = 5000, "glass" = 3750)
+	materials = list(MAT_STEEL = 8000, "gold" = 2000, "silver" = 3000, "phoron" = 5000, "glass" = 3750)
 	build_path = /obj/item/mecha_parts/mecha_equipment/combat_shield
 
 /datum/design/item/mecha/omni_shield
@@ -583,7 +583,7 @@
 	desc = "Integral shield projector. Can only protect the exosuit, but has no weak angles."
 	id = "mech_shield_omni"
 	req_tech = list(TECH_PHORON = 3, TECH_MAGNET = 6, TECH_ILLEGAL = 4)
-	materials = list(DEFAULT_WALL_MATERIAL = 8000, "gold" = 2000, "silver" = 3000, "phoron" = 5000, "glass" = 3750)
+	materials = list(MAT_STEEL = 8000, "gold" = 2000, "silver" = 3000, "phoron" = 5000, "glass" = 3750)
 	build_path = /obj/item/mecha_parts/mecha_equipment/omni_shield
 */
 
@@ -592,7 +592,7 @@
 	desc = "Deploys a small medical drone capable of patching small wounds in order to stabilize nearby patients."
 	id = "mech_med_droid"
 	req_tech = list(TECH_PHORON = 3, TECH_MAGNET = 6, TECH_BIO = 5, TECH_DATA = 4, TECH_ARCANE = 1)
-	materials = list(DEFAULT_WALL_MATERIAL = 8000, MAT_GOLD = 2000, MAT_SILVER = 3000, MAT_VERDANTIUM = 2500, MAT_GLASS = 3000)
+	materials = list(MAT_STEEL = 8000, MAT_GOLD = 2000, MAT_SILVER = 3000, MAT_VERDANTIUM = 2500, MAT_GLASS = 3000)
 	build_path = /obj/item/mecha_parts/mecha_equipment/crisis_drone
 
 /datum/design/item/mecha/rad_drone
@@ -600,7 +600,7 @@
 	desc = "Deploys a small hazmat drone capable of purging minor radiation damage in order to stabilize nearby patients."
 	id = "mech_rad_droid"
 	req_tech = list(TECH_PHORON = 4, TECH_MAGNET = 5, TECH_BIO = 6, TECH_DATA = 4, TECH_ARCANE = 1)
-	materials = list(DEFAULT_WALL_MATERIAL = 8000, MAT_GOLD = 2000, MAT_URANIUM = 3000, MAT_VERDANTIUM = 2500, MAT_GLASS = 3000)
+	materials = list(MAT_STEEL = 8000, MAT_GOLD = 2000, MAT_URANIUM = 3000, MAT_VERDANTIUM = 2500, MAT_GLASS = 3000)
 	build_path = /obj/item/mecha_parts/mecha_equipment/crisis_drone/rad
 
 /datum/design/item/mecha/medanalyzer
@@ -617,20 +617,20 @@
 	id = "mech_jetpack"
 	req_tech = list(TECH_ENGINEERING = 3, TECH_MAGNET = 4) //One less magnet than the actual got-damn teleporter.
 	build_path = /obj/item/mecha_parts/mecha_equipment/tool/jetpack
-	materials = list(DEFAULT_WALL_MATERIAL = 7500, "silver" = 300, "glass" = 600)
+	materials = list(MAT_STEEL = 7500, "silver" = 300, "glass" = 600)
 
 /datum/design/item/mecha/phoron_generator
 	desc = "Phoron Reactor"
 	id = "mech_phoron_generator"
 	req_tech = list(TECH_PHORON = 2, TECH_POWER= 2, TECH_ENGINEERING = 2)
 	build_path = /obj/item/mecha_parts/mecha_equipment/generator
-	materials = list(DEFAULT_WALL_MATERIAL = 7500, "silver" = 375, "glass" = 750)
+	materials = list(MAT_STEEL = 7500, "silver" = 375, "glass" = 750)
 
 /datum/design/item/mecha/energy_relay
 	name = "Energy Relay"
 	id = "mech_energy_relay"
 	req_tech = list(TECH_MAGNET = 4, TECH_POWER = 3)
-	materials = list(DEFAULT_WALL_MATERIAL = 7500, "gold" = 1500, "silver" = 2250, "glass" = 1500)
+	materials = list(MAT_STEEL = 7500, "gold" = 1500, "silver" = 2250, "glass" = 1500)
 	build_path = /obj/item/mecha_parts/mecha_equipment/tesla_energy_relay
 
 /datum/design/item/mecha/ccw_armor
@@ -638,7 +638,7 @@
 	desc = "Exosuit close-combat armor booster."
 	id = "mech_ccw_armor"
 	req_tech = list(TECH_MATERIAL = 5, TECH_COMBAT = 4)
-	materials = list(DEFAULT_WALL_MATERIAL = 11250, "silver" = 3750)
+	materials = list(MAT_STEEL = 11250, "silver" = 3750)
 	build_path = /obj/item/mecha_parts/mecha_equipment/anticcw_armor_booster
 
 /datum/design/item/mecha/proj_armor
@@ -646,7 +646,7 @@
 	desc = "Exosuit projectile armor booster."
 	id = "mech_proj_armor"
 	req_tech = list(TECH_MATERIAL = 5, TECH_COMBAT = 5, TECH_ENGINEERING = 3)
-	materials = list(DEFAULT_WALL_MATERIAL = 15000, "gold" = 3750)
+	materials = list(MAT_STEEL = 15000, "gold" = 3750)
 	build_path = /obj/item/mecha_parts/mecha_equipment/antiproj_armor_booster
 
 /datum/design/item/mecha/diamond_drill
@@ -654,7 +654,7 @@
 	desc = "A diamond version of the exosuit drill. It's harder, better, faster, stronger."
 	id = "mech_diamond_drill"
 	req_tech = list(TECH_MATERIAL = 4, TECH_ENGINEERING = 3)
-	materials = list(DEFAULT_WALL_MATERIAL = 7500, "diamond" = 4875)
+	materials = list(MAT_STEEL = 7500, "diamond" = 4875)
 	build_path = /obj/item/mecha_parts/mecha_equipment/tool/drill/diamonddrill
 
 /datum/design/item/mecha/ground_drill
@@ -662,7 +662,7 @@
 	desc = "A heavy duty bore. Bigger, better, stronger than the core sampler, but not quite as good as a large drill."
 	id = "mech_ground_drill"
 	req_tech = list(TECH_MATERIAL = 4, TECH_ENGINEERING = 2, TECH_PHORON = 1)
-	materials = list(DEFAULT_WALL_MATERIAL = 7000, "silver" = 3000, "phoron" = 2000)
+	materials = list(MAT_STEEL = 7000, "silver" = 3000, "phoron" = 2000)
 	build_path = /obj/item/mecha_parts/mecha_equipment/tool/drill/bore
 
 /datum/design/item/mecha/orescanner
@@ -670,7 +670,7 @@
 	desc = "A hefty device used to scan for subterranean veins of ore."
 	id = "mech_ore_scanner"
 	req_tech = list(TECH_MATERIAL = 2, TECH_MAGNET = 2, TECH_POWER = 2)
-	materials = list(DEFAULT_WALL_MATERIAL = 4000, "glass" = 1000)
+	materials = list(MAT_STEEL = 4000, "glass" = 1000)
 	build_path = /obj/item/mecha_parts/mecha_equipment/tool/orescanner
 
 /datum/design/item/mecha/advorescanner
@@ -678,7 +678,7 @@
 	desc = "A hefty device used to scan for the exact volumes of subterranean veins of ore."
 	id = "mech_ore_scanner_adv"
 	req_tech = list(TECH_MATERIAL = 5, TECH_MAGNET = 4, TECH_POWER = 4, TECH_BLUESPACE = 2)
-	materials = list(DEFAULT_WALL_MATERIAL = 5000, "osmium" = 3000, "silver" = 1000)
+	materials = list(MAT_STEEL = 5000, "osmium" = 3000, "silver" = 1000)
 	build_path = /obj/item/mecha_parts/mecha_equipment/tool/orescanner/advanced
 
 /datum/design/item/mecha/runningboard
@@ -686,7 +686,7 @@
 	desc = "A running board with a power-lifter attachment, to quickly catapult exosuit pilots into the cockpit. Only fits to working exosuits."
 	id = "mech_runningboard"
 	req_tech = list(TECH_MATERIAL = 6)
-	materials = list(DEFAULT_WALL_MATERIAL = 10000)
+	materials = list(MAT_STEEL = 10000)
 	build_path = /obj/item/mecha_parts/mecha_equipment/runningboard/limited
 
 /datum/design/item/mecha/powerwrench
@@ -694,7 +694,7 @@
 	desc = "A large, hydraulic wrench."
 	id = "mech_wrench"
 	req_tech = list(TECH_MATERIAL = 2, TECH_ENGINEERING = 2, TECH_POWER = 2)
-	materials = list(DEFAULT_WALL_MATERIAL = 5000, "plastic" = 2000, "glass" = 1250)
+	materials = list(MAT_STEEL = 5000, "plastic" = 2000, "glass" = 1250)
 	build_path = /obj/item/mecha_parts/mecha_equipment/tool/powertool
 
 /datum/design/item/mecha/powercrowbar
@@ -702,7 +702,7 @@
 	desc = "A large, hydraulic prybar."
 	id = "mech_crowbar"
 	req_tech = list(TECH_MATERIAL = 2, TECH_ENGINEERING = 2, TECH_POWER = 2)
-	materials = list(DEFAULT_WALL_MATERIAL = 4000, "osmium" = 3000, "glass" = 1000)
+	materials = list(MAT_STEEL = 4000, "osmium" = 3000, "glass" = 1000)
 	build_path = /obj/item/mecha_parts/mecha_equipment/tool/powertool/prybar
 
 /datum/design/item/mecha/powercutters
@@ -710,7 +710,7 @@
 	desc = "A large, hydraulic cablecutter."
 	id = "mech_wirecutter"
 	req_tech = list(TECH_MATERIAL = 2, TECH_ENGINEERING = 2, TECH_POWER = 2)
-	materials = list(DEFAULT_WALL_MATERIAL = 4000, "osmium" = 3000, "glass" = 1000)
+	materials = list(MAT_STEEL = 4000, "osmium" = 3000, "glass" = 1000)
 	build_path = /obj/item/mecha_parts/mecha_equipment/tool/powertool/cutter
 
 /datum/design/item/mecha/powerscrewdriver
@@ -718,7 +718,7 @@
 	desc = "A large, hydraulic screwdriver."
 	id = "mech_screwdriver"
 	req_tech = list(TECH_MATERIAL = 2, TECH_ENGINEERING = 2, TECH_POWER = 2)
-	materials = list(DEFAULT_WALL_MATERIAL = 4000, "osmium" = 3000, "glass" = 1000)
+	materials = list(MAT_STEEL = 4000, "osmium" = 3000, "glass" = 1000)
 	build_path = /obj/item/mecha_parts/mecha_equipment/tool/powertool/screwdriver
 
 /datum/design/item/mecha/powerwelder
@@ -726,7 +726,7 @@
 	desc = "A large welding laser."
 	id = "mech_welder"
 	req_tech = list(TECH_MATERIAL = 2, TECH_ENGINEERING = 2, TECH_POWER = 2)
-	materials = list(DEFAULT_WALL_MATERIAL = 4000, MAT_PHORON = 3000, "glass" = 1000)
+	materials = list(MAT_STEEL = 4000, MAT_PHORON = 3000, "glass" = 1000)
 	build_path = /obj/item/mecha_parts/mecha_equipment/tool/powertool/welding
 
 /datum/design/item/mecha/inflatables
@@ -734,7 +734,7 @@
 	desc = "A large pneumatic inflatable deployer."
 	id = "mech_inflatables"
 	req_tech = list(TECH_MATERIAL = 2, TECH_ENGINEERING = 2, TECH_POWER = 2)
-	materials = list(DEFAULT_WALL_MATERIAL = 2000, MAT_PLASTIC = 4000, "glass" = 1000)
+	materials = list(MAT_STEEL = 2000, MAT_PLASTIC = 4000, "glass" = 1000)
 	build_path = /obj/item/mecha_parts/mecha_equipment/tool/powertool/inflatables
 
 /datum/design/item/mecha/hardpoint_clamp
@@ -750,7 +750,7 @@
 	desc = "Exosuit-held nuclear reactor. Converts uranium and everyone's health to energy."
 	id = "mech_generator_nuclear"
 	req_tech = list(TECH_POWER= 3, TECH_ENGINEERING = 3, TECH_MATERIAL = 3)
-	materials = list(DEFAULT_WALL_MATERIAL = 7500, "silver" = 375, "glass" = 750)
+	materials = list(MAT_STEEL = 7500, "silver" = 375, "glass" = 750)
 	build_path = /obj/item/mecha_parts/mecha_equipment/generator/nuclear
 
 /datum/design/item/mecha/speedboost_ripley
@@ -758,7 +758,7 @@
 	desc = "System enhancements and overdrives to make a mech's legs move faster."
 	id = "mech_speedboost_ripley"
 	req_tech = list( TECH_POWER = 5, TECH_MATERIAL = 4, TECH_ENGINEERING = 4)
-	materials = list(DEFAULT_WALL_MATERIAL = 10000, "silver" = 1000, "gold" = 1000)
+	materials = list(MAT_STEEL = 10000, "silver" = 1000, "gold" = 1000)
 	build_path = /obj/item/mecha_parts/mecha_equipment/speedboost
 
 /datum/design/item/synthetic_flash
@@ -766,7 +766,7 @@
 	id = "sflash"
 	req_tech = list(TECH_MAGNET = 3, TECH_COMBAT = 2)
 	build_type = MECHFAB
-	materials = list(DEFAULT_WALL_MATERIAL = 562, "glass" = 562)
+	materials = list(MAT_STEEL = 562, "glass" = 562)
 	build_path = /obj/item/device/flash/synthetic
 	category = "Misc"
 
@@ -784,7 +784,7 @@
 	desc = "A space-bike's un-assembled frame."
 	id = "vehicle_chassis_spacebike"
 	req_tech = list(TECH_MATERIAL = 5, TECH_ENGINEERING = 6, TECH_BLUESPACE = 3, TECH_PHORON = 3)
-	materials = list(DEFAULT_WALL_MATERIAL = 12000, "silver" = 3000, "phoron" = 3000, "osmium" = 1000)
+	materials = list(MAT_STEEL = 12000, "silver" = 3000, "phoron" = 3000, "osmium" = 1000)
 	build_path = /obj/item/weapon/vehicle_assembly/spacebike
 
 /datum/design/item/mechfab/vehicle/quadbike_chassis
@@ -792,7 +792,7 @@
 	desc = "A space-bike's un-assembled frame."
 	id = "vehicle_chassis_quadbike"
 	req_tech = list(TECH_MATERIAL = 5, TECH_ENGINEERING = 6, TECH_MAGNET = 3, TECH_POWER = 2)
-	materials = list(DEFAULT_WALL_MATERIAL = 15000, "silver" = 3000, "plastic" = 3000, "osmium" = 1000)
+	materials = list(MAT_STEEL = 15000, "silver" = 3000, "plastic" = 3000, "osmium" = 1000)
 	build_path = /obj/item/weapon/vehicle_assembly/quadbike
 
 /*
@@ -1047,7 +1047,7 @@
 	build_path = /obj/item/device/uav
 	time = 20
 	req_tech = list(TECH_MATERIAL = 6, TECH_ENGINEERING = 5, TECH_PHORON = 3, TECH_MAGNET = 4, TECH_POWER = 6)
-	materials = list(DEFAULT_WALL_MATERIAL = 10000, "glass" = 6000, "silver" = 4000)
+	materials = list(MAT_STEEL = 10000, "glass" = 6000, "silver" = 4000)
 
 // Exosuit Internals
 
@@ -1061,7 +1061,7 @@
 	category = "Exosuit Internals"
 	id = "exo_int_armor_standard"
 	req_tech = list(TECH_MATERIAL = 2, TECH_ENGINEERING = 2)
-	materials = list(DEFAULT_WALL_MATERIAL = 10000)
+	materials = list(MAT_STEEL = 10000)
 	build_path = /obj/item/mecha_parts/component/armor
 
 /datum/design/item/mechfab/exointernal/light_armor
@@ -1069,7 +1069,7 @@
 	category = "Exosuit Internals"
 	id = "exo_int_armor_lightweight"
 	req_tech = list(TECH_MATERIAL = 2, TECH_ENGINEERING = 3)
-	materials = list(DEFAULT_WALL_MATERIAL = 5000, MAT_PLASTIC = 3000)
+	materials = list(MAT_STEEL = 5000, MAT_PLASTIC = 3000)
 	build_path = /obj/item/mecha_parts/component/armor/lightweight
 
 /datum/design/item/mechfab/exointernal/reinf_armor
@@ -1077,7 +1077,7 @@
 	category = "Exosuit Internals"
 	id = "exo_int_armor_reinforced"
 	req_tech = list(TECH_MATERIAL = 4, TECH_ENGINEERING = 4)
-	materials = list(DEFAULT_WALL_MATERIAL = 20000, MAT_PLASTEEL = 10000)
+	materials = list(MAT_STEEL = 20000, MAT_PLASTEEL = 10000)
 	build_path = /obj/item/mecha_parts/component/armor/reinforced
 
 /datum/design/item/mechfab/exointernal/mining_armor
@@ -1085,7 +1085,7 @@
 	category = "Exosuit Internals"
 	id = "exo_int_armor_blast"
 	req_tech = list(TECH_MATERIAL = 4, TECH_ENGINEERING = 4)
-	materials = list(DEFAULT_WALL_MATERIAL = 20000, MAT_PLASTEEL = 10000)
+	materials = list(MAT_STEEL = 20000, MAT_PLASTEEL = 10000)
 	build_path = /obj/item/mecha_parts/component/armor/mining
 
 /datum/design/item/mechfab/exointernal/gygax_armor
@@ -1093,7 +1093,7 @@
 	category = "Exosuit Internals"
 	id = "exo_int_armor_gygax"
 	req_tech = list(TECH_MATERIAL = 5, TECH_ENGINEERING = 4, TECH_COMBAT = 2)
-	materials = list(DEFAULT_WALL_MATERIAL = 40000, MAT_DIAMOND = 8000)
+	materials = list(MAT_STEEL = 40000, MAT_DIAMOND = 8000)
 	build_path = /obj/item/mecha_parts/component/armor/marshal
 
 /datum/design/item/mechfab/exointernal/darkgygax_armor
@@ -1108,7 +1108,7 @@
 	name = "Armor Plate (Military)"
 	id = "exo_int_armor_durand"
 	req_tech = list(TECH_MATERIAL = 5, TECH_ENGINEERING = 4, TECH_COMBAT = 2)
-	materials = list(DEFAULT_WALL_MATERIAL = 40000, MAT_PLASTEEL = 9525, "uranium" = 8000)
+	materials = list(MAT_STEEL = 40000, MAT_PLASTEEL = 9525, "uranium" = 8000)
 	build_path = /obj/item/mecha_parts/component/armor/military
 
 /datum/design/item/mechfab/exointernal/marauder_armour
@@ -1130,7 +1130,7 @@
 	category = "Exosuit Internals"
 	id = "exo_int_hull_standard"
 	req_tech = list(TECH_MATERIAL = 2, TECH_ENGINEERING = 2)
-	materials = list(DEFAULT_WALL_MATERIAL = 10000)
+	materials = list(MAT_STEEL = 10000)
 	build_path = /obj/item/mecha_parts/component/hull
 
 /datum/design/item/mechfab/exointernal/durable_hull
@@ -1138,7 +1138,7 @@
 	category = "Exosuit Internals"
 	id = "exo_int_hull_durable"
 	req_tech = list(TECH_MATERIAL = 2, TECH_ENGINEERING = 2)
-	materials = list(DEFAULT_WALL_MATERIAL = 8000, MAT_PLASTEEL = 5000)
+	materials = list(MAT_STEEL = 8000, MAT_PLASTEEL = 5000)
 	build_path = /obj/item/mecha_parts/component/hull/durable
 
 /datum/design/item/mechfab/exointernal/light_hull
@@ -1146,7 +1146,7 @@
 	category = "Exosuit Internals"
 	id = "exo_int_hull_light"
 	req_tech = list(TECH_MATERIAL = 3, TECH_ENGINEERING = 4)
-	materials = list(DEFAULT_WALL_MATERIAL = 5000, MAT_PLASTIC = 3000)
+	materials = list(MAT_STEEL = 5000, MAT_PLASTIC = 3000)
 	build_path = /obj/item/mecha_parts/component/hull/lightweight
 
 /datum/design/item/mechfab/exointernal/stan_gas
@@ -1154,7 +1154,7 @@
 	category = "Exosuit Internals"
 	id = "exo_int_lifesup_standard"
 	req_tech = list(TECH_MATERIAL = 2, TECH_ENGINEERING = 2)
-	materials = list(DEFAULT_WALL_MATERIAL = 10000)
+	materials = list(MAT_STEEL = 10000)
 	build_path = /obj/item/mecha_parts/component/gas
 
 /datum/design/item/mechfab/exointernal/reinf_gas
@@ -1162,7 +1162,7 @@
 	category = "Exosuit Internals"
 	id = "exo_int_lifesup_reinforced"
 	req_tech = list(TECH_MATERIAL = 4, TECH_ENGINEERING = 4)
-	materials = list(DEFAULT_WALL_MATERIAL = 8000, MAT_PLASTEEL = 8000, MAT_GRAPHITE = 1000)
+	materials = list(MAT_STEEL = 8000, MAT_PLASTEEL = 8000, MAT_GRAPHITE = 1000)
 	build_path = /obj/item/mecha_parts/component/gas/reinforced
 
 /datum/design/item/mechfab/exointernal/stan_electric
@@ -1170,7 +1170,7 @@
 	category = "Exosuit Internals"
 	id = "exo_int_electric_standard"
 	req_tech = list(TECH_POWER = 2, TECH_ENGINEERING = 2)
-	materials = list(DEFAULT_WALL_MATERIAL = 5000, MAT_PLASTIC = 1000)
+	materials = list(MAT_STEEL = 5000, MAT_PLASTIC = 1000)
 	build_path = /obj/item/mecha_parts/component/electrical
 
 /datum/design/item/mechfab/exointernal/efficient_electric
@@ -1178,7 +1178,7 @@
 	category = "Exosuit Internals"
 	id = "exo_int_electric_efficient"
 	req_tech = list(TECH_POWER = 4, TECH_ENGINEERING = 4, TECH_DATA = 2)
-	materials = list(DEFAULT_WALL_MATERIAL = 5000, MAT_PLASTIC = 3000, MAT_SILVER = 3000)
+	materials = list(MAT_STEEL = 5000, MAT_PLASTIC = 3000, MAT_SILVER = 3000)
 	build_path = /obj/item/mecha_parts/component/electrical/high_current
 
 /datum/design/item/mechfab/exointernal/stan_actuator
@@ -1186,7 +1186,7 @@
 	category = "Exosuit Internals"
 	id = "exo_int_actuator_standard"
 	req_tech = list(TECH_MATERIAL = 2, TECH_ENGINEERING = 2)
-	materials = list(DEFAULT_WALL_MATERIAL = 10000)
+	materials = list(MAT_STEEL = 10000)
 	build_path = /obj/item/mecha_parts/component/actuator
 
 /datum/design/item/mechfab/exointernal/hispeed_actuator

--- a/code/modules/research/prosfab_designs.dm
+++ b/code/modules/research/prosfab_designs.dm
@@ -92,7 +92,7 @@
 //////////////////// Prosthetics ////////////////////
 /datum/design/item/prosfab/pros/torso
 	time = 35
-	materials = list(DEFAULT_WALL_MATERIAL = 30000, "glass" = 7500)
+	materials = list(MAT_STEEL = 30000, "glass" = 7500)
 //	req_tech = list(TECH_ENGINEERING = 2, TECH_MATERIAL = 3, TECH_DATA = 3)	//Saving the values just in case
 	var/gender = MALE
 
@@ -115,7 +115,7 @@
 	id = "pros_head"
 	build_path = /obj/item/organ/external/head
 	time = 30
-	materials = list(DEFAULT_WALL_MATERIAL = 18750, "glass" = 3750)
+	materials = list(MAT_STEEL = 18750, "glass" = 3750)
 //	req_tech = list(TECH_ENGINEERING = 2, TECH_MATERIAL = 3, TECH_DATA = 3)	//Saving the values just in case
 
 /datum/design/item/prosfab/pros/l_arm
@@ -123,56 +123,56 @@
 	id = "pros_l_arm"
 	build_path = /obj/item/organ/external/arm
 	time = 20
-	materials = list(DEFAULT_WALL_MATERIAL = 10125)
+	materials = list(MAT_STEEL = 10125)
 
 /datum/design/item/prosfab/pros/l_hand
 	name = "Prosthetic Left Hand"
 	id = "pros_l_hand"
 	build_path = /obj/item/organ/external/hand
 	time = 15
-	materials = list(DEFAULT_WALL_MATERIAL = 3375)
+	materials = list(MAT_STEEL = 3375)
 
 /datum/design/item/prosfab/pros/r_arm
 	name = "Prosthetic Right Arm"
 	id = "pros_r_arm"
 	build_path = /obj/item/organ/external/arm/right
 	time = 20
-	materials = list(DEFAULT_WALL_MATERIAL = 10125)
+	materials = list(MAT_STEEL = 10125)
 
 /datum/design/item/prosfab/pros/r_hand
 	name = "Prosthetic Right Hand"
 	id = "pros_r_hand"
 	build_path = /obj/item/organ/external/hand/right
 	time = 15
-	materials = list(DEFAULT_WALL_MATERIAL = 3375)
+	materials = list(MAT_STEEL = 3375)
 
 /datum/design/item/prosfab/pros/l_leg
 	name = "Prosthetic Left Leg"
 	id = "pros_l_leg"
 	build_path = /obj/item/organ/external/leg
 	time = 20
-	materials = list(DEFAULT_WALL_MATERIAL = 8437)
+	materials = list(MAT_STEEL = 8437)
 
 /datum/design/item/prosfab/pros/l_foot
 	name = "Prosthetic Left Foot"
 	id = "pros_l_foot"
 	build_path = /obj/item/organ/external/foot
 	time = 15
-	materials = list(DEFAULT_WALL_MATERIAL = 2813)
+	materials = list(MAT_STEEL = 2813)
 
 /datum/design/item/prosfab/pros/r_leg
 	name = "Prosthetic Right Leg"
 	id = "pros_r_leg"
 	build_path = /obj/item/organ/external/leg/right
 	time = 20
-	materials = list(DEFAULT_WALL_MATERIAL = 8437)
+	materials = list(MAT_STEEL = 8437)
 
 /datum/design/item/prosfab/pros/r_foot
 	name = "Prosthetic Right Foot"
 	id = "pros_r_foot"
 	build_path = /obj/item/organ/external/foot/right
 	time = 15
-	materials = list(DEFAULT_WALL_MATERIAL = 2813)
+	materials = list(MAT_STEEL = 2813)
 
 /datum/design/item/prosfab/pros/internal
 	category = "Prosthetics, Internal"
@@ -182,7 +182,7 @@
 	id = "pros_cell"
 	build_path = /obj/item/organ/internal/cell
 	time = 15
-	materials = list(DEFAULT_WALL_MATERIAL = 7500, "glass" = 3000)
+	materials = list(MAT_STEEL = 7500, "glass" = 3000)
 //	req_tech = list(TECH_ENGINEERING = 2, TECH_MATERIAL = 2)
 
 /datum/design/item/prosfab/pros/internal/eyes
@@ -190,7 +190,7 @@
 	id = "pros_eyes"
 	build_path = /obj/item/organ/internal/eyes/robot
 	time = 15
-	materials = list(DEFAULT_WALL_MATERIAL = 5625, "glass" = 5625)
+	materials = list(MAT_STEEL = 5625, "glass" = 5625)
 //	req_tech = list(TECH_ENGINEERING = 2, TECH_MATERIAL = 2)
 
 /datum/design/item/prosfab/pros/internal/hydraulic
@@ -198,35 +198,35 @@
 	id = "pros_hydraulic"
 	build_path = /obj/item/organ/internal/heart/machine
 	time = 15
-	materials = list(DEFAULT_WALL_MATERIAL = 7500, MAT_PLASTIC = 3000)
+	materials = list(MAT_STEEL = 7500, MAT_PLASTIC = 3000)
 
 /datum/design/item/prosfab/pros/internal/reagcycler
 	name = "Reagent Cycler"
 	id = "pros_reagcycler"
 	build_path = /obj/item/organ/internal/stomach/machine
 	time = 15
-	materials = list(DEFAULT_WALL_MATERIAL = 7500, MAT_PLASTIC = 3000)
+	materials = list(MAT_STEEL = 7500, MAT_PLASTIC = 3000)
 
 /datum/design/item/prosfab/pros/internal/heatsink
 	name = "Heatsink"
 	id = "pros_heatsink"
 	build_path = /obj/item/organ/internal/robotic/heatsink
 	time = 15
-	materials = list(DEFAULT_WALL_MATERIAL = 7500, MAT_PLASTIC = 3000)
+	materials = list(MAT_STEEL = 7500, MAT_PLASTIC = 3000)
 
 /datum/design/item/prosfab/pros/internal/diagnostic
 	name = "Diagnostic Controller"
 	id = "pros_diagnostic"
 	build_path = /obj/item/organ/internal/robotic/diagnostic
 	time = 15
-	materials = list(DEFAULT_WALL_MATERIAL = 7500, MAT_PLASTIC = 3000)
+	materials = list(MAT_STEEL = 7500, MAT_PLASTIC = 3000)
 
 /datum/design/item/prosfab/pros/internal/heart
 	name = "Prosthetic Heart"
 	id = "pros_heart"
 	build_path = /obj/item/organ/internal/heart
 	time = 15
-	materials = list(DEFAULT_WALL_MATERIAL = 5625, "glass" = 1000)
+	materials = list(MAT_STEEL = 5625, "glass" = 1000)
 //	req_tech = list(TECH_ENGINEERING = 2, TECH_MATERIAL = 2)
 
 /datum/design/item/prosfab/pros/internal/lungs
@@ -234,7 +234,7 @@
 	id = "pros_lung"
 	build_path = /obj/item/organ/internal/lungs
 	time = 15
-	materials = list(DEFAULT_WALL_MATERIAL = 5625, "glass" = 1000)
+	materials = list(MAT_STEEL = 5625, "glass" = 1000)
 //	req_tech = list(TECH_ENGINEERING = 2, TECH_MATERIAL = 2)
 
 /datum/design/item/prosfab/pros/internal/liver
@@ -242,7 +242,7 @@
 	id = "pros_liver"
 	build_path = /obj/item/organ/internal/liver
 	time = 15
-	materials = list(DEFAULT_WALL_MATERIAL = 5625, "glass" = 1000)
+	materials = list(MAT_STEEL = 5625, "glass" = 1000)
 //	req_tech = list(TECH_ENGINEERING = 2, TECH_MATERIAL = 2)
 
 /datum/design/item/prosfab/pros/internal/kidneys
@@ -250,7 +250,7 @@
 	id = "pros_kidney"
 	build_path = /obj/item/organ/internal/kidneys
 	time = 15
-	materials = list(DEFAULT_WALL_MATERIAL = 5625, "glass" = 1000)
+	materials = list(MAT_STEEL = 5625, "glass" = 1000)
 //	req_tech = list(TECH_ENGINEERING = 2, TECH_MATERIAL = 2)
 
 /datum/design/item/prosfab/pros/internal/spleen
@@ -258,7 +258,7 @@
 	id = "pros_spleen"
 	build_path = /obj/item/organ/internal/spleen
 	time = 15
-	materials = list(DEFAULT_WALL_MATERIAL = 3000, MAT_GLASS = 750)
+	materials = list(MAT_STEEL = 3000, MAT_GLASS = 750)
 //	req_tech = list(TECH_ENGINEERING = 2, TECH_MATERIAL = 2)
 
 /datum/design/item/prosfab/pros/internal/larynx
@@ -266,62 +266,62 @@
 	id = "pros_larynx"
 	build_path = /obj/item/organ/internal/voicebox
 	time = 15
-	materials = list(DEFAULT_WALL_MATERIAL = 2000, MAT_GLASS = 750, MAT_PLASTIC = 500)
+	materials = list(MAT_STEEL = 2000, MAT_GLASS = 750, MAT_PLASTIC = 500)
 
 //////////////////// Cyborg Parts ////////////////////
 /datum/design/item/prosfab/cyborg
 	category = "Cyborg Parts"
 	time = 20
-	materials = list(DEFAULT_WALL_MATERIAL = 3750)
+	materials = list(MAT_STEEL = 3750)
 
 /datum/design/item/prosfab/cyborg/exoskeleton
 	name = "Robot Exoskeleton"
 	id = "robot_exoskeleton"
 	build_path = /obj/item/robot_parts/robot_suit
 	time = 50
-	materials = list(DEFAULT_WALL_MATERIAL = 37500)
+	materials = list(MAT_STEEL = 37500)
 
 /datum/design/item/prosfab/cyborg/torso
 	name = "Robot Torso"
 	id = "robot_torso"
 	build_path = /obj/item/robot_parts/chest
 	time = 35
-	materials = list(DEFAULT_WALL_MATERIAL = 30000)
+	materials = list(MAT_STEEL = 30000)
 
 /datum/design/item/prosfab/cyborg/head
 	name = "Robot Head"
 	id = "robot_head"
 	build_path = /obj/item/robot_parts/head
 	time = 35
-	materials = list(DEFAULT_WALL_MATERIAL = 18750)
+	materials = list(MAT_STEEL = 18750)
 
 /datum/design/item/prosfab/cyborg/l_arm
 	name = "Robot Left Arm"
 	id = "robot_l_arm"
 	build_path = /obj/item/robot_parts/l_arm
 	time = 20
-	materials = list(DEFAULT_WALL_MATERIAL = 13500)
+	materials = list(MAT_STEEL = 13500)
 
 /datum/design/item/prosfab/cyborg/r_arm
 	name = "Robot Right Arm"
 	id = "robot_r_arm"
 	build_path = /obj/item/robot_parts/r_arm
 	time = 20
-	materials = list(DEFAULT_WALL_MATERIAL = 13500)
+	materials = list(MAT_STEEL = 13500)
 
 /datum/design/item/prosfab/cyborg/l_leg
 	name = "Robot Left Leg"
 	id = "robot_l_leg"
 	build_path = /obj/item/robot_parts/l_leg
 	time = 20
-	materials = list(DEFAULT_WALL_MATERIAL = 11250)
+	materials = list(MAT_STEEL = 11250)
 
 /datum/design/item/prosfab/cyborg/r_leg
 	name = "Robot Right Leg"
 	id = "robot_r_leg"
 	build_path = /obj/item/robot_parts/r_leg
 	time = 20
-	materials = list(DEFAULT_WALL_MATERIAL = 11250)
+	materials = list(MAT_STEEL = 11250)
 
 
 //////////////////// Cyborg Internals ////////////////////
@@ -329,7 +329,7 @@
 	category = "Cyborg Internals"
 	build_type = PROSFAB
 	time = 12
-	materials = list(DEFAULT_WALL_MATERIAL = 7500)
+	materials = list(MAT_STEEL = 7500)
 
 /datum/design/item/prosfab/cyborg/component/binary_communication_device
 	name = "Binary Communication Device"
@@ -376,7 +376,7 @@
 	category = "Cyborg Modules"
 	build_type = PROSFAB
 	time = 12
-	materials = list(DEFAULT_WALL_MATERIAL = 7500)
+	materials = list(MAT_STEEL = 7500)
 
 /datum/design/item/prosfab/robot_upgrade/rename
 	name = "Rename Module"
@@ -394,35 +394,35 @@
 	name = "Emergency Restart Module"
 	desc = "Used to force a restart of a disabled-but-repaired robot, bringing it back online."
 	id = "borg_restart_module"
-	materials = list(DEFAULT_WALL_MATERIAL = 45000, "glass" = 3750)
+	materials = list(MAT_STEEL = 45000, "glass" = 3750)
 	build_path = /obj/item/borg/upgrade/restart
 
 /datum/design/item/prosfab/robot_upgrade/vtec
 	name = "VTEC Module"
 	desc = "Used to kick in a robot's VTEC systems, increasing their speed."
 	id = "borg_vtec_module"
-	materials = list(DEFAULT_WALL_MATERIAL = 60000, "glass" = 4500, "gold" = 3750)
+	materials = list(MAT_STEEL = 60000, "glass" = 4500, "gold" = 3750)
 	build_path = /obj/item/borg/upgrade/vtec
 
 /datum/design/item/prosfab/robot_upgrade/tasercooler
 	name = "Rapid Taser Cooling Module"
 	desc = "Used to cool a mounted taser, increasing the potential current in it and thus its recharge rate."
 	id = "borg_taser_module"
-	materials = list(DEFAULT_WALL_MATERIAL = 60000, "glass" = 4500, "gold" = 1500, "diamond" = 375)
+	materials = list(MAT_STEEL = 60000, "glass" = 4500, "gold" = 1500, "diamond" = 375)
 	build_path = /obj/item/borg/upgrade/tasercooler
 
 /datum/design/item/prosfab/robot_upgrade/jetpack
 	name = "Jetpack Module"
 	desc = "A carbon dioxide jetpack suitable for low-gravity mining operations."
 	id = "borg_jetpack_module"
-	materials = list(DEFAULT_WALL_MATERIAL = 7500, "phoron" = 11250, "uranium" = 15000)
+	materials = list(MAT_STEEL = 7500, "phoron" = 11250, "uranium" = 15000)
 	build_path = /obj/item/borg/upgrade/jetpack
 
 /datum/design/item/prosfab/robot_upgrade/advhealth
 	name = "Advanced Health Analyzer Module"
 	desc = "An advanced health analyzer suitable for diagnosing more serious injuries."
 	id = "borg_advhealth_module"
-	materials = list(DEFAULT_WALL_MATERIAL = 10000, "glass" = 6500, "diamond" = 350)
+	materials = list(MAT_STEEL = 10000, "glass" = 6500, "diamond" = 350)
 	build_path = /obj/item/borg/upgrade/advhealth
 
 /datum/design/item/prosfab/robot_upgrade/syndicate
@@ -430,7 +430,7 @@
 	desc = "Allows for the construction of lethal upgrades for cyborgs."
 	id = "borg_syndicate_module"
 	req_tech = list(TECH_COMBAT = 4, TECH_ILLEGAL = 3)
-	materials = list(DEFAULT_WALL_MATERIAL = 7500, "glass" = 11250, "diamond" = 7500)
+	materials = list(MAT_STEEL = 7500, "glass" = 11250, "diamond" = 7500)
 	build_path = /obj/item/borg/upgrade/syndicate
 
 /datum/design/item/prosfab/robot_upgrade/language
@@ -438,7 +438,7 @@
 	desc = "Used to let cyborgs other than clerical or service speak a variety of languages."
 	id = "borg_language_module"
 	req_tech = list(TECH_DATA = 6, TECH_MATERIAL = 6)
-	materials = list(DEFAULT_WALL_MATERIAL = 25000, "glass" = 3000, "gold" = 350)
+	materials = list(MAT_STEEL = 25000, "glass" = 3000, "gold" = 350)
 	build_path = /obj/item/borg/upgrade/language
 
 // Synthmorph Bags.
@@ -447,42 +447,42 @@
 	name = "Synthmorph Storage Bag"
 	desc = "Used to store or slowly defragment an FBP."
 	id = "misc_synth_bag"
-	materials = list(DEFAULT_WALL_MATERIAL = 250, "glass" = 250, "plastic" = 2000)
+	materials = list(MAT_STEEL = 250, "glass" = 250, "plastic" = 2000)
 	build_path = /obj/item/bodybag/cryobag/robobag
 
 /datum/design/item/prosfab/badge_nt
 	name = "NanoTrasen Tag"
 	desc = "Used to identify an empty NanoTrasen FBP."
 	id = "misc_synth_bag_tag_nt"
-	materials = list(DEFAULT_WALL_MATERIAL = 1000, "glass" = 500, "plastic" = 1000)
+	materials = list(MAT_STEEL = 1000, "glass" = 500, "plastic" = 1000)
 	build_path = /obj/item/clothing/accessory/badge/corporate_tag
 
 /datum/design/item/prosfab/badge_morph
 	name = "Morpheus Tag"
 	desc = "Used to identify an empty Morpheus FBP."
 	id = "misc_synth_bag_tag_morph"
-	materials = list(DEFAULT_WALL_MATERIAL = 1000, "glass" = 500, "plastic" = 1000)
+	materials = list(MAT_STEEL = 1000, "glass" = 500, "plastic" = 1000)
 	build_path = /obj/item/clothing/accessory/badge/corporate_tag/morpheus
 
 /datum/design/item/prosfab/badge_wardtaka
 	name = "Ward-Takahashi Tag"
 	desc = "Used to identify an empty Ward-Takahashi FBP."
 	id = "misc_synth_bag_tag_wardtaka"
-	materials = list(DEFAULT_WALL_MATERIAL = 1000, "glass" = 500, "plastic" = 1000)
+	materials = list(MAT_STEEL = 1000, "glass" = 500, "plastic" = 1000)
 	build_path = /obj/item/clothing/accessory/badge/corporate_tag/wardtaka
 
 /datum/design/item/prosfab/badge_zenghu
 	name = "Zeng-Hu Tag"
 	desc = "Used to identify an empty Zeng-Hu FBP."
 	id = "misc_synth_bag_tag_zenghu"
-	materials = list(DEFAULT_WALL_MATERIAL = 1000, "glass" = 500, "plastic" = 1000)
+	materials = list(MAT_STEEL = 1000, "glass" = 500, "plastic" = 1000)
 	build_path = /obj/item/clothing/accessory/badge/corporate_tag/zenghu
 
 /datum/design/item/prosfab/badge_gilthari
 	name = "Gilthari Tag"
 	desc = "Used to identify an empty Gilthari FBP."
 	id = "misc_synth_bag_tag_gilthari"
-	materials = list(DEFAULT_WALL_MATERIAL = 1000, "glass" = 500, "gold" = 1000)
+	materials = list(MAT_STEEL = 1000, "glass" = 500, "gold" = 1000)
 	build_path = /obj/item/clothing/accessory/badge/corporate_tag/gilthari
 	req_tech = list(TECH_MATERIAL = 4, TECH_ILLEGAL = 2, TECH_PHORON = 2)
 
@@ -490,7 +490,7 @@
 	name = "Vey-Medical Tag"
 	desc = "Used to identify an empty Vey-Medical FBP."
 	id = "misc_synth_bag_tag_veymed"
-	materials = list(DEFAULT_WALL_MATERIAL = 1000, "glass" = 500, "plastic" = 1000)
+	materials = list(MAT_STEEL = 1000, "glass" = 500, "plastic" = 1000)
 	build_path = /obj/item/clothing/accessory/badge/corporate_tag/veymed
 	req_tech = list(TECH_MATERIAL = 3, TECH_ILLEGAL = 1, TECH_BIO = 4)
 
@@ -498,26 +498,26 @@
 	name = "Hephaestus Tag"
 	desc = "Used to identify an empty Hephaestus FBP."
 	id = "misc_synth_bag_tag_heph"
-	materials = list(DEFAULT_WALL_MATERIAL = 1000, "glass" = 500, "plastic" = 1000)
+	materials = list(MAT_STEEL = 1000, "glass" = 500, "plastic" = 1000)
 	build_path = /obj/item/clothing/accessory/badge/corporate_tag/hephaestus
 
 /datum/design/item/prosfab/badge_grayson
 	name = "Grayson Tag"
 	desc = "Used to identify an empty Grayson FBP."
 	id = "misc_synth_bag_tag_grayson"
-	materials = list(DEFAULT_WALL_MATERIAL = 1000, "glass" = 500, "plastic" = 1000)
+	materials = list(MAT_STEEL = 1000, "glass" = 500, "plastic" = 1000)
 	build_path = /obj/item/clothing/accessory/badge/corporate_tag/grayson
 
 /datum/design/item/prosfab/badge_xion
 	name = "Xion Tag"
 	desc = "Used to identify an empty Xion FBP."
 	id = "misc_synth_bag_tag_xion"
-	materials = list(DEFAULT_WALL_MATERIAL = 1000, "glass" = 500, "plastic" = 1000)
+	materials = list(MAT_STEEL = 1000, "glass" = 500, "plastic" = 1000)
 	build_path = /obj/item/clothing/accessory/badge/corporate_tag/xion
 
 /datum/design/item/prosfab/badge_bishop
 	name = "Bishop Tag"
 	desc = "Used to identify an empty Bishop FBP."
 	id = "misc_synth_bag_tag_bishop"
-	materials = list(DEFAULT_WALL_MATERIAL = 500, "glass" = 2000, "plastic" = 500)
+	materials = list(MAT_STEEL = 500, "glass" = 2000, "plastic" = 500)
 	build_path = /obj/item/clothing/accessory/badge/corporate_tag/bishop

--- a/code/modules/research/protolathe.dm
+++ b/code/modules/research/protolathe.dm
@@ -15,7 +15,7 @@
 	var/mat_efficiency = 1
 	var/speed = 1
 
-	materials = list(DEFAULT_WALL_MATERIAL = 0, "glass" = 0, MAT_PLASTEEL = 0, "plastic" = 0, MAT_GRAPHITE = 0, "gold" = 0, "silver" = 0, "osmium" = 0, MAT_LEAD = 0, "phoron" = 0, "uranium" = 0, "diamond" = 0, MAT_DURASTEEL = 0, MAT_VERDANTIUM = 0, MAT_MORPHIUM = 0, MAT_METALHYDROGEN = 0, MAT_SUPERMATTER = 0)
+	materials = list(MAT_STEEL = 0, "glass" = 0, MAT_PLASTEEL = 0, "plastic" = 0, MAT_GRAPHITE = 0, "gold" = 0, "silver" = 0, "osmium" = 0, MAT_LEAD = 0, "phoron" = 0, "uranium" = 0, "diamond" = 0, MAT_DURASTEEL = 0, MAT_VERDANTIUM = 0, MAT_MORPHIUM = 0, MAT_METALHYDROGEN = 0, MAT_SUPERMATTER = 0)
 
 	hidden_materials = list(MAT_PLASTEEL, MAT_DURASTEEL, MAT_GRAPHITE, MAT_VERDANTIUM, MAT_MORPHIUM, MAT_METALHYDROGEN, MAT_SUPERMATTER)
 

--- a/code/modules/research/research.dm
+++ b/code/modules/research/research.dm
@@ -227,7 +227,7 @@ research holder datum.
 	item_state = "card-id"
 	randpixel = 5
 	w_class = ITEMSIZE_SMALL
-	matter = list(DEFAULT_WALL_MATERIAL = 30, "glass" = 10)
+	matter = list(MAT_STEEL = 30, "glass" = 10)
 	var/datum/tech/stored
 
 /obj/item/weapon/disk/tech_disk/New()
@@ -241,7 +241,7 @@ research holder datum.
 	item_state = "card-id"
 	randpixel = 5
 	w_class = ITEMSIZE_SMALL
-	matter = list(DEFAULT_WALL_MATERIAL = 30, "glass" = 10)
+	matter = list(MAT_STEEL = 30, "glass" = 10)
 	var/datum/design/blueprint
 
 /obj/item/weapon/disk/design_disk/New()

--- a/code/modules/tables/presets.dm
+++ b/code/modules/tables/presets.dm
@@ -12,7 +12,7 @@
 	color = "#666666"
 
 /obj/structure/table/steel/New()
-	material = get_material_by_name(DEFAULT_WALL_MATERIAL)
+	material = get_material_by_name(MAT_STEEL)
 	..()
 
 /obj/structure/table/marble
@@ -29,7 +29,7 @@
 
 /obj/structure/table/reinforced/New()
 	material = get_material_by_name(DEFAULT_TABLE_MATERIAL)
-	reinforced = get_material_by_name(DEFAULT_WALL_MATERIAL)
+	reinforced = get_material_by_name(MAT_STEEL)
 	..()
 
 /obj/structure/table/steel_reinforced
@@ -37,8 +37,8 @@
 	color = "#666666"
 
 /obj/structure/table/steel_reinforced/New()
-	material = get_material_by_name(DEFAULT_WALL_MATERIAL)
-	reinforced = get_material_by_name(DEFAULT_WALL_MATERIAL)
+	material = get_material_by_name(MAT_STEEL)
+	reinforced = get_material_by_name(MAT_STEEL)
 	..()
 
 /obj/structure/table/wooden_reinforced
@@ -47,7 +47,7 @@
 
 /obj/structure/table/wooden_reinforced/New()
 	material = get_material_by_name("wood")
-	reinforced = get_material_by_name(DEFAULT_WALL_MATERIAL)
+	reinforced = get_material_by_name(MAT_STEEL)
 	..()
 
 /obj/structure/table/woodentable
@@ -72,7 +72,7 @@
 
 /obj/structure/table/sifwooden_reinforced/New()
 	material = get_material_by_name("alien wood")
-	reinforced = get_material_by_name(DEFAULT_WALL_MATERIAL)
+	reinforced = get_material_by_name(MAT_STEEL)
 	..()
 
 /obj/structure/table/gamblingtable
@@ -97,14 +97,14 @@
 	color = "#EEEEEE"
 
 /obj/structure/table/holotable/New()
-	material = get_material_by_name("holo[DEFAULT_TABLE_MATERIAL]")
+	material = get_material_by_name("holo" + DEFAULT_TABLE_MATERIAL)
 	..()
 
 /obj/structure/table/woodentable/holotable
 	icon_state = "holo_preview"
 
 /obj/structure/table/woodentable/holotable/New()
-	material = get_material_by_name("holowood")
+	material = get_material_by_name("holo" + MAT_WOOD)
 	..()
 
 /obj/structure/table/alien
@@ -138,7 +138,7 @@
 	color = "#666666"
 
 /obj/structure/table/bench/steel/New()
-	material = get_material_by_name(DEFAULT_WALL_MATERIAL)
+	material = get_material_by_name(MAT_STEEL)
 	..()
 
 
@@ -156,7 +156,7 @@
 
 /obj/structure/table/bench/reinforced/New()
 	material = get_material_by_name(DEFAULT_TABLE_MATERIAL)
-	reinforced = get_material_by_name(DEFAULT_WALL_MATERIAL)
+	reinforced = get_material_by_name(MAT_STEEL)
 	..()
 
 /obj/structure/table/bench/steel_reinforced
@@ -164,8 +164,8 @@
 	color = "#666666"
 
 /obj/structure/table/bench/steel_reinforced/New()
-	material = get_material_by_name(DEFAULT_WALL_MATERIAL)
-	reinforced = get_material_by_name(DEFAULT_WALL_MATERIAL)
+	material = get_material_by_name(MAT_STEEL)
+	reinforced = get_material_by_name(MAT_STEEL)
 	..()
 
 /obj/structure/table/bench/wooden_reinforced
@@ -174,7 +174,7 @@
 
 /obj/structure/table/bench/wooden_reinforced/New()
 	material = get_material_by_name("wood")
-	reinforced = get_material_by_name(DEFAULT_WALL_MATERIAL)
+	reinforced = get_material_by_name(MAT_STEEL)
 	..()
 */
 /obj/structure/table/bench/wooden
@@ -201,7 +201,7 @@
 	icon_state = "padded_preview"
 
 /obj/structure/table/bench/padded/New()
-	material = get_material_by_name(DEFAULT_WALL_MATERIAL)
+	material = get_material_by_name(MAT_STEEL)
 	carpeted = 1
 	..()
 

--- a/code/modules/tables/tables.dm
+++ b/code/modules/tables/tables.dm
@@ -320,7 +320,7 @@
 	if(full_return || prob(20))
 		new /obj/item/stack/material/steel(src.loc)
 	else
-		var/datum/material/M = get_material_by_name(DEFAULT_WALL_MATERIAL)
+		var/datum/material/M = get_material_by_name(MAT_STEEL)
 		S = M.place_shard(loc)
 		if(S) shards += S
 	qdel(src)

--- a/code/modules/xenoarcheaology/finds/find_spawning.dm
+++ b/code/modules/xenoarcheaology/finds/find_spawning.dm
@@ -21,8 +21,8 @@
 	var/apply_prefix = 1
 
 	if(prob(40))
-		material_descriptor = pick("rusted ","dusty ","archaic ","fragile ", "damaged", "pristine")
-	source_material = pick("cordite","quadrinium",DEFAULT_WALL_MATERIAL,"titanium","aluminium","ferritic-alloy","plasteel","duranium")
+		material_descriptor = pick("rusted ", "dusty ", "archaic ", "fragile ", "damaged", "pristine")
+	source_material = pick("cordite", "quadrinium", MAT_STEEL, MAT_TITANIUM, MAT_ALIMUMIN, "ferritic-alloy", MAT_PLASTEEL, "duranium")
 
 	var/talkative = 0
 	if(prob(5))
@@ -477,7 +477,7 @@
 			var/new_boat_mat = pickweight(list(
 				MAT_WOOD = 100,
 				MAT_SIFWOOD = 200,
-				DEFAULT_WALL_MATERIAL = 60,
+				MAT_STEEL = 60,
 				MAT_URANIUM = 14,
 				MAT_MARBLE = 16,
 				MAT_GOLD = 20,
@@ -583,7 +583,7 @@
 
 	if(istype(new_item, /obj/item/weapon/material))
 		var/new_item_mat = pickweight(list(
-			DEFAULT_WALL_MATERIAL = 80,
+			MAT_STEEL = 80,
 			MAT_WOOD = 20,
 			MAT_SIFWOOD = 40,
 			MAT_URANIUM = 14,
@@ -612,7 +612,7 @@
 
 	var/decorations = ""
 	if(apply_material_decorations)
-		source_material = pick("cordite","quadrinium",DEFAULT_WALL_MATERIAL,"titanium","aluminium","ferritic-alloy","plasteel","duranium")
+		source_material = pick("cordite","quadrinium",MAT_STEEL,"titanium","aluminium","ferritic-alloy","plasteel","duranium")
 
 		if(istype(new_item, /obj/item/weapon/material))
 			var/obj/item/weapon/material/MW = new_item

--- a/code/modules/xenoarcheaology/finds/find_spawning.dm
+++ b/code/modules/xenoarcheaology/finds/find_spawning.dm
@@ -22,7 +22,7 @@
 
 	if(prob(40))
 		material_descriptor = pick("rusted ", "dusty ", "archaic ", "fragile ", "damaged", "pristine")
-	source_material = pick("cordite", "quadrinium", MAT_STEEL, MAT_TITANIUM, MAT_ALIMUMIN, "ferritic-alloy", MAT_PLASTEEL, "duranium")
+	source_material = pick("cordite", "quadrinium", MAT_STEEL, MAT_TITANIUM, MAT_ALUMINIUM, "ferritic-alloy", MAT_PLASTEEL, "duranium")
 
 	var/talkative = 0
 	if(prob(5))

--- a/code/modules/xenoarcheaology/tools/tools.dm
+++ b/code/modules/xenoarcheaology/tools/tools.dm
@@ -4,7 +4,7 @@
 	icon = 'icons/obj/xenoarchaeology.dmi'
 	icon_state = "measuring"
 	origin_tech = list(TECH_MATERIAL = 1)
-	matter = list(DEFAULT_WALL_MATERIAL = 100)
+	matter = list(MAT_STEEL = 100)
 	w_class = ITEMSIZE_SMALL
 
 /obj/item/weapon/storage/bag/fossils
@@ -37,7 +37,7 @@
 	icon_state = "flashgun"
 	item_state = "lampgreen"
 	origin_tech = list(TECH_BLUESPACE = 3, TECH_MAGNET = 3)
-	matter = list(DEFAULT_WALL_MATERIAL = 10000,"glass" = 5000)
+	matter = list(MAT_STEEL = 10000,"glass" = 5000)
 	w_class = ITEMSIZE_SMALL
 	slot_flags = SLOT_BELT
 
@@ -95,7 +95,7 @@
 	icon_state = "depth_scanner"
 	item_state = "analyzer"
 	origin_tech = list(TECH_MAGNET = 2, TECH_ENGINEERING = 2, TECH_BLUESPACE = 2)
-	matter = list(DEFAULT_WALL_MATERIAL = 1000,"glass" = 1000)
+	matter = list(MAT_STEEL = 1000,"glass" = 1000)
 	w_class = ITEMSIZE_SMALL
 	slot_flags = SLOT_BELT
 	var/list/positive_locations = list()
@@ -222,7 +222,7 @@
 	icon_state = "pinoff"	//pinonfar, pinonmedium, pinonclose, pinondirect, pinonnull
 	item_state = "electronic"
 	origin_tech = list(TECH_MAGNET = 3, TECH_ENGINEERING = 2, TECH_BLUESPACE = 3)
-	matter = list(DEFAULT_WALL_MATERIAL = 1000,"glass" = 500)
+	matter = list(MAT_STEEL = 1000,"glass" = 500)
 	var/frequency = PUB_FREQ
 	var/scan_ticks = 0
 	var/obj/item/device/radio/target_radio
@@ -318,7 +318,7 @@
 	item_state = "lampgreen"
 	icon = 'icons/obj/xenoarchaeology.dmi'
 	origin_tech = list(TECH_MAGNET = 3, TECH_ENGINEERING = 3, TECH_BLUESPACE = 2)
-	matter = list(DEFAULT_WALL_MATERIAL = 10000,"glass" = 5000)
+	matter = list(MAT_STEEL = 10000,"glass" = 5000)
 	w_class = ITEMSIZE_SMALL
 	slot_flags = SLOT_BELT
 	var/mode = 1 //Start off scanning. 1 = scanning, 0 = measuring


### PR DESCRIPTION
Oh boy, here I go messing with materials again.
This is almost entirely arbitrary but I think I got everything that shouldn't logically be "whatever the default wall material is supposed to be" (Which is actually pretty limited in scope)
Also redefines the default wall and table defines in terms of the MAT_ defines that are actually supposed to be the sources of truth.
Also touches up floorbot code a little bit because I saw that it was bad and made it a little less bad.
@Mechoid this isn't hard to review because I just find-replaced a bunch of stuff +/- some bits, but it does need careful review because it touches a lot of things and I shouldn't be the only one to judge whether or not something should be strictly dependent upon the default wall material or not. One very notable exception I made was in the RCD contents, since that's actually used to make walls and floors.

Eventually I want to make recipes into decls and unify the various types of recipes (probably in line with the assembled recipes being ported from /tg/? Subject to learning more about how those are structured), but for the moment my current task is to remove the material sheet recipes from the autolathe and add menu buttons like the protolathe has to eject materials. Presently materials can only be removed by the `materials` category, due to mechoid's recent generalization of how those recipes were generated, and this is unintuitive and bad. I'm also considering making some sort of #define syntax for materials similar to subsystems, because there's still a lot of distributed material code that I kinda want to unify.