### PR TITLE
Rootspeak isn't a RESTRICTED language

### DIFF
--- a/code/modules/mob/language/station.dm
+++ b/code/modules/mob/language/station.dm
@@ -7,7 +7,7 @@
 	colour = "soghun"
 	key = "q"
 	machine_understands = 0
-	flags = RESTRICTED
+	flags = WHITELISTED // RESTRICTED would make this completely unavailable from character select
 	syllables = list("hs","zt","kr","st","sh")
 
 /datum/language/diona_local/get_random_name()
@@ -20,7 +20,7 @@
 	desc = "A complex language known instinctively by Dionaea, 'spoken' by emitting modulated radio waves. This version uses low frequency waves for slow communication at long ranges."
 	key = "w"
 	machine_understands = 0
-	flags = RESTRICTED | HIVEMIND
+	flags = WHITELISTED | HIVEMIND // RESTRICTED would make this completely unavailable from character select
 
 /datum/language/unathi
 	name = LANGUAGE_UNATHI


### PR DESCRIPTION
Making it WHITELISTED instead achieves the same semantic function, where silly humans and friends can't select it from character select, but diona can. RESTRICTED was interpreted as completely unavailable to players in character select when I implemented the system that sanitizes invalid languages.

It's probably a better solution to make the `species_language` accept a list of languages but that would take a _lot_ more gutwork and it's 1AM, and I got a flight at 10:40AM.