### PR TITLE
Fixes simplemobs with 0 init nutrition runtiming

### DIFF
--- a/code/modules/mob/living/simple_mob/life.dm
+++ b/code/modules/mob/living/simple_mob/life.dm
@@ -54,7 +54,7 @@
 			healths.icon_state = "health7"
 
 	//Updates the nutrition while we're here
-	var/food_per = (nutrition / initial(nutrition)) * 100
+	var/food_per = (nutrition / max_nutrition) * 100
 	switch(food_per)
 		if(90 to INFINITY)
 			clear_alert("nutrition")


### PR DESCRIPTION
Fixes runtime spam caused by simplemobs with initial nutrition value of 0.