### PR TITLE
SSOverlays cuts queue from start to count, not count to end

### DIFF
--- a/code/controllers/subsystems/overlays.dm
+++ b/code/controllers/subsystems/overlays.dm
@@ -44,7 +44,7 @@ SUBSYSTEM_DEF(overlays)
 		if (no_mc_tick)
 			CHECK_TICK
 		else if (MC_TICK_CHECK)
-			queue.Cut(count)
+			queue.Cut(1, count)
 			return
 	queue.Cut()
 


### PR DESCRIPTION
Maybe also fixes other overlays issues? But this is mostly an issue at high queue volumes, like after SSOpenspace initializes.