### PR TITLE
adds git blame ignore and vscode workspace config

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,22 @@
+# git blame main ignore list.
+#
+# This file contains a list of git hashes of revisions to be ignored by git
+# blame. These revisions are considered "unimportant" in that they
+# are unlikely to be what you are interested in when blaming.
+#
+# Requires git 2.23 or later (or equivalent)
+# To enable, execute: git config blame.ignoreRevsFile .git-blame-ignore-revs
+#
+# Instructions:
+# - Only large (generally automated) reformatting or renaming CLs should be
+#   added to this list. Do not put things here just because you feel they are
+#   trivial or unimportant. If in doubt, do not put it on this list.
+# - Precede each revision with a comment containing the first line of its log.
+#   For bulk work over many commits, place all commits in a block with a single
+#   comment at the top describing the work done in those commits.
+# - Only put full 40-character hashes on this list (not short hashes or any
+#   other revision reference).
+# - Append to the bottom of the file (revisions should be in chronological order
+#   from oldest to newest).
+# - Because you must use a hash, you need to append to this list in a follow-up
+#   CL to the actual reformatting CL that you are trying to ignore.

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,11 @@
+{
+	"editor.detectIndentation": false,
+	"editor.insertSpaces": false,
+	"editor.tabSize": 4,
+	"files.eol": "\r\n",
+	"gitblame.commitUrl": "https://github.com/polarisss13/polaris/commit/${hash}",
+	"gitlens.advanced.blame.customArguments": [
+		"--ignore-revs-file",
+		".git-blame-ignore-revs"
+	]
+}


### PR DESCRIPTION
```
adds a git blame ignore list file
----
Commit hashes that are added will be ignored by blame.

Largely useful to prevent needing to dig through extra blame levels for
mass path changes, big whitespace edits, etc.

Initially empty. Read the instructions!
```

```
add vscode workspace settings
----
Provides some obvious basics for using vscode with dm / polaris.
- Does not attempt to detect indentation
- Always uses tabs
- Always uses windows line endings
- Makes use of the git blame ignore file in codelens
- configures the vscode git blame plugin[1] to use the polaris repository for view remote
```
[1] https://marketplace.visualstudio.com/items?itemName=waderyan.gitblame