### PR TITLE
Adds head accesses to bridge weapons locker

### DIFF
--- a/maps/southern_cross/southern_cross-1.dmm
+++ b/maps/southern_cross/southern_cross-1.dmm
@@ -106149,7 +106149,8 @@
 	dir = 8
 	},
 /obj/structure/closet/secure_closet/guncabinet/sidearm{
-	anchored = 1
+	anchored = 1;
+	req_one_access = list(3, 20, 30, 39, 56, 57, 58)
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 1


### PR DESCRIPTION
Fixes #8295 
This can't use `access_heads`, which is the access to the bridge in general, because we don't want to give access to the secretary.
We may need to copy this onto Cynosure

... I should really refactor accesses because the way they're defined just feels icky and full of magic numbers.