### PR TITLE
Makes the chirp emote available to Zaddat

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station.dm
@@ -433,6 +433,11 @@
 		/datum/mob_descriptor/height = 0,
 		/datum/mob_descriptor/build = -1
 		)
+
+	default_emotes = list(
+		/decl/emote/audible/chirp
+	)
+
 /datum/species/zaddat/equip_survival_gear(var/mob/living/carbon/human/H)
 	..()
 	if(H.wear_suit) //get rid of job labcoats so they don't stop us from equipping the Shroud


### PR DESCRIPTION
See title; no comment beyond that the Wiki mentions they chirp.

> Zaddat tend to chirp like crickets under high stress, which, Zaddat being Zaddat, is a fairly frequent occurrence.

