### PR TITLE
cleans up atom/movable/Destroy + adds walk(src, 0)

### DIFF
--- a/code/datums/orbit.dm
+++ b/code/datums/orbit.dm
@@ -115,10 +115,6 @@
 			if (O.orbiter)
 				O.orbiter.stop_orbit()
 
-/atom/movable/Destroy(force = FALSE)
-	. = ..()
-	if (orbiting)
-		stop_orbit()
 
 /*
 /atom/movable/proc/transfer_observers_to(atom/movable/target)

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -30,24 +30,30 @@
 	var/cloaked = FALSE //If we're cloaked or not
 	var/image/cloaked_selfimage //The image we use for our client to let them see where we are
 
+
 /atom/movable/Destroy()
-	. = ..()
-	if(reagents)
+	if (reagents)
 		qdel(reagents)
 		reagents = null
-	for(var/atom/movable/AM in contents)
-		qdel(AM)
-	var/turf/un_opaque
-	if(opacity && isturf(loc))
-		un_opaque = loc
-
+	walk(src, 0)
+	for (var/atom/movable/movable in contents)
+		qdel(movable)
+	if (orbiting)
+		stop_orbit()
+	var/turf/origin
+	if (opacity && isturf(loc))
+		origin = loc
+	unbuckle_all_mobs()
 	moveToNullspace()
-	if(un_opaque)
-		un_opaque.recalc_atom_opacity()
+	if (origin)
+		origin.recalc_atom_opacity()
+		origin.reconsider_lights()
 	if (pulledby)
 		if (pulledby.pulling == src)
 			pulledby.pulling = null
 		pulledby = null
+	return ..()
+
 
 /atom/movable/vv_edit_var(var_name, var_value)
 	if(var_name in GLOB.VVpixelmovement)			//Pixel movement is not yet implemented, changing this will break everything irreversibly.

--- a/code/game/gamemodes/events/clang.dm
+++ b/code/game/gamemodes/events/clang.dm
@@ -41,9 +41,6 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 	if(clong && prob(25))
 		src.loc = clong.loc
 
-/obj/effect/immovablerod/Destroy()
-	walk(src, 0) // Because we might have called walk_towards, we must stop the walk loop or BYOND keeps an internal reference to us forever.
-	return ..()
 
 /proc/immovablerod()
 	var/startx = 0

--- a/code/game/gamemodes/events/dust.dm
+++ b/code/game/gamemodes/events/dust.dm
@@ -81,9 +81,6 @@ The "dust" will damage the hull of the station causin minor hull breaches.
 	strength = 1
 	life = 40
 
-/obj/effect/space_dust/Destroy()
-	walk(src, 0) // Because we might have called walk_towards, we must stop the walk loop or BYOND keeps an internal reference to us forever.
-	return ..()
 
 /obj/effect/space_dust/touch_map_edge()
 	qdel(src)

--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -42,10 +42,6 @@
 /atom/movable/proc/has_buckled_mobs()
 	return LAZYLEN(buckled_mobs)
 
-/atom/movable/Destroy()
-	unbuckle_all_mobs()
-	return ..()
-
 
 /atom/movable/proc/buckle_mob(mob/living/M, forced = FALSE, check_loc = TRUE)
 	if(check_loc && M.loc != loc)

--- a/code/game/objects/effects/chem/chemsmoke.dm
+++ b/code/game/objects/effects/chem/chemsmoke.dm
@@ -12,9 +12,6 @@
 	create_reagents(500)
 	return
 
-/obj/effect/vfx/smoke/chem/Destroy()
-	walk(src, 0) // Because we might have called walk_to, we must stop the walk loop or BYOND keeps an internal reference to us forever.
-	return ..()
 
 /obj/effect/vfx/smoke/chem/transparent
 	opacity = FALSE

--- a/code/game/objects/effects/spiders.dm
+++ b/code/game/objects/effects/spiders.dm
@@ -163,7 +163,6 @@
 
 /obj/effect/spider/spiderling/Destroy()
 	STOP_PROCESSING(SSobj, src)
-	walk(src, 0) // Because we might have called walk_to, we must stop the walk loop or BYOND keeps an internal reference to us forever.
 	return ..()
 
 /obj/effect/spider/spiderling/Bump(atom/user)

--- a/code/game/objects/items/weapons/grenades/flashbang.dm
+++ b/code/game/objects/items/weapons/grenades/flashbang.dm
@@ -93,10 +93,6 @@
 	else if(M.ear_damage >= 5)
 		to_chat(M, "<span class='danger'>Your ears start to ring!</span>")
 
-/obj/item/weapon/grenade/flashbang/Destroy()
-	walk(src, 0) // Because we might have called walk_away, we must stop the walk loop or BYOND keeps an internal reference to us forever.
-	return ..()
-
 
 /obj/item/weapon/grenade/flashbang/clusterbang//Created by Polymorph, fixed by Sieve
 	desc = "Use of this weapon may constiute a war crime in your area, consult your local Site Manager."

--- a/code/modules/lighting/lighting_atom.dm
+++ b/code/modules/lighting/lighting_atom.dm
@@ -59,11 +59,6 @@
 		light = null
 	return ..()
 
-/atom/movable/Destroy()
-	var/turf/T = loc
-	if(opacity && istype(T))
-		T.reconsider_lights()
-	return ..()
 
 /atom/movable/Moved(atom/old_loc, direction, forced = FALSE)
 	. = ..()


### PR DESCRIPTION
atom/movable/Destroy had several overrides with a non-specific run order. Unified their behavior into a single signature, as is appropriate for Destroy.

Also adds walk(src, 0) to atom/movable/Destroy, and removes it from other Destroys where appropriate. This removes the burden of trying to manage whether a type has secret hidden walk refs or not by just clearing them for everything.