### PR TITLE
Gives the full toolbelt a multitool

### DIFF
--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -79,6 +79,7 @@
 		/obj/item/weapon/weldingtool,
 		/obj/item/weapon/tool/crowbar,
 		/obj/item/weapon/tool/wirecutters,
+		/obj/item/device/multitool,
 		/obj/item/stack/cable_coil/random_belt
 	)
 


### PR DESCRIPTION
## About this pull request
It adds a multitool to the full belts. The one that roboticists and engineers start with.

## Why is this good for the game 
Having to search for a multitool is a silly little bother when it is a perfectly essential tool. Especially for engineers. Given you end up just getting one anyway, it makes no sense that a wrench is the default gear, but not a multitool.
