### PR TITLE
fixes puke coating stealing nutriment reagent's id

### DIFF
--- a/code/modules/reagents/reagents/food_drinks.dm
+++ b/code/modules/reagents/reagents/food_drinks.dm
@@ -63,6 +63,8 @@
 	Generally coatings are intended for deep frying foods
 */
 /datum/reagent/nutriment/coating
+	name = "coating"
+	id = "coating"
 	nutriment_factor = 6 //Less dense than the food itself, but coatings still add extra calories
 	var/messaged = 0
 	var/icon_raw


### PR DESCRIPTION
How do you even miss this and how in the world is the code itself able to miss it too until something messes up a bunch of buns?