### PR TITLE
Vending machine throwing tweaks

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -926,3 +926,7 @@ modules/mob/living/carbon/human/life.dm if you die, you will be zoomed out.
 // Like the above, but used for RPED sorting of parts.
 /obj/item/proc/rped_rating()
 	return get_rating()
+
+// this gets called when the item gets chucked by the vending machine
+/obj/item/proc/vendor_action(var/obj/machinery/vending/V)
+	return

--- a/code/game/objects/items/weapons/grenades/grenade.dm
+++ b/code/game/objects/items/weapons/grenades/grenade.dm
@@ -112,3 +112,6 @@
 	walk(src, null, null)
 	..()
 	return
+
+/obj/item/weapon/grenade/vendor_action(var/obj/machinery/vending/V)
+	activate(V)

--- a/code/modules/economy/vending.dm
+++ b/code/modules/economy/vending.dm
@@ -60,6 +60,7 @@
 	emagged = 0 //Ignores if somebody doesn't have card access to that machine.
 	var/seconds_electrified = 0 //Shock customers like an airlock.
 	var/shoot_inventory = 0 //Fire items at customers! We're broken!
+	var/shoot_inventory_chance = 1
 
 	var/scan_id = 1
 	var/obj/item/weapon/coin/coin
@@ -662,7 +663,7 @@ GLOBAL_LIST_EMPTY(vending_products)
 		speak(slogan)
 		last_slogan = world.time
 
-	if(shoot_inventory && prob(2))
+	if(shoot_inventory && prob(shoot_inventory_chance))
 		throw_item()
 
 	return
@@ -702,20 +703,20 @@ GLOBAL_LIST_EMPTY(vending_products)
 
 //Somebody cut an important wire and now we're following a new definition of "pitch."
 /obj/machinery/vending/proc/throw_item()
-	var/obj/throw_item = null
+	var/obj/item/throw_item = null
 	var/mob/living/target = locate() in view(7,src)
 	if(!target)
 		return 0
 
-	for(var/datum/stored_item/vending_product/R in product_records)
+	for(var/datum/stored_item/vending_product/R in shuffle(product_records))
 		throw_item = R.get_product(loc)
 		if(!throw_item)
 			continue
 		break
 	if(!throw_item)
-		return 0
-	spawn(0)
-		throw_item.throw_at(target, 16, 3, src)
+		return FALSE
+	throw_item.vendor_action(src)
+	INVOKE_ASYNC(throw_item, /atom/movable.proc/throw_at, target, rand(3, 10), rand(1, 3), src)
 	visible_message("<span class='warning'>\The [src] launches \a [throw_item] at \the [target]!</span>")
 	return 1
 


### PR DESCRIPTION
- Vending machines can now perform actions on items when thrown - like activating a grenade, which they do. No vendor has lethal grenades as far as I'm aware anyway.
- Thrown items no longer accurately smash you in the fucking brain hole and have random inaccuracy.
- Reduced chance for items to be thrown (it gets a bit ridiculous currently.)
- Items are now thrown at random instead of going down the list of products in order.

:cl:
tweak - Vending machines are now less accurate and frequent throwers, and throw random items from their inventory.
/:cl: