### PR TITLE
Seed Contraband Changes

### DIFF
--- a/code/modules/hydroponics/seed_storage.dm
+++ b/code/modules/hydroponics/seed_storage.dm
@@ -43,41 +43,46 @@
 	..()
 	wires = new(src)
 	if(!contraband_seeds.len)
-		contraband_seeds = pick(list(
-			list(
-					/obj/item/seeds/ambrosiavulgarisseed = 3,
-					/obj/item/seeds/greengrapeseed = 3,
-					/obj/item/seeds/reishimycelium = 2,
-					/obj/item/seeds/bloodtomatoseed = 1
-					),
-			list(
-					/obj/item/seeds/ambrosiavulgarisseed = 3,
-					/obj/item/seeds/plastiseed = 3,
-					/obj/item/seeds/kudzuseed = 2,
-					/obj/item/seeds/rose/blood = 1
-					),
-			list(
-					/obj/item/seeds/ambrosiavulgarisseed = 3,
-					/obj/item/seeds/amanitamycelium = 3,
-					/obj/item/seeds/libertymycelium = 2,
-					/obj/item/seeds/glowshroom = 1
-					),
-			list(
-					/obj/item/seeds/ambrosiavulgarisseed = 3,
-					/obj/item/seeds/glowberryseed = 3,
-					/obj/item/seeds/icepepperseed = 2,
-					/obj/item/seeds/bluetomatoseed = 1
-					),
-			list(
-					/obj/item/seeds/durian = 2,
-					/obj/item/seeds/ambrosiadeusseed = 1,
-					/obj/item/seeds/killertomatoseed = 1
-					),
-			list(
-					/obj/item/seeds/ambrosiavulgarisseed = 3,
-					/obj/item/seeds/random = 6
-					)
-			))
+		contraband_seeds = pick( 	/// Some form of ambrosia in all lists.
+			prob(30);list( /// General produce
+				/obj/item/seeds/ambrosiavulgarisseed = 3,
+				/obj/item/seeds/greengrapeseed = 3,
+				/obj/item/seeds/icepepperseed = 2,
+				/obj/item/seeds/kudzuseed = 1
+			),
+			prob(30);list( ///Mushroom batch
+				/obj/item/seeds/ambrosiavulgarisseed = 1,
+				/obj/item/seeds/glowberryseed = 2,
+				/obj/item/seeds/libertymycelium = 1,
+				/obj/item/seeds/reishimycelium = 2,
+				/obj/item/seeds/sporemycelium = 1
+			),
+			prob(15);list( /// Survivalist
+				/obj/item/seeds/ambrosiadeusseed = 2,
+				/obj/item/seeds/redtowermycelium = 2,
+				/obj/item/seeds/vale = 2,
+				/obj/item/seeds/siflettuce = 2
+			),
+			prob(20);list( /// Cold plants
+				/obj/item/seeds/ambrosiavulgarisseed = 2,
+				/obj/item/seeds/thaadra = 2,
+				/obj/item/seeds/icepepperseed = 2,
+				/obj/item/seeds/siflettuce = 1
+			),
+			prob(10);list( ///Poison party
+				/obj/item/seeds/ambrosiavulgarisseed = 3,
+				/obj/item/seeds/surik = 1,
+				/obj/item/seeds/telriis = 1,
+				/obj/item/seeds/nettleseed = 2,
+				/obj/item/seeds/poisonberryseed = 1
+			),
+			prob(5);list( /// Extra poison party!
+				/obj/item/seeds/ambrosiainfernusseed = 1,
+				/obj/item/seeds/amauri = 1,
+				/obj/item/seeds/surik = 1,
+				/obj/item/seeds/deathberryseed = 1 /// Very ow.
+			)
+		)
 	return
 
 /obj/machinery/seed_storage/process()


### PR DESCRIPTION
Changes the contraband seeds to be more interesting and have probability. 6 list selections.

Happy to hear any balance concerns about the plant choices, but I thought it silly we had so many plants we never ever see. Of about 17 spawned vendors in testing, most had produce/mushrooms, a few of the cold plants and survivalist, about 3 poison, and none of the extra poison. 