### PR TITLE
isatom as istype /atom  -->  isloc && !isarea

### DIFF
--- a/code/__defines/is_helpers.dm
+++ b/code/__defines/is_helpers.dm
@@ -5,7 +5,7 @@
 //#define islist(D)		istype(D, /list)	//Built in
 
 //---------------
-#define isatom(D)		istype(D, /atom)
+#define isatom(D) (isloc(D) && !isarea(D))
 #define isclient(D)		istype(D, /client)
 
 //---------------


### PR DESCRIPTION
<https://github.com/Baystation12/Baystation12/pull/31809>

`istype(thing, /atom)` is one of the slower strategies for determining if thing is an atom; replaces isatom macro body with the type equivalent `(isloc(thing) && !isarea(thing))`
