### PR TITLE
Map Tweaks March 2022 + Locker Equipment

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
@@ -116,7 +116,10 @@
 		/obj/item/weapon/extinguisher/mini,
 		/obj/item/weapon/storage/box/freezer,
 		/obj/item/clothing/accessory/storage/white_vest,
-		/obj/item/taperoll/medical)
+		/obj/item/taperoll/medical,
+		/obj/item/device/gps/medical,
+		/obj/item/device/geiger
+		)
 
 /obj/structure/closet/secure_closet/CMO
 	name = "chief medical officer's locker"
@@ -142,7 +145,8 @@
 		/obj/item/taperoll/medical,
 		/obj/item/clothing/suit/bio_suit/cmo,
 		/obj/item/clothing/head/bio_hood/cmo,
-		/obj/item/clothing/shoes/white)
+		/obj/item/clothing/shoes/white,
+		/obj/item/device/gps/medical/cmo)
 
 /obj/structure/closet/secure_closet/CMO/Initialize()
 	if(prob(50))

--- a/code/game/objects/structures/signs.dm
+++ b/code/game/objects/structures/signs.dm
@@ -418,7 +418,7 @@
 /obj/structure/sign/levels/security
 	name = "\improper Security Department"
 	desc = "A level sign, stating the level to find the Security Department on."
-	icon_state = "direction_sec"
+	icon_state = "level_sec"
 
 /obj/structure/sign/directions/security/armory
 	name = "\improper Armory"
@@ -428,7 +428,7 @@
 /obj/structure/sign/levels/security/armory
 	name = "\improper Armory"
 	desc = "A level sign, stating the level to find the Armory on."
-	icon_state = "direction_armory"
+	icon_state = "level_armory"
 
 /obj/structure/sign/directions/security/brig
 	name = "\improper Brig"
@@ -510,12 +510,12 @@
 /obj/structure/sign/directions/science/toxins
 	name = "\improper Toxins Lab"
 	desc = "A direction sign, pointing out the way to the Toxins Lab."
-	icon_state = "direction_sci"
+	icon_state = "direction_toxins"
 
 /obj/structure/sign/levels/science/toxins
 	name = "\improper Toxins Lab"
 	desc = "A level sign, stating the level to find the Toxins Lab on."
-	icon_state = "level_sci"
+	icon_state = "level_toxins"
 
 /obj/structure/sign/directions/science/robotics
 	name = "\improper Robotics Workshop"
@@ -581,12 +581,12 @@
 /obj/structure/sign/directions/medical/chemlab
 	name = "\improper Chemistry Lab"
 	desc = "A direction sign, pointing out the way to the Chemistry Lab."
-	icon_state = "direction_med"
+	icon_state = "direction_chemlab"
 
 /obj/structure/sign/levels/medical/chemlab
 	name = "\improper Chemistry Lab"
 	desc = "A level sign, stating the level to find the Chemistry Lab on."
-	icon_state = "level_med"
+	icon_state = "level_chemlab"
 
 /obj/structure/sign/directions/medical/surgery
 	name = "\improper Surgery"
@@ -1007,7 +1007,7 @@
 	icon_state = "level-b-large"
 
 /obj/structure/sign/level/ground
-	name = "\improper Basement Level"
+	name = "\improper Ground Level"
 	icon_state = "level-g"
 
 /obj/structure/sign/level/ground/large

--- a/maps/cynosure/cynosure-1.dmm
+++ b/maps/cynosure/cynosure-1.dmm
@@ -194,6 +194,10 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/structure/sign/directions/stairs_up{
+	dir = 4;
+	pixel_y = 32
+	},
 /turf/simulated/floor/tiled,
 /area/surface/station/hallway/primary/bmt/north)
 "az" = (
@@ -281,16 +285,16 @@
 /obj/effect/floor_decal/corner/green/bordercorner{
 	dir = 1
 	},
-/obj/structure/sign/directions/security{
-	dir = 4;
+/obj/structure/sign/levels/medical{
+	dir = 5;
 	pixel_y = 38
 	},
-/obj/structure/sign/directions/engineering{
-	dir = 4;
+/obj/structure/sign/levels/engineering{
+	dir = 5;
 	pixel_y = 32
 	},
-/obj/structure/sign/directions/medical{
-	dir = 4;
+/obj/structure/sign/levels/security{
+	dir = 5;
 	pixel_y = 26
 	},
 /turf/simulated/floor/tiled,
@@ -1399,6 +1403,9 @@
 "cX" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/ladder/up,
+/obj/structure/sign/level/basement{
+	pixel_y = 32
+	},
 /turf/simulated/floor/plating,
 /area/surface/station/maintenance/storage/emergency/bmtseast)
 "cY" = (
@@ -2312,6 +2319,9 @@
 "fd" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/ladder/up,
+/obj/structure/sign/level/basement{
+	pixel_x = -32
+	},
 /turf/simulated/floor/plating,
 /area/surface/station/maintenance/security)
 "fe" = (
@@ -3264,6 +3274,9 @@
 "hp" = (
 /obj/structure/ladder/up,
 /obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/sign/level/basement{
+	pixel_x = 31
+	},
 /turf/simulated/floor/plating,
 /area/surface/station/maintenance/substation/medbay/bmt)
 "hq" = (
@@ -3532,6 +3545,9 @@
 	},
 /obj/item/clothing/glasses/meson,
 /obj/effect/floor_decal/industrial/warning/corner,
+/obj/structure/sign/level/basement{
+	pixel_y = 27
+	},
 /turf/simulated/floor/plating,
 /area/surface/station/maintenance/substation/cargo/bmt)
 "hR" = (
@@ -3596,6 +3612,9 @@
 "hY" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/ladder/up,
+/obj/structure/sign/level/basement{
+	pixel_y = 32
+	},
 /turf/simulated/floor/plating,
 /area/surface/station/maintenance/weststairwell/bmt)
 "hZ" = (
@@ -5902,6 +5921,12 @@
 /obj/structure/railing,
 /turf/simulated/floor/tiled/steel_grid,
 /area/surface/station/rnd/hallway/bmt)
+"mH" = (
+/obj/structure/marker_beacon{
+	mapped_in_color = "Olive"
+	},
+/turf/simulated/mineral/floor/ignore_mapgen/sif,
+/area/surface/cave/explored/normal)
 "mI" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/disposalpipe/segment{
@@ -6236,6 +6261,9 @@
 	},
 /obj/machinery/light/small{
 	dir = 1
+	},
+/obj/structure/sign/level/basement{
+	pixel_y = 33
 	},
 /turf/simulated/floor/plating,
 /area/surface/station/maintenance/substation/engineering/bmt)
@@ -7485,6 +7513,9 @@
 /obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 10
 	},
+/obj/structure/sign/level/basement{
+	pixel_x = 32
+	},
 /turf/simulated/floor/tiled,
 /area/surface/station/hallway/primary/bmt/west/elevator)
 "qn" = (
@@ -7569,6 +7600,9 @@
 /area/surface/station/hallway/primary/bmt/west)
 "qu" = (
 /obj/structure/railing,
+/obj/structure/sign/level/basement{
+	pixel_y = 29
+	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/surface/station/rnd/hallway/bmt)
 "qv" = (
@@ -9048,6 +9082,9 @@
 "tt" = (
 /obj/structure/ladder/up,
 /obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/sign/level/basement{
+	pixel_x = 32
+	},
 /turf/simulated/floor/plating,
 /area/surface/station/maintenance/medical/south)
 "tv" = (
@@ -9476,6 +9513,9 @@
 /obj/effect/floor_decal/corner/green/bordercorner{
 	dir = 4
 	},
+/obj/structure/sign/level/basement/large{
+	pixel_x = 32
+	},
 /turf/simulated/floor/tiled,
 /area/surface/station/hallway/secondary/bmt/eaststairwell)
 "uu" = (
@@ -9565,17 +9605,17 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
-/obj/structure/sign/directions/command{
-	dir = 4;
-	pixel_y = 38
+/obj/structure/sign/levels/cryo{
+	dir = 5;
+	pixel_y = 26
 	},
-/obj/structure/sign/directions/evac{
-	dir = 4;
+/obj/structure/sign/levels/evac{
+	dir = 5;
 	pixel_y = 32
 	},
-/obj/structure/sign/directions/cryo{
-	dir = 4;
-	pixel_y = 26
+/obj/structure/sign/levels/command{
+	dir = 1;
+	pixel_y = 38
 	},
 /turf/simulated/floor/tiled,
 /area/surface/station/hallway/primary/bmt/north)
@@ -9873,6 +9913,10 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/white,
 /area/surface/station/rnd/hallway/bmt)
+"vp" = (
+/obj/structure/sign/level/basement/large,
+/turf/simulated/wall/r_wall,
+/area/surface/station/engineering/hallway/bmt)
 "vq" = (
 /obj/structure/bed,
 /turf/simulated/floor/reinforced,
@@ -10490,6 +10534,9 @@
 "wC" = (
 /obj/structure/ladder/up,
 /obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/sign/level/basement{
+	pixel_x = -32
+	},
 /turf/simulated/floor/plating,
 /area/surface/station/maintenance/research/east)
 "wD" = (
@@ -11857,22 +11904,25 @@
 /turf/simulated/floor/tiled/neutral,
 /area/surface/outpost/research/xenoarcheology/entrance)
 "zx" = (
-/obj/structure/sign/directions/science/xenobiology{
-	dir = 1;
-	pixel_y = 6
+/obj/structure/sign/levels/science/xenoflora{
+	dir = 5
 	},
-/obj/structure/sign/directions/science/xenoflora{
-	dir = 1
-	},
-/obj/structure/sign/directions/science/exploration{
-	dir = 1;
+/obj/structure/sign/levels/science/xenobiology{
+	dir = 5;
 	pixel_y = -6
+	},
+/obj/structure/sign/levels/science/exploration{
+	dir = 5;
+	pixel_y = 6
 	},
 /turf/simulated/wall/r_wall,
 /area/surface/station/rnd/hallway/bmt)
 "zz" = (
 /obj/structure/ladder/up,
 /obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/sign/level/basement{
+	pixel_x = 32
+	},
 /turf/simulated/floor/plating,
 /area/surface/station/maintenance/medical/west)
 "zA" = (
@@ -13374,6 +13424,9 @@
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals_central4{
 	dir = 4
+	},
+/obj/structure/sign/level/basement/large{
+	pixel_y = 32
 	},
 /turf/simulated/floor/tiled,
 /area/surface/station/hallway/secondary/bmt/weststairwell)
@@ -18169,6 +18222,10 @@
 	dir = 8;
 	pixel_y = -26
 	},
+/obj/structure/sign/directions/stairs_up{
+	dir = 8;
+	pixel_y = -38
+	},
 /turf/simulated/floor/tiled,
 /area/surface/station/hallway/primary/bmt/west)
 "NA" = (
@@ -19121,6 +19178,9 @@
 "Pk" = (
 /obj/structure/ladder/up,
 /obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/sign/level/basement{
+	pixel_y = 34
+	},
 /turf/simulated/floor/plating,
 /area/surface/station/maintenance/storage/emergency/bmtswest)
 "Pl" = (
@@ -20502,6 +20562,20 @@
 	},
 /turf/simulated/floor/tiled,
 /area/surface/station/hallway/primary/bmt/north)
+"RW" = (
+/obj/structure/sign/levels/command{
+	dir = 1;
+	pixel_y = 6
+	},
+/obj/structure/sign/levels/dorms{
+	dir = 1
+	},
+/obj/structure/sign/levels/cargo{
+	dir = 5;
+	pixel_y = -6
+	},
+/turf/simulated/wall/r_wall,
+/area/surface/station/hallway/primary/bmt/west/elevator)
 "RY" = (
 /obj/structure/cable/green{
 	d2 = 2;
@@ -20525,6 +20599,11 @@
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals_central7{
 	dir = 4
+	},
+/obj/structure/sign/level/basement{
+	dir = 8;
+	pixel_x = 36;
+	pixel_y = 32
 	},
 /turf/simulated/floor/tiled,
 /area/surface/station/medical/hallway/bmt)
@@ -22624,17 +22703,17 @@
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 6
 	},
-/obj/structure/sign/directions/science/robotics{
+/obj/structure/sign/levels/science/robotics{
 	dir = 1;
 	pixel_y = -32
-	},
-/obj/structure/sign/directions/science/rnd{
-	dir = 1;
-	pixel_y = -26
 	},
 /obj/structure/sign/directions/stairs_up{
 	dir = 1;
 	pixel_y = -38
+	},
+/obj/structure/sign/levels/science/rnd{
+	dir = 1;
+	pixel_y = -26
 	},
 /turf/simulated/floor/tiled/white,
 /area/surface/station/rnd/hallway/bmt)
@@ -23587,6 +23666,9 @@
 	},
 /obj/machinery/light{
 	dir = 1
+	},
+/obj/structure/sign/level/basement{
+	pixel_y = 33
 	},
 /turf/simulated/floor/tiled,
 /area/surface/station/medical/hallway/bmt)
@@ -47714,7 +47796,7 @@ su
 KR
 rN
 oJ
-KT
+RW
 KT
 iD
 qg
@@ -50496,14 +50578,14 @@ HE
 HE
 Kj
 Kj
+mH
 Kj
 Kj
 Kj
 Kj
 Kj
 Kj
-Kj
-Kj
+mH
 Kj
 Kj
 Kj
@@ -51263,7 +51345,7 @@ HE
 Kj
 zZ
 Kj
-Kj
+mH
 Kj
 HE
 HE
@@ -51773,7 +51855,7 @@ HE
 HE
 HE
 Kj
-Kj
+mH
 sg
 jp
 Kj
@@ -52273,14 +52355,14 @@ QW
 Kj
 Kj
 Kj
+mH
 Kj
 Kj
 Kj
 Kj
 Kj
 Kj
-Kj
-Kj
+mH
 Kj
 Kj
 Kj
@@ -68279,7 +68361,7 @@ JL
 JL
 JL
 JL
-Na
+vp
 Na
 Na
 uJ

--- a/maps/cynosure/cynosure-2.dmm
+++ b/maps/cynosure/cynosure-2.dmm
@@ -892,6 +892,9 @@
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/flora/ausbushes/brflowers,
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -30
+	},
 /turf/simulated/floor/grass,
 /area/surface/station/park)
 "aBf" = (
@@ -1120,12 +1123,11 @@
 	dir = 5;
 	pixel_y = 6
 	},
-/obj/structure/sign/directions/stairs_down{
-	dir = 4;
+/obj/structure/sign/directions/stairwell{
 	pixel_y = -6
 	},
-/obj/structure/sign/directions/cargo/mining{
-	dir = 4
+/obj/structure/sign/levels/cargo/mining{
+	dir = 9
 	},
 /turf/simulated/wall,
 /area/surface/station/hallway/primary/groundfloor/east)
@@ -1641,6 +1643,13 @@
 	initial_flooring = /decl/flooring/tiling/asteroidfloor
 	},
 /area/surface/outside/plains/station)
+"aQf" = (
+/obj/structure/sign/level/ground/large{
+	pixel_x = 32;
+	pixel_y = 32
+	},
+/turf/simulated/floor/tiled/dark,
+/area/surface/station/hallway/secondary/groundfloor/civilian)
 "aQi" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -3607,6 +3616,9 @@
 "bIc" = (
 /obj/structure/railing{
 	dir = 4
+	},
+/obj/structure/sign/level/ground{
+	pixel_x = -32
 	},
 /turf/simulated/floor/tiled,
 /area/surface/station/engineering/workshop)
@@ -7445,12 +7457,9 @@
 /turf/simulated/floor/plating,
 /area/surface/station/quartermaster/storage)
 "dwo" = (
-/obj/structure/sign/directions/security/interrogation{
-	dir = 4;
-	pixel_y = -6
-	},
+/obj/structure/sign/level/ground,
 /turf/simulated/wall/r_wall,
-/area/surface/station/security/hallway/gnd)
+/area/surface/station/security/equiptment_storage/ses)
 "dwr" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -7931,6 +7940,10 @@
 "dIe" = (
 /obj/machinery/light{
 	dir = 1
+	},
+/obj/structure/sign/level/ground{
+	pixel_x = -32;
+	pixel_y = 32
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/surface/station/engineering/hallway/reactor)
@@ -9489,15 +9502,15 @@
 /turf/simulated/shuttle/floor/white,
 /area/shuttle/large_escape_pod1/station)
 "evz" = (
-/obj/structure/sign/directions/command{
-	dir = 4
-	},
 /obj/structure/sign/directions/stairs_up{
-	dir = 4;
+	dir = 5;
 	pixel_y = -6
 	},
-/obj/structure/sign/directions/dorms{
-	dir = 4;
+/obj/structure/sign/levels/dorms{
+	dir = 1
+	},
+/obj/structure/sign/levels/command{
+	dir = 1;
 	pixel_y = 6
 	},
 /turf/simulated/wall/r_wall,
@@ -12560,6 +12573,10 @@
 /obj/machinery/door/airlock/glass{
 	name = "Hallway"
 	},
+/obj/structure/sign/directions/recreation{
+	dir = 8;
+	pixel_y = -26
+	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/surface/station/hallway/secondary/groundfloor/civilian)
 "fJT" = (
@@ -14019,6 +14036,9 @@
 "gww" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/ladder,
+/obj/structure/sign/level/ground{
+	pixel_y = 30
+	},
 /turf/simulated/floor/plating,
 /area/surface/station/maintenance/kitchen)
 "gwH" = (
@@ -14358,11 +14378,16 @@
 /turf/simulated/floor/water,
 /area/surface/outside/river/gautelfr)
 "gDu" = (
-/obj/structure/sign/directions/cargo/mining{
-	dir = 8
-	},
-/obj/structure/sign/directions/stairs_down{
+/obj/structure/sign/levels/cargo/mining{
+	dir = 9;
 	pixel_y = -6
+	},
+/obj/structure/sign/directions/stairwell{
+	dir = 1;
+	pixel_y = 6
+	},
+/obj/structure/sign/levels/cargo{
+	dir = 1
 	},
 /turf/simulated/wall/r_wall,
 /area/surface/station/hallway/primary/groundfloor/west/elevator)
@@ -14513,6 +14538,13 @@
 /obj/structure/reagent_dispensers/he3,
 /turf/simulated/floor/plating,
 /area/surface/station/engineering/reactor_room)
+"gFW" = (
+/obj/structure/sign/directions/janitor{
+	dir = 8;
+	pixel_y = 6
+	},
+/turf/simulated/wall,
+/area/surface/station/library)
 "gGk" = (
 /obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/tiled/steel_grid,
@@ -15534,8 +15566,11 @@
 /obj/effect/floor_decal/corner/purple/bordercorner{
 	dir = 1
 	},
-/obj/structure/sign/directions/command{
-	dir = 4;
+/obj/structure/sign/directions/stairs_up{
+	pixel_y = 32
+	},
+/obj/structure/sign/levels/command{
+	dir = 1;
 	pixel_y = 26
 	},
 /turf/simulated/floor/tiled,
@@ -16801,6 +16836,9 @@
 /obj/machinery/alarm{
 	pixel_y = 22
 	},
+/obj/structure/sign/level/ground{
+	pixel_y = 42
+	},
 /turf/simulated/floor/tiled/white,
 /area/surface/station/rnd/hallway/stairwell)
 "hMj" = (
@@ -17322,6 +17360,19 @@
 	},
 /turf/simulated/floor/tiled/old_tile/gray,
 /area/surface/station/medical/surgery_storage)
+"ibT" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/green/border{
+	dir = 1
+	},
+/obj/structure/sign/level/ground{
+	dir = 4;
+	pixel_x = -35
+	},
+/turf/simulated/floor/tiled,
+/area/surface/station/park)
 "icz" = (
 /obj/structure/table/reinforced,
 /obj/machinery/firealarm{
@@ -17514,6 +17565,10 @@
 	},
 /obj/effect/floor_decal/corner/paleblue/bordercorner{
 	dir = 1
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 1;
+	pixel_y = 30
 	},
 /turf/simulated/floor/tiled,
 /area/surface/station/hallway/primary/groundfloor/north)
@@ -17729,6 +17784,10 @@
 	dir = 6
 	},
 /obj/effect/floor_decal/industrial/warning,
+/obj/effect/floor_decal/shuttles,
+/obj/effect/floor_decal/arrows{
+	dir = 1
+	},
 /turf/simulated/floor/tiled,
 /area/surface/station/hallway/primary/groundfloor/south)
 "ion" = (
@@ -18717,6 +18776,7 @@
 /obj/machinery/portable_atmospherics/canister/air/airlock,
 /obj/structure/sign/warning/cold{
 	layer = 3.3;
+	name = "\improper COLD ENVIRONMENT";
 	pixel_y = 32
 	},
 /turf/simulated/floor/tiled/dark,
@@ -18750,6 +18810,12 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/simulated/floor/grass,
 /area/surface/station/park)
+"iOD" = (
+/obj/structure/sign/level/ground/large{
+	pixel_y = -32
+	},
+/turf/simulated/floor/tiled,
+/area/surface/station/hallway/primary/groundfloor/east)
 "iPo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -23069,7 +23135,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/research{
-	name = "Miscellaneous Reseach";
+	name = "Miscellaneous Research";
 	req_one_access = list(7,29)
 	},
 /turf/simulated/floor/tiled/steel_grid,
@@ -25111,6 +25177,10 @@
 	},
 /turf/simulated/floor/tiled,
 /area/surface/station/security/lobby)
+"lIt" = (
+/obj/random/vendorfood,
+/turf/simulated/floor/tiled/hydro,
+/area/surface/station/park)
 "lIJ" = (
 /obj/machinery/computer/aifixer{
 	dir = 8
@@ -25377,6 +25447,16 @@
 	},
 /turf/simulated/floor/tiled/hydro,
 /area/surface/station/rnd/xenobiology/xenoflora_isolation)
+"lOS" = (
+/obj/structure/sign/directions/security/forensics/alt{
+	dir = 4
+	},
+/obj/structure/sign/directions/security/interrogation{
+	dir = 4;
+	pixel_y = 6
+	},
+/turf/simulated/wall/r_wall,
+/area/surface/station/security/hallway/gnd)
 "lOW" = (
 /obj/structure/ladder,
 /turf/simulated/floor/tiled/steel/sif/planetuse{
@@ -26593,6 +26673,9 @@
 /obj/machinery/power/breakerbox/activated{
 	RCon_tag = "Medical Substation Bypass"
 	},
+/obj/structure/sign/level/ground{
+	pixel_x = 32
+	},
 /turf/simulated/floor/plating,
 /area/surface/station/maintenance/substation/medbay/gnd)
 "moa" = (
@@ -27089,17 +27172,16 @@
 /turf/simulated/floor/tiled/white,
 /area/surface/station/medical/storage/primary_storage)
 "mxK" = (
-/obj/structure/sign/directions/science/toxins{
-	dir = 8;
-	icon_state = "direction_toxins"
-	},
-/obj/structure/sign/directions/science/xenoarch{
-	dir = 8;
-	pixel_y = 6
-	},
 /obj/structure/sign/directions/stairs_down{
 	dir = 8;
 	pixel_y = -6
+	},
+/obj/structure/sign/levels/science/toxins{
+	dir = 9
+	},
+/obj/structure/sign/levels/science/xenoarch{
+	dir = 9;
+	pixel_y = 6
 	},
 /turf/simulated/wall,
 /area/surface/station/rnd/hallway/stairwell)
@@ -27212,12 +27294,12 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/surface/station/hallway/primary/groundfloor/north)
 "mAl" = (
-/obj/structure/sign/directions/medical/virology{
-	dir = 1
-	},
 /obj/structure/sign/directions/stairs_up{
 	dir = 1;
 	pixel_y = -6
+	},
+/obj/structure/sign/levels/medical/virology{
+	dir = 1
 	},
 /turf/simulated/wall,
 /area/surface/station/medical/etc)
@@ -27626,6 +27708,14 @@
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/surface/station/medical/ward)
+"mJq" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/floor_decal/arrivals/right,
+/obj/effect/floor_decal/arrows{
+	pixel_y = 24
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/surface/station/arrivals/cynosure)
 "mJK" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/grille,
@@ -28326,6 +28416,10 @@
 /obj/item/weapon/folder/red,
 /turf/simulated/floor/plating,
 /area/surface/station/security/briefing_room)
+"mWO" = (
+/obj/machinery/vending/coffee,
+/turf/simulated/floor/tiled/hydro,
+/area/surface/station/park)
 "mXo" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -31006,6 +31100,13 @@
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/surface/station/hallway/primary/groundfloor/south)
+"okw" = (
+/obj/structure/sign/directions/bar{
+	dir = 4;
+	pixel_y = 6
+	},
+/turf/simulated/wall,
+/area/surface/station/crew_quarters/locker)
 "okF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -31151,7 +31252,8 @@
 	pixel_x = -32;
 	pixel_y = 26
 	},
-/obj/structure/sign/directions/medical/morgue{
+/obj/structure/sign/levels/medical/morgue{
+	dir = 9;
 	pixel_x = -32;
 	pixel_y = 32
 	},
@@ -31207,9 +31309,15 @@
 /turf/simulated/floor/tiled,
 /area/surface/station/quartermaster/storage)
 "ooJ" = (
-/obj/structure/sign/directions/command,
 /obj/structure/sign/directions/elevator{
 	pixel_y = -6
+	},
+/obj/structure/sign/levels/command{
+	dir = 1
+	},
+/obj/structure/sign/levels/eva{
+	dir = 1;
+	pixel_y = 6
 	},
 /turf/simulated/wall,
 /area/surface/station/park)
@@ -31397,6 +31505,10 @@
 /obj/machinery/camera/network/ground_floor{
 	c_tag = "Ground Floor - South Hallway 3";
 	dir = 8
+	},
+/obj/structure/sign/directions/bar{
+	dir = 5;
+	pixel_y = 39
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/surface/station/hallway/primary/groundfloor/south)
@@ -31672,6 +31784,9 @@
 /turf/simulated/floor/tiled,
 /area/surface/station/engineering/hallway)
 "owy" = (
+/obj/structure/sign/level/ground/large{
+	pixel_y = -32
+	},
 /turf/simulated/floor/tiled,
 /area/surface/station/hallway/primary/groundfloor/west/elevator)
 "owJ" = (
@@ -31830,6 +31945,18 @@
 	},
 /turf/simulated/floor/wood/sif,
 /area/surface/station/chapel/main)
+"ozO" = (
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/red/bordercorner{
+	dir = 8
+	},
+/obj/machinery/vending/coffee{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/surface/station/security/briefing_room)
 "ozQ" = (
 /obj/structure/sign/warning/secure_area,
 /turf/simulated/wall,
@@ -32576,6 +32703,7 @@
 	},
 /obj/structure/sign/warning/cold{
 	layer = 3.3;
+	name = "\improper COLD ENVIRONMENT";
 	pixel_y = 32
 	},
 /turf/simulated/floor/plating,
@@ -35633,8 +35761,9 @@
 	dir = 8
 	},
 /obj/structure/table/standard,
-/obj/item/weapon/storage/box/donut,
 /obj/item/device/retail_scanner/security,
+/obj/item/weapon/storage/box/glasses/coffeecup,
+/obj/item/weapon/storage/box/donut,
 /obj/item/device/retail_scanner/security,
 /turf/simulated/floor/tiled,
 /area/surface/station/security/briefing_room)
@@ -36017,6 +36146,10 @@
 	pixel_y = -31
 	},
 /obj/effect/map_helper/airlock/sensor/int_sensor,
+/obj/effect/floor_decal/shuttles/right,
+/obj/effect/floor_decal/arrows{
+	dir = 1
+	},
 /turf/simulated/floor/tiled,
 /area/surface/station/hallway/primary/groundfloor/south)
 "qoF" = (
@@ -36353,18 +36486,18 @@
 /obj/effect/floor_decal/corner/green/bordercorner2{
 	dir = 4
 	},
-/obj/structure/sign/directions/dorms{
-	dir = 1;
-	pixel_y = 26
-	},
-/obj/structure/sign/directions/command{
-	dir = 1;
-	pixel_y = 32
-	},
 /obj/machinery/light{
 	dir = 1
 	},
 /obj/effect/zone_divider,
+/obj/structure/sign/levels/command{
+	dir = 1;
+	pixel_y = 32
+	},
+/obj/structure/sign/levels/dorms{
+	dir = 1;
+	pixel_y = 26
+	},
 /turf/simulated/floor/tiled,
 /area/surface/station/hallway/secondary/groundfloor/civilian)
 "qtT" = (
@@ -37097,6 +37230,9 @@
 "qIj" = (
 /obj/structure/railing{
 	dir = 8
+	},
+/obj/structure/sign/level/ground{
+	pixel_x = 32
 	},
 /turf/simulated/floor/tiled/white,
 /area/surface/station/medical/etc)
@@ -38428,6 +38564,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
 	dir = 10
 	},
+/obj/structure/closet/medical_wall{
+	pixel_y = 32
+	},
+/obj/item/weapon/storage/pill_bottle/spaceacillin,
+/obj/item/weapon/storage/firstaid,
+/obj/item/roller,
+/obj/item/bodybag/cryobag,
 /turf/simulated/floor/tiled,
 /area/surface/station/engineering/hallway)
 "rnV" = (
@@ -40626,6 +40769,15 @@
 	},
 /turf/simulated/floor/tiled,
 /area/surface/station/engineering/hallway)
+"stD" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/green/border,
+/obj/structure/sign/level/ground{
+	dir = 8;
+	pixel_x = 36
+	},
+/turf/simulated/floor/tiled,
+/area/surface/station/park)
 "stF" = (
 /turf/simulated/floor/tiled/freezer,
 /area/surface/station/crew_quarters/kitchen)
@@ -40852,7 +41004,7 @@
 	dir = 1
 	},
 /obj/structure/sign/directions/science/exploration{
-	dir = 1;
+	dir = 5;
 	pixel_y = 6
 	},
 /turf/simulated/wall,
@@ -41825,12 +41977,14 @@
 	},
 /obj/structure/sign/warning/cold{
 	layer = 3.3;
+	name = "\improper COLD ENVIRONMENT";
 	pixel_y = -32
 	},
 /obj/item/weapon/melee/umbrella/random,
 /obj/item/weapon/melee/umbrella/random{
 	pixel_y = -4
 	},
+/obj/effect/floor_decal/arrows,
 /turf/simulated/floor/plating,
 /area/surface/station/hallway/primary/groundfloor/south)
 "sWe" = (
@@ -45693,17 +45847,17 @@
 /obj/machinery/door/airlock/glass{
 	name = "Hallway"
 	},
-/obj/structure/sign/directions/cargo{
-	dir = 8;
-	pixel_y = -26
-	},
-/obj/structure/sign/directions/science{
-	dir = 8;
-	pixel_y = -32
-	},
 /obj/structure/sign/directions/stairs_up{
 	dir = 8;
 	pixel_y = -38
+	},
+/obj/structure/sign/levels/cargo{
+	dir = 1;
+	pixel_y = -32
+	},
+/obj/structure/sign/levels/science{
+	dir = 1;
+	pixel_y = -26
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/surface/station/hallway/primary/groundfloor/west)
@@ -45747,6 +45901,9 @@
 "uPB" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 6
+	},
+/obj/structure/sign/level/ground{
+	pixel_x = -32
 	},
 /turf/simulated/floor/plating,
 /area/surface/station/maintenance/surgery)
@@ -47372,6 +47529,9 @@
 "vxR" = (
 /obj/structure/ladder/updown,
 /obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/sign/level/ground{
+	pixel_y = 32
+	},
 /turf/simulated/floor/plating,
 /area/surface/station/maintenance/substation/engineering/gnd)
 "vyi" = (
@@ -47460,6 +47620,12 @@
 /obj/machinery/meter,
 /turf/simulated/floor/plating,
 /area/surface/station/engineering/reactor_room)
+"vAs" = (
+/obj/structure/sign/level/ground{
+	pixel_x = 32
+	},
+/turf/simulated/floor/tiled/dark,
+/area/surface/station/engineering/hallway)
 "vBt" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/blast/regular/open{
@@ -47869,16 +48035,16 @@
 /turf/simulated/floor/plating,
 /area/surface/station/maintenance/east/gnd)
 "vJZ" = (
-/obj/structure/sign/directions/science/robotics{
-	dir = 8
-	},
-/obj/structure/sign/directions/science/rnd{
-	dir = 8;
-	pixel_y = 6
-	},
 /obj/structure/sign/directions/stairs_up{
 	dir = 8;
 	pixel_y = -6
+	},
+/obj/structure/sign/levels/science/robotics{
+	dir = 1
+	},
+/obj/structure/sign/levels/science/rnd{
+	dir = 1;
+	pixel_y = 6
 	},
 /turf/simulated/wall,
 /area/surface/station/rnd/hallway/stairwell)
@@ -48373,6 +48539,9 @@
 "vYM" = (
 /obj/structure/ladder,
 /obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/sign/level/ground{
+	pixel_x = 32
+	},
 /turf/simulated/floor/plating,
 /area/surface/station/maintenance/north/gnd)
 "vYO" = (
@@ -48670,11 +48839,14 @@
 /turf/simulated/floor/tiled/white,
 /area/surface/station/medical/surgery2)
 "wga" = (
-/obj/structure/sign/directions/security/armory,
 /obj/structure/sign/directions/stairs_up{
 	pixel_y = -6
 	},
-/obj/structure/sign/directions/security/brig{
+/obj/structure/sign/levels/security/armory{
+	dir = 1
+	},
+/obj/structure/sign/levels/security/brig{
+	dir = 1;
 	pixel_y = 6
 	},
 /turf/simulated/wall,
@@ -48774,6 +48946,20 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/surface/station/crew_quarters/locker)
+"wkf" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/effect/floor_decal/arrivals,
+/obj/effect/floor_decal/arrows{
+	pixel_y = 24
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/surface/station/arrivals/cynosure)
 "wkW" = (
 /obj/effect/floor_decal/techfloor/corner{
 	dir = 10
@@ -49357,13 +49543,13 @@
 	dir = 8;
 	pixel_y = 26
 	},
-/obj/structure/sign/directions/command{
-	dir = 8;
-	pixel_y = 38
-	},
-/obj/structure/sign/directions/dorms{
-	dir = 8;
+/obj/structure/sign/levels/dorms{
+	dir = 1;
 	pixel_y = 32
+	},
+/obj/structure/sign/levels/command{
+	dir = 1;
+	pixel_y = 38
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/surface/station/hallway/secondary/groundfloor/civilian)
@@ -50186,6 +50372,9 @@
 /obj/structure/railing{
 	dir = 8
 	},
+/obj/structure/sign/level/ground{
+	pixel_x = 31
+	},
 /turf/simulated/floor/tiled,
 /area/surface/station/security/hallway/gnd)
 "wRu" = (
@@ -50356,6 +50545,9 @@
 	pixel_x = -32
 	},
 /obj/effect/floor_decal/industrial/warning,
+/obj/structure/sign/level/ground{
+	pixel_y = 32
+	},
 /turf/simulated/floor/plating,
 /area/surface/station/garage)
 "wUn" = (
@@ -50563,6 +50755,9 @@
 "wYw" = (
 /obj/structure/ladder/updown,
 /obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/sign/level/ground{
+	pixel_x = -32
+	},
 /turf/simulated/floor/plating,
 /area/surface/station/maintenance/substation/research/gnd)
 "wYQ" = (
@@ -51566,6 +51761,17 @@
 /obj/structure/window/reinforced/full,
 /turf/simulated/floor/plating,
 /area/surface/station/crew_quarters/cafeteria)
+"xAC" = (
+/obj/effect/floor_decal/corner/white/diagonal,
+/obj/item/bodybag/cryobag,
+/obj/structure/closet/medical_wall{
+	pixel_x = 32
+	},
+/obj/item/weapon/storage/pill_bottle/spaceacillin,
+/obj/item/roller,
+/obj/item/weapon/storage/firstaid,
+/turf/simulated/floor/tiled/freezer,
+/area/surface/station/crew_quarters/pool)
 "xAM" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -52112,6 +52318,9 @@
 "xNJ" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
+	},
+/obj/structure/sign/level/ground{
+	pixel_y = 32
 	},
 /turf/simulated/floor/plating,
 /area/surface/station/maintenance/east/gnd)
@@ -53240,6 +53449,9 @@
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals_central1{
 	dir = 8
+	},
+/obj/structure/sign/level/ground{
+	pixel_y = -32
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/surface/station/engineering/hallway)
@@ -76264,7 +76476,7 @@ vfO
 vfO
 bwZ
 xxc
-lzq
+xAC
 aFI
 dZT
 dqe
@@ -77546,7 +77758,7 @@ xtS
 dPI
 aTi
 jIZ
-mvE
+aQf
 aOd
 xPR
 stJ
@@ -78063,7 +78275,7 @@ oPN
 bMx
 cLZ
 wnj
-stJ
+okw
 sLa
 lpY
 lpY
@@ -80656,7 +80868,7 @@ pXw
 wGW
 mBm
 uNd
-sOx
+wkf
 rng
 pHX
 sOx
@@ -80913,7 +81125,7 @@ iKP
 eRj
 cVf
 iDc
-oZE
+mJq
 bQa
 sFE
 oZE
@@ -83203,7 +83415,7 @@ rMU
 wAS
 ccz
 pgR
-lWA
+gFW
 kYu
 lmq
 lWA
@@ -83680,7 +83892,7 @@ oqM
 sYq
 oqM
 sYq
-pts
+ibT
 bql
 wAe
 rIC
@@ -84188,7 +84400,7 @@ mAO
 oQg
 adQ
 pfh
-oqM
+lIt
 pts
 hgA
 bql
@@ -84445,7 +84657,7 @@ bYc
 hFI
 uaI
 eNB
-hlM
+mWO
 pts
 bql
 bql
@@ -88318,7 +88530,7 @@ pfh
 bwR
 wAe
 bql
-hNc
+stD
 sYq
 oqM
 sYq
@@ -90103,7 +90315,7 @@ tgI
 hAV
 mCR
 lQT
-xgg
+iOD
 fRF
 mOM
 mOM
@@ -92396,7 +92608,7 @@ gci
 qhP
 hDr
 kcy
-aop
+ozO
 tyH
 ptQ
 tMM
@@ -92413,7 +92625,7 @@ tnh
 kNK
 bLZ
 moa
-dwo
+vvS
 vvS
 vvS
 vvS
@@ -92670,7 +92882,7 @@ mgM
 mLF
 mcT
 liB
-vvS
+lOS
 pOC
 pOC
 pOC
@@ -95993,7 +96205,7 @@ rut
 rut
 rut
 rut
-rut
+dwo
 vSu
 hyZ
 vYO
@@ -96026,7 +96238,7 @@ ktI
 ktI
 ktI
 wYQ
-lsu
+vAs
 uFg
 kgL
 vyB

--- a/maps/cynosure/cynosure-2.dmm
+++ b/maps/cynosure/cynosure-2.dmm
@@ -4837,6 +4837,7 @@
 	pixel_y = 4
 	},
 /obj/item/device/multitool,
+/obj/item/device/gps/medical,
 /turf/simulated/floor/tiled/monotile,
 /area/surface/station/medical/emt_bay)
 "cnU" = (
@@ -11650,10 +11651,11 @@
 	pixel_y = -3;
 	req_one_access = list(2,4)
 	},
+/obj/item/device/radio/off,
+/obj/item/device/gps/security/hos,
 /obj/item/device/flashlight/lamp/green{
 	pixel_y = 6
 	},
-/obj/item/device/radio/off,
 /turf/simulated/floor/tiled/dark,
 /area/surface/station/crew_quarters/heads/hos)
 "fnE" = (
@@ -12093,6 +12095,7 @@
 /obj/machinery/recharger/wallcharger{
 	pixel_x = 32
 	},
+/obj/item/device/gps/security,
 /turf/simulated/floor/tiled/techmaint,
 /area/surface/station/security/lockerroom)
 "fAm" = (
@@ -12217,7 +12220,7 @@
 /turf/simulated/wall,
 /area/surface/station/maintenance/kitchen)
 "fCP" = (
-/obj/structure/bed/chair,
+/obj/structure/bed/chair/office/dark,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
@@ -19495,6 +19498,9 @@
 	icon_state = "2-4"
 	},
 /obj/effect/catwalk_plated,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/simulated/floor/plating,
 /area/surface/station/security/lobby)
 "jjI" = (
@@ -26718,7 +26724,7 @@
 /turf/simulated/floor/tiled/neutral,
 /area/surface/station/crew_quarters/caferestroom)
 "mqd" = (
-/obj/structure/bed/chair,
+/obj/structure/bed/chair/office/dark,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},

--- a/maps/cynosure/cynosure-3.dmm
+++ b/maps/cynosure/cynosure-3.dmm
@@ -782,6 +782,14 @@
 	pixel_x = 21
 	},
 /obj/effect/floor_decal/spline/plain,
+/obj/structure/window/reinforced{
+	dir = 8;
+	pixel_x = -6
+	},
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 7
+	},
 /turf/simulated/floor/tiled/old_tile/gray,
 /area/surface/station/park/skybridge)
 "ayR" = (
@@ -6464,10 +6472,6 @@
 /obj/structure/railing{
 	dir = 4
 	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced,
 /turf/simulated/open,
 /area/surface/station/park/skybridge)
 "erq" = (
@@ -8947,10 +8951,6 @@
 /obj/structure/railing{
 	dir = 8
 	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
 /turf/simulated/open,
 /area/surface/station/park/skybridge)
 "fXe" = (
@@ -11521,6 +11521,9 @@
 /obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 9
 	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
 /turf/simulated/floor/tiled,
 /area/surface/station/park/skybridge)
 "huz" = (
@@ -12397,6 +12400,10 @@
 /obj/effect/floor_decal/corner/green/border{
 	dir = 1
 	},
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 6
+	},
 /turf/simulated/floor/tiled,
 /area/surface/station/park/skybridge)
 "hYb" = (
@@ -12437,12 +12444,6 @@
 	dir = 1
 	},
 /obj/structure/railing{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
 	dir = 4
 	},
 /turf/simulated/open,
@@ -12494,6 +12495,9 @@
 /obj/machinery/camera/network/second_floor{
 	c_tag = "Second Floor - Skybridge 1";
 	dir = 1
+	},
+/obj/structure/window/reinforced{
+	pixel_y = -6
 	},
 /turf/simulated/floor/tiled,
 /area/surface/station/park/skybridge)
@@ -14325,6 +14329,10 @@
 	},
 /obj/effect/floor_decal/corner/green/border{
 	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 6
 	},
 /turf/simulated/floor/tiled,
 /area/surface/station/park/skybridge)
@@ -16560,6 +16568,9 @@
 "kos" = (
 /obj/effect/floor_decal/borderfloor/corner,
 /obj/effect/floor_decal/corner/green/bordercorner,
+/obj/structure/window/reinforced{
+	pixel_y = -6
+	},
 /turf/simulated/floor/tiled,
 /area/surface/station/park/skybridge)
 "kox" = (
@@ -16569,6 +16580,12 @@
 	},
 /obj/effect/floor_decal/spline/plain{
 	dir = 1
+	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4;
+	pixel_x = 6;
+	pixel_y = 1
 	},
 /turf/simulated/floor/tiled/old_tile/gray,
 /area/surface/station/park/skybridge)
@@ -16585,6 +16602,10 @@
 	},
 /obj/effect/floor_decal/corner/green/border{
 	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 6
 	},
 /turf/simulated/floor/tiled,
 /area/surface/station/park/skybridge)
@@ -19226,6 +19247,9 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/green/border,
+/obj/structure/window/reinforced{
+	pixel_y = -6
+	},
 /turf/simulated/floor/tiled,
 /area/surface/station/park/skybridge)
 "mwp" = (
@@ -23250,6 +23274,10 @@
 /obj/effect/floor_decal/corner/green/bordercorner{
 	dir = 4
 	},
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 6
+	},
 /turf/simulated/floor/tiled,
 /area/surface/station/park/skybridge)
 "pkV" = (
@@ -24679,6 +24707,9 @@
 /obj/effect/floor_decal/corner/green/bordercorner{
 	dir = 8
 	},
+/obj/structure/window/reinforced{
+	pixel_y = -6
+	},
 /turf/simulated/floor/tiled,
 /area/surface/station/park/skybridge)
 "qcZ" = (
@@ -24984,6 +25015,9 @@
 	},
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/green/border,
+/obj/structure/window/reinforced{
+	pixel_y = -6
+	},
 /turf/simulated/floor/tiled,
 /area/surface/station/park/skybridge)
 "qrc" = (
@@ -25833,6 +25867,9 @@
 "qRF" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/green/border,
+/obj/structure/window/reinforced{
+	pixel_y = -6
+	},
 /turf/simulated/floor/tiled,
 /area/surface/station/park/skybridge)
 "qRK" = (
@@ -30715,6 +30752,10 @@
 /obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 10
 	},
+/obj/structure/window/reinforced{
+	dir = 4;
+	pixel_x = 6
+	},
 /turf/simulated/floor/tiled,
 /area/surface/station/park/skybridge)
 "udx" = (
@@ -31132,9 +31173,6 @@
 /obj/structure/railing{
 	dir = 1
 	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
 /turf/simulated/open,
 /area/surface/station/park/skybridge)
 "usH" = (
@@ -31145,6 +31183,9 @@
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/green/border,
 /obj/machinery/light/spot,
+/obj/structure/window/reinforced{
+	pixel_y = -6
+	},
 /turf/simulated/floor/tiled,
 /area/surface/station/park/skybridge)
 "usO" = (
@@ -31203,9 +31244,6 @@
 /area/surface/station/engineering/locker_room)
 "uwi" = (
 /obj/structure/railing{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/yellow/bordercorner{
@@ -32264,12 +32302,6 @@
 	dir = 1
 	},
 /obj/structure/railing{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
 	dir = 8
 	},
 /turf/simulated/open,
@@ -36187,7 +36219,6 @@
 /area/surface/station/engineering/hallway/sndaccess)
 "xzd" = (
 /obj/structure/railing,
-/obj/structure/window/reinforced,
 /turf/simulated/open,
 /area/surface/station/park/skybridge)
 "xzL" = (
@@ -36463,6 +36494,10 @@
 	},
 /obj/effect/floor_decal/corner/green/bordercorner{
 	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 6
 	},
 /turf/simulated/floor/tiled,
 /area/surface/station/park/skybridge)
@@ -37425,6 +37460,10 @@
 	},
 /obj/machinery/camera/network/second_floor{
 	c_tag = "Second Floor - Skybridge 2"
+	},
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 6
 	},
 /turf/simulated/floor/tiled,
 /area/surface/station/park/skybridge)

--- a/maps/cynosure/cynosure-3.dmm
+++ b/maps/cynosure/cynosure-3.dmm
@@ -2109,10 +2109,13 @@
 "bxR" = (
 /obj/structure/sign/directions/cargo{
 	dir = 8;
-	pixel_y = 6
+	pixel_y = -6
 	},
 /obj/structure/sign/directions/science{
 	dir = 8
+	},
+/obj/structure/sign/level/two{
+	pixel_y = 10
 	},
 /turf/simulated/wall,
 /area/surface/station/hallway/primary/secondfloor/east)
@@ -2993,6 +2996,10 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals7,
+/obj/structure/sign/level/two{
+	pixel_x = 32;
+	pixel_y = 32
+	},
 /turf/simulated/floor/tiled,
 /area/surface/station/hallway/secondary/secondfloor/civilian)
 "bXv" = (
@@ -5775,6 +5782,10 @@
 	dir = 1;
 	pixel_y = 30
 	},
+/obj/structure/sign/level/two{
+	pixel_x = -31;
+	pixel_y = 26
+	},
 /turf/simulated/floor/tiled,
 /area/surface/station/engineering/hallway/reactor)
 "dNq" = (
@@ -6316,6 +6327,10 @@
 /obj/structure/sign/directions/cargo{
 	dir = 8;
 	pixel_y = 32
+	},
+/obj/structure/sign/levels/security{
+	dir = 5;
+	pixel_y = 26
 	},
 /turf/simulated/floor/tiled,
 /area/surface/station/hallway/secondary/secondfloor/civilian)
@@ -7393,14 +7408,14 @@
 /area/surface/station/hallway/secondary/secondfloor/weststairwell)
 "eUC" = (
 /obj/structure/sign/directions/engineering/engeqp{
-	dir = 8;
-	pixel_y = 6
-	},
-/obj/structure/sign/directions/engineering/reactor{
-	dir = 1
+	dir = 8
 	},
 /obj/structure/sign/directions/engineering/atmospherics{
 	pixel_y = -6
+	},
+/obj/structure/sign/levels/engineering/reactor{
+	dir = 5;
+	pixel_y = 6
 	},
 /turf/simulated/wall,
 /area/surface/station/engineering/hallway/snd)
@@ -8462,6 +8477,10 @@
 "fEP" = (
 /turf/simulated/wall/r_wall,
 /area/surface/station/hallway/secondary/secondfloor/weststairwell)
+"fFc" = (
+/obj/structure/sign/level/two,
+/turf/simulated/wall,
+/area/surface/station/maintenance/cargo)
 "fFn" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -9447,6 +9466,9 @@
 /obj/item/device/radio/intercom/department/security{
 	dir = 8;
 	pixel_x = 21
+	},
+/obj/structure/sign/level/two/large{
+	pixel_y = -32
 	},
 /turf/simulated/floor/tiled/dark,
 /area/surface/station/hallway/primary/secondfloor/east)
@@ -11524,6 +11546,10 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
+/obj/structure/sign/level/two{
+	dir = 8;
+	pixel_x = 50
+	},
 /turf/simulated/floor/tiled,
 /area/surface/station/park/skybridge)
 "huz" = (
@@ -11692,6 +11718,9 @@
 /obj/machinery/light_switch{
 	pixel_x = 12;
 	pixel_y = 24
+	},
+/obj/structure/sign/level/two{
+	pixel_x = -32
 	},
 /turf/simulated/floor/plating,
 /area/surface/station/maintenance/substation/security/snd)
@@ -12237,6 +12266,7 @@
 /obj/item/weapon/stool/padded{
 	dir = 8
 	},
+/obj/structure/sign/levels/evac,
 /turf/simulated/floor/tiled,
 /area/surface/station/holodeck_control)
 "hUe" = (
@@ -13033,25 +13063,30 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/structure/sign/directions/medical/cloning{
-	dir = 1;
-	pixel_x = 32;
-	pixel_y = 26
-	},
-/obj/structure/sign/directions/medical/surgery{
-	dir = 1;
-	pixel_x = 32;
-	pixel_y = 32
-	},
-/obj/structure/sign/directions/medical/morgue{
-	dir = 1;
-	pixel_x = 32;
-	pixel_y = 38
-	},
 /obj/structure/sign/directions/stairs_down{
 	dir = 1;
 	pixel_x = 32;
 	pixel_y = 20
+	},
+/obj/structure/sign/levels/medical/morgue{
+	dir = 9;
+	pixel_x = 32;
+	pixel_y = 26
+	},
+/obj/structure/sign/levels/medical/surgery{
+	dir = 5;
+	pixel_x = 32;
+	pixel_y = 32
+	},
+/obj/structure/sign/levels/medical/cloning{
+	dir = 5;
+	pixel_x = 32;
+	pixel_y = 44
+	},
+/obj/structure/sign/levels/medical/chemlab{
+	dir = 5;
+	pixel_x = 32;
+	pixel_y = 38
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/surface/station/medical/hallway/snd)
@@ -14232,6 +14267,10 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/structure/sign/level/two/large{
+	pixel_x = 32;
+	pixel_y = -32
+	},
 /turf/simulated/floor/tiled,
 /area/surface/station/holodeck_control)
 "iVV" = (
@@ -14752,16 +14791,16 @@
 /turf/simulated/floor/tiled,
 /area/surface/station/hallway/primary/secondfloor/east)
 "jmb" = (
-/obj/structure/sign/directions/evac{
-	dir = 4;
-	pixel_y = 6
-	},
-/obj/structure/sign/directions/cryo{
-	dir = 4
-	},
 /obj/structure/sign/directions/stairs_down{
 	dir = 4;
 	pixel_y = -6
+	},
+/obj/structure/sign/levels/evac{
+	dir = 5;
+	pixel_y = 6
+	},
+/obj/structure/sign/levels/cryo{
+	dir = 5
 	},
 /turf/simulated/wall,
 /area/surface/station/hallway/primary/secondfloor/east)
@@ -18884,6 +18923,9 @@
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 1
 	},
+/obj/structure/sign/level/two{
+	pixel_x = 32
+	},
 /turf/simulated/floor/plating,
 /area/surface/station/maintenance/substation/research/snd)
 "mkS" = (
@@ -19031,7 +19073,7 @@
 /turf/simulated/wall/r_wall,
 /area/surface/station/engineering/foyer/secondfloor)
 "mrb" = (
-/obj/structure/closet/emcloset,
+/obj/random/vendorfood,
 /turf/simulated/floor/tiled/techmaint,
 /area/surface/station/hallway/secondary/secondfloor/command)
 "mrz" = (
@@ -19891,6 +19933,12 @@
 	},
 /turf/simulated/floor/carpet/sblucarpet,
 /area/surface/station/medical/psych)
+"mPU" = (
+/obj/random/vendorfood{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/surface/station/hallway/primary/secondfloor/east)
 "mPV" = (
 /obj/machinery/light{
 	dir = 4
@@ -23708,6 +23756,9 @@
 "pBM" = (
 /obj/structure/ladder,
 /obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/sign/level/two{
+	pixel_y = 32
+	},
 /turf/simulated/floor/plating,
 /area/surface/station/maintenance/weststairwell/snd)
 "pBN" = (
@@ -24064,24 +24115,24 @@
 	},
 /obj/effect/catwalk_plated,
 /obj/effect/floor_decal/industrial/warning/full,
-/obj/structure/sign/directions/security{
-	dir = 4;
-	pixel_x = -32;
-	pixel_y = 6
-	},
-/obj/structure/sign/directions/engineering{
-	dir = 4;
-	pixel_x = -32
-	},
-/obj/structure/sign/directions/medical{
-	dir = 4;
-	pixel_x = -32;
-	pixel_y = -6
-	},
 /obj/structure/sign/directions/stairs_down{
 	dir = 4;
 	pixel_x = -32;
 	pixel_y = -12
+	},
+/obj/structure/sign/levels/security{
+	dir = 5;
+	pixel_x = -32;
+	pixel_y = 6
+	},
+/obj/structure/sign/levels/engineering{
+	dir = 5;
+	pixel_x = -32
+	},
+/obj/structure/sign/levels/medical{
+	dir = 5;
+	pixel_x = -32;
+	pixel_y = -6
 	},
 /turf/simulated/floor/plating,
 /area/surface/station/hallway/primary/secondfloor/east)
@@ -24100,6 +24151,10 @@
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = 24
+	},
+/obj/structure/sign/level/two{
+	dir = 8;
+	pixel_x = 48
 	},
 /turf/simulated/floor/plating,
 /area/surface/station/maintenance/eva)
@@ -24129,6 +24184,7 @@
 /obj/effect/floor_decal/steeldecal/steel_decals5{
 	dir = 8
 	},
+/obj/structure/sign/level/two,
 /turf/simulated/floor/tiled,
 /area/surface/station/quartermaster/office)
 "pNl" = (
@@ -24615,6 +24671,10 @@
 	},
 /turf/simulated/floor/tiled,
 /area/surface/station/hallway/secondary/secondfloor/civilian)
+"qbs" = (
+/obj/structure/closet/emcloset,
+/turf/simulated/floor/tiled/techmaint,
+/area/surface/station/hallway/secondary/secondfloor/command)
 "qbt" = (
 /obj/structure/cable/green{
 	d2 = 8;
@@ -27068,6 +27128,10 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
 	},
+/obj/structure/sign/level/two{
+	pixel_x = 32;
+	pixel_y = 8
+	},
 /turf/simulated/floor/plating,
 /area/surface/station/maintenance/substation/engineering/snd)
 "rPw" = (
@@ -27789,6 +27853,9 @@
 "spA" = (
 /obj/structure/ladder,
 /obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/sign/level/two{
+	pixel_x = 32
+	},
 /turf/simulated/floor/plating,
 /area/surface/station/maintenance/substation/medbay/snd)
 "srf" = (
@@ -27803,6 +27870,10 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/sign/level/two{
+	dir = 8;
+	pixel_x = 37
+	},
 /turf/simulated/floor/tiled/white,
 /area/surface/station/medical/patient_wing)
 "srn" = (
@@ -28890,6 +28961,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/surface/station/crew_quarters/heads/cmo)
+"sVu" = (
+/obj/random/vendordrink,
+/turf/simulated/floor/tiled/techmaint,
+/area/surface/station/hallway/secondary/secondfloor/command)
 "sVx" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -29011,6 +29086,9 @@
 	},
 /obj/structure/flora/pottedplant/smallcactus{
 	pixel_y = 10
+	},
+/obj/structure/sign/level/two{
+	pixel_x = 64
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/surface/station/medical/hallway/snd)
@@ -29545,6 +29623,10 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -30
 	},
+/obj/structure/sign/level/two/large{
+	pixel_x = 32;
+	pixel_y = -32
+	},
 /turf/simulated/floor/tiled,
 /area/surface/station/hallway/secondary/secondfloor/weststairwell)
 "tsl" = (
@@ -29668,6 +29750,20 @@
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals3{
 	dir = 9
+	},
+/obj/structure/sign/levels/security/seceqp{
+	dir = 5;
+	pixel_x = 64
+	},
+/obj/structure/sign/levels/security/interrogation{
+	dir = 5;
+	pixel_x = 64;
+	pixel_y = 6
+	},
+/obj/structure/sign/levels/security/forensics{
+	dir = 5;
+	pixel_x = 64;
+	pixel_y = -6
 	},
 /turf/simulated/floor/tiled/dark,
 /area/surface/station/security/hallway/stairwell)
@@ -29838,14 +29934,20 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/sign/directions/evac{
-	pixel_y = -26
-	},
 /obj/structure/sign/directions/stairs_down{
 	pixel_y = -38
 	},
-/obj/structure/sign/directions/cryo{
+/obj/structure/sign/levels/cryo{
+	dir = 5;
 	pixel_y = -32
+	},
+/obj/structure/sign/levels/evac{
+	dir = 5;
+	pixel_y = -26
+	},
+/obj/structure/sign/levels/recreation{
+	dir = 5;
+	pixel_y = -20
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/surface/station/hallway/secondary/secondfloor/civilian)
@@ -30755,6 +30857,10 @@
 /obj/structure/window/reinforced{
 	dir = 4;
 	pixel_x = 6
+	},
+/obj/structure/sign/level/two{
+	dir = 4;
+	pixel_x = -48
 	},
 /turf/simulated/floor/tiled,
 /area/surface/station/park/skybridge)
@@ -31867,6 +31973,10 @@
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = 24
+	},
+/obj/structure/sign/level/two{
+	pixel_x = 32;
+	pixel_y = 32
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/surface/station/security/hallway/stairwell)
@@ -33035,6 +33145,9 @@
 	},
 /obj/effect/floor_decal/borderfloor/corner,
 /obj/effect/floor_decal/corner/brown/bordercorner,
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -30
+	},
 /turf/simulated/floor/tiled,
 /area/surface/station/hallway/primary/secondfloor/west)
 "vHm" = (
@@ -33086,6 +33199,10 @@
 /obj/structure/sign/directions/command{
 	dir = 4;
 	pixel_y = 38
+	},
+/obj/structure/sign/levels/medical{
+	dir = 5;
+	pixel_y = 26
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/surface/station/hallway/secondary/secondfloor/civilian)
@@ -34583,6 +34700,9 @@
 /obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 6
 	},
+/obj/structure/sign/level/two{
+	pixel_y = 32
+	},
 /turf/simulated/floor/tiled,
 /area/surface/station/engineering/hallway/sndaccess)
 "wGL" = (
@@ -35294,6 +35414,11 @@
 	},
 /obj/effect/floor_decal/corner/brown/border{
 	dir = 4
+	},
+/obj/structure/sign/level/two{
+	dir = 8;
+	pixel_x = 35;
+	pixel_y = -11
 	},
 /turf/simulated/floor/tiled,
 /area/surface/station/quartermaster/office)
@@ -64708,7 +64833,7 @@ cqr
 hgN
 hgN
 vjy
-iyT
+fFc
 sfy
 ozu
 iyT
@@ -65483,7 +65608,7 @@ nWW
 nWW
 nWW
 nWW
-lMj
+sVu
 gdk
 imJ
 fAL
@@ -67282,7 +67407,7 @@ kzF
 fnp
 wym
 nWW
-lMj
+qbs
 dLh
 uiT
 tsE
@@ -73694,7 +73819,7 @@ wIt
 nUP
 nUP
 fAz
-ggd
+mPU
 hWE
 jRF
 rcC

--- a/maps/cynosure/structures/closets/misc.dm
+++ b/maps/cynosure/structures/closets/misc.dm
@@ -41,6 +41,8 @@
 
 	starts_with = list(
 		/obj/item/clothing/under/explorer,
+		/obj/item/clothing/suit/armor/pcarrier/explorer/light,
+		/obj/item/clothing/head/helmet/explorer,
 		/obj/item/clothing/suit/storage/hooded/explorer,
 		/obj/item/clothing/mask/gas/explorer,
 		/obj/item/clothing/shoes/boots/winter/explorer,


### PR DESCRIPTION
- Added GPS to Paramedic and CMO lockers (using the new GPS variant sprites).
- Returned modular armour to explorer lockers, accidentally removed in map switch.
- Added a single non-secured GPS each to the paramedic bay and security locker room for emergencies.
- Added a light to the security lobby desk area.
- Switched security lobby chairs for office chairs.
- Moved skybridge window panes onto the "inner" tiles to prevent them from falling immediately when unfastened. Visuals remain the same.
- First aid lockers in the pool and engineering for more of a spread (there is currently ONE in the cafeteria)
- Stairwell/elevator/maintenance ladder signage and floor numbers.
- Coffee cups in security.
- Coffee machine in security.
- A couple of additional general vending machines around the station (Atrium coffee/snack, outside upper engineering snack, by dorm rooms snack/drink)
- A couple of additional fire extinguisher cabinets in public hallways.
- Renamed Misc. "Reseach" door.
- Marker beacons on the underground path between Xenoarch and Research due to extreme darkness.

