### PR TITLE
Unfixes bad age fix

### DIFF
--- a/code/game/jobs/job/captain.dm
+++ b/code/game/jobs/job/captain.dm
@@ -23,7 +23,7 @@ var/datum/announcement/minor/captain_announcement = new(do_newscast = 1)
 	economic_modifier = 20
 
 	minimum_character_age = 25
-	min_age_by_species = list(SPECIES_HUMAN_VATBORN = 44)
+	min_age_by_species = list(SPECIES_HUMAN_VATBORN = 14)
 	ideal_character_age = 70 // Old geezer captains ftw
 	ideal_age_by_species = list(SPECIES_HUMAN_VATBORN = 55) /// Vatborn live shorter, no other race eligible for captain besides human/skrell 
 	banned_job_species = list(SPECIES_UNATHI, SPECIES_TAJ, SPECIES_DIONA, SPECIES_PROMETHEAN, SPECIES_ZADDAT, "mechanical", "digital")


### PR DESCRIPTION
For some reason, in the rush of this morning, I thought captains were min age higher than the other roles because I was reading the preferred age, and adjusted vatborn to match while fixing their general command min age to 14. Fixes the captain misjudgement while keeping the 14 update. Entirely my bad.