### PR TITLE
Fixes paper missing write links

### DIFF
--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -113,7 +113,6 @@
 		name = title
 	if(istext(text))
 		info = text
-		addtimer(CALLBACK(src, .proc/update_info), 0)
 
 	if(mapload) // Jank, but we do this to prevent maploaded papers from somehow stacking across rounds if re-added to the board by a player.
 		was_maploaded = TRUE
@@ -121,12 +120,13 @@
 	pixel_y = rand(-8, 8)
 	pixel_x = rand(-9, 9)
 	stamps = ""
+	addtimer(CALLBACK(src, .proc/update_info, FALSE), 0)
 
-/obj/item/weapon/paper/proc/update_info()
+/obj/item/weapon/paper/proc/update_info(var/sanitize = TRUE)
 	if(name != "paper")
 		desc = "This is a paper titled '" + name + "'."
 
-	if(info != initial(info))
+	if(info != initial(info) && sanitize)
 		info = html_encode(info)
 		info = replacetext(info, "\n", "<BR>")
 		info = parsepencode(info)


### PR DESCRIPTION
This is how I should have done it in the first place. Not triggering the callback on initialize was preventing info_links from being set, which is the thing that actually has the "write links"