### PR TITLE
human/get_visible_gender applies user perspective

### DIFF
--- a/code/__defines/mobs.dm
+++ b/code/__defines/mobs.dm
@@ -443,3 +443,13 @@
 #define DEATHGASP_NO_MESSAGE "no message"
 
 #define RESIST_COOLDOWN		2 SECONDS
+
+
+/// Used by human/get_visible_gender(user, force) to return PLURAL
+#define VISIBLE_GENDER_FORCE_PLURAL 1
+
+/// Used by human/get_visible_gender(user, force) to return the mob's identifying gender
+#define VISIBLE_GENDER_FORCE_IDENTIFYING 2
+
+/// Used by human/get_visible_gender(user, force) to return the mob's biological gender
+#define VISIBLE_GENDER_FORCE_BIOLOGICAL 3

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -649,5 +649,5 @@ var/global/list/pre_init_created_atoms // atom creation ordering means some stuf
 	. = ..()
 	SEND_SIGNAL(src, COMSIG_ATOM_EXITED, AM, new_loc)
 
-/atom/proc/get_visible_gender()
+/atom/proc/get_visible_gender(mob/user, force)
 	return gender

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -76,22 +76,12 @@
 		BP_L_LEG = skip_body & EXAMINE_SKIPLEGS,
 		BP_R_LEG = skip_body & EXAMINE_SKIPLEGS)
 
-	var/datum/gender/T = gender_datums[get_visible_gender()]
-
-	if((skip_gear & EXAMINE_SKIPJUMPSUIT) && (skip_body & EXAMINE_SKIPFACE)) //big suits/masks/helmets make it hard to tell their gender
-		T = gender_datums[PLURAL]
-
-	else if(species && species.ambiguous_genders)
-		if(ishuman(user))
-			var/mob/living/carbon/human/H = user
-			if(H.species && !istype(species, H.species))
-				T = gender_datums[PLURAL]// Species with ambiguous_genders will not show their true gender upon examine if the examiner is not also the same species.
-		if(!(issilicon(user) || isobserver(user))) // Ghosts and borgs are all knowing
-			T = gender_datums[PLURAL]
-
-	if(!T)
-		// Just in case someone VVs the gender to something strange. It'll runtime anyway when it hits usages, better to CRASH() now with a helpful message.
-		CRASH("Gender datum was null; key was '[((skip_gear & EXAMINE_SKIPJUMPSUIT) && (skip_body & EXAMINE_SKIPFACE)) ? PLURAL : gender]'")
+	
+	var/gender_hidden = (skip_gear & EXAMINE_SKIPJUMPSUIT) && (skip_body & EXAMINE_SKIPFACE)
+	var/gender_key = get_visible_gender(user, gender_hidden)
+	var/datum/gender/T = gender_datums[gender_key]
+	if (!T)
+		CRASH({"Null gender datum on examine: mob="[src]",hidden="[gender_hidden]",key="[gender_key]",bio="[gender]",id="[identifying_gender]""})
 
 	var/name_ender = ""
 	if(!((skip_gear & EXAMINE_SKIPJUMPSUIT) && (skip_body & EXAMINE_SKIPFACE)))

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -849,13 +849,27 @@
 		remoteview_target = null
 		reset_view(0)
 
-/mob/living/carbon/human/get_visible_gender()
-	if(wear_suit && wear_suit.flags_inv & HIDEJUMPSUIT && ((head && head.flags_inv & HIDEMASK) || wear_mask))
-		return PLURAL //plural is the gender-neutral default
-	if(species)
-		if(species.ambiguous_genders)
-			return PLURAL // regardless of what you're wearing, your gender can't be figured out
-	return get_gender()
+
+/mob/living/carbon/human/get_visible_gender(mob/user, force)
+	switch (force)
+		if (VISIBLE_GENDER_FORCE_PLURAL)
+			return PLURAL
+		if (VISIBLE_GENDER_FORCE_IDENTIFYING)
+			return get_gender()
+		if (VISIBLE_GENDER_FORCE_BIOLOGICAL)
+			return gender
+		else
+			if ((wear_mask || (head?.flags_inv & HIDEMASK)) && (wear_suit?.flags_inv & HIDEJUMPSUIT))
+				return PLURAL
+			if (species?.ambiguous_genders && user)
+				if (ishuman(user))
+					var/mob/living/carbon/human/human = user
+					if (!istype(human.species, species))
+						return PLURAL
+				else if (!isobserver(user) && !issilicon(user))
+					return PLURAL
+			return get_gender()
+
 
 /mob/living/carbon/human/proc/increase_germ_level(n)
 	if(gloves)


### PR DESCRIPTION
:cl:
bugfix - Species with ambiguous gender can identify one another on examine again.
/:cl:

Changed the signature of atom/get_visible_gender to support human* mob use
human/get_visible_gender accepts a user and a force var
force can be used to force PLURAL, the examinee's id gender, or bio gender
human/get_visible_gender takes the examinee's clothing into account
human/get_visible_gender handles ambiguous_gender when there is a user:
- if also human*, same species gets id gender, otherwise plural
- if observer / silicon, id gender

fixes #7207