### PR TITLE
Fixes runtime on server start: SSAtoms doesn't exist yet

### DIFF
--- a/code/__defines/subsystems.dm
+++ b/code/__defines/subsystems.dm
@@ -33,7 +33,7 @@
 	..();\
 	if(!initialized) {\
 		args[1] = TRUE;\
-		SSatoms.InitAtom(src, args);\
+		SSatoms?.InitAtom(src, args);\
 	}\
 }
 

--- a/code/_helpers/unsorted.dm
+++ b/code/_helpers/unsorted.dm
@@ -1260,7 +1260,6 @@ var/mob/dview/dview_mob = new
 		color = origin.color
 		set_light(origin.light_range, origin.light_power, origin.light_color)
 
-INITIALIZE_IMMEDIATE(/mob/dview)
 /mob/dview/Initialize()
 	. = ..()
 	// We don't want to be in any mob lists; we're a dummy not a mob.


### PR DESCRIPTION
Spotted this while looking at integration checks. Not sure why it doesn't trigger CI failures.
```
 runtime error: Cannot execute null.InitAtom().
proc name: New (/mob/dview/New)
  source file: unsorted.dm,1263
  usr: (src)
  src: the dview (/mob/dview)
  src.loc: null
  call stack:
the dview (/mob/dview): New(1)
world: ()
```