### PR TITLE
adds material armor crafting recipes

### DIFF
--- a/code/datums/components/crafting/crafting.dm
+++ b/code/datums/components/crafting/crafting.dm
@@ -301,6 +301,8 @@
 				// If we need to consume some amount of it
 				if(amt > 0)
 					var/datum/reagent/RG = RC.reagents.get_reagent(id)
+					if (!istype (RG))
+						continue
 					var/A = min(RG.volume, amt)
 					RC.reagents.remove_reagent(id, A)
 					amt -= A

--- a/code/datums/components/crafting/recipes.dm
+++ b/code/datums/components/crafting/recipes.dm
@@ -93,3 +93,63 @@
 	var/obj/item/weapon/material/twohanded/spear/S = result
 	S.set_material(M.material.name)
 	qdel(M)
+
+
+/datum/crafting_recipe/material_armor
+	name = "Material Armor Plate"
+	result = /obj/item/clothing/accessory/material/advanced
+	reqs = list(
+		list(/obj/item/weapon/material/armor_plating/insert = 1),
+		list(/datum/reagent/toxin/plasticide = 5),
+		list(/datum/reagent/glycerol = 10),
+		list(/datum/reagent/silicon = 10)
+	)
+	parts = list(
+		/obj/item/weapon/material/armor_plating/insert = 1
+	)
+	machinery = list(
+		/obj/machinery/r_n_d/protolathe = CRAFTING_MACHINERY_USE
+	)
+	always_available = FALSE
+	time = 80
+	category = CAT_CLOTHING
+
+
+/datum/crafting_recipe/material_armor/chestplate
+	name = "Material armor plate"
+	result = /obj/item/clothing/accessory/material/advanced
+	always_available = TRUE
+
+
+/datum/crafting_recipe/material_armor/legguards
+	name = "Material armor arm-guards"
+	result = /obj/item/clothing/accessory/material/advanced/armguards
+	reqs = list(
+		list(/obj/item/weapon/material/armor_plating/insert = 1),
+		list(/datum/reagent/toxin/plasticide = 5),
+		list(/datum/reagent/glycerol = 10),
+		list(/datum/reagent/silicon = 10)
+	)
+	always_available = TRUE
+
+
+/datum/crafting_recipe/material_armor/armguards
+	name = "Material armor leg-guards"
+	result = /obj/item/clothing/accessory/material/advanced/legguards
+	reqs = list(
+		list(/obj/item/weapon/material/armor_plating/insert = 1),
+		list(/datum/reagent/toxin/plasticide = 5),
+		list(/datum/reagent/glycerol = 10),
+		list(/datum/reagent/silicon = 10)
+	)
+	always_available = TRUE
+
+
+/datum/crafting_recipe/material_armor/on_craft_completion(mob/user, obj/item/clothing/result)
+	var/obj/item/weapon/material/armor_plating/insert/insert = locate() in result
+	var/material_name = insert?.material?.name
+	if (!material_name)
+		qdel(result)
+		return
+	result.set_material(material_name)
+	qdel(insert)

--- a/code/game/objects/items/weapons/material/material_armor.dm
+++ b/code/game/objects/items/weapons/material/material_armor.dm
@@ -230,16 +230,47 @@ Protectiveness | Armor %
 	material_slowdown_modifier = 0
 	material_slowdown_multiplier = 0.5
 
-/obj/item/clothing/accessory/material/custom //Not yet craftable, advanced version made with science!
+
+/obj/item/clothing/accessory/material/advanced
 	name = "custom armor plate"
 	desc = "A composite plate of custom machined material, designed to fit into a plate carrier. Attaches to a plate carrier."
 	icon = 'icons/obj/clothing/modular_armor.dmi'
+	description_info = "This armoured plate has been custom machined out of a piece of material. It is backed by a shear-hardening gel layer, allowing the whole piece to flex and conform to the wearer's body shape. If it was made using strong materials it could be very protective."
 	icon_state = "armor_tactical"
-	body_parts_covered = UPPER_TORSO|LOWER_TORSO
+	body_parts_covered = UPPER_TORSO | LOWER_TORSO
 	slot = ACCESSORY_SLOT_ARMOR_C
 	material_armor_modifier = 1.2
 	material_slowdown_modifier = 0.5
 	material_slowdown_multiplier = 0.4
+
+
+/obj/item/clothing/accessory/material/advanced/armguards
+	name = "arm guards"
+	desc = "A pair of arm pads reinforced with material. Attaches to a plate carrier."
+	icon = 'icons/obj/clothing/modular_armor.dmi'
+	icon_override = 'icons/mob/modular_armor.dmi'
+	icon_state = "armguards_material"
+	gender = PLURAL
+	body_parts_covered = ARMS
+	slot = ACCESSORY_SLOT_ARMOR_A
+	material_armor_modifier = 1.1
+	material_slowdown_modifier = 1
+	material_slowdown_multiplier = 0.4
+
+
+/obj/item/clothing/accessory/material/advanced/legguards
+	name = "leg guards"
+	desc = "A pair of leg guards reinforced with material. Attaches to a plate carrier."
+	icon = 'icons/obj/clothing/modular_armor.dmi'
+	icon_override = 'icons/mob/modular_armor.dmi'
+	icon_state = "legguards_material"
+	gender = PLURAL
+	body_parts_covered = LEGS
+	slot = ACCESSORY_SLOT_ARMOR_L
+	material_armor_modifier = 1.1
+	material_slowdown_modifier = 1
+	material_slowdown_multiplier = 0.4
+
 
 /obj/item/clothing/accessory/material/makeshift/armguards
 	name = "arm guards"
@@ -290,7 +321,7 @@ Protectiveness | Armor %
 	unbreakable = FALSE
 	name = "plate insert"
 	desc = "used to craft armor plates for a plate carrier. Trim with a welder for light armor or add a second for heavy armor"
-	
+
 /obj/item/weapon/material/armor_plating/attackby(var/obj/O, mob/user)
 	if(istype(O, /obj/item/stack/cable_coil))
 		var/obj/item/stack/cable_coil/S = O


### PR DESCRIPTION
:cl: Fenodyree
tweak - Added craftable material plates for plate carriers.
/:cl:

alt / closes #8320

Minor differences to make the code sane - The main plate option only takes one insert and doesn't do the crazy spear loop. This is so that you can't cheat by supplying one great insert and one crappy insert in a specific order.