### PR TITLE
Patches runtime when update_icon() is called without a user on hats

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -497,6 +497,9 @@
 	return 1
 
 /obj/item/clothing/head/update_icon(var/mob/user)
+	if(!ismob(user))
+		return
+
 	var/mob/living/carbon/human/H
 	if(ishuman(user))
 		H = user


### PR DESCRIPTION
As promised, followup to the CI failure from #8317 