### PR TITLE
Fixes displaced steel displaced

### DIFF
--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -1,4 +1,5 @@
 /obj/structure/girder
+	name = "girder"
 	icon_state = "girder"
 	anchored = 1
 	density = 1


### PR DESCRIPTION
There was no initial name for the proc to fetch so the "displaced ~~[girder_material.display_name] [initial(name)]~~" became its initial name.