### PR TITLE
updated get_atom_on_turf

### DIFF
--- a/code/_helpers/turfs.dm
+++ b/code/_helpers/turfs.dm
@@ -1,10 +1,20 @@
-// Returns the atom sitting on the turf.
-// For example, using this on a disk, which is in a bag, on a mob, will return the mob because it's on the turf.
-/proc/get_atom_on_turf(var/atom/movable/M)
-	var/atom/mloc = M
-	while(mloc && mloc.loc && !istype(mloc.loc, /turf/))
-		mloc = mloc.loc
-	return mloc
+/**
+* Returns a best attempt at the least-nested containing movable of subject, or subject.
+* eg, if subject is an item in a bag on a mob in a locker in the world, returns the locker.
+*/
+/proc/get_atom_on_turf(atom/movable/subject)
+	var/atom/parent = subject?.loc
+	if (!parent || !ismovable(subject) || isarea(parent))
+		return subject
+	var/atom/current = subject
+	do
+		parent = current.loc
+		if (isturf(parent))
+			return current
+		current = parent
+	while (current)
+	return subject
+
 
 /proc/iswall(turf/T)
 	return (istype(T, /turf/simulated/wall) || istype(T, /turf/unsimulated/wall) || istype(T, /turf/simulated/shuttle/wall))


### PR DESCRIPTION
nufc

improves behavior of /proc/get_atom_on_turf
- accounts for bad cases (non-movable subject, subject with a bad loc)
- gently improves loop test performance