### PR TITLE
03202022 Machine Drill Terrain Fix

### DIFF
--- a/maps/cynosure/datums/random_map.dm
+++ b/maps/cynosure/datums/random_map.dm
@@ -120,9 +120,9 @@
 /datum/random_map/noise/sif/underground/get_appropriate_path(var/value)
 	switch(value)
 		if(0 to 2)
-			return /turf/simulated/floor/outdoors/mud/sif/planetuse
+			return /turf/simulated/mineral/floor/sif/mud
 		if(3 to 4)
-			return /turf/simulated/floor/outdoors/dirt/sif/planetuse
+			return /turf/simulated/mineral/floor/sif/dirt
 
 /datum/random_map/noise/sif/underground/get_additional_spawns(var/value, var/turf/T)
 	if(value <= 1 && prob(30)) // Mud is very fun-gy.

--- a/maps/cynosure/turfs/outdoors.dm
+++ b/maps/cynosure/turfs/outdoors.dm
@@ -78,6 +78,16 @@
 	nitrogen	= MOLES_N2SIF
 	temperature	= TEMPERATURE_SIF
 
+/turf/simulated/mineral/floor/sif/mud
+	name = "mud"
+	icon_state = "mud"
+	sand_icon_state = "mud"
+
+/turf/simulated/mineral/floor/sif/dirt
+	name = "sand"
+	icon_state = "dirt"
+	sand_icon_state = "dirt"
+
 /turf/simulated/floor/outdoors/mud/sif/planetuse
 	oxygen		= MOLES_O2SIF
 	nitrogen	= MOLES_N2SIF


### PR DESCRIPTION
Switches the terrain generation that adds mud and dirt for the underground mining caverns from regular sif mud and dirt to mineral/floor/sif/mud and dirt so that way the large machine based drills can actually drill on those tiles and obtain mining materials.

Side effect includes pulling from the asteroid dmi file for the terrain (seems to mesh better with the underground sand).