### PR TITLE
Adds config-enabled whitelist for sprite accessories

### DIFF
--- a/code/_helpers/global_lists.dm
+++ b/code/_helpers/global_lists.dm
@@ -206,28 +206,28 @@ var/global/list/string_slot_flags = list(
 			GLOB.whitelisted_species += S.name
 
 	//Ores
-	paths = typesof(/ore)-/ore
+	paths = subtypesof(/ore)
 	for(var/oretype in paths)
 		var/ore/OD = new oretype()
 		GLOB.ore_data[OD.name] = OD
 
-	paths = typesof(/datum/alloy)-/datum/alloy
+	paths = subtypesof(/datum/alloy)
 	for(var/alloytype in paths)
 		GLOB.alloy_data += new alloytype()
 
-	paths = typesof(/datum/sprite_accessory/ears) - /datum/sprite_accessory/ears
+	paths = subtypesof(/datum/sprite_accessory/ears)
 	for(var/path in paths)
 		var/obj/item/clothing/head/instance = new path()
 		ear_styles_list[path] = instance
 
 	// Custom Tails
-	paths = typesof(/datum/sprite_accessory/tail) - /datum/sprite_accessory/tail - /datum/sprite_accessory/tail/taur
+	paths = subtypesof(/datum/sprite_accessory/tail) - /datum/sprite_accessory/tail/taur
 	for(var/path in paths)
 		var/datum/sprite_accessory/tail/instance = new path()
 		tail_styles_list[path] = instance
 
 	// Custom Wings
-	paths = typesof(/datum/sprite_accessory/wing) - /datum/sprite_accessory/wing
+	paths = subtypesof(/datum/sprite_accessory/wing)
 	for(var/path in paths)
 		var/datum/sprite_accessory/wing/instance = new path()
 		wing_styles_list[path] = instance

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -290,6 +290,9 @@ var/list/gamemode_cache = list()
 	// How strictly the loadout enforces object species whitelists
 	var/loadout_whitelist = LOADOUT_WHITELIST_LAX
 
+	// Whether whitelists are enforced for ears/tail/etc modifications
+	var/genemod_whitelist = FALSE
+
 	var/disable_webhook_embeds = FALSE
 
 /datum/configuration/New()
@@ -940,6 +943,9 @@ var/list/gamemode_cache = list()
 
 				if("enable_night_shifts")
 					config.enable_night_shifts = TRUE
+
+				if("genemod_whitelist")
+					config.genemod_whitelist = TRUE
 
 				else
 					log_misc("Unknown setting in configuration: '[name]'")

--- a/code/game/jobs/whitelist.dm
+++ b/code/game/jobs/whitelist.dm
@@ -1,19 +1,17 @@
-#define WHITELISTFILE "data/whitelist.txt"
-
 var/list/whitelist = list()
 
 /hook/startup/proc/loadWhitelist()
 	if(config.usewhitelist)
 		load_whitelist()
-	return 1
+	return TRUE
 
 /proc/load_whitelist()
-	whitelist = file2list(WHITELISTFILE)
+	whitelist = file2list("data/whitelist.txt")
 	if(!whitelist.len)	whitelist = null
 
 /proc/check_whitelist(mob/M /*, var/rank*/)
 	if(!whitelist)
-		return 0
+		return FALSE
 	return ("[M.ckey]" in whitelist)
 
 /var/list/alien_whitelist = list()
@@ -21,7 +19,7 @@ var/list/whitelist = list()
 /hook/startup/proc/loadAlienWhitelist()
 	if(config.usealienwhitelist)
 		load_alienwhitelist()
-	return 1
+	return TRUE
 
 /proc/load_alienwhitelist()
 	var/text = file2text("config/alienwhitelist.txt")
@@ -33,51 +31,55 @@ var/list/whitelist = list()
 /proc/is_alien_whitelisted(mob/M, var/datum/species/species)
 	//They are admin or the whitelist isn't in use
 	if(whitelist_overrides(M))
-		return 1
+		return TRUE
 
 	//You did something wrong
 	if(!M || !species)
-		return 0
+		return FALSE
 
 	//The species isn't even whitelisted
 	if(!(species.spawn_flags & SPECIES_IS_WHITELISTED))
-		return 1
+		return TRUE
 
 	//If we have a loaded file, search it
 	if(alien_whitelist)
 		for (var/s in alien_whitelist)
 			if(findtext(s,"[M.ckey] - [species.name]"))
-				return 1
+				return TRUE
 			if(findtext(s,"[M.ckey] - All"))
-				return 1
+				return TRUE
 
 /proc/is_lang_whitelisted(mob/M, var/datum/language/language)
 	//They are admin or the whitelist isn't in use
 	if(whitelist_overrides(M))
-		return 1
+		return TRUE
 
 	//You did something wrong
 	if(!M || !language)
-		return 0
+		return FALSE
 
 	//The language isn't even whitelisted
 	if(!(language.flags & WHITELISTED))
-		return 1
+		return TRUE
 
 	//If we have a loaded file, search it
 	if(alien_whitelist)
 		for (var/s in alien_whitelist)
 			if(findtext(s,"[M.ckey] - [language.name]"))
-				return 1
+				return TRUE
 			if(findtext(s,"[M.ckey] - All"))
-				return 1
+				return TRUE
 
 /proc/whitelist_overrides(mob/M)
-	if(!config.usealienwhitelist)
-		return 1
-	if(check_rights(R_ADMIN|R_EVENT, 0, M))
-		return 1
+	return !config.usealienwhitelist || check_rights(R_ADMIN|R_EVENT, 0, M)
 
-	return 0
+/var/list/genemod_whitelist = list()
+/hook/startup/proc/LoadGenemodWhitelist()
+	global.genemod_whitelist = file2list("config/genemodwhitelist.txt")
+	return TRUE
 
-#undef WHITELISTFILE
+/proc/is_genemod_whitelisted(mob/M)
+	return M && M.client && M.client.ckey && LAZYLEN(global.genemod_whitelist) && (M.client.ckey in global.genemod_whitelist)
+
+/proc/foo()
+	to_world(list2text(global.genemod_whitelist))

--- a/code/modules/client/preference_setup/general/03_body.dm
+++ b/code/modules/client/preference_setup/general/03_body.dm
@@ -73,16 +73,11 @@ var/global/list/valid_bloodtypes = list("A+", "A-", "B+", "B-", "AB+", "AB-", "O
 
 		// Is an admin OR
 		// Instance is species-whitelisted AND current species matches whitelist OR
-		// ~~Is NOT species-whitelisted AND~~ config ckey-whitelist is enabled AND ckey matches whitelist
-		
-		// There's 3 dedicated species for events that are species-whitelisted for ALL sprites,
-		// so the list at present actually has a minimum length of 3.
-		// But because I don't trust SS13 developers to actually respect a #define I set somewhere,
-		// I'm just throwing out that requirement altogether. -Ater
-		// TODO: Implement a framework for dynamically creating new singleton even species in-round (Don't @ me with this)
+		// config ckey-whitelist is enabled AND ckey matches whitelist AND the ckey-whitelist enables this instance for current species.
+		// That last list is entirely arbitrary. Take complaints up with Kholdstare.
 		if((istype(client) && check_rights(R_ADMIN | R_EVENT | R_FUN, 0, client)) || \
 				(LAZYLEN(instance.species_allowed) && species && (species in instance.species_allowed)) || \
-				(config.genemod_whitelist && is_genemod_whitelisted(src)))
+				(config.genemod_whitelist && is_genemod_whitelisted(src) && LAZYLEN(instance.whitelist_allowed) && (species in instance.whitelist_allowed)))
 			.[instance.name] = instance
 
 /datum/category_item/player_setup_item/general/body

--- a/code/modules/client/preference_setup/general/03_body.dm
+++ b/code/modules/client/preference_setup/general/03_body.dm
@@ -70,9 +70,20 @@ var/global/list/valid_bloodtypes = list("A+", "A-", "B+", "B-", "AB+", "AB-", "O
 			continue
 		if(instance.ckeys_allowed && (!client || !(client.ckey in instance.ckeys_allowed)))
 			continue
-		if(instance.species_allowed && (!species || !(species in instance.species_allowed)) && (!client || !check_rights(R_ADMIN | R_EVENT | R_FUN, 0, client)))
-			continue
-		.[instance.name] = instance
+
+		// Is an admin OR
+		// Instance is species-whitelisted AND current species matches whitelist OR
+		// ~~Is NOT species-whitelisted AND~~ config ckey-whitelist is enabled AND ckey matches whitelist
+		
+		// There's 3 dedicated species for events that are species-whitelisted for ALL sprites,
+		// so the list at present actually has a minimum length of 3.
+		// But because I don't trust SS13 developers to actually respect a #define I set somewhere,
+		// I'm just throwing out that requirement altogether. -Ater
+		// TODO: Implement a framework for dynamically creating new singleton even species in-round (Don't @ me with this)
+		if((istype(client) && check_rights(R_ADMIN | R_EVENT | R_FUN, 0, client)) || \
+				(LAZYLEN(instance.species_allowed) && species && (species in instance.species_allowed)) || \
+				(config.genemod_whitelist && is_genemod_whitelisted(src)))
+			.[instance.name] = instance
 
 /datum/category_item/player_setup_item/general/body
 	name = "Body"

--- a/code/modules/mob/new_player/sprite_accessories.dm
+++ b/code/modules/mob/new_player/sprite_accessories.dm
@@ -30,6 +30,7 @@
 
 	// Restrict some styles to specific species. Set to null to perform no checking.
 	var/list/species_allowed = list(SPECIES_HUMAN,SPECIES_PROMETHEAN,SPECIES_HUMAN_VATBORN)
+	var/list/whitelist_allowed = list()
 
 	// Whether or not the accessory can be affected by colouration
 	var/do_colouration = 1

--- a/code/modules/mob/new_player/sprite_accessories_ear.dm
+++ b/code/modules/mob/new_player/sprite_accessories_ear.dm
@@ -16,6 +16,7 @@
 	var/desc = "You should not see this..."
 
 	species_allowed = list(SPECIES_EVENT1, SPECIES_EVENT2, SPECIES_EVENT3)
+	whitelist_allowed = list(SPECIES_HUMAN, SPECIES_HUMAN_VATBORN, SPECIES_PROMETHEAN)
 
 /datum/sprite_accessory/ears/shadekin
 	name = "Shadekin Ears, colorable"
@@ -24,6 +25,7 @@
 	do_colouration = 1
 	color_blend_mode = ICON_MULTIPLY
 	species_allowed = list() // SPECIES_SHADEKIN, SPECIES_SHADEKIN_CREW
+	whitelist_allowed = list()
 
 /datum/sprite_accessory/ears/taj_ears
 	name = "Tajaran Ears"
@@ -31,6 +33,7 @@
 	do_colouration = 1
 	color_blend_mode = ICON_MULTIPLY
 	species_allowed = list(SPECIES_TAJ, SPECIES_EVENT1, SPECIES_EVENT2, SPECIES_EVENT3)
+	whitelist_allowed = list(SPECIES_PROMETHEAN)
 	extra_overlay = "ears_plain-inner"
 
 /datum/sprite_accessory/ears/taj_ears_tall
@@ -39,6 +42,7 @@
 	do_colouration = 1
 	color_blend_mode = ICON_MULTIPLY
 	species_allowed = list(SPECIES_TAJ, SPECIES_EVENT1, SPECIES_EVENT2, SPECIES_EVENT3)
+	whitelist_allowed = list(SPECIES_PROMETHEAN)
 	extra_overlay = "msai_plain-inner"
 
 /datum/sprite_accessory/ears/squirrel_orange
@@ -168,15 +172,18 @@
 	name = "highlander zorren ears"
 	desc = ""
 	icon_state = "foxears"
+	whitelist_allowed = list()
 
 /datum/sprite_accessory/ears/fenears
 	name = "flatland zorren ears"
 	desc = ""
 	icon_state = "fenears"
+	whitelist_allowed = list()
 
 /datum/sprite_accessory/ears/sergal //Redundant
 	name = "Sergal ears"
 	icon_state = "serg_plain_s"
+	whitelist_allowed = list()
 
 /datum/sprite_accessory/ears/foxearshc
 	name = "highlander zorren ears, colorable"
@@ -184,6 +191,7 @@
 	icon_state = "foxearshc"
 	do_colouration = 1
 	color_blend_mode = ICON_MULTIPLY
+	whitelist_allowed = list()
 
 /datum/sprite_accessory/ears/fenearshc
 	name = "flatland zorren ears, colorable"
@@ -192,12 +200,14 @@
 	extra_overlay = "fenears-inner"
 	do_colouration = 1
 	color_blend_mode = ICON_MULTIPLY
+	whitelist_allowed = list()
 
 /datum/sprite_accessory/ears/sergalhc
 	name = "Sergal ears, colorable"
 	icon_state = "serg_plain_s"
 	do_colouration = 1
 	color_blend_mode = ICON_MULTIPLY
+	whitelist_allowed = list()
 
 /datum/sprite_accessory/ears/mousehc
 	name = "mouse, colorable"
@@ -328,6 +338,7 @@
 	do_colouration = 1
 	color_blend_mode = ICON_MULTIPLY
 	extra_overlay = "otie-inner"
+	whitelist_allowed = list()
 
 /datum/sprite_accessory/ears/donkey
 	name = "donkey, colorable"
@@ -396,6 +407,7 @@
 	icon_state = "drake"
 	do_colouration = 1
 	color_blend_mode = ICON_MULTIPLY
+	whitelist_allowed = list()
 
 /datum/sprite_accessory/ears/vulp
 	name = "vulpkanin, dual-color"
@@ -443,6 +455,7 @@
 	color_blend_mode = ICON_MULTIPLY
 	extra_overlay = "teshariinner"
 	species_allowed = list(SPECIES_TESHARI, SPECIES_EVENT1, SPECIES_EVENT2, SPECIES_EVENT3)
+	whitelist_allowed = list()
 
 /datum/sprite_accessory/ears/tesharihigh
 	name = "Teshari upper ears (colorable fluff)"
@@ -452,6 +465,7 @@
 	color_blend_mode = ICON_MULTIPLY
 	extra_overlay = "tesharihighinner"
 	species_allowed = list(SPECIES_TESHARI, SPECIES_EVENT1, SPECIES_EVENT2, SPECIES_EVENT3)
+	whitelist_allowed = list()
 
 /datum/sprite_accessory/ears/tesharilow
 	name = "Teshari lower ears (colorable fluff)"
@@ -461,6 +475,7 @@
 	color_blend_mode = ICON_MULTIPLY
 	extra_overlay = "tesharilowinner"
 	species_allowed = list(SPECIES_TESHARI, SPECIES_EVENT1, SPECIES_EVENT2, SPECIES_EVENT3)
+	whitelist_allowed = list()
 
 /datum/sprite_accessory/ears/inkling
 	name = "colorable mature inkling hair"
@@ -469,6 +484,7 @@
 	icon_state = "inkling-colorable"
 	color_blend_mode = ICON_MULTIPLY
 	do_colouration = 1
+	whitelist_allowed = list()
 
 /datum/sprite_accessory/ears/large_dragon
 	name = "Large dragon horns"

--- a/code/modules/mob/new_player/sprite_accessories_tail.dm
+++ b/code/modules/mob/new_player/sprite_accessories_tail.dm
@@ -25,6 +25,7 @@
 	var/icon/clip_mask = null //Instantiated clip mask of given icon and state
 
 	species_allowed = list(SPECIES_EVENT1, SPECIES_EVENT2, SPECIES_EVENT3)
+	whitelist_allowed = list(SPECIES_HUMAN, SPECIES_HUMAN_VATBORN, SPECIES_PROMETHEAN)
 
 /datum/sprite_accessory/tail/New()
 	. = ..()
@@ -203,6 +204,7 @@
 	extra_overlay = "nevreantail_dc_tail"
 	do_colouration = 1
 	color_blend_mode = ICON_MULTIPLY
+	whitelist_allowed = list()
 
 /datum/sprite_accessory/tail/nevreanwagdc
 	name = "nevrean wagtail, dual-color"
@@ -211,6 +213,7 @@
 	extra_overlay = "wagtail_dc_tail"
 	do_colouration = 1
 	color_blend_mode = ICON_MULTIPLY
+	whitelist_allowed = list()
 
 /datum/sprite_accessory/tail/nevreanwagdc_alt
 	name = "nevrean wagtail, marked, dual-color"
@@ -219,6 +222,7 @@
 	extra_overlay = "wagtail2_dc_mark"
 	do_colouration = 1
 	color_blend_mode = ICON_MULTIPLY
+	whitelist_allowed = list()
 
 /datum/sprite_accessory/tail/crossfox
 	name = "cross fox"
@@ -229,6 +233,7 @@
 	name = "bee thorax"
 	desc = ""
 	icon_state = "beethorax"
+	whitelist_allowed = list()
 
 /datum/sprite_accessory/tail/doublekitsune
 	name = "double kitsune tail, colorable"
@@ -242,16 +247,19 @@
 	desc = ""
 	icon_state = "spadetail-black"
 	do_colouration = 1
+	whitelist_allowed = list()
 
 /datum/sprite_accessory/tail/snag
 	name = "xenomorph tail 1"
 	desc = ""
 	icon_state = "snag"
+	whitelist_allowed = list()
 
 /datum/sprite_accessory/tail/xenotail
 	name = "xenomorph tail 2"
 	desc = ""
 	icon_state = "xenotail"
+	whitelist_allowed = list()
 
 /datum/sprite_accessory/tail/eboop
 	name = "EGN mech tail (dual color)"
@@ -260,6 +268,7 @@
 	do_colouration = 1
 	color_blend_mode = ICON_MULTIPLY
 	extra_overlay = "eboop_mark"
+	whitelist_allowed = list()
 
 /datum/sprite_accessory/tail/ketrai_wag
 	name = "fennix tail (vwag)"
@@ -267,12 +276,14 @@
 	icon_state = "ketraitail"
 	ani_state = "ketraitail_w"
 	//ckeys_allowed = list("ketrai") //They requested it to be enabled for everyone.
+	whitelist_allowed = list()
 
 /datum/sprite_accessory/tail/ketrainew_wag
 	name = "new fennix tail (vwag)"
 	desc = ""
 	icon_state = "ketraitailnew"
 	ani_state = "ketraitailnew_w"
+	whitelist_allowed = list()
 
 /datum/sprite_accessory/tail/redpanda
 	name = "red panda"
@@ -296,6 +307,7 @@
 	hide_body_parts = list(BP_L_LEG, BP_L_FOOT, BP_R_LEG, BP_R_FOOT) //Exclude pelvis just in case.
 	clip_mask_icon = 'icons/mob/human_races/sprite_accessories/taurs.dmi'
 	clip_mask_state = "taur_clip_mask_def" //Used to clip off the lower part of suits & uniforms.
+	whitelist_allowed = list()
 
 /datum/sprite_accessory/tail/tailmaw
 	name = "tailmaw, colorable"
@@ -303,6 +315,7 @@
 	icon_state = "tailmaw"
 	color_blend_mode = ICON_MULTIPLY
 	do_colouration = 1
+	whitelist_allowed = list()
 
 /datum/sprite_accessory/tail/curltail
 	name = "curltail (vwag)"
@@ -331,7 +344,7 @@
 	color_blend_mode = ICON_MULTIPLY
 	extra_overlay = "sneptail_mark"
 	extra_overlay_w = "sneptail_mark_w"
-
+	whitelist_allowed = list()
 
 /datum/sprite_accessory/tail/tiger_new
 	name = "tiger tail (vwag)"
@@ -352,6 +365,7 @@
 	color_blend_mode = ICON_MULTIPLY
 	extra_overlay = "vulptail_mark"
 	extra_overlay_w = "vulptail_mark_w"
+	whitelist_allowed = list()
 
 /datum/sprite_accessory/tail/otietail
 	name = "otie tail (vwag)"
@@ -360,6 +374,7 @@
 	ani_state = "otie_w"
 	do_colouration = 1
 	color_blend_mode = ICON_MULTIPLY
+	whitelist_allowed = list()
 
 /datum/sprite_accessory/tail/newtailmaw
 	name = "new tailmaw (vwag)"
@@ -368,6 +383,7 @@
 	ani_state = "newtailmaw_w"
 	do_colouration = 1
 	color_blend_mode = ICON_MULTIPLY
+	whitelist_allowed = list()
 
 /datum/sprite_accessory/tail/ztail
 	name = "jagged flufftail"
@@ -389,6 +405,7 @@
 	icon_state = "vulptail_alt"
 	do_colouration = 1
 	color_blend_mode = ICON_MULTIPLY
+	whitelist_allowed = list()
 
 /datum/sprite_accessory/tail/sergaltaildc
 	name = "sergal, dual-color"
@@ -397,6 +414,7 @@
 	do_colouration = 1
 	color_blend_mode = ICON_MULTIPLY
 	extra_overlay = "sergal_mark"
+	whitelist_allowed = list()
 
 /datum/sprite_accessory/tail/skunktail
 	name = "skunk, dual-color"
@@ -422,6 +440,7 @@
 	do_colouration = 1
 	color_blend_mode = ICON_MULTIPLY
 	species_allowed = list(SPECIES_TESHARI, SPECIES_EVENT1, SPECIES_EVENT2, SPECIES_EVENT3)
+	whitelist_allowed = list()
 
 /datum/sprite_accessory/tail/nightstalker
 	name = "Nightstalker, colorable"
@@ -429,11 +448,13 @@
 	icon_state = "nightstalker"
 	do_colouration = 1
 	color_blend_mode = ICON_MULTIPLY
+	whitelist_allowed = list()
 
 //For all species tails. Includes haircolored tails.
 /datum/sprite_accessory/tail/special
 	name = "Blank tail. Do not select."
 	icon = 'icons/effects/species_tails.dmi'
+	whitelist_allowed = list()
 
 /datum/sprite_accessory/tail/special/unathi
 	name = "unathi tail"
@@ -443,6 +464,7 @@
 	color_blend_mode = ICON_MULTIPLY
 
 	species_allowed = list(SPECIES_UNATHI, SPECIES_EVENT1, SPECIES_EVENT2, SPECIES_EVENT3)
+	whitelist_allowed = list()
 
 /datum/sprite_accessory/tail/special/tajaran
 	name = "tajaran tail"
@@ -451,6 +473,7 @@
 	do_colouration = 1
 	color_blend_mode = ICON_MULTIPLY
 	species_allowed = list(SPECIES_TAJ, SPECIES_EVENT1, SPECIES_EVENT2, SPECIES_EVENT3)
+	whitelist_allowed = list()
 
 /datum/sprite_accessory/tail/special/sergal
 	name = "sergal tail"
@@ -458,6 +481,7 @@
 	icon_state = "sergtail_s"
 	do_colouration = 1
 	color_blend_mode = ICON_MULTIPLY
+	whitelist_allowed = list()
 
 /datum/sprite_accessory/tail/special/akula
 	name = "akula tail"
@@ -465,6 +489,7 @@
 	icon_state = "sharktail_s"
 	do_colouration = 1
 	color_blend_mode = ICON_MULTIPLY
+	whitelist_allowed = list()
 
 /datum/sprite_accessory/tail/special/nevrean
 	name = "nevrean tail"
@@ -633,6 +658,7 @@
 	name = "Zeng-Hu Tajaran Synth tail"
 	desc = ""
 	icon_state = "zenghu_taj"
+	whitelist_allowed = list()
 
 //Taurs moved to a separate file due to extra code around them
 
@@ -644,6 +670,7 @@
 	icon_state = "buggo_s"
 	do_colouration = 1
 	color_blend_mode = ICON_MULTIPLY
+	whitelist_allowed = list()
 
 /datum/sprite_accessory/tail/buggobee
 	name = "Bug abdomen, bee top, dual-colorable"
@@ -652,6 +679,7 @@
 	do_colouration = 1
 	color_blend_mode = ICON_MULTIPLY
 	extra_overlay = "buggobee_markings"
+	whitelist_allowed = list()
 
 /datum/sprite_accessory/tail/buggobeefull
 	name = "Bug abdomen, bee full, dual-colorable"
@@ -660,6 +688,7 @@
 	do_colouration = 1
 	color_blend_mode = ICON_MULTIPLY
 	extra_overlay = "buggobeefull_markings"
+	whitelist_allowed = list()
 
 /datum/sprite_accessory/tail/buggounder
 	name = "Bug abdomen, underside, dual-colorable"
@@ -668,6 +697,7 @@
 	do_colouration = 1
 	color_blend_mode = ICON_MULTIPLY
 	extra_overlay = "buggounder_markings"
+	whitelist_allowed = list()
 
 /datum/sprite_accessory/tail/buggofirefly
 	name = "Bug abdomen, firefly, dual-colorable"
@@ -676,6 +706,7 @@
 	do_colouration = 1
 	color_blend_mode = ICON_MULTIPLY
 	extra_overlay = "buggofirefly_markings"
+	whitelist_allowed = list()
 
 /datum/sprite_accessory/tail/buggofat
 	name = "Fat bug abdomen, colorable"
@@ -683,6 +714,7 @@
 	icon_state = "buggofat_s"
 	do_colouration = 1
 	color_blend_mode = ICON_MULTIPLY
+	whitelist_allowed = list()
 
 /datum/sprite_accessory/tail/buggofatbee
 	name = "Fat bug abdomen, bee top, dual-colorable"
@@ -691,6 +723,7 @@
 	do_colouration = 1
 	color_blend_mode = ICON_MULTIPLY
 	extra_overlay = "buggofatbee_markings"
+	whitelist_allowed = list()
 
 /datum/sprite_accessory/tail/buggofatbeefull
 	name = "Fat bug abdomen, bee full, dual-colorable"
@@ -699,6 +732,7 @@
 	do_colouration = 1
 	color_blend_mode = ICON_MULTIPLY
 	extra_overlay = "buggofatbeefull_markings"
+	whitelist_allowed = list()
 
 /datum/sprite_accessory/tail/buggofatunder
 	name = "Fat bug abdomen, underside, dual-colorable"
@@ -707,6 +741,7 @@
 	do_colouration = 1
 	color_blend_mode = ICON_MULTIPLY
 	extra_overlay = "buggofatunder_markings"
+	whitelist_allowed = list()
 
 /datum/sprite_accessory/tail/buggofatfirefly
 	name = "Fat bug abdomen, firefly, dual-colorable"
@@ -715,6 +750,7 @@
 	do_colouration = 1
 	color_blend_mode = ICON_MULTIPLY
 	extra_overlay = "buggofatfirefly_markings"
+	whitelist_allowed = list()
 
 /datum/sprite_accessory/tail/buggowag
 	name = "Bug abdomen, colorable, vwag change"
@@ -723,6 +759,7 @@
 	ani_state = "buggofat_s"
 	do_colouration = 1
 	color_blend_mode = ICON_MULTIPLY
+	whitelist_allowed = list()
 
 /datum/sprite_accessory/tail/buggobeewag
 	name = "Bug abdomen, bee top, dual color, vwag"
@@ -733,6 +770,7 @@
 	color_blend_mode = ICON_MULTIPLY
 	extra_overlay = "buggobee_markings"
 	extra_overlay_w = "buggofatbee_markings"
+	whitelist_allowed = list()
 
 /datum/sprite_accessory/tail/buggobeefullwag
 	name = "Bug abdomen, bee full, dual color, vwag"
@@ -743,6 +781,7 @@
 	color_blend_mode = ICON_MULTIPLY
 	extra_overlay = "buggobeefull_markings"
 	extra_overlay_w = "buggofatbeefull_markings"
+	whitelist_allowed = list()
 
 /datum/sprite_accessory/tail/buggounderwag
 	name = "Bug abdomen, underside, dual color, vwag"
@@ -753,6 +792,7 @@
 	color_blend_mode = ICON_MULTIPLY
 	extra_overlay = "buggounder_markings"
 	extra_overlay_w = "buggofatunder_markings"
+	whitelist_allowed = list()
 
 /datum/sprite_accessory/tail/buggofireflywag
 	name = "Bug abdomen, firefly, dual color, vwag"
@@ -763,6 +803,7 @@
 	color_blend_mode = ICON_MULTIPLY
 	extra_overlay = "buggofirefly_markings"
 	extra_overlay_w = "buggofatfirefly_markings"
+	whitelist_allowed = list()
 
 //Vass buggo variants!
 
@@ -772,6 +813,7 @@
 	icon_state = "buggo_vass_s"
 	do_colouration = 1
 	color_blend_mode = ICON_MULTIPLY
+	whitelist_allowed = list()
 
 /datum/sprite_accessory/tail/buggovassbee
 	name = "Bug abdomen, bee top, dc, vass"
@@ -780,6 +822,7 @@
 	do_colouration = 1
 	color_blend_mode = ICON_MULTIPLY
 	extra_overlay = "buggobee_vass_markings"
+	whitelist_allowed = list()
 
 /datum/sprite_accessory/tail/buggovassbeefull
 	name = "Bug abdomen, bee full, dc, vass"
@@ -788,6 +831,7 @@
 	do_colouration = 1
 	color_blend_mode = ICON_MULTIPLY
 	extra_overlay = "buggobeefull_vass_markings"
+	whitelist_allowed = list()
 
 /datum/sprite_accessory/tail/buggovassunder
 	name = "Bug abdomen, underside, dc, vass"
@@ -796,6 +840,7 @@
 	do_colouration = 1
 	color_blend_mode = ICON_MULTIPLY
 	extra_overlay = "buggounder_vass_markings"
+	whitelist_allowed = list()
 
 /datum/sprite_accessory/tail/buggovassfirefly
 	name = "Bug abdomen, firefly, dc, vass"
@@ -804,6 +849,7 @@
 	do_colouration = 1
 	color_blend_mode = ICON_MULTIPLY
 	extra_overlay = "buggofirefly_vass_markings"
+	whitelist_allowed = list()
 
 /datum/sprite_accessory/tail/buggovassfat
 	name = "Fat bug abdomen, vass, colorable"
@@ -811,6 +857,7 @@
 	icon_state = "buggofat_vass_s"
 	do_colouration = 1
 	color_blend_mode = ICON_MULTIPLY
+	whitelist_allowed = list()
 
 /datum/sprite_accessory/tail/buggovassfatbee
 	name = "Fat bug abdomen, bee top, dc, vass"
@@ -819,6 +866,7 @@
 	do_colouration = 1
 	color_blend_mode = ICON_MULTIPLY
 	extra_overlay = "buggofatbee_vass_markings"
+	whitelist_allowed = list()
 
 /datum/sprite_accessory/tail/buggovassfatbeefull
 	name = "Fat bug abdomen, bee full, dc, vass"
@@ -827,6 +875,7 @@
 	do_colouration = 1
 	color_blend_mode = ICON_MULTIPLY
 	extra_overlay = "buggofatbeefull_vass_markings"
+	whitelist_allowed = list()
 
 /datum/sprite_accessory/tail/buggovassfatunder
 	name = "Fat bug abdomen, underside, dc, vass"
@@ -835,6 +884,7 @@
 	do_colouration = 1
 	color_blend_mode = ICON_MULTIPLY
 	extra_overlay = "buggofatunder_vass_markings"
+	whitelist_allowed = list()
 
 /datum/sprite_accessory/tail/buggovassfatfirefly
 	name = "Fat bug abdomen, firefly, dc, vass"
@@ -843,6 +893,7 @@
 	do_colouration = 1
 	color_blend_mode = ICON_MULTIPLY
 	extra_overlay = "buggofatfirefly_vass_markings"
+	whitelist_allowed = list()
 
 /datum/sprite_accessory/tail/buggovasswag
 	name = "Bug abdomen, vass, colorable, vwag change"
@@ -851,6 +902,7 @@
 	ani_state = "buggofat_vass_s"
 	do_colouration = 1
 	color_blend_mode = ICON_MULTIPLY
+	whitelist_allowed = list()
 
 /datum/sprite_accessory/tail/buggovassbeewag
 	name = "Bug abdomen, bee top, dc, vass, vwag"
@@ -861,6 +913,7 @@
 	color_blend_mode = ICON_MULTIPLY
 	extra_overlay = "buggobee_vass_markings"
 	extra_overlay_w = "buggofatbee_vass_markings"
+	whitelist_allowed = list()
 
 /datum/sprite_accessory/tail/buggovassbeefullwag
 	name = "Bug abdomen, bee full, dc, vass, vwag"
@@ -871,6 +924,7 @@
 	color_blend_mode = ICON_MULTIPLY
 	extra_overlay = "buggobeefull_vass_markings"
 	extra_overlay_w = "buggofatbeefull_vass_markings"
+	whitelist_allowed = list()
 
 /datum/sprite_accessory/tail/buggovassunderwag
 	name = "Bug abdomen, underside, dc, vass, vwag"
@@ -881,6 +935,7 @@
 	color_blend_mode = ICON_MULTIPLY
 	extra_overlay = "buggounder_vass_markings"
 	extra_overlay_w = "buggofatunder_vass_markings"
+	whitelist_allowed = list()
 
 /datum/sprite_accessory/tail/buggovassfireflywag
 	name = "Bug abdomen, firefly, dc, vass, vwag"
@@ -891,6 +946,7 @@
 	color_blend_mode = ICON_MULTIPLY
 	extra_overlay = "buggofirefly_vass_markings"
 	extra_overlay_w = "buggofatfirefly_vass_markings"
+	whitelist_allowed = list()
 
 /datum/sprite_accessory/tail/tail_smooth
 	name = "Smooth Lizard Tail, colorable"
@@ -923,6 +979,7 @@
 	do_colouration = 1
 	color_blend_mode = ICON_MULTIPLY
 	//species_allowed = list(SPECIES_SHADEKIN, SPECIES_SHADEKIN_CREW)
+	whitelist_allowed = list()
 
 /datum/sprite_accessory/tail/wartacosushi_tail //brightened +20RGB from matching roboparts
 	name = "Ward-Takahashi Tail"
@@ -930,6 +987,7 @@
 	icon_state = "wardtakahashi_vulp"
 	do_colouration = 1
 	color_blend_mode = ICON_MULTIPLY
+	whitelist_allowed = list()
 
 /datum/sprite_accessory/tail/wartacosushi_tail_dc
 	name = "Ward-Takahashi Tail, dual-color"
@@ -938,3 +996,4 @@
 	do_colouration = 1
 	color_blend_mode = ICON_MULTIPLY
 	extra_overlay = "wardtakahashi_vulp_dc_mark"
+	whitelist_allowed = list()

--- a/code/modules/mob/new_player/sprite_accessories_taur.dm
+++ b/code/modules/mob/new_player/sprite_accessories_taur.dm
@@ -3,6 +3,7 @@
 	nonhuman_key_exemption = FALSE	// If true, nonhumans who can't hold keys don't need them, like borgs and simplemobs.
 	key_name = "a riding crop"		// What the 'keys' for the thing being rided on would be called.
 	only_one_driver = TRUE			// If true, only the person in 'front' (first on list of riding mobs) can drive.
+	whitelist_allowed = list()
 
 /datum/riding/taur/handle_vehicle_layer()
 	if(ridden.has_buckled_mobs())

--- a/code/modules/mob/new_player/sprite_accessories_wing.dm
+++ b/code/modules/mob/new_player/sprite_accessories_wing.dm
@@ -21,6 +21,7 @@
 	var/extra_overlay2_w
 
 	species_allowed = list(SPECIES_EVENT1, SPECIES_EVENT2, SPECIES_EVENT3)
+	whitelist_allowed = list()
 
 /datum/sprite_accessory/wing/featheredlarge //Made by Natje!
 	name = "large feathered wings (colorable)"

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -547,3 +547,7 @@ ENGINE_MAP Supermatter Engine,Edison's Bane
 # Controls how strictly the species whitelists on loadout entries are enforced
 # Possible values: 0 (Off), 1 (Lax, user must be whitelisted for the species), 2 (Strict, user must be the species)
 LOADOUT_WHITELIST 1
+
+# Enables whitelisting ckeys for ears/tail/etc modifications to players.
+# Uncomment to ENABLE the whitelist
+# GENEMOD_WHITELIST

--- a/config/example/genemodwhitelist.txt
+++ b/config/example/genemodwhitelist.txt
@@ -1,0 +1,16 @@
+# The ckeys of players whitelisted to use general-use sprite accessories.
+# Note that this is in the format of "canonical" ckeys, which according to the byond docs are basically just lower-case:
+#
+# Format:
+#    ckey(Key) 
+# Args:
+#    Key
+#        The player key to convert to canonical form.
+# Returns:
+#    The key in canonical form. To do this, it strips all punctuation and space from the key and converts to lowercase. The result is still unique for each different key. 
+#
+# You can actually fill this file with whatever besides the whitelisted ckeys because the matching is very dumb
+
+some_user
+someotheruser
+text that has spaces and so isn't really a ckey (It does nothing)


### PR DESCRIPTION
Tested, seems to work locally. The formatting for the whitelist file is finicky because it differs from the others (It uses canonical ckey).
Each sprite accessory defines a list of species that gain access to them through the genemod whitelist. That is, if you have the whitelist, and are of one of those species, you get access. Currently this is restricted to humans, vatborn, and prometheans, because that's what I was looking at, but the list is also basically arbitrary.
~~I would've liked to restrict this whitelist to apply to only sprite accessories that _aren't_ already species-whitelisted (i.e., taj ears). But because of our hardcoded 3 event species by default being whitelisted for all of them, that approach doesn't work without serious work.
Practically speaking, that system should be replaced with infrastructure to dynamically add new singleton species defines at runtime. But that's `Out of Scope`.~~