### PR TITLE
Allergy severity tweaks

### DIFF
--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -55,7 +55,7 @@
 	var/allergens = null									// Things that will make this species very sick
 	var/allergen_reaction = AG_TOX_DMG|AG_OXY_DMG|AG_EMOTE|AG_PAIN|AG_WEAKEN		// What type of reactions will you have? These the 'main' options and are intended to approximate anaphylactic shock at high doses.
 	var/allergen_damage_severity = 1.2							// How bad are reactions to the allergen? Touch with extreme caution.
-	var/allergen_disable_severity = 3							// Whilst this determines how long nonlethal effects last and how common emotes are.
+	var/allergen_disable_severity = 2.5							// Whilst this determines how long nonlethal effects last and how common emotes are.
 
 	var/min_age = 17
 	var/max_age = 70
@@ -107,7 +107,7 @@
 	var/alcohol_mod =		1						// Multiplier to alcohol strength; 0.5 = half, 0 = no effect at all, 2 = double, etc.
 	var/pain_mod =			1						// Multiplier to pain effects; 0.5 = half, 0 = no effect (equal to NO_PAIN, really), 2 = double, etc.
 	var/spice_mod =			1						// Multiplier to spice/capsaicin/frostoil effects; 0.5 = half, 0 = no effect (immunity), 2 = double, etc.
-	var/trauma_mod = 		1						// Affects traumatic shock (how fast pain crit happens). 0 = no effect (immunity to pain crit), 2 = double etc.Overriden by "can_feel_pain" var	
+	var/trauma_mod = 		1						// Affects traumatic shock (how fast pain crit happens). 0 = no effect (immunity to pain crit), 2 = double etc.Overriden by "can_feel_pain" var
 	// set below is EMP interactivity for nonsynth carbons
 	var/emp_sensitivity =		0			// bitflag. valid flags are: EMP_PAIN, EMP_BLIND, EMP_DEAFEN, EMP_CONFUSE, EMP_STUN, and EMP_(BRUTE/BURN/TOX/OXY)_DMG
 	var/emp_dmg_mod =		1			// Multiplier to all EMP damage sustained by the mob, if it's EMP-sensitive

--- a/code/modules/reagents/reagents/_reagents.dm
+++ b/code/modules/reagents/reagents/_reagents.dm
@@ -25,7 +25,7 @@
 
 	var/affects_dead = 0	// Does this chem process inside a corpse?
 	var/affects_robots = 0	// Does this chem process inside a Synth?
-	
+
 	var/allergen_type		// What potential allergens does this contain?
 	var/allergen_factor = 1	// If the potential allergens are mixed and low-volume, they're a bit less dangerous. Needed for drinks because they're a single reagent compared to food which contains multiple seperate reagents.
 
@@ -162,17 +162,17 @@
 				affect_touch(M, alien, removed)
 	if(overdose && (volume > overdose * M?.species.chemOD_threshold) && (active_metab.metabolism_class != CHEM_TOUCH && !can_overdose_touch))
 		overdose(M, alien, removed)
-	if(M.species.allergens & allergen_type)	//uhoh, we can't handle this!	
+	if(M.species.allergens & allergen_type)	//uhoh, we can't handle this!
 		var/damage_severity = M.species.allergen_damage_severity*allergen_factor
-		var/disable_severity = M.species.allergen_disable_severity*allergen_factor	
+		var/disable_severity = M.species.allergen_disable_severity*allergen_factor
 		if(M.species.allergen_reaction & AG_TOX_DMG)
-			M.adjustToxLoss(damage_severity)
+			M.adjustToxLoss(damage_severity * removed)
 		if(M.species.allergen_reaction & AG_OXY_DMG)
-			M.adjustOxyLoss(damage_severity)
-			if(prob(2.5*disable_severity))
+			M.adjustOxyLoss(damage_severity * removed)
+			if(prob(2*disable_severity))
 				M.emote(pick("cough","gasp","choke"))
 		if(M.species.allergen_reaction & AG_EMOTE)
-			if(prob(2.5*disable_severity))	//this has a higher base chance, but not *too* high
+			if(prob(2*disable_severity))
 				M.emote(pick("pale","shiver","twitch"))
 		if(M.species.allergen_reaction & AG_PAIN)
 			M.adjustHalLoss(disable_severity)


### PR DESCRIPTION
Current allergy effects seem best tuned for an entirely opt-in system like downstream where allergies and their severity are based on optional traits instead of being inherent to half of the station species.
So this:

- Reduces damage taken to be based on the amount of harmful reagent ingested. It will still hurt a bit, it just won't send you to surgery after one refreshing sip of poison. You probably won't see 'lasting' oxy damage unless you REALLY couldn't help yourself sipping that refreshing poison.
- Slightly lowers the chance for visible emotes.
- Very slightly lowers the severity of non-lethal disabling effects like weakness/drowsiness so you aren't totally physically immobilized for several minutes after one refreshing sip of poison.