### PR TITLE
Properly fixes holodeck landmark deletion

### DIFF
--- a/code/modules/holodeck/HolodeckControl.dm
+++ b/code/modules/holodeck/HolodeckControl.dm
@@ -334,6 +334,7 @@
 
 	spawn(30)
 		for(var/obj/effect/landmark/L in linkedholodeck)
+			L.delete_me = 1
 			if(L.name=="Atmospheric Test Start")
 				spawn(20)
 					var/turf/T = get_turf(L)


### PR DESCRIPTION
Apparently landmark objects need a special var set to be deletable at all.