### PR TITLE
Fixes temp sector initialization

### DIFF
--- a/code/modules/overmap/spacetravel.dm
+++ b/code/modules/overmap/spacetravel.dm
@@ -10,16 +10,23 @@
 	loc = locate(nx, ny, global.using_map.overmap_z)
 	x = nx
 	y = ny
-	var/emptyz = global.using_map.get_empty_zlevel()
-	map_z += emptyz
-	map_sectors["[emptyz]"] = src
-	testing("Temporary sector at [x],[y] was created, corresponding zlevel is [emptyz].")
+	map_sectors["[map_z[1]]"] = src
+	if(!map_z[1])
+		log_and_message_admins("Could not create empty sector at [nx], [ny]. No available z levels to allocate.")
+		return INITIALIZE_HINT_QDEL
+
+	testing("Temporary sector at [x],[y] was created, corresponding zlevel is [map_z[1]].")
 
 /obj/effect/overmap/visitable/sector/temporary/Destroy()
 	for(var/zlevel in map_z)
 		using_map.cache_empty_zlevel(zlevel)
 	testing("Temporary sector at [x],[y] was destroyed, returning empty zlevel [map_z[1]] to map datum.")
 	return ..()
+
+/obj/effect/overmap/visitable/sector/temporary/find_z_levels()
+	if(!LAZYLEN(map_z))
+		map_z = list()
+	map_z += global.using_map.get_empty_zlevel()
 
 /obj/effect/overmap/visitable/sector/temporary/proc/is_empty(var/mob/observer)
 	if(!LAZYLEN(map_z))
@@ -43,7 +50,10 @@
 	var/obj/effect/overmap/visitable/sector/temporary/res = locate() in overmap_turf
 	if(istype(res))
 		return res
-	return new /obj/effect/overmap/visitable/sector/temporary(x, y)
+	res = new /obj/effect/overmap/visitable/sector/temporary(x, y)
+	if(QDELETED(res))
+		res = null
+	return res
 
 /atom/movable/proc/lost_in_space()
 	for(var/atom/movable/AM in contents)
@@ -128,8 +138,10 @@
 		if(O != M && O.in_space && prob(50))
 			TM = O
 			break
-	if(!TM)
+	if(!istype(TM))
 		TM = get_deepspace(M.x,M.y)
+	if(!istype(TM))
+		return
 	nz = pick(TM.get_space_zlevels())
 
 	var/turf/dest = locate(nx,ny,nz)
@@ -139,5 +151,7 @@
 			var/mob/D = A
 			if(D.pulling)
 				D.pulling.forceMove(dest)
+	else
+		to_world("CANARY: Could not move [A] to [nx], [ny], [nz]: [dest ? "[dest]" : "null"]")
 
 	M.cleanup()

--- a/code/modules/overmap/spacetravel.dm
+++ b/code/modules/overmap/spacetravel.dm
@@ -24,8 +24,6 @@
 	return ..()
 
 /obj/effect/overmap/visitable/sector/temporary/find_z_levels()
-	if(!LAZYLEN(map_z))
-		map_z = list()
 	LAZYADD(map_z, global.using_map.get_empty_zlevel())
 
 /obj/effect/overmap/visitable/sector/temporary/proc/is_empty(var/mob/observer)

--- a/code/modules/overmap/spacetravel.dm
+++ b/code/modules/overmap/spacetravel.dm
@@ -10,11 +10,11 @@
 	loc = locate(nx, ny, global.using_map.overmap_z)
 	x = nx
 	y = ny
-	map_sectors["[map_z[1]]"] = src
 	if(!map_z[1])
 		log_and_message_admins("Could not create empty sector at [nx], [ny]. No available z levels to allocate.")
 		return INITIALIZE_HINT_QDEL
 
+	map_sectors["[map_z[1]]"] = src
 	testing("Temporary sector at [x],[y] was created, corresponding zlevel is [map_z[1]].")
 
 /obj/effect/overmap/visitable/sector/temporary/Destroy()
@@ -26,7 +26,7 @@
 /obj/effect/overmap/visitable/sector/temporary/find_z_levels()
 	if(!LAZYLEN(map_z))
 		map_z = list()
-	map_z += global.using_map.get_empty_zlevel()
+	LAZYADD(map_z, global.using_map.get_empty_zlevel())
 
 /obj/effect/overmap/visitable/sector/temporary/proc/is_empty(var/mob/observer)
 	if(!LAZYLEN(map_z))

--- a/maps/~map_system/maps.dm
+++ b/maps/~map_system/maps.dm
@@ -183,13 +183,21 @@ var/list/all_maps = list()
 	return text2num(pickweight(candidates))
 
 /datum/map/proc/get_empty_zlevel()
+	// Try to free up a z level from existing temp sectors
+	if(!empty_levels.len)
+		for(var/Z in map_sectors)
+			var/obj/effect/overmap/visitable/sector/temporary/T = map_sectors[Z]
+			T.cleanup() // If we can release some of these, do that.
+
+	// Else, we need to buy a new one.
 	if(!empty_levels.len)
 		world.increment_max_z()
 		empty_levels += world.maxz
 	return pick_n_take(empty_levels)
 
 /datum/map/proc/cache_empty_zlevel(var/z)
-	empty_levels |= z
+	if(z) // Else, it's not a valid z and we want to expunge it
+		empty_levels |= z
 
 // Get a list of 'nearby' or 'connected' zlevels.
 // You should at least return a list with the given z if nothing else.


### PR DESCRIPTION
Fixes #8310 . Notably, stuff will accumulate on z levels if they're unalocated, because it can't leave the z-level, but they will do so at the borders of the z, so might not be accessible to players.

The issue was that improper initialization was allowing them to try to use the z level of 0, which is invalid.
https://puu.sh/IgmpN/78da742122.mp4