### PR TITLE
Adds discord button to UI + config

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -124,6 +124,7 @@ var/list/gamemode_cache = list()
 	var/wikisearchurl
 	var/forumurl
 	var/githuburl
+	var/discordurl
 	var/rulesurl
 	var/mapurl
 
@@ -540,6 +541,9 @@ var/list/gamemode_cache = list()
 					config.githuburl = value
 				if ("guest_jobban")
 					config.guest_jobban = 1
+
+				if ("discordurl")
+					config.discordurl = value
 
 				if ("guest_ban")
 					config.guests_allowed = 0
@@ -1002,10 +1006,10 @@ var/list/gamemode_cache = list()
 
 				if("use_loyalty_implants")
 					config.use_loyalty_implants = 1
-				
+
 				if("loadout_whitelist")
 					config.loadout_whitelist = text2num(value)
-				
+
 				else
 					log_misc("Unknown setting in configuration: '[name]'")
 

--- a/code/modules/vchat/js/vchat.js
+++ b/code/modules/vchat/js/vchat.js
@@ -924,7 +924,7 @@ function get_cookie(key, deffo) {
 
 // Button Controls that need background-color and text-color set.
 var SKIN_BUTTONS = [
-	/* Rpane */ "rpane.textb", "rpane.infob", "rpane.wikib", "rpane.forumb", "rpane.rulesb", "rpane.github", "rpane.mapb", "rpane.changelog",
+	/* Rpane */ "rpane.textb", "rpane.infob", "rpane.wikib", "rpane.forumb", "rpane.rulesb", "rpane.github", "rpane.discord", "rpane.mapb", "rpane.changelog",
 	/* Mainwindow */ "mainwindow.saybutton", "mainwindow.mebutton", "mainwindow.hotkey_toggle"
 	
 ];

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -247,8 +247,12 @@ GUEST_BAN
 
 ## GitHub address
 # GITHUBURL https://github.com/example-user/example-repository
+
 ## Ban appeals URL - usually for a forum or wherever people should go to contact your admins.
 # BANAPPEALS http://example.com
+
+## Discord address
+#DISCORDURL https://discord.gg/someinvite
 
 ## In-game features
 ## spawns a spellbook which gives object-type spells instead of verb-type spells for the wizard

--- a/interface/interface.dm
+++ b/interface/interface.dm
@@ -67,6 +67,19 @@
 		to_chat(src, "<span class='danger'>The GitHub URL is not set in the server configuration.</span>")
 	return
 
+/client/verb/discord()
+	set name = "Discord"
+	set desc = "Visit the discord"
+	set hidden = 1
+
+	if(config.discordurl)
+		if(alert(usr, "This will open the Discord in your browser. Are you sure?","Visit Website",list("Yes","No"))=="No")
+			return
+		src << link(config.discordurl)
+	else
+		to_chat(src, "<span class='danger'>The Discord URL is not set in the server configuration.</span>")
+	return
+
 /client/verb/hotkeys_help()
 	set name = "hotkeys-help"
 	set category = "OOC"

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -1324,9 +1324,19 @@ window "rpane"
 		saved-params = "splitter"
 		right = "outputwindow"
 		is-vert = false
+	elem "discord"
+		type = BUTTON
+		pos = 428,0
+		size = 60x16
+		anchor1 = none
+		anchor2 = none
+		saved-params = "is-checked"
+		text = "Discord"
+		command = "discord"
+		group = "rpanemode"
 	elem "github"
 		type = BUTTON
-		pos = 392,0
+		pos = 368,0
 		size = 60x16
 		anchor1 = none
 		anchor2 = none
@@ -1336,7 +1346,7 @@ window "rpane"
 		group = "rpanemode"
 	elem "mapb"
 		type = BUTTON
-		pos = 332,0
+		pos = 308,0
 		size = 60x16
 		anchor1 = none
 		anchor2 = none
@@ -1346,7 +1356,7 @@ window "rpane"
 		group = "rpanemode"
 	elem "rulesb"
 		type = BUTTON
-		pos = 272,0
+		pos = 248,0
 		size = 60x16
 		anchor1 = none
 		anchor2 = none
@@ -1366,7 +1376,7 @@ window "rpane"
 		group = "rpanemode"
 	elem "forumb"
 		type = BUTTON
-		pos = 212,0
+		pos = 188,0
 		size = 60x16
 		anchor1 = none
 		anchor2 = none
@@ -1376,7 +1386,7 @@ window "rpane"
 		group = "rpanemode"
 	elem "wikib"
 		type = BUTTON
-		pos = 152,0
+		pos = 128,0
 		size = 60x16
 		anchor1 = none
 		anchor2 = none


### PR DESCRIPTION
Does what it says on the tin. Other buttons bumped along to make space.
Required defining a discord invite URL in the config.
(We should also fix the config map link to link to the wiki maps page while we're at it.)