### PR TITLE
Prevents Pop-up for Already Seen Lore News

### DIFF
--- a/code/modules/client/preference_setup/global/02_settings.dm
+++ b/code/modules/client/preference_setup/global/02_settings.dm
@@ -9,6 +9,7 @@
 /datum/category_item/player_setup_item/player_global/settings/load_preferences(var/savefile/S)
 	S["lastchangelog"]        >> pref.lastchangelog
 	S["lastnews"]             >> pref.lastnews
+	S["lastlorenews"]         >> pref.lastlorenews
 	S["default_slot"]	      >> pref.default_slot
 	S["preferences"]          >> pref.preferences_enabled
 	S["preferences_disabled"] >> pref.preferences_disabled
@@ -16,6 +17,7 @@
 /datum/category_item/player_setup_item/player_global/settings/save_preferences(var/savefile/S)
 	S["lastchangelog"]        << pref.lastchangelog
 	S["lastnews"]             << pref.lastnews
+	S["lastlorenews"]         << pref.lastlorenews
 	S["default_slot"]         << pref.default_slot
 	S["preferences"]          << pref.preferences_enabled
 	S["preferences_disabled"] << pref.preferences_disabled

--- a/code/modules/client/preference_setup/global/setting_datums.dm
+++ b/code/modules/client/preference_setup/global/setting_datums.dm
@@ -115,7 +115,7 @@ var/list/_client_preferences_by_type
 	key = "SOUND_AIRPUMP"
 	enabled_description = "Audible"
 	disabled_description = "Silent"
-	
+
 /datum/client_preference/old_door_sounds
 	description ="Old Door Sounds"
 	key = "SOUND_OLDDOORS"
@@ -284,6 +284,13 @@ var/list/_client_preferences_by_type
 	if(preference_mob && preference_mob.plane_holder)
 		var/datum/plane_holder/PH = preference_mob.plane_holder
 		PH.set_vis(VIS_STATUS, enabled)
+
+/datum/client_preference/show_lore_news
+	description = "Lore News Popup"
+	key = "NEWS_POPUP"
+	enabled_by_default = TRUE
+	enabled_description = "Popup New On Login"
+	disabled_description = "Do Nothing"
 
 /********************
 * Staff Preferences *

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -139,6 +139,7 @@ var/list/preferences_datums = list()
 	var/datum/browser/panel
 
 	var/lastnews // Hash of last seen lobby news content.
+	var/lastlorenews //ID of last seen lore news article.
 
 	var/examine_text_mode = 0 // Just examine text, include usage (description_info), switch to examine panel.
 	var/multilingual_mode = 0 // Default behaviour, delimiter-key-space, delimiter-key-delimiter, off

--- a/code/modules/lore_codex/news_data/main.dm
+++ b/code/modules/lore_codex/news_data/main.dm
@@ -112,6 +112,8 @@
 		/datum/lore/codex/page/about_news,
 		)
 
+	var/newsindex = "103" //Update with number of latest article
+
 /datum/lore/codex/page/about_news
 	name = "About the Publisher"
 	data = "The <i>Daedalus Pocket Newscaster</i> is produced and maintained by Occulum Broadcast, the foremost authority on media distribution \

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -73,9 +73,9 @@
 
 	if(GLOB.news_data.station_newspaper)
 		if(client.prefs.lastlorenews == GLOB.news_data.newsindex)
-			output += "<a href='byond://?src=\ref[src];open_station_news=1'>Show [using_map.station_name] News</A>"
+			output += "<p><a href='byond://?src=\ref[src];open_station_news=1'>Show [using_map.station_name] News</A></p>"
 		else
-			output += "<a href='byond://?src=\ref[src];open_station_news=1'>Show [using_map.station_name] News (NEW!)</A>"
+			output += "<p><b><a href='byond://?src=\ref[src];open_station_news=1'>Show [using_map.station_name] News (NEW!)</A></b></p>"
 
 	output += "</div>"
 

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -72,14 +72,17 @@
 		output += "<p>[href(src, list("give_feedback" = 1), "Give Feedback")]</p>"
 
 	if(GLOB.news_data.station_newspaper)
-		output += "<a href='byond://?src=\ref[src];open_station_news=1'>Show [using_map.station_name] News</A>"
+		if(client.prefs.lastlorenews == GLOB.news_data.newsindex)
+			output += "<a href='byond://?src=\ref[src];open_station_news=1'>Show [using_map.station_name] News</A>"
+		else
+			output += "<a href='byond://?src=\ref[src];open_station_news=1'>Show [using_map.station_name] News (NEW!)</A>"
 
 	output += "</div>"
 
 	if (client.prefs.lastlorenews == GLOB.news_data.newsindex)
 		client.seen_news = 1
 
-	if(GLOB.news_data.station_newspaper && !client.seen_news)
+	if(GLOB.news_data.station_newspaper && !client.seen_news && client.is_preference_enabled(/datum/client_preference/show_lore_news))
 		show_latest_news(GLOB.news_data.station_newspaper)
 		client.prefs.lastnews = GLOB.news_data.newsindex
 		SScharacter_setup.queue_preferences_save(client.prefs)

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -76,8 +76,13 @@
 
 	output += "</div>"
 
+	if (client.prefs.lastlorenews == GLOB.news_data.newsindex)
+		client.seen_news = 1
+
 	if(GLOB.news_data.station_newspaper && !client.seen_news)
 		show_latest_news(GLOB.news_data.station_newspaper)
+		client.prefs.lastnews = GLOB.news_data.newsindex
+		SScharacter_setup.queue_preferences_save(client.prefs)
 
 	panel = new(src, "Welcome","Welcome", 500, 480, src)
 	panel.set_window_options("can_close=0")

--- a/code/modules/news/news_init.dm
+++ b/code/modules/news/news_init.dm
@@ -7,6 +7,7 @@ GLOBAL_DATUM_INIT(news_data, /datum/lore/news, new)
 /datum/lore/news
 	var/datum/feed_channel/station_newspaper
 	var/datum/lore/codex/category/main_news/news_codex = new()
+	var/newsindex
 
 /datum/lore/news/New()
 	..()
@@ -17,6 +18,10 @@ GLOBAL_DATUM_INIT(news_data, /datum/lore/news, new)
 				break
 	spawn(300) // Yes, again.
 		fill_codex_news()
+	if (!news_codex.newsindex)
+		return
+	else
+		newsindex = news_codex.newsindex
 
 /datum/lore/news/proc/fill_codex_news()
 	if(!news_network)


### PR DESCRIPTION
The "Player Already Saw News" variable is now actually saved between connections, preventing the news from popping up for people who have already seen it.

Also incorporates the preference option from #8162 for those who do not want to have the popup under any circumstances, and the planned bolding of the main menu option for those with the popup off.
The preference for the popup is on by default due to the far less intrusive nature of it after this change.