### PR TITLE
Toilet + donut box sprite fixes

### DIFF
--- a/code/game/objects/items/weapons/storage/misc.dm
+++ b/code/game/objects/items/weapons/storage/misc.dm
@@ -49,7 +49,7 @@ var/list/random_weighted_donuts = list(
 	update_icon()
 
 /obj/item/weapon/storage/box/donut/update_icon()
-	overlays.Cut()
+	cut_overlays()
 	var/x_offset = 0
 	for(var/obj/item/weapon/reagent_containers/food/snacks/donut/D in contents)
 		var/mutable_appearance/ma = mutable_appearance(icon = icon, icon_state = D.overlay_state)

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -41,7 +41,7 @@
 	update_icon()
 
 /obj/structure/toilet/update_icon()
-	icon_state = "toilet[initial(icon_state)][open][cistern]"
+	icon_state = "[initial(icon_state)][open][cistern]"
 
 /obj/structure/toilet/attackby(obj/item/I as obj, mob/living/user as mob)
 	if(I.is_crowbar())


### PR DESCRIPTION
Fixes invisible toilets due to typo, and donut box sprite updates just infinitely stacking overlays instead of refreshing.