### PR TITLE
Fixes various Init qdels/bad returns.

### DIFF
--- a/code/game/objects/effects/alien/aliens.dm
+++ b/code/game/objects/effects/alien/aliens.dm
@@ -174,7 +174,7 @@
 
 /obj/effect/alien/weeds/Initialize(var/mapload, var/node, var/newcolor)
 	. = ..()
-	if(isspace(loc))
+	if(isspace(loc) || (locate(/obj/effect/alien/weeds) in loc) != src)
 		return INITIALIZE_HINT_QDEL
 
 	linked_node = node
@@ -188,14 +188,11 @@
 
 /obj/effect/alien/weeds/Destroy()
 	var/turf/T = get_turf(src)
-	// To not mess up the overlay updates.
-	loc = null
-
-	for (var/obj/effect/alien/weeds/W in range(1,T))
-		W.updateWeedOverlays()
-
 	linked_node = null
-	return ..()
+	. = ..()
+	if(T)
+		for (var/obj/effect/alien/weeds/W in range(1,T))
+			W.updateWeedOverlays()
 
 /obj/effect/alien/weeds/node
 	icon_state = "weednode"
@@ -210,10 +207,10 @@
 /obj/effect/alien/weeds/node/Initialize(var/mapload, var/node, var/newcolor)
 	. = ..()
 
-	for(var/obj/effect/alien/weeds/existing in loc)
-		if(existing == src)
-			continue
-		else
+	if(. != INITIALIZE_HINT_QDEL && !mapload)
+		for(var/obj/effect/alien/weeds/existing in loc)
+			if(existing == src)
+				continue
 			qdel(existing)
 
 	linked_node = src
@@ -255,8 +252,6 @@
 /obj/effect/alien/weeds/proc/fullUpdateWeedOverlays()
 	for (var/obj/effect/alien/weeds/W in range(1,src))
 		W.updateWeedOverlays()
-
-	return
 
 // NB: This is not actually called by a processing subsystem, it's called by the node processing
 /obj/effect/alien/weeds/process()

--- a/code/game/objects/structures/lattice.dm
+++ b/code/game/objects/structures/lattice.dm
@@ -18,6 +18,7 @@
 		if(LAT != src)
 			crash_with("Found multiple lattices at '[log_info_line(loc)]'")
 			return INITIALIZE_HINT_QDEL
+
 	icon = 'icons/obj/smoothlattice.dmi'
 	icon_state = "latticeblank"
 	updateOverlays()

--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -48,6 +48,9 @@
 		if(prob(dirty_prob))
 			dirt += rand(50,100)
 			update_dirt() //5% chance to start with dirt on a floor tile- give the janitor something to do
+	if(!mapload)
+		for(var/obj/structure/lattice/L in src)
+			qdel(L)
 
 /turf/simulated/floor/LateInitialize()
 	. = ..()

--- a/code/game/turfs/turf_changing.dm
+++ b/code/game/turfs/turf_changing.dm
@@ -3,12 +3,6 @@
 	spawn()
 		new /obj/structure/lattice( locate(src.x, src.y, src.z) )
 
-// Removes all signs of lattice on the pos of the turf -Donkieyo
-/turf/proc/RemoveLattice()
-	var/obj/structure/lattice/L = locate(/obj/structure/lattice, src)
-	if(L)
-		qdel(L)
-
 // Called after turf replaces old one
 /turf/proc/post_change()
 	levelupdate()
@@ -44,12 +38,11 @@
 	qdel(src)
 
 	var/turf/W = new N( locate(src.x, src.y, src.z) )
-	if(istype(W, /turf/simulated/floor))
-		if(old_fire)
+	if(old_fire)
+		if(istype(W, /turf/simulated/floor))
 			W.fire = old_fire
-		W.RemoveLattice()
-	else if(old_fire)
-		old_fire.RemoveFire()
+		else
+			old_fire.RemoveFire()
 
 	if(tell_universe)
 		universe.OnTurfChange(W)

--- a/code/modules/mob/living/carbon/human/ai_controlled/ai_controlled.dm
+++ b/code/modules/mob/living/carbon/human/ai_controlled/ai_controlled.dm
@@ -39,7 +39,7 @@
 	if(generate_id_gender)
 		identifying_gender = pick(list(MALE, FEMALE, PLURAL, NEUTER))
 
-	..(loc, generate_species)
+	. = ..(loc, generate_species)
 
 	h_style = to_wear_hair
 


### PR DESCRIPTION
- Weeds now return qdel hints instead of directly qdeling other atoms (except if we're not maploading, in which case init has run already).
- Lattices are now cleaned up in floor Initialize only if not maploading, to avoid qcing before init. Lattices already return an init hint on their turf being wrong.
- ai_controlled human mobtype returns an init value.