### PR TITLE
Fixes skrell being excluded from skrell hair

### DIFF
--- a/code/modules/mob/new_player/sprite_accessories.dm
+++ b/code/modules/mob/new_player/sprite_accessories.dm
@@ -1722,6 +1722,7 @@ shaved
 /datum/sprite_accessory/hair/skr
 	name = "Skrell Average Tentacles"
 	icon_state = "skrell_hair_average"
+	species_allowed = list(SPECIES_SKRELL, SPECIES_EVENT1, SPECIES_EVENT2, SPECIES_EVENT3)
 
 /datum/sprite_accessory/hair/skr/tentacle_veryshort
 	name = "Skrell Short Tentacles"


### PR DESCRIPTION
Victim of overzealous cleanup during repathing and removing redundant code. This one line was not redundant code I was just mashing that backspace like nobody's business I guess.