### PR TITLE
default client fps is 40 instead of match-server

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -22,7 +22,7 @@ var/list/preferences_datums = list()
 	var/UI_style_color = "#ffffff"
 	var/UI_style_alpha = 255
 	var/tooltipstyle = "Midnight"		//Style for popup tooltips
-	var/client_fps = 0
+	var/client_fps = 40
 	var/ambience_freq = 5				// How often we're playing repeating ambience to a client.
 	var/ambience_chance = 35			// What's the % chance we'll play ambience (in conjunction with the above frequency)
 


### PR DESCRIPTION
There's no meaningful relationship between client and server FPS, so having the default client behavior be matching the server is pointless. Fixed 40 is a much nicer default experience than `20-ish`.