### PR TITLE
SAR as alt title

### DIFF
--- a/maps/cynosure/cynosure_jobs.dm
+++ b/maps/cynosure/cynosure_jobs.dm
@@ -36,6 +36,16 @@ var/global/const/access_explorer = 43
 	alt_titles = list(
 		"Pilot" = /decl/hierarchy/outfit/job/pilot)
 
+/datum/job/paramedic
+	alt_titles = list(
+					"Emergency Medical Technician" = /datum/alt_title/emt,
+					"Search and Rescue" = /datum/alt_title/sar)
+
+/datum/alt_title/sar
+	title = "Search and Rescue"
+	title_blurb = "A Search and Rescue operative recovers individuals who are injured or dead on the surface of Sif."
+	title_outfit = /decl/hierarchy/outfit/job/medical/sar
+
 /datum/job/rd
     access = list(access_rd, access_heads, access_tox, access_genetics, access_morgue,
                         access_tox_storage, access_teleporter, access_sec_doors,
@@ -47,9 +57,3 @@ var/global/const/access_explorer = 43
                         access_research, access_robotics, access_xenobiology, access_ai_upload, access_tech_storage,
                         access_RC_announce, access_keycard_auth, access_tcomsat, access_gateway, access_xenoarch,
                         access_network, access_maint_tunnels, access_explorer, access_eva, access_external_airlocks)
-			
-/*
-	alt_titles = list(
-		"Explorer Technician" = /decl/hierarchy/outfit/job/explorer2/technician,
-		"Explorer Medic" = /decl/hierarchy/outfit/job/explorer2/medic)
-*/

--- a/maps/cynosure/loadout/loadout_suit.dm
+++ b/maps/cynosure/loadout/loadout_suit.dm
@@ -1,3 +1,8 @@
 /datum/gear/suit/bomber_pilot
 	display_name = "bomber jacket, pilot"
 	path = /obj/item/clothing/suit/storage/toggle/bomber/pilot
+
+/datum/gear/suit/wintercoat/medical/sar
+	display_name = "winter coat, search and rescue"
+	path = /obj/item/clothing/suit/storage/hooded/wintercoat/medical/sar
+	allowed_roles = list("Medical Doctor", "Chief Medical Officer", "Paramedic", "Psychiatrist", "Field Medic")

--- a/maps/cynosure/structures/closets/misc.dm
+++ b/maps/cynosure/structures/closets/misc.dm
@@ -104,6 +104,47 @@
 		/obj/item/geiger,
 		/obj/item/bodybag/cryobag)
 
+//Cynosure Paramedic Locker
+
+/obj/structure/closet/secure_closet/paramedic
+	name = "paramedic locker"
+	desc = "Supplies for a first responder."
+	req_access = list(access_medical_equip)
+	closet_appearance = /decl/closet_appearance/secure_closet/medical/paramedic
+
+	starts_with = list(
+		/obj/item/storage/backpack/dufflebag/emt,
+		/obj/item/storage/box/autoinjectors,
+		/obj/item/storage/box/syringes,
+		/obj/item/reagent_containers/glass/bottle/inaprovaline,
+		/obj/item/reagent_containers/glass/bottle/antitoxin,
+		/obj/item/storage/belt/medical/emt,
+		/obj/item/clothing/mask/gas,
+		/obj/item/clothing/suit/storage/toggle/fr_jacket,
+		/obj/item/clothing/suit/storage/toggle/labcoat/emt,
+		/obj/item/clothing/suit/storage/hooded/wintercoat/medical/sar,
+		/obj/item/clothing/shoes/boots/winter/explorer,
+		/obj/item/radio/headset/headset_med/alt,
+		/obj/item/radio/headset/sar,
+		/obj/item/cartridge/medical,
+		/obj/item/storage/briefcase/inflatable,
+		/obj/item/flashlight,
+		/obj/item/tank/emergency/oxygen/engi,
+		/obj/item/clothing/glasses/hud/health,
+		/obj/item/healthanalyzer,
+		/obj/item/radio/off,
+		/obj/random/medical,
+		/obj/item/tool/crowbar,
+		/obj/item/extinguisher/mini,
+		/obj/item/storage/box/freezer,
+		/obj/item/clothing/accessory/storage/white_vest,
+		/obj/item/taperoll/medical,
+		/obj/item/gps/medical,
+		/obj/item/geiger,
+		/obj/item/gun/energy/phasegun/pistol,
+		/obj/item/cell/device/weapon
+		)
+
 //Pilot Locker
 
 /obj/structure/closet/secure_closet/pilot


### PR DESCRIPTION
Name on the tin:

- Moved Search and Rescue role to being an alt title to Paramedic.

- Removed the commented out Explorer Medic and Enigee (unlikely to come back anytime soon).

- Adds Search and Rescue coat, boots, headset, and a phase pistol plus one energy cell to paramedic locker.

- Search and Rescue coat can now be selected by all medical staff except for chemistry.