### PR TITLE
Adds sanity check to overmap temp Z level can_die()

### DIFF
--- a/code/modules/overmap/spacetravel.dm
+++ b/code/modules/overmap/spacetravel.dm
@@ -21,6 +21,8 @@
 	return ..()
 
 /obj/effect/overmap/visitable/sector/temporary/proc/can_die(var/mob/observer)
+	if(LAZYLEN(map_z) <= 1)
+		return 0
 	testing("Checking if sector at [map_z[1]] can die.")
 	for(var/mob/M in global.player_list)
 		if(M != observer && (M.z in map_z))

--- a/code/modules/overmap/spacetravel.dm
+++ b/code/modules/overmap/spacetravel.dm
@@ -5,7 +5,7 @@
 	known = 0
 	in_space = TRUE
 
-/obj/effect/overmap/visitable/sector/temporary/New(var/nx, var/ny)
+/obj/effect/overmap/visitable/sector/temporary/Initialize(var/nx, var/ny)
 	loc = locate(nx, ny, global.using_map.overmap_z)
 	x = nx
 	y = ny
@@ -13,6 +13,7 @@
 	map_z += emptyz
 	map_sectors["[emptyz]"] = src
 	testing("Temporary sector at [x],[y] was created, corresponding zlevel is [emptyz].")
+	return ..()
 
 /obj/effect/overmap/visitable/sector/temporary/Destroy()
 	for(var/zlevel in map_z)
@@ -21,14 +22,15 @@
 	return ..()
 
 /obj/effect/overmap/visitable/sector/temporary/proc/can_die(var/mob/observer)
-	if(LAZYLEN(map_z) <= 1)
-		return 0
+	if(!LAZYLEN(map_z))
+		log_and_message_admins("CANARY: [src] tried to check can_die, but map_z is `[map_z]`[map_z == null ? "(null)" : ""]")
+		return TRUE
 	testing("Checking if sector at [map_z[1]] can die.")
 	for(var/mob/M in global.player_list)
 		if(M != observer && (M.z in map_z))
 			testing("There are people on it.")
-			return 0
-	return 1
+			return FALSE
+	return TRUE
 
 /obj/effect/overmap/visitable/sector/temporary/cleanup()
 	if(can_die())

--- a/code/modules/overmap/spacetravel.dm
+++ b/code/modules/overmap/spacetravel.dm
@@ -6,6 +6,7 @@
 	in_space = TRUE
 
 /obj/effect/overmap/visitable/sector/temporary/Initialize(var/nx, var/ny)
+	. = ..()
 	loc = locate(nx, ny, global.using_map.overmap_z)
 	x = nx
 	y = ny
@@ -13,7 +14,6 @@
 	map_z += emptyz
 	map_sectors["[emptyz]"] = src
 	testing("Temporary sector at [x],[y] was created, corresponding zlevel is [emptyz].")
-	return ..()
 
 /obj/effect/overmap/visitable/sector/temporary/Destroy()
 	for(var/zlevel in map_z)

--- a/code/modules/overmap/spacetravel.dm
+++ b/code/modules/overmap/spacetravel.dm
@@ -21,11 +21,11 @@
 	testing("Temporary sector at [x],[y] was destroyed, returning empty zlevel [map_z[1]] to map datum.")
 	return ..()
 
-/obj/effect/overmap/visitable/sector/temporary/proc/can_die(var/mob/observer)
+/obj/effect/overmap/visitable/sector/temporary/proc/is_empty(var/mob/observer)
 	if(!LAZYLEN(map_z))
-		log_and_message_admins("CANARY: [src] tried to check can_die, but map_z is `[map_z]`[map_z == null ? "(null)" : ""]")
+		log_and_message_admins("CANARY: [src] tried to check is_empty, but map_z is `[map_z || "null"]`")
 		return TRUE
-	testing("Checking if sector at [map_z[1]] can die.")
+	testing("Checking if sector at [map_z[1]] has no players.")
 	for(var/mob/M in global.player_list)
 		if(M != observer && (M.z in map_z))
 			testing("There are people on it.")
@@ -33,7 +33,7 @@
 	return TRUE
 
 /obj/effect/overmap/visitable/sector/temporary/cleanup()
-	if(can_die())
+	if(is_empty())
 		qdel(src)
 
 /proc/get_deepspace(x,y)


### PR DESCRIPTION
Should fix spurious can_die runtimes:
```
[2021-09-12T21:11:20] Runtime in spacetravel.dm,24: cannot read from list
   proc name: can die (/obj/effect/overmap/visitable/sector/temporary/proc/can_die)
```

Relevant code is attempting to access index 1, hence list must have at least two elements.