### PR TITLE
Adjusts vatborn ages

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/human_subspecies.dm
+++ b/code/modules/mob/living/carbon/human/species/station/human_subspecies.dm
@@ -37,8 +37,13 @@
 	name_plural = "Vatborn"
 	blurb = "With cloning on the forefront of human scientific advancement, cheap mass production \
 	of bodies is a very real and rather ethically grey industry. Vat-grown or Vatborn humans tend to be \
-	paler than baseline, with no appendix and fewer inherited genetic disabilities, but a more aggressive metabolism."
+	paler than baseline, with no appendix and fewer inherited genetic disabilities, but a more aggressive metabolism. \
+	Most vatborn are engineered to experience rapid maturation, reaching approximately sixteen years of growth in only five \
+	before slowing to normal growth rates."
 	icobase = 'icons/mob/human_races/subspecies/r_vatgrown.dmi'
+
+	min_age = 6  /// Accounting for rapid growth.
+	max_age = 110
 
 	toxins_mod =   1.1
 	metabolic_rate = 1.15

--- a/code/modules/mob/living/carbon/human/species/station/human_subspecies.dm
+++ b/code/modules/mob/living/carbon/human/species/station/human_subspecies.dm
@@ -43,7 +43,7 @@
 	icobase = 'icons/mob/human_races/subspecies/r_vatgrown.dmi'
 
 	min_age = 6  /// Accounting for rapid growth.
-	max_age = 110
+	max_age = 90
 
 	toxins_mod =   1.1
 	metabolic_rate = 1.15


### PR DESCRIPTION
Adjusting the min/max age to vatborn to be accurate to [the wiki](https://wiki.ss13polaris.com/index.php?title=Vatborn#.22Natural.22_Vatborn). Lowered the min significantly, lowered the max a wee bit. Added to the blurb a bit about how the aging works to hopefully avoid anyone trying to play as an actual child.