### PR TITLE
Fixes holodeck landmarks not clearing themselves

### DIFF
--- a/code/modules/holodeck/HolodeckControl.dm
+++ b/code/modules/holodeck/HolodeckControl.dm
@@ -314,6 +314,9 @@
 	for(var/obj/effect/decal/cleanable/blood/B in linkedholodeck)
 		qdel(B)
 
+	for(var/obj/effect/landmark/L in linkedholodeck)
+		qdel(L)
+
 	holographic_objs = A.copy_contents_to(linkedholodeck , 1)
 	for(var/obj/holo_obj in holographic_objs)
 		holo_obj.alpha *= 0.8 //give holodeck objs a slight transparency


### PR DESCRIPTION
Fixes holodeck spawn landmarks (such as carps and "atmos test") not getting cleared when the program is unloaded and thus permanently leaving the holodeck to spawn endless carps and sparks on every simulation without any way to fix ingame.