### PR TITLE
Tweaks to outdoors turf interactions.

### DIFF
--- a/code/game/turfs/simulated/outdoors/outdoors.dm
+++ b/code/game/turfs/simulated/outdoors/outdoors.dm
@@ -28,63 +28,16 @@ var/global/list/turf_edge_cache = list()
 	var/loot_count
 
 /turf/simulated/floor/outdoors/proc/get_loot_type()
-	if(loot_count && prob(60))
-		return pick( \
-			12;/obj/item/reagent_containers/food/snacks/worm, \
-			1;/obj/item/material/knife/machete/hatchet/stone  \
-		)
+	if(loot_count)
+		return pickweight(list(
+			/obj/item/reagent_containers/food/snacks/worm = 6,
+			/obj/item/material/knife/machete/hatchet/stone = 1
+		))
 
 /turf/simulated/floor/outdoors/Initialize(mapload)
 	. = ..()
 	if(can_dig && prob(33))
 		loot_count = rand(1,3)
-
-/turf/simulated/floor/outdoors/attack_generic(mob/user)
-	if(isanimal(user) && user.loc == src && user.a_intent == I_HELP)
-		var/mob/living/simple_mob/animal/critter = user
-		if(critter.burrower)
-			if(locate(/obj/structure/animal_den) in contents)
-				to_chat(critter, SPAN_WARNING("There is already a den here."))
-				return TRUE
-			critter.visible_message(SPAN_NOTICE("\The [critter] begins digging industriously."))
-			critter.setClickCooldown(10 SECONDS)
-			if(!do_after(critter, 10 SECONDS, src))
-				return TRUE
-			if(locate(/obj/structure/animal_den) in contents)
-				to_chat(critter, SPAN_WARNING("There is already a den here."))
-				return TRUE
-			critter.visible_message(SPAN_NOTICE("\The [critter] finishes digging a den!"))
-			new /obj/structure/animal_den(src)
-			if(prob(66))
-				var/worms = 0
-				for(var/worm in 1 to rand(3))
-					new /obj/item/reagent_containers/food/snacks/worm(src)
-					worms++
-				to_chat(critter, SPAN_NOTICE("You unearthed [worms] worm\s!"))
-			return TRUE
-	. = ..()
-
-/turf/simulated/floor/outdoors/attackby(obj/item/C, mob/user)
-
-	if(can_dig && istype(C, /obj/item/shovel))
-		to_chat(user, SPAN_NOTICE("\The [user] begins digging into \the [src] with \the [C]."))
-		var/delay = (3 SECONDS * C.toolspeed)
-		user.setClickCooldown(delay)
-		if(do_after(user, delay, src))
-			if(!(locate(/obj/machinery/portable_atmospherics/hydroponics/soil) in contents))
-				var/obj/machinery/portable_atmospherics/hydroponics/soil/soil = new(src)
-				user.visible_message(SPAN_NOTICE("\The [user] digs \a [soil] into \the [src]."))
-			else
-				var/loot_type = get_loot_type()
-				if(loot_type)
-					loot_count--
-					var/obj/item/loot = new loot_type(src)
-					to_chat(user, SPAN_NOTICE("You dug up \a [loot]!"))
-				else
-					to_chat(user, SPAN_NOTICE("You didn't find anything of note in \the [src]."))
-			return
-
-	. = ..()
 
 /turf/simulated/floor/Initialize(mapload)
 	if(is_outdoors())

--- a/code/game/turfs/simulated/outdoors/outdoors_attackby.dm
+++ b/code/game/turfs/simulated/outdoors/outdoors_attackby.dm
@@ -1,7 +1,55 @@
-// this code here enables people to dig up worms from certain tiles.
+/turf/simulated/floor/outdoors/attack_generic(mob/user)
+	if(isanimal(user) && user.loc == src && user.a_intent == I_HELP)
+		var/mob/living/simple_mob/animal/critter = user
+		if(critter.burrower)
+			if(locate(/obj/structure/animal_den) in contents)
+				to_chat(critter, SPAN_WARNING("There is already a den here."))
+				return TRUE
+			critter.visible_message(SPAN_NOTICE("\The [critter] begins digging industriously."))
+			critter.setClickCooldown(10 SECONDS)
+			if(!do_after(critter, 10 SECONDS, src))
+				return TRUE
+			if(locate(/obj/structure/animal_den) in contents)
+				to_chat(critter, SPAN_WARNING("There is already a den here."))
+				return TRUE
+			critter.visible_message(SPAN_NOTICE("\The [critter] finishes digging a den!"))
+			new /obj/structure/animal_den(src)
+			var/list/dug_up = list()
+			while(loot_count)
+				var/loot = get_loot_type()
+				if(!ispath(loot))
+					break
+				loot_count--
+				dug_up += new loot(src)
+			if(length(dug_up))
+				to_chat(critter, SPAN_NOTICE("You unearthed [english_list(dug_up)]!"))
+			return TRUE
+	. = ..()
 
-/turf/simulated/floor/outdoors/grass/attackby(obj/item/S as obj, mob/user as mob)
-	if(istype(S, /obj/item/stack/tile/floor))
+/turf/simulated/floor/outdoors/attackby(obj/item/C, mob/user)
+
+	if(can_dig && istype(C, /obj/item/shovel))
+		to_chat(user, SPAN_NOTICE("\The [user] begins digging into \the [src] with \the [C]."))
+		var/delay = (3 SECONDS * C.toolspeed)
+		user.setClickCooldown(delay)
+		if(do_after(user, delay, src))
+			if(!(locate(/obj/machinery/portable_atmospherics/hydroponics/soil) in contents))
+				var/obj/machinery/portable_atmospherics/hydroponics/soil/soil = new(src)
+				user.visible_message(SPAN_NOTICE("\The [user] digs \a [soil] into \the [src]."))
+			else
+				var/loot_type = get_loot_type()
+				if(loot_type)
+					loot_count--
+					var/obj/item/loot = new loot_type(src)
+					to_chat(user, SPAN_NOTICE("You dug up \a [loot]!"))
+				else
+					to_chat(user, SPAN_NOTICE("You didn't find anything of note in \the [src]."))
+		return TRUE
+
+	if(istype(C, /obj/item/stack/tile/floor))
+		var/obj/item/stack/stack = C
+		stack.use(1)
 		ChangeTurf(/turf/simulated/floor, preserve_outdoors = TRUE)
-		return
+		return TRUE
+
 	. = ..()

--- a/code/game/turfs/simulated/outdoors/snow.dm
+++ b/code/game/turfs/simulated/outdoors/snow.dm
@@ -28,16 +28,21 @@
 
 /turf/simulated/floor/outdoors/snow/attackby(var/obj/item/W, var/mob/user)
 	if(istype(W, /obj/item/shovel))
-		to_chat(user, "<span class='notice'>You begin to remove \the [src] with your [W].</span>")
+		to_chat(user, SPAN_NOTICE("You begin to remove \the [src] with your [W.name]."))
 		if(do_after(user, 4 SECONDS * W.toolspeed))
-			to_chat(user, "<span class='notice'>\The [src] has been dug up, and now lies in a pile nearby.</span>")
+			to_chat(user, SPAN_NOTICE("\The [src] has been dug up, and now lies in a pile nearby."))
 			var/obj/item/stack/material/snow/S = new(src)
 			S.amount = 10
 			demote()
 		else
-			to_chat(user, "<span class='notice'>You decide to not finish removing \the [src].</span>")
-	else
-		..()
+			to_chat(user, SPAN_NOTICE("You decide to not finish removing \the [src]."))
+		return TRUE
+
+	if(istype(W, /obj/item/stack/tile/floor))
+		to_chat(user, SPAN_WARNING("Remove the snow with a shovel first!"))
+		return TRUE
+
+	return ..()
 
 /turf/simulated/floor/outdoors/snow/attack_hand(mob/user as mob)
 	visible_message("[user] starts scooping up some snow.", "You start scooping up some snow.")
@@ -45,7 +50,6 @@
 		var/obj/S = new /obj/item/stack/material/snow(user.loc)
 		user.put_in_hands(S)
 		visible_message("[user] scoops up a pile of snow.", "You scoop up a pile of snow.")
-	return
 
 /turf/simulated/floor/outdoors/ice
 	name = "ice"


### PR DESCRIPTION
- Floor construction is now handled on the base outdoors turf instead of the grass turf specifically.
- Digging a den now unearths all loot on the turf instead of magic worms.
- Loot no longer has a 66% fail chance regardless of the outdoors turf having loot or not.
- Stones are more common when digging on an outdoors turf.