### PR TITLE
Overhauls loadout naming and point costs

### DIFF
--- a/code/modules/client/preference_setup/loadout/loadout_accessories.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_accessories.dm
@@ -35,7 +35,7 @@
 	path = /obj/item/storage/wallet/poly
 
 /datum/gear/accessory/wallet/womens
-	display_name = "wallet, womens"
+	display_name = "wallet, women's"
 	path = /obj/item/storage/wallet/womens
 
 /datum/gear/accessory/wallet/womens/New()
@@ -232,7 +232,7 @@
 	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(sweaters))
 
 /datum/gear/accessory/bracelet/material
-	display_name = "bracelet selection"
+	display_name = "bracelet, selection"
 	description = "Choose from a number of bracelets."
 	path = /obj/item/clothing/accessory/bracelet
 	cost = 1
@@ -254,11 +254,11 @@
 	gear_tweaks += new/datum/gear_tweak/path(bracelettype)
 
 /datum/gear/accessory/bracelet/friendship
-	display_name = "friendship bracelet"
+	display_name = "bracelet, friendship"
 	path = /obj/item/clothing/accessory/bracelet/friendship
 
 /datum/gear/accessory/bracelet/slap
-	display_name = "slap bracelet (recolorable)"
+	display_name = "bracelet, slap (recolorable)"
 	path = /obj/item/clothing/accessory/bracelet/slap
 
 /datum/gear/accessory/bracelet/slap/New()
@@ -266,7 +266,7 @@
 	gear_tweaks += gear_tweak_free_color_choice
 
 /datum/gear/accessory/bracelet/beaded
-	display_name = "beaded bracelet (recolorable)"
+	display_name = "bracelet, beaded (recolorable)"
 	path = /obj/item/clothing/accessory/bracelet/beaded
 
 /datum/gear/accessory/bracelet/beaded/New()
@@ -283,11 +283,11 @@
 	path = /obj/item/clothing/accessory/locket
 
 /datum/gear/accessory/halfcape
-	display_name = "half cape"
+	display_name = "cape, half"
 	path = /obj/item/clothing/accessory/halfcape
 
 /datum/gear/accessory/fullcape
-	display_name = "full cape"
+	display_name = "cape, full"
 	path = /obj/item/clothing/accessory/fullcape
 
 /datum/gear/accessory/sash

--- a/code/modules/client/preference_setup/loadout/loadout_contraband.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_contraband.dm
@@ -44,7 +44,7 @@
 	display_name = "phase pistol"
 	description = "A phase pistol designed for handling the typical wildlife found on Sif. Not particularly effective against anything else..."
 	path = /obj/item/gun/energy/phasegun/pistol
-	cost = 5
+	cost = 4
 
 /datum/gear/contraband/knives /// Steel by default
 	display_name = "knife selection"

--- a/code/modules/client/preference_setup/loadout/loadout_contraband.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_contraband.dm
@@ -44,7 +44,7 @@
 	display_name = "phase pistol"
 	description = "A phase pistol designed for handling the typical wildlife found on Sif. Not particularly effective against anything else..."
 	path = /obj/item/gun/energy/phasegun/pistol
-	cost = 4
+	cost = 5
 
 /datum/gear/contraband/knives /// Steel by default
 	display_name = "knife selection"

--- a/code/modules/client/preference_setup/loadout/loadout_eyes.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_eyes.dm
@@ -36,15 +36,15 @@
 	gear_tweaks += gear_tweak_free_color_choice
 
 /datum/gear/eyes/glasses
-	display_name = "Glasses, prescription"
+	display_name = "glasses, prescription"
 	path = /obj/item/clothing/glasses/regular
 
 /datum/gear/eyes/glasses/green
-	display_name = "Glasses, green"
+	display_name = "glasses, green"
 	path = /obj/item/clothing/glasses/gglasses
 
 /datum/gear/eyes/glasses/prescriptionhipster
-	display_name = "Glasses, hipster"
+	display_name = "glasses, hipster"
 	path = /obj/item/clothing/glasses/regular/hipster
 
 /datum/gear/eyes/glasses/monocle
@@ -52,100 +52,100 @@
 	path = /obj/item/clothing/glasses/monocle
 
 /datum/gear/eyes/goggles
-	display_name = "plain goggles"
+	display_name = "goggles, plain"
 	path = /obj/item/clothing/glasses/goggles
 
 /datum/gear/eyes/goggles/scanning
-	display_name = "scanning goggles"
+	display_name = "goggles, scanning"
 	path = /obj/item/clothing/glasses/regular/scanners
 
 /datum/gear/eyes/goggles/science
-	display_name = "Science Goggles"
+	display_name = "goggles, science"
 	path = /obj/item/clothing/glasses/science
 
 /datum/gear/eyes/security
-	display_name = "Security HUD (Security)"
+	display_name = "security HUD (Security)"
 	path = /obj/item/clothing/glasses/hud/security
 	allowed_roles = list("Security Officer","Head of Security","Warden", "Detective")
 
 /datum/gear/eyes/security/prescriptionsec
-	display_name = "Security HUD, prescription (Security)"
+	display_name = "security HUD, prescription (Security)"
 	path = /obj/item/clothing/glasses/hud/security/prescription
 
 /datum/gear/eyes/security/sunglasshud
-	display_name = "Security HUD, sunglasses (Security)"
+	display_name = "security HUD, sunglasses (Security)"
 	path = /obj/item/clothing/glasses/sunglasses/sechud
 
 /datum/gear/eyes/security/aviator
-	display_name = "Security HUD Aviators (Security)"
+	display_name = "security HUD Aviators (Security)"
 	path = /obj/item/clothing/glasses/sunglasses/sechud/aviator
 
 /datum/gear/eyes/security/aviator/prescription
-	display_name = "Security HUD Aviators, prescription (Security)"
+	display_name = "security HUD Aviators, prescription (Security)"
 	path = /obj/item/clothing/glasses/sunglasses/sechud/aviator/prescription
 
 /datum/gear/eyes/medical
-	display_name = "Medical HUD (Medical)"
+	display_name = "medical HUD (Medical)"
 	path = /obj/item/clothing/glasses/hud/health
 	allowed_roles = list("Medical Doctor","Chief Medical Officer","Chemist","Paramedic","Geneticist", "Psychiatrist", "Search and Rescue")
 
 /datum/gear/eyes/medical/prescriptionmed
-	display_name = "Medical HUD, prescription (Medical)"
+	display_name = "medical HUD, prescription (Medical)"
 	path = /obj/item/clothing/glasses/hud/health/prescription
 
 /datum/gear/eyes/medical/aviator
-	display_name = "Medical HUD Aviators (Medical)"
+	display_name = "medical HUD Aviators (Medical)"
 	path = /obj/item/clothing/glasses/hud/health/aviator
 
 /datum/gear/eyes/medical/aviator/prescription
-	display_name = "Medical HUD Aviators, prescription (Medical)"
+	display_name = "medical HUD Aviators, prescription (Medical)"
 	path = /obj/item/clothing/glasses/hud/health/aviator/prescription
 
 /datum/gear/eyes/meson
-	display_name = "Optical Meson Scanners (Engineering, Science, Mining)"
+	display_name = "optical meson scanners (Engineering, Science, Mining)"
 	path = /obj/item/clothing/glasses/meson
 	allowed_roles = list("Station Engineer","Chief Engineer","Atmospheric Technician", "Scientist", "Research Director", "Shaft Miner")
 
 /datum/gear/eyes/meson/prescription
-	display_name = "Optical Meson Scanners, prescription (Engineering, Science, Mining)"
+	display_name = "optical meson scanners, prescription (Engineering, Science, Mining)"
 	path = /obj/item/clothing/glasses/meson/prescription
 
 /datum/gear/eyes/material
-	display_name = "Optical Material Scanners (Mining)"
+	display_name = "optical material scanners (Mining)"
 	path = /obj/item/clothing/glasses/material
 	allowed_roles = list("Shaft Miner","Quartermaster")
 
 /datum/gear/eyes/material/prescription
-	display_name = "Prescription Optical Material Scanners (Mining)"
+	display_name = "optical material scanners, prescription (Mining)"
 	path = /obj/item/clothing/glasses/material/prescription
 
 /datum/gear/eyes/meson/aviator
-	display_name = "Optical Meson Aviators, (Engineering, Science, Mining)"
+	display_name = "optical meson aviators (Engineering, Science, Mining)"
 	path = /obj/item/clothing/glasses/meson/aviator
 
 /datum/gear/eyes/meson/aviator/prescription
-	display_name = "Optical Meson Aviators, prescription (Engineering, Science, Mining)"
+	display_name = "optical meson aviators, prescription (Engineering, Science, Mining)"
 	path = /obj/item/clothing/glasses/meson/aviator/prescription
 
 /datum/gear/eyes/glasses/fakesun
-	display_name = "Sunglasses, stylish"
+	display_name = "sunglasses, stylish"
 	path = /obj/item/clothing/glasses/fakesunglasses
 
 /datum/gear/eyes/glasses/fakeaviator
-	display_name = "Sunglasses, stylish aviators"
+	display_name = "sunglasses, stylish aviators"
 	path = /obj/item/clothing/glasses/fakesunglasses/aviator
 
 /datum/gear/eyes/sun
-	display_name = "Sunglasses (Security/Command)"
+	display_name = "sunglasses (Security/Command)"
 	path = /obj/item/clothing/glasses/sunglasses
 	allowed_roles = list("Security Officer","Head of Security","Warden","Site Manager","Head of Personnel","Quartermaster","Internal Affairs Agent","Detective")
 
 /datum/gear/eyes/sun/shades
-	display_name = "Sunglasses, fat (Security/Command)"
+	display_name = "sunglasses, fat (Security/Command)"
 	path = /obj/item/clothing/glasses/sunglasses/big
 
 /datum/gear/eyes/sun/aviators
-	display_name = "Sunglasses, aviators (Security/Command)"
+	display_name = "sunglasses, aviators (Security/Command)"
 	path = /obj/item/clothing/glasses/sunglasses/aviator
 
 /datum/gear/eyes/sun/prescriptionsun
@@ -157,17 +157,17 @@
 	path = /obj/item/clothing/glasses/circuitry
 
 /datum/gear/eyes/glasses/rimless
-	display_name = "Glasses, rimless"
+	display_name = "glasses, rimless"
 	path = /obj/item/clothing/glasses/rimless
 
 /datum/gear/eyes/glasses/prescriptionrimless
-	display_name = "Glasses, prescription rimless"
+	display_name = "glasses, prescription rimless"
 	path = /obj/item/clothing/glasses/regular/rimless
 
 /datum/gear/eyes/glasses/thin
-	display_name = "Glasses, thin frame"
+	display_name = "glasses, thin frame"
 	path = /obj/item/clothing/glasses/thin
 
 /datum/gear/eyes/glasses/prescriptionthin
-	display_name = "Glasses, prescription thin frame"
+	display_name = "glasses, prescription thin frame"
 	path = /obj/item/clothing/glasses/regular/thin

--- a/code/modules/client/preference_setup/loadout/loadout_general.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_general.dm
@@ -3,11 +3,11 @@
 	path = /obj/item/cane
 
 /datum/gear/cane/white
-	display_name = "white cane"
+	display_name = "cane, white"
 	path = /obj/item/cane/white
 
 /datum/gear/cane/white2
-	display_name = "telescopic white cane"
+	display_name = "cane, white, telescopic"
 	path = /obj/item/cane/white/collapsible
 
 /datum/gear/crutch
@@ -89,7 +89,7 @@
 
 
 /datum/gear/flask
-	display_name = "flask"
+	display_name = "flask, standard"
 	path = /obj/item/reagent_containers/food/drinks/flask/barflask
 
 /datum/gear/flask/New()
@@ -97,7 +97,7 @@
 	gear_tweaks += new/datum/gear_tweak/reagents(lunchables_ethanol_reagents())
 
 /datum/gear/vacflask
-	display_name = "vacuum-flask"
+	display_name = "flask, vacuum"
 	path = /obj/item/reagent_containers/food/drinks/flask/vacuumflask
 
 /datum/gear/vacflask/New()

--- a/code/modules/client/preference_setup/loadout/loadout_gloves.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_gloves.dm
@@ -67,7 +67,7 @@
 	cost = 1
 
 /datum/gear/gloves/evening
-	display_name = "evening gloves"
+	display_name = "gloves, evening"
 	path = /obj/item/clothing/gloves/evening
 	cost = 1
 
@@ -76,7 +76,7 @@
 	gear_tweaks += gear_tweak_free_color_choice
 
 /datum/gear/gloves/duty
-	display_name = "duty gloves"
+	display_name = "gloves, duty"
 	path = /obj/item/clothing/gloves/duty
 	cost = 2
 
@@ -87,7 +87,7 @@
 	cost = 1
 
 /datum/gear/gloves/fingerless
-	display_name = "fingerless gloves"
+	display_name = "gloves, fingerless"
 	path = /obj/item/clothing/gloves/fingerless
 	cost = 1
 

--- a/code/modules/client/preference_setup/loadout/loadout_gloves.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_gloves.dm
@@ -2,29 +2,34 @@
 /datum/gear/gloves
 	display_name = "gloves, black"
 	path = /obj/item/clothing/gloves/black
-	cost = 1
+	cost = 2
 	slot = slot_gloves
 	sort_category = "Gloves and Handwear"
 
 /datum/gear/gloves/blue
 	display_name = "gloves, blue"
 	path = /obj/item/clothing/gloves/blue
+	cost = 1
 
 /datum/gear/gloves/brown
 	display_name = "gloves, brown"
 	path = /obj/item/clothing/gloves/brown
+	cost = 1
 
 /datum/gear/gloves/light_brown
 	display_name = "gloves, light-brown"
 	path = /obj/item/clothing/gloves/light_brown
+	cost = 1
 
 /datum/gear/gloves/green
 	display_name = "gloves, green"
 	path = /obj/item/clothing/gloves/green
+	cost = 1
 
 /datum/gear/gloves/grey
 	display_name = "gloves, grey"
 	path = /obj/item/clothing/gloves/grey
+	cost = 1
 
 /datum/gear/gloves/latex
 	display_name = "gloves, latex"
@@ -39,44 +44,52 @@
 /datum/gear/gloves/orange
 	display_name = "gloves, orange"
 	path = /obj/item/clothing/gloves/orange
+	cost = 1
 
 /datum/gear/gloves/purple
 	display_name = "gloves, purple"
 	path = /obj/item/clothing/gloves/purple
+	cost = 1
 
 /datum/gear/gloves/rainbow
 	display_name = "gloves, rainbow"
 	path = /obj/item/clothing/gloves/rainbow
+	cost = 1
 
 /datum/gear/gloves/red
 	display_name = "gloves, red"
 	path = /obj/item/clothing/gloves/red
+	cost = 1
 
 /datum/gear/gloves/white
 	display_name = "gloves, white"
 	path = /obj/item/clothing/gloves/white
+	cost = 1
 
 /datum/gear/gloves/evening
 	display_name = "evening gloves"
 	path = /obj/item/clothing/gloves/evening
+	cost = 1
 
 /datum/gear/gloves/evening/New()
 	..()
 	gear_tweaks += gear_tweak_free_color_choice
 
 /datum/gear/gloves/duty
-	display_name = "gloves, work"
+	display_name = "duty gloves"
 	path = /obj/item/clothing/gloves/duty
-	cost = 3
+	cost = 2
 
 /datum/gear/gloves/forensic
 	display_name = "gloves, forensic (Detective)"
 	path = /obj/item/clothing/gloves/forensic
 	allowed_roles = list("Detective")
+	cost = 1
 
 /datum/gear/gloves/fingerless
 	display_name = "fingerless gloves"
 	path = /obj/item/clothing/gloves/fingerless
+	cost = 1
 
 /datum/gear/gloves/fingerless/New()
 	..()
@@ -112,3 +125,4 @@
 /datum/gear/gloves/circuitry
 	display_name = "gloves, circuitry (empty)"
 	path = /obj/item/clothing/gloves/circuitry
+	cost = 1

--- a/code/modules/client/preference_setup/loadout/loadout_gloves.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_gloves.dm
@@ -126,3 +126,8 @@
 	display_name = "gloves, circuitry (empty)"
 	path = /obj/item/clothing/gloves/circuitry
 	cost = 1
+
+/datum/gear/gloves/botanic_leather
+	display_name = "gloves, botanic leather"
+	path = /obj/item/clothing/gloves/botanic_leather
+	cost = 2

--- a/code/modules/client/preference_setup/loadout/loadout_head.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_head.dm
@@ -131,19 +131,19 @@
 	path = /obj/item/clothing/head/soft/mbill
 
 /datum/gear/head/cap/sol
-	display_name = "cap, sol"
+	display_name = "cap, solgov"
 	path = /obj/item/clothing/head/soft/solgov
 
 /datum/gear/head/cowboy
-	display_name = "cowboy, rodeo"
+	display_name = "cowboy hat, rodeo"
 	path = /obj/item/clothing/head/cowboy_hat
 
 /datum/gear/head/cowboy/black
-	display_name = "cowboy, black"
+	display_name = "cowboy hat, black"
 	path = /obj/item/clothing/head/cowboy_hat/black
 
 /datum/gear/head/cowboy/wide
-	display_name = "cowboy, wide"
+	display_name = "cowboy hat, wide"
 	path = /obj/item/clothing/head/cowboy_hat/wide
 
 /datum/gear/head/fedora
@@ -265,11 +265,11 @@
 	gear_tweaks += gear_tweak_free_color_choice
 
 /datum/gear/head/kitty
-	display_name = "kitty ears"
+	display_name = "ears, kitty"
 	path = /obj/item/clothing/head/kitty
 
 /datum/gear/head/rabbit
-	display_name = "rabbit ears"
+	display_name = "ears, rabbit"
 	path = /obj/item/clothing/head/rabbitears
 
 /datum/gear/head/beanie
@@ -281,7 +281,7 @@
 	gear_tweaks += gear_tweak_free_color_choice
 
 /datum/gear/head/loose_beanie
-	display_name = "loose beanie"
+	display_name = "beanie, loose"
 	path = /obj/item/clothing/head/beanie_loose
 
 /datum/gear/head/loose_beanie/New()
@@ -301,7 +301,7 @@
 	path = /obj/item/clothing/head/sombrero
 
 /datum/gear/head/flatcapg
-	display_name = "flat cap"
+	display_name = "cap, flat"
 	path = /obj/item/clothing/head/flatcap/grey
 
 /datum/gear/head/flatcapg/New()
@@ -339,7 +339,7 @@
 	path = /obj/item/clothing/head/welding/engie
 
 /datum/gear/head/beret/solgov
-	display_name = "beret government, selection"
+	display_name = "beret, solgov selection"
 	path = /obj/item/clothing/head/beret/solgov
 
 /datum/gear/head/beret/solgov/New()
@@ -351,7 +351,7 @@
 	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(sols))
 
 /datum/gear/head/surgery
-	display_name = "surgical cap selection"
+	display_name = "cap, surgical selection"
 	description = "Choose from a number of rings of different caps."
 	path = /obj/item/clothing/head/surgery
 
@@ -386,19 +386,19 @@
 	path = /obj/item/clothing/head/jingasa
 
 /datum/gear/head/sunflower_crown
-	display_name = "sunflower crown"
+	display_name = "flower crown, sunflower"
 	path = /obj/item/clothing/head/sunflower_crown
 
 /datum/gear/head/lavender_crown
-	display_name = "lavender crown"
+	display_name = "flower crown, lavender"
 	path = /obj/item/clothing/head/lavender_crown
 
 /datum/gear/head/poppy_crown
-	display_name = "poppy crown"
+	display_name = "flower crown, poppy"
 	path = /obj/item/clothing/head/poppy_crown
 
 /datum/gear/head/rose_crown
-	display_name = "rose crown"
+	display_name = "flower crown, rose"
 	path = /obj/item/clothing/head/rose_crown
 
 /datum/gear/head/blackngoldheaddress
@@ -406,5 +406,5 @@
 	path = /obj/item/clothing/head/blackngoldheaddress
 
 /datum/gear/head/plaguedoctor2
-	display_name = "golden plague doctor's hat"
+	display_name = "hat, golden plague doctor"
 	path = /obj/item/clothing/head/plaguedoctorhat/gold

--- a/code/modules/client/preference_setup/loadout/loadout_mask.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_mask.dm
@@ -18,7 +18,7 @@
 	path = /obj/item/clothing/mask/bandana/red
 
 /datum/gear/mask/sterile
-	display_name = "sterile mask"
+	display_name = "mask, sterile"
 	path = /obj/item/clothing/mask/surgical
 	cost = 2
 
@@ -41,7 +41,7 @@
 	gear_tweaks += new/datum/gear_tweak/path(masks)
 
 /datum/gear/mask/cloth
-	display_name = "cloth mask (recolorable)"
+	display_name = "mask, cloth (recolorable)"
 	path = /obj/item/clothing/mask/surgical/cloth
 	cost = 2
 
@@ -50,6 +50,6 @@
 	gear_tweaks += gear_tweak_free_color_choice
 
 /datum/gear/mask/dust
-	display_name = "dust mask"
+	display_name = "mask, dust"
 	path = /obj/item/clothing/mask/surgical/dust
 	cost = 2

--- a/code/modules/client/preference_setup/loadout/loadout_shoes.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_shoes.dm
@@ -8,22 +8,27 @@
 /datum/gear/shoes/jackboots
 	display_name = "jackboots"
 	path = /obj/item/clothing/shoes/boots/jackboots
+	cost = 2
 
 /datum/gear/shoes/kneeboots
 	display_name = "jackboots, knee-length"
 	path = /obj/item/clothing/shoes/boots/jackboots/knee
+	cost = 2
 
 /datum/gear/shoes/thighboots
-	display_name = "jackboots. thigh-length"
+	display_name = "jackboots, thigh-length"
 	path = /obj/item/clothing/shoes/boots/jackboots/thigh
+	cost = 2
 
 /datum/gear/shoes/workboots
 	display_name = "workboots"
 	path = /obj/item/clothing/shoes/boots/workboots
+	cost = 2
 
 /datum/gear/shoes/workboots/toeless
 	display_name = "toe-less workboots"
 	path = /obj/item/clothing/shoes/boots/workboots/toeless
+	cost = 2
 
 /datum/gear/shoes/black
 	display_name = "shoes, black"
@@ -140,7 +145,7 @@
 
 /datum/gear/shoes/duty
 	display_name = "duty boots"
-	path = 	/obj/item/clothing/shoes/boots/duty
+	path = /obj/item/clothing/shoes/boots/duty
 	cost = 2
 
 /datum/gear/shoes/dress

--- a/code/modules/client/preference_setup/loadout/loadout_shoes.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_shoes.dm
@@ -26,7 +26,7 @@
 	cost = 2
 
 /datum/gear/shoes/workboots/toeless
-	display_name = "toe-less workboots"
+	display_name = "workboots, toe-less"
 	path = /obj/item/clothing/shoes/boots/workboots/toeless
 	cost = 2
 
@@ -82,17 +82,17 @@
 	display_name = "shoes, yellow"
 	path = /obj/item/clothing/shoes/yellow
 
-/datum/gear/shoes/hitops/
-	display_name = "high-top selection"
-	path = /obj/item/clothing/shoes/hitops/
+/datum/gear/shoes/hitops
+	display_name = "shoes, high-top selection"
+	path = /obj/item/clothing/shoes/hitops
 
 /datum/gear/shoes/hitops/New()
-    ..()
-    var/list/hitops = list()
-    for(var/hitop in typesof(/obj/item/clothing/shoes/hitops))
-        var/obj/item/clothing/shoes/hitops/hitop_type = hitop
-        hitops[initial(hitop_type.name)] = hitop_type
-    gear_tweaks += new/datum/gear_tweak/path(sortAssoc(hitops))
+	..()
+	var/list/hitops = list()
+	for(var/hitop in typesof(/obj/item/clothing/shoes/hitops))
+		var/obj/item/clothing/shoes/hitops/hitop_type = hitop
+		hitops[initial(hitop_type.name)] = hitop_type
+	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(hitops))
 
 /datum/gear/shoes/flipflops
 	display_name = "flip flops"
@@ -103,7 +103,7 @@
 	gear_tweaks += gear_tweak_free_color_choice
 
 /datum/gear/shoes/athletic
-	display_name = "athletic shoes"
+	display_name = "shoes, athletic"
 	path = /obj/item/clothing/shoes/athletic
 
 /datum/gear/shoes/athletic/New()
@@ -111,7 +111,7 @@
 	gear_tweaks += gear_tweak_free_color_choice
 
 /datum/gear/shoes/skater
-	display_name = "skater shoes"
+	display_name = "shoes, skater"
 	path = /obj/item/clothing/shoes/skater
 
 /datum/gear/shoes/skater/New()
@@ -127,24 +127,24 @@
 	gear_tweaks += gear_tweak_free_color_choice
 
 /datum/gear/shoes/cowboy
-	display_name = "cowboy boots"
+	display_name = "boots, cowboy"
 	path = /obj/item/clothing/shoes/boots/cowboy
 
 /datum/gear/shoes/cowboy/classic
-	display_name = "classic cowboy boots"
+	display_name = "boots, cowboy classic"
 	path = /obj/item/clothing/shoes/boots/cowboy/classic
 
 /datum/gear/shoes/cowboy/snakeskin
-	display_name = "snakeskin cowboy boots"
+	display_name = "boots, cowboy snakeskin"
 	path = /obj/item/clothing/shoes/boots/cowboy/snakeskin
 
 /datum/gear/shoes/jungle
-	display_name = "jungle boots"
+	display_name = "boots, jungle"
 	path = /obj/item/clothing/shoes/boots/jungle
 	cost = 2
 
 /datum/gear/shoes/duty
-	display_name = "duty boots"
+	display_name = "boots, duty"
 	path = /obj/item/clothing/shoes/boots/duty
 	cost = 2
 
@@ -173,41 +173,41 @@
 	path = /obj/item/clothing/shoes/boots/winter
 
 /datum/gear/shoes/boots/winter/security
-	display_name = "security winter boots"
+	display_name = "winter boots, security"
 	path = /obj/item/clothing/shoes/boots/winter/security
 	allowed_roles = list("Security Officer", "Head of Security", "Warden", "Detective")
 
 /datum/gear/shoes/boots/winter/science
-	display_name = "science winter boots"
+	display_name = "winter boots, science"
 	path = /obj/item/clothing/shoes/boots/winter/science
 
 /datum/gear/shoes/boots/winter/command
-	display_name = "site manager's winter boots"
+	display_name = "winter boots, site manager"
 	path = /obj/item/clothing/shoes/boots/winter/command
 	allowed_roles = list("Site Manager")
 
 /datum/gear/shoes/boots/winter/engineering
-	display_name = "engineering winter boots"
+	display_name = "winter boots, engineering"
 	path = /obj/item/clothing/shoes/boots/winter/engineering
 
 /datum/gear/shoes/boots/winter/atmos
-	display_name = "atmospherics winter boots"
+	display_name = "winter boots, atmospherics"
 	path = /obj/item/clothing/shoes/boots/winter/atmos
 
 /datum/gear/shoes/boots/winter/medical
-	display_name = "medical winter boots"
+	display_name = "winter boots, medical"
 	path = /obj/item/clothing/shoes/boots/winter/medical
 
 /datum/gear/shoes/boots/winter/mining
-	display_name = "mining winter boots"
+	display_name = "winter boots, mining"
 	path = /obj/item/clothing/shoes/boots/winter/mining
 
 /datum/gear/shoes/boots/winter/supply
-	display_name = "supply winter boots"
+	display_name = "winter boots, supply"
 	path = /obj/item/clothing/shoes/boots/winter/supply
 
 /datum/gear/shoes/boots/winter/hydro
-	display_name = "hydroponics winter boots"
+	display_name = "winter boots, hydroponics"
 	path = /obj/item/clothing/shoes/boots/winter/hydro
 
 /datum/gear/shoes/circuitry

--- a/code/modules/client/preference_setup/loadout/loadout_smoking.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_smoking.dm
@@ -16,11 +16,11 @@
 	path = /obj/item/storage/box/matches
 
 /datum/gear/lighter
-	display_name = "cheap lighter"
+	display_name = "lighter, cheap"
 	path = /obj/item/flame/lighter
 
 /datum/gear/lighter/zippo
-	display_name = "Zippo selection"
+	display_name = "lighter, zippo selection"
 	path = /obj/item/flame/lighter/zippo
 
 /datum/gear/lighter/zippo/New()

--- a/code/modules/client/preference_setup/loadout/loadout_suit.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_suit.dm
@@ -4,7 +4,7 @@
 	path = /obj/item/clothing/suit/storage/apron
 	slot = slot_wear_suit
 	sort_category = "Suits and Overwear"
-	cost = 2
+	cost = 1
 
 /datum/gear/suit/apron_white
 	display_name = "apron, colorable"
@@ -25,22 +25,27 @@
 /datum/gear/suit/puffer_coat
 	display_name = "puffer coat"
 	path = /obj/item/clothing/suit/jacket/puffer
+	cost = 2
 
 /datum/gear/suit/puffer_vest
 	display_name = "puffer vest"
 	path = /obj/item/clothing/suit/jacket/puffer/vest
+	cost = 2
 
 /datum/gear/suit/bomber
 	display_name = "bomber jacket"
 	path = /obj/item/clothing/suit/storage/toggle/bomber
+	cost = 2
 
 /datum/gear/suit/bomber_alt
 	display_name = "bomber jacket 2"
 	path = /obj/item/clothing/suit/storage/bomber/alt
+	cost = 2
 
 /datum/gear/suit/bomber_retro
 	display_name = "bomber jacket, retro"
 	path = /obj/item/clothing/suit/storage/toggle/bomber/retro
+	cost = 2
 
 /datum/gear/suit/leather_jacket
 	display_name = "leather jacket, black"
@@ -125,6 +130,7 @@
 /datum/gear/suit/hoodie
 	display_name = "hoodie selection"
 	path = /obj/item/clothing/suit/storage/toggle/hoodie
+	cost = 2
 
 /datum/gear/suit/hoodie/New()
 	..()
@@ -137,6 +143,7 @@
 /datum/gear/suit/labcoat
 	display_name = "labcoat"
 	path = /obj/item/clothing/suit/storage/toggle/labcoat
+	cost = 2
 
 /datum/gear/suit/labcoat/blue
 	display_name = "labcoat, blue"
@@ -188,16 +195,15 @@
 	display_name = "surgical apron"
 	path = /obj/item/clothing/suit/surgicalapron
 	allowed_roles = list("Medical Doctor","Chief Medical Officer")
+	cost = 1
 
 /datum/gear/suit/overalls
 	display_name = "overalls"
 	path = /obj/item/clothing/suit/storage/apron/overalls
-	cost = 1
 
 /datum/gear/suit/poncho
 	display_name = "poncho selection"
 	path = /obj/item/clothing/accessory/poncho
-	cost = 1
 
 /datum/gear/suit/poncho/New()
 	..()
@@ -210,7 +216,6 @@
 /datum/gear/suit/roles/poncho
 	display_name = "poncho, cargo"
 	path = /obj/item/clothing/accessory/poncho/roles/cargo
-	cost = 1
 
 /datum/gear/suit/roles/poncho/security
 	display_name = "poncho, security"
@@ -306,7 +311,6 @@
 /datum/gear/suit/unathi_robe
 	display_name = "roughspun robe"
 	path = /obj/item/clothing/suit/unathi/robe
-	cost = 1
 
 /datum/gear/suit/black_lawyer_jacket
 	display_name = "suit jacket, black"
@@ -349,6 +353,7 @@
 /datum/gear/suit/wintercoat
 	display_name = "winter coat"
 	path = /obj/item/clothing/suit/storage/hooded/wintercoat
+	cost = 2
 
 /datum/gear/suit/wintercoat/captain
 	display_name = "winter coat, site manager"
@@ -595,6 +600,7 @@
 /datum/gear/suit/snowsuit
 	display_name = "snowsuit"
 	path = /obj/item/clothing/suit/storage/snowsuit
+	cost = 2
 
 /datum/gear/suit/snowsuit/command
 	display_name = "snowsuit, command"

--- a/code/modules/client/preference_setup/loadout/loadout_suit.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_suit.dm
@@ -96,7 +96,7 @@
 	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(mil_jackets))
 
 /datum/gear/suit/greyjacket
-	display_name = "grey jacket"
+	display_name = "jacket, grey"
 	path = /obj/item/clothing/suit/storage/greyjacket
 
 /datum/gear/suit/brown_trenchcoat
@@ -192,7 +192,7 @@
 	path = /obj/item/clothing/suit/storage/toggle/labcoat/plaguedoctor
 
 /datum/gear/suit/roles/surgical_apron
-	display_name = "surgical apron"
+	display_name = "apron, surgical"
 	path = /obj/item/clothing/suit/surgicalapron
 	allowed_roles = list("Medical Doctor","Chief Medical Officer")
 	cost = 1
@@ -415,7 +415,6 @@
 	path = /obj/item/clothing/suit/storage/hooded/wintercoat/science
 	allowed_roles = list("Research Director","Scientist", "Roboticist", "Xenobiologist", "Xenobotanist")
 
-
 /datum/gear/suit/wintercoat/science/robotics
 	display_name = "winter coat, robotics"
 	path = /obj/item/clothing/suit/storage/hooded/wintercoat/science/robotics
@@ -490,7 +489,7 @@
 // winter coats end here
 
 /datum/gear/suit/varsity
-	display_name = "varsity jacket selection"
+	display_name = "jacket, varsity selection"
 	path = /obj/item/clothing/suit/varsity
 
 /datum/gear/suit/varsity/New()
@@ -502,7 +501,7 @@
 	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(varsities))
 
 /datum/gear/suit/track
-	display_name = "track jacket selection"
+	display_name = "jacket, track selection"
 	path = /obj/item/clothing/suit/storage/toggle/track
 
 /datum/gear/suit/track/New()
@@ -514,19 +513,19 @@
 	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(tracks))
 
 /datum/gear/suit/flannel
-	display_name = "grey flannel"
+	display_name = "flannel, grey"
 	path = /obj/item/clothing/suit/storage/flannel
 
 /datum/gear/suit/flannel/red
-	display_name = "red flannel"
+	display_name = "flannel, red"
 	path = /obj/item/clothing/suit/storage/flannel/red
 
 /datum/gear/suit/flannel/aqua
-	display_name = "aqua flannel"
+	display_name = "flannel, aqua"
 	path = /obj/item/clothing/suit/storage/flannel/aqua
 
 /datum/gear/suit/flannel/brown
-	display_name = "brown flannel"
+	display_name = "flannel, brown"
 	path = /obj/item/clothing/suit/storage/flannel/brown
 
 /datum/gear/suit/denim_jacket

--- a/code/modules/client/preference_setup/loadout/loadout_uniform.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_uniform.dm
@@ -78,7 +78,7 @@
 	gear_tweaks += gear_tweak_free_color_choice
 
 /datum/gear/uniform/skirt
-	display_name = "skirt selection"
+	display_name = "skirt, selection"
 	path = /obj/item/clothing/under/skirt
 
 /datum/gear/uniform/skirt/New()
@@ -90,7 +90,7 @@
 	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(skirts))
 
 /datum/gear/uniform/pants
-	display_name = "pants selection"
+	display_name = "pants, selection"
 	path = /obj/item/clothing/under/pants/white
 
 /datum/gear/uniform/pants/New()
@@ -312,7 +312,7 @@
 	path = /obj/item/clothing/under/sundress_white
 
 /datum/gear/uniform/dress_fire
-	display_name = "flame dress"
+	display_name = "dress, flame"
 	path = /obj/item/clothing/under/dress/dress_fire
 
 /datum/gear/uniform/uniform_captain
@@ -367,7 +367,7 @@
 	allowed_roles = list("Head of Security")
 
 /datum/gear/uniform/shortplaindress
-	display_name = "plain dress"
+	display_name = "dress, plain"
 	path = /obj/item/clothing/under/dress/white3
 
 /datum/gear/uniform/shortplaindress/New()
@@ -375,7 +375,7 @@
 	gear_tweaks += gear_tweak_free_color_choice
 
 /datum/gear/uniform/longdress
-	display_name = "long dress"
+	display_name = "dress, long"
 	path = /obj/item/clothing/under/dress/white2
 
 /datum/gear/uniform/longdress/New()
@@ -383,7 +383,7 @@
 	gear_tweaks += gear_tweak_free_color_choice
 
 /datum/gear/uniform/longwidedress
-	display_name = "long wide dress"
+	display_name = "dress, long and wide"
 	path = /obj/item/clothing/under/dress/white4
 
 /datum/gear/uniform/longwidedress/New()
@@ -391,27 +391,27 @@
 	gear_tweaks += gear_tweak_free_color_choice
 
 /datum/gear/uniform/reddress
-	display_name = "red dress with belt"
+	display_name = "dress, red with belt"
 	path = /obj/item/clothing/under/dress/darkred
 
 /datum/gear/uniform/whitewedding
-	display_name= "white wedding dress"
+	display_name = "dress, white wedding"
 	path = /obj/item/clothing/under/wedding/bride_white
 
 /datum/gear/uniform/skirts
-	display_name = "executive skirt"
+	display_name = "skirt, executive"
 	path = /obj/item/clothing/under/suit_jacket/female/skirt
 
 /datum/gear/uniform/dresses
-	display_name = "sailor dress"
+	display_name = "dress, sailor"
 	path = /obj/item/clothing/under/dress/sailordress
 
 /datum/gear/uniform/dresses/eveninggown
-	display_name = "red evening gown"
+	display_name = "evening gown, red"
 	path = /obj/item/clothing/under/dress/redeveninggown
 
 /datum/gear/uniform/dresses/maid
-	display_name = "maid uniform selection"
+	display_name = "uniform, maid selection"
 	path = /obj/item/clothing/under/dress/maid
 
 /datum/gear/uniform/dresses/maid/New()
@@ -527,7 +527,7 @@
 	path = 	/obj/item/clothing/under/frontier
 
 /datum/gear/uniform/yogapants
-	display_name = "yoga pants"
+	display_name = "pants, yoga"
 	path = /obj/item/clothing/under/pants/yogapants
 
 /datum/gear/uniform/yogapants/New()
@@ -539,11 +539,11 @@
 	path = /obj/item/clothing/under/dress/black_corset
 
 /datum/gear/uniform/flower_dress
-	display_name = "flower dress"
+	display_name = "dress, flower"
 	path = /obj/item/clothing/under/dress/flower_dress
 
 /datum/gear/uniform/red_swept_dress
-	display_name = "red swept dress"
+	display_name = "dress, red swept"
 	path = /obj/item/clothing/under/dress/red_swept_dress
 
 /datum/gear/uniform/bathrobe
@@ -551,15 +551,15 @@
 	path = /obj/item/clothing/under/bathrobe
 
 /datum/gear/uniform/flamenco
-	display_name = "flamenco dress"
+	display_name = "dress, flamenco"
 	path = /obj/item/clothing/under/dress/flamenco
 
 /datum/gear/uniform/alpinedress
-	display_name = "alpine dress"
+	display_name = "dress, alpine"
 	path = /obj/item/clothing/under/dress/alpine
 
 /datum/gear/uniform/westernbustle
-	display_name = "western bustle"
+	display_name = "dress, western bustle"
 	path = /obj/item/clothing/under/dress/westernbustle
 
 /datum/gear/uniform/circuitry
@@ -595,39 +595,39 @@
 	gear_tweaks += gear_tweak_free_color_choice
 
 /datum/gear/uniform/lilacdress
-	display_name = "lilac dress"
+	display_name = "dress, lilac"
 	path = /obj/item/clothing/under/dress/lilacdress
 
 /datum/gear/uniform/polka
-	display_name = "polka dot dress"
+	display_name = "dress, polka dot"
 	path = /obj/item/clothing/under/dress/polka
 
 /datum/gear/uniform/twistfront
-	display_name = "twistfront crop dress"
+	display_name = "dress, twistfront crop"
 	path = /obj/item/clothing/under/dress/twistfront
 
 /datum/gear/uniform/cropdress
-	display_name = "crop dress"
+	display_name = "dress, crop"
 	path = /obj/item/clothing/under/dress/cropdress
 
 /datum/gear/uniform/vneckdress
-	display_name = "v-neck dress"
+	display_name = "dress, v-neck"
 	path = /obj/item/clothing/under/dress/vneck
 
 /datum/gear/uniform/bluedress
-	display_name = "blue dress"
+	display_name = "dress, blue"
 	path = /obj/item/clothing/under/dress/bluedress
 
 /datum/gear/uniform/wench
-	display_name = "wench's dress"
+	display_name = "dress, wench"
 	path = /obj/item/clothing/under/dress/wench
 
 /datum/gear/uniform/littleblackdress
-	display_name = "little black dress"
+	display_name = "dress, little black"
 	path = /obj/item/clothing/under/dress/littleblackdress
 
 /datum/gear/uniform/golddress
-	display_name = "golden dress"
+	display_name = "dress, golden"
 	path =/obj/item/clothing/under/dress/golddress
 
 /datum/gear/uniform/goldwrap
@@ -639,7 +639,7 @@
 	path = /obj/item/clothing/under/dress/pinktutu
 
 /datum/gear/uniform/festivedress
-	display_name = "festive dress"
+	display_name = "dress, festive"
 	path = /obj/item/clothing/under/dress/festivedress
 
 /datum/gear/uniform/haltertop
@@ -647,7 +647,7 @@
 	path = /obj/item/clothing/under/haltertop
 
 /datum/gear/uniform/revealingdress
-	display_name = "revealing dress"
+	display_name = "dress, revealing"
 	path = /obj/item/clothing/under/dress/revealingdress
 
 /datum/gear/uniform/rippedpunk
@@ -655,19 +655,19 @@
 	path = /obj/item/clothing/under/rippedpunk
 
 /datum/gear/uniform/gothic
-	display_name = "gothic dress"
+	display_name = "dress, gothic"
 	path = /obj/item/clothing/under/dress/gothic
 
 /datum/gear/uniform/formalred
-	display_name = "formal red dress"
+	display_name = "dress, formal red"
 	path = /obj/item/clothing/under/dress/formalred
 
 /datum/gear/uniform/pentagram
-	display_name = "pentagram dress"
+	display_name = "dress, pentagram"
 	path = /obj/item/clothing/under/dress/pentagram
 
 /datum/gear/uniform/yellowswoop
-	display_name = "yellow swooped dress"
+	display_name = "dress, yellow swooped"
 	path = /obj/item/clothing/under/dress/yellowswoop
 
 /datum/gear/uniform/greenasym
@@ -683,7 +683,7 @@
 	path = /obj/item/clothing/under/wedding/whitegown
 
 /datum/gear/uniform/floofdress
-	display_name = "floofy dress"
+	display_name = "dress, floofy"
 	path = /obj/item/clothing/under/wedding/floofdress
 
 /datum/gear/uniform/floofdress/New()
@@ -695,7 +695,7 @@
 	path = /obj/item/clothing/under/blackngold
 
 /datum/gear/uniform/sheerblue
-	display_name = "sheer blue dress"
+	display_name = "dress, sheer blue"
 	path = /obj/item/clothing/under/sheerblue
 
 /datum/gear/uniform/disheveled
@@ -703,39 +703,39 @@
 	path = /obj/item/clothing/under/disheveled
 
 /datum/gear/uniform/orangedress
-	display_name = "orange dress"
+	display_name = "dress, orange"
 	path = /obj/item/clothing/under/dress/dress_orange
 
 /datum/gear/uniform/sundress_pink
-	display_name = "pink sundress"
+	display_name = "sundress, pink"
 	path = /obj/item/clothing/under/dress/sundress_pink
 
 /datum/gear/uniform/sundress_white
-	display_name = "white sundress"
+	display_name = "sundress, white"
 	path = /obj/item/clothing/under/dress/sundress_white
 
 /datum/gear/uniform/sundress_pinkbow
-	display_name = "bowed pink sundress"
+	display_name = "sundress, bowed pink"
 	path = /obj/item/clothing/under/dress/sundress_pinkbow
 
 /datum/gear/uniform/sundress_blue
-	display_name = "long blue sundress"
+	display_name = "sundress, long blue"
 	path = /obj/item/clothing/under/dress/sundress_blue
 
 /datum/gear/uniform/sundress_pinkshort
-	display_name = "short pink sundress"
+	display_name = "sundress, short pink"
 	path = /obj/item/clothing/under/dress/sundress_pinkshort
 
 /datum/gear/uniform/twopiece
-	display_name = "two-piece dress"
+	display_name = "dress, two-piece"
 	path = /obj/item/clothing/under/dress/twopiece
 
 /datum/gear/uniform/gothic2
-	display_name = "lacey gothic dress"
+	display_name = "dress, lacey gothic"
 	path = /obj/item/clothing/under/dress/gothic2
 
 /datum/gear/uniform/flowerskirt
-	display_name = "flower skirt"
+	display_name = "skirt, flower"
 	path = /obj/item/clothing/under/flower_skirt
 
 /datum/gear/uniform/flowerskirt/New()
@@ -743,7 +743,7 @@
 	gear_tweaks += gear_tweak_free_color_choice
 
 /datum/gear/uniform/countess
-	display_name = "countess dress"
+	display_name = "dress, countess"
 	path = /obj/item/clothing/under/dress/countess
 
 /datum/gear/uniform/vampire

--- a/code/modules/client/preference_setup/loadout/loadout_utility.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_utility.dm
@@ -75,7 +75,7 @@
 	path = /obj/item/paicard
 
 /datum/gear/utility/securecase
-	display_name = "secure briefcase"
+	display_name = "briefcase, secure"
 	path =/obj/item/storage/secure/briefcase
 	cost = 2
 
@@ -114,11 +114,11 @@
 	path = /obj/item/cell/device
 
 /datum/gear/utility/pen
-	display_name = "Fountain Pen"
+	display_name = "fountain pen"
 	path = /obj/item/pen/fountain
 
 /datum/gear/utility/umbrella
-	display_name = "Umbrella"
+	display_name = "umbrella"
 	path = /obj/item/melee/umbrella
 	cost = 1
 
@@ -145,19 +145,16 @@ modular computers
 ****************/
 
 /datum/gear/utility/cheaptablet
-	display_name = "tablet computer: cheap"
 	display_name = "tablet computer, cheap"
 	path = /obj/item/modular_computer/tablet/preset/custom_loadout/cheap
 	cost = 3
 
 /datum/gear/utility/normaltablet
-	display_name = "tablet computer: advanced"
 	display_name = "tablet computer, advanced"
 	path = /obj/item/modular_computer/tablet/preset/custom_loadout/advanced
 	cost = 4
 
 /datum/gear/utility/customtablet
-	display_name = "tablet computer: custom"
 	display_name = "tablet computer, custom"
 	path = /obj/item/modular_computer/tablet
 	cost = 4

--- a/code/modules/client/preference_setup/loadout/loadout_utility.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_utility.dm
@@ -120,7 +120,7 @@
 /datum/gear/utility/umbrella
 	display_name = "Umbrella"
 	path = /obj/item/melee/umbrella
-	cost = 3
+	cost = 1
 
 /datum/gear/utility/umbrella/New()
 	..()
@@ -130,7 +130,7 @@
 	display_name = "wheelchair selection"
 	path = /obj/item/wheelchair
 	cost = 4
-	
+
 /datum/gear/utility/wheelchair/New()
 	..()
 	gear_tweaks += gear_tweak_free_color_choice
@@ -179,7 +179,7 @@ modular computers
 /datum/gear/utility/customlaptop
 	display_name = "laptop computer, custom"
 	path = /obj/item/modular_computer/laptop/preset/
-	cost = 7
+	cost = 5
 
 /datum/gear/utility/customlaptop/New()
 	..()

--- a/code/modules/client/preference_setup/loadout/loadout_xeno.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_xeno.dm
@@ -73,7 +73,7 @@
 	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(longtypes))
 
 /datum/gear/ears/skrell/colored/band
-	display_name = "Colored bands (Skrell)"
+	display_name = "colored bands (Skrell)"
 	path = /obj/item/clothing/ears/skrell/colored/band
 	sort_category = "Xenowear"
 	whitelisted = SPECIES_SKRELL
@@ -83,7 +83,7 @@
 	gear_tweaks += gear_tweak_free_color_choice
 
 /datum/gear/ears/skrell/colored/chain
-	display_name = "Colored chain (Skrell)"
+	display_name = "colored chain (Skrell)"
 	path = /obj/item/clothing/ears/skrell/colored/chain
 	sort_category = "Xenowear"
 	whitelisted = SPECIES_SKRELL
@@ -167,107 +167,107 @@
 	sort_category = "Xenowear"
 
 /datum/gear/uniform/dept/undercoat/cap
-	display_name = "facility director undercoat (Teshari)"
+	display_name = "undercoat, facility director (Teshari)"
 	path = /obj/item/clothing/under/teshari/undercoat/jobs/cap
 	allowed_roles = list("Facility Director")
 
 /datum/gear/uniform/dept/undercoat/hop
-	display_name = "head of personnel undercoat (Teshari)"
+	display_name = "undercoat, head of personnel (Teshari)"
 	path = /obj/item/clothing/under/teshari/undercoat/jobs/hop
 	allowed_roles = list("Head of Personnel")
 
 /datum/gear/uniform/dept/undercoat/rd
-	display_name = "research director undercoat (Teshari)"
+	display_name = "undercoat, research director (Teshari)"
 	path = /obj/item/clothing/under/teshari/undercoat/jobs/rd
 	allowed_roles = list("Research Director")
 
 /datum/gear/uniform/dept/undercoat/hos
-	display_name = "head of security undercoat (Teshari)"
+	display_name = "undercoat, head of security (Teshari)"
 	path = /obj/item/clothing/under/teshari/undercoat/jobs/hos
 	allowed_roles = list("Head of Security")
 
 /datum/gear/uniform/dept/undercoat/ce
-	display_name = "chief engineer undercoat (Teshari)"
+	display_name = "undercoat, chief engineer (Teshari)"
 	path = /obj/item/clothing/under/teshari/undercoat/jobs/ce
 	allowed_roles = list("Chief Engineer")
 
 /datum/gear/uniform/dept/undercoat/cmo
-	display_name = "chief medical officer undercoat (Teshari)"
+	display_name = "undercoat, chief medical officer (Teshari)"
 	path = /obj/item/clothing/under/teshari/undercoat/jobs/cmo
 	allowed_roles = list("Chief Medical Officer")
 
 /datum/gear/uniform/dept/undercoat/qm
-	display_name = "quartermaster undercoat (Teshari)"
+	display_name = "undercoat, quartermaster (Teshari)"
 	path = /obj/item/clothing/under/teshari/undercoat/jobs/qm
 	allowed_roles = list("Quartermaster")
 
 /datum/gear/uniform/dept/undercoat/cargo
-	display_name = "cargo undercoat (Teshari)"
+	display_name = "undercoat, cargo (Teshari)"
 	path = /obj/item/clothing/under/teshari/undercoat/jobs/cargo
 	allowed_roles = list("Cargo Technician","Quartermaster","Shaft Miner")
 
 /datum/gear/uniform/dept/undercoat/mining
-	display_name = "mining undercoat (Teshari)"
+	display_name = "undercoat, mining (Teshari)"
 	path = /obj/item/clothing/under/teshari/undercoat/jobs/mining
 	allowed_roles = list("Quartermaster","Shaft Miner")
 
 /datum/gear/uniform/dept/undercoat/security
-	display_name = "security undercoat (Teshari)"
+	display_name = "undercoat, security (Teshari)"
 	path = /obj/item/clothing/under/teshari/undercoat/jobs/sec
 	allowed_roles = list("Head of Security","Detective","Warden","Security Officer",)
 
 /datum/gear/uniform/dept/undercoat/service
-	display_name = "service undercoat (Teshari)"
+	display_name = "undercoat, service (Teshari)"
 	path = /obj/item/clothing/under/teshari/undercoat/jobs/service
 	allowed_roles = list("Head of Personnel","Bartender","Botanist","Janitor","Chef","Librarian","Chaplain")
 
 /datum/gear/uniform/dept/undercoat/engineer
-	display_name = "engineering undercoat (Teshari)"
+	display_name = "undercoat, engineering (Teshari)"
 	path = /obj/item/clothing/under/teshari/undercoat/jobs/engineer
 	allowed_roles = list("Chief Engineer","Station Engineer")
 
 /datum/gear/uniform/dept/undercoat/atmos
-	display_name = "atmospherics undercoat (Teshari)"
+	display_name = "undercoat, atmospherics (Teshari)"
 	path = /obj/item/clothing/under/teshari/undercoat/jobs/atmos
 	allowed_roles = list("Chief Engineer","Atmospheric Technician")
 
 /datum/gear/uniform/dept/undercoat/research
-	display_name = "scientist undercoat (Teshari)"
+	display_name = "undercoat, scientist (Teshari)"
 	path = /obj/item/clothing/under/teshari/undercoat/jobs/sci
 	allowed_roles = list("Research Director","Scientist", "Roboticist", "Xenobiologist")
 
 /datum/gear/uniform/dept/undercoat/robo
-	display_name = "roboticist undercoat (Teshari)"
+	display_name = "undercoat, roboticist (Teshari)"
 	path = /obj/item/clothing/under/teshari/undercoat/jobs/robo
 	allowed_roles = list("Research Director","Roboticist")
 
 /datum/gear/uniform/dept/undercoat/medical
-	display_name = "medical undercoat (Teshari)"
+	display_name = "undercoat, medical (Teshari)"
 	path = /obj/item/clothing/under/teshari/undercoat/jobs/medical
 	allowed_roles = list("Chief Medical Officer","Medical Doctor","Chemist","Paramedic","Geneticist","Psychiatrist")
 
 /datum/gear/uniform/dept/undercoat/chemistry
-	display_name = "chemist undercoat (Teshari)"
+	display_name = "undercoat, chemist (Teshari)"
 	path = /obj/item/clothing/under/teshari/undercoat/jobs/chemistry
 	allowed_roles = list("Chief Medical Officer","Chemist")
 
 /datum/gear/uniform/dept/undercoat/virology
-	display_name = "virologist undercoat (Teshari)"
+	display_name = "undercoat, virologist (Teshari)"
 	path = /obj/item/clothing/under/teshari/undercoat/jobs/viro
 	allowed_roles = list("Chief Medical Officer","Medical Doctor")
 
 /datum/gear/uniform/dept/undercoat/psych
-	display_name = "psychiatrist undercoat (Teshari)"
+	display_name = "undercoat, psychiatrist (Teshari)"
 	path = /obj/item/clothing/under/teshari/undercoat/jobs/psych
 	allowed_roles = list("Chief Medical Officer","Psychiatrist")
 
 /datum/gear/uniform/dept/undercoat/paramedic
-	display_name = "paramedic undercoat (Teshari)"
+	display_name = "undercoat, paramedic (Teshari)"
 	path = /obj/item/clothing/under/teshari/undercoat/jobs/para
 	allowed_roles = list("Chief Medical Officer","Paramedic")
 
 /datum/gear/uniform/dept/undercoat/iaa
-	display_name = "internal affairs undercoat (Teshari)"
+	display_name = "undercoat, internal affairs (Teshari)"
 	path = /obj/item/clothing/under/teshari/undercoat/jobs/iaa
 	allowed_roles = list("Internal Affairs Agent")
 
@@ -276,22 +276,22 @@
 	sort_category = "Xenowear"
 
 /datum/gear/suit/dept/cloak/cap
-	display_name = "facility director cloak (Teshari)"
+	display_name = "cloak, facility director (Teshari)"
 	path = /obj/item/clothing/suit/storage/teshari/cloak/jobs
 	allowed_roles = list("Facility Director")
 
 /datum/gear/suit/dept/cloak/hop
-	display_name = "head of personnel cloak (Teshari)"
+	display_name = "cloak, head of personnel (Teshari)"
 	path = /obj/item/clothing/suit/storage/teshari/cloak/jobs/hop
 	allowed_roles = list("Head of Personnel")
 
 /datum/gear/suit/dept/cloak/rd
-	display_name = "research director cloak (Teshari)"
+	display_name = "cloak, research director (Teshari)"
 	path = /obj/item/clothing/suit/storage/teshari/cloak/jobs/rd
 	allowed_roles = list("Research Director")
 
 /datum/gear/suit/dept/cloak/hos
-	display_name = "head of security cloak (Teshari)"
+	display_name = "cloak, head of security (Teshari)"
 	path = /obj/item/clothing/suit/storage/teshari/cloak/jobs/hos
 	allowed_roles = list("Head of Security")
 
@@ -304,7 +304,7 @@
 	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(cloaks))
 
 /datum/gear/suit/cloak/dept/ce
-	display_name = "chief engineer cloak (Teshari)"
+	display_name = "cloak, chief engineer (Teshari)"
 	path = /obj/item/clothing/suit/storage/teshari/cloak/jobs/ce
 	allowed_roles = list("Chief Engineer")
 
@@ -317,7 +317,7 @@
 	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(cloaks))
 
 /datum/gear/suit/dept/cloak/cmo
-	display_name = "chief medical officer cloak (Teshari)"
+	display_name = "cloak, chief medical officer (Teshari)"
 	path = /obj/item/clothing/suit/storage/teshari/cloak/jobs/cmo
 	allowed_roles = list("Chief Medical Officer")
 
@@ -330,7 +330,7 @@
 	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(cloaks))
 
 /datum/gear/suit/dept/cloak/qm
-	display_name = "quartermaster cloak (Teshari)"
+	display_name = "cloak, quartermaster (Teshari)"
 	path = /obj/item/clothing/suit/storage/teshari/cloak/jobs/qm
 	allowed_roles = list("Chief Medical Officer")
 
@@ -343,7 +343,7 @@
 	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(cloaks))
 
 /datum/gear/suit/dept/cloak/cargo
-	display_name = "cargo cloak (Teshari)"
+	display_name = "cloak, cargo (Teshari)"
 	path = /obj/item/clothing/suit/storage/teshari/cloak/jobs/cargo
 	allowed_roles = list("Quartermaster","Shaft Miner","Cargo Technician")
 
@@ -356,7 +356,7 @@
 	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(cloaks))
 
 /datum/gear/suit/dept/cloak/mining
-	display_name = "mining cloak (Teshari)"
+	display_name = "cloak, mining (Teshari)"
 	path = /obj/item/clothing/suit/storage/teshari/cloak/jobs/mining
 	allowed_roles = list("Quartermaster","Shaft Miner")
 
@@ -369,7 +369,7 @@
 	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(cloaks))
 
 /datum/gear/suit/dept/cloak/security
-	display_name = "security cloak (Teshari)"
+	display_name = "cloak, security (Teshari)"
 	path = /obj/item/clothing/suit/storage/teshari/cloak/jobs/sec
 	allowed_roles = list("Head of Security","Detective","Warden","Security Officer")
 
@@ -382,7 +382,7 @@
 	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(cloaks))
 
 /datum/gear/suit/dept/cloak/service
-	display_name = "service cloak (Teshari)"
+	display_name = "cloak, service (Teshari)"
 	path = /obj/item/clothing/suit/storage/teshari/cloak/jobs/service
 	allowed_roles = list("Head of Personnel","Bartender","Botanist","Janitor","Chef","Librarian","Chaplain")
 
@@ -395,7 +395,7 @@
 	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(cloaks))
 
 /datum/gear/suit/dept/cloak/engineer
-	display_name = "engineering cloak (Teshari)"
+	display_name = "cloak, engineering (Teshari)"
 	path = /obj/item/clothing/suit/storage/teshari/cloak/jobs/engineer
 	allowed_roles = list("Chief Engineer","Station Engineer")
 
@@ -408,7 +408,7 @@
 	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(cloaks))
 
 /datum/gear/suit/dept/cloak/atmos
-	display_name = "atmospherics cloak (Teshari)"
+	display_name = "cloak, atmospherics (Teshari)"
 	path = /obj/item/clothing/suit/storage/teshari/cloak/jobs/atmos
 	allowed_roles = list("Chief Engineer","Atmospheric Technician")
 
@@ -421,7 +421,7 @@
 	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(cloaks))
 
 /datum/gear/suit/dept/cloak/research
-	display_name = "scientist cloak (Teshari)"
+	display_name = "cloak, scientist (Teshari)"
 	path = /obj/item/clothing/suit/storage/teshari/cloak/jobs/sci
 	allowed_roles = list("Research Director","Scientist","Roboticist","Xenobiologist")
 
@@ -434,7 +434,7 @@
 	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(cloaks))
 
 /datum/gear/suit/dept/cloak/robo
-	display_name = "roboticist cloak (Teshari)"
+	display_name = "cloak, roboticist (Teshari)"
 	path = /obj/item/clothing/suit/storage/teshari/cloak/jobs/robo
 	allowed_roles = list("Research Director","Roboticist")
 
@@ -447,7 +447,7 @@
 	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(cloaks))
 
 /datum/gear/suit/dept/cloak/medical
-	display_name = "medical cloak (Teshari)"
+	display_name = "cloak, medical (Teshari)"
 	path = /obj/item/clothing/suit/storage/teshari/cloak/jobs/medical
 	allowed_roles = list("Chief Medical Officer","Medical Doctor","Chemist","Paramedic","Geneticist", "Psychiatrist")
 
@@ -460,7 +460,7 @@
 	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(cloaks))
 
 /datum/gear/suit/dept/cloak/chemistry
-	display_name = "chemist cloak (Teshari)"
+	display_name = "cloak, chemist (Teshari)"
 	path = /obj/item/clothing/suit/storage/teshari/cloak/jobs/chemistry
 	allowed_roles = list("Chemist")
 
@@ -473,7 +473,7 @@
 	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(cloaks))
 
 /datum/gear/suit/dept/cloak/virology
-	display_name = "virologist cloak (Teshari)"
+	display_name = "cloak, virologist (Teshari)"
 	path = /obj/item/clothing/suit/storage/teshari/cloak/jobs/viro
 	allowed_roles = list("Medical Doctor")
 
@@ -486,12 +486,12 @@
 	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(cloaks))
 
 /datum/gear/suit/dept/cloak/psych
-	display_name = "psychiatrist cloak (Teshari)"
+	display_name = "cloak, psychiatrist (Teshari)"
 	path = /obj/item/clothing/suit/storage/teshari/cloak/jobs/psych
 	allowed_roles = list("Chief Medical Officer","Psychiatrist")
 
 /datum/gear/suit/dept/cloak/paramedic
-	display_name = "paramedic cloak (Teshari)"
+	display_name = "cloak, paramedic (Teshari)"
 	path = /obj/item/clothing/suit/storage/teshari/cloak/jobs/para
 	allowed_roles = list("Chief Medical Officer","Paramedic")
 
@@ -504,7 +504,7 @@
 	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(cloaks))
 
 /datum/gear/suit/dept/cloak/iaa
-	display_name = "internal affairs cloak (Teshari)"
+	display_name = "cloak, internal affairs (Teshari)"
 	path = /obj/item/clothing/suit/storage/teshari/cloak/jobs/iaa
 	allowed_roles = list("Internal Affairs Agent")
 
@@ -527,7 +527,7 @@
 	gear_tweaks += gear_tweak_free_color_choice
 
 /datum/gear/suit/beltcloak
-	display_name = "belted cloak selection (Teshari)"
+	display_name = "belted cloak, selection (Teshari)"
 	path = /obj/item/clothing/suit/storage/teshari/beltcloak/standard
 	whitelisted = SPECIES_TESHARI
 	sort_category = "Xenowear"
@@ -551,17 +551,17 @@
 	gear_tweaks += gear_tweak_free_color_choice
 
 /datum/gear/suit/dept/beltcloak/wrdn
-	display_name = "warden belted cloak (Teshari)"
+	display_name = "belted cloak, warden (Teshari)"
 	path = /obj/item/clothing/suit/storage/teshari/beltcloak/jobs/wrdn
 	allowed_roles = list("Head of Security","Warden")
 
 /datum/gear/suit/dept/beltcloak/jani
-	display_name = "janitor belted cloak (Teshari)"
+	display_name = "belted cloak, janitor (Teshari)"
 	path = /obj/item/clothing/suit/storage/teshari/beltcloak/jobs/jani
 	allowed_roles = list("Janitor")
 
 /datum/gear/suit/dept/beltcloak/cmd
-	display_name = "command belted cloak (Teshari)"
+	display_name = "belted cloak, command (Teshari)"
 	path = /obj/item/clothing/suit/storage/teshari/beltcloak/jobs/command
 	allowed_roles = list("Site Manager","Head of Personnel","Head of Security","Chief Engineer","Chief Medical Officer","Research Director")
 
@@ -654,17 +654,17 @@
 	gear_tweaks += gear_tweak_free_color_choice
 
 /datum/gear/shoes/toelessjack
-	display_name = "toe-less jackboots"
+	display_name = "jackboots, toe-less"
 	path = /obj/item/clothing/shoes/boots/jackboots/toeless
 	cost = 2
 
 /datum/gear/shoes/toelessknee
-	display_name = "toe-less jackboots, knee-length"
+	display_name = "jackboots, toe-less, knee-length"
 	path = /obj/item/clothing/shoes/boots/jackboots/toeless/knee
 	cost = 2
 
 /datum/gear/shoes/toelessthigh
-	display_name = "toe-less jackboots, thigh-length"
+	display_name = "jackboots, toe-less, thigh-length"
 	path = /obj/item/clothing/shoes/boots/jackboots/toeless/thigh
 	cost = 2
 

--- a/code/modules/client/preference_setup/loadout/loadout_xeno.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_xeno.dm
@@ -656,14 +656,17 @@
 /datum/gear/shoes/toelessjack
 	display_name = "toe-less jackboots"
 	path = /obj/item/clothing/shoes/boots/jackboots/toeless
+	cost = 2
 
 /datum/gear/shoes/toelessknee
 	display_name = "toe-less jackboots, knee-length"
 	path = /obj/item/clothing/shoes/boots/jackboots/toeless/knee
+	cost = 2
 
 /datum/gear/shoes/toelessthigh
 	display_name = "toe-less jackboots, thigh-length"
 	path = /obj/item/clothing/shoes/boots/jackboots/toeless/thigh
+	cost = 2
 
 /datum/gear/eyes/aerogelgoggles
 	display_name = "airtight orange goggles (Teshari)"

--- a/maps/cynosure/loadout/loadout_suit.dm
+++ b/maps/cynosure/loadout/loadout_suit.dm
@@ -1,6 +1,7 @@
 /datum/gear/suit/bomber_pilot
 	display_name = "bomber jacket, pilot"
 	path = /obj/item/clothing/suit/storage/toggle/bomber/pilot
+	cost = 2
 
 /datum/gear/suit/wintercoat/medical/sar
 	display_name = "winter coat, search and rescue"

--- a/maps/southern_cross/loadout/loadout_suit.dm
+++ b/maps/southern_cross/loadout/loadout_suit.dm
@@ -1,3 +1,4 @@
 /datum/gear/suit/bomber_pilot
 	display_name = "bomber jacket, pilot"
 	path = /obj/item/clothing/suit/storage/toggle/bomber/pilot
+	cost = 2


### PR DESCRIPTION
Renames almost every loadout option to follow the "category, type" naming scheme, IE:
- "gloves, duty"
- "jackboots, toe-less"
- "cloak, chief medical officer"
- "shoes, skater"

Adds a loadout option for botanic leather gloves, costing 2 points.

Tweaks the loadout point costs of the following items:
- Black Gloves: 1 -> 2 (for consistency with other functional gloves)
- Duty Gloves: 3 -> 2 (same as above)
- Jackboots (all variants): 1 -> 2 (for consistency with other functional item variants)
- Workboots (all variants): 1 -> 2 (same as above)
- Umbrella: 3 -> 1 (an umbrella is arguably the same amount of functional as a briefcase)
- Custom Laptop: 7 -> 5 (follows the custom tablet having the same cost as the advanced tablet, custom laptop has the same as the advanced laptop)

Reduces the baseline loadout point cost of suits and overwear from 2 -> 1.

The loadout costs of the following suits/overwear remain at 2 points:
- Puffer Coat (all variants): (cold protection)
- Bomber Jacket (all variants): (cold protection)
- Hoodies (all variants): (cold protection)
- Labcoats (all variants): (bio protection)
- Winter Coats (all variants): (cold protection)

These cost changes aim to bring more consistency to the loadout system, factoring in cosmetics vs game balance. Cosmetic items such as shoes, gloves and non-functional accessories have a generally lower point cost than their functional variants. A good example of this is coloured gloves vs nitrile or latex variants - the former are non-functional and cost 1 point, while the latter cost 2 as they provide a tangible mechanical benefit above that of their base type.

Additionally, this PR also seeks to fix a few egregious outliers within the existing system where they've been spotted (I'm looking at you umbrellas) and overall establish a baseline from which further changes could be made down the line or as more items are added.

Finally, following a suggestion by Cerebulon, this PR now generally overhauls the naming of all loadout options to make them more consistent across the board.

🆑
tweak: Changed almost every loadout option name to a "category, type" naming scheme. This makes things more consistent and should make items easier to find.
bugfix: A typo in the "jackboots, thigh-length" loadout option has been fixed.
rscadd: Botanic leather gloves can now be selected as a loadout option, costing two points.
tweak: The loadout point cost of black gloves has been increased from one to two.
tweak: The loadout point cost of all jackboot and workboot variants has been increased from one to two.
tweak: The loadout point cost of umbrellas has been reduced from three to one.
tweak: The loadout point cost of custom laptops has been reduced from seven to five.
tweak: The baseline loadout point cost of cosmetic suits and overwear has been reduced from two to one.
/🆑