### PR TITLE
Removes irrelevant gluttony regen code segment.

### DIFF
--- a/code/modules/mob/_modifiers/unholy.dm
+++ b/code/modules/mob/_modifiers/unholy.dm
@@ -185,16 +185,14 @@
 			var/mob/living/carbon/human/H = holder
 			var/starting_nutrition = H.nutrition
 			H.adjust_nutrition(-10)
-			var/healing_amount = starting_nutrition - H.nutrition
-			if(healing_amount < 0) // If you are eating enough to somehow outpace this, congratulations, you are gluttonous enough to gain a boon.
-				healing_amount *= -2
+			var/healing_amount = starting_nutrition - H.nutrition //Anything above 9 nutrition will return 10. Anything below will give 0-9. Nutrition is capped at 0.
+			if(healing_amount)
+				H.adjustBruteLoss(-healing_amount * 0.25)
 
-			H.adjustBruteLoss(-healing_amount * 0.25)
+				H.adjustFireLoss(-healing_amount * 0.25)
 
-			H.adjustFireLoss(-healing_amount * 0.25)
+				H.adjustOxyLoss(-healing_amount * 0.25)
 
-			H.adjustOxyLoss(-healing_amount * 0.25)
-
-			H.adjustToxLoss(-healing_amount * 0.25)
+				H.adjustToxLoss(-healing_amount * 0.25)
 
 	..()


### PR DESCRIPTION
This fires every life tick so it's impossible to increase your nutrition in the middle of this firing off. 

Additionally, it's impossible to have this ever return a negative value in any manner, since adjust_nutrition has a minimum cap of 0, meaning you won't ever go into a negative. 
Healing_amount will always return 10 (if above 9 nutrition), 1-9 (if your starting nutrition is 1-9) or 0 (if nutrition when this fired was 0)

Additionally, prevents it from trying to heal you if your healing_amount is 0. 
-0 multiplied by 0.025 is still zero.

