### PR TITLE
Checks the no_clone modifier stored in DNA records as a path

### DIFF
--- a/code/modules/organs/internal/brain.dm
+++ b/code/modules/organs/internal/brain.dm
@@ -234,7 +234,7 @@ GLOBAL_LIST_BOILERPLATE(all_brain_organs, /obj/item/organ/internal/brain)
 					return 0
 
 	for(var/modifier_type in R.genetic_modifiers)	//Can't be revived. Probably won't happen...?
-		if(istype(modifier_type, /datum/modifier/no_clone))
+		if(ispath(modifier_type, /datum/modifier/no_clone))
 			return 0
 
 	var/mob/living/carbon/human/H = new /mob/living/carbon/human(get_turf(src), R.dna.species)


### PR DESCRIPTION
Fixes #8664.
The list of `genetic_modifiers` stored in the DNA record is a list of types, so `ispath()` is the correct function call, not `istype()` (Which operates upon _instances_.