### PR TITLE
Expands the material values of certain items.

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -3,6 +3,8 @@
 	icon = 'icons/obj/items.dmi'
 	w_class = ITEMSIZE_NORMAL
 
+	matter = list(DEFAULT_WALL_MATERIAL = 1)
+
 	var/image/blood_overlay = null //this saves our blood splatter overlay, which will be processed not to go over the edges of the sprite
 	var/randpixel = 6
 	var/abstract = 0

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -3,7 +3,7 @@
 	icon = 'icons/obj/items.dmi'
 	w_class = ITEMSIZE_NORMAL
 
-	matter = list(DEFAULT_WALL_MATERIAL = 1)
+	matter = list(MAT_STEEL = 1)
 
 	var/image/blood_overlay = null //this saves our blood splatter overlay, which will be processed not to go over the edges of the sprite
 	var/randpixel = 6

--- a/code/game/objects/items/apc_frame.dm
+++ b/code/game/objects/items/apc_frame.dm
@@ -6,6 +6,7 @@
 	icon = 'icons/obj/apc_repair.dmi'
 	icon_state = "apc_frame"
 	refund_amt = 2
+	matter = list(DEFAULT_WALL_MATERIAL = 100,"glass" = 30)
 
 /obj/item/frame/apc/try_build(turf/on_wall, mob/user as mob)
 	if (get_dist(on_wall, user)>1)

--- a/code/game/objects/items/apc_frame.dm
+++ b/code/game/objects/items/apc_frame.dm
@@ -6,7 +6,7 @@
 	icon = 'icons/obj/apc_repair.dmi'
 	icon_state = "apc_frame"
 	refund_amt = 2
-	matter = list(DEFAULT_WALL_MATERIAL = 100,"glass" = 30)
+	matter = list(MAT_STEEL = 100, MAT_GLASS = 30)
 
 /obj/item/frame/apc/try_build(turf/on_wall, mob/user as mob)
 	if (get_dist(on_wall, user)>1)

--- a/code/game/objects/items/bells.dm
+++ b/code/game/objects/items/bells.dm
@@ -6,6 +6,7 @@
 	force = 2
 	throwforce = 2
 	w_class = 2.0
+	matter = list(DEFAULT_WALL_MATERIAL = 50)
 	var/broken
 	attack_verb = list("annoyed")
 	var/static/radial_examine = image(icon = 'icons/mob/radial.dmi', icon_state = "radial_examine")

--- a/code/game/objects/items/bells.dm
+++ b/code/game/objects/items/bells.dm
@@ -6,7 +6,7 @@
 	force = 2
 	throwforce = 2
 	w_class = 2.0
-	matter = list(DEFAULT_WALL_MATERIAL = 50)
+	matter = list(MAT_STEEL = 50)
 	var/broken
 	attack_verb = list("annoyed")
 	var/static/radial_examine = image(icon = 'icons/mob/radial.dmi', icon_state = "radial_examine")

--- a/code/game/objects/items/trash.dm
+++ b/code/game/objects/items/trash.dm
@@ -8,7 +8,7 @@
 	desc = "This is rubbish."
 	drop_sound = 'sound/items/drop/wrapper.ogg'
 	pickup_sound = 'sound/items/pickup/wrapper.ogg'
-	matter = list(DEFAULT_WALL_MATERIAL = 30)
+	matter = list(MAT_STEEL = 30)
 	var/age = 0
 
 /obj/item/trash/New(var/newloc, var/_age)

--- a/code/game/objects/items/trash.dm
+++ b/code/game/objects/items/trash.dm
@@ -8,6 +8,7 @@
 	desc = "This is rubbish."
 	drop_sound = 'sound/items/drop/wrapper.ogg'
 	pickup_sound = 'sound/items/pickup/wrapper.ogg'
+	matter = list(DEFAULT_WALL_MATERIAL = 30)
 	var/age = 0
 
 /obj/item/trash/New(var/newloc, var/_age)

--- a/code/game/objects/items/weapons/AI_modules.dm
+++ b/code/game/objects/items/weapons/AI_modules.dm
@@ -18,7 +18,7 @@ AI MODULES
 	throw_range = 15
 	origin_tech = list(TECH_DATA = 3)
 	preserve_item = 1
-	matter = list(DEFAULT_WALL_MATERIAL = 30,"glass" = 10)
+	matter = list(MAT_STEEL = 30, MAT_GLASS = 10)
 	var/datum/ai_laws/laws = null
 
 /obj/item/weapon/aiModule/proc/install(var/atom/movable/AM, var/mob/living/user)

--- a/code/game/objects/items/weapons/AI_modules.dm
+++ b/code/game/objects/items/weapons/AI_modules.dm
@@ -18,6 +18,7 @@ AI MODULES
 	throw_range = 15
 	origin_tech = list(TECH_DATA = 3)
 	preserve_item = 1
+	matter = list(DEFAULT_WALL_MATERIAL = 30,"glass" = 10)
 	var/datum/ai_laws/laws = null
 
 /obj/item/weapon/aiModule/proc/install(var/atom/movable/AM, var/mob/living/user)

--- a/code/game/objects/items/weapons/circuitboards/circuitboard.dm
+++ b/code/game/objects/items/weapons/circuitboards/circuitboard.dm
@@ -16,7 +16,7 @@
 	throwforce = 5.0
 	throw_speed = 3
 	throw_range = 15
-	matter = list(DEFAULT_WALL_MATERIAL = 30,"glass" = 10)
+	matter = list(MAT_STEEL = 30, MAT_GLASS = 10)
 	var/build_path = null
 	var/board_type = new /datum/frame/frame_types/computer
 	var/list/req_components = null

--- a/code/game/objects/items/weapons/circuitboards/circuitboard.dm
+++ b/code/game/objects/items/weapons/circuitboards/circuitboard.dm
@@ -16,6 +16,7 @@
 	throwforce = 5.0
 	throw_speed = 3
 	throw_range = 15
+	matter = list(DEFAULT_WALL_MATERIAL = 30,"glass" = 10)
 	var/build_path = null
 	var/board_type = new /datum/frame/frame_types/computer
 	var/list/req_components = null


### PR DESCRIPTION
## About this pull request
This adds some default values to a few extra objects for materials.
This mostly comes into play regarding autolathes and recycling gear.
This also adds a default value of 1 metal to every item which you can reasonably expect to be holding.

## Why is this good for the game
What can be recycled or not along with the exact yields of which are really, really not consistent at all. 
But because it would take ages to go through and make a comprehensive update of material costs, i simply added a few to the more outlandish ones, and given the base tiny value of one to everything. 