### PR TITLE
Remove evening gloves temp. protection

### DIFF
--- a/code/modules/clothing/gloves/color.dm
+++ b/code/modules/clothing/gloves/color.dm
@@ -86,11 +86,6 @@
 	icon_state = "evening_gloves"
 	addblends = "evening_gloves_a"
 
-	cold_protection = HANDS
-	min_cold_protection_temperature = GLOVES_MIN_COLD_PROTECTION_TEMPERATURE
-	heat_protection = HANDS
-	max_heat_protection_temperature = GLOVES_MAX_HEAT_PROTECTION_TEMPERATURE
-
 /obj/item/clothing/gloves/fingerless
 	desc = "A pair of gloves that don't actually cover the fingers."
 	name = "fingerless gloves"


### PR DESCRIPTION
Elbow-length evening gloves are very fancy and all, but I'm reasonably certain they don't protect your delicate fingies from temperatures ranging from as low as 2K (-271.15C/-456.1F) to as high as 1500K (1226C/2240F).

So they won't any more.

:cl:
tweak - evening gloves no longer have amazing thermal protection values
/:cl: