### PR TITLE
Adjusts frequency of anomalies and weights effect rarity

### DIFF
--- a/code/game/objects/random/_random.dm
+++ b/code/game/objects/random/_random.dm
@@ -32,9 +32,8 @@
 		A.pixel_x = pixel_x
 		A.pixel_y = pixel_y
 		A.set_dir(dir)
-		if(start_anomalous)
-			if(prob(50))
-				A.become_anomalous()
+		if(start_anomalous && prob(50))
+			A.become_anomalous()
 
 /obj/random/drop_location()
 	return drop_get_turf ? get_turf(src) : ..()

--- a/code/game/objects/random/_random.dm
+++ b/code/game/objects/random/_random.dm
@@ -33,7 +33,8 @@
 		A.pixel_y = pixel_y
 		A.set_dir(dir)
 		if(start_anomalous)
-			A.become_anomalous()
+			if(prob(50))
+				A.become_anomalous()
 
 /obj/random/drop_location()
 	return drop_get_turf ? get_turf(src) : ..()

--- a/code/modules/shieldgen/energy_field.dm
+++ b/code/modules/shieldgen/energy_field.dm
@@ -35,8 +35,8 @@
 		if(istype(my_gen))
 			my_gen.field.Remove(src)
 			my_gen = null
-		else if(istype(my_gen, /datum/artifact_effect/forcefield))
-			var/datum/artifact_effect/forcefield/AE = my_gen
+		else if(istype(my_gen, /datum/artifact_effect/uncommon/forcefield))
+			var/datum/artifact_effect/uncommon/forcefield/AE = my_gen
 			AE.created_field.Remove(src)
 			my_gen = null
 	var/turf/current_loc = get_turf(src)

--- a/code/modules/xenoarcheaology/artifacts/predefined/hungry_statue.dm
+++ b/code/modules/xenoarcheaology/artifacts/predefined/hungry_statue.dm
@@ -8,6 +8,6 @@
 
 /datum/component/artifact_master/hungry_statue
 	make_effects = list(
-		/datum/artifact_effect/animate_anomaly,
-		/datum/artifact_effect/vampire
+		/datum/artifact_effect/common/animate_anomaly,
+		/datum/artifact_effect/rare/vampire
 	)

--- a/code/modules/xenoarcheaology/effect_master.dm
+++ b/code/modules/xenoarcheaology/effect_master.dm
@@ -138,7 +138,7 @@
 
 /datum/component/artifact_master/proc/generate_effects()
 	while(effect_generation_chance > 0)
-		var/chosen_path = pick(subtypesof(/datum/artifact_effect))
+		var/chosen_path = pick_effect()
 		if(effect_generation_chance >= 100)	// If we're above 100 percent, just cut a flat amount and add an effect.
 			var/datum/artifact_effect/AE = new chosen_path(src)
 			if(istype(holder, AE.req_type))
@@ -155,6 +155,14 @@
 			my_effects += new chosen_path(src)
 
 		effect_generation_chance = round(effect_generation_chance)
+
+/datum/component/artifact_master/proc/pick_effect()
+	return pickweight(list(
+		pick(subtypesof(/datum/artifact_effect/common)) = 50,
+		pick(subtypesof(/datum/artifact_effect/uncommon)) = 30,
+		pick(subtypesof(/datum/artifact_effect/rare)) = 17,
+		pick(subtypesof(/datum/artifact_effect/extreme)) = 3
+		))
 
 /datum/component/artifact_master/proc/get_holder()	// Returns the holder.
 	return holder

--- a/code/modules/xenoarcheaology/effects/animate_anomaly.dm
+++ b/code/modules/xenoarcheaology/effects/animate_anomaly.dm
@@ -1,5 +1,5 @@
 
-/datum/artifact_effect/animate_anomaly
+/datum/artifact_effect/common/animate_anomaly
 	name = "animate anomaly"
 	effect_type = EFFECT_PSIONIC
 	var/mob/living/target = null
@@ -7,15 +7,15 @@
 	effect_state = "pulsing"
 	effect_color = "#00c3ff"
 
-/datum/artifact_effect/animate_anomaly/ToggleActivate(var/reveal_toggle = 1)
+/datum/artifact_effect/common/animate_anomaly/ToggleActivate(var/reveal_toggle = 1)
 	..()
 	find_target()
 
-/datum/artifact_effect/animate_anomaly/New()
+/datum/artifact_effect/common/animate_anomaly/New()
 	..()
 	effectrange = max(3, effectrange)
 
-/datum/artifact_effect/animate_anomaly/proc/find_target()
+/datum/artifact_effect/common/animate_anomaly/proc/find_target()
 	var/atom/masterholder = get_master_holder()
 
 	if(!target || target.z != masterholder.z || get_dist(target, masterholder) > effectrange)
@@ -32,7 +32,7 @@
 
 		target = ClosestMob
 
-/datum/artifact_effect/animate_anomaly/DoEffectTouch(var/mob/living/user)
+/datum/artifact_effect/common/animate_anomaly/DoEffectTouch(var/mob/living/user)
 	var/atom/holder = get_master_holder()
 	var/obj/O = holder
 	var/turf/T = get_step_away(O, user)
@@ -41,7 +41,7 @@
 		O.Move(T)
 		O.visible_message("<span class='alien'>\The [holder] lurches away from [user]</span>")
 
-/datum/artifact_effect/animate_anomaly/DoEffectAura()
+/datum/artifact_effect/common/animate_anomaly/DoEffectAura()
 	var/obj/O = get_master_holder()
 	find_target()
 
@@ -55,5 +55,5 @@
 			O.Move(get_step_to(O, target))
 			O.visible_message("<span class='alien'>\The [O] lurches toward [target]</span>")
 
-/datum/artifact_effect/animate_anomaly/DoEffectPulse()
+/datum/artifact_effect/common/animate_anomaly/DoEffectPulse()
 	DoEffectAura()

--- a/code/modules/xenoarcheaology/effects/badfeeling.dm
+++ b/code/modules/xenoarcheaology/effects/badfeeling.dm
@@ -1,4 +1,4 @@
-/datum/artifact_effect/badfeeling
+/datum/artifact_effect/common/badfeeling
 	name = "badfeeling"
 	effect_type = EFFECT_PSIONIC
 	var/list/messages = list("You feel worried.",
@@ -28,7 +28,7 @@
 	effect_state = "summoning"
 	effect_color = "#643232"
 
-/datum/artifact_effect/badfeeling/DoEffectTouch(var/mob/user)
+/datum/artifact_effect/common/badfeeling/DoEffectTouch(var/mob/user)
 	if(user)
 		if (istype(user, /mob/living/carbon/human))
 			var/mob/living/carbon/human/H = user
@@ -41,7 +41,7 @@
 			if(prob(50))
 				H.dizziness += rand(3,5)
 
-/datum/artifact_effect/badfeeling/DoEffectAura()
+/datum/artifact_effect/common/badfeeling/DoEffectAura()
 	var/atom/holder = get_master_holder()
 	if(holder)
 		var/turf/T = get_turf(holder)
@@ -56,7 +56,7 @@
 				H.dizziness += rand(3,5)
 		return 1
 
-/datum/artifact_effect/badfeeling/DoEffectPulse()
+/datum/artifact_effect/common/badfeeling/DoEffectPulse()
 	var/atom/holder = get_master_holder()
 	if(holder)
 		var/turf/T = get_turf(holder)

--- a/code/modules/xenoarcheaology/effects/berserk.dm
+++ b/code/modules/xenoarcheaology/effects/berserk.dm
@@ -1,11 +1,11 @@
-/datum/artifact_effect/berserk
+/datum/artifact_effect/uncommon/berserk
 	name = "berserk"
 	effect_type = EFFECT_PSIONIC
 
 	effect_state = "summoning"
 	effect_color = "#5f0000"
 
-/datum/artifact_effect/berserk/proc/apply_berserk(var/mob/living/L)
+/datum/artifact_effect/uncommon/berserk/proc/apply_berserk(var/mob/living/L)
 	if(!istype(L))
 		return FALSE
 
@@ -25,12 +25,12 @@
 			it quickly passes.</span>")
 		return FALSE
 
-/datum/artifact_effect/berserk/DoEffectTouch(var/mob/toucher)
+/datum/artifact_effect/uncommon/berserk/DoEffectTouch(var/mob/toucher)
 	if(toucher && isliving(toucher))
 		apply_berserk(toucher)
 		return TRUE
 
-/datum/artifact_effect/berserk/DoEffectAura()
+/datum/artifact_effect/uncommon/berserk/DoEffectAura()
 	var/atom/holder = get_master_holder()
 	if(holder)
 		var/turf/T = get_turf(holder)
@@ -39,7 +39,7 @@
 				apply_berserk(L)
 		return TRUE
 
-/datum/artifact_effect/berserk/DoEffectPulse()
+/datum/artifact_effect/uncommon/berserk/DoEffectPulse()
 	var/atom/holder = get_master_holder()
 	if(holder)
 		var/turf/T = get_turf(holder)

--- a/code/modules/xenoarcheaology/effects/cannibal.dm
+++ b/code/modules/xenoarcheaology/effects/cannibal.dm
@@ -1,4 +1,4 @@
-/datum/artifact_effect/cannibalfeeling
+/datum/artifact_effect/uncommon/cannibalfeeling
 	name = "cannibalfeeling"
 	effect_type = EFFECT_PSIONIC
 	var/list/messages = list("You feel peckish.",
@@ -28,7 +28,7 @@
 	effect_state = "summoning"
 	effect_color = "#c50303"
 
-/datum/artifact_effect/cannibalfeeling/DoEffectTouch(var/mob/user)
+/datum/artifact_effect/uncommon/cannibalfeeling/DoEffectTouch(var/mob/user)
 	if(user)
 		if (istype(user, /mob/living/carbon/human))
 			var/mob/living/carbon/human/H = user
@@ -43,7 +43,7 @@
 					H.dizziness += rand(3,5)
 					H.nutrition = H.nutrition / 1.5
 
-/datum/artifact_effect/cannibalfeeling/DoEffectAura()
+/datum/artifact_effect/uncommon/cannibalfeeling/DoEffectAura()
 	var/atom/holder = get_master_holder()
 	if(holder)
 		var/turf/T = get_turf(holder)
@@ -60,7 +60,7 @@
 					H.nutrition = H.nutrition / 2
 		return 1
 
-/datum/artifact_effect/cannibalfeeling/DoEffectPulse()
+/datum/artifact_effect/uncommon/cannibalfeeling/DoEffectPulse()
 	var/atom/holder = get_master_holder()
 	if(holder)
 		var/turf/T = get_turf(holder)

--- a/code/modules/xenoarcheaology/effects/cellcharge.dm
+++ b/code/modules/xenoarcheaology/effects/cellcharge.dm
@@ -1,12 +1,12 @@
 //todo
-/datum/artifact_effect/cellcharge
+/datum/artifact_effect/uncommon/cellcharge
 	name = "cell charge"
 	effect_type = EFFECT_ELECTRO
 	var/last_message
 
 	effect_color = "#ffee06"
 
-/datum/artifact_effect/cellcharge/DoEffectTouch(var/mob/user)
+/datum/artifact_effect/uncommon/cellcharge/DoEffectTouch(var/mob/user)
 	if(user)
 		if(istype(user, /mob/living/silicon/robot))
 			var/mob/living/silicon/robot/R = user
@@ -15,7 +15,7 @@
 				to_chat(R, "<font color='blue'>SYSTEM ALERT: Large energy boost detected!</font>")
 			return 1
 
-/datum/artifact_effect/cellcharge/DoEffectAura()
+/datum/artifact_effect/uncommon/cellcharge/DoEffectAura()
 	var/atom/holder = get_master_holder()
 	if(holder)
 		var/turf/T = get_turf(holder)
@@ -32,7 +32,7 @@
 					last_message = world.time
 		return 1
 
-/datum/artifact_effect/cellcharge/DoEffectPulse()
+/datum/artifact_effect/uncommon/cellcharge/DoEffectPulse()
 	var/atom/holder = get_master_holder()
 	if(holder)
 		var/turf/T = get_turf(holder)

--- a/code/modules/xenoarcheaology/effects/celldrain.dm
+++ b/code/modules/xenoarcheaology/effects/celldrain.dm
@@ -1,5 +1,5 @@
 //todo
-/datum/artifact_effect/celldrain
+/datum/artifact_effect/uncommon/celldrain
 	name = "cell drain"
 	effect_type = EFFECT_ELECTRO
 	var/last_message
@@ -7,7 +7,7 @@
 	effect_state = "pulsing"
 	effect_color = "#fbff02"
 
-/datum/artifact_effect/celldrain/DoEffectTouch(var/mob/user)
+/datum/artifact_effect/uncommon/celldrain/DoEffectTouch(var/mob/user)
 	if(user)
 		if(istype(user, /mob/living/silicon/robot))
 			var/mob/living/silicon/robot/R = user
@@ -18,7 +18,7 @@
 
 		return 1
 
-/datum/artifact_effect/celldrain/DoEffectAura()
+/datum/artifact_effect/uncommon/celldrain/DoEffectAura()
 	var/atom/holder = get_master_holder()
 	if(holder)
 		var/turf/T = get_turf(holder)
@@ -35,7 +35,7 @@
 					last_message = world.time
 	return 1
 
-/datum/artifact_effect/celldrain/DoEffectPulse()
+/datum/artifact_effect/uncommon/celldrain/DoEffectPulse()
 	var/atom/holder = get_master_holder()
 	if(holder)
 		var/turf/T = get_turf(holder)

--- a/code/modules/xenoarcheaology/effects/cold.dm
+++ b/code/modules/xenoarcheaology/effects/cold.dm
@@ -1,17 +1,17 @@
 //inverse of /datum/artifact_effect/heat, the two effects split up for neatness' sake
-/datum/artifact_effect/cold
+/datum/artifact_effect/common/cold
 	name = "cold"
 	var/target_temp
 
 	effect_color = "#b3f6ff"
 
-/datum/artifact_effect/cold/New()
+/datum/artifact_effect/common/cold/New()
 	..()
 	target_temp = rand(0, 250)
 	effect = pick(EFFECT_TOUCH, EFFECT_AURA)
 	effect_type = pick(EFFECT_ORGANIC, EFFECT_BLUESPACE, EFFECT_SYNTH)
 
-/datum/artifact_effect/cold/DoEffectTouch(var/mob/user)
+/datum/artifact_effect/common/cold/DoEffectTouch(var/mob/user)
 	var/atom/holder = get_master_holder()
 	if(holder)
 		to_chat(user, "<font color='blue'>A chill passes up your spine!</font>")
@@ -19,7 +19,7 @@
 		if(env)
 			env.temperature = max(env.temperature - rand(5,50), 0)
 
-/datum/artifact_effect/cold/DoEffectAura()
+/datum/artifact_effect/common/cold/DoEffectAura()
 	var/atom/holder = get_master_holder()
 	if(holder)
 		var/datum/gas_mixture/env = holder.loc.return_air()

--- a/code/modules/xenoarcheaology/effects/dnaswitch.dm
+++ b/code/modules/xenoarcheaology/effects/dnaswitch.dm
@@ -1,5 +1,5 @@
 //todo
-/datum/artifact_effect/dnaswitch
+/datum/artifact_effect/extreme/dnaswitch
 	name = "dnaswitch"
 	effect_type = EFFECT_ORGANIC
 	var/severity
@@ -7,14 +7,14 @@
 	effect_state = "smoke"
 	effect_color = "#77ff83"
 
-/datum/artifact_effect/dnaswitch/New()
+/datum/artifact_effect/extreme/dnaswitch/New()
 	..()
 	if(effect == EFFECT_AURA)
 		severity = rand(5,30)
 	else
 		severity = rand(25,95)
 
-/datum/artifact_effect/dnaswitch/DoEffectTouch(var/mob/toucher)
+/datum/artifact_effect/extreme/dnaswitch/DoEffectTouch(var/mob/toucher)
 	var/weakness = GetAnomalySusceptibility(toucher)
 	if(ishuman(toucher) && prob(weakness * 100))
 		to_chat(toucher,pick("<font color='green'>You feel a little different.</font>",
@@ -30,7 +30,7 @@
 			scramble(0, toucher, weakness * severity)
 	return 1
 
-/datum/artifact_effect/dnaswitch/DoEffectAura()
+/datum/artifact_effect/extreme/dnaswitch/DoEffectAura()
 	var/atom/holder = get_master_holder()
 	if(holder)
 		var/turf/T = get_turf(holder)
@@ -50,7 +50,7 @@
 				else
 					scramble(0, H, weakness * severity)
 
-/datum/artifact_effect/dnaswitch/DoEffectPulse()
+/datum/artifact_effect/extreme/dnaswitch/DoEffectPulse()
 	var/atom/holder = get_master_holder()
 	if(holder)
 		var/turf/T = get_turf(holder)

--- a/code/modules/xenoarcheaology/effects/electric_field.dm
+++ b/code/modules/xenoarcheaology/effects/electric_field.dm
@@ -1,11 +1,11 @@
 
-/datum/artifact_effect/electric_field
+/datum/artifact_effect/uncommon/electric_field
 	name = "electric field"
 	effect_type = EFFECT_ENERGY
 
 	effect_color = "#ffff00"
 
-/datum/artifact_effect/electric_field/DoEffectTouch(var/mob/user)
+/datum/artifact_effect/uncommon/electric_field/DoEffectTouch(var/mob/user)
 	var/atom/holder = get_master_holder()
 	var/list/nearby_mobs = list()
 	for(var/mob/living/L in oview(effectrange, get_turf(holder)))
@@ -29,7 +29,7 @@
 		else
 			L.electrocute_act(rand(25, 40), holder, 0.75, BP_TORSO)
 
-/datum/artifact_effect/electric_field/DoEffectAura()
+/datum/artifact_effect/uncommon/electric_field/DoEffectAura()
 	var/atom/holder = get_master_holder()
 	var/list/nearby_mobs = list()
 	for(var/mob/living/L in oview(effectrange, get_turf(holder)))
@@ -51,7 +51,7 @@
 		else
 			L.electrocute_act(rand(1, 10), holder, 0.75, BP_TORSO)
 
-/datum/artifact_effect/electric_field/DoEffectPulse()
+/datum/artifact_effect/uncommon/electric_field/DoEffectPulse()
 	var/atom/holder = get_master_holder()
 	var/list/nearby_mobs = list()
 	for(var/mob/living/L in oview(effectrange, get_turf(holder)))

--- a/code/modules/xenoarcheaology/effects/emp.dm
+++ b/code/modules/xenoarcheaology/effects/emp.dm
@@ -1,14 +1,14 @@
-/datum/artifact_effect/emp
+/datum/artifact_effect/rare/emp
 	name = "emp"
 	effect_type = EFFECT_ELECTRO
 
 	effect_state = "empdisable"
 
-/datum/artifact_effect/emp/New()
+/datum/artifact_effect/rare/emp/New()
 	..()
 	effect = EFFECT_PULSE
 
-/datum/artifact_effect/emp/DoEffectPulse()
+/datum/artifact_effect/rare/emp/DoEffectPulse()
 	var/atom/holder = get_master_holder()
 	if(holder)
 		var/turf/T = get_turf(holder)

--- a/code/modules/xenoarcheaology/effects/feysight.dm
+++ b/code/modules/xenoarcheaology/effects/feysight.dm
@@ -1,11 +1,11 @@
-/datum/artifact_effect/feysight
+/datum/artifact_effect/rare/feysight
 	name = "feysight"
 	effect_type = EFFECT_PSIONIC
 
 	effect_state = "pulsing"
 	effect_color = "#00c763"
 
-/datum/artifact_effect/feysight/proc/apply_modifier(var/mob/living/L)
+/datum/artifact_effect/rare/feysight/proc/apply_modifier(var/mob/living/L)
 	if(!istype(L))
 		return FALSE
 
@@ -25,12 +25,12 @@
 			it quickly passes.</span>")
 		return FALSE
 
-/datum/artifact_effect/feysight/DoEffectTouch(var/mob/toucher)
+/datum/artifact_effect/rare/feysight/DoEffectTouch(var/mob/toucher)
 	if(toucher && isliving(toucher))
 		apply_modifier(toucher)
 		return TRUE
 
-/datum/artifact_effect/feysight/DoEffectAura()
+/datum/artifact_effect/rare/feysight/DoEffectAura()
 	var/atom/holder = get_master_holder()
 	if(holder)
 		var/turf/T = get_turf(holder)
@@ -39,7 +39,7 @@
 				apply_modifier(L)
 		return TRUE
 
-/datum/artifact_effect/feysight/DoEffectPulse()
+/datum/artifact_effect/rare/feysight/DoEffectPulse()
 	var/atom/holder = get_master_holder()
 	if(holder)
 		var/turf/T = get_turf(holder)

--- a/code/modules/xenoarcheaology/effects/forcefield.dm
+++ b/code/modules/xenoarcheaology/effects/forcefield.dm
@@ -1,4 +1,4 @@
-/datum/artifact_effect/forcefield
+/datum/artifact_effect/uncommon/forcefield
 	name = "force field"
 	var/list/created_field = list()
 	effect_type = EFFECT_PARTICLE
@@ -6,11 +6,11 @@
 	effect_state = "shield-old"
 	effect_color = "#00b7ff"
 
-/datum/artifact_effect/forcefield/New()
+/datum/artifact_effect/uncommon/forcefield/New()
 	..()
 	trigger = TRIGGER_TOUCH
 
-/datum/artifact_effect/forcefield/ToggleActivate()
+/datum/artifact_effect/uncommon/forcefield/ToggleActivate()
 	var/atom/holder = get_master_holder()
 	..()
 	if(created_field.len)
@@ -30,7 +30,7 @@
 			UpdateMove()
 	return 1
 
-/datum/artifact_effect/forcefield/process()
+/datum/artifact_effect/uncommon/forcefield/process()
 	..()
 	for(var/obj/effect/energy_field/E in created_field)
 		if(E.strength < 1)
@@ -38,7 +38,7 @@
 		else if(E.strength < 5)
 			E.adjust_strength(0.25, 0)
 
-/datum/artifact_effect/forcefield/UpdateMove()
+/datum/artifact_effect/uncommon/forcefield/UpdateMove()
 	var/atom/holder = get_master_holder()
 	if(created_field.len && holder)
 		var/turf/T = get_turf(holder)

--- a/code/modules/xenoarcheaology/effects/gaia.dm
+++ b/code/modules/xenoarcheaology/effects/gaia.dm
@@ -1,5 +1,4 @@
-
-/datum/artifact_effect/gaia
+/datum/artifact_effect/uncommon/gaia
 	name = "gaia"
 	effect_type = EFFECT_ORGANIC
 
@@ -7,7 +6,7 @@
 
 	effect_color = "#8cd448"
 
-/datum/artifact_effect/gaia/proc/age_plantlife(var/obj/machinery/portable_atmospherics/hydroponics/Tray = null)
+/datum/artifact_effect/uncommon/gaia/proc/age_plantlife(var/obj/machinery/portable_atmospherics/hydroponics/Tray = null)
 	if(istype(Tray) && Tray.seed)
 		Tray.health += rand(1,3) * HYDRO_SPEED_MULTIPLIER
 		Tray.age += 1
@@ -31,7 +30,7 @@
 			age_plantlife(Tray)
 			P.update_icon()
 
-/datum/artifact_effect/gaia/DoEffectTouch(var/mob/user)
+/datum/artifact_effect/uncommon/gaia/DoEffectTouch(var/mob/user)
 	var/atom/holder = get_master_holder()
 	to_chat(user, "<span class='alien'>You feel the presence of something long forgotten.</span>")
 	for(var/obj/machinery/portable_atmospherics/hydroponics/Tray in view(world.view,get_turf(holder)))
@@ -46,7 +45,7 @@
 	for(var/obj/effect/plant/P in view(world.view,get_turf(holder)))
 		age_plantlife(P)
 
-/datum/artifact_effect/gaia/DoEffectAura()
+/datum/artifact_effect/uncommon/gaia/DoEffectAura()
 	var/atom/holder = get_master_holder()
 	for(var/obj/machinery/portable_atmospherics/hydroponics/Tray in view(effectrange,holder))
 		age_plantlife(Tray)
@@ -60,7 +59,7 @@
 	for(var/obj/effect/plant/P in view(effectrange,get_turf(holder)))
 		age_plantlife(P)
 
-/datum/artifact_effect/gaia/DoEffectPulse()
+/datum/artifact_effect/uncommon/gaia/DoEffectPulse()
 	var/atom/holder = get_master_holder()
 	for(var/obj/machinery/portable_atmospherics/hydroponics/Tray in view(effectrange,holder))
 		age_plantlife(Tray)
@@ -74,7 +73,7 @@
 	for(var/obj/effect/plant/P in view(effectrange,get_turf(holder)))
 		age_plantlife(P)
 
-/datum/artifact_effect/gaia/process()
+/datum/artifact_effect/uncommon/gaia/process()
 	var/atom/holder = get_master_holder()
 	..()
 

--- a/code/modules/xenoarcheaology/effects/gasco2.dm
+++ b/code/modules/xenoarcheaology/effects/gasco2.dm
@@ -1,21 +1,21 @@
-/datum/artifact_effect/gasco2
+/datum/artifact_effect/common/gasco2
 	name = "CO2 creation"
 
 	effect_color = "#a5a5a5"
 
-/datum/artifact_effect/gasco2/New()
+/datum/artifact_effect/common/gasco2/New()
 	..()
 	effect = pick(EFFECT_TOUCH, EFFECT_AURA)
 	effect_type = pick(EFFECT_BLUESPACE, EFFECT_SYNTH)
 
-/datum/artifact_effect/gasco2/DoEffectTouch(var/mob/user)
+/datum/artifact_effect/common/gasco2/DoEffectTouch(var/mob/user)
 	var/atom/holder = get_master_holder()
 	if(holder)
 		var/turf/holder_loc = holder.loc
 		if(istype(holder_loc))
 			holder_loc.assume_gas("carbon_dioxide", rand(2, 15))
 
-/datum/artifact_effect/gasco2/DoEffectAura()
+/datum/artifact_effect/common/gasco2/DoEffectAura()
 	var/atom/holder = get_master_holder()
 	if(holder)
 		var/turf/holder_loc = holder.loc

--- a/code/modules/xenoarcheaology/effects/gasnitro.dm
+++ b/code/modules/xenoarcheaology/effects/gasnitro.dm
@@ -1,21 +1,21 @@
-/datum/artifact_effect/gasnitro
+/datum/artifact_effect/common/gasnitro
 	name = "N2 creation"
 
 	effect_color = "#c2d3d8"
 
-/datum/artifact_effect/gasnitro/New()
+/datum/artifact_effect/common/gasnitro/New()
 	..()
 	effect = pick(EFFECT_TOUCH, EFFECT_AURA)
 	effect_type = pick(EFFECT_BLUESPACE, EFFECT_SYNTH)
 
-/datum/artifact_effect/gasnitro/DoEffectTouch(var/mob/user)
+/datum/artifact_effect/common/gasnitro/DoEffectTouch(var/mob/user)
 	var/atom/holder = get_master_holder()
 	if(holder)
 		var/turf/holder_loc = holder.loc
 		if(istype(holder_loc))
 			holder_loc.assume_gas("nitrogen", rand(2, 15))
 
-/datum/artifact_effect/gasnitro/DoEffectAura()
+/datum/artifact_effect/common/gasnitro/DoEffectAura()
 	var/atom/holder = get_master_holder()
 	if(holder)
 		var/turf/holder_loc = holder.loc

--- a/code/modules/xenoarcheaology/effects/gasoxy.dm
+++ b/code/modules/xenoarcheaology/effects/gasoxy.dm
@@ -1,19 +1,19 @@
-/datum/artifact_effect/gasoxy
+/datum/artifact_effect/common/gasoxy
 	name = "O2 creation"
 
-/datum/artifact_effect/gasoxy/New()
+/datum/artifact_effect/common/gasoxy/New()
 	..()
 	effect = pick(EFFECT_TOUCH, EFFECT_AURA)
 	effect_type = pick(EFFECT_BLUESPACE, EFFECT_SYNTH)
 
-/datum/artifact_effect/gasoxy/DoEffectTouch(var/mob/user)
+/datum/artifact_effect/common/gasoxy/DoEffectTouch(var/mob/user)
 	var/atom/holder = get_master_holder()
 	if(holder)
 		var/turf/holder_loc = holder.loc
 		if(istype(holder_loc))
 			holder_loc.assume_gas("oxygen", rand(2, 15))
 
-/datum/artifact_effect/gasoxy/DoEffectAura()
+/datum/artifact_effect/common/gasoxy/DoEffectAura()
 	var/atom/holder = get_master_holder()
 	if(holder)
 		var/turf/holder_loc = holder.loc

--- a/code/modules/xenoarcheaology/effects/gasphoron.dm
+++ b/code/modules/xenoarcheaology/effects/gasphoron.dm
@@ -1,21 +1,21 @@
-/datum/artifact_effect/gasphoron
+/datum/artifact_effect/uncommon/gasphoron
 	name = "phoron creation"
 
 	effect_color = "#c408ba"
 
-/datum/artifact_effect/gasphoron/New()
+/datum/artifact_effect/uncommon/gasphoron/New()
 	..()
 	effect = pick(EFFECT_TOUCH, EFFECT_AURA)
 	effect_type = pick(EFFECT_BLUESPACE, EFFECT_SYNTH)
 
-/datum/artifact_effect/gasphoron/DoEffectTouch(var/mob/user)
+/datum/artifact_effect/uncommon/gasphoron/DoEffectTouch(var/mob/user)
 	var/atom/holder = get_master_holder()
 	if(holder)
 		var/turf/holder_loc = holder.loc
 		if(istype(holder_loc))
 			holder_loc.assume_gas("phoron", rand(2, 15))
 
-/datum/artifact_effect/gasphoron/DoEffectAura()
+/datum/artifact_effect/uncommon/gasphoron/DoEffectAura()
 	var/atom/holder = get_master_holder()
 	if(holder)
 		var/turf/holder_loc = holder.loc

--- a/code/modules/xenoarcheaology/effects/gassleeping.dm
+++ b/code/modules/xenoarcheaology/effects/gassleeping.dm
@@ -1,4 +1,4 @@
-/datum/artifact_effect/gassleeping
+/datum/artifact_effect/rare/gassleeping
 	name = "N2O creation"
 
 /datum/artifact_effect/gassleeping/New()
@@ -6,14 +6,14 @@
 	effect = pick(EFFECT_TOUCH, EFFECT_AURA)
 	effect_type = pick(EFFECT_BLUESPACE, EFFECT_SYNTH)
 
-/datum/artifact_effect/gassleeping/DoEffectTouch(var/mob/user)
+/datum/artifact_effect/rare/gassleeping/DoEffectTouch(var/mob/user)
 	var/atom/holder = get_master_holder()
 	if(holder)
 		var/turf/holder_loc = holder.loc
 		if(istype(holder_loc))
 			holder_loc.assume_gas("nitrous_oxide", rand(2, 15))
 
-/datum/artifact_effect/gassleeping/DoEffectAura()
+/datum/artifact_effect/rare/gassleeping/DoEffectAura()
 	var/atom/holder = get_master_holder()
 	if(holder)
 		var/turf/holder_loc = holder.loc

--- a/code/modules/xenoarcheaology/effects/goodfeeling.dm
+++ b/code/modules/xenoarcheaology/effects/goodfeeling.dm
@@ -1,4 +1,4 @@
-/datum/artifact_effect/goodfeeling
+/datum/artifact_effect/common/goodfeeling
 	name = "good feeling"
 	effect_type = EFFECT_PSIONIC
 	var/list/messages = list("You feel good.",
@@ -26,7 +26,7 @@
 	effect_state = "summoning"
 	effect_color = "#009118"
 
-/datum/artifact_effect/goodfeeling/DoEffectTouch(var/mob/user)
+/datum/artifact_effect/common/goodfeeling/DoEffectTouch(var/mob/user)
 	if(user)
 		if (istype(user, /mob/living/carbon/human))
 			var/mob/living/carbon/human/H = user
@@ -39,7 +39,7 @@
 			if(prob(50))
 				H.dizziness += rand(3,5)
 
-/datum/artifact_effect/goodfeeling/DoEffectAura()
+/datum/artifact_effect/common/goodfeeling/DoEffectAura()
 	var/atom/holder = get_master_holder()
 	if(holder)
 		var/turf/T = get_turf(holder)
@@ -54,7 +54,7 @@
 				H.dizziness += rand(3,5)
 		return 1
 
-/datum/artifact_effect/goodfeeling/DoEffectPulse()
+/datum/artifact_effect/common/goodfeeling/DoEffectPulse()
 	var/atom/holder = get_master_holder()
 	if(holder)
 		var/turf/T = get_turf(holder)

--- a/code/modules/xenoarcheaology/effects/gravitational_waves.dm
+++ b/code/modules/xenoarcheaology/effects/gravitational_waves.dm
@@ -1,5 +1,4 @@
-
-/datum/artifact_effect/gravity_wave
+/datum/artifact_effect/uncommon/gravity_wave
 	name = "gravity wave"
 	effect_type = EFFECT_ENERGY
 
@@ -8,10 +7,10 @@
 	effect_state = "gravisphere"
 	effect_color = "#d8c3ff"
 
-/datum/artifact_effect/gravity_wave/DoEffectTouch(var/mob/user)
+/datum/artifact_effect/uncommon/gravity_wave/DoEffectTouch(var/mob/user)
 	gravwave(user, effectrange, STAGE_TWO)
 
-/datum/artifact_effect/gravity_wave/DoEffectAura()
+/datum/artifact_effect/uncommon/gravity_wave/DoEffectAura()
 	var/atom/holder = get_master_holder()
 	var/seconds_since_last_pull = max(0, round((last_wave_pull - world.time) / 10))
 
@@ -20,7 +19,7 @@
 		last_wave_pull = world.time
 		gravwave(get_turf(holder), effectrange, STAGE_TWO)
 
-/datum/artifact_effect/gravity_wave/DoEffectPulse()
+/datum/artifact_effect/uncommon/gravity_wave/DoEffectPulse()
 	var/atom/holder = get_master_holder()
 	holder.visible_message("<span class='alien'>\The [holder] distorts as local gravity intensifies, and shifts toward it.</span>")
 	gravwave(get_turf(holder), effectrange, STAGE_TWO)

--- a/code/modules/xenoarcheaology/effects/heal.dm
+++ b/code/modules/xenoarcheaology/effects/heal.dm
@@ -1,9 +1,9 @@
-/datum/artifact_effect/heal
+/datum/artifact_effect/uncommon/heal
 	name = "heal"
 	effect_type = EFFECT_ORGANIC
 	effect_color = "#4649ff"
 
-/datum/artifact_effect/heal/DoEffectTouch(var/mob/toucher)
+/datum/artifact_effect/uncommon/heal/DoEffectTouch(var/mob/toucher)
 	//todo: check over this properly
 	if(toucher && iscarbon(toucher))
 		var/weakness = GetAnomalySusceptibility(toucher)
@@ -33,7 +33,7 @@
 			C.regenerate_icons()
 			return 1
 
-/datum/artifact_effect/heal/DoEffectAura()
+/datum/artifact_effect/uncommon/heal/DoEffectAura()
 	var/atom/holder = get_master_holder()
 	//todo: check over this properly
 	if(holder)
@@ -50,7 +50,7 @@
 				C.adjustBrainLoss(-1 * weakness)
 				C.updatehealth()
 
-/datum/artifact_effect/heal/DoEffectPulse()
+/datum/artifact_effect/uncommon/heal/DoEffectPulse()
 	var/atom/holder = get_master_holder()
 	//todo: check over this properly
 	if(holder)

--- a/code/modules/xenoarcheaology/effects/heat.dm
+++ b/code/modules/xenoarcheaology/effects/heat.dm
@@ -1,16 +1,16 @@
 //inverse of /datum/artifact_effect/cold, the two effects split up for neatness' sake
-/datum/artifact_effect/heat
+/datum/artifact_effect/common/heat
 	name = "heat"
 	var/target_temp
 	effect_color = "#ff6600"
 
-/datum/artifact_effect/heat/New()
+/datum/artifact_effect/common/heat/New()
 	..()
 	effect = pick(EFFECT_TOUCH, EFFECT_AURA)
 	effect_type = pick(EFFECT_ORGANIC, EFFECT_BLUESPACE, EFFECT_SYNTH)
 	target_temp = rand(300, 600)
 
-/datum/artifact_effect/heat/DoEffectTouch(var/mob/user)
+/datum/artifact_effect/common/heat/DoEffectTouch(var/mob/user)
 	var/atom/holder = get_master_holder()
 	if(holder)
 		to_chat(user, "<font color='red'> You feel a wave of heat travel up your spine!</font>")
@@ -18,7 +18,7 @@
 		if(env)
 			env.temperature += rand(5,50)
 
-/datum/artifact_effect/heat/DoEffectAura()
+/datum/artifact_effect/common/heat/DoEffectAura()
 	var/atom/holder = get_master_holder()
 	if(holder)
 		var/datum/gas_mixture/env = holder.loc.return_air()

--- a/code/modules/xenoarcheaology/effects/hurt.dm
+++ b/code/modules/xenoarcheaology/effects/hurt.dm
@@ -1,10 +1,10 @@
-/datum/artifact_effect/hurt
+/datum/artifact_effect/uncommon/hurt
 	name = "hurt"
 	effect_type = EFFECT_ORGANIC
 
 	effect_color = "#6d1212"
 
-/datum/artifact_effect/hurt/DoEffectTouch(var/mob/toucher)
+/datum/artifact_effect/uncommon/hurt/DoEffectTouch(var/mob/toucher)
 	if(toucher)
 		var/weakness = GetAnomalySusceptibility(toucher)
 		if(iscarbon(toucher) && prob(weakness * 100))
@@ -21,7 +21,7 @@
 			C.make_dizzy(6 * weakness)
 			C.weakened += 6 * weakness
 
-/datum/artifact_effect/hurt/DoEffectAura()
+/datum/artifact_effect/uncommon/hurt/DoEffectAura()
 	var/atom/holder = get_master_holder()
 	if(holder)
 		var/turf/T = get_turf(holder)
@@ -37,7 +37,7 @@
 				C.adjustBrainLoss(0.1 * weakness)
 				C.updatehealth()
 
-/datum/artifact_effect/hurt/DoEffectPulse()
+/datum/artifact_effect/uncommon/hurt/DoEffectPulse()
 	var/atom/holder = get_master_holder()
 	if(holder)
 		var/turf/T = get_turf(holder)

--- a/code/modules/xenoarcheaology/effects/poltergeist.dm
+++ b/code/modules/xenoarcheaology/effects/poltergeist.dm
@@ -1,12 +1,12 @@
 
-/datum/artifact_effect/poltergeist
+/datum/artifact_effect/rare/poltergeist
 	name = "poltergeist"
 	effect_type = EFFECT_ENERGY
 
 	effect_state = "shield2"
 	effect_color = "#a824c9"
 
-/datum/artifact_effect/poltergeist/proc/throw_at_mob(var/mob/living/target, var/damage = 20)
+/datum/artifact_effect/rare/poltergeist/proc/throw_at_mob(var/mob/living/target, var/damage = 20)
 	var/list/valid_targets = list()
 
 	for(var/obj/O in oview(world.view, target))
@@ -18,10 +18,10 @@
 		obj_to_throw.visible_message("<span class='alien'>\The [obj_to_throw] levitates, befure hurtling toward [target]!</span>")
 		obj_to_throw.throw_at(target, world.view, min(40, damage * GetAnomalySusceptibility(target)))
 
-/datum/artifact_effect/poltergeist/DoEffectTouch(var/mob/user)
+/datum/artifact_effect/rare/poltergeist/DoEffectTouch(var/mob/user)
 	throw_at_mob(user, rand(10, 30))
 
-/datum/artifact_effect/poltergeist/DoEffectAura()
+/datum/artifact_effect/rare/poltergeist/DoEffectAura()
 	var/atom/holder = get_master_holder()
 	var/mob/living/target = null
 	for(var/mob/living/L in oview(get_turf(holder), effectrange))
@@ -36,7 +36,7 @@
 	if(target)
 		throw_at_mob(target, rand(15, 30))
 
-/datum/artifact_effect/poltergeist/DoEffectPulse()
+/datum/artifact_effect/rare/poltergeist/DoEffectPulse()
 	var/atom/holder = get_master_holder()
 	var/mob/living/target = null
 	for(var/mob/living/L in oview(get_turf(holder), effectrange))

--- a/code/modules/xenoarcheaology/effects/radiate.dm
+++ b/code/modules/xenoarcheaology/effects/radiate.dm
@@ -1,27 +1,27 @@
-/datum/artifact_effect/radiate
+/datum/artifact_effect/rare/radiate
 	name = "radiation"
 	var/radiation_amount
 
 	effect_color = "#007006"
 
-/datum/artifact_effect/radiate/New()
+/datum/artifact_effect/rare/radiate/New()
 	..()
 	radiation_amount = rand(1, 10)
 	effect_type = pick(EFFECT_PARTICLE, EFFECT_ORGANIC)
 
-/datum/artifact_effect/radiate/DoEffectTouch(var/mob/living/user)
+/datum/artifact_effect/rare/radiate/DoEffectTouch(var/mob/living/user)
 	if(user)
 		user.apply_effect(radiation_amount * 5,IRRADIATE,0)
 		user.updatehealth()
 		return 1
 
-/datum/artifact_effect/radiate/DoEffectAura()
+/datum/artifact_effect/rare/radiate/DoEffectAura()
 	var/atom/holder = get_master_holder()
 	if(holder)
 		SSradiation.flat_radiate(holder, radiation_amount, src.effectrange)
 		return 1
 
-/datum/artifact_effect/radiate/DoEffectPulse()
+/datum/artifact_effect/rare/radiate/DoEffectPulse()
 	var/atom/holder = get_master_holder()
 	if(holder)
 		SSradiation.radiate(holder, ((radiation_amount * 25) * (sqrt(src.effectrange)))) //Need to get feedback on this

--- a/code/modules/xenoarcheaology/effects/resurrect.dm
+++ b/code/modules/xenoarcheaology/effects/resurrect.dm
@@ -1,4 +1,4 @@
-/datum/artifact_effect/resurrect
+/datum/artifact_effect/extreme/resurrect
 	name = "resurrect"
 	effect_type = EFFECT_ORGANIC
 
@@ -7,7 +7,7 @@
 	effect_state = "pulsing"
 	effect_color = "#ff0000"
 
-/datum/artifact_effect/resurrect/proc/steal_life(var/mob/living/target = null)
+/datum/artifact_effect/extreme/resurrect/proc/steal_life(var/mob/living/target = null)
 	var/atom/holder = get_master_holder()
 	if(!istype(target))
 		return 0
@@ -19,7 +19,7 @@
 
 	return 0
 
-/datum/artifact_effect/resurrect/proc/give_life(var/mob/living/target = null)
+/datum/artifact_effect/extreme/resurrect/proc/give_life(var/mob/living/target = null)
 	var/atom/holder = get_master_holder()
 	if(!istype(target))
 		return
@@ -38,7 +38,7 @@
 			attempt_revive(target)
 			stored_life = 0
 
-/datum/artifact_effect/resurrect/proc/attempt_revive(var/mob/living/L = null)
+/datum/artifact_effect/extreme/resurrect/proc/attempt_revive(var/mob/living/L = null)
 	var/atom/holder = get_master_holder()
 	spawn()
 		if(istype(L, /mob/living/simple_mob))
@@ -75,7 +75,7 @@
 
 				holder.visible_message("<span class='alien'>\The [H]'s eyes open in a flash of light!</span>")
 
-/datum/artifact_effect/resurrect/DoEffectTouch(var/mob/user)
+/datum/artifact_effect/extreme/resurrect/DoEffectTouch(var/mob/user)
 	var/atom/holder = get_master_holder()
 	for(var/mob/living/L in oview(effectrange, get_turf(holder)))
 		stored_life += 4 * steal_life(L)
@@ -86,7 +86,7 @@
 			give_life(L)
 			break
 
-/datum/artifact_effect/resurrect/DoEffectAura()
+/datum/artifact_effect/extreme/resurrect/DoEffectAura()
 	var/atom/holder = get_master_holder()
 	for(var/mob/living/L in oview(effectrange, get_turf(holder)))
 		stored_life += steal_life(L)
@@ -97,7 +97,7 @@
 			give_life(L)
 			break
 
-/datum/artifact_effect/resurrect/DoEffectPulse()
+/datum/artifact_effect/extreme/resurrect/DoEffectPulse()
 	var/atom/holder = get_master_holder()
 	for(var/mob/living/L in oview(effectrange, get_turf(holder)))
 		stored_life += 2 * steal_life(L)

--- a/code/modules/xenoarcheaology/effects/roboheal.dm
+++ b/code/modules/xenoarcheaology/effects/roboheal.dm
@@ -1,14 +1,14 @@
-/datum/artifact_effect/roboheal
+/datum/artifact_effect/uncommon/roboheal
 	name = "robotic healing"
 	var/last_message
 
 	effect_color = "#3879ad"
 
-/datum/artifact_effect/roboheal/New()
+/datum/artifact_effect/uncommon/roboheal/New()
 	..()
 	effect_type = pick(EFFECT_ELECTRO, EFFECT_PARTICLE)
 
-/datum/artifact_effect/roboheal/DoEffectTouch(var/mob/user)
+/datum/artifact_effect/uncommon/roboheal/DoEffectTouch(var/mob/user)
 	if(user)
 		if (istype(user, /mob/living/silicon/robot))
 			var/mob/living/silicon/robot/R = user
@@ -17,7 +17,7 @@
 			R.adjustFireLoss(rand(-10,-30))
 			return 1
 
-/datum/artifact_effect/roboheal/DoEffectAura()
+/datum/artifact_effect/uncommon/roboheal/DoEffectAura()
 	var/atom/holder = get_master_holder()
 	if(holder)
 		var/turf/T = get_turf(holder)
@@ -30,7 +30,7 @@
 			M.updatehealth()
 		return 1
 
-/datum/artifact_effect/roboheal/DoEffectPulse()
+/datum/artifact_effect/uncommon/roboheal/DoEffectPulse()
 	var/atom/holder = get_master_holder()
 	if(holder)
 		var/turf/T = get_turf(holder)

--- a/code/modules/xenoarcheaology/effects/robohurt.dm
+++ b/code/modules/xenoarcheaology/effects/robohurt.dm
@@ -1,10 +1,10 @@
-/datum/artifact_effect/robohurt
+/datum/artifact_effect/uncommon/robohurt
 	name = "robotic harm"
 	var/last_message
 
 	effect_color = "#5432cf"
 
-/datum/artifact_effect/robohurt/New()
+/datum/artifact_effect/uncommon/robohurt/New()
 	..()
 	effect_type = pick(EFFECT_ELECTRO, EFFECT_PARTICLE)
 
@@ -17,7 +17,7 @@
 			R.adjustFireLoss(rand(10,50))
 			return 1
 
-/datum/artifact_effect/robohurt/DoEffectAura()
+/datum/artifact_effect/uncommon/robohurt/DoEffectAura()
 	var/atom/holder = get_master_holder()
 	if(holder)
 		var/turf/T = get_turf(holder)
@@ -30,7 +30,7 @@
 			M.updatehealth()
 		return 1
 
-/datum/artifact_effect/robohurt/DoEffectPulse()
+/datum/artifact_effect/uncommon/robohurt/DoEffectPulse()
 	var/atom/holder = get_master_holder()
 	if(holder)
 		var/turf/T = get_turf(holder)

--- a/code/modules/xenoarcheaology/effects/sleepy.dm
+++ b/code/modules/xenoarcheaology/effects/sleepy.dm
@@ -1,5 +1,5 @@
 //todo
-/datum/artifact_effect/sleepy
+/datum/artifact_effect/uncommon/sleepy
 	name = "sleepy"
 	effect_color = "#a36fa1"
 
@@ -7,7 +7,7 @@
 	..()
 	effect_type = pick(EFFECT_PSIONIC, EFFECT_ORGANIC)
 
-/datum/artifact_effect/sleepy/DoEffectTouch(var/mob/toucher)
+/datum/artifact_effect/uncommon/sleepy/DoEffectTouch(var/mob/toucher)
 	if(toucher)
 		var/weakness = GetAnomalySusceptibility(toucher)
 		if(ishuman(toucher) && prob(weakness * 100))
@@ -20,7 +20,7 @@
 			to_chat(toucher, "<font color='red'>SYSTEM ALERT: CPU cycles slowing down.</font>")
 			return 1
 
-/datum/artifact_effect/sleepy/DoEffectAura()
+/datum/artifact_effect/uncommon/sleepy/DoEffectAura()
 	var/atom/holder = get_master_holder()
 	if(holder)
 		var/turf/T = get_turf(holder)
@@ -35,7 +35,7 @@
 			to_chat(R, "<font color='red'>SYSTEM ALERT: CPU cycles slowing down.</font>")
 		return 1
 
-/datum/artifact_effect/sleepy/DoEffectPulse()
+/datum/artifact_effect/uncommon/sleepy/DoEffectPulse()
 	var/atom/holder = get_master_holder()
 	if(holder)
 		var/turf/T = get_turf(holder)

--- a/code/modules/xenoarcheaology/effects/stun.dm
+++ b/code/modules/xenoarcheaology/effects/stun.dm
@@ -1,12 +1,12 @@
-/datum/artifact_effect/stun
+/datum/artifact_effect/uncommon/stun
 	name = "stun"
 	effect_color = "#00eeff"
 
-/datum/artifact_effect/stun/New()
+/datum/artifact_effect/uncommon/stun/New()
 	..()
 	effect_type = pick(EFFECT_PSIONIC, EFFECT_ORGANIC)
 
-/datum/artifact_effect/stun/DoEffectTouch(var/mob/toucher)
+/datum/artifact_effect/uncommon/stun/DoEffectTouch(var/mob/toucher)
 	if(toucher && iscarbon(toucher))
 		var/mob/living/carbon/C = toucher
 		var/susceptibility = GetAnomalySusceptibility(C)
@@ -16,7 +16,7 @@
 			C.stuttering += 30 * susceptibility
 			C.Stun(rand(1,10) * susceptibility)
 
-/datum/artifact_effect/stun/DoEffectAura()
+/datum/artifact_effect/uncommon/stun/DoEffectAura()
 	var/atom/holder = get_master_holder()
 	if(holder)
 		var/turf/T = get_turf(holder)
@@ -31,7 +31,7 @@
 			else if(prob(10))
 				to_chat(C, "<font color='red'>You feel numb.</font>")
 
-/datum/artifact_effect/stun/DoEffectPulse()
+/datum/artifact_effect/uncommon/stun/DoEffectPulse()
 	var/atom/holder = get_master_holder()
 	if(holder)
 		var/turf/T = get_turf(holder)

--- a/code/modules/xenoarcheaology/effects/teleport.dm
+++ b/code/modules/xenoarcheaology/effects/teleport.dm
@@ -1,10 +1,10 @@
-/datum/artifact_effect/teleport
+/datum/artifact_effect/rare/teleport
 	name = "teleport"
 	effect_type = EFFECT_BLUESPACE
 	effect_state = "pulsing"
 	effect_color = "#88ffdb"
 
-/datum/artifact_effect/teleport/DoEffectTouch(var/mob/user)
+/datum/artifact_effect/rare/teleport/DoEffectTouch(var/mob/user)
 	var/atom/holder = get_master_holder()
 	var/weakness = GetAnomalySusceptibility(user)
 	if(prob(100 * weakness))
@@ -22,7 +22,7 @@
 		sparks.set_up(3, 0, user.loc)
 		sparks.start()
 
-/datum/artifact_effect/teleport/DoEffectAura()
+/datum/artifact_effect/rare/teleport/DoEffectAura()
 	var/atom/holder = get_master_holder()
 	if(holder)
 		var/turf/T = get_turf(holder)
@@ -42,7 +42,7 @@
 				sparks.set_up(3, 0, M.loc)
 				sparks.start()
 
-/datum/artifact_effect/teleport/DoEffectPulse()
+/datum/artifact_effect/rare/teleport/DoEffectPulse()
 	var/atom/holder = get_master_holder()
 	if(holder)
 		var/turf/T = get_turf(holder)

--- a/code/modules/xenoarcheaology/effects/vampire.dm
+++ b/code/modules/xenoarcheaology/effects/vampire.dm
@@ -1,5 +1,5 @@
 
-/datum/artifact_effect/vampire
+/datum/artifact_effect/rare/vampire
 	name = "vampire"
 	effect_type = EFFECT_ORGANIC
 	var/last_bloodcall = 0
@@ -12,7 +12,7 @@
 	effect_state = "gravisphere"
 	effect_color = "#ff0000"
 
-/datum/artifact_effect/vampire/proc/bloodcall(var/mob/living/carbon/human/M)
+/datum/artifact_effect/rare/vampire/proc/bloodcall(var/mob/living/carbon/human/M)
 	var/atom/holder = get_master_holder()
 	last_bloodcall = world.time
 	if(istype(M))
@@ -29,11 +29,11 @@
 		B.blood_DNA[M.dna.unique_enzymes] = M.dna.b_type
 		M.vessel.remove_reagent("blood",rand(10,30))
 
-/datum/artifact_effect/vampire/DoEffectTouch(var/mob/user)
+/datum/artifact_effect/rare/vampire/DoEffectTouch(var/mob/user)
 	bloodcall(user)
 	DoEffectAura()
 
-/datum/artifact_effect/vampire/DoEffectAura()
+/datum/artifact_effect/rare/vampire/DoEffectAura()
 	var/atom/holder = get_master_holder()
 	if(nearby_mobs.len)
 		nearby_mobs.Cut()
@@ -86,5 +86,5 @@
 			holder.visible_message("<span class='alien'>\icon[holder] \The [holder] gleams a bloody red!</span>")
 			charges -= 0.1
 
-/datum/artifact_effect/vampire/DoEffectPulse()
+/datum/artifact_effect/rare/vampire/DoEffectPulse()
 	DoEffectAura()


### PR DESCRIPTION
- Random anomaly spawns are now only a 50% chance of actually being anomalous. Should prevent anomalies being in practically ever PoI.
- Added a rarity rating to effects, so that more disruptive and/or useful effects are rarer.

Weighting will not function correctly until #8547 is merged, so do not advise merging until that PR is fixed/merged otherwise may result in DNA Fucker anomalies being more common instead of much, much rarer.