### PR TITLE
By-species age restrictions

### DIFF
--- a/code/game/jobs/job/captain.dm
+++ b/code/game/jobs/job/captain.dm
@@ -23,13 +23,15 @@ var/datum/announcement/minor/captain_announcement = new(do_newscast = 1)
 	economic_modifier = 20
 
 	minimum_character_age = 25
-	ideal_character_age = 70 // Old geezer captains ftw
+	min_age_by_species = list(SPECIES_UNATHI = 70, SPECIES_TESHARI = 20, "mechanical" = 10)
+///	ideal_character_age = 70 // Old geezer captains ftw
 
 	outfit_type = /decl/hierarchy/outfit/job/captain
 	job_description = "The Site Manager manages the other Command Staff, and through them the rest of the station. Though they have access to everything, \
 						they do not understand everything, and are expected to delegate tasks to the appropriate crew member. The Site Manager is expected to \
 						have an understanding of Standard Operating Procedure, and is subject to it, and legal action, in the same way as every other crew member."
 	alt_titles = list("Overseer"= /datum/alt_title/overseer)
+
 
 /*
 /datum/job/captain/equip(var/mob/living/carbon/human/H)
@@ -66,7 +68,8 @@ var/datum/announcement/minor/captain_announcement = new(do_newscast = 1)
 	economic_modifier = 10
 
 	minimum_character_age = 25
-	ideal_character_age = 50
+	min_age_by_species = list(SPECIES_UNATHI = 70, SPECIES_TESHARI = 20, "mechanical" = 10)
+///	ideal_character_age = 50
 
 	outfit_type = /decl/hierarchy/outfit/job/hop
 	job_description = "The Head of Personnel manages the Service department, the Exploration team, and most other civilians. They also \

--- a/code/game/jobs/job/captain.dm
+++ b/code/game/jobs/job/captain.dm
@@ -23,8 +23,10 @@ var/datum/announcement/minor/captain_announcement = new(do_newscast = 1)
 	economic_modifier = 20
 
 	minimum_character_age = 25
-	min_age_by_species = list(SPECIES_UNATHI = 70, SPECIES_TESHARI = 20, "mechanical" = 10)
-///	ideal_character_age = 70 // Old geezer captains ftw
+	min_age_by_species = list(SPECIES_HUMAN_VATBORN = 12)
+	ideal_character_age = 70 // Old geezer captains ftw
+	ideal_age_by_species = list(SPECIES_HUMAN_VATBORN = 55) /// Vatborn live shorter, no other race eligible for captain besides human/skrell 
+	banned_job_species = list(SPECIES_UNATHI, SPECIES_TAJ, SPECIES_DIONA, SPECIES_PROMETHEAN, SPECIES_ZADDAT, "mechanical", "digital")
 
 	outfit_type = /decl/hierarchy/outfit/job/captain
 	job_description = "The Site Manager manages the other Command Staff, and through them the rest of the station. Though they have access to everything, \
@@ -68,8 +70,10 @@ var/datum/announcement/minor/captain_announcement = new(do_newscast = 1)
 	economic_modifier = 10
 
 	minimum_character_age = 25
-	min_age_by_species = list(SPECIES_UNATHI = 70, SPECIES_TESHARI = 20, "mechanical" = 10)
-///	ideal_character_age = 50
+	min_age_by_species = list(SPECIES_UNATHI = 70, SPECIES_TESHARI = 20, "mechanical" = 10, SPECIES_HUMAN_VATBORN = 12)
+	ideal_character_age = 50
+	ideal_age_by_species = list(SPECIES_UNATHI = 140, SPECIES_TESHARI = 27, "mechanical" = 20, SPECIES_HUMAN_VATBORN = 20)
+	banned_job_species = list(SPECIES_PROMETHEAN, SPECIES_ZADDAT, "digital", SPECIES_DIONA)
 
 	outfit_type = /decl/hierarchy/outfit/job/hop
 	job_description = "The Head of Personnel manages the Service department, the Exploration team, and most other civilians. They also \

--- a/code/game/jobs/job/civilian.dm
+++ b/code/game/jobs/job/civilian.dm
@@ -99,6 +99,7 @@
 	economic_modifier = 5
 	access = list(access_maint_tunnels, access_mailsorting, access_cargo, access_cargo_bot, access_qm, access_mining, access_mining_station)
 	minimal_access = list(access_maint_tunnels, access_mailsorting, access_cargo, access_cargo_bot, access_qm, access_mining, access_mining_station)
+	banned_job_species = list("digital", SPECIES_PROMETHEAN)
 
 	ideal_character_age = 40
 
@@ -231,6 +232,7 @@
 	access = list(access_lawyer, access_sec_doors, access_maint_tunnels, access_heads)
 	minimal_access = list(access_lawyer, access_sec_doors, access_heads)
 	minimal_player_age = 7
+	banned_job_species = list(SPECIES_PROMETHEAN, SPECIES_UNATHI, SPECIES_DIONA, SPECIES_TESHARI, SPECIES_ZADDAT, "digital")
 
 	outfit_type = /decl/hierarchy/outfit/job/internal_affairs_agent
 	job_description = "An Internal Affairs Agent makes sure that the crew is following Standard Operating Procedure. They also \

--- a/code/game/jobs/job/engineering.dm
+++ b/code/game/jobs/job/engineering.dm
@@ -17,8 +17,10 @@
 	economic_modifier = 10
 
 	minimum_character_age = 25
-	min_age_by_species = list(SPECIES_UNATHI = 70, SPECIES_TESHARI = 20, "mechanical" = 10)
-///	ideal_character_age = 50
+	min_age_by_species = list(SPECIES_UNATHI = 70, "mechanical" = 10, SPECIES_HUMAN_VATBORN = 12)
+	ideal_character_age = 50
+	ideal_age_by_species = list(SPECIES_UNATHI = 140, "mechanical" = 20, SPECIES_HUMAN_VATBORN = 20)
+	banned_job_species = list(SPECIES_TESHARI, SPECIES_DIONA, SPECIES_PROMETHEAN, SPECIES_ZADDAT, "digital")
 
 
 	access = list(access_engine, access_engine_equip, access_tech_storage, access_maint_tunnels,

--- a/code/game/jobs/job/engineering.dm
+++ b/code/game/jobs/job/engineering.dm
@@ -58,7 +58,6 @@
 						"Engine Technician" = /datum/alt_title/engine_tech, "Electrician" = /datum/alt_title/electrician)
 
 	minimal_player_age = 3
-	minimum_character_age = 1
 	min_age_by_species = list(SPECIES_PROMETHEAN = 2)
 
 	outfit_type = /decl/hierarchy/outfit/job/engineering/engineer
@@ -99,7 +98,6 @@
 	minimal_access = list(access_eva, access_engine, access_atmospherics, access_maint_tunnels, access_emergency_storage, access_construction, access_external_airlocks)
 
 	minimal_player_age = 3
-	minimum_character_age = 1
 	min_age_by_species = list(SPECIES_PROMETHEAN = 2)
 
 	outfit_type = /decl/hierarchy/outfit/job/engineering/atmos

--- a/code/game/jobs/job/engineering.dm
+++ b/code/game/jobs/job/engineering.dm
@@ -17,7 +17,8 @@
 	economic_modifier = 10
 
 	minimum_character_age = 25
-	ideal_character_age = 50
+	min_age_by_species = list(SPECIES_UNATHI = 70, SPECIES_TESHARI = 20, "mechanical" = 10)
+///	ideal_character_age = 50
 
 
 	access = list(access_engine, access_engine_equip, access_tech_storage, access_maint_tunnels,
@@ -55,6 +56,8 @@
 						"Engine Technician" = /datum/alt_title/engine_tech, "Electrician" = /datum/alt_title/electrician)
 
 	minimal_player_age = 3
+	minimum_character_age = 1
+	min_age_by_species = list(SPECIES_PROMETHEAN = 2)
 
 	outfit_type = /decl/hierarchy/outfit/job/engineering/engineer
 	job_description = "An Engineer keeps the station running. They repair damages, keep the atmosphere stable, and ensure that power is being \
@@ -94,6 +97,8 @@
 	minimal_access = list(access_eva, access_engine, access_atmospherics, access_maint_tunnels, access_emergency_storage, access_construction, access_external_airlocks)
 
 	minimal_player_age = 3
+	minimum_character_age = 1
+	min_age_by_species = list(SPECIES_PROMETHEAN = 2)
 
 	outfit_type = /decl/hierarchy/outfit/job/engineering/atmos
 	job_description = "An Atmospheric Technician is primarily concerned with keeping the station's atmosphere breathable. They are expected to have a good \

--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -24,6 +24,8 @@
 	var/minimum_character_age = 0
 	var/list/min_age_by_species = null
 	var/ideal_character_age = 30
+	var/list/ideal_age_by_species = null
+	var/list/banned_job_species = null
 	var/has_headset = TRUE                //Do people with this job need to be given headsets and told how to use them?  E.g. Cyborgs don't.
 
 	var/account_allowed = 1				  // Does this job type come with a station account?
@@ -165,3 +167,14 @@
 ///Will first check based on brain type, then based on species.
 /datum/job/proc/get_min_age(species_name, brain_type)
     return (brain_type && LAZYACCESS(min_age_by_species, brain_type)) || LAZYACCESS(min_age_by_species, species_name) || minimum_character_age
+
+/datum/job/proc/get_ideal_age(species_name, brain_type)
+	return (brain_type && LAZYACCESS(ideal_age_by_species, brain_type)) || LAZYACCESS(ideal_age_by_species, brain_type) || ideal_character_age
+
+/datum/job/proc/is_species_banned(species_name, brain_type)
+	if(banned_job_species == null)
+		return
+	if(species_name in banned_job_species)
+		return TRUE
+	if(brain_type in banned_job_species)
+		return TRUE

--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -22,6 +22,7 @@
 	var/department_accounts = null        // Which department accounts should people with this position be given the pin for?
 	var/assignable = TRUE                 // Should it show up on things like the ID computer?
 	var/minimum_character_age = 0
+	var/list/min_age_by_species = null
 	var/ideal_character_age = 30
 	var/has_headset = TRUE                //Do people with this job need to be given headsets and told how to use them?  E.g. Cyborgs don't.
 
@@ -159,3 +160,8 @@
 		var/obj/O = mannequin.back
 		mannequin.drop_from_inventory(O)
 		qdel(O)
+
+///Assigns minimum age by race & brain type. Code says Positronic = mechanical and Drone = digital because nothing can be simple.
+///Will first check based on brain type, then based on species.
+/datum/job/proc/get_min_age(species_name, brain_type)
+    return (brain_type && LAZYACCESS(min_age_by_species, brain_type)) || LAZYACCESS(min_age_by_species, species_name) || minimum_character_age

--- a/code/game/jobs/job/medical.dm
+++ b/code/game/jobs/job/medical.dm
@@ -61,7 +61,6 @@
 					"Nurse" = /datum/alt_title/nurse,
 					"Virologist" = /datum/alt_title/virologist)
 
-	minimum_character_age = 1
 	min_age_by_species = list(SPECIES_PROMETHEAN = 3)
 
 //Medical Doctor Alt Titles
@@ -109,7 +108,6 @@
 	access = list(access_medical, access_medical_equip, access_morgue, access_surgery, access_chemistry, access_virology, access_genetics)
 	minimal_access = list(access_medical, access_medical_equip, access_chemistry)
 	minimal_player_age = 3
-	minimum_character_age = 0
 	min_age_by_species = list(SPECIES_PROMETHEAN = 3)
 
 	outfit_type = /decl/hierarchy/outfit/job/medical/chemist
@@ -196,7 +194,6 @@
 	alt_titles = list("Emergency Medical Technician" = /datum/alt_title/emt)
 	banned_job_species = list(SPECIES_DIONA)
 
-	minimum_character_age = 1
 	min_age_by_species = list(SPECIES_PROMETHEAN = 2)
 
 // Paramedic Alt Titles

--- a/code/game/jobs/job/medical.dm
+++ b/code/game/jobs/job/medical.dm
@@ -23,9 +23,11 @@
 			access_keycard_auth, access_sec_doors, access_psychiatrist, access_eva, access_external_airlocks, access_maint_tunnels)
 
 	minimum_character_age = 25
-	min_age_by_species = list(SPECIES_UNATHI = 70, SPECIES_TESHARI = 20, "mechanical" = 10)
+	min_age_by_species = list(SPECIES_UNATHI = 70, "mechanical" = 10, SPECIES_HUMAN_VATBORN = 12)
 	minimal_player_age = 10
-//	ideal_character_age = 50
+	ideal_character_age = 50
+	ideal_age_by_species = list(SPECIES_UNATHI = 140, "mechanical" = 20, SPECIES_HUMAN_VATBORN = 20)
+	banned_job_species = list(SPECIES_TESHARI, SPECIES_DIONA, SPECIES_PROMETHEAN, SPECIES_ZADDAT, "digital")
 
 	outfit_type = /decl/hierarchy/outfit/job/medical/cmo
 	job_description = "The CMO manages the Medical department and is a position requiring experience and skill; their goal is to ensure that their \
@@ -163,6 +165,7 @@
 	job_description = "A Psychiatrist provides mental health services to crew members in need. They may also be called upon to determine whatever \
 					ails the mentally unwell, frequently under Security supervision. They understand the effects of various psychoactive drugs."
 	alt_titles = list("Psychologist" = /datum/alt_title/psychologist)
+	banned_job_species = list(SPECIES_PROMETHEAN, SPECIES_DIONA)
 
 //Psychiatrist Alt Titles
 /datum/alt_title/psychologist
@@ -191,6 +194,7 @@
 	job_description = "A Paramedic is primarily concerned with the recovery of patients who are unable to make it to the Medical Department on their own. \
 						They may also be called upon to keep patients stable when Medical is busy or understaffed."
 	alt_titles = list("Emergency Medical Technician" = /datum/alt_title/emt)
+	banned_job_species = list(SPECIES_DIONA)
 
 	minimum_character_age = 1
 	min_age_by_species = list(SPECIES_PROMETHEAN = 2)

--- a/code/game/jobs/job/medical.dm
+++ b/code/game/jobs/job/medical.dm
@@ -23,8 +23,9 @@
 			access_keycard_auth, access_sec_doors, access_psychiatrist, access_eva, access_external_airlocks, access_maint_tunnels)
 
 	minimum_character_age = 25
+	min_age_by_species = list(SPECIES_UNATHI = 70, SPECIES_TESHARI = 20, "mechanical" = 10)
 	minimal_player_age = 10
-	ideal_character_age = 50
+//	ideal_character_age = 50
 
 	outfit_type = /decl/hierarchy/outfit/job/medical/cmo
 	job_description = "The CMO manages the Medical department and is a position requiring experience and skill; their goal is to ensure that their \
@@ -57,6 +58,9 @@
 					"Emergency Physician" = /datum/alt_title/emergency_physician,
 					"Nurse" = /datum/alt_title/nurse,
 					"Virologist" = /datum/alt_title/virologist)
+
+	minimum_character_age = 1
+	min_age_by_species = list(SPECIES_PROMETHEAN = 3)
 
 //Medical Doctor Alt Titles
 /datum/alt_title/surgeon
@@ -103,6 +107,8 @@
 	access = list(access_medical, access_medical_equip, access_morgue, access_surgery, access_chemistry, access_virology, access_genetics)
 	minimal_access = list(access_medical, access_medical_equip, access_chemistry)
 	minimal_player_age = 3
+	minimum_character_age = 0
+	min_age_by_species = list(SPECIES_PROMETHEAN = 3)
 
 	outfit_type = /decl/hierarchy/outfit/job/medical/chemist
 	job_description = "A Chemist produces and maintains a stock of basic to advanced chemicals for medical and occasionally research use. \
@@ -185,6 +191,9 @@
 	job_description = "A Paramedic is primarily concerned with the recovery of patients who are unable to make it to the Medical Department on their own. \
 						They may also be called upon to keep patients stable when Medical is busy or understaffed."
 	alt_titles = list("Emergency Medical Technician" = /datum/alt_title/emt)
+
+	minimum_character_age = 1
+	min_age_by_species = list(SPECIES_PROMETHEAN = 2)
 
 // Paramedic Alt Titles
 /datum/alt_title/emt

--- a/code/game/jobs/job/science.dm
+++ b/code/game/jobs/job/science.dm
@@ -26,8 +26,10 @@
 
 	minimum_character_age = 25
 	minimal_player_age = 14
-	min_age_by_species = list(SPECIES_UNATHI = 70, SPECIES_TESHARI = 20, "mechanical" = 10)
-///	ideal_character_age = 50
+	min_age_by_species = list(SPECIES_UNATHI = 70, "mechanical" = 10, SPECIES_HUMAN_VATBORN = 12)
+	ideal_character_age = 50
+	ideal_age_by_species = list(SPECIES_UNATHI = 140, "mechanical" = 20, SPECIES_HUMAN_VATBORN = 20)
+	banned_job_species = list(SPECIES_TESHARI, SPECIES_DIONA, SPECIES_PROMETHEAN, SPECIES_ZADDAT, "digital")
 
 	outfit_type = /decl/hierarchy/outfit/job/science/rd
 	job_description = "The Research Director manages and maintains the Research department. They are required to ensure the safety of the entire crew, \
@@ -57,6 +59,8 @@
 	economic_modifier = 7
 	access = list(access_robotics, access_tox, access_tox_storage, access_research, access_xenobiology, access_xenoarch)
 	minimal_access = list(access_tox, access_tox_storage, access_research, access_xenoarch)
+	min_age_by_species = list(SPECIES_PROMETHEAN = 2)
+	banned_job_species = list("digital")
 
 	minimal_player_age = 14
 
@@ -100,6 +104,7 @@
 	economic_modifier = 7
 	access = list(access_robotics, access_tox, access_tox_storage, access_research, access_xenobiology, access_hydroponics)
 	minimal_access = list(access_research, access_xenobiology, access_hydroponics, access_tox_storage)
+	banned_job_species = list("digital")
 
 	minimal_player_age = 14
 	minimum_character_age = 1
@@ -135,6 +140,7 @@
 	minimal_player_age = 7
 	minimum_character_age = 1
 	min_age_by_species = list(SPECIES_PROMETHEAN = 2)
+	banned_job_species = list("digital")
 
 	outfit_type = /decl/hierarchy/outfit/job/science/roboticist
 	job_description = "A Roboticist maintains and repairs the station's synthetics, including crew with prosthetic limbs. \

--- a/code/game/jobs/job/science.dm
+++ b/code/game/jobs/job/science.dm
@@ -107,7 +107,6 @@
 	banned_job_species = list("digital")
 
 	minimal_player_age = 14
-	minimum_character_age = 1
 	min_age_by_species = list(SPECIES_PROMETHEAN = 2)
 
 	outfit_type = /decl/hierarchy/outfit/job/science/xenobiologist
@@ -138,7 +137,6 @@
 	access = list(access_robotics, access_tox, access_tox_storage, access_tech_storage, access_morgue, access_research) //As a job that handles so many corpses, it makes sense for them to have morgue access.
 	minimal_access = list(access_robotics, access_tech_storage, access_morgue, access_research) //As a job that handles so many corpses, it makes sense for them to have morgue access.
 	minimal_player_age = 7
-	minimum_character_age = 1
 	min_age_by_species = list(SPECIES_PROMETHEAN = 2)
 	banned_job_species = list("digital")
 

--- a/code/game/jobs/job/science.dm
+++ b/code/game/jobs/job/science.dm
@@ -26,7 +26,8 @@
 
 	minimum_character_age = 25
 	minimal_player_age = 14
-	ideal_character_age = 50
+	min_age_by_species = list(SPECIES_UNATHI = 70, SPECIES_TESHARI = 20, "mechanical" = 10)
+///	ideal_character_age = 50
 
 	outfit_type = /decl/hierarchy/outfit/job/science/rd
 	job_description = "The Research Director manages and maintains the Research department. They are required to ensure the safety of the entire crew, \
@@ -34,6 +35,7 @@
 						might originate from Research. The Research Director often has at least passing knowledge of most of the Research department, but \
 						are encouraged to allow their staff to perform their own duties."
 	alt_titles = list("Research Supervisor" = /datum/alt_title/research_supervisor)
+
 
 // Research Director Alt Titles
 /datum/alt_title/research_supervisor
@@ -100,6 +102,8 @@
 	minimal_access = list(access_research, access_xenobiology, access_hydroponics, access_tox_storage)
 
 	minimal_player_age = 14
+	minimum_character_age = 1
+	min_age_by_species = list(SPECIES_PROMETHEAN = 2)
 
 	outfit_type = /decl/hierarchy/outfit/job/science/xenobiologist
 	job_description = "A Xenobiologist studies esoteric lifeforms, usually in the relative safety of their lab. They attempt to find ways to benefit \
@@ -129,6 +133,8 @@
 	access = list(access_robotics, access_tox, access_tox_storage, access_tech_storage, access_morgue, access_research) //As a job that handles so many corpses, it makes sense for them to have morgue access.
 	minimal_access = list(access_robotics, access_tech_storage, access_morgue, access_research) //As a job that handles so many corpses, it makes sense for them to have morgue access.
 	minimal_player_age = 7
+	minimum_character_age = 1
+	min_age_by_species = list(SPECIES_PROMETHEAN = 2)
 
 	outfit_type = /decl/hierarchy/outfit/job/science/roboticist
 	job_description = "A Roboticist maintains and repairs the station's synthetics, including crew with prosthetic limbs. \

--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -24,8 +24,11 @@
 			            access_research, access_engine, access_mining, access_medical, access_construction, access_mailsorting,
 			            access_heads, access_hos, access_RC_announce, access_keycard_auth, access_gateway, access_external_airlocks)
 	minimum_character_age = 25
-	min_age_by_species = list(SPECIES_UNATHI = 70, SPECIES_TESHARI = 20, "mechanical" = 10)
+	min_age_by_species = list(SPECIES_HUMAN_VATBORN = 12)
 	minimal_player_age = 14
+	ideal_character_age = 50
+	ideal_age_by_species = list(SPECIES_HUMAN_VATBORN = 20)
+	banned_job_species = list(SPECIES_TESHARI, SPECIES_DIONA, SPECIES_PROMETHEAN, SPECIES_ZADDAT, "digital", SPECIES_UNATHI, "mechanical")
 
 	outfit_type = /decl/hierarchy/outfit/job/security/hos
 	job_description = "	The Head of Security manages the Security Department, keeping the station safe and making sure the rules are followed. They are expected to \
@@ -59,6 +62,7 @@
 	access = list(access_security, access_eva, access_sec_doors, access_brig, access_armory, access_maint_tunnels, access_morgue, access_external_airlocks)
 	minimal_access = list(access_security, access_eva, access_sec_doors, access_brig, access_armory, access_maint_tunnels, access_external_airlocks)
 	minimal_player_age = 5
+	banned_job_species = list(SPECIES_ZADDAT, SPECIES_PROMETHEAN, SPECIES_TESHARI, SPECIES_DIONA)
 
 	outfit_type = /decl/hierarchy/outfit/job/security/warden
 	job_description = "The Warden watches over the physical Security Department, making sure the Brig and Armoury are secure and in order at all times. They oversee \
@@ -83,6 +87,7 @@
 	minimal_access = list(access_security, access_sec_doors, access_forensics_lockers, access_morgue, access_maint_tunnels, access_eva, access_external_airlocks)
 	economic_modifier = 5
 	minimal_player_age = 3
+	banned_job_species = list(SPECIES_ZADDAT, SPECIES_PROMETHEAN, SPECIES_DIONA)
 
 	outfit_type = /decl/hierarchy/outfit/job/security/detective
 	job_description = "A Detective works to help Security find criminals who have not properly been identified, through interviews and forensic work. \
@@ -112,6 +117,7 @@
 	access = list(access_security, access_eva, access_sec_doors, access_brig, access_maint_tunnels, access_morgue, access_external_airlocks)
 	minimal_access = list(access_security, access_eva, access_sec_doors, access_brig, access_maint_tunnels, access_external_airlocks)
 	minimal_player_age = 3
+	banned_job_species = list(SPECIES_ZADDAT, SPECIES_TESHARI, SPECIES_DIONA)
 
 	outfit_type = /decl/hierarchy/outfit/job/security/officer
 	job_description = "A Security Officer is concerned with maintaining the safety and security of the station as a whole, dealing with external threats and \

--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -125,7 +125,6 @@
 						No one is above the Law, not Security or Command."
 	alt_titles = list("Junior Officer" = /datum/alt_title/junior_officer)
 
-	minimum_character_age = 1
 	min_age_by_species = list(SPECIES_PROMETHEAN = 3)
 
 // Security Officer Alt Titles

--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -24,6 +24,7 @@
 			            access_research, access_engine, access_mining, access_medical, access_construction, access_mailsorting,
 			            access_heads, access_hos, access_RC_announce, access_keycard_auth, access_gateway, access_external_airlocks)
 	minimum_character_age = 25
+	min_age_by_species = list(SPECIES_UNATHI = 70, SPECIES_TESHARI = 20, "mechanical" = 10)
 	minimal_player_age = 14
 
 	outfit_type = /decl/hierarchy/outfit/job/security/hos
@@ -31,6 +32,7 @@
 						keep the other Department Heads, and the rest of the crew, aware of developing situations that may be a threat. If necessary, the HoS may \
 						perform the duties of absent Security roles, such as distributing gear from the Armory."
 	alt_titles = list("Security Commander" = /datum/alt_title/sec_commander, "Chief of Security" = /datum/alt_title/sec_chief)
+
 
 // Head of Security Alt Titles
 /datum/alt_title/sec_commander
@@ -116,6 +118,9 @@
 						apprehending criminals. A Security Officer is responsible for the health, safety, and processing of any prisoner they arrest. \
 						No one is above the Law, not Security or Command."
 	alt_titles = list("Junior Officer" = /datum/alt_title/junior_officer)
+
+	minimum_character_age = 1
+	min_age_by_species = list(SPECIES_PROMETHEAN = 3)
 
 // Security Officer Alt Titles
 /datum/alt_title/junior_officer

--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -54,7 +54,7 @@ var/global/datum/controller/occupations/job_master
 		var/datum/job/job = GetJob(rank)
 		if(!job)
 			return 0
-		if(job.minimum_character_age && (player.client.prefs.age < job.minimum_character_age))
+		if(job.minimum_character_age && (player.client.prefs.age < job.get_min_age(player.client.prefs.species, player.client.prefs.organ_data["brain"])))
 			return 0
 		if(jobban_isbanned(player, rank))
 			return 0

--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -91,8 +91,11 @@ var/global/datum/controller/occupations/job_master
 		if(!job.player_old_enough(player.client))
 			Debug("FOC player not old enough, Player: [player]")
 			continue
-		if(job.minimum_character_age && (player.client.prefs.age < job.minimum_character_age))
+		if(job.minimum_character_age && (player.client.prefs.age < job.get_min_age(player.client.prefs.species, player.client.prefs.organ_data["brain"])))
 			Debug("FOC character not old enough, Player: [player]")
+			continue
+		if(job.is_species_banned(player.client.prefs.species, player.client.prefs.organ_data["brain"]) == TRUE)
+			Debug("FOC character species invalid for job, Player: [player]")
 			continue
 		if(flag && !(player.client.prefs.be_special & flag))
 			Debug("FOC flag failed, Player: [player], Flag: [flag], ")
@@ -108,7 +111,10 @@ var/global/datum/controller/occupations/job_master
 		if(!job)
 			continue
 
-		if(job.minimum_character_age && (player.client.prefs.age < job.minimum_character_age))
+		if(job.minimum_character_age && (player.client.prefs.age < job.get_min_age(player.client.prefs.species, player.client.prefs.organ_data["brain"])))
+			continue
+
+		if(job.is_species_banned(player.client.prefs.species, player.client.prefs.organ_data["brain"]) == TRUE)
 			continue
 
 		if(istype(job, GetJob("Assistant"))) // We don't want to give him assistant, that's boring!
@@ -157,20 +163,18 @@ var/global/datum/controller/occupations/job_master
 				if(!V.client) continue
 				var/age = V.client.prefs.age
 
-				if(age < job.minimum_character_age) // Nope.
+				if(age < job.get_min_age(V.client.prefs.species, V.client.prefs.organ_data["brain"])) // Nope.
 					continue
 
-				switch(age)
-					if(job.minimum_character_age to (job.minimum_character_age+10))
-						weightedCandidates[V] = 3 // Still a bit young.
-					if((job.minimum_character_age+10) to (job.ideal_character_age-10))
-						weightedCandidates[V] = 6 // Better.
-					if((job.ideal_character_age-10) to (job.ideal_character_age+10))
-						weightedCandidates[V] = 10 // Great.
-					if((job.ideal_character_age+10) to (job.ideal_character_age+20))
-						weightedCandidates[V] = 6 // Still good.
-					if((job.ideal_character_age+20) to INFINITY)
-						weightedCandidates[V] = 3 // Geezer.
+				var/idealage = job.get_ideal_age(V.client.prefs.species, V.client.prefs.organ_data["brain"])
+				var/agediff = abs(idealage - age) // Compute the absolute difference in age from target
+				switch(agediff) /// If the math sucks, it's because I almost failed algebra in high school.
+					if(20 to INFINITY)
+						weightedCandidates[V] = 3 // Too far off
+					if(10 to 20)
+						weightedCandidates[V] = 6 // Nearer the mark, but not quite
+					if(0 to 10)
+						weightedCandidates[V] = 10 // On the mark
 					else
 						// If there's ABSOLUTELY NOBODY ELSE
 						if(candidates.len == 1) weightedCandidates[V] = 1

--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -54,7 +54,7 @@ var/global/datum/controller/occupations/job_master
 		var/datum/job/job = GetJob(rank)
 		if(!job)
 			return 0
-		if(job.minimum_character_age && (player.client.prefs.age < job.get_min_age(player.client.prefs.species, player.client.prefs.organ_data["brain"])))
+		if((job.minimum_character_age || job.min_age_by_species) && (player.client.prefs.age < job.get_min_age(player.client.prefs.species, player.client.prefs.organ_data["brain"])))
 			return 0
 		if(jobban_isbanned(player, rank))
 			return 0
@@ -111,7 +111,7 @@ var/global/datum/controller/occupations/job_master
 		if(!job)
 			continue
 
-		if(job.minimum_character_age && (player.client.prefs.age < job.get_min_age(player.client.prefs.species, player.client.prefs.organ_data["brain"])))
+		if((job.minimum_character_age || job.min_age_by_species) && (player.client.prefs.age < job.get_min_age(player.client.prefs.species, player.client.prefs.organ_data["brain"])))
 			continue
 
 		if(job.is_species_banned(player.client.prefs.species, player.client.prefs.organ_data["brain"]) == TRUE)

--- a/code/modules/client/preference_setup/occupation/occupation.dm
+++ b/code/modules/client/preference_setup/occupation/occupation.dm
@@ -123,8 +123,8 @@
 			var/available_in_days = job.available_in_days(user.client)
 			. += "<del>[rank]</del></td></a><td> \[IN [(available_in_days)] DAYS]</td></tr>"
 			continue
-		if(job.minimum_character_age && user.client && (user.client.prefs.age < job.minimum_character_age))
-			. += "<del>[rank]</del></td></a><td> \[MINIMUM CHARACTER AGE: [job.minimum_character_age]]</td></tr>"
+		if(job.minimum_character_age && user.client && (user.client.prefs.age < job.get_min_age(user.client.prefs.species, user.client.prefs.organ_data["brain"])))
+			. += "<del>[rank]</del></td></a><td> \[MINIMUM CHARACTER AGE FOR SELECTED RACE & BRAIN TYPE: [job.get_min_age(user.client.prefs.species, user.client.prefs.organ_data["brain"])]\]</td></tr>"
 			continue
 		if((pref.job_civilian_low & ASSISTANT) && job.type != /datum/job/assistant)
 			. += "<font color=grey>[rank]</font></a></td><td></td></tr>"

--- a/code/modules/client/preference_setup/occupation/occupation.dm
+++ b/code/modules/client/preference_setup/occupation/occupation.dm
@@ -126,7 +126,7 @@
 		if(job.is_species_banned(user.client.prefs.species, user.client.prefs.organ_data["brain"]) == TRUE)
 			. += "<del>[rank]</del></td></a><td> \[THIS RACE/BRAIN TYPE CANNOT TAKE THIS ROLE.\]</td></tr>"
 			continue
-		if(job.minimum_character_age && user.client && (user.client.prefs.age < job.get_min_age(user.client.prefs.species, user.client.prefs.organ_data["brain"])))
+		if((job.minimum_character_age || job.min_age_by_species) && user.client && (user.client.prefs.age < job.get_min_age(user.client.prefs.species, user.client.prefs.organ_data["brain"])))
 			. += "<del>[rank]</del></td></a><td> \[MINIMUM CHARACTER AGE FOR SELECTED RACE/BRAIN TYPE: [job.get_min_age(user.client.prefs.species, user.client.prefs.organ_data["brain"])]\]</td></tr>"
 			continue
 		if((pref.job_civilian_low & ASSISTANT) && job.type != /datum/job/assistant)

--- a/code/modules/client/preference_setup/occupation/occupation.dm
+++ b/code/modules/client/preference_setup/occupation/occupation.dm
@@ -123,8 +123,11 @@
 			var/available_in_days = job.available_in_days(user.client)
 			. += "<del>[rank]</del></td></a><td> \[IN [(available_in_days)] DAYS]</td></tr>"
 			continue
+		if(job.is_species_banned(user.client.prefs.species, user.client.prefs.organ_data["brain"]) == TRUE)
+			. += "<del>[rank]</del></td></a><td> \[THIS RACE/BRAIN TYPE CANNOT TAKE THIS ROLE.\]</td></tr>"
+			continue
 		if(job.minimum_character_age && user.client && (user.client.prefs.age < job.get_min_age(user.client.prefs.species, user.client.prefs.organ_data["brain"])))
-			. += "<del>[rank]</del></td></a><td> \[MINIMUM CHARACTER AGE FOR SELECTED RACE & BRAIN TYPE: [job.get_min_age(user.client.prefs.species, user.client.prefs.organ_data["brain"])]\]</td></tr>"
+			. += "<del>[rank]</del></td></a><td> \[MINIMUM CHARACTER AGE FOR SELECTED RACE/BRAIN TYPE: [job.get_min_age(user.client.prefs.species, user.client.prefs.organ_data["brain"])]\]</td></tr>"
 			continue
 		if((pref.job_civilian_low & ASSISTANT) && job.type != /datum/job/assistant)
 			. += "<font color=grey>[rank]</font></a></td><td></td></tr>"

--- a/code/modules/mob/living/carbon/human/species/station/prometheans.dm
+++ b/code/modules/mob/living/carbon/human/species/station/prometheans.dm
@@ -45,7 +45,7 @@ var/datum/species/shapeshifter/promethean/prometheans
 	female_cough_sounds = list('sound/effects/slime_squish.ogg')
 
 	min_age =		1
-	max_age =		10
+	max_age =		16
 
 	economic_modifier = 3
 

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -494,7 +494,7 @@
 	for(var/datum/job/job in job_master.occupations)
 		if(job && IsJobAvailable(job.title))
 			// Checks for jobs with minimum age requirements
-			if(job.minimum_character_age && (client.prefs.age < job.minimum_character_age))
+			if(job.minimum_character_age && (client.prefs.age < job.get_min_age(client.prefs.species, client.prefs.organ_data["brain"])))
 				continue
 			// Checks for jobs set to "Never" in preferences	//TODO: Figure out a better way to check for this
 			if(!(client.prefs.GetJobDepartment(job, 1) & job.flag))

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -494,7 +494,7 @@
 	for(var/datum/job/job in job_master.occupations)
 		if(job && IsJobAvailable(job.title))
 			// Checks for jobs with minimum age requirements
-			if(job.minimum_character_age && (client.prefs.age < job.get_min_age(client.prefs.species, client.prefs.organ_data["brain"])))
+			if((job.minimum_character_age || job.min_age_by_species) && (client.prefs.age < job.get_min_age(client.prefs.species, client.prefs.organ_data["brain"])))
 				continue
 			// Checks for jobs set to "Never" in preferences	//TODO: Figure out a better way to check for this
 			if(!(client.prefs.GetJobDepartment(job, 1) & job.flag))

--- a/maps/southern_cross/southern_cross_jobs.dm
+++ b/maps/southern_cross/southern_cross_jobs.dm
@@ -109,7 +109,6 @@ var/const/access_explorer = 43
 	economic_modifier = 4
 	access = list(access_medical, access_medical_equip, access_morgue, access_surgery, access_chemistry, access_virology, access_eva, access_maint_tunnels, access_external_airlocks, access_psychiatrist, access_explorer)
 	minimal_access = list(access_medical, access_medical_equip, access_morgue, access_explorer)
-	minimum_character_age = 1
 	min_age_by_species = list(SPECIES_PROMETHEAN = 2)
 
 	outfit_type = /decl/hierarchy/outfit/job/medical/sar

--- a/maps/southern_cross/southern_cross_jobs.dm
+++ b/maps/southern_cross/southern_cross_jobs.dm
@@ -85,6 +85,7 @@ var/const/access_explorer = 43
 	economic_modifier = 4
 	access = list(access_explorer, access_research)
 	minimal_access = list(access_explorer, access_research)
+	banned_job_species = list(SPECIES_ZADDAT)
 
 	outfit_type = /decl/hierarchy/outfit/job/explorer2
 	job_description = "An Explorer searches for interesting things on the surface of Sif, and returns them to the station."

--- a/maps/southern_cross/southern_cross_jobs.dm
+++ b/maps/southern_cross/southern_cross_jobs.dm
@@ -108,6 +108,8 @@ var/const/access_explorer = 43
 	economic_modifier = 4
 	access = list(access_medical, access_medical_equip, access_morgue, access_surgery, access_chemistry, access_virology, access_eva, access_maint_tunnels, access_external_airlocks, access_psychiatrist, access_explorer)
 	minimal_access = list(access_medical, access_medical_equip, access_morgue, access_explorer)
+	minimum_character_age = 1
+	min_age_by_species = list(SPECIES_PROMETHEAN = 2)
 
 	outfit_type = /decl/hierarchy/outfit/job/medical/sar
 	job_description = "A Search and Rescue operative recovers individuals who are injured or dead on the surface of Sif."


### PR DESCRIPTION
Allows jobs to have an age restriction based on their species/brain type. Currently adjusts the following:

All command jobs require Unathi to be 70, Teshari to be 20, Positronics to be 10.

Prometheans have the following age restrictions applied:
Junior Officer: 3
Nurse & Chemist: 3
Paramedic: 2
SAR: 2
Roboticist: 2
Xenobio&botany: 3
Scientist: 3
Engineer & Atmos Tech: 2

Disables the "ideal age" vars as well, because it's not balanced for species and I personally think it's unfair to not just pick the round-start character at random for those jobs anyways.

~~This does NOT make any restrictions to jobs these species should not be taking, but that will be intended in a separate PR. Whitelisted species should already know what jobs not to snag in the meantime like they always did.~~ Did it anyways for visual clarity.

ALSO bumps the max prommie age appropriately. They can now legally drive.

Absolutely needs staff discussion, but the age choices were discussed with the proper maintainers.

:cl:
tweak - Age restricted jobs now account for species.
rscadd - Adds age restrictions to a fair few promethean jobs.
rscadd - Jobs will prevent species that are not supposed to be in that role from taking it.
tweak - Prometheans can now be as old as 16.
/:cl:
