### PR TITLE
fix reactor pool heating up cooling pipes

### DIFF
--- a/code/ATMOSPHERICS/datum_pipeline.dm
+++ b/code/ATMOSPHERICS/datum_pipeline.dm
@@ -161,16 +161,14 @@
 
 	if(istype(target, /turf/simulated))
 		var/turf/simulated/modeled_location = target
-		
-		if(modeled_location.special_temperature)//First do special interactions then the usuall stuff
 
-			var/delta_temp = modeled_location.special_temperature - air.temperature//2200C - 20C = 2180K
-			//assuming aluminium with thermal conductivity 235 W * K / m, Copper (400), Silver (430), steel (50), gold (320)
-			var/heat_gain = 23500 * 100 * delta_temp
-			air.add_thermal_energy(heat_gain)
-			if(network)
-				network.update = 1
-		
+		if (modeled_location.special_temperature)
+			air.temperature += thermal_conductivity * (modeled_location.special_temperature - air.temperature)
+			if (air.temperature < TCMB)
+				air.temperature = TCMB
+			if (network)
+				network.update = TRUE
+
 		if(modeled_location.blocks_air)
 
 			if((modeled_location.heat_capacity>0) && (partial_heat_capacity>0))


### PR DESCRIPTION
thermal_conductivity is a 0..1 multiplier, not a massive watt/k/m thing. This caused Problems.
using add_thermal_energy also caused problems.

The new thing simply assumes that a turf with a special temperature doesn't care about all the heat capacity and air pressure jazz, and uses the normal passed thermal conductivity as a multiplier against moving the pipeline's temperature toward the special temperature, correcting if scary.

I've tested this by running the engine for a bit and the cold loop stays cold and the hot loop stays hot, as is tradition. 🤷 

I don't think this feature is useful or good, but this fix is an optional alternative to reverting it.