### PR TITLE
pool swimwear locker names, holo floor/item names

### DIFF
--- a/code/modules/holodeck/HolodeckObjects.dm
+++ b/code/modules/holodeck/HolodeckObjects.dm
@@ -4,6 +4,7 @@
 // Holographic racks are in code/modules/tables/rack.dm
 
 /turf/simulated/floor/holofloor
+	desc = "A convincing simulation."
 	thermal_conductivity = 0
 
 /turf/simulated/floor/holofloor/attackby(obj/item/W as obj, mob/user as mob)
@@ -272,6 +273,7 @@
 	no_attack_log = 1
 
 /obj/item/holo/esword
+	name = "holographic energy sword"
 	desc = "May the force be within you. Sorta."
 	icon = 'icons/obj/weapons.dmi'
 	icon_state = "esword"

--- a/maps/cynosure/cynosure-2.dmm
+++ b/maps/cynosure/cynosure-2.dmm
@@ -3156,7 +3156,9 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/structure/closet/athletic_swimwear,
+/obj/structure/closet/athletic_swimwear{
+	name = "swimwear wardrobe"
+	},
 /turf/simulated/floor/tiled/freezer,
 /area/surface/station/crew_quarters/pool)
 "bwp" = (
@@ -9122,7 +9124,9 @@
 "eni" = (
 /obj/effect/floor_decal/corner/white/diagonal,
 /obj/structure/window/reinforced,
-/obj/structure/closet/athletic_swimwear,
+/obj/structure/closet/athletic_swimwear{
+	name = "swimwear wardrobe"
+	},
 /turf/simulated/floor/tiled/freezer,
 /area/surface/station/crew_quarters/pool)
 "enM" = (


### PR DESCRIPTION
from #8589 by Cerebulon

Poolside swimwear lockers are named swimwear wardrobes.

Holodeck floor and holodeck esword have holodeck names.
Fixes #8565
Fixes #8566