### PR TITLE
Fixes doubled name when deathgasping

### DIFF
--- a/code/modules/emotes/definitions/human.dm
+++ b/code/modules/emotes/definitions/human.dm
@@ -11,7 +11,7 @@
 	. = ..() 
 	
 /decl/emote/human/deathgasp/get_emote_message_3p(var/mob/living/carbon/human/user)
-	return "USER [user.species.get_death_message(user)]"
+	return "[user.species.get_death_message(user)]"
 
 /decl/emote/human/swish
 	key = "swish"


### PR DESCRIPTION
Cerebulon Cerebulon seizes up and falls limp, their eyes dead and lifeless...

User was in the emote when emotes already does that innit,