### PR TITLE
un-recommends editorconfig for vscode

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,7 +2,6 @@
   "recommendations": [
     "gbasood.byond-dm-language-support",
     "platymuus.dm-langclient",
-    "EditorConfig.EditorConfig",
     "eamodio.gitlens"
   ]
 }


### PR DESCRIPTION
I determined that the editorconfig plugin for vscode was causing files to be completely rewritten for people using it. Since that's a heck of a pitfall and the vscode settings are more nuanced to begin with, no longer recommends that plugin.

The editorconfig file is still useful, so it's retained - I'm honestly not sure why the plugin does that, but a separate editor natively supporting .editorconfig didn't have the same horrid behavior.