### PR TITLE
Throw Mode QoL Tweaks

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -84,12 +84,10 @@
 		RestrainedClickOn(A)
 		return 1
 
-	if(in_throw_mode)
-		if(isturf(A) || isturf(A.loc))
-			throw_item(A)
-			trigger_aiming(TARGET_CAN_CLICK)
-			return 1
+	if(in_throw_mode && (isturf(A) || isturf(A.loc)) && throw_item(A))
+		trigger_aiming(TARGET_CAN_CLICK)
 		throw_mode_off()
+		return TRUE
 
 	var/obj/item/W = get_active_hand()
 
@@ -270,7 +268,7 @@
 	if(T && user.TurfAdjacent(T))
 		user.ToggleTurfTab(T)
 	return 1
-	
+
 /mob/proc/ToggleTurfTab(var/turf/T)
 	if(listed_turf == T)
 		listed_turf = null

--- a/code/modules/mob/living/carbon/give.dm
+++ b/code/modules/mob/living/carbon/give.dm
@@ -16,31 +16,33 @@
 	if(!I)
 		I = src.get_inactive_hand()
 	if(!I)
-		to_chat(src, "<span class='warning'>You don't have anything in your hands to give to \the [target].</span>")
+		to_chat(src, SPAN_WARNING("You don't have anything in your hands to give to \the [target]."))
 		return
 
+	usr.visible_message(SPAN_NOTICE("\The [usr] holds out \the [I] to \the [target]."), SPAN_NOTICE("You hold out \the [I] to \the [target], waiting for them to accept it."))
+
 	if(alert(target,"[src] wants to give you \a [I]. Will you accept it?",,"No","Yes") == "No")
-		target.visible_message("<span class='notice'>\The [src] tried to hand \the [I] to \the [target], \
-		but \the [target] didn't want it.</span>")
+		target.visible_message(SPAN_NOTICE("\The [src] tried to hand \the [I] to \the [target], \
+		but \the [target] didn't want it."))
 		return
 
 	if(!I) return
 
 	if(!Adjacent(target))
-		to_chat(src, "<span class='warning'>You need to stay in reaching distance while giving an object.</span>")
-		to_chat(target, "<span class='warning'>\The [src] moved too far away.</span>")
+		to_chat(src, SPAN_WARNING("You need to stay in reaching distance while giving an object"))
+		to_chat(target, SPAN_WARNING("\The [src] moved too far away."))
 		return
 
 	if(I.loc != src || !src.item_is_in_hands(I))
-		to_chat(src, "<span class='warning'>You need to keep the item in your hands.</span>")
-		to_chat(target, "<span class='warning'>\The [src] seems to have given up on passing \the [I] to you.</span>")
+		to_chat(src, SPAN_WARNING("You need to keep the item in your hands."))
+		to_chat(target, SPAN_WARNING("\The [src] seems to have given up on passing \the [I] to you."))
 		return
 
 	if(target.hands_are_full())
-		to_chat(target, "<span class='warning'>Your hands are full.</span>")
-		to_chat(src, "<span class='warning'>Their hands are full.</span>")
+		to_chat(target, SPAN_WARNING("Your hands are full."))
+		to_chat(src, SPAN_WARNING("Their hands are full."))
 		return
 
 	if(src.unEquip(I))
 		target.put_in_hands(I) // If this fails it will just end up on the floor, but that's fitting for things like dionaea.
-		target.visible_message("<span class='notice'>\The [src] handed \the [I] to \the [target].</span>")
+		target.visible_message(SPAN_NOTICE("\The [src] handed \the [I] to \the [target]"))

--- a/code/modules/mob/living/carbon/give.dm
+++ b/code/modules/mob/living/carbon/give.dm
@@ -6,10 +6,9 @@
 
 /mob/living/proc/do_give(var/mob/living/carbon/human/target)
 
-	// TODO :  Change to incapacitated() on merge.
 	if(src.incapacitated())
 		return
-	if(!istype(target) || target.stat || target.lying || target.resting || target.handcuffed || target.client == null)
+	if(!istype(target) || target.incapacitated() || target.client == null)
 		return
 
 	var/obj/item/I = src.get_active_hand()

--- a/code/modules/mob/living/carbon/give.dm
+++ b/code/modules/mob/living/carbon/give.dm
@@ -1,9 +1,13 @@
-/mob/living/carbon/human/verb/give(var/mob/living/carbon/target in living_mobs(1))
+/mob/living/verb/give(var/mob/living/target in living_mobs(1))
 	set category = "IC"
 	set name = "Give"
 
+	do_give(target)
+
+/mob/living/proc/do_give(var/mob/living/carbon/human/target)
+
 	// TODO :  Change to incapacitated() on merge.
-	if(src.stat || src.lying || src.resting || src.handcuffed)
+	if(src.incapacitated())
 		return
 	if(!istype(target) || target.stat || target.lying || target.resting || target.handcuffed || target.client == null)
 		return

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -839,9 +839,9 @@
 
 	if(lying)
 		density = 0
-		if(l_hand) 
+		if(l_hand)
 			unEquip(l_hand)
-		if(r_hand) 
+		if(r_hand)
 			unEquip(r_hand)
 		for(var/obj/item/weapon/holder/holder in get_mob_riding_slots())
 			unEquip(holder)
@@ -984,14 +984,13 @@
 		swap_hand()
 
 /mob/living/throw_item(atom/target)
-	src.throw_mode_off()
-	if(usr.stat || !target)
-		return
-	if(target.type == /obj/screen) return
+	if(stat || !target || istype(target, /obj/screen))
+		return FALSE
 
 	var/atom/movable/item = src.get_active_hand()
 
-	if(!item) return
+	if(!item)
+		return FALSE
 
 	var/throw_range = item.throw_range
 	if (istype(item, /obj/item/weapon/grab))
@@ -1011,10 +1010,30 @@
 				if((N.health + N.halloss) < config.health_threshold_crit || N.stat == DEAD)
 					N.adjustBruteLoss(rand(10,30))
 			src.drop_from_inventory(G)
+			return TRUE
+		else
+			return FALSE
 
-	src.drop_from_inventory(item)
-	if(!item || !isturf(item.loc))
-		return
+	if(!item)
+		return FALSE //Grab processing has a chance of returning null
+
+	if(a_intent == I_HELP && Adjacent(target) && isitem(item))
+		var/obj/item/I = item
+		if(ishuman(target))
+			var/mob/living/carbon/human/H = target
+			if(H.in_throw_mode && H.a_intent == I_HELP && unEquip(I))
+				H.put_in_hands(I) // If this fails it will just end up on the floor, but that's fitting for things like dionaea.
+				visible_message("<b>[src]</b> hands \the [H] \a [I].", SPAN_NOTICE("You give \the [target] \a [I]."))
+			else
+				to_chat(src, SPAN_NOTICE("You offer \the [I] to \the [target]."))
+				do_give(H)
+			return TRUE
+		remove_from_mob(I)
+		make_item_drop_sound(I)
+		I.forceMove(get_turf(target))
+		return TRUE
+
+	drop_from_inventory(item)
 
 	//actually throw it!
 	src.visible_message("<span class='warning'>[src] has thrown [item].</span>")
@@ -1035,6 +1054,7 @@
 
 
 	item.throw_at(target, throw_range, item.throw_speed, src)
+	return TRUE
 
 /mob/living/get_sound_env(var/pressure_factor)
 	if (hallucination)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1034,6 +1034,9 @@
 
 	drop_from_inventory(item)
 
+	if(!item || QDELETED(item))
+		return TRUE //It may not have thrown, but it sure as hell left your hand successfully.
+
 	//actually throw it!
 	src.visible_message("<span class='warning'>[src] has thrown [item].</span>")
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -984,7 +984,7 @@
 		swap_hand()
 
 /mob/living/throw_item(atom/target)
-	if(stat || !target || istype(target, /obj/screen))
+	if(incapacitated() || !target || istype(target, /obj/screen))
 		return FALSE
 
 	var/atom/movable/item = src.get_active_hand()
@@ -1028,7 +1028,6 @@
 				to_chat(src, SPAN_NOTICE("You offer \the [I] to \the [target]."))
 				do_give(H)
 			return TRUE
-		remove_from_mob(I)
 		make_item_drop_sound(I)
 		I.forceMove(get_turf(target))
 		return TRUE

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1111,7 +1111,7 @@
 
 //Throwing stuff
 /mob/proc/throw_item(atom/target)
-	return
+	return FALSE
 
 /mob/proc/will_show_tooltip()
 	if(alpha <= EFFECTIVE_INVIS)


### PR DESCRIPTION
Requested combo of https://github.com/Aurorastation/Aurora.3/pull/12094 and https://github.com/Aurorastation/Aurora.3/pull/12161

:cl:
rscadd - Clicking on an adjacent person while on help intent with throw mode on will 'Give' them the item. If both parties have help intent throw mode on the item will automatically be accepted.
tweak - Situations where clicking in throw mode would not actually throw an item will no longer cancel throw mode.
/:cl:

Also give code is now on /living instead of /living/carbon/human for maximum giving.