### PR TITLE
Fixes fruits missing their stems

### DIFF
--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -142,7 +142,7 @@
 		if("[seed.get_trait(TRAIT_PRODUCT_ICON)]-leaf" in cached_icon_states('icons/obj/hydroponics_products.dmi'))
 			var/image/fruit_leaves = image('icons/obj/hydroponics_products.dmi',"[seed.get_trait(TRAIT_PRODUCT_ICON)]-leaf")
 			fruit_leaves.color = "[seed.get_trait(TRAIT_PLANT_COLOUR)]"
-			add_overlay(fruit_leaves)
+			plant_icon.add_overlay(fruit_leaves)
 		plant_controller.plant_icon_cache[icon_key] = plant_icon
 	add_overlay(plant_icon)
 
@@ -189,7 +189,7 @@
 				pocell.charge = pocell.maxcharge
 				qdel(src)
 				return
-	
+
 		if(W.sharp)
 
 			if(seed.kitchen_tag == "pumpkin") // Ugggh these checks are awful.
@@ -217,7 +217,7 @@
 						to_chat(user, "You add the newly-formed wood to the stack. It now contains [NG.amount] planks.")
 					qdel(src)
 					return
-				
+
 				if(seed.kitchen_tag == "sunflower")
 					new /obj/item/reagent_containers/food/snacks/rawsunflower(get_turf(src))
 					to_chat(user, SPAN_NOTICE("You remove the seeds from the flower, slightly damaging them."))
@@ -229,25 +229,25 @@
 					new /obj/item/reagent_containers/food/snacks/rawsticks(get_turf(src))
 					qdel(src)
 					return
-				
+
 				if(!isnull(seed.chems["carrotjuice"]))
 					to_chat(user, "You slice \the [src] into sticks.")
 					new /obj/item/reagent_containers/food/snacks/carrotfries(get_turf(src))
 					qdel(src)
 					return
-				
+
 				if(!isnull(seed.chems["pineapplejuice"]))
 					to_chat(user, "You slice \the [src] into rings.")
 					new /obj/item/reagent_containers/food/snacks/pineapple_ring(get_turf(src))
 					qdel(src)
 					return
-				
+
 				if(!isnull(seed.chems["soymilk"]))
 					to_chat(user, "You roughly chop up \the [src].")
 					new /obj/item/reagent_containers/food/snacks/soydope(get_turf(src))
 					qdel(src)
 					return
-				
+
 				if(seed.get_trait(TRAIT_FLESH_COLOUR))
 					to_chat(user, "You slice up \the [src].")
 					var/slices = rand(3,5)


### PR DESCRIPTION
The fruit icon is getting cached without the stem. If the icon is cached, then it is pulled directly without recompiling. Hence, the stem exists only the first time the fruit of a given key is _ever_ `update_icon()`'d.