### PR TITLE
Fixes rocket launcher

### DIFF
--- a/code/modules/projectiles/projectile/explosive.dm
+++ b/code/modules/projectiles/projectile/explosive.dm
@@ -8,22 +8,20 @@
 	damage = 30	//Meaty whack. *Chuckles*
 	does_spin = 0
 
-/obj/item/projectile/bullet/srmrocket/on_hit(atom/target, blocked=0)
-	..()
+/obj/item/projectile/bullet/srmrocket/throw_impact(atom/target, var/speed)
 	if(!isliving(target)) //if the target isn't alive, so is a wall or something
 		explosion(target, 0, 1, 2, 4)
 	else
 		explosion(target, 0, 0, 2, 4)
-	return 1
+	qdel(src)
 
 
 /obj/item/projectile/bullet/srmrocket/weak	//Used in the jury rigged one.
 	damage = 10
 
-/obj/item/projectile/bullet/srmrocket/weak/on_hit(atom/target, blocked=0)
-	..()
+/obj/item/projectile/bullet/srmrocket/weak/throw_impact(atom/target, var/speed)
 	explosion(target, 0, 0, 2, 4)//No need to have a question.
-	return 1
+	qdel(src)
 
 /*Old vars here for reference.
 	var/devastation = 0

--- a/code/modules/projectiles/projectile/explosive.dm
+++ b/code/modules/projectiles/projectile/explosive.dm
@@ -8,6 +8,13 @@
 	damage = 30	//Meaty whack. *Chuckles*
 	does_spin = 0
 
+/obj/item/projectile/bullet/srmrocket/on_hit(atom/target, blocked=0)
+	if(!isliving(target)) //if the target isn't alive, so is a wall or something
+		explosion(target, 0, 1, 2, 4)
+	else
+		explosion(target, 0, 0, 2, 4)
+	return 1
+
 /obj/item/projectile/bullet/srmrocket/throw_impact(atom/target, var/speed)
 	if(!isliving(target)) //if the target isn't alive, so is a wall or something
 		explosion(target, 0, 1, 2, 4)
@@ -15,9 +22,12 @@
 		explosion(target, 0, 0, 2, 4)
 	qdel(src)
 
-
 /obj/item/projectile/bullet/srmrocket/weak	//Used in the jury rigged one.
 	damage = 10
+
+/obj/item/projectile/bullet/srmrocket/weak/on_hit(atom/target, blocked=0)
+	explosion(target, 0, 0, 2, 4)//No need to have a question.
+	return 1
 
 /obj/item/projectile/bullet/srmrocket/weak/throw_impact(atom/target, var/speed)
 	explosion(target, 0, 0, 2, 4)//No need to have a question.


### PR DESCRIPTION
The launcher type guns use throw_at instead of the fancy bullet projectile features, so the fancy bullet projectile mechanics were unable to make things go boom by having several dead-end returns happen before the projectiles could even reach the on_hit, which already bonks into a return in the ..()'d parent proc anyway.