### PR TITLE
corrects isolation alarm IDs

### DIFF
--- a/maps/cynosure/cynosure-1.dmm
+++ b/maps/cynosure/cynosure-1.dmm
@@ -5097,9 +5097,10 @@
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 4
 	},
-/obj/machinery/alarm{
+/obj/machinery/alarm/monitor/isolation{
 	dir = 4;
-	pixel_x = -22
+	pixel_x = -22;
+	alarm_id = "isolation_one"
 	},
 /obj/machinery/camera/network/research_outpost{
 	c_tag = "OPR - Isolation Cell A";
@@ -10298,9 +10299,10 @@
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 4
 	},
-/obj/machinery/alarm{
+/obj/machinery/alarm/monitor/isolation{
 	dir = 4;
-	pixel_x = -22
+	pixel_x = -22;
+	alarm_id = "isolation_three"
 	},
 /obj/machinery/camera/network/research_outpost{
 	c_tag = "OPR - Isolation Cell C";
@@ -18639,9 +18641,10 @@
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 4
 	},
-/obj/machinery/alarm{
+/obj/machinery/alarm/monitor/isolation{
 	dir = 4;
-	pixel_x = -22
+	pixel_x = -22;
+	alarm_id = "isolation_two"
 	},
 /obj/machinery/camera/network/research_outpost{
 	c_tag = "OPR - Isolation Cell B";


### PR DESCRIPTION
from #8589 by Cerebulon

Anomaly isolation cell air alarm IDs match the control laptop, and are repathed to monitor versions to prevent normal alarms.

fixes #8553