### PR TITLE
Medicine Tweaks

### DIFF
--- a/code/datums/uplink/medical.dm
+++ b/code/datums/uplink/medical.dm
@@ -33,13 +33,24 @@
 /datum/uplink_item/item/medical/bonemeds
 	name = "Bone Repair injector"
 	item_cost = 10
-	path = /obj/item/weapon/reagent_containers/hypospray/autoinjector/biginjector/bonemed
+	path = /obj/item/weapon/reagent_containers/hypospray/autoinjector/bonemed
+
+/datum/uplink_item/item/medical/clonemeds
+	name = "Clone injector"
+	item_cost = 15
+	path = /obj/item/weapon/reagent_containers/hypospray/autoinjector/clonemed
 
 /datum/uplink_item/item/medical/bonemeds_case
 	name = "Bone Repair case"
 	item_cost = 20
 	desc = "A case of three osteodaxon injectors. Can rapidly remove and stow up to six injectors."
 	path = /obj/item/weapon/storage/quickdraw/syringe_case/bonemed
+
+/datum/uplink_item/item/medical/clonemeds_case
+	name = "Clone case"
+	item_cost = 30
+	desc = "A case of three rezadone injectors. Can rapidly remove and stow up to six injectors."
+	path = /obj/item/weapon/storage/quickdraw/syringe_case/clonemed
 
 /datum/uplink_item/item/medical/ambrosiadeusseeds
 	name = "Box of 7x ambrosia deus seed packets"

--- a/code/game/objects/items/weapons/storage/firstaid.dm
+++ b/code/game/objects/items/weapons/storage/firstaid.dm
@@ -163,7 +163,7 @@
 	name = "bone repair kit"
 	desc = "Contains chemicals to mend broken bones."
 	max_storage_space = ITEMSIZE_COST_SMALL * 7
-	starts_with = list(/obj/item/weapon/reagent_containers/hypospray/autoinjector/biginjector/bonemed = 8)
+	starts_with = list(/obj/item/weapon/reagent_containers/hypospray/autoinjector/bonemed = 8)
 
 /*
  * Pill Bottles

--- a/code/game/objects/items/weapons/storage/quickdraw.dm
+++ b/code/game/objects/items/weapons/storage/quickdraw.dm
@@ -92,7 +92,16 @@
 	desc = "A small case for safely carrying sharps around. This one is deluxe!"
 	max_w_class = ITEMSIZE_SMALL
 	starts_with = list(
-		/obj/item/weapon/reagent_containers/hypospray/autoinjector/biginjector/bonemed,
-		/obj/item/weapon/reagent_containers/hypospray/autoinjector/biginjector/bonemed,
-		/obj/item/weapon/reagent_containers/hypospray/autoinjector/biginjector/bonemed
+		/obj/item/weapon/reagent_containers/hypospray/autoinjector/bonemed,
+		/obj/item/weapon/reagent_containers/hypospray/autoinjector/bonemed,
+		/obj/item/weapon/reagent_containers/hypospray/autoinjector/bonemed
+	)
+
+/obj/item/weapon/storage/quickdraw/syringe_case/clonemed
+	desc = "A small case for safely carrying sharps around. This one is deluxe!"
+	max_w_class = ITEMSIZE_SMALL
+	starts_with = list(
+		/obj/item/weapon/reagent_containers/hypospray/autoinjector/clonemed,
+		/obj/item/weapon/reagent_containers/hypospray/autoinjector/clonemed,
+		/obj/item/weapon/reagent_containers/hypospray/autoinjector/clonemed
 	)

--- a/code/game/objects/random/unidentified/medicine.dm
+++ b/code/game/objects/random/unidentified/medicine.dm
@@ -63,7 +63,7 @@ much more likely to show up. This is done for several purposes;
 // Medicine belonging to a place still being occupied (or was recently), meaning the goods might still be fresh, and better.
 /obj/random/unidentified_medicine/fresh_medicine/item_to_spawn()
 	// More likely to get something good, and a chance to get rare medicines.
-	// 75 Good, 25 Bad. 75% chance of getting something good.
+	// 80 Good, 25 Bad. 76% chance of getting something good.
 	// Good odds, but the contents aren't super great unless someone gets lucky.
 	return pick(
 		prob(5);/obj/item/weapon/reagent_containers/hypospray/autoinjector/bonemed/unidentified,
@@ -84,7 +84,7 @@ much more likely to show up. This is done for several purposes;
 	// 75 Good, 30 Bad, roughly 71.4% chance to get something good.
 	// Very high but very hard to reach and still has a chance of ending poorly if injecting blind.
 	return pick(
-		prob(10);/obj/item/weapon/reagent_containers/hypospray/autoinjector/bonemed/unidentified,
+		prob(5);/obj/item/weapon/reagent_containers/hypospray/autoinjector/bonemed/unidentified,
 		prob(5);/obj/item/weapon/reagent_containers/hypospray/autoinjector/clonemed/unidentified,
 		prob(5);/obj/item/weapon/reagent_containers/hypospray/autoinjector/biginjector/brute/unidentified,
 		prob(5);/obj/item/weapon/reagent_containers/hypospray/autoinjector/biginjector/burn/unidentified,
@@ -98,7 +98,7 @@ much more likely to show up. This is done for several purposes;
 // Hyposprays found inside various illicit places.
 /obj/random/unidentified_medicine/drug_den/item_to_spawn()
 	// Combat stims are common, but so are nasty drugs.
-	// 65 Good, 160 Bad, roughly 28.8% to get something good.
+	// 70 Good, 160 Bad, roughly 30% to get something good.
 	// Poor odds, but there are a lot of these scattered in the drug dens and illegal chem labs.
 	return pick(
 		prob(5);/obj/item/weapon/reagent_containers/hypospray/autoinjector/bonemed/unidentified,
@@ -124,8 +124,8 @@ much more likely to show up. This is done for several purposes;
 	// 45 Good, 45 Bad, 50% chance to get something good.
 	// Do you feel lucky?
 	return pick(
-		prob(10);/obj/item/weapon/reagent_containers/hypospray/autoinjector/bonemed/unidentified,
-		prob(10);/obj/item/weapon/reagent_containers/hypospray/autoinjector/clonemed/unidentified,
+		prob(5);/obj/item/weapon/reagent_containers/hypospray/autoinjector/bonemed/unidentified,
+		prob(5);/obj/item/weapon/reagent_containers/hypospray/autoinjector/clonemed/unidentified,
 		prob(10);/obj/item/weapon/reagent_containers/hypospray/autoinjector/biginjector/organ/unidentified,
 		prob(10);/obj/item/weapon/reagent_containers/hypospray/autoinjector/biginjector/clotting/unidentified,
 		prob(10);/obj/item/weapon/reagent_containers/hypospray/autoinjector/biginjector/combat/unidentified,

--- a/code/game/objects/random/unidentified/medicine.dm
+++ b/code/game/objects/random/unidentified/medicine.dm
@@ -19,6 +19,8 @@ much more likely to show up. This is done for several purposes;
 
 /obj/random/unidentified_medicine/item_to_spawn()
 	return pick(
+		/obj/item/weapon/reagent_containers/hypospray/autoinjector/bonemed/unidentified,
+		/obj/item/weapon/reagent_containers/hypospray/autoinjector/clonemed/unidentified,
 		/obj/item/weapon/reagent_containers/hypospray/autoinjector/biginjector/brute/unidentified,
 		/obj/item/weapon/reagent_containers/hypospray/autoinjector/biginjector/burn/unidentified,
 		/obj/item/weapon/reagent_containers/hypospray/autoinjector/biginjector/toxin/unidentified,
@@ -27,7 +29,6 @@ much more likely to show up. This is done for several purposes;
 		/obj/item/weapon/reagent_containers/hypospray/autoinjector/biginjector/pain/unidentified,
 		/obj/item/weapon/reagent_containers/hypospray/autoinjector/biginjector/organ/unidentified,
 		/obj/item/weapon/reagent_containers/hypospray/autoinjector/biginjector/clotting/unidentified,
-		/obj/item/weapon/reagent_containers/hypospray/autoinjector/biginjector/bonemed/unidentified,
 		/obj/item/weapon/reagent_containers/hypospray/autoinjector/biginjector/combat/unidentified,
 		/obj/item/weapon/reagent_containers/hypospray/autoinjector/biginjector/healing_nanites/unidentified,
 		/obj/item/weapon/reagent_containers/hypospray/autoinjector/biginjector/stimm/unidentified,
@@ -65,6 +66,8 @@ much more likely to show up. This is done for several purposes;
 	// 75 Good, 25 Bad. 75% chance of getting something good.
 	// Good odds, but the contents aren't super great unless someone gets lucky.
 	return pick(
+		prob(5);/obj/item/weapon/reagent_containers/hypospray/autoinjector/bonemed/unidentified,
+		prob(5);/obj/item/weapon/reagent_containers/hypospray/autoinjector/clonemed/unidentified,
 		prob(10);/obj/item/weapon/reagent_containers/hypospray/autoinjector/biginjector/brute/unidentified,
 		prob(10);/obj/item/weapon/reagent_containers/hypospray/autoinjector/biginjector/burn/unidentified,
 		prob(10);/obj/item/weapon/reagent_containers/hypospray/autoinjector/biginjector/toxin/unidentified,
@@ -73,7 +76,6 @@ much more likely to show up. This is done for several purposes;
 		prob(10);/obj/item/weapon/reagent_containers/hypospray/autoinjector/biginjector/pain/unidentified,
 		prob(5);/obj/item/weapon/reagent_containers/hypospray/autoinjector/biginjector/organ/unidentified,
 		prob(5);/obj/item/weapon/reagent_containers/hypospray/autoinjector/biginjector/clotting/unidentified,
-		prob(5);/obj/item/weapon/reagent_containers/hypospray/autoinjector/biginjector/bonemed/unidentified,
 		prob(25);/obj/item/weapon/reagent_containers/hypospray/autoinjector/biginjector/expired/unidentified)
 
 // For military PoIs like BSD. High odds of good loot since those PoIs are really hard.
@@ -82,12 +84,13 @@ much more likely to show up. This is done for several purposes;
 	// 75 Good, 30 Bad, roughly 71.4% chance to get something good.
 	// Very high but very hard to reach and still has a chance of ending poorly if injecting blind.
 	return pick(
+		prob(10);/obj/item/weapon/reagent_containers/hypospray/autoinjector/bonemed/unidentified,
+		prob(5);/obj/item/weapon/reagent_containers/hypospray/autoinjector/clonemed/unidentified,
 		prob(5);/obj/item/weapon/reagent_containers/hypospray/autoinjector/biginjector/brute/unidentified,
 		prob(5);/obj/item/weapon/reagent_containers/hypospray/autoinjector/biginjector/burn/unidentified,
 		prob(5);/obj/item/weapon/reagent_containers/hypospray/autoinjector/biginjector/pain/unidentified,
 		prob(10);/obj/item/weapon/reagent_containers/hypospray/autoinjector/biginjector/organ/unidentified,
 		prob(10);/obj/item/weapon/reagent_containers/hypospray/autoinjector/biginjector/clotting/unidentified,
-		prob(10);/obj/item/weapon/reagent_containers/hypospray/autoinjector/biginjector/bonemed/unidentified,
 		prob(30);/obj/item/weapon/reagent_containers/hypospray/autoinjector/biginjector/combat/unidentified,
 		prob(10);/obj/item/weapon/reagent_containers/hypospray/autoinjector/biginjector/soporific/unidentified,
 		prob(30);/obj/item/weapon/reagent_containers/hypospray/autoinjector/biginjector/cyanide/unidentified)
@@ -98,10 +101,11 @@ much more likely to show up. This is done for several purposes;
 	// 65 Good, 160 Bad, roughly 28.8% to get something good.
 	// Poor odds, but there are a lot of these scattered in the drug dens and illegal chem labs.
 	return pick(
+		prob(5);/obj/item/weapon/reagent_containers/hypospray/autoinjector/bonemed/unidentified,
+		prob(5);/obj/item/weapon/reagent_containers/hypospray/autoinjector/clonemed/unidentified,
 		prob(10);/obj/item/weapon/reagent_containers/hypospray/autoinjector/biginjector/pain/unidentified,
 		prob(5);/obj/item/weapon/reagent_containers/hypospray/autoinjector/biginjector/organ/unidentified,
 		prob(5);/obj/item/weapon/reagent_containers/hypospray/autoinjector/biginjector/clotting/unidentified,
-		prob(5);/obj/item/weapon/reagent_containers/hypospray/autoinjector/biginjector/bonemed/unidentified,
 		prob(40);/obj/item/weapon/reagent_containers/hypospray/autoinjector/biginjector/combat/unidentified,
 		prob(20);/obj/item/weapon/reagent_containers/hypospray/autoinjector/biginjector/stimm/unidentified,
 		prob(20);/obj/item/weapon/reagent_containers/hypospray/autoinjector/biginjector/space_drugs/unidentified,
@@ -120,9 +124,10 @@ much more likely to show up. This is done for several purposes;
 	// 45 Good, 45 Bad, 50% chance to get something good.
 	// Do you feel lucky?
 	return pick(
+		prob(10);/obj/item/weapon/reagent_containers/hypospray/autoinjector/bonemed/unidentified,
+		prob(10);/obj/item/weapon/reagent_containers/hypospray/autoinjector/clonemed/unidentified,
 		prob(10);/obj/item/weapon/reagent_containers/hypospray/autoinjector/biginjector/organ/unidentified,
 		prob(10);/obj/item/weapon/reagent_containers/hypospray/autoinjector/biginjector/clotting/unidentified,
-		prob(10);/obj/item/weapon/reagent_containers/hypospray/autoinjector/biginjector/bonemed/unidentified,
 		prob(10);/obj/item/weapon/reagent_containers/hypospray/autoinjector/biginjector/combat/unidentified,
 		prob(5);/obj/item/weapon/reagent_containers/hypospray/autoinjector/biginjector/healing_nanites/unidentified,
 		prob(20);/obj/item/weapon/reagent_containers/hypospray/autoinjector/biginjector/contaminated/unidentified,

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -179,6 +179,17 @@
 	icon_state = "green"
 	filled_reagents = list("anti_toxin" = 5)
 
+//Special autoinjectors, while having potent chems like the 15u ones, the chems are usually potent enough that 5u is enough
+/obj/item/weapon/reagent_containers/hypospray/autoinjector/bonemed
+	name = "bone repair injector"
+	desc = "A rapid and safe way to administer small amounts of drugs by untrained or trained personnel. This one excels at treating damage to bones."
+	filled_reagents = list("osteodaxon" = 5)
+
+/obj/item/weapon/reagent_containers/hypospray/autoinjector/clonemed
+	name = "clone injector"
+	desc = "A rapid and safe way to administer small amounts of drugs by untrained or trained personnel. This one excels at treating genetic damage."
+	filled_reagents = list("rezadone" = 5)
+
 // These have a 15u capacity, somewhat higher tech level, and generally more useful chems, but are otherwise the same as the regular autoinjectors.
 /obj/item/weapon/reagent_containers/hypospray/autoinjector/biginjector
 	name = "empty hypo"
@@ -239,11 +250,6 @@
 	name = "clotting agent"
 	desc = "A refined version of the standard autoinjector, allowing greater capacity. This variant excels at treating bleeding wounds and internal bleeding."
 	filled_reagents = list("inaprovaline" = 5, "myelamine" = 10)
-
-/obj/item/weapon/reagent_containers/hypospray/autoinjector/biginjector/bonemed
-	name = "bone repair injector"
-	desc = "A refined version of the standard autoinjector, allowing greater capacity. This one excels at treating damage to bones."
-	filled_reagents = list("inaprovaline" = 5, "osteodaxon" = 10)
 
 /obj/item/weapon/reagent_containers/hypospray/autoinjector/biginjector/glucose
 	name = "glucose hypo"

--- a/code/modules/reagents/reagent_containers/unidentified_hypospray.dm
+++ b/code/modules/reagents/reagent_containers/unidentified_hypospray.dm
@@ -5,6 +5,14 @@
 	identity_type = /datum/identification/hypo
 
 // The good.
+/obj/item/weapon/reagent_containers/hypospray/autoinjector/bonemed/unidentified
+	init_hide_identity = TRUE
+	flags = 0
+
+/obj/item/weapon/reagent_containers/hypospray/autoinjector/clonemed/unidentified
+	init_hide_identity = TRUE
+	flags = 0
+
 /obj/item/weapon/reagent_containers/hypospray/autoinjector/biginjector/brute/unidentified
 	init_hide_identity = TRUE
 	flags = 0
@@ -34,10 +42,6 @@
 	flags = 0
 
 /obj/item/weapon/reagent_containers/hypospray/autoinjector/biginjector/clotting/unidentified
-	init_hide_identity = TRUE
-	flags = 0
-
-/obj/item/weapon/reagent_containers/hypospray/autoinjector/biginjector/bonemed/unidentified
 	init_hide_identity = TRUE
 	flags = 0
 

--- a/code/modules/reagents/reagents/medicine.dm
+++ b/code/modules/reagents/reagents/medicine.dm
@@ -8,7 +8,7 @@
 	reagent_state = LIQUID
 	color = "#00BFFF"
 	overdose = REAGENTS_OVERDOSE * 2
-	metabolism = REM * 0.5
+	metabolism = REM * 0.1
 	scannable = 1
 
 /datum/reagent/inaprovaline/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
@@ -24,9 +24,9 @@
 	reagent_state = LIQUID
 	color = "#00BFFF"
 	overdose = REAGENTS_OVERDOSE * 2
-	metabolism = REM * 0.5
+	metabolism = REM * 0.1
 	scannable = 1
-	touch_met = REM * 0.75
+	touch_met = REM * 0.15
 	can_overdose_touch = TRUE
 
 /datum/reagent/inaprovaline/topical/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
@@ -60,7 +60,7 @@
 
 /datum/reagent/bicaridine/overdose(var/mob/living/carbon/M, var/alien, var/removed)
 	..()
-	var/wound_heal = 1.5 * removed
+	var/wound_heal = 2.5 * removed
 	M.eye_blurry = min(M.eye_blurry + wound_heal, 250)
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
@@ -730,7 +730,7 @@
 	overdose = REAGENTS_OVERDOSE * 0.5
 	overdose_mod = 1.5
 	scannable = 1
-	var/repair_strength = 3
+	var/repair_strength = 5
 
 /datum/reagent/myelamine/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	if(alien == IS_DIONA)

--- a/code/modules/reagents/reagents/medicine.dm
+++ b/code/modules/reagents/reagents/medicine.dm
@@ -8,7 +8,7 @@
 	reagent_state = LIQUID
 	color = "#00BFFF"
 	overdose = REAGENTS_OVERDOSE * 2
-	metabolism = REM * 0.1
+	metabolism = REM * 0.2
 	scannable = 1
 
 /datum/reagent/inaprovaline/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
@@ -24,9 +24,9 @@
 	reagent_state = LIQUID
 	color = "#00BFFF"
 	overdose = REAGENTS_OVERDOSE * 2
-	metabolism = REM * 0.1
+	metabolism = REM * 0.2
 	scannable = 1
-	touch_met = REM * 0.15
+	touch_met = REM * 0.3
 	can_overdose_touch = TRUE
 
 /datum/reagent/inaprovaline/topical/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)

--- a/code/modules/reagents/reagents/other.dm
+++ b/code/modules/reagents/reagents/other.dm
@@ -167,7 +167,7 @@
 	taste_description = "bwoink"
 	reagent_state = LIQUID
 	color = "#C8A5DC"
-	affects_dead = 1 //This can even heal dead people.
+	affects_dead = TRUE //This can even heal dead people.
 	metabolism = 0.1
 	mrate_static = TRUE //Just in case
 
@@ -178,11 +178,10 @@
 	affect_blood(M, alien, removed)
 
 /datum/reagent/adminordrazine/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
-	M.setCloneLoss(0)
-	M.setOxyLoss(0)
-	M.radiation = 0
-	M.heal_organ_damage(20,20)
-	M.adjustToxLoss(-20)
+	M.heal_organ_damage(40,40)
+	M.adjustCloneLoss(-40)
+	M.adjustToxLoss(-40)
+	M.adjustOxyLoss(-300)
 	M.hallucination = 0
 	M.setBrainLoss(0)
 	M.disabilities = 0
@@ -202,6 +201,10 @@
 	M.radiation = 0
 	M.ExtinguishMob()
 	M.fire_stacks = 0
+	M.add_chemical_effect(CE_ANTIBIOTIC, ANTIBIO_SUPER)
+	M.add_chemical_effect(CE_STABLE, 15)
+	M.add_chemical_effect(CE_PAINKILLER, 200)
+	M.remove_a_modifier_of_type(/datum/modifier/poisoned)
 	if(M.bodytemperature > 310)
 		M.bodytemperature = max(310, M.bodytemperature - (40 * TEMPERATURE_DAMAGE_COEFFICIENT))
 	else if(M.bodytemperature < 311)
@@ -209,6 +212,9 @@
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
 		var/wound_heal = 5
+		for(var/obj/item/organ/I in H.internal_organs)
+			if(I.damage > 0) //Adminordrazine heals even robits, it is magic
+				I.damage = max(I.damage - wound_heal, 0)
 		for(var/obj/item/organ/external/O in H.bad_external_organs)
 			if(O.status & ORGAN_BROKEN)
 				O.mend_fracture()		//Only works if the bone won't rebreak, as usual


### PR DESCRIPTION
Mostly, these are based off of notes I have been collecting over the past year or so, and I just got the motivation to actually act on those notes.

- Adminordrazine buffed again
- Myelamine buffed slightly, to reduce the chances of a standard clotting injector failing to treat IB
- Bicaridine Overdose slightly more effective at treating IB
- Inaprovaline metabolizes slower, to make it more useful in its role of patient stabilization
- Bone repair autoinjector changed to a 5u autoinjector with 5u of osteodaxon. Considering how osteodaxon works, 10u is overkill and leaves the patient feeling the side effects for longer than they should.
- Clone loss autoinjector added, patterned off the new bone repair autoinjector. 5u of Rezadone to deal with clone loss. Added to uplink as well as random unknown autoinjector spawners.