### PR TITLE
mapfluff

### DIFF
--- a/maps/cynosure/cynosure_areas.dm
+++ b/maps/cynosure/cynosure_areas.dm
@@ -1533,13 +1533,13 @@
 	icon_state = "shuttle2"
 
 /area/shuttle/exploration/general
-	name = "\improper Exploration Shuttle"
+	name = "\improper NTC Calvera Passenger Compartment"
 
 /area/shuttle/exploration/cockpit
-	name = "\improper Exploration Shuttle Cockpit"
+	name = "\improper NTC Calvera Cockpit"
 
 /area/shuttle/exploration/cargo
-	name = "\improper Exploration Shuttle Cargo"
+	name = "\improper NTC Calvera Cargo and Engine Room"
 
 //Centcomm Antags and Others
 

--- a/maps/cynosure/cynosure_jobs.dm
+++ b/maps/cynosure/cynosure_jobs.dm
@@ -34,7 +34,12 @@ var/global/const/access_explorer = 43
 	job_description = "An Explorer searches for interesting things on the surface of Sif, and returns them to the station."
 
 	alt_titles = list(
-		"Pilot" = /decl/hierarchy/outfit/job/pilot)
+		"Pilot" = /datum/alt_title/pilot)
+
+/datum/alt_title/pilot
+	title = "Pilot"
+	title_blurb = "A pilot ferries crew around in Cynosure Station's shuttle, the NTC Calvera."
+	title_outfit = /decl/hierarchy/outfit/job/pilot
 
 /datum/job/paramedic
 	alt_titles = list(

--- a/maps/cynosure/cynosure_shuttles.dm
+++ b/maps/cynosure/cynosure_shuttles.dm
@@ -426,7 +426,7 @@ ESCAPE_POD(1)
 // Explorer Shuttle
 
 /datum/shuttle/autodock/overmap/explorer_shuttle
-	name = "Exploration Shuttle"
+	name = "NTC Calvera"
 	warmup_time = 0
 	current_location = "nav_pad4_cynosure"
 	docking_controller_tag = "expshuttle_docker"
@@ -435,15 +435,16 @@ ESCAPE_POD(1)
 	ceiling_type = /turf/simulated/floor/reinforced
 
 /obj/effect/overmap/visitable/ship/landable/explorer_shuttle
-	name = "Exploration Shuttle"
+	name = "NTC Calvera"
 	desc = "The exploration team's shuttle."
+	scanner_desc = "A Wulf Vagabond-class short-range expedition shuttle. It is broadcasting NanoTrasen identification codes: VIR-472-320377 - NTC Calvera."
 	vessel_mass = 2000
 	vessel_size = SHIP_SIZE_SMALL
-	shuttle = "Exploration Shuttle"
+	shuttle = "NTC Calvera"
 
 /obj/machinery/computer/shuttle_control/explore/explorer_shuttle
 	name = "takeoff and landing console"
-	shuttle_tag = "Exploration Shuttle"
+	shuttle_tag = "NTC Calvera"
 	req_one_access = list(access_explorer)
 
 /*

--- a/maps/cynosure/overmap/sectors.dm
+++ b/maps/cynosure/overmap/sectors.dm
@@ -2,6 +2,7 @@
 /obj/effect/overmap/visitable/planet/Sif
 	name = "Sif"
 	desc = "A cold, Earth-like planet. Cynosure Station is located here."
+	scanner_desc = "The third planet in the Vir system. SCG membership registered 2332. Primary settlement: New Reykjavik. Sensors detect abundant flora and fauna. Atmosphere suitable for human habitation. High activity on communications wavebands."
 	map_z = list(
 		Z_LEVEL_STATION_ONE,
 		Z_LEVEL_STATION_TWO,
@@ -39,7 +40,9 @@
 	tmp.pixel_y = skybox_offset_y
 	return tmp
 /obj/effect/overmap/visitable/telecomm_sat
-	name = "Telecommunications Satellite"
+	name = "NLS CommRelay Sif-48"
+	desc = "A small satellite with multiple antennas, providing telecommuncation connections to  groundside facilities."
+	scanner_desc = "An automated satellite in orbit of Sif. It is broadcasting NanoTrasen identification codes: VIR-524-285935."
 	icon_state = "object"
 	initial_generic_waypoints = list(
 		"nav_telecomm_dockarm" //Tcomm sat docking


### PR DESCRIPTION
Adds some sensor data to current overmap objects.
Renames the explorer shuttle to the name that was voted on, the NTC Calvera.
adds a name to the telecoms sat.
makes the pilot alt title into a proper alt title. This Fixes #8462