### PR TITLE
Fixes infinite naming loop

### DIFF
--- a/code/modules/surgery/robotics.dm
+++ b/code/modules/surgery/robotics.dm
@@ -473,11 +473,9 @@
 			if(clean_name)
 				var/okay = alert(target,"New name will be '[clean_name]', ok?", "Confirmation","Cancel","Ok")
 				if(okay == "Ok")
-					new_name = clean_name
-
-		new_name = sanitizeName(new_name, allow_numbers = TRUE)
-		target.name = new_name
-		target.real_name = target.name
+					target.name = new_name
+					target.real_name = target.name
+					return
 
 /datum/surgery_step/robotics/install_mmi/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	user.visible_message("<span class='warning'>[user]'s hand slips.</span>", \


### PR DESCRIPTION
Ater's requested changes to the surgery code, should fix the bug where entering a name infinitely loops and requires a relog to get rid of the prompt.

I could not test this personally because it requires two people fyi