### PR TITLE
Kills Doorstop

### DIFF
--- a/maps/~map_system/maps.dm
+++ b/maps/~map_system/maps.dm
@@ -194,14 +194,9 @@ var/list/all_maps = list()
 // Get a list of 'nearby' or 'connected' zlevels.
 // You should at least return a list with the given z if nothing else.
 /datum/map/proc/get_map_levels(var/srcz, var/long_range = FALSE, var/om_range = -1)
-	//Overmap behavior
-	if(use_overmap)
-		//Get what sector we're in
-		var/obj/effect/overmap/visitable/O = get_overmap_sector(srcz)
-		if(!istype(O))
-			//Not in a sector, just the passed zlevel
-			return list(srcz)
-
+	//Get what sector we're in
+	var/obj/effect/overmap/visitable/O = get_overmap_sector(srcz)
+	if(istype(O))
 		//Just the sector we're in
 		if(om_range == -1)
 			return O.map_z.Copy()
@@ -214,7 +209,7 @@ var/list/all_maps = list()
 			connections += V.map_z // Adding list to list adds contents
 		return connections
 
-	//Traditional behavior
+	//Traditional behavior, if not in an overmap sector
 	else
 		//If long range, and they're at least in contact levels, return contact levels.
 		if (long_range && (srcz in contact_levels))


### PR DESCRIPTION
Fixes the arrivals announcements not being received by the station by allowing a fallback to non-overmap behavior while not on an overmap sector, not just when the overmap is not being used.