### PR TITLE
Adds Preference for Graffiti Engraving

### DIFF
--- a/code/game/turfs/simulated/floor_attackby.dm
+++ b/code/game/turfs/simulated/floor_attackby.dm
@@ -164,10 +164,3 @@
 	if(flooring)
 		return
 	attackby(T, user)
-
-/turf/simulated/floor/AltClick(mob/user)
-	if(isliving(user))
-		var/mob/living/livingUser = user
-		if(try_graffiti(livingUser, livingUser.get_active_hand()))
-			return
-	. = ..()

--- a/code/game/turfs/simulated/floor_attackby.dm
+++ b/code/game/turfs/simulated/floor_attackby.dm
@@ -9,8 +9,11 @@
 			attack_tile(C, L) // Be on help intent if you want to decon something.
 			return
 
-	if(!(C.is_screwdriver() && flooring && (flooring.flags & TURF_REMOVE_SCREWDRIVER)) && try_graffiti(user, C))
-		return
+	if(!(C.has_tool_quality(TOOL_SCREWDRIVER) && flooring && (flooring.flags & TURF_REMOVE_SCREWDRIVER)))
+		if(isliving(user))
+			var/mob/living/L = user
+			if(L.a_intent == I_HELP && L.is_preference_enabled(/datum/client_preference/engrave_graffiti))
+				try_graffiti(L, C)
 
 	if(istype(C, /obj/item/stack/tile/roofing))
 		var/expended_tile = FALSE // To track the case. If a ceiling is built in a multiz zlevel, it also necessarily roofs it against weather
@@ -161,3 +164,10 @@
 	if(flooring)
 		return
 	attackby(T, user)
+
+/turf/simulated/floor/AltClick(mob/user)
+	if(isliving(user))
+		var/mob/living/livingUser = user
+		if(try_graffiti(livingUser, livingUser.get_active_hand()))
+			return
+	. = ..()

--- a/code/game/turfs/simulated/wall_attacks.dm
+++ b/code/game/turfs/simulated/wall_attacks.dm
@@ -406,11 +406,3 @@
 
 	else if(!istype(W,/obj/item/weapon/rcd) && !istype(W, /obj/item/weapon/reagent_containers))
 		return attack_hand(user)
-
-
-/turf/simulated/wall/AltClick(mob/user)
-	if(isliving(user))
-		var/mob/living/livingUser = user
-		if(try_graffiti(livingUser, livingUser.get_active_hand()))
-			return
-	. = ..()

--- a/code/game/turfs/simulated/wall_attacks.dm
+++ b/code/game/turfs/simulated/wall_attacks.dm
@@ -131,8 +131,9 @@
 
 	user.setClickCooldown(user.get_attack_speed(W))
 
-	if(!construction_stage && try_graffiti(user, W))
-		return
+	if(!construction_stage && user.a_intent == I_HELP && user.is_preference_enabled(/datum/client_preference/engrave_graffiti))
+		if(try_graffiti(user,W))
+			return
 
 	if (!user.IsAdvancedToolUser())
 		to_chat(user, "<span class='warning'>You don't have the dexterity to do this!</span>")
@@ -407,3 +408,9 @@
 		return attack_hand(user)
 
 
+/turf/simulated/wall/AltClick(mob/user)
+	if(isliving(user))
+		var/mob/living/livingUser = user
+		if(try_graffiti(livingUser, livingUser.get_active_hand()))
+			return
+	. = ..()

--- a/code/modules/client/preference_setup/global/setting_datums.dm
+++ b/code/modules/client/preference_setup/global/setting_datums.dm
@@ -298,6 +298,13 @@ var/list/_client_preferences_by_type
 	enabled_description = "Popup New On Login"
 	disabled_description = "Do Nothing"
 
+/datum/client_preference/engrave_graffiti
+	description = "Engrave Graffiti with Sharp Objects"
+	key = "ENGRAVE_GRAFFITI"
+	enabled_by_default = TRUE
+	enabled_description = "Enabled"
+	disabled_description = "Disabled"
+
 /********************
 * Staff Preferences *
 ********************/

--- a/code/modules/client/preferences_toggle_procs.dm
+++ b/code/modules/client/preferences_toggle_procs.dm
@@ -400,7 +400,7 @@
 	toggle_preference(pref_path)
 	SScharacter_setup.queue_preferences_save(prefs)
 
-	to_chat(src, "You will now [(is_preference_enabled(/datum/client_preference/TEngraveGraffiti)) ? "engrave" : "not engrave"] graffiti.")
+	to_chat(src, "You will now [(is_preference_enabled(/datum/client_preference/engrave_graffiti)) ? "engrave" : "not engrave"] graffiti.")
 
 	feedback_add_details("admin_verb","TEngraveGraffiti")
 

--- a/code/modules/client/preferences_toggle_procs.dm
+++ b/code/modules/client/preferences_toggle_procs.dm
@@ -391,6 +391,19 @@
 
 	feedback_add_details("admin_verb","TRadioSounds")
 
+/client/verb/toggle_graffiti_engraving()
+	set name = "Toggle Graffiti Engraving"
+	set category = "Preferences"
+	set desc = "Enable/Disable engraving messages on hard surfaces with sharp objects on help intent."
+
+	var/pref_path = /datum/client_preference/engrave_graffiti
+	toggle_preference(pref_path)
+	SScharacter_setup.queue_preferences_save(prefs)
+
+	to_chat(src, "You will now [(is_preference_enabled(/datum/client_preference/TEngraveGraffiti)) ? "engrave" : "not engrave"] graffiti.")
+
+	feedback_add_details("admin_verb","TEngraveGraffiti")
+
 // Not attached to a pref datum because those are strict binary toggles
 /client/verb/toggle_examine_mode()
 	set name = "Toggle Examine Mode"


### PR DESCRIPTION
Meant to do this a while ago. Saw downstream's half-fixes and compensations for those half fixes and just... Did the sensible thing and added a toggle.

The pref is on by default.
When on, it behaves as it currently does, engraving with sharp objects on hard surfaces (floor/wall) happens on help intent.
When off, sharp object + help intent = nothing, no accidental clickies.
~~Regardless of preference, you can alt click on a hard surface (floor/wall) with a sharp object and do an engraving that way.~~

It's also extremely funny that you can engrave with syringes but that's something for another day.