### PR TITLE
Fixes flamethrower fuel spread runtime

### DIFF
--- a/code/game/objects/effects/decals/Cleanable/fuel.dm
+++ b/code/game/objects/effects/decals/Cleanable/fuel.dm
@@ -37,7 +37,7 @@
 	for(var/d in cardinal)
 		var/turf/simulated/target = get_step(src,d)
 		var/turf/simulated/origin = get_turf(src)
-		if(origin.CanPass(null, target, 0, 0) && target.CanPass(null, origin, 0, 0))
+		if(origin.CanPass(src, target, 0, 0) && target.CanPass(src, origin, 0, 0))
 			var/obj/effect/decal/cleanable/liquid_fuel/other_fuel = locate() in target
 			if(other_fuel)
 				other_fuel.amount += amount*0.25
@@ -72,7 +72,7 @@
 		var/turf/simulated/O = get_step(S,d)
 		if(locate(/obj/effect/decal/cleanable/liquid_fuel/flamethrower_fuel) in O)
 			continue
-		if(O.CanPass(null, S, 0, 0) && S.CanPass(null, O, 0, 0))
+		if(O.CanPass(src, S, 0, 0) && S.CanPass(src, O, 0, 0))
 			var/new_pool_amount = amount * 0.25
 			if(new_pool_amount > 0.1)
 				var/obj/effect/decal/cleanable/liquid_fuel/flamethrower_fuel/F = new(O, new_pool_amount, d)


### PR DESCRIPTION
null is not something that can pass from turf to another.