### PR TITLE
Fixes Persistence Issues

### DIFF
--- a/code/modules/persistence/effects/paper.dm
+++ b/code/modules/persistence/effects/paper.dm
@@ -16,7 +16,7 @@
 		return
 	var/obj/item/weapon/paper/paper = new paper_type(creating)
 	paper.info = token["message"]
-	paper.name = token["title"]
+	paper.name = token["name"]
 	paper.last_modified_ckey = token["author"]
 	paper.age = token["age"]+1
 	if(requires_noticeboard)

--- a/code/modules/persistence/storage/smartfridge.dm
+++ b/code/modules/persistence/storage/smartfridge.dm
@@ -48,14 +48,8 @@
 
 		// Delete some stacks if we want
 		if(stacks_go_missing)
-			var/fuzzy = rand(-5,5)
-			switch(count / max_amount)
-				if(0 to 1)
-					count -= 10+fuzzy // 1 stack or less, lose 10
-				if(1 to 10)
-					count -= max_amount+fuzzy // 1 to 10 stacks, lose a stack
-				if(10 to INFINITY)
-					count -= max_amount*3+fuzzy // 10+ stacks, lose 3 stacks
+			var/fuzzy = rand(55,65)
+			count = round(count*0.01*fuzzy) // loss of 35-45% with rounding down
 			if(count <= 0)
 				continue
 

--- a/code/modules/persistence/storage/smartfridge.dm
+++ b/code/modules/persistence/storage/smartfridge.dm
@@ -16,9 +16,6 @@
 			qdel(A) // Should clean this up here, it couldn't be stocked
 
 
-
-
-
 /datum/persistent/storage/smartfridge/sheet_storage
 	name = "sheet storage"
 	max_storage = 50
@@ -61,8 +58,8 @@
 					count -= max_amount*3+fuzzy // 10+ stacks, lose 3 stacks
 			if(count <= 0)
 				continue
-		
-		while(count > 0)	
+
+		while(count > 0)
 			inst = new real_path
 			inst.amount = min(count, max_amount)
 			count -= inst.get_amount()
@@ -78,6 +75,16 @@
 /datum/persistent/storage/smartfridge/produce/lossy
 	name = "fruit storage lossy"
 	go_missing_chance = 12.5 // 10% loss between rounds
+
+/datum/persistent/storage/smartfridge/produce/generate_items(var/list/L)			// Mostly same as storage/generate_items() but without converting string to path
+	. = list()
+	for(var/fruit_type in L)
+		for(var/i in 1 to L[fruit_type])
+			if(prob(go_missing_chance))
+				continue
+			var/atom/A = create_item(fruit_type)
+			if(!QDELETED(A))
+				. += A
 
 /datum/persistent/storage/smartfridge/produce/create_item(var/seedtype)
 	return new /obj/item/weapon/reagent_containers/food/snacks/grown(null, seedtype) // Smartfridge will be stock()ed with it, loc is unimportant

--- a/code/modules/persistence/storage/smartfridge.dm
+++ b/code/modules/persistence/storage/smartfridge.dm
@@ -26,7 +26,7 @@
 
 /datum/persistent/storage/smartfridge/sheet_storage/lossy
 	name = "sheet storage lossy"
-	max_storage = 250
+	max_storage = 150
 	stacks_go_missing = TRUE
 
 /datum/persistent/storage/smartfridge/sheet_storage/generate_items(var/list/L)
@@ -62,8 +62,8 @@
 
 /datum/persistent/storage/smartfridge/produce
 	name = "fruit storage"
-	max_storage = 50
-	store_per_type = FALSE
+	max_storage = 10
+	store_per_type = TRUE
 	target_type = /obj/machinery/smartfridge/produce
 
 /datum/persistent/storage/smartfridge/produce/lossy


### PR DESCRIPTION
Fixes persistent paper/notes being utterly busted, was a misnamed tag from when it was converted to JSON format. Was loading a different tag from the one it saved and resulting in items that didn't interact good.

Produce Storage now caps per item (at a much lower rate) instead of only saving sequentially until it hit the global cap.

Replaced slightly wonky switch statement for material sheets to a flat rate (as was done downstream) on request.

Fixes #8503 
Fixes #8414