### PR TITLE
Halves Item Slowdown Effects

### DIFF
--- a/code/game/gamemodes/changeling/powers/armor.dm
+++ b/code/game/gamemodes/changeling/powers/armor.dm
@@ -103,7 +103,7 @@
 	armor = list(melee = 75, bullet = 60, laser = 60, energy = 60, bomb = 60, bio = 0, rad = 0) //It costs 3 points, so it should be very protective.
 	siemens_coefficient = 0.3
 	max_heat_protection_temperature = FIRESUIT_MAX_HEAT_PROTECTION_TEMPERATURE
-	slowdown = 3
+	slowdown = 1.5
 
 /obj/item/clothing/suit/space/changeling/armored/New()
 	..()

--- a/code/game/gamemodes/cult/cult_items.dm
+++ b/code/game/gamemodes/cult/cult_items.dm
@@ -115,7 +115,7 @@
 	desc = "A bulky suit of armour, bristling with spikes. It looks space-worthy."
 	w_class = ITEMSIZE_NORMAL
 	allowed = list(/obj/item/weapon/book/tome,/obj/item/weapon/melee/cultblade,/obj/item/weapon/tank/emergency/oxygen,/obj/item/device/suit_cooling_unit)
-	slowdown = 1
+	slowdown = 0.5
 	armor = list(melee = 60, bullet = 50, laser = 30, energy = 80, bomb = 30, bio = 30, rad = 30)
 	siemens_coefficient = 0
 	flags_inv = HIDEGLOVES|HIDEJUMPSUIT|HIDETAIL|HIDETIE|HIDEHOLSTER

--- a/code/game/gamemodes/technomancer/core_obj.dm
+++ b/code/game/gamemodes/technomancer/core_obj.dm
@@ -252,7 +252,7 @@
 	energy = 7000
 	max_energy = 7000
 	regen_rate = 70 //100 seconds to full
-	slowdown = -1
+	slowdown = -0.5
 	instability_modifier = 0.9
 	cooldown_modifier = 0.9
 
@@ -266,7 +266,7 @@
 	energy = 20000
 	max_energy = 20000
 	regen_rate = 25 //800 seconds to full
-	slowdown = 1
+	slowdown = 0.5
 	instability_modifier = 1.0
 	spell_power_modifier = 1.4
 

--- a/code/game/gamemodes/technomancer/devices/tesla_armor.dm
+++ b/code/game/gamemodes/technomancer/devices/tesla_armor.dm
@@ -12,7 +12,7 @@
 	desc = "This rather dangerous looking armor will hopefully shock your enemies, and not you in the process."
 	icon_state = "tesla_armor_1" //wip
 	blood_overlay_type = "armor"
-	slowdown = 1
+	slowdown = 0.5
 	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0)
 	action_button_name = "Toggle Tesla Armor"
 	var/active = 1	//Determines if the armor will zap or block

--- a/code/game/objects/items/uav.dm
+++ b/code/game/objects/items/uav.dm
@@ -13,7 +13,7 @@
 	var/cell_type = null //Can put a starting cell here
 
 	density = 1 //Is dense, but not anchored, so you can swap with it
-	slowdown = 3 //Heevvee.
+	slowdown = 1.5 //Heevvee.
 
 	health = 100
 	var/power_per_process = 50 // About 6.5 minutes of use on a high-cell (10,000)
@@ -201,14 +201,14 @@
 		if(UAV_OFF) //Packing
 			state = UAV_PACKED
 			w_class = ITEMSIZE_LARGE
-			slowdown = 1
+			slowdown = 0.5
 			density = FALSE
 			update_icon()
 			return TRUE
 		if(UAV_PACKED) //Unpacking
 			state = UAV_OFF
 			w_class = ITEMSIZE_HUGE
-			slowdown = 3
+			slowdown = 1.5
 			density = TRUE
 			update_icon()
 			return TRUE

--- a/code/game/objects/items/weapons/material/material_armor.dm
+++ b/code/game/objects/items/weapons/material/material_armor.dm
@@ -33,7 +33,7 @@ Protectiveness | Armor %
 	var/default_material = null // Set this to something else if you want material attributes on init.
 	var/material_armor_modifier = 1 // Adjust if you want seperate types of armor made from the same material to have different protectiveness (e.g. makeshift vs real armor)
 	var/material_slowdown_modifier = 0
-	var/material_slowdown_multiplier = 1
+	var/material_slowdown_multiplier = 0.5
 
 /obj/item/clothing/New(var/newloc, var/material_key)
 	..(newloc)
@@ -217,7 +217,7 @@ Protectiveness | Armor %
 	slot = ACCESSORY_SLOT_ARMOR_C
 	material_armor_modifier = 0.8
 	material_slowdown_modifier = 0.5 //Subtracted from total slowdown
-	material_slowdown_multiplier = 0.8 //Multiplied by total slowdown
+	material_slowdown_multiplier = 0.4 //Multiplied by total slowdown
 
 /obj/item/clothing/accessory/material/makeshift/heavy //Craftable with 8 material sheets, more slowdown, more armour
 	name = "heavy armor plate"
@@ -228,7 +228,7 @@ Protectiveness | Armor %
 	slot = ACCESSORY_SLOT_ARMOR_C
 	material_armor_modifier = 1.2
 	material_slowdown_modifier = 0
-	material_slowdown_multiplier = 1
+	material_slowdown_multiplier = 0.5
 
 /obj/item/clothing/accessory/material/custom //Not yet craftable, advanced version made with science!
 	name = "custom armor plate"
@@ -239,7 +239,7 @@ Protectiveness | Armor %
 	slot = ACCESSORY_SLOT_ARMOR_C
 	material_armor_modifier = 1.2
 	material_slowdown_modifier = 0.5
-	material_slowdown_multiplier = 0.8
+	material_slowdown_multiplier = 0.4
 
 /obj/item/clothing/accessory/material/makeshift/armguards
 	name = "arm guards"
@@ -253,7 +253,7 @@ Protectiveness | Armor %
 	slot = ACCESSORY_SLOT_ARMOR_A
 	material_armor_modifier = 0.8
 	material_slowdown_modifier = 0.8
-	material_slowdown_multiplier = 0.8
+	material_slowdown_multiplier = 0.4
 
 /obj/item/clothing/accessory/material/makeshift/legguards
 	name = "leg guards"
@@ -267,7 +267,7 @@ Protectiveness | Armor %
 	slot = ACCESSORY_SLOT_ARMOR_L
 	material_armor_modifier = 0.8
 	material_slowdown_modifier = 0.8
-	material_slowdown_multiplier = 0.8
+	material_slowdown_multiplier = 0.4
 
 /obj/item/clothing/suit/armor/material/makeshift/durasteel
 	default_material = "durasteel"

--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -135,7 +135,7 @@
 	name = "dufflebag"
 	desc = "A large dufflebag for holding extra things."
 	icon_state = "duffle"
-	slowdown = 1
+	slowdown = 0.5
 	max_storage_space = INVENTORY_DUFFLEBAG_SPACE
 
 /obj/item/weapon/storage/backpack/dufflebag/syndie

--- a/code/game/objects/items/weapons/storage/bags.dm
+++ b/code/game/objects/items/weapons/storage/bags.dm
@@ -366,7 +366,7 @@
 	desc = "A bag for storing pills, patches, and bottles."
 	max_storage_space = 200
 	w_class = ITEMSIZE_LARGE
-	slowdown = 1
+	slowdown = 3
 	can_hold = list(/obj/item/weapon/reagent_containers/pill,/obj/item/weapon/reagent_containers/glass/beaker,/obj/item/weapon/reagent_containers/glass/bottle)
 
 	// -----------------------------

--- a/code/game/objects/items/weapons/tools/screwdriver.dm
+++ b/code/game/objects/items/weapons/tools/screwdriver.dm
@@ -98,7 +98,6 @@
 	icon_state = "hybscrewdriver"
 	item_state = "screwdriver_black"
 	origin_tech = list(TECH_MATERIAL = 3, TECH_ENGINEERING = 3)
-	slowdown = 0.1
 	w_class = ITEMSIZE_NORMAL
 	usesound = 'sound/effects/uncloak.ogg'
 	toolspeed = 0.4

--- a/code/game/objects/items/weapons/tools/weldingtool.dm
+++ b/code/game/objects/items/weapons/tools/weldingtool.dm
@@ -456,7 +456,6 @@
 	icon_state = "hybwelder"
 	max_fuel = 80 //more max fuel is better! Even if it doesn't actually use fuel.
 	eye_safety_modifier = -2	// Brighter than the sun. Literally, you can look at the sun with a welding mask of proper grade, this will burn through that.
-	slowdown = 0.1
 	toolspeed = 0.25
 	w_class = ITEMSIZE_NORMAL
 	flame_intensity = 5

--- a/code/game/objects/items/weapons/tools/wirecutters.dm
+++ b/code/game/objects/items/weapons/tools/wirecutters.dm
@@ -78,7 +78,6 @@
 	desc = "This cuts wires.  With <span class='alien'>Science!</span>"
 	icon_state = "hybcutters"
 	w_class = ITEMSIZE_NORMAL
-	slowdown = 0.1
 	origin_tech = list(TECH_MATERIAL = 3, TECH_ENGINEERING = 3, TECH_PHORON = 2)
 	attack_verb = list("pinched", "nipped", "warped", "blasted")
 	usesound = 'sound/effects/stealthoff.ogg'

--- a/code/game/objects/items/weapons/tools/wrench.dm
+++ b/code/game/objects/items/weapons/tools/wrench.dm
@@ -34,7 +34,6 @@
 	force = 8
 	throwforce = 10
 	w_class = ITEMSIZE_NORMAL
-	slowdown = 0.1
 	origin_tech = list(TECH_MATERIAL = 3, TECH_ENGINEERING = 3, TECH_PHORON = 2)
 	attack_verb = list("bashed", "battered", "bludgeoned", "whacked", "warped", "blasted")
 	usesound = 'sound/effects/stealthoff.ogg'

--- a/code/modules/artifice/telecube.dm
+++ b/code/modules/artifice/telecube.dm
@@ -28,7 +28,7 @@
 
 	catalogue_data = list(/datum/category_item/catalogue/anomalous/precursor_a/telecube)
 
-	slowdown = 5
+	slowdown = 2.5
 
 	throw_range = 2
 

--- a/code/modules/clothing/shoes/leg_guards.dm
+++ b/code/modules/clothing/shoes/leg_guards.dm
@@ -60,7 +60,7 @@
 	icon_state = "leg_guards_flexitac"
 	item_state_slots = list(slot_r_hand_str = "jackboots", slot_l_hand_str = "jackboots")
 	siemens_coefficient = 0.6
-	slowdown = SHOES_SLOWDOWN+0.2
+	slowdown = SHOES_SLOWDOWN+0.5
 	armor = list(melee = 40, bullet = 40, laser = 60, energy = 35, bomb = 30, bio = 0, rad = 0)
 	min_cold_protection_temperature = T0C - 20
 	cold_protection = LEGS

--- a/code/modules/clothing/shoes/miscellaneous.dm
+++ b/code/modules/clothing/shoes/miscellaneous.dm
@@ -24,7 +24,7 @@
 	permeability_coefficient = 0.05
 	siemens_coefficient = 0 //They're thick rubber boots! Of course they won't conduct electricity!
 	item_flags = NOSLIP
-	slowdown = SHOES_SLOWDOWN+1
+	slowdown = SHOES_SLOWDOWN+0.5
 	species_restricted = null
 	drop_sound = 'sound/items/drop/rubber.ogg'
 	pickup_sound = 'sound/items/pickup/rubber.ogg'
@@ -63,7 +63,7 @@
 	desc = "The prankster's standard-issue clowning shoes. Damn they're huge!"
 	name = "clown shoes"
 	icon_state = "clown"
-	slowdown = SHOES_SLOWDOWN+1
+	slowdown = SHOES_SLOWDOWN+0.5
 	force = 0
 	var/footstep = 1	//used for squeeks whilst walking
 	species_restricted = null
@@ -134,7 +134,7 @@
 	icon_state = "flippers"
 	item_state_slots = list(slot_r_hand_str = "galoshes", slot_l_hand_str = "galoshes")
 	item_flags = NOSLIP
-	slowdown = SHOES_SLOWDOWN+1
+	slowdown = SHOES_SLOWDOWN+0.5
 	species_restricted = null
 
 /obj/item/clothing/shoes/flipflop

--- a/code/modules/clothing/spacesuits/miscellaneous.dm
+++ b/code/modules/clothing/spacesuits/miscellaneous.dm
@@ -99,4 +99,4 @@
 	name = "Emergency Softsuit"
 	icon_state = "syndicate-orange"
 	desc = "A thin, ungainly softsuit colored in blaze orange for rescuers to easily locate, looks pretty fragile."
-	slowdown = 4
+	slowdown = 2

--- a/code/modules/clothing/spacesuits/rig/modules/specific/sprinter.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/specific/sprinter.dm
@@ -3,7 +3,7 @@
 	desc = "A robust hardsuit-integrated sprint module."
 	icon_state = "sprinter"
 
-	var/sprint_speed = 1
+	var/sprint_speed = 0.5
 
 	toggleable = 1
 	disruptable = 1

--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -81,7 +81,7 @@
 	var/seal_delay = SEAL_DELAY
 	var/sealing                                               // Keeps track of seal status independantly of canremove.
 	var/offline = 1                                           // Should we be applying suit maluses?
-	var/offline_slowdown = 3                                  // If the suit is deployed and unpowered, it sets slowdown to this.
+	var/offline_slowdown = 1.5                                  // If the suit is deployed and unpowered, it sets slowdown to this.
 	var/vision_restriction
 	var/offline_vision_restriction = 1                        // 0 - none, 1 - welder vision, 2 - blind. Maybe move this to helmets.
 	var/airtight = 1 //If set, will adjust AIRTIGHT flag and pressure protections on components. Otherwise it should leave them untouched.
@@ -508,7 +508,7 @@
 			if(!offline)
 				if(istype(wearer))
 					if(!canremove)
-						if (offline_slowdown < 3)
+						if (offline_slowdown < 1.5)
 							to_chat(wearer, "<span class='danger'>Your suit beeps stridently, and suddenly goes dead.</span>")
 						else
 							to_chat(wearer, "<span class='danger'>Your suit beeps stridently, and suddenly you're wearing a leaden mass of metal and plastic composites instead of a powered suit.</span>")

--- a/code/modules/clothing/spacesuits/rig/suits/alien.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/alien.dm
@@ -50,7 +50,7 @@
 	flags = PHORONGUARD
 	item_flags = THICKMATERIAL
 	siemens_coefficient = 0.2
-	offline_slowdown = 5
+	offline_slowdown = 2.5
 	allowed = list(
 		/obj/item/weapon/gun,
 		/obj/item/device/flashlight,

--- a/code/modules/clothing/spacesuits/rig/suits/combat.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/combat.dm
@@ -7,8 +7,8 @@
 	icon_state = "security_rig"
 	suit_type = "combat hardsuit"
 	armor = list(melee = 80, bullet = 65, laser = 50, energy = 15, bomb = 80, bio = 100, rad = 60)
-	slowdown = 1
-	offline_slowdown = 3
+	slowdown = 0.5
+	offline_slowdown = 1.5
 	offline_vision_restriction = 1
 
 	helm_type = /obj/item/clothing/head/helmet/space/rig/combat
@@ -46,8 +46,8 @@
 	icon_state = "military_rig"
 	suit_type = "military hardsuit"
 	armor = list(melee = 80, bullet = 70, laser = 55, energy = 15, bomb = 80, bio = 100, rad = 30)
-	slowdown = 1
-	offline_slowdown = 3
+	slowdown = 0.5
+	offline_slowdown = 1.5
 	offline_vision_restriction = 1
 	allowed = list(
 		/obj/item/device/flashlight,

--- a/code/modules/clothing/spacesuits/rig/suits/merc.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/merc.dm
@@ -8,8 +8,8 @@
 	icon_state = "merc_rig"
 	suit_type = "crimson hardsuit"
 	armor = list(melee = 80, bullet = 65, laser = 50, energy = 15, bomb = 80, bio = 100, rad = 60)
-	slowdown = 1
-	offline_slowdown = 3
+	slowdown = 0.5
+	offline_slowdown = 1.5
 	offline_vision_restriction = 1
 	siemens_coefficient = 0.3
 	glove_type = /obj/item/clothing/gloves/gauntlets/rig/eva

--- a/code/modules/clothing/spacesuits/rig/suits/robotics.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/robotics.dm
@@ -6,8 +6,8 @@
 	icon_state = "void_explorer2"
 	slot_flags = SLOT_BELT
 	armor = list(melee = 40, bullet = 30, laser = 20, energy = 15, bomb = 30, bio = 100, rad = 50)
-	slowdown = 1
-	offline_slowdown = 2
+	slowdown = 0.5
+	offline_slowdown = 1
 	offline_vision_restriction = 0
 	emp_protection = -20
 	siemens_coefficient= 0.75

--- a/code/modules/clothing/spacesuits/rig/suits/station.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/station.dm
@@ -68,8 +68,8 @@
 	desc = "A heavy, powerful hardsuit used by construction crews and mining corporations."
 	icon_state = "engineering_rig"
 	armor = list(melee = 60, bullet = 50, laser = 30,energy = 15, bomb = 30, bio = 100, rad = 50)
-	slowdown = 1
-	offline_slowdown = 10
+	slowdown = 0.5
+	offline_slowdown = 5
 	offline_vision_restriction = 2
 	emp_protection = -20
 	siemens_coefficient= 0.75
@@ -109,7 +109,7 @@
 	icon_state = "eva_rig"
 	armor = list(melee = 30, bullet = 10, laser = 20,energy = 25, bomb = 20, bio = 100, rad = 100)
 	slowdown = 0
-	offline_slowdown = 1
+	offline_slowdown = 0.5
 	offline_vision_restriction = 1
 	siemens_coefficient= 0.75
 
@@ -199,7 +199,7 @@
 	desc = "An Anomalous Material Interaction hardsuit that protects against the strangest energies the universe can throw at it."
 	icon_state = "science_rig"
 	armor = list(melee = 45, bullet = 5, laser = 45, energy = 80, bomb = 60, bio = 100, rad = 100)
-	slowdown = 1
+	slowdown = 0.5
 	offline_vision_restriction = 1
 	siemens_coefficient= 0.75
 
@@ -244,7 +244,7 @@
 	desc = "A durable suit designed for medical rescue in high risk areas."
 	icon_state = "medical_rig"
 	armor = list(melee = 30, bullet = 15, laser = 20, energy = 60, bomb = 30, bio = 100, rad = 100)
-	slowdown = 1
+	slowdown = 0.5
 	offline_vision_restriction = 1
 	siemens_coefficient= 0.75
 
@@ -282,8 +282,8 @@
 	desc = "A Security hardsuit designed for prolonged EVA in dangerous environments."
 	icon_state = "hazard_rig"
 	armor = list(melee = 60, bullet = 40, laser = 30, energy = 15, bomb = 60, bio = 100, rad = 30)
-	slowdown = 1
-	offline_slowdown = 3
+	slowdown = 0.5
+	offline_slowdown = 1.5
 	offline_vision_restriction = 1
 	siemens_coefficient= 0.7
 

--- a/code/modules/clothing/spacesuits/spacesuits.dm
+++ b/code/modules/clothing/spacesuits/spacesuits.dm
@@ -76,7 +76,7 @@
 	item_flags = THICKMATERIAL
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|FEET|ARMS|HANDS
 	allowed = list(/obj/item/device/flashlight,/obj/item/weapon/tank/emergency/oxygen,/obj/item/device/suit_cooling_unit)
-	slowdown = 3
+	slowdown = 1.5
 	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 100, rad = 50)
 	flags_inv = HIDEGLOVES|HIDESHOES|HIDEJUMPSUIT|HIDETAIL|HIDETIE|HIDEHOLSTER
 	cold_protection = UPPER_TORSO | LOWER_TORSO | LEGS | FEET | ARMS | HANDS

--- a/code/modules/clothing/spacesuits/syndi.dm
+++ b/code/modules/clothing/spacesuits/syndi.dm
@@ -12,7 +12,7 @@
 	desc = "A crimson spacesuit sporting clean lines and durable plating. Robust, reliable, and slightly suspicious."
 	w_class = ITEMSIZE_NORMAL
 	allowed = list(/obj/item/weapon/gun,/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/weapon/melee/baton,/obj/item/weapon/melee/energy/sword,/obj/item/weapon/handcuffs,/obj/item/weapon/tank/emergency/oxygen)
-	slowdown = 1
+	slowdown = 0.5
 	armor = list(melee = 60, bullet = 50, laser = 30,energy = 15, bomb = 30, bio = 30, rad = 30)
 	siemens_coefficient = 0.6
 

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -389,7 +389,7 @@
 	armor = list(melee = 40, bullet = 40, laser = 60, energy = 35, bomb = 30, bio = 0, rad = 0)
 	cold_protection = UPPER_TORSO|LOWER_TORSO
 	min_cold_protection_temperature = T0C - 20
-	slowdown = 0.3
+	slowdown = 0.5
 
 /obj/item/clothing/suit/storage/vest/detective
 	name = "detective armor vest"

--- a/code/modules/clothing/under/accessories/armor.dm
+++ b/code/modules/clothing/under/accessories/armor.dm
@@ -63,7 +63,6 @@
 	desc = "A collection of black pouches that can be attached to a plate carrier. Carries up to four items."
 	icon_state = "lpouches"
 	slots = 4
-	slowdown = 0.25
 
 /obj/item/clothing/accessory/storage/pouches/large/blue
 	desc = "A collection of blue pouches that can be attached to a plate carrier. Carries up to four items."
@@ -134,7 +133,7 @@
 	name = "ballistic armor plate"
 	desc = "A woven armor plate with additional plating, providing good protection against high-velocity trauma. Attaches to a plate carrier."
 	icon_state = "armor_ballistic"
-	slowdown = 0.6
+	slowdown = 0.5
 	armor = list(melee = 10, bullet = 70, laser = 10, energy = 10, bomb = 0, bio = 0, rad = 0)
 	armorsoak = list(melee = 0, bullet = 10, laser = 0, energy = 5, bomb = 0, bio = 0, rad = 0)
 	siemens_coefficient = 0.7
@@ -143,7 +142,7 @@
 	name = "riot armor plate"
 	desc = "A thick armor plate with additional padding, providing good protection against low-velocity trauma. Attaches to a plate carrier."
 	icon_state = "armor_riot"
-	slowdown = 0.6
+	slowdown = 0.5
 	armor = list(melee = 70, bullet = 10, laser = 10, energy = 10, bomb = 0, bio = 0, rad = 0)
 	armorsoak = list(melee = 10, bullet = 0, laser = 0, energy = 5, bomb = 0, bio = 0, rad = 0)
 	siemens_coefficient = 0.7
@@ -152,7 +151,7 @@
 	name = "ablative armor plate"
 	desc = "A durasteel-scaled synthetic armor plate, providing good protection against lasers. Attaches to a plate carrier."
 	icon_state = "armor_ablative"
-	slowdown = 0.6
+	slowdown = 0.5
 	armor = list(melee = 10, bullet = 10, laser = 70, energy = 50, bomb = 0, bio = 0, rad = 0)
 	armorsoak = list(melee = 0, bullet = 0, laser = 10, energy = 15, bomb = 0, bio = 0, rad = 0)
 	siemens_coefficient = 0.1

--- a/code/modules/clothing/under/accessories/temperature/poncho.dm
+++ b/code/modules/clothing/under/accessories/temperature/poncho.dm
@@ -8,8 +8,6 @@
 	cold_protection = UPPER_TORSO|LOWER_TORSO|ARMS
 	heat_protection = UPPER_TORSO|LOWER_TORSO|ARMS
 
-	slowdown = 0.2
-
 	min_cold_protection_temperature = T0C - 40
 	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE
 

--- a/code/modules/fishing/fishing_net.dm
+++ b/code/modules/fishing/fishing_net.dm
@@ -14,7 +14,7 @@
 	w_class = ITEMSIZE_SMALL
 	flags = NOBLUDGEON
 
-	slowdown = 0.25
+	slowdown = 0.5
 
 	reach = 2
 


### PR DESCRIPTION
Most items in the codebase have a slowdown multiplier of one, when slowdown is handled species-side in multiples of 0.5. This makes the effect of species slowdown almost non-existant when item slowdown is involved, and makes species that have item slowdown reduction (such as Unathi) unnaturally fast.

Do note that I also went through and removed odd slowdown numbers as well, as, due to the way slowdown is tied to tickrate, it should be done in intervals of 0.5.

I tried to view things on a case by case scenario but there will probably be changes that will need to be double checked.

Some items will be handled differently, I will list the exceptions below.
Boots of Speed: Kept at -1, it is boots of speed after all.
Chemistry Bag: Increased to 3. This should not really be toted around outside of chemistry.
Hybrid Tools: They already have a lot of other disadvantages, and are kind of hard to get, and 0.1 is a weird number for slowdown.
Site Manager's armor: Already 1.5
Unathi Breacher modules: These things are overpowered and Unathi already have a racial trait to virtually remove item slowdown.
Voidsuits: Already done in intervals of 0.5, no change.
RHR Accellerator: This thing probably has appropriate slowdown values for what it is.
Utility suits: Already done in intervals of 0.5
Clothing/suits/armor: Already done in intervals of 0.5
Fishing net: 0.25 is an odd number, I decided to bump it up to 0.5.