### PR TITLE
Lateload breaker boxes.

### DIFF
--- a/code/modules/power/breaker_box.dm
+++ b/code/modules/power/breaker_box.dm
@@ -37,7 +37,11 @@
 
 // Enabled on server startup. Used in substations to keep them in bypass mode.
 /obj/machinery/power/breakerbox/activated/Initialize()
-	. = ..()
+	..()
+	return INITIALIZE_HINT_LATELOAD // Lateload due to problems with powernet initialization and ordering
+
+/obj/machinery/power/breakerbox/activated/LateInitialize()
+	..()
 	set_state(1)
 
 /obj/machinery/power/breakerbox/examine(mob/user)


### PR DESCRIPTION
@Novacat reported issues with this on Virgo and it seems like it wasn't fixed on Polaris either.