### PR TITLE
Adds a base matter cost to mech weapons and equipment.

### DIFF
--- a/code/game/mecha/equipment/tools/tools.dm
+++ b/code/game/mecha/equipment/tools/tools.dm
@@ -1,2 +1,3 @@
 /obj/item/mecha_parts/mecha_equipment/tool
+	materials = list(MAT_STEEL = 5000, MAT_GLASS = 3000)
 	equip_type = EQUIP_UTILITY

--- a/code/game/mecha/equipment/tools/tools.dm
+++ b/code/game/mecha/equipment/tools/tools.dm
@@ -1,3 +1,3 @@
 /obj/item/mecha_parts/mecha_equipment/tool
-	materials = list(MAT_STEEL = 5000, MAT_GLASS = 3000)
+	matter = list(MAT_STEEL = 5000, MAT_GLASS = 3000)
 	equip_type = EQUIP_UTILITY

--- a/code/game/mecha/equipment/weapons/weapons.dm
+++ b/code/game/mecha/equipment/weapons/weapons.dm
@@ -2,7 +2,7 @@
 	name = "mecha weapon"
 	range = RANGED
 	origin_tech = list(TECH_MATERIAL = 3, TECH_COMBAT = 3)
-	materials = list(MAT_STEEL = 6000, MAT_GLASS = 3000)
+	matter = list(MAT_STEEL = 6000, MAT_GLASS = 3000)
 	var/projectile //Type of projectile fired.
 	var/projectiles = 1 //Amount of projectiles loaded.
 	var/projectiles_per_shot = 1 //Amount of projectiles fired per single shot.

--- a/code/game/mecha/equipment/weapons/weapons.dm
+++ b/code/game/mecha/equipment/weapons/weapons.dm
@@ -2,6 +2,7 @@
 	name = "mecha weapon"
 	range = RANGED
 	origin_tech = list(TECH_MATERIAL = 3, TECH_COMBAT = 3)
+	materials = list(MAT_STEEL = 6000, MAT_GLASS = 3000)
 	var/projectile //Type of projectile fired.
 	var/projectiles = 1 //Amount of projectiles loaded.
 	var/projectiles_per_shot = 1 //Amount of projectiles fired per single shot.


### PR DESCRIPTION
## About this pull request
This PR adds matter values to mech weapons and all tools. 
This is a base value that does not take into account special materials, but at least you can get your steel and glass back.

The values are inspired from the drill and scattershot respectively, but it is a lower average still.

## Why is this good for the game
More immersion and something to do with unneeded equipment.