### PR TITLE
More Map Mods March

### DIFF
--- a/maps/cynosure/cynosure-1.dmm
+++ b/maps/cynosure/cynosure-1.dmm
@@ -4032,7 +4032,7 @@
 	id = "disvent";
 	name = "Incinerator Vent Control";
 	pixel_y = 24;
-	req_one_access = list(7)
+	req_one_access = list(12)
 	},
 /turf/simulated/floor/tiled/old_tile/gray,
 /area/surface/station/maintenance/incinerator)
@@ -15709,6 +15709,9 @@
 /obj/machinery/firealarm{
 	pixel_y = 24
 	},
+/obj/machinery/camera/network/civilian{
+	c_tag = "CIV - Waste Disposal"
+	},
 /turf/simulated/floor/tiled/old_tile/gray,
 /area/surface/station/maintenance/incinerator)
 "HW" = (
@@ -21680,10 +21683,6 @@
 	},
 /obj/machinery/conveyor_switch/oneway{
 	id = "garbage"
-	},
-/obj/machinery/camera/network/civilian{
-	c_tag = "CIV - Waste Disposal";
-	dir = 1
 	},
 /obj/item/device/radio/intercom{
 	pixel_y = -21

--- a/maps/cynosure/cynosure-2.dmm
+++ b/maps/cynosure/cynosure-2.dmm
@@ -4593,7 +4593,7 @@
 /area/surface/station/medical/ward)
 "cgM" = (
 /obj/structure/table/glass,
-/obj/item/weapon/reagent_containers/food/drinks/britcup,
+/obj/random/mug,
 /turf/simulated/floor/tiled/techmaint,
 /area/surface/station/medical/hallway/gnd)
 "cgV" = (
@@ -18872,6 +18872,9 @@
 /obj/effect/floor_decal/corner/brown/border{
 	dir = 4
 	},
+/obj/structure/sign/level/ground{
+	pixel_y = -32
+	},
 /turf/simulated/floor/tiled,
 /area/surface/station/quartermaster/storage)
 "iPF" = (
@@ -29015,6 +29018,7 @@
 /obj/structure/table/marble,
 /obj/item/weapon/material/knife/butch,
 /obj/item/weapon/material/kitchen/rollingpin,
+/obj/random/mug,
 /turf/simulated/floor/tiled/eris/cafe,
 /area/surface/station/crew_quarters/kitchen)
 "nnd" = (
@@ -30007,6 +30011,7 @@
 	dir = 8
 	},
 /obj/structure/table/woodentable,
+/obj/random/mug,
 /turf/simulated/floor/tiled/hydro,
 /area/surface/station/park)
 "nLW" = (
@@ -31043,6 +31048,9 @@
 	pixel_y = 22
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/sign/level/ground{
+	pixel_x = -32
+	},
 /turf/simulated/floor/plating,
 /area/surface/station/maintenance/substation/civilian)
 "oiZ" = (
@@ -34509,7 +34517,7 @@
 	name = "Medical Reception";
 	req_access = list(5)
 	},
-/obj/item/weapon/reagent_containers/food/drinks/britcup,
+/obj/random/mug,
 /turf/simulated/floor/tiled/neutral,
 /area/surface/station/medical/reception)
 "pzA" = (

--- a/maps/cynosure/cynosure-2.dmm
+++ b/maps/cynosure/cynosure-2.dmm
@@ -5534,12 +5534,12 @@
 /turf/simulated/floor/tiled,
 /area/surface/station/engineering/workshop)
 "cJc" = (
-/obj/structure/closet,
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = -24
 	},
+/obj/structure/filingcabinet,
 /turf/simulated/floor/tiled/dark,
 /area/surface/station/security/evidence_storage)
 "cJk" = (
@@ -26122,7 +26122,9 @@
 /turf/simulated/floor/tiled,
 /area/surface/station/security/range)
 "maD" = (
-/obj/structure/closet,
+/obj/structure/closet{
+	name = "evidence locker"
+	},
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/machinery/light/small{
 	dir = 1
@@ -32652,7 +32654,9 @@
 /turf/simulated/floor/plating,
 /area/surface/station/engineering/reactor_room)
 "oRs" = (
-/obj/structure/closet,
+/obj/structure/closet{
+	name = "contraband locker"
+	},
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -52179,7 +52183,9 @@
 /turf/simulated/floor/tiled,
 /area/surface/station/security/lobby)
 "xKl" = (
-/obj/structure/closet,
+/obj/structure/closet{
+	name = "evidence locker"
+	},
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/item/device/radio/intercom{
@@ -52928,7 +52934,9 @@
 /turf/simulated/floor/outdoors/mask,
 /area/surface/outside/plains/station)
 "xXF" = (
-/obj/structure/closet,
+/obj/structure/closet{
+	name = "evidence locker"
+	},
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/machinery/alarm{
 	pixel_y = 22

--- a/maps/cynosure/cynosure-3.dmm
+++ b/maps/cynosure/cynosure-3.dmm
@@ -12266,7 +12266,6 @@
 /obj/item/weapon/stool/padded{
 	dir = 8
 	},
-/obj/structure/sign/levels/evac,
 /turf/simulated/floor/tiled,
 /area/surface/station/holodeck_control)
 "hUe" = (
@@ -22953,6 +22952,7 @@
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/brigdoor/eastleft,
 /obj/item/sticky_pad/random,
+/obj/random/mug,
 /turf/simulated/floor/tiled/dark,
 /area/surface/station/security/warden)
 "oWN" = (
@@ -23408,6 +23408,7 @@
 "pmw" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/storage/box/donut,
+/obj/random/mug,
 /turf/simulated/floor/carpet,
 /area/surface/station/crew_quarters/captain)
 "pmL" = (
@@ -24184,7 +24185,6 @@
 /obj/effect/floor_decal/steeldecal/steel_decals5{
 	dir = 8
 	},
-/obj/structure/sign/level/two,
 /turf/simulated/floor/tiled,
 /area/surface/station/quartermaster/office)
 "pNl" = (
@@ -31607,22 +31607,6 @@
 	},
 /turf/simulated/shuttle/wall/dark/no_join,
 /area/shuttle/large_escape_pod2/station)
-"uDG" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/machinery/door/blast/regular/open{
-	dir = 4;
-	id = "captainlockdown";
-	layer = 3.3;
-	name = "Site Manager Lockdown"
-	},
-/turf/simulated/floor/plating,
-/area/surface/station/crew_quarters/captain)
 "uDX" = (
 /obj/machinery/light{
 	dir = 1
@@ -34411,6 +34395,7 @@
 /obj/item/weapon/pen,
 /obj/item/sticky_pad/random,
 /obj/item/weapon/storage/firstaid/regular,
+/obj/random/mug,
 /turf/simulated/floor/wood/sif,
 /area/surface/station/rnd/research)
 "wzs" = (
@@ -35952,22 +35937,6 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/surface/station/storage/art)
-"xpe" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/machinery/door/blast/regular/open{
-	dir = 4;
-	id = "captainlockdown";
-	layer = 3.3;
-	name = "Site Manager Lockdown"
-	},
-/turf/simulated/floor/plating,
-/area/surface/station/crew_quarters/captain)
 "xpk" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
@@ -68684,7 +68653,7 @@ uwO
 uwO
 uwO
 uwO
-xpe
+xVv
 pmw
 mMW
 nlh
@@ -69198,7 +69167,7 @@ uwO
 uwO
 uwO
 uwO
-uDG
+aPW
 iaD
 iaD
 jIo


### PR DESCRIPTION
- Added filing cabinet to evidence storage.
- Renamed evidence lockers appropriately, one as contraband locker (requested).
- Included atrium-overlooking windows in captain office window tint to avoid people overhearing private conversations from below.
- Removed stray signage from previous map tweak.
- Added random mugs in place of existing british mugs, plus a couple more in break room areas.
- Moved disposals security camera so it can see the door.
- Changed incinerator vent blast door access to maintenance instead of toxins.