### PR TITLE
Fixes inactive vr pods trapping occupant

### DIFF
--- a/code/game/machinery/virtual_reality/vr_console.dm
+++ b/code/game/machinery/virtual_reality/vr_console.dm
@@ -185,7 +185,8 @@
 	if(!forced && avatar && alert(avatar, "Someone wants to remove you from virtual reality. Do you want to leave?", "Leave VR?", "Yes", "No") == "No")
 		return
 
-	avatar.exit_vr()
+	if(avatar)
+		avatar.exit_vr()
 	avatar = null
 
 	if(occupant.client)


### PR DESCRIPTION
Lack of avatar here meant a runtime that would block the pod from ever reaching the part where the occupant actually gets released.