### PR TITLE
Removes suicide verb function

### DIFF
--- a/code/game/verbs/suicide.dm
+++ b/code/game/verbs/suicide.dm
@@ -1,6 +1,6 @@
 /mob/var/suiciding = 0
 
-/mob/living/carbon/human/verb/suicide()
+/mob/living/carbon/human/verb/suicide() /// At best, useful for admins to see if it's being called. Advising keeping function commented out.
 	set hidden = 1
 
 	if (stat == DEAD)
@@ -10,7 +10,11 @@
 	if (!ticker)
 		to_chat(src, "You can't commit suicide before the game starts!")
 		return
+	
+	to_chat(src, "No. Adminhelp if there is a legitimate reason, and please review our server rules.")
+	message_admins("[ckey] has tried to trigger the suicide verb as human, but it is currently disabled.")
 
+/* Only useful if the full function is implimented. 
 	if(!player_is_antag(mind))
 		message_admins("[ckey] has tried to suicide, but they were not permitted due to not being antagonist as human.", 1)
 		to_chat(src, "No. Adminhelp if there is a legitimate reason.")
@@ -19,7 +23,6 @@
 	if (suiciding)
 		to_chat(src, "You're already committing suicide! Be patient!")
 		return
-
 	var/confirm = alert("Are you sure you want to commit suicide?", "Confirm Suicide", "Yes", "No")
 
 	if(confirm == "Yes")
@@ -87,6 +90,7 @@
 
 		adjustOxyLoss(max(175 - getToxLoss() - getFireLoss() - getBruteLoss() - getOxyLoss(), 0))
 		updatehealth()
+*/
 
 /mob/living/carbon/brain/verb/suicide()
 	set hidden = 1

--- a/code/game/verbs/suicide.dm
+++ b/code/game/verbs/suicide.dm
@@ -1,6 +1,6 @@
 /mob/var/suiciding = 0
 
-/mob/living/carbon/human/verb/suicide() /// At best, useful for admins to see if it's being called. Advising keeping function commented out.
+/mob/living/carbon/human/verb/suicide() /// At best, useful for admins to see if it's being called.
 	set hidden = 1
 
 	if (stat == DEAD)
@@ -13,84 +13,6 @@
 	
 	to_chat(src, "No. Adminhelp if there is a legitimate reason, and please review our server rules.")
 	message_admins("[ckey] has tried to trigger the suicide verb as human, but it is currently disabled.")
-
-/* Only useful if the full function is implimented. 
-	if(!player_is_antag(mind))
-		message_admins("[ckey] has tried to suicide, but they were not permitted due to not being antagonist as human.", 1)
-		to_chat(src, "No. Adminhelp if there is a legitimate reason.")
-		return
-
-	if (suiciding)
-		to_chat(src, "You're already committing suicide! Be patient!")
-		return
-	var/confirm = alert("Are you sure you want to commit suicide?", "Confirm Suicide", "Yes", "No")
-
-	if(confirm == "Yes")
-		if(!canmove || restrained())	//just while I finish up the new 'fun' suiciding verb. This is to prevent metagaming via suicide
-			to_chat(src, "You can't commit suicide whilst restrained! ((You can type Ghost instead however.))")
-			return
-		suiciding = 15
-		does_not_breathe = 0			//Prevents ling-suicide zombies, or something
-		var/obj/item/held_item = get_active_hand()
-		if(held_item)
-			var/damagetype = held_item.suicide_act(src)
-			if(damagetype)
-				log_and_message_admins("[key_name(src)] commited suicide using \a [held_item]")
-				var/damage_mod = 1
-				switch(damagetype) //Sorry about the magic numbers.
-								   //brute = 1, burn = 2, tox = 4, oxy = 8
-					if(15) //4 damage types
-						damage_mod = 4
-
-					if(6, 11, 13, 14) //3 damage types
-						damage_mod = 3
-
-					if(3, 5, 7, 9, 10, 12) //2 damage types
-						damage_mod = 2
-
-					if(1, 2, 4, 8) //1 damage type
-						damage_mod = 1
-
-					else //This should not happen, but if it does, everything should still work
-						damage_mod = 1
-
-				//Do 175 damage divided by the number of damage types applied.
-				if(damagetype & BRUTELOSS)
-					adjustBruteLoss(30/damage_mod)	//hack to prevent gibbing
-					adjustOxyLoss(145/damage_mod)
-
-				if(damagetype & FIRELOSS)
-					adjustFireLoss(175/damage_mod)
-
-				if(damagetype & TOXLOSS)
-					adjustToxLoss(175/damage_mod)
-
-				if(damagetype & OXYLOSS)
-					adjustOxyLoss(175/damage_mod)
-
-				//If something went wrong, just do normal oxyloss
-				if(!(damagetype | BRUTELOSS) && !(damagetype | FIRELOSS) && !(damagetype | TOXLOSS) && !(damagetype | OXYLOSS))
-					adjustOxyLoss(max(175 - getToxLoss() - getFireLoss() - getBruteLoss() - getOxyLoss(), 0))
-
-				updatehealth()
-				return
-
-		log_and_message_admins("[key_name(src)] commited suicide")
-		
-		var/datum/gender/T = gender_datums[get_visible_gender()]
-		
-		var/suicidemsg
-		suicidemsg = pick("<span class='danger'>[src] is attempting to bite [T.his] tongue off! It looks like [T.he] [T.is] trying to commit suicide.</span>", \
-		                     "<span class='danger'>[src] is jamming [T.his] thumbs into [T.his] eye sockets! It looks like [T.he] [T.is] trying to commit suicide.</span>", \
-		                     "<span class='danger'>[src] is twisting [T.his] own neck! It looks like [T.he] [T.is] trying to commit suicide.</span>", \
-		                     "<span class='danger'>[src] is holding [T.his] breath! It looks like [T.he] [T.is] trying to commit suicide.</span>")
-		if(isSynthetic())
-			suicidemsg = "<span class='danger'>[src] is attempting to switch [T.his] power off! It looks like [T.he] [T.is] trying to commit suicide.</span>"
-		visible_message(suicidemsg)
-
-		adjustOxyLoss(max(175 - getToxLoss() - getFireLoss() - getBruteLoss() - getOxyLoss(), 0))
-		updatehealth()
-*/
 
 /mob/living/carbon/brain/verb/suicide()
 	set hidden = 1

--- a/code/game/verbs/suicide.dm
+++ b/code/game/verbs/suicide.dm
@@ -11,7 +11,7 @@
 		to_chat(src, "You can't commit suicide before the game starts!")
 		return
 	
-	to_chat(src, "No. Adminhelp if there is a legitimate reason, and please review our server rules.")
+	to_chat(src, "<span class='warning'>No. Adminhelp if there is a legitimate reason, and please review our server rules.</span>")
 	message_admins("[ckey] has tried to trigger the suicide verb as human, but it is currently disabled.")
 
 /mob/living/carbon/brain/verb/suicide()


### PR DESCRIPTION
**Why this is good for the game:** It's only ever abused, and it's outright against our rules.

**Why the verb is staying at all:** It's good for admins to know if someone is trying to do it.

**Why didn't you remove borg verbs:** Wasn't sure on this one. I feel there's probably edge cases where appropriate. They're not the particularly problematic one anyways.

**Why comment it out and not delete it:** In case it needs to come back for an unforeseen edge case, I guess. Felt weird to keep the verb and not keep its function there to at least see.