### PR TITLE
Fixes utensils, adds variable scoop size

### DIFF
--- a/code/game/objects/items/weapons/material/kitchen.dm
+++ b/code/game/objects/items/weapons/material/kitchen.dm
@@ -15,23 +15,42 @@
 	edge = TRUE
 	force_divisor = 0.1 // 6 when wielded with hardness 60 (steel)
 	thrown_force_divisor = 0.25 // 5 when thrown with weight 20 (steel)
-	var/weakref/loaded //Weakref for currently loaded food object.
+	var/scoop_volume = 5
+	var/loaded // Name for currently loaded food object.
+	var/loaded_color // Color for currently loaded food object.
 
-/obj/item/weapon/material/kitchen/utensil/New()
-	..()
+/obj/item/weapon/material/kitchen/utensil/Initialize()
+	. = ..()
 	if (prob(60))
 		src.pixel_y = rand(0, 4)
-	create_reagents(5)
-	return
+	create_reagents(scoop_volume)
 
 /obj/item/weapon/material/kitchen/utensil/update_icon()
 	. = ..()
 	cut_overlays()
-	var/obj/item/weapon/reagent_containers/food/snacks/eaten = loaded?.resolve()
-	if(eaten)
+	if(loaded)
 		var/image/I = new(icon, "loadedfood")
-		I.color = eaten.filling_color
+		I.color = loaded_color
 		add_overlay(I)
+
+/obj/item/weapon/material/kitchen/utensil/proc/load_food(var/mob/user, var/obj/item/weapon/reagent_containers/food/snacks/loading)
+	if (reagents.total_volume > 0)
+		to_chat(user, SPAN_DANGER("There is already something on \the [src]."))
+		return
+	if (!loading?.reagents?.total_volume)
+		to_chat(user, SPAN_NOTIE("Nothing to scoop up in \the [loading]!"))
+
+	loaded = "\the [loading]"
+	user.visible_message( \
+		"<b>\The [user]</b> scoops up some of [loaded] with \the [src]!",
+		SPAN_NOTICE("You scoop up some of [loaded] with \the [src]!")
+	)
+	loading.bitecount++
+	loading.reagents.trans_to_obj(src, min(loading.reagents.total_volume, scoop_volume))
+	loaded_color = loading.filling_color
+	if (loading.reagents.total_volume <= 0)
+		qdel(loading)
+	update_icon()
 
 /obj/item/weapon/material/kitchen/utensil/attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob)
 	if(!istype(M))
@@ -46,19 +65,18 @@
 			return ..()
 
 	if (loaded && reagents.total_volume > 0)
-		var/atom/movable/eaten = loaded?.resolve()
 		reagents.trans_to_mob(M, reagents.total_volume, CHEM_INGEST)
-		if(eaten)	
-			if(M == user)
-				if(!M.can_eat(eaten))
-					return
-				M.visible_message(SPAN_NOTICE("\The [user] eats some of \the [eaten] with \the [src]."))
-			else
-				user.visible_message(SPAN_WARNING("\The [user] begins to feed \the [M]!"))
-				if(!(M.can_force_feed(user, eaten) && do_mob(user, M, 5 SECONDS)))
-					return
-				M.visible_message(SPAN_NOTICE("\The [user] feeds some of \the [eaten] to \the [M] with \the [src]."))
-			playsound(src,'sound/items/eatfood.ogg', rand(10,40), 1)
+		if(M == user)
+			if(!M.can_eat(loaded))
+				return
+			M.visible_message("<b>\The [user]</b> eats some of [loaded] with \the [src].")
+		else
+			user.visible_message(SPAN_WARNING("\The [user] begins to feed \the [M]!"))
+			if(!(M.can_force_feed(user, loaded) && do_mob(user, M, 5 SECONDS)))
+				return
+			M.visible_message("<b>\The [user]</b> feeds some of [loaded] to \the [M] with \the [src].")
+		playsound(src,'sound/items/eatfood.ogg', rand(10,40), 1)
+		loaded = null
 		update_icon()
 		return
 	else

--- a/code/game/objects/items/weapons/material/kitchen.dm
+++ b/code/game/objects/items/weapons/material/kitchen.dm
@@ -38,7 +38,8 @@
 		to_chat(user, SPAN_DANGER("There is already something on \the [src]."))
 		return
 	if (!loading?.reagents?.total_volume)
-		to_chat(user, SPAN_NOTIE("Nothing to scoop up in \the [loading]!"))
+		to_chat(user, SPAN_NOTICE("Nothing to scoop up in \the [loading]!"))
+
 
 	loaded = "\the [loading]"
 	user.visible_message( \

--- a/code/modules/food/food/snacks.dm
+++ b/code/modules/food/food/snacks.dm
@@ -160,24 +160,7 @@
 	// Eating with forks
 	if(istype(W,/obj/item/weapon/material/kitchen/utensil))
 		var/obj/item/weapon/material/kitchen/utensil/U = W
-		if(!U.reagents)
-			U.create_reagents(5)
-
-		if (U.reagents.total_volume > 0)
-			to_chat(user, "<font color='red'>You already have something on your [U].</font>")
-			return
-
-		user.visible_message( \
-			"[user] scoops up some [src] with \the [U]!", \
-			"<font color='blue'>You scoop up some [src] with \the [U]!</font>" \
-		)
-
-		bitecount++
-
-		reagents.trans_to_obj(U, min(reagents.total_volume,5))
-
-		if (reagents.total_volume <= 0)
-			qdel(src)
+		U.load_food(user, src)
 		return
 
 	if (is_sliceable())

--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -8,7 +8,7 @@
 		return 1
 	if(feedback)
 		if(status[1] == HUMAN_EATING_NO_MOUTH)
-			to_chat(src, "Where do you intend to put \the [food]? You don't have a mouth!")
+			to_chat(src, "Where do you intend to put [food]? You don't have a mouth!")
 		else if(status[1] == HUMAN_EATING_BLOCKED_MOUTH)
 			to_chat(src, "<span class='warning'>\The [status[2]] is in the way!</span>")
 	return 0
@@ -19,7 +19,7 @@
 		return 1
 	if(feedback)
 		if(status[1] == HUMAN_EATING_NO_MOUTH)
-			to_chat(feeder, "Where do you intend to put \the [food]? \The [src] doesn't have a mouth!")
+			to_chat(feeder, "Where do you intend to put [food]? \The [src] doesn't have a mouth!")
 		else if(status[1] == HUMAN_EATING_BLOCKED_MOUTH)
 			to_chat(feeder, "<span class='warning'>\The [status[2]] is in the way!</span>")
 	return 0

--- a/html/changelogs/MDP-utensilfix.yml
+++ b/html/changelogs/MDP-utensilfix.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: MoondancerPony
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Makes utensils work for eating food again."


### PR DESCRIPTION
I feel kind of bad for missing something this obvious.
- Adds two missing lines I forgot that actually set/unset the loaded food item.
- Undoes the weakref stuff and actually fixed the issue with `the The food` when eating using a utensil.
- Cleans up some utensil code.
- Utensil scoop volume is now a var rather than hardcoded. Make the comically large spoon of your dreams!