### PR TITLE
Airlock assembly naming window starts with base_name

### DIFF
--- a/code/game/objects/structures/door_assembly.dm
+++ b/code/game/objects/structures/door_assembly.dm
@@ -157,7 +157,7 @@
 		bound_height = width * world.icon_size
 
 /obj/structure/door_assembly/proc/rename_door(mob/living/user)
-	var/t = sanitizeSafe(input(user, "Enter the name for the windoor.", src.name, src.created_name), MAX_NAME_LEN)
+	var/t = sanitizeSafe(input(user, "Enter the name for the [base_name].", src.name, src.created_name), MAX_NAME_LEN)
 	if(!in_range(src, user) && src.loc != user)	return
 	created_name = t
 	update_state()


### PR DESCRIPTION
Fixes #8647.