### PR TITLE
updates byond major.minor and dmm suite versions

### DIFF
--- a/_build_dependencies.sh
+++ b/_build_dependencies.sh
@@ -1,11 +1,11 @@
 # This file has all the information on what versions of libraries are thrown into the code
 # For dreamchecker
-export SPACEMAN_DMM_VERSION=suite-1.7
+export SPACEMAN_DMM_VERSION=suite-1.7.2
 # For NanoUI + TGUI
 export NODE_VERSION=12
 # Byond Major
-export BYOND_MAJOR=513
+export BYOND_MAJOR=514
 # Byond Minor
-export BYOND_MINOR=1528
+export BYOND_MINOR=1575
 # Macro Count
 export MACRO_COUNT=4


### PR DESCRIPTION
514.1575 is a recent 514 a few builds behind latest that is broadly used for hosting, and is what live runs on now.

dmm suite 1.7.2 has some bugfixes and improvements. It probably won't create any new warnings because the VSC plugin has targeted it for some time now, and those have been resolved already.

ed: as updates go, this one is relatively important. The prior byond version was a badly dated 513. 514 has been stable channel for a long time and has no meaningful migration overhead, while introducing features and improvements.