### PR TITLE
Fixes Cynosure Shuttle Issue

### DIFF
--- a/code/modules/multiz/turf.dm
+++ b/code/modules/multiz/turf.dm
@@ -39,6 +39,7 @@
 	if(T)
 		GLOB.turf_entered_event.unregister(T, src, .proc/BelowOpenUpdated)
 		GLOB.turf_exited_event.unregister(T, src, .proc/BelowOpenUpdated)
+		turf_changed_event.unregister(T, src, /atom/proc/update_icon)
 	. = ..()
 
 /turf/simulated/open/Initialize()


### PR DESCRIPTION
The shuttles that create roofs will no longer cause what was thought of to be a crash, but was actually an hour long lagspike. This  makes the new map playable once more..
Also give thanks to @Atermonera, @PrismaticGynoid, and @Woodratt for their help, too.