### PR TITLE
Fixes changeling transform bug

### DIFF
--- a/code/game/gamemodes/changeling/changeling_powers.dm
+++ b/code/game/gamemodes/changeling/changeling_powers.dm
@@ -102,7 +102,8 @@ var/global/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","E
 
 	var/mob/living/carbon/human/H = src
 	if(istype(H))
-		var/datum/absorbed_dna/newDNA = new(H.real_name, H.dna, H.species.name, H.languages, H.identifying_gender, H.flavor_texts)
+		var/saved_dna = H.dna.Clone() /// Prevent transform from breaking. 
+		var/datum/absorbed_dna/newDNA = new(H.real_name, saved_dna, H.species.name, H.languages, H.identifying_gender, H.flavor_texts, H.modifiers)
 		absorbDNA(newDNA)
 
 	return 1

--- a/code/game/gamemodes/changeling/powers/extract_dna_sting.dm
+++ b/code/game/gamemodes/changeling/powers/extract_dna_sting.dm
@@ -37,7 +37,8 @@
 
 	add_attack_logs(src,T,"DNA extraction sting (changeling)")
 
-	var/datum/absorbed_dna/newDNA = new(T.real_name, T.dna, T.species.name, T.languages)
+	var/saved_dna = T.dna.Clone() /// Prevent transforming bugginess. 
+	var/datum/absorbed_dna/newDNA = new(T.real_name, saved_dna, T.species.name, T.languages, T.identifying_gender, T.flavor_text, T.modifiers)
 	absorbDNA(newDNA)
 
 	feedback_add_details("changeling_powers","ED")


### PR DESCRIPTION
fixes #7434 

Seems it was simply saving the dna var, which would change your species when you transformed, corrupting it when you tried to change back.

Also went in and made it save the flavor text and gender for people you sting, because it seemed it wasn't? And save the modifiers, because it only seemed to be doing that for absorb victims and no one else.