### PR TITLE
correct empty first aid kits in lockers to regular

### DIFF
--- a/maps/cynosure/cynosure-1.dmm
+++ b/maps/cynosure/cynosure-1.dmm
@@ -19525,7 +19525,7 @@
 	},
 /obj/item/roller,
 /obj/item/bodybag/cryobag,
-/obj/item/storage/firstaid,
+/obj/item/storage/firstaid/regular,
 /obj/item/storage/pill_bottle/spaceacillin,
 /turf/simulated/floor/tiled/white,
 /area/surface/outpost/research/xenoarcheology)

--- a/maps/cynosure/cynosure-2.dmm
+++ b/maps/cynosure/cynosure-2.dmm
@@ -51796,7 +51796,7 @@
 	},
 /obj/item/storage/pill_bottle/spaceacillin,
 /obj/item/roller,
-/obj/item/storage/firstaid,
+/obj/item/storage/firstaid/regular,
 /turf/simulated/floor/tiled/freezer,
 /area/surface/station/crew_quarters/pool)
 "xAM" = (


### PR DESCRIPTION
from #8589 by Cerebulon

First aid kits in lockers no longer spawn empty in some cases.
