### PR TITLE
update readme links, add agpl-3.0 license button

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# polaris
+# Polaris [![License: AGPL v3](https://img.shields.io/badge/License-AGPL_v3.0-orange.svg)](https://opensource.org/licenses/AGPL-3.0) <!--[![CI Status](https://github.com/polarisss13/polaris/workflows/MAIN-BRANCH-CI-HERE/badge.svg)](https://github.com/polarisss13/polaris/actions)-->
 
-[Forums](https://forum.ss13polaris.com/) - [Wiki](http://wiki.ss13polaris.com/) - [Discord](https://discord.gg/dvUcacC)
+[Wiki](http://ss13polaris.com) - [Discord](https://discord.gg/dvUcacC) - [Forum](https://forum.ss13polaris.com)
 
 Polaris is a fork of the Baystation12 code branch for the game Spacestation13.
 


### PR DESCRIPTION
Also adds guts for a main branch CI status button; leaves it commented because there is no main branch CI.

Appearance of button:
<https://github.com/Spookerton/Polaris/tree/spkrtn/sys/no-read-me-instead#readme>
![https://i.imgur.com/pXpUuz3.png](https://i.imgur.com/pXpUuz3.png)

