### PR TITLE
Adds checking on target to mob shoot_target proc.

### DIFF
--- a/code/modules/mob/living/simple_mob/combat.dm
+++ b/code/modules/mob/living/simple_mob/combat.dm
@@ -86,6 +86,10 @@
 //The actual top-level ranged attack proc
 /mob/living/simple_mob/proc/shoot_target(atom/A)
 	set waitfor = FALSE
+
+	if(!istype(A) || QDELETED(A))
+		return
+
 	setClickCooldown(get_attack_speed())
 
 	face_atom(A)

--- a/code/modules/mob/living/simple_mob/subtypes/humanoid/mercs/mercs.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/humanoid/mercs/mercs.dm
@@ -301,6 +301,10 @@
 
 /mob/living/simple_mob/humanoid/merc/ranged/sniper/shoot_target(atom/A)
 	set waitfor = FALSE
+
+	if(!istype(A) || QDELETED(A))
+		return
+
 	setClickCooldown(get_attack_speed())
 
 	face_atom(A)


### PR DESCRIPTION
This is to fix a runtime observed in CI. I am not familiar enough with the entire call chain to know why a null target is making it this far, but heigh ho.