### PR TITLE
Less Dreary Nightshift

### DIFF
--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -75,7 +75,7 @@ var/global/list/light_type_cache = list()
 
 /obj/machinery/light_construct/attack_hand(mob/user)
 	. = ..()
-	if(.) 
+	if(.)
 		return . // obj/machinery/attack_hand returns 1 if user can't use the machine
 	if(cell)
 		user.visible_message("[user] removes [cell] from [src]!","<span class='notice'>You remove [cell].</span>")
@@ -261,6 +261,9 @@ var/global/list/light_type_cache = list()
 	light_type = /obj/item/weapon/light/bulb
 	construct_type = /obj/machinery/light_construct/small
 
+/obj/machinery/light/small/no_nightshift
+	nightshift_allowed = FALSE
+
 /obj/machinery/light/small/flicker
 	auto_flicker = TRUE
 
@@ -288,7 +291,7 @@ var/global/list/light_type_cache = list()
 		update_icon()
 	else if(start_with_cell && !no_emergency)
 		cell = new/obj/item/weapon/cell/emergency_light(src)
-	
+
 
 /obj/machinery/light/flamp/flicker
 	auto_flicker = TRUE
@@ -664,7 +667,7 @@ var/global/list/light_type_cache = list()
 	update(FALSE)
 	return
 
-// ai alt click - Make light flicker.  Very important for atmosphere.  
+// ai alt click - Make light flicker.  Very important for atmosphere.
 /obj/machinery/light/AIAltClick(mob/user)
 	flicker(1)
 
@@ -851,7 +854,7 @@ var/global/list/light_type_cache = list()
 	var/brightness_color = LIGHT_COLOR_INCANDESCENT_TUBE
 
 	var/nightshift_range = 8
-	var/nightshift_power = 0.7
+	var/nightshift_power = 0.8
 	var/nightshift_color = LIGHT_COLOR_NIGHTSHIFT
 	drop_sound = 'sound/items/drop/glass.ogg'
 	pickup_sound = 'sound/items/pickup/glass.ogg'
@@ -873,7 +876,7 @@ var/global/list/light_type_cache = list()
 	brightness_power = 9
 
 	nightshift_range = 10
-	nightshift_power = 0.9
+	nightshift_power = 7
 
 /obj/item/weapon/light/bulb
 	name = "light bulb"
@@ -887,7 +890,7 @@ var/global/list/light_type_cache = list()
 	brightness_color = LIGHT_COLOR_INCANDESCENT_BULB
 
 	nightshift_range = 3
-	nightshift_power = 0.35
+	nightshift_power = 2
 
 /obj/item/weapon/light/throw_impact(atom/hit_atom)
 	..()

--- a/maps/cynosure/cynosure-1.dmm
+++ b/maps/cynosure/cynosure-1.dmm
@@ -4403,6 +4403,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
+	nightshift_setting = 2;
 	pixel_y = 24
 	},
 /obj/machinery/light_switch{
@@ -9765,7 +9766,7 @@
 /obj/effect/floor_decal/industrial/warning/dust{
 	dir = 1
 	},
-/obj/machinery/light/small,
+/obj/machinery/light/small/no_nightshift,
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/tiled/steel/sif/planetuse{
 	icon_state = "asteroidfloor";
@@ -13146,7 +13147,7 @@
 /obj/effect/floor_decal/industrial/warning/dust{
 	dir = 10
 	},
-/obj/machinery/light/small{
+/obj/machinery/light/small/no_nightshift{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/steel/sif/planetuse{
@@ -18120,6 +18121,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "west bump";
+	nightshift_setting = 2;
 	pixel_x = -24
 	},
 /obj/effect/floor_decal/rust,

--- a/maps/cynosure/cynosure-2.dmm
+++ b/maps/cynosure/cynosure-2.dmm
@@ -4355,7 +4355,7 @@
 /turf/simulated/floor/tiled/white,
 /area/surface/station/medical/etc)
 "cac" = (
-/obj/machinery/light,
+/obj/machinery/light/no_nightshift,
 /turf/simulated/floor/tiled/steel/sif/planetuse{
 	icon_state = "steel_dirty";
 	initial_flooring = /decl/flooring/tiling/steel_dirty
@@ -4585,7 +4585,7 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/surface/station/medical/hallway/gnd)
 "cgV" = (
-/obj/machinery/light,
+/obj/machinery/light/no_nightshift,
 /turf/simulated/floor/tiled/steel/sif/planetuse{
 	icon_state = "steel_dirty";
 	initial_flooring = /decl/flooring/tiling/steel_dirty
@@ -6391,6 +6391,7 @@
 	},
 /obj/machinery/power/apc{
 	name = "south bump";
+	nightshift_setting = 2;
 	pixel_y = -24
 	},
 /obj/effect/floor_decal/techfloor/corner{
@@ -6504,6 +6505,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
+	nightshift_setting = 2;
 	pixel_y = 24
 	},
 /obj/machinery/light_switch{
@@ -7427,7 +7429,7 @@
 /turf/simulated/floor/tiled/monofloor,
 /area/surface/station/security/range)
 "dvS" = (
-/obj/machinery/light{
+/obj/machinery/light/no_nightshift{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/steel/sif/planetuse{
@@ -7687,7 +7689,7 @@
 /area/surface/outpost/research/xenoarcheology/surface)
 "dDa" = (
 /obj/effect/floor_decal/corner/green/full,
-/obj/machinery/light/small,
+/obj/machinery/light/small/no_nightshift,
 /turf/simulated/floor/reinforced,
 /area/surface/station/engineering/atmos)
 "dDm" = (
@@ -8061,7 +8063,7 @@
 /turf/simulated/floor/tiled,
 /area/surface/station/engineering/atmos)
 "dLD" = (
-/obj/machinery/light,
+/obj/machinery/light/no_nightshift,
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/tiled/steel/sif/planetuse{
 	icon_state = "steel_dirty";
@@ -11297,7 +11299,7 @@
 /turf/simulated/floor/plating,
 /area/surface/station/medical/etc)
 "fhL" = (
-/obj/machinery/light,
+/obj/machinery/light/no_nightshift,
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -14297,6 +14299,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "east bump";
+	nightshift_setting = 2;
 	pixel_x = 24
 	},
 /obj/machinery/light_switch{
@@ -15666,6 +15669,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
+	nightshift_setting = 2;
 	pixel_y = 24
 	},
 /obj/machinery/light_switch{
@@ -16122,7 +16126,7 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/surface/station/garage)
 "hvu" = (
-/obj/machinery/light{
+/obj/machinery/light/no_nightshift{
 	dir = 1
 	},
 /obj/effect/floor_decal/rust,
@@ -16519,6 +16523,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "west bump";
+	nightshift_setting = 2;
 	pixel_x = -24
 	},
 /obj/structure/cable/cyan{
@@ -17959,7 +17964,7 @@
 /area/surface/station/engineering/reactor_room)
 "itw" = (
 /obj/effect/floor_decal/corner/blue/full,
-/obj/machinery/light/small,
+/obj/machinery/light/small/no_nightshift,
 /turf/simulated/floor/reinforced/oxygen,
 /area/surface/station/engineering/atmos)
 "ity" = (
@@ -19201,6 +19206,7 @@
 /obj/machinery/power/apc/super/critical{
 	dir = 8;
 	name = "west bump";
+	nightshift_setting = 2;
 	pixel_x = -24
 	},
 /turf/simulated/floor/plating,
@@ -19778,7 +19784,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/light{
+/obj/machinery/light/no_nightshift{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/steel/sif/planetuse{
@@ -20812,7 +20818,7 @@
 /obj/effect/floor_decal/corner/orange/diagonal{
 	dir = 4
 	},
-/obj/machinery/light/small{
+/obj/machinery/light/small/no_nightshift{
 	dir = 4
 	},
 /turf/simulated/floor/reinforced/phoron,
@@ -22125,7 +22131,7 @@
 /turf/simulated/floor/plating,
 /area/surface/station/security/hallway/gnd)
 "kmM" = (
-/obj/machinery/light{
+/obj/machinery/light/no_nightshift{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/steel/sif/planetuse{
@@ -22474,7 +22480,7 @@
 /area/surface/station/security/detectives_office/lab)
 "kwF" = (
 /obj/effect/floor_decal/corner/red/full,
-/obj/machinery/light/small,
+/obj/machinery/light/small/no_nightshift,
 /turf/simulated/floor/reinforced/nitrogen,
 /area/surface/station/engineering/atmos)
 "kwY" = (
@@ -25038,6 +25044,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
+	nightshift_setting = 2;
 	pixel_y = 24
 	},
 /obj/machinery/light_switch{
@@ -25079,6 +25086,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "west bump";
+	nightshift_setting = 2;
 	pixel_x = -24
 	},
 /obj/machinery/light_switch{
@@ -26543,6 +26551,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "west bump";
+	nightshift_setting = 2;
 	pixel_x = -24
 	},
 /obj/machinery/light_switch{
@@ -28754,7 +28763,7 @@
 /obj/effect/floor_decal/corner/black/full{
 	dir = 4
 	},
-/obj/machinery/light/small{
+/obj/machinery/light/small/no_nightshift{
 	dir = 4
 	},
 /turf/simulated/floor/reinforced/carbon_dioxide,
@@ -29244,6 +29253,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
+	nightshift_setting = 2;
 	pixel_y = 24
 	},
 /obj/machinery/light_switch{
@@ -30124,6 +30134,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
+	nightshift_setting = 2;
 	pixel_y = 24
 	},
 /obj/machinery/light_switch{
@@ -35479,6 +35490,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
+	nightshift_setting = 2;
 	pixel_y = 24
 	},
 /obj/structure/cable/cyan{
@@ -35800,6 +35812,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "west bump";
+	nightshift_setting = 2;
 	pixel_x = -24
 	},
 /obj/machinery/light_switch{
@@ -37614,6 +37627,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "east bump";
+	nightshift_setting = 2;
 	pixel_x = 24
 	},
 /obj/structure/cable/cyan{
@@ -40048,6 +40062,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
+	nightshift_setting = 2;
 	pixel_y = 24
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -41334,6 +41349,7 @@
 /obj/structure/cable,
 /obj/machinery/power/apc{
 	name = "south bump";
+	nightshift_setting = 2;
 	pixel_y = -24
 	},
 /obj/machinery/light_switch{
@@ -41594,6 +41610,7 @@
 	},
 /obj/machinery/power/apc{
 	name = "south bump";
+	nightshift_setting = 2;
 	pixel_y = -24
 	},
 /obj/structure/cable/cyan{
@@ -42527,7 +42544,7 @@
 /obj/effect/floor_decal/industrial/warning/dust/corner{
 	dir = 8
 	},
-/obj/machinery/light/small,
+/obj/machinery/light/small/no_nightshift,
 /turf/simulated/floor/tiled/steel/sif/planetuse{
 	icon_state = "asteroidfloor";
 	initial_flooring = /decl/flooring/tiling/asteroidfloor
@@ -42541,6 +42558,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
+	nightshift_setting = 2;
 	pixel_y = 24
 	},
 /obj/machinery/light_switch{
@@ -42706,7 +42724,7 @@
 /obj/effect/floor_decal/corner/white/diagonal{
 	dir = 4
 	},
-/obj/machinery/light/small,
+/obj/machinery/light/small/no_nightshift,
 /turf/simulated/floor/reinforced/airmix,
 /area/surface/station/engineering/atmos)
 "trQ" = (
@@ -45184,6 +45202,7 @@
 	},
 /obj/machinery/power/apc{
 	name = "south bump";
+	nightshift_setting = 2;
 	pixel_y = -24
 	},
 /obj/machinery/light_switch{
@@ -46315,6 +46334,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "west bump";
+	nightshift_setting = 2;
 	pixel_x = -24
 	},
 /obj/machinery/light_switch{
@@ -47664,7 +47684,7 @@
 /obj/effect/floor_decal/industrial/warning/dust/corner{
 	dir = 8
 	},
-/obj/machinery/light/small{
+/obj/machinery/light/small/no_nightshift{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/steel/sif/planetuse{
@@ -48952,9 +48972,7 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/red,
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/no_nightshift,
 /turf/simulated/floor/reinforced/n20,
 /area/surface/station/engineering/atmos)
 "wop" = (
@@ -53260,6 +53278,7 @@
 	},
 /obj/machinery/power/apc{
 	name = "south bump";
+	nightshift_setting = 2;
 	pixel_y = -24
 	},
 /obj/machinery/light_switch{

--- a/maps/cynosure/cynosure-3.dmm
+++ b/maps/cynosure/cynosure-3.dmm
@@ -202,7 +202,7 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/surface/station/security/hallway/cell_hallway)
 "ahf" = (
-/obj/machinery/light{
+/obj/machinery/light/no_nightshift{
 	dir = 1
 	},
 /obj/structure/bed/chair/shuttle,
@@ -3314,6 +3314,7 @@
 	},
 /obj/machinery/power/apc{
 	name = "south bump";
+	nightshift_setting = 2;
 	pixel_y = -24
 	},
 /obj/machinery/light_switch{
@@ -3904,7 +3905,7 @@
 /area/surface/station/construction/office)
 "cBH" = (
 /obj/effect/floor_decal/rust,
-/obj/machinery/light/small{
+/obj/machinery/light/small/no_nightshift{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/steel/sif/planetuse{
@@ -8097,6 +8098,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "west bump";
+	nightshift_setting = 2;
 	pixel_x = -24
 	},
 /obj/effect/floor_decal/techfloor/corner{
@@ -27287,6 +27289,7 @@
 	},
 /obj/machinery/power/apc/super/critical{
 	name = "south bump";
+	nightshift_setting = 2;
 	pixel_y = -24
 	},
 /obj/machinery/light_switch{
@@ -27722,7 +27725,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/light/small{
+/obj/machinery/light/small/no_nightshift{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -27815,7 +27818,7 @@
 /obj/effect/floor_decal/corner/orange/border{
 	dir = 6
 	},
-/obj/machinery/light/small{
+/obj/machinery/light/small/no_nightshift{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
@@ -29013,6 +29016,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
+	nightshift_setting = 2;
 	pixel_y = 24
 	},
 /obj/machinery/light_switch{
@@ -30799,7 +30803,7 @@
 	},
 /obj/effect/floor_decal/industrial/warning/dust/corner,
 /obj/effect/floor_decal/rust,
-/obj/machinery/light/small,
+/obj/machinery/light/small/no_nightshift,
 /turf/simulated/floor/tiled/steel/sif/planetuse{
 	icon_state = "steel_dirty"
 	},
@@ -34055,7 +34059,7 @@
 /turf/simulated/floor/plating,
 /area/surface/station/security/riot_control)
 "wtg" = (
-/obj/machinery/light/small{
+/obj/machinery/light/small/no_nightshift{
 	dir = 1
 	},
 /obj/machinery/embedded_controller/radio/simple_docking_controller/escape_pod_berth{
@@ -34400,6 +34404,13 @@
 	},
 /turf/simulated/floor/wood,
 /area/surface/station/command/meeting_room)
+"wDZ" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/machinery/light/small/no_nightshift,
+/turf/simulated/open,
+/area/surface/station/ai)
 "wEo" = (
 /obj/machinery/door/blast/regular/open{
 	id = "seclockdown";
@@ -35646,7 +35657,7 @@
 /obj/item/weapon/reagent_containers/blood/empty,
 /obj/item/weapon/reagent_containers/blood/empty,
 /obj/item/weapon/reagent_containers/blood/empty,
-/obj/machinery/light,
+/obj/machinery/light/no_nightshift,
 /turf/simulated/shuttle/floor/white,
 /area/shuttle/large_escape_pod2/station)
 "xmF" = (
@@ -35958,6 +35969,7 @@
 	},
 /obj/machinery/power/apc{
 	name = "south bump";
+	nightshift_setting = 2;
 	pixel_y = -24
 	},
 /obj/effect/floor_decal/borderfloor{
@@ -72666,7 +72678,7 @@ jvB
 fOc
 sCn
 uEC
-jbK
+wDZ
 fOc
 sCn
 fXT

--- a/maps/cynosure/cynosure-4.dmm
+++ b/maps/cynosure/cynosure-4.dmm
@@ -1127,6 +1127,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
+	nightshift_setting = 2;
 	pixel_y = 24
 	},
 /obj/machinery/light_switch{
@@ -1220,6 +1221,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
+	nightshift_setting = 2;
 	pixel_y = 24
 	},
 /obj/machinery/light_switch{
@@ -1432,6 +1434,7 @@
 /obj/structure/cable,
 /obj/machinery/power/apc{
 	name = "south bump";
+	nightshift_setting = 2;
 	pixel_y = -24
 	},
 /obj/machinery/light_switch{
@@ -2102,6 +2105,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
+	nightshift_setting = 2;
 	pixel_y = 24
 	},
 /obj/machinery/light_switch{
@@ -2132,6 +2136,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "east bump";
+	nightshift_setting = 2;
 	pixel_x = 24
 	},
 /obj/machinery/light_switch{
@@ -2200,6 +2205,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "east bump";
+	nightshift_setting = 2;
 	pixel_x = 24
 	},
 /obj/machinery/light_switch{
@@ -2768,6 +2774,7 @@
 /obj/machinery/power/apc/super/critical{
 	dir = 1;
 	name = "north bump";
+	nightshift_setting = 2;
 	pixel_y = 24
 	},
 /obj/machinery/light_switch{
@@ -2788,6 +2795,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "west bump";
+	nightshift_setting = 2;
 	pixel_x = -24
 	},
 /obj/machinery/light_switch{
@@ -4699,6 +4707,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "east bump";
+	nightshift_setting = 2;
 	pixel_x = 24
 	},
 /obj/machinery/light_switch{

--- a/maps/cynosure/cynosure-6.dmm
+++ b/maps/cynosure/cynosure-6.dmm
@@ -1678,7 +1678,7 @@
 /area/skipjack_station)
 "bXb" = (
 /obj/structure/bed/chair/shuttle,
-/obj/machinery/light{
+/obj/machinery/light/no_nightshift{
 	dir = 8
 	},
 /turf/simulated/shuttle/floor/white,
@@ -3346,7 +3346,7 @@
 /turf/simulated/shuttle/wall/dark/no_join,
 /area/shuttle/arrival/pre_game)
 "dZT" = (
-/obj/machinery/light,
+/obj/machinery/light/no_nightshift,
 /turf/simulated/shuttle/floor,
 /area/shuttle/arrival/pre_game)
 "ebh" = (
@@ -4397,7 +4397,7 @@
 /obj/structure/table/standard,
 /obj/random/maintenance/clean,
 /obj/random/maintenance/clean,
-/obj/machinery/light,
+/obj/machinery/light/no_nightshift,
 /turf/simulated/shuttle/floor/white,
 /area/shuttle/arrival/pre_game)
 "fjB" = (
@@ -7121,7 +7121,7 @@
 /area/syndicate_station)
 "irx" = (
 /obj/structure/bed/chair/shuttle,
-/obj/machinery/light{
+/obj/machinery/light/no_nightshift{
 	dir = 4
 	},
 /turf/simulated/shuttle/floor/white,
@@ -11709,7 +11709,7 @@
 	},
 /area/centcom/specops)
 "nol" = (
-/obj/machinery/light{
+/obj/machinery/light/no_nightshift{
 	dir = 1
 	},
 /turf/simulated/shuttle/floor,
@@ -17499,7 +17499,7 @@
 /area/centcom/evac)
 "tDS" = (
 /obj/structure/bed/chair/shuttle,
-/obj/machinery/light{
+/obj/machinery/light/no_nightshift{
 	dir = 1
 	},
 /turf/simulated/shuttle/floor/white,
@@ -18718,7 +18718,7 @@
 	},
 /area/centcom/medical)
 "uTx" = (
-/obj/machinery/light{
+/obj/machinery/light/no_nightshift{
 	dir = 1
 	},
 /turf/simulated/shuttle/floor/red,
@@ -19212,7 +19212,7 @@
 	icon_state = "ai-red";
 	name = "Arrivals Announcement Computer"
 	},
-/obj/machinery/light{
+/obj/machinery/light/no_nightshift{
 	dir = 1
 	},
 /turf/simulated/shuttle/floor{
@@ -20984,7 +20984,7 @@
 /obj/machinery/computer/shuttle_control/emergency{
 	dir = 1
 	},
-/obj/machinery/light,
+/obj/machinery/light/no_nightshift,
 /turf/simulated/shuttle/floor,
 /area/shuttle/escape/centcom)
 "xpp" = (


### PR DESCRIPTION
Slightly increases the brightness of night lighting (by about 10-20%) so it doesn't feel like the lights are literally off.

Before:
![](https://i.gyazo.com/8d25d2d31ec292abbc765c81d1bb0f4c.png)
After:
![](https://i.gyazo.com/4e6ef09605a2d50abb6a4af01f9496da.png)


Disables nightmode by default for the following areas:

Exterior Areas
AI Core/Upload areas
Medical Lobby
EMT Bay
Medical Trauma Center
Virology
Operating Theatres
Security Front Desk
Permabrig cells
Engineering Front Desk
(Behind the) bar
Engine Core + Control Rooms
Operations (Bridge)
Central corridors on the main level (Main North and South corridors + atrium)

This should keep the Vibe of night shift mode without making it feel like you're fumbling around in the dark in critical areas unless you turn the lights back up manually.
