### PR TITLE
Ports Vaurca autohiss from Aurora to Zaddat

### DIFF
--- a/code/modules/mob/living/autohiss.dm
+++ b/code/modules/mob/living/autohiss.dm
@@ -55,6 +55,18 @@
 		)
 	autohiss_exempt = list(LANGUAGE_SIIK,LANGUAGE_AKHANI)
 
+/datum/species/zaddat
+	autohiss_basic_map = list(
+			"f" = list("v","vh"),
+			"ph" = list("v", "vh")
+		)
+	autohiss_extra_map = list(
+			"s" = list("z", "zz", "zzz"),
+			"ce" = list("z", "zz"),
+			"ci" = list("z", "zz"),
+			"v" = list("vv", "vvv")
+		)
+	autohiss_exempt = list(LANGUAGE_ZADDAT)
 
 /datum/species/proc/handle_autohiss(message, datum/language/lang, mode)
 	if(!autohiss_basic_map)


### PR DESCRIPTION
> Zaddat Shrouds also assist in muting the natural buzzing accent Zaddat have when speaking Galactic Common, though cybernetic modification of the larynx for clearer speech has become popular in the last few decades.

I thought it might be some fun to actually use that natural buzzing accent - I have not checked with lore yet, however, so this will require a thumbs up or down.