### PR TITLE
Allergen CE Conversion

### DIFF
--- a/code/__defines/chemistry.dm
+++ b/code/__defines/chemistry.dm
@@ -36,6 +36,7 @@
 #define CE_SPEEDBOOST "gofast" // Hyperzine
 #define CE_SLOWDOWN "goslow" // Slowdown
 #define CE_ANTACID "nopuke" // Don't puke.
+#define CE_ALLERGEN "allergyreaction" // Self explanatory
 
 #define REAGENTS_PER_SHEET 20
 

--- a/code/__defines/species_languages.dm
+++ b/code/__defines/species_languages.dm
@@ -47,6 +47,7 @@
 #define AG_WEAKEN	0x10	// too weak to move, oof
 #define AG_BLURRY	0x20	// blurred vision!
 #define AG_SLEEPY	0x40	// fatigue/exhaustion
+#define AG_CONFUSE	0x80	// disorientation
 
 // Species spawn flags
 #define SPECIES_IS_WHITELISTED      0x1  // Must be whitelisted to play.

--- a/code/__defines/species_languages.dm
+++ b/code/__defines/species_languages.dm
@@ -40,14 +40,16 @@
 #define ALLERGEN_STIMULANT	0x1000	// Stimulants are what makes the Tajaran heart go ruh roh - not just coffee!
 
 // Allergen reactions
-#define AG_TOX_DMG	0x1	// the classic
-#define AG_OXY_DMG	0x2	// intense airway reactions
-#define AG_EMOTE	0x4	// general emote reactions based on affect type
-#define AG_PAIN		0x8	// short-lived hurt
-#define AG_WEAKEN	0x10	// too weak to move, oof
-#define AG_BLURRY	0x20	// blurred vision!
-#define AG_SLEEPY	0x40	// fatigue/exhaustion
-#define AG_CONFUSE	0x80	// disorientation
+#define AG_PHYS_DMG	0x1	// brute
+#define AG_BURN_DMG	0x2	// burns
+#define AG_TOX_DMG	0x4	// the classic
+#define AG_OXY_DMG	0x8	// intense airway reactions
+#define AG_EMOTE	0x10	// general emote reactions based on affect type
+#define AG_PAIN		0x20	// short-lived hurt
+#define AG_WEAKEN	0x40	// too weak to move, oof
+#define AG_BLURRY	0x80	// blurred vision!
+#define AG_SLEEPY	0x100	// fatigue/exhaustion
+#define AG_CONFUSE	0x200	// disorientation
 
 // Species spawn flags
 #define SPECIES_IS_WHITELISTED      0x1  // Must be whitelisted to play.

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -435,6 +435,12 @@
 	else
 		chem_effects[effect] = magnitude
 
+/mob/living/carbon/proc/remove_chemical_effect(var/effect, var/magnitude)
+	if(effect in chem_effects && magnitude)
+		chem_effects[effect] -= magnitude
+	else if(effect in chem_effects && !magnitude)
+		chem_effects[effect] = 0
+
 /mob/living/carbon/get_default_language()
 	if(default_language)
 		if(can_speak(default_language))

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -436,10 +436,8 @@
 		chem_effects[effect] = magnitude
 
 /mob/living/carbon/proc/remove_chemical_effect(var/effect, var/magnitude)
-	if(effect in chem_effects && magnitude)
-		chem_effects[effect] = max(0,chem_effects[effect]-magnitude)
-	else if(effect in chem_effects)
-		chem_effects[effect] = 0
+	if(effect in chem_effects)
+		chem_effects[effect] = magnitude ? max(0,chem_effects[effect]-magnitude) : 0
 
 /mob/living/carbon/get_default_language()
 	if(default_language)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -437,8 +437,8 @@
 
 /mob/living/carbon/proc/remove_chemical_effect(var/effect, var/magnitude)
 	if(effect in chem_effects && magnitude)
-		chem_effects[effect] -= magnitude
-	else if(effect in chem_effects && !magnitude)
+		chem_effects[effect] = max(0,chem_effects[effect]-magnitude)
+	else if(effect in chem_effects)
 		chem_effects[effect] = 0
 
 /mob/living/carbon/get_default_language()

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -82,6 +82,8 @@
 		handle_shock()
 
 		handle_pain()
+		
+		handle_allergens()
 
 		handle_medical_side_effects()
 
@@ -629,6 +631,30 @@
 
 	breath.update_values()
 	return 1
+
+/mob/living/carbon/human/proc/handle_allergens()
+	if(chem_effects[CE_ALLERGEN])
+		var/damage_severity = species.allergen_damage_severity
+		var/disable_severity = species.allergen_disable_severity
+		if(species.allergen_reaction & AG_TOX_DMG)
+			adjustToxLoss(damage_severity)
+		if(species.allergen_reaction & AG_OXY_DMG)
+			adjustOxyLoss(damage_severity)
+			if(prob(2*disable_severity))
+				emote(pick("cough","gasp","choke"))
+		if(species.allergen_reaction & AG_EMOTE)
+			if(prob(2*disable_severity))
+				emote(pick("pale","shiver","twitch"))
+		if(species.allergen_reaction & AG_PAIN)
+			adjustHalLoss(disable_severity)
+		if(species.allergen_reaction & AG_WEAKEN)
+			Weaken(disable_severity)
+		if(species.allergen_reaction & AG_BLURRY)
+			eye_blurry = max(eye_blurry, disable_severity)
+		if(species.allergen_reaction & AG_SLEEPY)
+			drowsyness = max(drowsyness, disable_severity)
+		if(species.allergen_reaction & AG_CONFUSE)
+			Confuse(disable_severity/4)
 
 /mob/living/carbon/human/handle_environment(datum/gas_mixture/environment)
 	if(!environment)

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -634,16 +634,17 @@
 
 /mob/living/carbon/human/proc/handle_allergens()
 	if(chem_effects[CE_ALLERGEN])
-		var/damage_severity = species.allergen_damage_severity
-		var/disable_severity = species.allergen_disable_severity
+		//first, multiply the basic species-level value by our allergen effect rating, so consuming multiple seperate allergen typess simultaneously hurts more
+		var/damage_severity = species.allergen_damage_severity * chem_effects[CE_ALLERGEN]
+		var/disable_severity = species.allergen_disable_severity * chem_effects[CE_ALLERGEN]
 		if(species.allergen_reaction & AG_TOX_DMG)
 			adjustToxLoss(damage_severity)
 		if(species.allergen_reaction & AG_OXY_DMG)
 			adjustOxyLoss(damage_severity)
-			if(prob(2*disable_severity))
+			if(prob(disable_severity/2))
 				emote(pick("cough","gasp","choke"))
 		if(species.allergen_reaction & AG_EMOTE)
-			if(prob(2*disable_severity))
+			if(prob(disable_severity/2))
 				emote(pick("pale","shiver","twitch"))
 		if(species.allergen_reaction & AG_PAIN)
 			adjustHalLoss(disable_severity)

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -637,6 +637,10 @@
 		//first, multiply the basic species-level value by our allergen effect rating, so consuming multiple seperate allergen typess simultaneously hurts more
 		var/damage_severity = species.allergen_damage_severity * chem_effects[CE_ALLERGEN]
 		var/disable_severity = species.allergen_disable_severity * chem_effects[CE_ALLERGEN]
+		if(species.allergen_reaction & AG_PHYS_DMG)
+			adjustBruteLoss(damage_severity)
+		if(species.allergen_reaction & AG_BURN_DMG)
+			adjustFireLoss(damage_severity)
 		if(species.allergen_reaction & AG_TOX_DMG)
 			adjustToxLoss(damage_severity)
 		if(species.allergen_reaction & AG_OXY_DMG)

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -54,7 +54,7 @@
 	var/taste_sensitivity = TASTE_NORMAL							// How sensitive the species is to minute tastes.
 	var/allergens = null									// Things that will make this species very sick
 	var/allergen_reaction = AG_TOX_DMG|AG_OXY_DMG|AG_EMOTE|AG_PAIN|AG_BLURRY|AG_CONFUSE	// What type of reactions will you have? These the 'main' options and are intended to approximate anaphylactic shock at high doses.
-	var/allergen_damage_severity = 4							// How bad are reactions to the allergen? Touch with extreme caution.
+	var/allergen_damage_severity = 2.5							// How bad are reactions to the allergen? Touch with extreme caution.
 	var/allergen_disable_severity = 10							// Whilst this determines how long nonlethal effects last and how common emotes are.
 
 	var/min_age = 17

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -53,7 +53,7 @@
 
 	var/taste_sensitivity = TASTE_NORMAL							// How sensitive the species is to minute tastes.
 	var/allergens = null									// Things that will make this species very sick
-	var/allergen_reaction = AG_TOX_DMG|AG_OXY_DMG|AG_EMOTE|AG_PAIN|AG_WEAKEN		// What type of reactions will you have? These the 'main' options and are intended to approximate anaphylactic shock at high doses.
+	var/allergen_reaction = AG_TOX_DMG|AG_OXY_DMG|AG_EMOTE|AG_PAIN|AG_BLURRY|AG_CONFUSE	// What type of reactions will you have? These the 'main' options and are intended to approximate anaphylactic shock at high doses.
 	var/allergen_damage_severity = 1.2							// How bad are reactions to the allergen? Touch with extreme caution.
 	var/allergen_disable_severity = 2.5							// Whilst this determines how long nonlethal effects last and how common emotes are.
 

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -54,8 +54,8 @@
 	var/taste_sensitivity = TASTE_NORMAL							// How sensitive the species is to minute tastes.
 	var/allergens = null									// Things that will make this species very sick
 	var/allergen_reaction = AG_TOX_DMG|AG_OXY_DMG|AG_EMOTE|AG_PAIN|AG_BLURRY|AG_CONFUSE	// What type of reactions will you have? These the 'main' options and are intended to approximate anaphylactic shock at high doses.
-	var/allergen_damage_severity = 1.2							// How bad are reactions to the allergen? Touch with extreme caution.
-	var/allergen_disable_severity = 2.5							// Whilst this determines how long nonlethal effects last and how common emotes are.
+	var/allergen_damage_severity = 4							// How bad are reactions to the allergen? Touch with extreme caution.
+	var/allergen_disable_severity = 10							// Whilst this determines how long nonlethal effects last and how common emotes are.
 
 	var/min_age = 17
 	var/max_age = 70

--- a/code/modules/reagents/reagents/_reagents.dm
+++ b/code/modules/reagents/reagents/_reagents.dm
@@ -30,7 +30,7 @@
 	var/affects_robots = 0	// Does this chem process inside a Synth?
 
 	var/allergen_type		// What potential allergens does this contain?
-	var/allergen_factor = 100	// If the potential allergens are mixed and low-volume, they're a bit less dangerous. Needed for drinks because they're a single reagent compared to food which contains multiple seperate reagents.
+	var/allergen_factor = 2	// If the potential allergens are mixed and low-volume, they're a bit less dangerous. Needed for drinks because they're a single reagent compared to food which contains multiple seperate reagents.
 
 	var/cup_icon_state = null
 	var/cup_name = null

--- a/code/modules/reagents/reagents/_reagents.dm
+++ b/code/modules/reagents/reagents/_reagents.dm
@@ -30,7 +30,7 @@
 	var/affects_robots = 0	// Does this chem process inside a Synth?
 
 	var/allergen_type		// What potential allergens does this contain?
-	var/allergen_factor = 1	// If the potential allergens are mixed and low-volume, they're a bit less dangerous. Needed for drinks because they're a single reagent compared to food which contains multiple seperate reagents.
+	var/allergen_factor = 100	// If the potential allergens are mixed and low-volume, they're a bit less dangerous. Needed for drinks because they're a single reagent compared to food which contains multiple seperate reagents.
 
 	var/cup_icon_state = null
 	var/cup_name = null
@@ -169,25 +169,7 @@
 	if(overdose && (volume > overdose * M?.species.chemOD_threshold) && (active_metab.metabolism_class != CHEM_TOUCH && !can_overdose_touch))
 		overdose(M, alien, removed)
 	if(M.species.allergens & allergen_type)	//uhoh, we can't handle this!
-		var/damage_severity = M.species.allergen_damage_severity*allergen_factor
-		var/disable_severity = M.species.allergen_disable_severity*allergen_factor
-		if(M.species.allergen_reaction & AG_TOX_DMG)
-			M.adjustToxLoss(damage_severity * removed)
-		if(M.species.allergen_reaction & AG_OXY_DMG)
-			M.adjustOxyLoss(damage_severity * removed)
-			if(prob(2*disable_severity))
-				M.emote(pick("cough","gasp","choke"))
-		if(M.species.allergen_reaction & AG_EMOTE)
-			if(prob(2*disable_severity))
-				M.emote(pick("pale","shiver","twitch"))
-		if(M.species.allergen_reaction & AG_PAIN)
-			M.adjustHalLoss(disable_severity)
-		if(M.species.allergen_reaction & AG_WEAKEN)
-			M.Weaken(disable_severity)
-		if(M.species.allergen_reaction & AG_BLURRY)
-			M.eye_blurry = max(M.eye_blurry, disable_severity)
-		if(M.species.allergen_reaction & AG_SLEEPY)
-			M.drowsyness = max(M.drowsyness, disable_severity)
+		M.add_chemical_effect(CE_ALLERGEN,allergen_factor)
 	remove_self(removed)
 	return
 

--- a/code/modules/reagents/reagents/dispenser.dm
+++ b/code/modules/reagents/reagents/dispenser.dm
@@ -92,7 +92,7 @@
 
 	glass_name = "ethanol"
 	glass_desc = "A well-known alcohol with a variety of applications."
-	allergen_factor = 0.5	//simulates mixed drinks containing less of the allergen, as they have only a single actual reagent unlike food
+	allergen_factor = 75	//simulates mixed drinks containing less of the allergen, as they have only a single actual reagent unlike food
 
 /datum/reagent/ethanol/touch_mob(var/mob/living/L, var/amount)
 	..()

--- a/code/modules/reagents/reagents/dispenser.dm
+++ b/code/modules/reagents/reagents/dispenser.dm
@@ -92,7 +92,7 @@
 
 	glass_name = "ethanol"
 	glass_desc = "A well-known alcohol with a variety of applications."
-	allergen_factor = 75	//simulates mixed drinks containing less of the allergen, as they have only a single actual reagent unlike food
+	allergen_factor = 1	//simulates mixed drinks containing less of the allergen, as they have only a single actual reagent unlike food
 
 /datum/reagent/ethanol/touch_mob(var/mob/living/L, var/amount)
 	..()

--- a/code/modules/reagents/reagents/medicine.dm
+++ b/code/modules/reagents/reagents/medicine.dm
@@ -15,7 +15,7 @@
 	if(alien != IS_DIONA)
 		M.add_chemical_effect(CE_STABLE, 15)
 		M.add_chemical_effect(CE_PAINKILLER, 10 * M.species.chem_strength_pain)
-		M.remove_chemical_effect(CE_ALLERGEN, 10)	//counters all but the most severe combo-reactions
+		M.remove_chemical_effect(CE_ALLERGEN)
 
 /datum/reagent/inaprovaline/topical
 	name = "Inaprovalaze"

--- a/code/modules/reagents/reagents/medicine.dm
+++ b/code/modules/reagents/reagents/medicine.dm
@@ -15,7 +15,7 @@
 	if(alien != IS_DIONA)
 		M.add_chemical_effect(CE_STABLE, 15)
 		M.add_chemical_effect(CE_PAINKILLER, 10 * M.species.chem_strength_pain)
-		M.remove_chemical_effect(CE_ALLERGEN, 15)
+		M.remove_chemical_effect(CE_ALLERGEN, 10)	//counters all but the most severe combo-reactions
 
 /datum/reagent/inaprovaline/topical
 	name = "Inaprovalaze"

--- a/code/modules/reagents/reagents/medicine.dm
+++ b/code/modules/reagents/reagents/medicine.dm
@@ -3,7 +3,7 @@
 /datum/reagent/inaprovaline
 	name = "Inaprovaline"
 	id = "inaprovaline"
-	description = "Inaprovaline is a synaptic stimulant and cardiostimulant. Commonly used to stabilize patients."
+	description = "Inaprovaline is a synaptic stimulant and cardiostimulant. Commonly used to stabilize patients. Also counteracts allergic reactions."
 	taste_description = "bitterness"
 	reagent_state = LIQUID
 	color = "#00BFFF"
@@ -15,6 +15,7 @@
 	if(alien != IS_DIONA)
 		M.add_chemical_effect(CE_STABLE, 15)
 		M.add_chemical_effect(CE_PAINKILLER, 10 * M.species.chem_strength_pain)
+		M.remove_chemical_effect(CE_ALLERGEN, 15)
 
 /datum/reagent/inaprovaline/topical
 	name = "Inaprovalaze"


### PR DESCRIPTION
Consider all numbers to be testing placeholders. Needs some tuning. Tested as a skrell by eating two bites of regular meat: this briefly incapacitated the test dummy and left them functionally crippled for a short duration, but __wasn't__ fatal.

Some long overdue updates and improvements to the allergen system.
- Converts allergen reactions to be based off the chemical effects system; if a reagent is an allergen to the mob, it simply adds the allergen chem_effect to their list of chem_effects, and actual effect processing now occurs in Life() rather than on the reagent's end.
- Adds Brute Damage, Burn Damage, and Confusion to the list of possible effects. Weaken is replaced with Pain and Confusion in the default reactions: no more instant collapse, but you're still vulnerable.
- Adds a remove effect proc so that reagents or procs can remove/reduce existing effects on the target. If a magnitude is specified they'll reduce it by that amount (to a minimum of 0), else they'll just flatten it entirely. Could be used to have sedatives counteract hyperzine (or vice versa) and other interactions.
- Makes inaprovaline counter immediate allergic reactions as they occur, so there's a reliable means of treating reactions besides "carbon and pray". You can either administer it ahead of time if you expect to encounter an allergen, or quickly administrate to an ongoing reaction to halt it. If they're still taking damage, administer inaprovaline: if not, administer dylovene and painkillers.

Treatment of an *ongoing* allergic reaction is now "apply inaprovaline". Treatment of one that *already happened* is now dylo+painkillers. Your window to apply inaprovaline will be fairly small, but if you're quick you can head off a reaction at the pass and at least keep it from getting any worse.

As a bonus if you apply inaprovaline _ahead_ of taking an allergen you can prevent the reaction entirely and enjoy what would otherwise be deadly poison (for as long as the inaprovaline is in your system), though you still won't gain any nutrition or other benefits.

:cl:
tweak - standard allergic reactions now use the chemical effects system, and can be prevented or reduced by administering inaprovaline. doesn't apply to special cases like unathi + sugar/etc.
tweak - allergic reactions no longer apply weaken, instead they now cause pain, blurred vision, and confusion. they can still knockdown/incap through paincrit or softcrit.
/:cl: