### PR TITLE
Some admin log "usr" fixes

### DIFF
--- a/code/controllers/subsystems/webhooks.dm
+++ b/code/controllers/subsystems/webhooks.dm
@@ -68,7 +68,7 @@ SUBSYSTEM_DEF(webhooks)
 		return
 
 	to_world_log("[usr.key] has reloaded webhooks.")
-	log_and_message_admins("has reloaded webhooks.")
+	log_and_message_admins("has reloaded webhooks.", usr)
 	SSwebhooks.load_webhooks()
 
 /client/proc/ping_webhook()

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -203,7 +203,7 @@
 		if(mind)
 			mind.ambitions = sanitize(new_ambition)
 			to_chat(mind.current, "<span class='warning'>Your ambitions have been changed by higher powers, they are now: [mind.ambitions]</span>")
-		log_and_message_admins("made [key_name(mind.current)]'s ambitions be '[mind.ambitions]'.")
+		log_and_message_admins("made [key_name(mind.current)]'s ambitions be '[mind.ambitions]'.", usr)
 
 	else if (href_list["obj_edit"] || href_list["obj_add"])
 		var/datum/objective/objective

--- a/code/game/gamemodes/changeling/powers/electric_lockpick.dm
+++ b/code/game/gamemodes/changeling/powers/electric_lockpick.dm
@@ -90,7 +90,7 @@
 		to_chat(user, "<span class='notice'>We send an electrical pulse up our finger, and into \the [O].</span>")
 		O.add_fingerprint(user)
 		O.emag_act(1,user,src)
-		log_and_message_admins("finger-lockpicked \an [O].")
+		log_and_message_admins("finger-lockpicked \an [O].", user)
 		ling_datum.chem_charges -= 10
 
 		return 1

--- a/code/game/gamemodes/changeling/powers/electric_lockpick.dm
+++ b/code/game/gamemodes/changeling/powers/electric_lockpick.dm
@@ -81,7 +81,7 @@
 		else //Probably broken or no power.
 			to_chat(user, "<span class='warning'>The door does not respond to the pulse.</span>")
 		door.add_fingerprint(user)
-		log_and_message_admins("finger-lockpicked \an [door].")
+		log_and_message_admins("finger-lockpicked \an [door].", user)
 		ling_datum.chem_charges -= 10
 		return 1
 

--- a/code/game/gamemodes/cult/construct_spells.dm
+++ b/code/game/gamemodes/cult/construct_spells.dm
@@ -505,7 +505,7 @@
 		var/obj/item/projectile/new_projectile = make_projectile(spell_projectile, user)
 		new_projectile.old_style_target(hit_atom)
 		new_projectile.fire()
-		log_and_message_admins("has casted [src] at \the [hit_atom].")
+		log_and_message_admins("has casted [src] at \the [hit_atom].", user)
 		if(fire_sound)
 			playsound(src, fire_sound, 75, 1)
 		return 1
@@ -542,7 +542,7 @@
 	if(T)
 		new spawner_type(T)
 		to_chat(user, "<span class='cult'>You shift \the [src] onto \the [T].</span>")
-		log_and_message_admins("has casted [src] at [T.x],[T.y],[T.z].")
+		log_and_message_admins("has casted [src] at [T.x],[T.y],[T.z].", user)
 		qdel(src)
 
 //Harvester Laser.

--- a/code/game/gamemodes/cult/ritual.dm
+++ b/code/game/gamemodes/cult/ritual.dm
@@ -407,7 +407,7 @@ var/global/list/rnwords = list("ire","ego","nahlizet","certum","veri","jatkaa","
 		user.take_overall_damage((rand(9)+1)/10) // 0.1 to 1.0 damage
 		if(do_after(user, 50))
 			var/area/A = get_area(user)
-			log_and_message_admins("created \an [chosen_rune] rune at \the [A.name] - [user.loc.x]-[user.loc.y]-[user.loc.z].")
+			log_and_message_admins("created \an [chosen_rune] rune at \the [A.name] - [user.loc.x]-[user.loc.y]-[user.loc.z].", user)
 			if(usr.get_active_hand() != src)
 				return
 			var/mob/living/carbon/human/H = user
@@ -455,7 +455,7 @@ var/global/list/rnwords = list("ire","ego","nahlizet","certum","veri","jatkaa","
 			R.blood_DNA = list()
 			R.blood_DNA[H.dna.unique_enzymes] = H.dna.b_type
 		var/area/A = get_area(user)
-		log_and_message_admins("created \an [r] rune at \the [A.name] - [user.loc.x]-[user.loc.y]-[user.loc.z].")
+		log_and_message_admins("created \an [r] rune at \the [A.name] - [user.loc.x]-[user.loc.y]-[user.loc.z].", user)
 		switch(r)
 			if("teleport")
 				var/list/words = list("ire", "ego", "nahlizet", "certum", "veri", "jatkaa", "balaq", "mgar", "karazet", "geeri")

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -216,7 +216,7 @@ var/list/sacrificed = list()
 /////////////////////////////////////////FIFTH RUNE
 
 /obj/effect/rune/proc/emp(var/U,var/range_red) //range_red - var which determines by which number to reduce the default emp range, U is the source loc, needed because of talisman emps which are held in hand at the moment of using and that apparently messes things up -- Urist
-	log_and_message_admins("activated an EMP rune.")
+	log_and_message_admins("activated an EMP rune.", usr)
 	if(istype(src,/obj/effect/rune))
 		usr.say("Ta'gh fara[pick("'","`")]qha fel d'amar det!")
 	else
@@ -489,7 +489,7 @@ var/list/sacrificed = list()
 		D.real_name += " "
 		D.real_name += pick("Apparition", "Aptrgangr", "Dis", "Draugr", "Dybbuk", "Eidolon", "Fetch", "Fylgja", "Ghast", "Ghost", "Gjenganger", "Haint", "Phantom", "Phantasm", "Poltergeist", "Revenant", "Shade", "Shadow", "Soul", "Spectre", "Spirit", "Spook", "Visitant", "Wraith")
 
-	log_and_message_admins("used a manifest rune.")
+	log_and_message_admins("used a manifest rune.", usr)
 	var/mob/living/user = usr
 	while(this_rune && user && user.stat==CONSCIOUS && user.client && user.loc==this_rune.loc)
 		user.take_organ_damage(1, 0)
@@ -625,7 +625,7 @@ var/list/sacrificed = list()
 		usr.whisper("O bidai nabora se[pick("'","`")]sma!")
 
 	input = sanitize(input)
-	log_and_message_admins("used a communicate rune to say '[input]'")
+	log_and_message_admins("used a communicate rune to say '[input]'", usr)
 	for(var/datum/mind/H in cult.current_antagonists)
 		if (H.current)
 			to_chat(H.current, "<span class='cult'>[input]</span>")

--- a/code/game/gamemodes/technomancer/spells/resurrect.dm
+++ b/code/game/gamemodes/technomancer/spells/resurrect.dm
@@ -59,7 +59,7 @@
 					visible_message("<span class='danger'>\The [H]'s eyes open!</span>")
 					to_chat(user, "<span class='notice'>It's alive!</span>")
 					adjust_instability(50)
-					log_and_message_admins("has resurrected [H].")
+					log_and_message_admins("has resurrected [H].", user)
 				else
 					to_chat(user, "<span class='warning'>The body of \the [H] doesn't seem to respond, perhaps you could try again?</span>")
 					adjust_instability(10)

--- a/code/game/gamemodes/technomancer/spells/spawner/spawner.dm
+++ b/code/game/gamemodes/technomancer/spells/spawner/spawner.dm
@@ -11,5 +11,5 @@
 	if(T)
 		new spawner_type(T)
 		to_chat(user, "<span class='notice'>You shift \the [src] onto \the [T].</span>")
-		log_and_message_admins("has casted [src] at [T.x],[T.y],[T.z].")
+		log_and_message_admins("has casted [src] at [T.x],[T.y],[T.z].", user)
 		qdel(src)

--- a/code/game/gamemodes/technomancer/spells/summon/summon.dm
+++ b/code/game/gamemodes/technomancer/spells/summon/summon.dm
@@ -29,7 +29,7 @@
 			on_summon(L)
 			to_chat(user, "<span class='notice'>You've successfully teleported \a [L] to you!</span>")
 			visible_message("<span class='warning'>\A [L] appears from no-where!</span>")
-			log_and_message_admins("has summoned \a [L] at [T.x],[T.y],[T.z].")
+			log_and_message_admins("has summoned \a [L] at [T.x],[T.y],[T.z].", user)
 			user.adjust_instability(instability_cost)
 
 /obj/item/weapon/spell/summon/on_use_cast(mob/living/user)

--- a/code/game/objects/items/devices/defib.dm
+++ b/code/game/objects/items/devices/defib.dm
@@ -436,7 +436,7 @@
 
 	make_alive(H)
 
-	log_and_message_admins("used \a [src] to revive [key_name(H)].")
+	log_and_message_admins("used \a [src] to revive [key_name(H)].", user)
 
 
 /obj/item/weapon/shockpaddles/proc/do_electrocute(mob/living/carbon/human/H, mob/user, var/target_zone)

--- a/code/game/objects/items/weapons/AI_modules.dm
+++ b/code/game/objects/items/weapons/AI_modules.dm
@@ -116,7 +116,7 @@ AI MODULES
 /obj/item/weapon/aiModule/proc/log_law_changes(var/mob/living/silicon/ai/target, var/mob/sender)
 	var/time = time2text(world.realtime,"hh:mm:ss")
 	lawchanges.Add("[time] <B>:</B> [sender.name]([sender.key]) used [src.name] on [target.name]([target.key])")
-	log_and_message_admins("used [src.name] on [target.name]([target.key])")
+	log_and_message_admins("used [src.name] on [target.name]([target.key])", sender)
 
 /obj/item/weapon/aiModule/proc/addAdditionalLaws(var/mob/living/silicon/ai/target, var/mob/sender)
 

--- a/code/game/objects/items/weapons/id cards/cards.dm
+++ b/code/game/objects/items/weapons/id cards/cards.dm
@@ -110,7 +110,7 @@
 
 	uses -= used_uses
 	A.add_fingerprint(user)
-	log_and_message_admins("emagged \an [A].")
+	log_and_message_admins("emagged \an [A].", user)
 
 	if(uses<1)
 		user.visible_message("<span class='warning'>\The [src] fizzles and sparks - it seems it's been used once too often, and is now spent.</span>")

--- a/code/game/objects/structures/ghost_pods/human.dm
+++ b/code/game/objects/structures/ghost_pods/human.dm
@@ -50,7 +50,7 @@
 		to_chat(M, "<span class='warning'>Your intent may not be completely beneficial.</span>")
 	H.ckey = M.ckey
 	visible_message("<span class='warning'>As \the [src] opens, the pipes on \the [src] surge, before it grows dark.</span>")
-	log_and_message_admins("successfully opened \a [src] and became a [occupant_type].")
+	log_and_message_admins("successfully opened \a [src] and became a [occupant_type].", H)
 
 	var/list/uniform_options
 	var/list/shoe_options
@@ -178,7 +178,7 @@
 		to_chat(M, "<span class='warning'>Your intent may not be completely beneficial.</span>")
 	H.ckey = M.ckey
 	visible_message("<span class='warning'>As \the [src] opens, the pipes on \the [src] surge, before it grows dark.</span>")
-	log_and_message_admins("successfully opened \a [src] and got a [occupant_type].")
+	log_and_message_admins("successfully opened \a [src] and got a [occupant_type].", H)
 
 	var/list/uniform_options
 	var/list/shoe_options

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -814,7 +814,7 @@ var/global/floorIsLava = 0
 		to_world("<B>The OOC channel has been globally enabled!</B>")
 	else
 		to_world("<B>The OOC channel has been globally disabled!</B>")
-	log_and_message_admins("toggled OOC.")
+	log_and_message_admins("toggled OOC.", usr)
 	feedback_add_details("admin_verb","TOOC") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /datum/admins/proc/togglelooc()
@@ -830,7 +830,7 @@ var/global/floorIsLava = 0
 		to_world("<B>The LOOC channel has been globally enabled!</B>")
 	else
 		to_world("<B>The LOOC channel has been globally disabled!</B>")
-	log_and_message_admins("toggled LOOC.")
+	log_and_message_admins("toggled LOOC.", usr)
 	feedback_add_details("admin_verb","TLOOC") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 
@@ -907,7 +907,7 @@ var/global/floorIsLava = 0
 	else
 		SSticker.start_immediately = FALSE
 		to_world("<span class='notice'>Immediate game start canceled.  Normal startup resumed.</span>")
-		log_and_message_admins("cancelled immediate game start.")
+		log_and_message_admins("cancelled immediate game start.", usr)
 
 /datum/admins/proc/toggleenter()
 	set category = "Server"
@@ -1197,7 +1197,7 @@ var/global/floorIsLava = 0
 	else
 		new chosen(usr.loc)
 
-	log_and_message_admins("spawned [chosen] at ([usr.x],[usr.y],[usr.z])")
+	log_and_message_admins("spawned [chosen] at ([usr.x],[usr.y],[usr.z])", usr)
 	feedback_add_details("admin_verb","SA") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 
@@ -1492,7 +1492,7 @@ var/global/floorIsLava = 0
 		to_chat(usr, "Mode has not started.")
 		return
 
-	log_and_message_admins("attempting to force mode autospawn.")
+	log_and_message_admins("attempting to force mode autospawn.", usr)
 	ticker.mode.try_latespawn()
 
 /datum/admins/proc/paralyze_mob(mob/living/H as mob)
@@ -1506,12 +1506,12 @@ var/global/floorIsLava = 0
 		if (H.paralysis == 0)
 			H.SetParalysis(8000)
 			msg = "has paralyzed [key_name(H)]."
-			log_and_message_admins(msg)
+			log_and_message_admins(msg, usr)
 		else
 			if(alert(src, "[key_name(H)] is paralyzed, would you like to unparalyze them?",,"Yes","No") == "Yes")
 				H.SetParalysis(0)
 				msg = "has unparalyzed [key_name(H)]."
-				log_and_message_admins(msg)
+				log_and_message_admins(msg, usr)
 
 /datum/admins/proc/set_tcrystals(mob/living/carbon/human/H as mob)
 	set category = "Debug"

--- a/code/modules/admin/admin_attack_log.dm
+++ b/code/modules/admin/admin_attack_log.dm
@@ -3,7 +3,7 @@
 /mob/var/attack_log = list( )
 /mob/var/dialogue_log = list( )
 
-/proc/log_and_message_admins(var/message as text, var/mob/user = usr)
+/proc/log_and_message_admins(var/message as text, var/mob/user)
 	log_admin(user ? "[key_name(user)] [message]" : "EVENT [message]")
 	message_admins(user ? "[key_name_admin(user)] [message]" : "EVENT [message]")
 

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -188,7 +188,7 @@
 			createStealthKey()
 			if(istype(mob, /mob/new_player))
 				mob.name = new_key
-		log_and_message_admins("[key_name(usr)] has turned stealth mode [holder.fakekey ? "ON" : "OFF"]")
+		log_and_message_admins("[key_name(usr)] has turned stealth mode [holder.fakekey ? "ON" : "OFF"]", usr)
 	feedback_add_details("admin_verb","SM") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 #define MAX_WARNS 3
@@ -313,7 +313,7 @@
 		duration = duration SECONDS
 
 	L.add_modifier(new_modifier_type, duration)
-	log_and_message_admins("has given [key_name(L)] the modifer [new_modifier_type], with a duration of [duration ? "[duration / 600] minutes" : "forever"].")
+	log_and_message_admins("has given [key_name(L)] the modifer [new_modifier_type], with a duration of [duration ? "[duration / 600] minutes" : "forever"].", usr)
 
 /client/proc/make_sound(var/obj/O in world) // -- TLE
 	set category = "Special Verbs"
@@ -406,7 +406,7 @@
 
 	var/new_name = sanitizeSafe(input(src, "Enter new name. Leave blank or as is to cancel.", "[S.real_name] - Enter new silicon name", S.real_name))
 	if(new_name && new_name != S.real_name)
-		log_and_message_admins("has renamed the silicon '[S.real_name]' to '[new_name]'")
+		log_and_message_admins("has renamed the silicon '[S.real_name]' to '[new_name]'", usr)
 		S.SetName(new_name)
 	feedback_add_details("admin_verb","RAI") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
@@ -421,7 +421,7 @@
 
 	var/datum/tgui_module/law_manager/admin/L = new(S)
 	L.tgui_interact(usr)
-	log_and_message_admins("has opened [S]'s law manager.")
+	log_and_message_admins("has opened [S]'s law manager.", usr)
 	feedback_add_details("admin_verb","MSL") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /client/proc/change_security_level()

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1656,7 +1656,7 @@
 									var/mob/M = O
 									M.real_name = obj_name
 
-		log_and_message_admins("created [number] [english_list(paths)]")
+		log_and_message_admins("created [number] [english_list(paths)]", usr)
 		return
 
 	else if(href_list["admin_secrets_panel"])

--- a/code/modules/admin/verbs/change_appearance.dm
+++ b/code/modules/admin/verbs/change_appearance.dm
@@ -8,7 +8,7 @@
 	var/mob/living/carbon/human/H = input("Select mob.", "Change Mob Appearance - Admin") as null|anything in human_mob_list
 	if(!H) return
 
-	log_and_message_admins("is altering the appearance of [H].")
+	log_and_message_admins("is altering the appearance of [H].", usr)
 	H.change_appearance(APPEARANCE_ALL, usr, check_species_whitelist = 0, state = GLOB.tgui_admin_state)
 	feedback_add_details("admin_verb","CHAA") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
@@ -28,10 +28,10 @@
 	var/datum/gender/T = gender_datums[H.get_visible_gender()]
 	switch(alert("Do you wish for [H] to be allowed to select non-whitelisted races?","Alter Mob Appearance","Yes","No","Cancel"))
 		if("Yes")
-			log_and_message_admins("has allowed [H] to change [T.his] appearance, without whitelisting of races.")
+			log_and_message_admins("has allowed [H] to change [T.his] appearance, without whitelisting of races.", usr)
 			H.change_appearance(APPEARANCE_ALL, H, check_species_whitelist = 0)
 		if("No")
-			log_and_message_admins("has allowed [H] to change [T.his] appearance, with whitelisting of races.")
+			log_and_message_admins("has allowed [H] to change [T.his] appearance, with whitelisting of races.", usr)
 			H.change_appearance(APPEARANCE_ALL, H, check_species_whitelist = 1)
 	feedback_add_details("admin_verb","CMAS") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -445,7 +445,7 @@
 	if(outfit.undress)
 		H.delete_inventory()
 	outfit.equip(H)
-	log_and_message_admins("changed the equipment of [key_name(H)] to [outfit.name].")
+	log_and_message_admins("changed the equipment of [key_name(H)] to [outfit.name].", usr)
 
 /client/proc/startSinglo()
 

--- a/code/modules/assembly/signaler.dm
+++ b/code/modules/assembly/signaler.dm
@@ -146,7 +146,7 @@
 	set desc = "BOOOOM!"
 	deadman = TRUE
 	START_PROCESSING(SSobj, src)
-	log_and_message_admins("is threatening to trigger a signaler deadman's switch")
+	log_and_message_admins("is threatening to trigger a signaler deadman's switch", usr)
 	usr.visible_message("<font color='red'>[usr] moves their finger over [src]'s signal button...</font>")
 
 /obj/item/device/assembly/signaler/Destroy()

--- a/code/modules/events/event_manager.dm
+++ b/code/modules/events/event_manager.dm
@@ -132,41 +132,41 @@
 
 	if(href_list["toggle_report"])
 		report_at_round_end = !report_at_round_end
-		log_and_message_admins("has [report_at_round_end ? "enabled" : "disabled"] the round end event report.")
+		log_and_message_admins("has [report_at_round_end ? "enabled" : "disabled"] the round end event report.", usr)
 	else if(href_list["dec_timer"])
 		var/datum/event_container/EC = locate(href_list["event"])
 		var/decrease = 60 * (10 ** text2num(href_list["dec_timer"]))
 		EC.next_event_time -= decrease
-		log_and_message_admins("decreased timer for [severity_to_string[EC.severity]] events by [decrease/600] minute(s).")
+		log_and_message_admins("decreased timer for [severity_to_string[EC.severity]] events by [decrease/600] minute(s).", usr)
 	else if(href_list["inc_timer"])
 		var/datum/event_container/EC = locate(href_list["event"])
 		var/increase = 60 * (10 ** text2num(href_list["inc_timer"]))
 		EC.next_event_time += increase
-		log_and_message_admins("increased timer for [severity_to_string[EC.severity]] events by [increase/600] minute(s).")
+		log_and_message_admins("increased timer for [severity_to_string[EC.severity]] events by [increase/600] minute(s).", usr)
 	else if(href_list["select_event"])
 		var/datum/event_container/EC = locate(href_list["select_event"])
 		var/datum/event_meta/EM = EC.SelectEvent()
 		if(EM)
-			log_and_message_admins("has queued the [severity_to_string[EC.severity]] event '[EM.name]'.")
+			log_and_message_admins("has queued the [severity_to_string[EC.severity]] event '[EM.name]'.", usr)
 	else if(href_list["pause"])
 		var/datum/event_container/EC = locate(href_list["pause"])
 		EC.delayed = !EC.delayed
-		log_and_message_admins("has [EC.delayed ? "paused" : "resumed"] countdown for [severity_to_string[EC.severity]] events.")
+		log_and_message_admins("has [EC.delayed ? "paused" : "resumed"] countdown for [severity_to_string[EC.severity]] events.", usr)
 	else if(href_list["pause_all"])
 		config.allow_random_events = text2num(href_list["pause_all"])
-		log_and_message_admins("has [config.allow_random_events ? "resumed" : "paused"] countdown for all events.")
+		log_and_message_admins("has [config.allow_random_events ? "resumed" : "paused"] countdown for all events.", usr)
 	else if(href_list["interval"])
 		var/delay = input("Enter delay modifier. A value less than one means events fire more often, higher than one less often.", "Set Interval Modifier") as num|null
 		if(delay && delay > 0)
 			var/datum/event_container/EC = locate(href_list["interval"])
 			EC.delay_modifier = delay
-			log_and_message_admins("has set the interval modifier for [severity_to_string[EC.severity]] events to [EC.delay_modifier].")
+			log_and_message_admins("has set the interval modifier for [severity_to_string[EC.severity]] events to [EC.delay_modifier].", usr)
 	else if(href_list["stop"])
 		if(alert("Stopping an event may have unintended side-effects. Continue?","Stopping Event!","Yes","No") != "Yes")
 			return
 		var/datum/event/E = locate(href_list["stop"])
 		var/datum/event_meta/EM = E.event_meta
-		log_and_message_admins("has stopped the [severity_to_string[EM.severity]] event '[EM.name]'.")
+		log_and_message_admins("has stopped the [severity_to_string[EM.severity]] event '[EM.name]'.", usr)
 		E.kill()
 	else if(href_list["view_events"])
 		selected_event_container = locate(href_list["view_events"])
@@ -188,23 +188,23 @@
 			var/datum/event_meta/EM = locate(href_list["set_weight"])
 			EM.weight = weight
 			if(EM != new_event)
-				log_and_message_admins("has changed the weight of the [severity_to_string[EM.severity]] event '[EM.name]' to [EM.weight].")
+				log_and_message_admins("has changed the weight of the [severity_to_string[EM.severity]] event '[EM.name]' to [EM.weight].", usr)
 	else if(href_list["toggle_oneshot"])
 		var/datum/event_meta/EM = locate(href_list["toggle_oneshot"])
 		EM.one_shot = !EM.one_shot
 		if(EM != new_event)
-			log_and_message_admins("has [EM.one_shot ? "set" : "unset"] the oneshot flag for the [severity_to_string[EM.severity]] event '[EM.name]'.")
+			log_and_message_admins("has [EM.one_shot ? "set" : "unset"] the oneshot flag for the [severity_to_string[EM.severity]] event '[EM.name]'.", usr)
 	else if(href_list["toggle_enabled"])
 		var/datum/event_meta/EM = locate(href_list["toggle_enabled"])
 		EM.enabled = !EM.enabled
-		log_and_message_admins("has [EM.enabled ? "enabled" : "disabled"] the [severity_to_string[EM.severity]] event '[EM.name]'.")
+		log_and_message_admins("has [EM.enabled ? "enabled" : "disabled"] the [severity_to_string[EM.severity]] event '[EM.name]'.", usr)
 	else if(href_list["remove"])
 		if(alert("This will remove the event from rotation. Continue?","Removing Event!","Yes","No") != "Yes")
 			return
 		var/datum/event_meta/EM = locate(href_list["remove"])
 		var/datum/event_container/EC = locate(href_list["EC"])
 		EC.available_events -= EM
-		log_and_message_admins("has removed the [severity_to_string[EM.severity]] event '[EM.name]'.")
+		log_and_message_admins("has removed the [severity_to_string[EM.severity]] event '[EM.name]'.", usr)
 	else if(href_list["add"])
 		if(!new_event.name || !new_event.event_type)
 			return
@@ -212,12 +212,12 @@
 			return
 		new_event.severity = selected_event_container.severity
 		selected_event_container.available_events += new_event
-		log_and_message_admins("has added \a [severity_to_string[new_event.severity]] event '[new_event.name]' of type [new_event.event_type] with weight [new_event.weight].")
+		log_and_message_admins("has added \a [severity_to_string[new_event.severity]] event '[new_event.name]' of type [new_event.event_type] with weight [new_event.weight].", usr)
 		new_event = new
 	else if(href_list["clear"])
 		var/datum/event_container/EC = locate(href_list["clear"])
 		if(EC.next_event)
-			log_and_message_admins("has dequeued the [severity_to_string[EC.severity]] event '[EC.next_event.name]'.")
+			log_and_message_admins("has dequeued the [severity_to_string[EC.severity]] event '[EC.next_event.name]'.", usr)
 			EC.next_event = null
 
 	Interact(usr)

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -105,7 +105,7 @@
 	if(istype(get_active_hand(),/obj/item/device/assembly/signaler))
 		var/obj/item/device/assembly/signaler/signaler = get_active_hand()
 		if(signaler.deadman && prob(80))
-			log_and_message_admins("has triggered a signaler deadman's switch")
+			log_and_message_admins("has triggered a signaler deadman's switch", src)
 			src.visible_message("<font color='red'>[src] triggers their deadman's switch!</font>")
 			signaler.signal()
 

--- a/code/modules/mob/living/silicon/pai/admin.dm
+++ b/code/modules/mob/living/silicon/pai/admin.dm
@@ -11,7 +11,7 @@
 		if(!C) return
 		pai_key = C.key
 
-	log_and_message_admins("made a pAI with key=[pai_key] at ([t.x],[t.y],[t.z])")
+	log_and_message_admins("made a pAI with key=[pai_key] at ([t.x],[t.y],[t.z])", usr)
 	var/obj/item/device/paicard/card = new(t)
 	var/mob/living/silicon/pai/pai = new(card)
 	pai.key = pai_key

--- a/code/modules/projectiles/targeting/targeting_overlay.dm
+++ b/code/modules/projectiles/targeting/targeting_overlay.dm
@@ -168,7 +168,7 @@
 		owner.visible_message("<span class='danger'>\The [owner] turns \the [thing] on \the [target]!</span>")
 	else
 		owner.visible_message("<span class='danger'>\The [owner] aims \the [thing] at \the [target]!</span>")
-	log_and_message_admins("aimed \a [thing] at [key_name(target)].")
+	log_and_message_admins("aimed \a [thing] at [key_name(target)].", owner)
 
 	if(owner.client)
 		owner.client.add_gun_icons()

--- a/code/modules/shuttles/shuttle_emergency.dm
+++ b/code/modules/shuttles/shuttle_emergency.dm
@@ -72,9 +72,9 @@
 			emergency_shuttle.autopilot = 0
 			to_world("<span class='notice'><b>Alert: The shuttle autopilot has been overridden. Launch sequence initiated!</b></span>")
 
-	if(usr)
-		log_admin("[key_name(usr)] has overridden the departure shuttle's autopilot and activated the launch sequence.")
-		message_admins("[key_name_admin(usr)] has overridden the departure shuttle's autopilot and activated the launch sequence.")
+	if(user)
+		log_admin("[key_name(user)] has overridden the departure shuttle's autopilot and activated the launch sequence.")
+		message_admins("[key_name_admin(user)] has overridden the departure shuttle's autopilot and activated the launch sequence.")
 
 	..(user)
 
@@ -86,9 +86,9 @@
 			emergency_shuttle.autopilot = 0
 			to_world("<span class='notice'><b>Alert: The shuttle autopilot has been overridden. Bluespace drive engaged!</b></span>")
 
-	if(usr)
-		log_admin("[key_name(usr)] has overridden the departure shuttle's autopilot and forced immediate launch.")
-		message_admins("[key_name_admin(usr)] has overridden the departure shuttle's autopilot and forced immediate launch.")
+	if(user)
+		log_admin("[key_name(user)] has overridden the departure shuttle's autopilot and forced immediate launch.")
+		message_admins("[key_name_admin(user)] has overridden the departure shuttle's autopilot and forced immediate launch.")
 
 	..(user)
 
@@ -100,9 +100,9 @@
 			emergency_shuttle.autopilot = 0
 			to_chat(world, "<span class='notice'><b>Alert: The shuttle autopilot has been overridden. Launch sequence aborted!</b></span>")
 
-	if(usr)
-		log_admin("[key_name(usr)] has overridden the departure shuttle's autopilot and cancelled the launch sequence.")
-		message_admins("[key_name_admin(usr)] has overridden the departure shuttle's autopilot and cancelled the launch sequence.")
+	if(user)
+		log_admin("[key_name(user)] has overridden the departure shuttle's autopilot and cancelled the launch sequence.")
+		message_admins("[key_name_admin(user)] has overridden the departure shuttle's autopilot and cancelled the launch sequence.")
 
 	..(user)
 

--- a/code/modules/tgui/modules/law_manager.dm
+++ b/code/modules/tgui/modules/law_manager.dm
@@ -100,7 +100,7 @@
 				if(AL)
 					var/new_law = sanitize(input(usr, "Enter new law. Leaving the field blank will cancel the edit.", "Edit Law", AL.law))
 					if(new_law && new_law != AL.law && is_malf(usr) && can_still_topic(usr, state))
-						log_and_message_admins("has changed a law of [owner] from '[AL.law]' to '[new_law]'")
+						log_and_message_admins("has changed a law of [owner] from '[AL.law]' to '[new_law]'", usr)
 						AL.law = new_law
 				return TRUE
 
@@ -125,7 +125,7 @@
 			if(is_malf(usr))
 				var/datum/ai_laws/ALs = locate(params["transfer_laws"]) in (is_admin(usr) ? admin_laws : player_laws)
 				if(ALs)
-					log_and_message_admins("has transfered the [ALs.name] laws to [owner].")
+					log_and_message_admins("has transfered the [ALs.name] laws to [owner].", usr)
 					ALs.sync(owner, 0)
 			return TRUE
 


### PR DESCRIPTION
"usr" is only meant for manually operated verbs and only causes issues when used in automated procs.

Fixes adminlog messages occasionally slapping the first completely unrelated mob as a "prefix" for the message itself.
Fixes emergency shuttle overrides also blaming the adminlog messages on the randomly picked hapless "usr" instead of the actual "user" operating the things.