### PR TITLE
Fix Reagenttank / Puddle Bugsons and Oversight

### DIFF
--- a/code/game/objects/effects/chem/puddle.dm
+++ b/code/game/objects/effects/chem/puddle.dm
@@ -22,6 +22,10 @@
 		CP.update_icon(TRUE)
 
 /obj/effect/decal/cleanable/chempuddle/proc/Spread(exclude=list())
+	if(!reagents && !QDELETED(src))
+		qdel(src)
+		return
+
 	if(reagents.total_volume < (25 * reagents.get_viscosity())) return
 	var/turf/simulated/S = get_turf(src)
 	if(!istype(S)) return
@@ -99,7 +103,7 @@
 
 	reagents.remove_any(evaporation_rate)
 
-	if(reagents.total_volume <= 0)
+	if(!reagents || reagents.total_volume <= 0)
 		qdel(src)
 		return
 

--- a/code/modules/reagents/holder/holder.dm
+++ b/code/modules/reagents/holder/holder.dm
@@ -409,7 +409,6 @@
 		if(!CP)
 			CP = new(target)
 		trans_to_holder(CP.reagents, amount)
-		CP.Spread()
 
 	update_total()
 

--- a/code/modules/reagents/machinery/dispenser/reagent_tank.dm
+++ b/code/modules/reagents/machinery/dispenser/reagent_tank.dm
@@ -119,7 +119,7 @@
 			message_admins("[key_name_admin(Proj.firer)] shot reagent tank at [loc.loc.name] ([loc.x],[loc.y],[loc.z]) (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[loc.x];Y=[loc.y];Z=[loc.z]'>JMP</a>).")
 			log_game("[key_name(Proj.firer)] shot reagent tank at [loc.loc.name] ([loc.x],[loc.y],[loc.z]).")
 
-		if(Proj.sharp || (istype(Proj, /obj/item/projectile/beam) && !Proj.damage))
+		if(Proj.sharp || (istype(Proj, /obj/item/projectile/beam) && Proj.damage))
 			rupture()
 
 /obj/structure/reagent_dispensers/ex_act()
@@ -129,23 +129,32 @@
 	rupture()
 
 /obj/structure/reagent_dispensers/proc/rupture()
-	var/severity = 1
 	var/violent = FALSE
 
 	if (reagents.total_volume > 500)
-		severity = 3
 		reagents.trans_to_turf(get_turf(src), reagents.total_volume / 5)
 	else if (reagents.total_volume > 100)
-		severity = 2
 		reagents.trans_to_turf(get_turf(src), reagents.total_volume / 3)
 	else if (reagents.total_volume > 50)
-		severity = 1
 		reagents.trans_to_turf(get_turf(src), reagents.total_volume / 2)
 
-	if(reagents.has_any_reagent(list("phoron","fuel","hydrophoron")))
+	var/list/explodium = list("phoron","fuel","hydrophoron")
+	if(reagents.has_any_reagent(explodium))
 		violent = TRUE
 
 	if(violent)
+		var/severity = 1
+		var/fuelvolume = 0
+		for(var/ID in explodium)
+			fuelvolume += reagents.get_reagent_amount(ID)
+		
+		if(fuelvolume >= 500)
+			severity = 3
+		else if(fuelvolume >= 100)
+			severity = 2
+		else if(fuelvolume >= 50)
+			severity = 1
+
 		switch(severity)
 			if(3)
 				explosion(get_turf(src),1,2,4)


### PR DESCRIPTION
:cl:
fix - Reagent tanks can now be detonated with damaging lasers properly.
fix - Puddles don't turn into shinies and try multiplying forever (again).
fix - Explodium in fueltanks is now logically based upon actual explodium volume, instead of total volume.
/:cl: