### PR TITLE
Cynosure map fixes #9

### DIFF
--- a/maps/cynosure/cynosure-1.dmm
+++ b/maps/cynosure/cynosure-1.dmm
@@ -6350,8 +6350,8 @@
 /area/surface/outpost/research/xenoarcheology/smes)
 "nN" = (
 /obj/machinery/door/window/westright{
-	name = "EVA Suit";
-	req_one_access = list(43)
+	name = "Sample Preparation";
+	req_one_access = list(65)
 	},
 /turf/simulated/floor/tiled/white,
 /area/surface/outpost/research/xenoarcheology/analysis)

--- a/maps/cynosure/cynosure-2.dmm
+++ b/maps/cynosure/cynosure-2.dmm
@@ -17683,7 +17683,7 @@
 	dir = 1
 	},
 /obj/structure/table/reinforced,
-/obj/machinery/chemical_dispenser,
+/obj/machinery/chemical_dispenser/full,
 /turf/simulated/floor/tiled/neutral,
 /area/surface/station/rnd/xenobiology/xenoflora_isolation)
 "imM" = (
@@ -19062,13 +19062,13 @@
 /turf/simulated/floor/outdoors/mask,
 /area/surface/outside/plains/station)
 "iWb" = (
-/obj/machinery/honey_extractor,
 /obj/effect/floor_decal/borderfloor{
 	dir = 10
 	},
 /obj/effect/floor_decal/corner/lime/border{
 	dir = 10
 	},
+/obj/machinery/seed_extractor,
 /turf/simulated/floor/tiled/hydro,
 /area/surface/station/hydroponics)
 "iWu" = (
@@ -19418,10 +19418,10 @@
 /turf/simulated/floor/tiled,
 /area/surface/station/security/hallway/gnd)
 "jgB" = (
-/obj/machinery/seed_extractor,
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/lime/border,
 /obj/machinery/light,
+/obj/machinery/honey_extractor,
 /turf/simulated/floor/tiled/hydro,
 /area/surface/station/hydroponics)
 "jhl" = (

--- a/maps/cynosure/cynosure-3.dmm
+++ b/maps/cynosure/cynosure-3.dmm
@@ -34257,7 +34257,7 @@
 /obj/item/weapon/clipboard,
 /obj/item/weapon/pen,
 /obj/item/sticky_pad/random,
-/obj/item/weapon/storage/firstaid,
+/obj/item/weapon/storage/firstaid/regular,
 /turf/simulated/floor/wood/sif,
 /area/surface/station/rnd/research)
 "wzs" = (

--- a/maps/cynosure/cynosure-6.dmm
+++ b/maps/cynosure/cynosure-6.dmm
@@ -3161,6 +3161,19 @@
 /obj/item/weapon/deck/cards,
 /turf/simulated/shuttle/floor/black,
 /area/skipjack_station/start)
+"dNX" = (
+/obj/effect/floor_decal/corner/yellow/diagonal,
+/obj/effect/floor_decal/corner/blue/diagonal{
+	dir = 4
+	},
+/obj/item/weapon/stool/padded{
+	dir = 8
+	},
+/turf/unsimulated/floor{
+	icon = 'icons/turf/flooring/tiles.dmi';
+	icon_state = "steel"
+	},
+/area/centcom/living)
 "dOl" = (
 /obj/structure/table/steel,
 /obj/random/energy,
@@ -13351,7 +13364,9 @@
 /turf/simulated/floor/holofloor/tiled,
 /area/holodeck/source_emptycourt)
 "pte" = (
-/obj/item/weapon/stool/padded,
+/obj/item/weapon/stool/padded{
+	dir = 8
+	},
 /turf/unsimulated/floor{
 	icon_state = "dark"
 	},
@@ -16038,9 +16053,11 @@
 /turf/simulated/shuttle/floor/black,
 /area/shuttle/merchant/home)
 "rZv" = (
-/obj/item/weapon/stool/padded,
 /obj/effect/floor_decal/corner/yellow/diagonal,
 /obj/effect/floor_decal/corner/blue/diagonal{
+	dir = 4
+	},
+/obj/item/weapon/stool/padded{
 	dir = 4
 	},
 /turf/unsimulated/floor{
@@ -19673,6 +19690,14 @@
 	},
 /turf/simulated/shuttle/floor/voidcraft/light,
 /area/syndicate_station/start)
+"wcg" = (
+/obj/item/weapon/stool/padded{
+	dir = 1
+	},
+/turf/unsimulated/floor{
+	icon_state = "dark"
+	},
+/area/wizard_station)
 "wcv" = (
 /obj/effect/step_trigger/thrower{
 	affect_ghosts = 1;
@@ -44916,14 +44941,14 @@ quS
 qTA
 quS
 qDH
-rZv
-rZv
+dNX
+dNX
 cXa
 shY
 cXa
 cXa
-rZv
-rZv
+dNX
+dNX
 qDH
 puk
 puk
@@ -45176,7 +45201,7 @@ qDH
 cXa
 cXa
 cXa
-rZv
+dNX
 cXa
 cXa
 cXa
@@ -81109,7 +81134,7 @@ jeX
 ixy
 uCF
 fBf
-pte
+wcg
 xIh
 xIh
 puk
@@ -81366,7 +81391,7 @@ jeX
 tbt
 cDr
 ofp
-pte
+wcg
 xIh
 puk
 puk

--- a/maps/cynosure/cynosure-7.dmm
+++ b/maps/cynosure/cynosure-7.dmm
@@ -21,19 +21,19 @@
 "fy" = (
 /obj/structure/cliff/automatic,
 /turf/simulated/floor/outdoors/mask,
-/area/surface/outside/wilderness/normal)
+/area/surface/outside/wilderness/mountains)
 "gl" = (
 /obj/structure/cliff/automatic{
 	dir = 9
 	},
 /turf/simulated/floor/outdoors/mask,
-/area/surface/outside/wilderness/normal)
+/area/surface/outside/wilderness/mountains)
 "hb" = (
 /obj/structure/cliff/automatic{
 	dir = 8
 	},
 /turf/simulated/floor/outdoors/mask,
-/area/surface/outside/wilderness/normal)
+/area/surface/outside/wilderness/mountains)
 "id" = (
 /turf/simulated/wall/sifwood,
 /area/surface/outside/path/wilderness)
@@ -71,7 +71,7 @@
 	dir = 9
 	},
 /turf/simulated/floor/outdoors/mask,
-/area/surface/outside/wilderness/normal)
+/area/surface/outside/wilderness/mountains)
 "ne" = (
 /turf/simulated/floor/outdoors/grass/sif,
 /area/surface/outside/path/wilderness)
@@ -113,12 +113,6 @@
 "tM" = (
 /turf/simulated/floor/water,
 /area/surface/outside/river/gautelfr)
-"tV" = (
-/obj/structure/cliff/automatic{
-	dir = 10
-	},
-/turf/simulated/floor/outdoors/mask,
-/area/surface/outside/wilderness/normal)
 "ub" = (
 /obj/effect/map_effect/portal/line/side_b{
 	dir = 1
@@ -130,12 +124,6 @@
 	tree_chance = 0
 	},
 /area/surface/outside/wilderness/deep)
-"vu" = (
-/obj/structure/cliff/automatic/corner{
-	dir = 10
-	},
-/turf/simulated/floor/outdoors/mask,
-/area/surface/outside/wilderness/normal)
 "vQ" = (
 /obj/structure/prop/rock/small/wateralt,
 /turf/simulated/floor/water,
@@ -147,12 +135,6 @@
 /obj/effect/zone_divider,
 /turf/simulated/floor/outdoors/mask,
 /area/surface/outside/wilderness/mountains)
-"wt" = (
-/obj/structure/cliff/automatic{
-	dir = 6
-	},
-/turf/simulated/floor/outdoors/mask,
-/area/surface/outside/wilderness/normal)
 "wN" = (
 /turf/simulated/floor/outdoors/dirt/sif,
 /area/surface/outside/path/wilderness)
@@ -188,19 +170,13 @@
 	},
 /obj/effect/zone_divider,
 /turf/simulated/floor/outdoors/mask,
-/area/surface/outside/wilderness/normal)
+/area/surface/outside/wilderness/mountains)
 "BR" = (
 /obj/structure/cliff/automatic{
 	dir = 8
 	},
 /turf/simulated/floor/outdoors/grass/sif,
 /area/surface/outside/wilderness/mountains)
-"Cb" = (
-/obj/structure/cliff/automatic/corner{
-	dir = 6
-	},
-/turf/simulated/floor/outdoors/mask,
-/area/surface/outside/wilderness/normal)
 "CR" = (
 /turf/simulated/floor/outdoors/dirt/sif,
 /area/surface/outside/wilderness/mountains)
@@ -272,12 +248,6 @@
 "NP" = (
 /turf/simulated/floor/outdoors/grass/sif,
 /area/surface/outside/wilderness/mountains)
-"Pe" = (
-/obj/structure/cliff/automatic{
-	dir = 4
-	},
-/turf/simulated/floor/outdoors/mask,
-/area/surface/outside/wilderness/normal)
 "PH" = (
 /obj/effect/zone_divider,
 /turf/simulated/floor/outdoors/mask,
@@ -52959,7 +52929,7 @@ hb
 hb
 hb
 hb
-tV
+jE
 Ax
 Ax
 Ax
@@ -53216,8 +53186,8 @@ Ax
 Ax
 Ax
 Ax
-vu
-tV
+UA
+jE
 Ax
 Ax
 Ax
@@ -53474,7 +53444,7 @@ Ax
 Ax
 Ax
 Ax
-vu
+UA
 hb
 hb
 hb
@@ -53484,7 +53454,7 @@ hb
 hb
 hb
 hb
-tV
+jE
 Ax
 Ax
 Aq
@@ -53741,8 +53711,8 @@ Ax
 Ax
 Ax
 Ax
-vu
-tV
+UA
+jE
 Ax
 Aq
 Ax
@@ -53999,7 +53969,7 @@ Ax
 Ax
 Ax
 Ax
-vu
+UA
 hb
 Be
 hb
@@ -54007,7 +53977,7 @@ hb
 hb
 hb
 hb
-tV
+jE
 Ax
 Ax
 Ax
@@ -54264,8 +54234,8 @@ Ax
 Ax
 Ax
 Ax
-vu
-tV
+UA
+jE
 Ax
 Ax
 Ax
@@ -54280,7 +54250,7 @@ hb
 hb
 hb
 hb
-tV
+jE
 Ax
 Ax
 Ax
@@ -54302,7 +54272,7 @@ hb
 hb
 hb
 hb
-tV
+jE
 Ax
 Ax
 Ax
@@ -54522,7 +54492,7 @@ Ax
 Ax
 Ax
 Ax
-vu
+UA
 hb
 hb
 hb
@@ -54537,7 +54507,7 @@ Ax
 Ax
 Ax
 Ax
-vu
+UA
 hb
 hb
 hb
@@ -54546,7 +54516,7 @@ hb
 hb
 hb
 hb
-tV
+jE
 Ax
 Ax
 Ax
@@ -54559,12 +54529,12 @@ Ax
 Ax
 Ax
 Ax
-vu
+UA
 hb
 hb
 hb
 hb
-tV
+jE
 Ax
 Ax
 Ax
@@ -54572,7 +54542,7 @@ gl
 hb
 hb
 hb
-tV
+jE
 Ax
 Ax
 Ax
@@ -54803,7 +54773,7 @@ Ax
 Ax
 Ax
 Ax
-vu
+UA
 hb
 hb
 hb
@@ -54821,7 +54791,7 @@ Ax
 Ax
 Ax
 Ax
-vu
+UA
 hb
 hb
 hb
@@ -54829,7 +54799,7 @@ mZ
 Sl
 kx
 Sl
-vu
+UA
 hb
 hb
 hb
@@ -58166,12 +58136,12 @@ Ax
 Ax
 Ax
 Ax
-Cb
-Pe
-Pe
-Pe
-Pe
-Pe
+Mf
+cv
+cv
+cv
+cv
+cv
 Gf
 cv
 qh
@@ -58417,13 +58387,13 @@ Ax
 Ax
 Ax
 Ax
-Cb
-Pe
-Pe
-Pe
-Pe
-Pe
-wt
+Mf
+cv
+cv
+cv
+cv
+cv
+qh
 Ax
 Ax
 Ax
@@ -58669,12 +58639,12 @@ Ax
 Ax
 Ax
 Ax
-Pe
-Pe
-Pe
-Pe
-Pe
-wt
+cv
+cv
+cv
+cv
+cv
+qh
 Ax
 Ax
 Ax


### PR DESCRIPTION
Fixes POIs spawning in overlapping wilderness cliffs
Replaces faulty windoor in xenoarch sample preparation
Adds cartridges to xenoflora chem dispenser
Replaces medkit in research break room with a non-empty one
Correctly rotates some stools on the admin z-level