### PR TITLE
Readds SA_ANIMAL vulnerability to phase projectiles

### DIFF
--- a/code/modules/projectiles/projectile/energy.dm
+++ b/code/modules/projectiles/projectile/energy.dm
@@ -275,6 +275,7 @@
 	range = 6
 	damage = 5
 	SA_bonus_damage = 45	// 50 total on animals
+	SA_vulnerability = SA_ANIMAL
 	hud_state = "laser_heat"
 
 /obj/item/projectile/energy/phase/light


### PR DESCRIPTION
Someone did a dumb and deleted a line.

Working hunter ammo has:
```
/obj/item/projectile/bullet/rifle/a545/hunter
	damage = 15
	SA_bonus_damage = 35 // 50 total on animals.
	SA_vulnerability = SA_ANIMAL
	hud_state = "rifle_heavy"
```