### PR TITLE
Another round of map tweaks/fixes

### DIFF
--- a/maps/cynosure/cynosure-1.dmm
+++ b/maps/cynosure/cynosure-1.dmm
@@ -9167,6 +9167,9 @@
 "tC" = (
 /obj/structure/ladder/up,
 /obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/sign/level/basement{
+	pixel_x = 32
+	},
 /turf/simulated/floor/plating,
 /area/surface/station/maintenance/engineering/north)
 "tE" = (

--- a/maps/cynosure/cynosure-2.dmm
+++ b/maps/cynosure/cynosure-2.dmm
@@ -13612,6 +13612,10 @@
 /obj/item/weapon/storage/box/donkpockets,
 /obj/item/weapon/reagent_containers/glass/beaker,
 /obj/item/weapon/reagent_containers/food/condiment/enzyme,
+/obj/item/weapon/reagent_containers/food/condiment/soysauce{
+	pixel_x = 10;
+	pixel_y = 4
+	},
 /turf/simulated/floor/tiled/eris/cafe,
 /area/surface/station/crew_quarters/kitchen)
 "gnA" = (
@@ -30730,6 +30734,14 @@
 	},
 /obj/item/weapon/reagent_containers/food/condiment/small/saltshaker{
 	pixel_x = 2
+	},
+/obj/item/weapon/reagent_containers/food/condiment/ketchup{
+	pixel_x = 10;
+	pixel_y = 7
+	},
+/obj/item/weapon/reagent_containers/food/condiment/mustard{
+	pixel_x = -11;
+	pixel_y = 7
 	},
 /turf/simulated/floor/tiled/eris/cafe,
 /area/surface/station/crew_quarters/kitchen)

--- a/maps/cynosure/cynosure-2.dmm
+++ b/maps/cynosure/cynosure-2.dmm
@@ -36954,6 +36954,9 @@
 	icon_state = "1-2"
 	},
 /obj/effect/catwalk_plated,
+/obj/machinery/computer/secure_data{
+	dir = 1
+	},
 /turf/simulated/floor/plating,
 /area/surface/station/security/lobby)
 "qDs" = (

--- a/maps/cynosure/cynosure-3.dmm
+++ b/maps/cynosure/cynosure-3.dmm
@@ -22371,10 +22371,13 @@
 /turf/simulated/floor/tiled,
 /area/surface/station/hallway/secondary/secondfloor/command)
 "oAJ" = (
-/obj/structure/closet,
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/brown/border,
 /obj/machinery/light,
+/obj/structure/table/standard,
+/obj/machinery/photocopier/faxmachine{
+	department = "Quartermaster's Office"
+	},
 /turf/simulated/floor/tiled,
 /area/surface/station/quartermaster/qm)
 "oBl" = (
@@ -25157,7 +25160,9 @@
 	icon_state = "0-2"
 	},
 /obj/structure/grille,
-/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced/polarized/full{
+	id = "captain_tint"
+	},
 /obj/machinery/status_display,
 /obj/machinery/door/blast/regular/open{
 	dir = 4;
@@ -30581,7 +30586,7 @@
 /obj/effect/floor_decal/corner/paleblue/border{
 	dir = 5
 	},
-/obj/item/weapon/reagent_containers/food/drinks/britcup,
+/obj/random/mug,
 /turf/simulated/floor/tiled/white,
 /area/surface/station/medical/office)
 "tUU" = (

--- a/maps/cynosure/cynosure-4.dmm
+++ b/maps/cynosure/cynosure-4.dmm
@@ -311,7 +311,7 @@
 /obj/machinery/turretid/lethal{
 	ailock = 1;
 	check_synth = 1;
-	control_area = "\improper Telecoms Satellite";
+	control_area = "\improper Telecomms Satellite";
 	desc = "A firewall prevents AIs from interacting with this device.";
 	name = "Telecoms lethal turret control";
 	pixel_y = 24;
@@ -3518,7 +3518,7 @@
 /obj/machinery/turretid/stun{
 	ailock = 1;
 	check_synth = 1;
-	control_area = "\improper Telecoms Foyer";
+	control_area = "\improper Telecomms Foyer";
 	desc = "A firewall prevents AIs from interacting with this device.";
 	name = "Telecoms Foyer turret control";
 	pixel_y = 24;

--- a/maps/cynosure/cynosure-6.dmm
+++ b/maps/cynosure/cynosure-6.dmm
@@ -2313,7 +2313,7 @@
 	name = "Shuttle Hatch";
 	req_access = list(13)
 	},
-/turf/simulated/shuttle/floor,
+/turf/simulated/shuttle/plating,
 /area/shuttle/supply)
 "cLJ" = (
 /obj/effect/floor_decal/steeldecal/steel_decals4,
@@ -2333,6 +2333,10 @@
 /obj/effect/floor_decal/corner/white/diagonal,
 /obj/effect/floor_decal/spline/plain{
 	dir = 4
+	},
+/obj/item/weapon/reagent_containers/food/snacks/beetsoup,
+/obj/item/weapon/reagent_containers/food/snacks/flowerchildsalad{
+	pixel_y = 9
 	},
 /turf/unsimulated/floor{
 	icon = 'icons/turf/flooring/tiles.dmi';
@@ -5553,6 +5557,21 @@
 	icon_state = "carpet"
 	},
 /area/centcom/living)
+"gza" = (
+/obj/structure/table/marble,
+/obj/effect/floor_decal/corner/white/diagonal,
+/obj/effect/floor_decal/spline/plain{
+	dir = 4
+	},
+/obj/item/weapon/reagent_containers/food/snacks/spesslaw,
+/obj/item/weapon/reagent_containers/food/snacks/crab_legs{
+	pixel_y = 11
+	},
+/turf/unsimulated/floor{
+	icon = 'icons/turf/flooring/tiles.dmi';
+	icon_state = "steel"
+	},
+/area/centcom/bar)
 "gzc" = (
 /obj/machinery/body_scanconsole{
 	dir = 4
@@ -6966,7 +6985,10 @@
 	name = "Security Processing";
 	req_access = list(1)
 	},
-/turf/space,
+/turf/unsimulated/floor{
+	icon = 'icons/turf/flooring/tiles.dmi';
+	icon_state = "dark"
+	},
 /area/centcom/security)
 "ift" = (
 /obj/machinery/door/airlock{
@@ -10521,7 +10543,9 @@
 	dir = 4;
 	id = "QMLoad"
 	},
-/turf/simulated/shuttle/floor,
+/turf/simulated/shuttle/floor{
+	outdoors = 0
+	},
 /area/shuttle/supply)
 "lUp" = (
 /obj/machinery/door/airlock/multi_tile/glass{
@@ -10837,7 +10861,9 @@
 	},
 /area/syndicate_station)
 "mpn" = (
-/turf/simulated/shuttle/floor,
+/turf/simulated/shuttle/floor{
+	outdoors = 0
+	},
 /area/shuttle/supply)
 "mpv" = (
 /obj/item/toy/chess/bishop_black,
@@ -11152,7 +11178,9 @@
 	dir = 4;
 	id = "QMLoad2"
 	},
-/turf/simulated/shuttle/floor,
+/turf/simulated/shuttle/floor{
+	outdoors = 0
+	},
 /area/shuttle/supply)
 "mHX" = (
 /obj/machinery/vending/cigarette{
@@ -12681,7 +12709,9 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/simulated/shuttle/floor,
+/turf/simulated/shuttle/floor{
+	outdoors = 0
+	},
 /area/shuttle/supply)
 "oyt" = (
 /obj/machinery/shower{
@@ -19018,7 +19048,9 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/shuttle/floor,
+/turf/simulated/shuttle/floor{
+	outdoors = 0
+	},
 /area/shuttle/supply)
 "vpD" = (
 /obj/structure/table/bench/padded,
@@ -20235,7 +20267,9 @@
 	tag_door = "supply_shuttle_hatch"
 	},
 /obj/effect/shuttle_landmark/cynosure/supply_offsite,
-/turf/simulated/shuttle/floor,
+/turf/simulated/shuttle/floor{
+	outdoors = 0
+	},
 /area/shuttle/supply)
 "wGX" = (
 /obj/structure/window/reinforced,
@@ -30777,7 +30811,7 @@ fVm
 fVm
 fVm
 cMH
-cMH
+gza
 ogY
 tKn
 lwf


### PR DESCRIPTION
- Fixed meeting room + captain office window tints
- Fixed space tile in centcom Security
- Added food to centcom cafe
- Fixed Telecomms turret controllers not controlling turrets
- Added a functional roof to the cargo shuttle
- Added security records console to security lobby, medbay style.
- Added a fax machine to the QM office (replaced the completely empty generic locker)
- Single Missed ladder sign and random-mug.
- Added soysauce, ketchup, and mustard to kitchen at roundstart.

Fixes #8415
Fixes #8440 