### PR TITLE
legacy text number handling

### DIFF
--- a/code/_helpers/text.dm
+++ b/code/_helpers/text.dm
@@ -213,23 +213,58 @@
 		t = replacetext(t, char, repl_chars[char])
 	return t
 
-//Adds 'u' number of zeros ahead of the text 't'
-/proc/add_zero(t, u)
-	while (length(t) < u)
-		t = "0[t]"
-	return t
 
-//Adds 'u' number of spaces ahead of the text 't'
-/proc/add_lspace(t, u)
-	while(length(t) < u)
-		t = " [t]"
-	return t
+/// Returns a string of hexadecimal characters of length size, uppercased if uppercase is truthy
+/proc/random_hex_text(size, uppercase)
+	if (!ISINTEGER(size))
+		return
+	var/list/result = list()
+	for (var/i = size to 1 step -1)
+		result += num2hex(rand(0, 0xF))
+	result = jointext(result, null)
+	if (uppercase)
+		return uppertext(result)
+	return result
 
-//Adds 'u' number of spaces behind the text 't'
-/proc/add_tspace(t, u)
-	while(length(t) < u)
-		t = "[t] "
-	return t
+
+/// Builds a string of padding repeated until its character count meets or exceeds size
+/proc/generate_padding(size, padding)
+	var/padding_size = length_char(padding)
+	if (!padding_size)
+		return ""
+	var/padding_count = CEILING(size / padding_size, 1)
+	var/list/result = list()
+	for (var/i = padding_count to 1 step -1)
+		result += padding // pow2 strategies could be used here at the cost of complexity
+	return result.Join(null)
+
+
+/// Pads the matter of padding onto the start of text until the result length is size
+/proc/pad_left(text, size, padding)
+	var/text_length = length_char(text)
+	if (text_length >= size)
+		return text
+	if (!text_length)
+		text = ""
+	var/result = "[generate_padding(size - text_length, padding)][text]"
+	var/length_difference = length_char(result) - size
+	if (!length_difference)
+		return result
+	return copytext_char(result, length_difference + 1)
+
+
+/// Pads the matter of padding onto the start of text until the result length is size
+/proc/pad_right(text, size, padding)
+	var/text_length = length_char(text)
+	if (text_length >= size)
+		return text
+	if (!text_length)
+		text = ""
+	var/result = "[text][generate_padding(size - text_length, padding)]"
+	var/length_difference = length_char(result) - size
+	if (!length_difference)
+		return result
+	return copytext_char(result, 1, -length_difference)
 
 //Returns a string with reserved characters and spaces before the first letter removed
 /proc/trim_left(text)

--- a/code/_helpers/time.dm
+++ b/code/_helpers/time.dm
@@ -110,8 +110,8 @@ GLOBAL_VAR_INIT(round_start_time, 0)
 	var/mins = round((mills % 36000) / 600)
 	var/hours = round(mills / 36000)
 
-	mins = mins < 10 ? add_zero(mins, 1) : mins
-	hours = hours < 10 ? add_zero(hours, 1) : hours
+	mins = pad_left("[mins]", 2, "0")
+	hours = pad_left("[hours]", 2, "0")
 
 	last_round_duration = "[hours]:[mins]"
 	next_duration_update = world.time + 1 MINUTES

--- a/code/_helpers/type2type.dm
+++ b/code/_helpers/type2type.dm
@@ -1,55 +1,3 @@
-/*
- * Holds procs designed to change one type of value, into another.
- * Contains:
- *			hex2num & num2hex
- *			text2list & list2text
- *			file2list
- *			angle2dir
- *			angle2text
- *			worldtime2text
- */
-
-// Returns an integer given a hexadecimal number string as input.
-/proc/hex2num(hex)
-	if (!istext(hex))
-		return
-
-	var/num   = 0
-	var/power = 1
-	var/i     = length(hex)
-
-	while (i)
-		var/char = text2ascii(hex, i)
-		switch(char)
-			if(48)                                  // 0 -- do nothing
-			if(49 to 57) num += (char - 48) * power // 1-9
-			if(97,  65)  num += power * 10          // A
-			if(98,  66)  num += power * 11          // B
-			if(99,  67)  num += power * 12          // C
-			if(100, 68)  num += power * 13          // D
-			if(101, 69)  num += power * 14          // E
-			if(102, 70)  num += power * 15          // F
-			else
-				return
-		power *= 16
-		i--
-	return num
-
-// Returns the hex value of a number given a value assumed to be a base-ten value
-/proc/num2hex(num, padlength)
-	var/global/list/hexdigits = list("0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "A", "B", "C", "D", "E", "F")
-
-	. = ""
-	while(num > 0)
-		var/hexdigit = hexdigits[(num & 0xF) + 1]
-		. = "[hexdigit][.]"
-		num >>= 4 //go to the next half-byte
-
-	//pad with zeroes
-	var/left = padlength - length(.)
-	while (left-- > 0)
-		. = "0[.]"
-
 /proc/text2numlist(text, delimiter="\n")
 	var/list/num_list = list()
 	for(var/x in splittext(text, delimiter))
@@ -151,25 +99,6 @@
 	if (rights & R_EVENT)       . += "[seperator]+EVENT"
 	return .
 
-// Converts a hexadecimal color (e.g. #FF0050) to a list of numbers for red, green, and blue (e.g. list(255,0,80) ).
-/proc/hex2rgb(hex)
-	// Strips the starting #, in case this is ever supplied without one, so everything doesn't break.
-	if(findtext(hex,"#",1,2))
-		hex = copytext(hex, 2)
-	return list(hex2rgb_r(hex), hex2rgb_g(hex), hex2rgb_b(hex))
-
-// The three procs below require that the '#' part of the hex be stripped, which hex2rgb() does automatically.
-/proc/hex2rgb_r(hex)
-	var/hex_to_work_on = copytext(hex,1,3)
-	return hex2num(hex_to_work_on)
-
-/proc/hex2rgb_g(hex)
-	var/hex_to_work_on = copytext(hex,3,5)
-	return hex2num(hex_to_work_on)
-
-/proc/hex2rgb_b(hex)
-	var/hex_to_work_on = copytext(hex,5,7)
-	return hex2num(hex_to_work_on)
 
 // heat2color functions. Adapted from: http://www.tannerhelland.com/4435/convert-temperature-rgb-algorithm-code/
 /proc/heat2color(temp)

--- a/code/_helpers/unsorted.dm
+++ b/code/_helpers/unsorted.dm
@@ -14,30 +14,6 @@
     locate(min(CENTER.x+(RADIUS),world.maxx), min(CENTER.y+(RADIUS),world.maxy), CENTER.z) \
   )
 
-//Inverts the colour of an HTML string
-/proc/invertHTML(HTMLstring)
-
-	if (!( istext(HTMLstring) ))
-		CRASH("Given non-text argument!")
-	else
-		if (length(HTMLstring) != 7)
-			CRASH("Given non-HTML argument!")
-	var/textr = copytext(HTMLstring, 2, 4)
-	var/textg = copytext(HTMLstring, 4, 6)
-	var/textb = copytext(HTMLstring, 6, 8)
-	var/r = hex2num(textr)
-	var/g = hex2num(textg)
-	var/b = hex2num(textb)
-	textr = num2hex(255 - r)
-	textg = num2hex(255 - g)
-	textb = num2hex(255 - b)
-	if (length(textr) < 2)
-		textr = text("0[]", textr)
-	if (length(textg) < 2)
-		textr = text("0[]", textg)
-	if (length(textb) < 2)
-		textr = text("0[]", textb)
-	return text("#[][][]", textr, textg, textb)
 
 //Returns the middle-most value
 /proc/dd_range(var/low, var/high, var/num)
@@ -1279,7 +1255,7 @@ var/list/WALLITEMS = list(
 	return colour
 
 /proc/color_square(red, green, blue, hex)
-	var/color = hex ? hex : "#[num2hex(red, 2)][num2hex(green, 2)][num2hex(blue, 2)]"
+	var/color = hex || rgb(red, green, blue)
 	return "<span style='font-face: fixedsys; font-size: 14px; background-color: [color]; color: [color]'>___</span>"
 
 var/mob/dview/dview_mob = new

--- a/code/_macros.dm
+++ b/code/_macros.dm
@@ -38,6 +38,15 @@
 
 #define random_id(key,min_id,max_id) uniqueness_repository.Generate(/datum/uniqueness_generator/id_random, key, min_id, max_id)
 
+
+/// Given a hexadeximal text, returns the corresponding integer
+#define hex2num(hex) (text2num(hex, 16) || 0)
+
+
+/// Given an integer number, returns a hexadecimal representation
+#define num2hex(num) num2text(num, 1, 16)
+
+
 #define ARGS_DEBUG log_debug("[__FILE__] - [__LINE__]") ; for(var/arg in args) { log_debug("\t[log_info_line(arg)]") }
 
 #define WORLD_ICON_SIZE 32 //Needed for the R-UST port

--- a/code/controllers/emergency_shuttle_controller.dm
+++ b/code/controllers/emergency_shuttle_controller.dm
@@ -228,14 +228,14 @@ var/global/datum/emergency_shuttle_controller/emergency_shuttle = new
 	if (online())
 		if (shuttle.has_arrive_time())
 			var/timeleft = emergency_shuttle.estimate_arrival_time()
-			return "ETA-[(timeleft / 60) % 60]:[add_zero(num2text(timeleft % 60), 2)]"
+			return "ETA-[(timeleft / 60) % 60]:[pad_left(num2text(timeleft % 60), 2, "0")]"
 
 		if (waiting_to_leave())
 			if (shuttle.moving_status == SHUTTLE_WARMUP)
 				return "Departing..."
 
 			var/timeleft = emergency_shuttle.estimate_launch_time()
-			return "ETD-[(timeleft / 60) % 60]:[add_zero(num2text(timeleft % 60), 2)]"
+			return "ETD-[(timeleft / 60) % 60]:[pad_left(num2text(timeleft % 60), 2, "0")]"
 
 	return ""
 /*

--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -416,7 +416,8 @@ var/global/list/PDA_Manifest = list()
 	return
 
 /proc/generate_record_id()
-	return add_zero(num2hex(rand(1, 65535)), 4)	//no point generating higher numbers because of the limitations of num2hex
+	return "000[random_hex_text(3, TRUE)]"
+
 
 /datum/datacore/proc/CreateGeneralRecord(var/mob/living/carbon/human/H, var/id, var/hidden)
 	ResetPDAManifest()
@@ -431,7 +432,7 @@ var/global/list/PDA_Manifest = list()
 		side = icon('html/images/no_image32.png')
 
 	if(!id)
-		id = text("[]", add_zero(num2hex(rand(1, 65536)), 4))
+		id = generate_record_id()
 	var/datum/data/record/G = new /datum/data/record()
 	G.name = "Employee Record #[id]"
 	G.fields["name"] = "New Record"

--- a/code/game/dna/dna2.dm
+++ b/code/game/dna/dna2.dm
@@ -328,8 +328,8 @@ var/global/list/datum/dna/gene/dna_genes[0]
 	SetSEBlock(block,newBlock,defer)
 
 
-/proc/EncodeDNABlock(var/value)
-	return add_zero2(num2hex(value,1), 3)
+/proc/EncodeDNABlock(value)
+	return pad_left(num2hex(value), 3, "0")
 
 /datum/dna/proc/UpdateUI()
 	src.uni_identity=""

--- a/code/game/dna/dna2_helpers.dm
+++ b/code/game/dna/dna2_helpers.dm
@@ -2,15 +2,6 @@
 // Helpers for DNA2
 /////////////////////////////
 
-// Pads 0s to t until length == u
-/proc/add_zero2(t, u)
-	var/temp1
-	while (length(t) < u)
-		t = "0[t]"
-	temp1 = t
-	if (length(t) > u)
-		temp1 = copytext(t,2,u+1)
-	return temp1
 
 // DNA Gene activation boundaries, see dna2.dm.
 // Returns a list object with 4 numbers.

--- a/code/game/machinery/computer/guestpass.dm
+++ b/code/game/machinery/computer/guestpass.dm
@@ -224,7 +224,7 @@
 
 			if ("issue")
 				if (giver)
-					var/number = add_zero("[rand(0,9999)]", 4)
+					var/number = pad_left("[rand(1, 9999)]", 4, "0")
 					var/entry = "\[[stationtime2text()]\] Pass #[number] issued by [giver.registered_name] ([giver.assignment]) to [giv_name]. Reason: [reason]. Grants access to following areas: "
 					for (var/i=1 to accesses.len)
 						var/A = accesses[i]

--- a/code/game/machinery/status_display.dm
+++ b/code/game/machinery/status_display.dm
@@ -210,7 +210,7 @@
 	var/timeleft = emergency_shuttle.estimate_arrival_time()
 	if(timeleft < 0)
 		return ""
-	return "[add_zero(num2text((timeleft / 60) % 60),2)]:[add_zero(num2text(timeleft % 60), 2)]"
+	return "[pad_left(num2text(timeleft / 60 % 60), 2, "0")]:[pad_left(num2text(timeleft % 60), 2, "0")]"
 
 /obj/machinery/status_display/proc/get_shuttle_timer_departure()
 	if(!emergency_shuttle)
@@ -218,7 +218,7 @@
 	var/timeleft = emergency_shuttle.estimate_launch_time()
 	if(timeleft < 0)
 		return ""
-	return "[add_zero(num2text((timeleft / 60) % 60),2)]:[add_zero(num2text(timeleft % 60), 2)]"
+	return "[pad_left(num2text(timeleft / 60 % 60), 2, "0")]:[pad_left(num2text(timeleft % 60), 2, "0")]"
 
 /obj/machinery/status_display/proc/get_supply_shuttle_timer()
 	var/datum/shuttle/autodock/ferry/supply/shuttle = SSsupply.shuttle
@@ -229,7 +229,7 @@
 		var/timeleft = round((shuttle.arrive_time - world.time) / 10,1)
 		if(timeleft < 0)
 			return "Late"
-		return "[add_zero(num2text((timeleft / 60) % 60),2)]:[add_zero(num2text(timeleft % 60), 2)]"
+		return "[pad_left(num2text(timeleft / 60 % 60), 2, "0")]:[pad_left(num2text(timeleft % 60), 2, "0")]"
 	return ""
 
 /obj/machinery/status_display/proc/remove_display()

--- a/code/modules/admin/player_panel.dm
+++ b/code/modules/admin/player_panel.dm
@@ -393,11 +393,11 @@
 		else
 			if (emergency_shuttle.wait_for_launch)
 				var/timeleft = emergency_shuttle.estimate_launch_time()
-				dat += "ETL: <a href='?src=\ref[src];edit_shuttle_time=1'>[(timeleft / 60) % 60]:[add_zero(num2text(timeleft % 60), 2)]</a><BR>"
+				dat += "ETL: <a href='?src=\ref[src];edit_shuttle_time=1'>[(timeleft / 60) % 60]:[pad_left(num2text(timeleft % 60), 2, "0")]</a><BR>"
 
 			else if (emergency_shuttle.shuttle.has_arrive_time())
 				var/timeleft = emergency_shuttle.estimate_arrival_time()
-				dat += "ETA: <a href='?src=\ref[src];edit_shuttle_time=1'>[(timeleft / 60) % 60]:[add_zero(num2text(timeleft % 60), 2)]</a><BR>"
+				dat += "ETA: <a href='?src=\ref[src];edit_shuttle_time=1'>[(timeleft / 60) % 60]:[pad_left(num2text(timeleft % 60), 2, "0")]</a><BR>"
 				dat += "<a href='?src=\ref[src];call_shuttle=2'>Send Back</a><br>"
 
 			if (emergency_shuttle.shuttle.moving_status == SHUTTLE_WARMUP)

--- a/code/modules/events/money_hacker.dm
+++ b/code/modules/events/money_hacker.dm
@@ -52,7 +52,7 @@ GLOBAL_VAR_INIT(account_hack_attempted, 0)
 		var/date2 = "[num2text(rand(1,31))] [pick("January","February","March","April","May","June","July","August","September","October","November","December")], [rand(1000,3000)]"
 		T.date = pick("", current_date_string, date1, date2)
 		var/time1 = rand(0, 99999999)
-		var/time2 = "[round(time1 / 36000)+12]:[(time1 / 600 % 60) < 10 ? add_zero(time1 / 600 % 60, 1) : time1 / 600 % 60]"
+		var/time2 = "[round(time1 / 36000)+12]:[(time1 / 600 % 60) < 10 ? pad_left("[time1 / 600 % 60]", 2, "0") : time1 / 600 % 60]"
 		T.time = pick("", stationtime2text(), time2)
 		T.source_terminal = pick("","[pick("Biesel","New Gibson")] GalaxyNet Terminal #[rand(111,999)]","your mums place","nantrasen high CommanD")
 

--- a/code/modules/gamemaster/event2/events/command/money_hacker.dm
+++ b/code/modules/gamemaster/event2/events/command/money_hacker.dm
@@ -103,7 +103,7 @@
 	T.date = pick("", current_date_string, date1, date2,"Nowhen")
 
 	var/time1 = rand(0, 99999999)
-	var/time2 = "[round(time1 / 36000)+12]:[(time1 / 600 % 60) < 10 ? add_zero(time1 / 600 % 60, 1) : time1 / 600 % 60]"
+	var/time2 = "[round(time1 / 36000)+12]:[(time1 / 600 % 60) < 10 ? pad_left("[time1 / 600 % 60]", 2, "0") : time1 / 600 % 60]"
 	T.time = pick("", stationtime2text(), time2, "Never")
 
 	T.source_terminal = pick("","[pick("Biesel","New Gibson")] GalaxyNet Terminal #[rand(111,999)]","your mums place","nantrasen high CommanD","Angessa's Pearl","Nowhere")

--- a/code/modules/hydroponics/seed_controller.dm
+++ b/code/modules/hydroponics/seed_controller.dm
@@ -97,11 +97,10 @@ var/global/datum/controller/plants/plant_controller // Set in New().
 	var/list/plant_traits = ALL_GENES
 	while(plant_traits && plant_traits.len)
 		var/gene_tag = pick(plant_traits)
-		var/gene_mask = "[uppertext(num2hex(rand(0,255), 2))]"
-
-		while(gene_mask in used_masks)
-			gene_mask = "[uppertext(num2hex(rand(0,255), 2))]"
-
+		var/gene_mask
+		do
+			gene_mask = random_hex_text(2, TRUE)
+		while (gene_mask in used_masks)
 		var/decl/plantgene/G
 
 		for(var/D in gene_datums)

--- a/code/modules/mob/living/carbon/human/species/species_shapeshift.dm
+++ b/code/modules/mob/living/carbon/human/species/species_shapeshift.dm
@@ -322,7 +322,7 @@ var/list/wrapped_species_by_ref = list()
 
 /mob/living/carbon/human/proc/shapeshifter_set_eye_color(var/new_eyes)
 	
-	var/list/new_color_rgb_list = hex2rgb(new_eyes)
+	var/list/new_color_rgb_list = rgb2num(new_eyes)
 	// First, update mob vars.
 	r_eyes = new_color_rgb_list[1]
 	g_eyes = new_color_rgb_list[2]

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -938,7 +938,7 @@
 			var/B = 0
 
 			for(var/C in colors_to_blend)
-				var/RGB = hex2rgb(C)
+				var/RGB = rgb2num(C)
 				R = between(0, R + RGB[1], 255)
 				G = between(0, G + RGB[2], 255)
 				B = between(0, B + RGB[3], 255)

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -133,7 +133,7 @@
 /mob/living/silicon/pai/proc/show_silenced()
 	if(src.silence_time)
 		var/timeleft = round((silence_time - world.timeofday)/10 ,1)
-		stat(null, "Communications system reboot in -[(timeleft / 60) % 60]:[add_zero(num2text(timeleft % 60), 2)]")
+		stat(null, "Communications system reboot in -[(timeleft / 60) % 60]:[pad_left(num2text(timeleft % 60), 2, "0")]")
 
 
 /mob/living/silicon/pai/Stat()

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -86,13 +86,6 @@
 	return check_rights(R_ADMIN|R_EVENT, 0, user) != 0
 
 
-/proc/hsl2rgb(h, s, l)
-	return //TODO: Implement
-
-/*
-	Miss Chance
-*/
-
 /proc/check_zone(zone)
 	if(!zone)	return BP_TORSO
 	switch(zone)

--- a/code/modules/organs/internal/eyes.dm
+++ b/code/modules/organs/internal/eyes.dm
@@ -40,7 +40,7 @@
 	var/new_color = input("Pick a new color for your eyes.","Eye Color", current_color) as null|color
 	if(new_color && owner)
 		// input() supplies us with a hex color, which we can't use, so we convert it to rbg values.
-		var/list/new_color_rgb_list = hex2rgb(new_color)
+		var/list/new_color_rgb_list = rgb2num(new_color)
 		// First, update mob vars.
 		owner.r_eyes = new_color_rgb_list[1]
 		owner.g_eyes = new_color_rgb_list[2]

--- a/code/modules/planet/sif.dm
+++ b/code/modules/planet/sif.dm
@@ -81,12 +81,12 @@ var/datum/planet/sif/planet_sif = null
 	if(weather_holder && weather_holder.current_weather && weather_holder.current_weather.light_color)
 		new_color = weather_holder.current_weather.light_color
 	else
-		var/list/low_color_list = hex2rgb(low_color)
+		var/list/low_color_list = rgb2num(low_color)
 		var/low_r = low_color_list[1]
 		var/low_g = low_color_list[2]
 		var/low_b = low_color_list[3]
 
-		var/list/high_color_list = hex2rgb(high_color)
+		var/list/high_color_list = rgb2num(high_color)
 		var/high_r = high_color_list[1]
 		var/high_g = high_color_list[2]
 		var/high_b = high_color_list[3]

--- a/code/modules/shieldgen/directional_shield.dm
+++ b/code/modules/shieldgen/directional_shield.dm
@@ -158,12 +158,12 @@
 	// This is done at the projector instead of the shields themselves to avoid needing to calculate this more than once every update.
 	var/interpolate_weight = shield_health / max_shield_health
 
-	var/list/low_color_list = hex2rgb(low_color)
+	var/list/low_color_list = rgb2num(low_color)
 	var/low_r = low_color_list[1]
 	var/low_g = low_color_list[2]
 	var/low_b = low_color_list[3]
 
-	var/list/high_color_list = hex2rgb(high_color)
+	var/list/high_color_list = rgb2num(high_color)
 	var/high_r = high_color_list[1]
 	var/high_g = high_color_list[2]
 	var/high_b = high_color_list[3]

--- a/code/modules/tgui/modules/communications.dm
+++ b/code/modules/tgui/modules/communications.dm
@@ -152,7 +152,7 @@
 	if(emergency_shuttle.has_eta())
 		var/timeleft = emergency_shuttle.estimate_arrival_time()
 		data["esc_status"] = emergency_shuttle.online() ? "ETA:" : "RECALLING:"
-		data["esc_status"] += " [timeleft / 60 % 60]:[add_zero(num2text(timeleft % 60), 2)]"
+		data["esc_status"] += " [timeleft / 60 % 60]:[pad_left(num2text(timeleft % 60), 2, "0")]"
 	return data
 
 /datum/tgui_module/communications/proc/setCurrentMessage(mob/user, value)

--- a/code/modules/virus2/disease2.dm
+++ b/code/modules/virus2/disease2.dm
@@ -14,7 +14,7 @@
 	var/resistance = 10 // % chance a disease will resist cure, up to 100
 
 /datum/disease2/disease/New()
-	uniqueID = rand(0,10000)
+	uniqueID = rand(1, 9999)
 	..()
 
 /datum/disease2/disease/proc/makerandom(var/severity=1)
@@ -25,7 +25,7 @@
 		holder.getrandomeffect(severity, excludetypes)
 		excludetypes += holder.effect.type
 		effects += holder
-	uniqueID = rand(0,10000)
+	uniqueID = rand(1, 9999)
 	switch(severity)
 		if(1)
 			infectionchance = 1
@@ -135,13 +135,13 @@
 	BITSET(mob.hud_updateflag, STATUS_HUD)
 
 /datum/disease2/disease/proc/minormutate()
-	//uniqueID = rand(0,10000)
+	//uniqueID = rand(1, 9999)
 	var/datum/disease2/effectholder/holder = pick(effects)
 	holder.minormutate()
 	//infectionchance = min(50,infectionchance + rand(0,10))
 
 /datum/disease2/disease/proc/majormutate()
-	uniqueID = rand(0,10000)
+	uniqueID = rand(1, 9999)
 	var/datum/disease2/effectholder/holder = pick(effects)
 	var/list/exclude = list()
 	for(var/datum/disease2/effectholder/D in effects)
@@ -208,7 +208,7 @@
 var/global/list/virusDB = list()
 
 /datum/disease2/disease/proc/name()
-	.= "stamm #[add_zero("[uniqueID]", 4)]"
+	.= "stamm #[pad_left(uniqueID, 8, "0")]"
 	if ("[uniqueID]" in virusDB)
 		var/datum/data/record/V = virusDB["[uniqueID]"]
 		.= V.fields["name"]

--- a/code/modules/xenobio2/controller.dm
+++ b/code/modules/xenobio2/controller.dm
@@ -34,11 +34,10 @@ var/global/datum/controller/xenobio/xenobio_controller // Set in New().
 	var/list/xenobio_traits = ALL_XENO_GENES
 	while(xenobio_traits && xenobio_traits.len)
 		var/gene_tag = pick(xenobio_traits)
-		var/gene_mask = "[uppertext(num2hex(rand(0,255), 2))]"
-
-		while(gene_mask in used_masks)
-			gene_mask = "[uppertext(num2hex(rand(0,255), 2))]"
-
+		var/gene_mask
+		do
+			gene_mask = random_hex_text(2, TRUE)
+		while (gene_mask in used_masks)
 		used_masks += gene_mask
 		xenobio_traits -= gene_tag
 		gene_tag_masks[gene_tag] = gene_mask


### PR DESCRIPTION
NB: Will need rebase after #8472 but is based on it for appropriate test runs

NUFC

removed add_lspace — unused
removed add_tspace — unused
removed invertHTML — unused
removed hsl2rgb — unimplemented

removed hex2num — replaced with define
removed num2hex — replaced with define
removed add_zero — replaced with pad_left
removed add_zero2 — replaced with pad_left
removes hex2rgb — replaced with behavior of rgb2num()
removes hex2rgb_r — replaced with behavior of rgb2num()
removes hex2rgb_g — replaced with behavior of rgb2num()
removes hex2rgb_b — replaced with behavior of rgb2num()
removes assorted inline list(rgb) > hex — replaced with behavior of rgb()
removes assorted inline rand > hex — replace with random_hex_text

added hex2num define
added num2hex define
added random_hex_text
added generate_padding
added pad_left
added pad_right