### PR TITLE
Fixes buns having the power to break food inits

### DIFF
--- a/code/modules/food/food/snacks.dm
+++ b/code/modules/food/food/snacks.dm
@@ -3580,7 +3580,7 @@
 	bitesize = 2
 	center_of_mass = list("x"=16, "y"=12)
 	nutriment_amt = 4
-	nutriment_desc = "bun"
+	nutriment_desc = list("bun" = 4)
 
 /obj/item/weapon/reagent_containers/food/snacks/bun/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	// Bun + meatball = burger


### PR DESCRIPTION
Fixes a bug that caused a bad index runtime on mapped-in buns during map init that somehow apparently makes all food cause nausea and vomiting or something.