### PR TITLE
Removing references to non-existent type path.

### DIFF
--- a/code/__defines/dcs/signals.dm
+++ b/code/__defines/dcs/signals.dm
@@ -398,10 +398,6 @@
 ///called when removing a given item from a mob, from mob/living/carbon/remove_embedded_object(mob/living/carbon/target, /obj/item)
 #define COMSIG_CARBON_EMBED_REMOVAL "item_embed_remove_safe"
 
-// /mob/living/simple_animal/hostile signals
-#define COMSIG_HOSTILE_ATTACKINGTARGET "hostile_attackingtarget"
-	#define COMPONENT_HOSTILE_NO_ATTACK (1<<0)
-
 // /obj signals
 
 ///from base of obj/deconstruct(): (disassembled)

--- a/code/game/gamemodes/events/holidays/Christmas.dm
+++ b/code/game/gamemodes/events/holidays/Christmas.dm
@@ -4,8 +4,6 @@
 		for(var/turf/simulated/floor/T in orange(1,xmas))
 			for(var/i=1,i<=rand(1,5),i++)
 				new /obj/item/a_gift(T)
-	//for(var/mob/living/simple_animal/corgi/Ian/Ian in mob_list)
-	//	Ian.place_on_head(new /obj/item/clothing/head/helmet/space/santahat(Ian))
 
 /proc/ChristmasEvent()
 	for(var/obj/structure/flora/tree/pine/xmas in world)
@@ -57,4 +55,3 @@
 	flags_inv = 0
 	body_parts_covered = 0
 	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 0, rad = 0)
-

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -300,11 +300,6 @@
 	if(!MP)
 		return 0	//Sanity, this should never happen.
 
-/*
-	if(ispath(MP, /mob/living/simple_animal/space_worm))
-		return 0 //Unfinished. Very buggy, they seem to just spawn additional space worms everywhere and eating your own tail results in new worms spawning.
-*/
-
 //Good mobs!
 	if(ispath(MP, /mob/living/simple_mob/animal/passive/cat))
 		return 1
@@ -327,6 +322,3 @@
 
 	//Not in here? Must be untested!
 	return 0
-
-
-

--- a/code/modules/tgui/states/notcontained.dm
+++ b/code/modules/tgui/states/notcontained.dm
@@ -21,6 +21,3 @@ GLOBAL_DATUM_INIT(tgui_notcontained_state, /datum/tgui_state/notcontained_state,
 
 /mob/living/silicon/notcontained_can_use_tgui_topic(src_object)
 	return default_can_use_tgui_topic(src_object) // Silicons use default bevhavior.
-
-/mob/living/simple_animal/drone/notcontained_can_use_tgui_topic(src_object)
-	return default_can_use_tgui_topic(src_object) // Drones use default bevhavior.


### PR DESCRIPTION
`/mob/living/simple_animal` doesn't exist on this codebase and the defines/etc referencing it are unused as far as I can tell.