### PR TITLE
Improves RD access on Cynosure

### DIFF
--- a/maps/cynosure/cynosure_jobs.dm
+++ b/maps/cynosure/cynosure_jobs.dm
@@ -36,6 +36,18 @@ var/const/access_explorer = 43
 	alt_titles = list(
 		"Pilot" = /decl/hierarchy/outfit/job/pilot)
 
+/datum/job/rd
+    access = list(access_rd, access_heads, access_tox, access_genetics, access_morgue,
+                        access_tox_storage, access_teleporter, access_sec_doors,
+                        access_research, access_robotics, access_xenobiology, access_ai_upload, access_tech_storage,
+                        access_RC_announce, access_keycard_auth, access_tcomsat, access_gateway, access_xenoarch,
+                        access_network, access_maint_tunnels, access_explorer, access_eva, access_external_airlocks)
+    minimal_access = list(access_rd, access_heads, access_tox, access_genetics, access_morgue,
+                        access_tox_storage, access_teleporter, access_sec_doors,
+                        access_research, access_robotics, access_xenobiology, access_ai_upload, access_tech_storage,
+                        access_RC_announce, access_keycard_auth, access_tcomsat, access_gateway, access_xenoarch,
+                        access_network, access_maint_tunnels, access_explorer, access_eva, access_external_airlocks)
+			
 /*
 	alt_titles = list(
 		"Explorer Technician" = /decl/hierarchy/outfit/job/explorer2/technician,


### PR DESCRIPTION
As discussed in Discord, gives access to Maintenance, EVA and Exploration to the RD. Should only be valid on Cynosure.

First PR, Mechoid helped out with the actual meat of the thing, so lmk if it is proper or not and if things need changing.