### PR TITLE
Fix 2 Anomaly Bugsons

### DIFF
--- a/code/modules/xenoarcheaology/effect_master.dm
+++ b/code/modules/xenoarcheaology/effect_master.dm
@@ -346,6 +346,12 @@
 			my_effect.UpdateMove()
 
 /datum/component/artifact_master/process()
+	if(!holder)	// Some instances can be created and rapidly lose their holder, if they are destroyed rapidly on creation. IE, during excavation.
+		STOP_PROCESSING(SSobj, src)
+		if(!QDELETED(src))
+			qdel(src)
+			return
+
 	var/turf/L = holder.loc
 	if(!istype(L) && !isliving(L)) 	// We're inside a non-mob container or on null turf, either way stop processing effects
 		return

--- a/code/modules/xenoarcheaology/effects/vampire.dm
+++ b/code/modules/xenoarcheaology/effects/vampire.dm
@@ -65,13 +65,13 @@
 	if(charges >= 10)
 		charges -= 10
 		var/manifestation = pick(/obj/item/device/soulstone, /mob/living/simple_mob/faithless/cult/strong, /mob/living/simple_mob/creature/cult/strong, /mob/living/simple_mob/animal/space/bats/cult/strong)
-		new manifestation(get_turf(pick(view(1,T))))
+		new manifestation(get_turf(pick(range(1,T))))
 
 	if(charges >= 3)
 		if(prob(5))
 			charges -= 1
 			var/spawn_type = pick(/mob/living/simple_mob/animal/space/bats, /mob/living/simple_mob/creature, /mob/living/simple_mob/faithless)
-			new spawn_type(get_turf(pick(view(1,T))))
+			new spawn_type(get_turf(pick(range(1,T))))
 			playsound(holder, pick('sound/hallucinations/growl1.ogg','sound/hallucinations/growl2.ogg','sound/hallucinations/growl3.ogg'), 50, 1, -3)
 
 	if(charges >= 1 && nearby_mobs.len && prob(15 * nearby_mobs.len))


### PR DESCRIPTION
:cl:
bugfix - Fix rapidly destroyed anomalies' effect_masters staying behind.
bugfix - Fix vampire anomalies not being able to pick a turf to spawn something because they're blind.
/:cl: