### PR TITLE
Concrete Map Integration

### DIFF
--- a/code/game/objects/random/misc.dm
+++ b/code/game/objects/random/misc.dm
@@ -500,7 +500,8 @@
 				/obj/item/stack/rods{amount = 10},
 				/obj/item/stack/material/sandstone{amount = 10},
 				/obj/item/stack/material/marble{amount = 10},
-				/obj/item/stack/material/plasteel{amount = 10})
+				/obj/item/stack/material/plasteel{amount = 10},
+				/obj/item/stack/material/concrete{amount = 10})
 
 /obj/random/material/refined //Random materials for building stuff
 	name = "random refined material"
@@ -530,7 +531,9 @@
 				/obj/item/stack/material/osmium{amount = 3},
 				/obj/item/stack/material/titanium{amount = 5},
 				/obj/item/stack/material/tritium{amount = 3},
-				/obj/item/stack/material/verdantium{amount = 2})
+				/obj/item/stack/material/verdantium{amount = 2},
+				/obj/item/stack/material/concrete{amount =10},
+				/obj/item/stack/material/plasteel/rebar{amount = 5})
 
 /obj/random/material/precious //Precious metals, go figure
 	name = "random precious metal"

--- a/code/game/turfs/simulated/wall_icon.dm
+++ b/code/game/turfs/simulated/wall_icon.dm
@@ -126,6 +126,6 @@
 	wall_connections = dirs_to_corner_states(dirs)
 
 /turf/simulated/wall/proc/can_join_with(var/turf/simulated/wall/W)
-	if(istype(material) && istype(W.material) && material.icon_base == W.material.icon_base)
+	if (istype(material) && istype(W.material) && ((material.icon_base == W.material.icon_base) || (material.icon_base == "solid" && W.material.icon_base == "brick")))
 		return 1
 	return 0

--- a/code/game/turfs/simulated/wall_types.dm
+++ b/code/game/turfs/simulated/wall_types.dm
@@ -103,8 +103,6 @@
 	desc = "A wall made out of concrete bricks"
 	material = MAT_CONCRETE
 	icon_state = "brick"
-
-
 /turf/simulated/wall/r_concrete
 	desc = "A sturdy wall made of concrete and reinforced with plasteel rebar"
 	material = MAT_CONCRETE

--- a/maps/cynosure/cynosure-1.dmm
+++ b/maps/cynosure/cynosure-1.dmm
@@ -445,7 +445,7 @@
 /turf/simulated/floor/tiled/white,
 /area/surface/outpost/research/xenoarcheology)
 "aY" = (
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall/r_concrete,
 /area/surface/station/maintenance/substation/research/bmt)
 "aZ" = (
 /obj/machinery/mineral/processing_unit_console{
@@ -477,7 +477,7 @@
 /turf/simulated/floor/tiled/white,
 /area/surface/outpost/research/xenoarcheology)
 "bc" = (
-/turf/simulated/wall,
+/turf/simulated/wall/concrete,
 /area/surface/station/hallway/primary/bmt/west)
 "bd" = (
 /obj/effect/floor_decal/industrial/warning/dust{
@@ -839,6 +839,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/surface/station/maintenance/storage/emergency/bmtseast)
+"bM" = (
+/obj/structure/sign/warning/caution,
+/turf/simulated/wall/r_concrete,
+/area/surface/cave/explored/normal)
 "bN" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -1225,10 +1229,10 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/surface/station/vault)
 "cB" = (
-/turf/simulated/wall,
+/turf/simulated/wall/concrete,
 /area/surface/station/construction/bmt/construction1)
 "cE" = (
-/turf/simulated/wall,
+/turf/simulated/wall/concrete,
 /area/surface/station/maintenance/medical/south)
 "cF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1324,7 +1328,7 @@
 /turf/simulated/floor/plating,
 /area/surface/station/maintenance/medical/south)
 "cN" = (
-/turf/simulated/wall,
+/turf/simulated/wall/concrete,
 /area/surface/station/construction/elevator)
 "cP" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -1561,7 +1565,7 @@
 /turf/simulated/wall,
 /area/surface/outpost/research/xenoarcheology/smes)
 "ds" = (
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall/r_concrete,
 /area/surface/station/rnd/server)
 "dt" = (
 /obj/structure/curtain/open/shower{
@@ -1682,7 +1686,7 @@
 	},
 /area/surface/station/rnd/test_area)
 "dE" = (
-/turf/simulated/wall,
+/turf/simulated/wall/concrete,
 /area/surface/station/hallway/secondary/bmt/weststairwell)
 "dF" = (
 /obj/effect/floor_decal/industrial/warning/dust,
@@ -1781,7 +1785,7 @@
 /turf/simulated/floor/plating,
 /area/surface/station/maintenance/storage/emergency/bmtswest)
 "dP" = (
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall/r_concrete,
 /area/surface/station/construction/elevator)
 "dQ" = (
 /obj/structure/closet/emcloset,
@@ -2120,6 +2124,9 @@
 	},
 /turf/simulated/floor/tiled/steel_dirty,
 /area/surface/station/engineering/auxiliary_engineering)
+"eE" = (
+/turf/simulated/wall/concrete,
+/area/surface/station/hallway/primary/bmt/east)
 "eF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -2271,7 +2278,7 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/surface/station/rnd/hallway/bmt)
 "eY" = (
-/turf/simulated/wall,
+/turf/simulated/wall/concrete,
 /area/surface/station/maintenance/research/east)
 "eZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -2397,11 +2404,11 @@
 /turf/simulated/floor/tiled/white,
 /area/surface/station/rnd/hallway/bmt)
 "fj" = (
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall/r_concrete,
 /area/surface/station/maintenance/research/east)
 "fk" = (
 /obj/structure/sign/warning/lethal_turrets,
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall/r_concrete,
 /area/surface/station/vault)
 "fl" = (
 /obj/effect/floor_decal/borderfloor{
@@ -2463,7 +2470,7 @@
 /turf/simulated/floor/plating,
 /area/surface/station/maintenance/mining)
 "fr" = (
-/turf/simulated/wall,
+/turf/simulated/wall/concrete,
 /area/surface/station/hallway/primary/bmt/north)
 "fs" = (
 /obj/effect/floor_decal/industrial/warning/dust{
@@ -2490,7 +2497,7 @@
 /area/surface/station/maintenance/eaststairwell)
 "fu" = (
 /obj/structure/sign/warning/secure_area,
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall/r_concrete,
 /area/surface/station/rnd/hallway/bmt)
 "fv" = (
 /obj/structure/safe,
@@ -2511,7 +2518,7 @@
 /turf/simulated/floor/plating,
 /area/surface/station/mining_main/refinery)
 "fx" = (
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall/r_concrete,
 /area/surface/station/maintenance/storage/emergency/bmtswest)
 "fy" = (
 /turf/simulated/floor/tiled/dark,
@@ -2577,15 +2584,15 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/surface/station/medical/hallway/bmt)
 "fG" = (
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall/r_concrete,
 /area/surface/station/construction/genetics)
 "fH" = (
 /obj/effect/landmark/submap_position/random_subtype/cynosure_nine_by_eight_maint,
-/turf/simulated/wall,
+/turf/simulated/wall/concrete,
 /area/surface/station/construction/bmt/construction2)
 "fI" = (
 /obj/structure/sign/warning/high_voltage,
-/turf/simulated/wall,
+/turf/simulated/wall/concrete,
 /area/surface/station/engineering/auxiliary_engineering)
 "fJ" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -2794,7 +2801,7 @@
 /area/surface/station/maintenance/storage/emergency/bmtswest)
 "gk" = (
 /obj/structure/sign/directions/cargo/refinery,
-/turf/simulated/wall,
+/turf/simulated/wall/concrete,
 /area/surface/station/mining_main)
 "gl" = (
 /obj/structure/cable/cyan{
@@ -3141,10 +3148,10 @@
 /turf/simulated/floor/tiled,
 /area/surface/station/engineering/hallway/bmt)
 "gY" = (
-/turf/simulated/wall,
+/turf/simulated/wall/concrete,
 /area/surface/station/engineering/drone_fabrication)
 "ha" = (
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall/r_concrete,
 /area/surface/station/mining_main/storage)
 "hc" = (
 /turf/simulated/wall,
@@ -3210,7 +3217,7 @@
 /turf/simulated/floor/plating,
 /area/surface/station/hallway/primary/bmt/west)
 "hh" = (
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall/r_concrete,
 /area/surface/station/maintenance/research/south)
 "hi" = (
 /obj/structure/disposalpipe/segment{
@@ -3567,7 +3574,7 @@
 /turf/simulated/floor/plating,
 /area/surface/station/maintenance/security)
 "hN" = (
-/turf/simulated/wall,
+/turf/simulated/wall/concrete,
 /area/surface/station/storage/tech)
 "hP" = (
 /obj/structure/closet/hydrant{
@@ -3675,6 +3682,9 @@
 	outdoors = 0
 	},
 /area/surface/cave/explored/normal)
+"id" = (
+/turf/simulated/wall/r_concrete,
+/area/surface/station/medical/hallway/bmt)
 "ie" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
@@ -3872,7 +3882,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/wall,
+/turf/simulated/wall/concrete,
 /area/surface/station/maintenance/incinerator)
 "iz" = (
 /obj/effect/floor_decal/steeldecal/steel_decals4{
@@ -4369,7 +4379,7 @@
 /turf/simulated/floor/tiled/white,
 /area/surface/station/rnd/hallway/bmt)
 "jw" = (
-/turf/simulated/wall,
+/turf/simulated/wall/concrete,
 /area/surface/station/maintenance/medical/west)
 "jx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -4476,6 +4486,9 @@
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/tiled/dark,
 /area/surface/station/rnd/hallway/bmt)
+"jG" = (
+/turf/simulated/wall/concrete,
+/area/surface/station/maintenance/weststairwell/bmt)
 "jH" = (
 /obj/structure/table/rack,
 /obj/random/maintenance/cargo,
@@ -4493,10 +4506,10 @@
 /turf/simulated/floor/plating,
 /area/surface/station/engineering/drone_fabrication)
 "jK" = (
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall/r_concrete,
 /area/surface/station/maintenance/substation/cargo/bmt)
 "jL" = (
-/turf/simulated/wall,
+/turf/simulated/wall/concrete,
 /area/surface/station/construction/bmt/construction4)
 "jN" = (
 /obj/structure/table/rack{
@@ -4807,7 +4820,7 @@
 /turf/simulated/floor/plating,
 /area/surface/station/construction/elevator)
 "ks" = (
-/turf/simulated/wall,
+/turf/simulated/wall/concrete,
 /area/surface/station/hallway/secondary/bmt/eaststairwell)
 "ku" = (
 /obj/machinery/portable_atmospherics/canister/empty,
@@ -5083,7 +5096,7 @@
 /area/surface/station/vault)
 "kX" = (
 /obj/effect/landmark/submap_position/random_subtype/cynosure_eight_by_nine_maint,
-/turf/simulated/wall,
+/turf/simulated/wall/concrete,
 /area/surface/station/construction/bmt/construction1)
 "kZ" = (
 /obj/structure/closet/l3closet/medical,
@@ -5181,6 +5194,9 @@
 /obj/effect/floor_decal/corner/green/border,
 /turf/simulated/floor/tiled/steel_dirty,
 /area/surface/station/hallway/primary/bmt/east)
+"lk" = (
+/turf/simulated/wall/concrete,
+/area/surface/station/maintenance/engineering/north)
 "lm" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 8
@@ -5211,7 +5227,7 @@
 /area/surface/outpost/research/xenoarcheology/analysis)
 "lq" = (
 /obj/machinery/status_display,
-/turf/simulated/wall,
+/turf/simulated/wall/concrete,
 /area/surface/station/medical/hallway/bmt)
 "lr" = (
 /obj/effect/floor_decal/borderfloorwhite/corner{
@@ -5461,7 +5477,7 @@
 /area/surface/station/rnd/hallway/bmt)
 "lN" = (
 /obj/machinery/ai_status_display,
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall/r_concrete,
 /area/surface/station/construction/warehouse)
 "lO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -6099,7 +6115,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/surface/station/engineering/hallway/bmt)
 "mV" = (
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall/r_concrete,
 /area/surface/station/mining_main/exterior)
 "mW" = (
 /obj/structure/table/steel,
@@ -6150,7 +6166,7 @@
 /turf/simulated/floor/plating,
 /area/surface/station/mining_main/refinery)
 "nb" = (
-/turf/simulated/wall,
+/turf/simulated/wall/concrete,
 /area/surface/station/maintenance/incineratormaint)
 "nc" = (
 /obj/effect/floor_decal/borderfloor,
@@ -6610,7 +6626,7 @@
 /area/surface/station/engineering/drone_fabrication)
 "oj" = (
 /obj/structure/sign/directions/cargo/mining,
-/turf/simulated/wall,
+/turf/simulated/wall/concrete,
 /area/surface/station/mining_main/locker)
 "ok" = (
 /obj/machinery/alarm{
@@ -6629,7 +6645,7 @@
 /turf/simulated/floor/tiled/white,
 /area/surface/station/rnd/hallway/bmt)
 "om" = (
-/turf/simulated/wall,
+/turf/simulated/wall/concrete,
 /area/surface/station/maintenance/incinerator)
 "op" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -6700,7 +6716,7 @@
 /area/surface/station/hallway/primary/bmt/south)
 "ov" = (
 /obj/machinery/status_display,
-/turf/simulated/wall,
+/turf/simulated/wall/concrete,
 /area/surface/station/medical/morgue)
 "ow" = (
 /obj/machinery/mineral/equipment_vendor,
@@ -6972,6 +6988,9 @@
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
 /area/surface/station/hallway/primary/bmt/west)
+"oT" = (
+/turf/simulated/wall/concrete,
+/area/surface/station/mining_main/refinery)
 "oU" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
@@ -7036,7 +7055,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/surface/station/hallway/primary/bmt/north)
 "pd" = (
-/turf/simulated/wall,
+/turf/simulated/wall/concrete,
 /area/surface/station/construction/bmt/construction6)
 "pe" = (
 /obj/structure/bed/chair{
@@ -7105,7 +7124,7 @@
 /turf/simulated/floor/tiled,
 /area/surface/station/hallway/primary/bmt/east)
 "pj" = (
-/turf/simulated/wall,
+/turf/simulated/wall/concrete,
 /area/surface/station/medical/morgue)
 "pl" = (
 /obj/machinery/mineral/unloading_machine,
@@ -7162,7 +7181,7 @@
 /area/surface/station/hallway/primary/bmt/north)
 "ps" = (
 /obj/machinery/status_display,
-/turf/simulated/wall,
+/turf/simulated/wall/concrete,
 /area/surface/station/construction/bmt/construction1)
 "pt" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -7277,7 +7296,7 @@
 /turf/simulated/floor/tiled/white,
 /area/surface/outpost/research/xenoarcheology/anomaly)
 "pF" = (
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall/r_concrete,
 /area/surface/station/construction/bmt/construction6)
 "pG" = (
 /obj/structure/disposalpipe/segment{
@@ -7451,7 +7470,7 @@
 /turf/simulated/floor/tiled/white,
 /area/surface/station/rnd/hallway/bmt)
 "qa" = (
-/turf/simulated/wall,
+/turf/simulated/wall/concrete,
 /area/surface/station/hallway/primary/bmt/south)
 "qb" = (
 /obj/structure/cable/green{
@@ -7496,7 +7515,7 @@
 /area/surface/station/rnd/storage)
 "qf" = (
 /obj/structure/sign/warning/bomb_range,
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall/r_concrete,
 /area/surface/cave/explored/normal)
 "qg" = (
 /obj/effect/floor_decal/borderfloorblack{
@@ -7917,10 +7936,10 @@
 /turf/simulated/floor/plating,
 /area/surface/station/medical/hallway/bmt)
 "qU" = (
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall/r_concrete,
 /area/surface/station/maintenance/security)
 "qV" = (
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall/r_concrete,
 /area/surface/station/mining_main/locker)
 "qW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -7936,7 +7955,7 @@
 /area/surface/station/hallway/primary/bmt/east)
 "qX" = (
 /obj/effect/landmark/submap_position/random_subtype/cynosure_eight_by_five_maint,
-/turf/simulated/wall,
+/turf/simulated/wall/concrete,
 /area/surface/station/construction/bmt/construction6)
 "qY" = (
 /obj/item/camera_assembly,
@@ -8276,6 +8295,9 @@
 /obj/machinery/meter,
 /turf/simulated/floor/plating,
 /area/surface/station/maintenance/research/south)
+"rH" = (
+/turf/simulated/wall/concrete,
+/area/surface/station/rnd/hallway/bmt)
 "rJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -8624,7 +8646,7 @@
 /turf/simulated/wall,
 /area/surface/outpost/research/xenoarcheology/smes)
 "su" = (
-/turf/simulated/wall,
+/turf/simulated/wall/concrete,
 /area/surface/station/hallway/primary/bmt/west/elevator)
 "sv" = (
 /obj/structure/grille,
@@ -9338,7 +9360,7 @@
 /turf/simulated/floor/plating,
 /area/surface/station/maintenance/bar)
 "tR" = (
-/turf/simulated/wall,
+/turf/simulated/wall/concrete,
 /area/surface/station/maintenance/security)
 "tS" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -9533,7 +9555,7 @@
 /area/surface/station/hallway/primary/bmt/south)
 "ui" = (
 /obj/effect/landmark/submap_position/random_subtype/cynosure_nine_by_ten_maint,
-/turf/simulated/wall,
+/turf/simulated/wall/concrete,
 /area/surface/station/construction/bmt/construction3)
 "uk" = (
 /turf/simulated/floor/tiled,
@@ -9638,7 +9660,7 @@
 /turf/simulated/wall/r_wall,
 /area/surface/station/rnd/storage)
 "uC" = (
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall/r_concrete,
 /area/surface/station/medical/storage/second_storage)
 "uD" = (
 /obj/structure/reagent_dispensers/watertank,
@@ -9779,7 +9801,7 @@
 /turf/simulated/floor/tiled/white,
 /area/surface/outpost/research/xenoarcheology)
 "uQ" = (
-/turf/simulated/wall,
+/turf/simulated/wall/concrete,
 /area/surface/station/maintenance/substation/medbay/bmt)
 "uS" = (
 /obj/structure/disposalpipe/segment{
@@ -9844,6 +9866,9 @@
 	},
 /turf/simulated/floor/plating,
 /area/surface/station/maintenance/mining)
+"uY" = (
+/turf/simulated/wall/r_concrete,
+/area/surface/station/engineering/hallway/bmt)
 "uZ" = (
 /turf/simulated/wall/r_wall,
 /area/surface/outpost/research/xenoarcheology/entrance)
@@ -9868,7 +9893,7 @@
 /turf/simulated/floor/tiled,
 /area/surface/station/hallway/primary/bmt/east)
 "vd" = (
-/turf/simulated/wall,
+/turf/simulated/wall/concrete,
 /area/surface/station/maintenance/mining)
 "ve" = (
 /obj/effect/floor_decal/industrial/warning/dust{
@@ -9983,7 +10008,7 @@
 /area/surface/station/rnd/hallway/bmt)
 "vp" = (
 /obj/structure/sign/level/basement/large,
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall/r_concrete,
 /area/surface/station/engineering/hallway/bmt)
 "vq" = (
 /obj/structure/bed,
@@ -10398,7 +10423,7 @@
 /area/surface/station/engineering/hallway/bmt)
 "wi" = (
 /obj/structure/disposalpipe/segment,
-/turf/simulated/wall,
+/turf/simulated/wall/concrete,
 /area/surface/station/maintenance/medical/west)
 "wj" = (
 /obj/structure/sign/warning/caution,
@@ -10543,7 +10568,7 @@
 /turf/simulated/floor/tiled,
 /area/surface/station/hallway/primary/bmt/west)
 "ww" = (
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall/r_concrete,
 /area/surface/station/storage/tech)
 "wx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -10629,7 +10654,7 @@
 /area/surface/station/rnd/hallway/bmt)
 "wF" = (
 /obj/machinery/ai_status_display,
-/turf/simulated/wall,
+/turf/simulated/wall/concrete,
 /area/surface/station/engineering/drone_fabrication)
 "wH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -10770,7 +10795,7 @@
 /area/surface/station/mining_main/storage)
 "wV" = (
 /obj/structure/sign/warning/secure_area,
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall/r_concrete,
 /area/surface/station/engineering/hallway/bmt)
 "wW" = (
 /obj/machinery/mech_recharger,
@@ -10901,7 +10926,7 @@
 /obj/structure/sign/directions/engineering/solars{
 	dir = 1
 	},
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall/r_concrete,
 /area/surface/station/maintenance/security)
 "xn" = (
 /obj/machinery/door/firedoor/border_only,
@@ -11049,7 +11074,7 @@
 /area/surface/station/medical/morgue)
 "xD" = (
 /obj/structure/sign/warning/moving_parts,
-/turf/simulated/wall,
+/turf/simulated/wall/concrete,
 /area/surface/station/mining_main/refinery)
 "xE" = (
 /obj/effect/floor_decal/industrial/warning/dust{
@@ -11179,7 +11204,7 @@
 /area/surface/station/maintenance/substation/research/bmt)
 "xT" = (
 /obj/machinery/status_display,
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall/r_concrete,
 /area/surface/station/hallway/primary/bmt/west/elevator)
 "xU" = (
 /obj/effect/floor_decal/steeldecal/steel_decals_central4,
@@ -11655,7 +11680,7 @@
 /turf/simulated/floor/tiled,
 /area/surface/station/medical/hallway/bmt)
 "yN" = (
-/turf/simulated/wall,
+/turf/simulated/wall/concrete,
 /area/surface/station/engineering/auxiliary_engineering)
 "yO" = (
 /obj/effect/floor_decal/borderfloor,
@@ -11836,7 +11861,7 @@
 /turf/simulated/floor/plating,
 /area/surface/station/maintenance/medical/south)
 "zg" = (
-/turf/simulated/wall,
+/turf/simulated/wall/concrete,
 /area/surface/station/maintenance/research/south)
 "zh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -11920,6 +11945,9 @@
 	},
 /turf/simulated/floor/tiled,
 /area/surface/station/engineering/hallway/bmt)
+"zr" = (
+/turf/simulated/wall/r_concrete,
+/area/surface/outpost/research/xenoarcheology/entrance)
 "zt" = (
 /obj/effect/floor_decal/borderfloorwhite,
 /obj/effect/floor_decal/corner/purple/border,
@@ -11940,7 +11968,7 @@
 /area/surface/outpost/research/xenoarcheology)
 "zu" = (
 /obj/machinery/ai_status_display,
-/turf/simulated/wall,
+/turf/simulated/wall/concrete,
 /area/surface/station/storage/tech)
 "zv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -11984,7 +12012,7 @@
 	dir = 5;
 	pixel_y = 6
 	},
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall/r_concrete,
 /area/surface/station/rnd/hallway/bmt)
 "zz" = (
 /obj/structure/ladder/up,
@@ -12091,7 +12119,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/surface/station/medical/storage/second_storage)
 "zL" = (
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall/r_concrete,
 /area/surface/station/maintenance/weststairwell/bmt)
 "zM" = (
 /turf/simulated/floor/plating,
@@ -12442,7 +12470,7 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/surface/station/mining_main)
 "Az" = (
-/turf/simulated/wall,
+/turf/simulated/wall/concrete,
 /area/surface/station/maintenance/storage/emergency/bmtseast)
 "AB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -13002,7 +13030,7 @@
 /turf/simulated/floor/tiled,
 /area/surface/station/rnd/toxins_launch)
 "BA" = (
-/turf/simulated/wall,
+/turf/simulated/wall/concrete,
 /area/surface/station/maintenance/bar)
 "BB" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -13946,6 +13974,9 @@
 	outdoors = 0
 	},
 /area/surface/station/rnd/test_area)
+"DD" = (
+/turf/simulated/wall/r_concrete,
+/area/surface/station/medical/morgue)
 "DE" = (
 /obj/machinery/alarm{
 	dir = 8;
@@ -14113,6 +14144,9 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/plating,
 /area/surface/station/maintenance/substation/medbay/bmt)
+"DY" = (
+/turf/simulated/wall/r_concrete,
+/area/surface/station/mining_main/refinery)
 "DZ" = (
 /obj/machinery/space_heater,
 /obj/effect/zone_divider,
@@ -14352,7 +14386,7 @@
 /turf/simulated/floor/tiled/old_tile/white,
 /area/surface/station/rnd/mixing)
 "EA" = (
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall/r_concrete,
 /area/surface/station/maintenance/substation/medbay/bmt)
 "EB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -14717,6 +14751,9 @@
 	},
 /turf/simulated/floor/tiled,
 /area/surface/station/hallway/primary/bmt/west/elevator)
+"Fp" = (
+/turf/simulated/wall/r_concrete,
+/area/surface/cave/explored/normal)
 "Fq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/effect/floor_decal/borderfloor/corner{
@@ -14751,7 +14788,7 @@
 /area/surface/station/rnd/hallway/bmt)
 "Ft" = (
 /obj/structure/sign/warning/server_room,
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall/r_concrete,
 /area/surface/station/rnd/server)
 "Fu" = (
 /obj/effect/floor_decal/industrial/warning/dust{
@@ -14765,7 +14802,7 @@
 /area/surface/station/mining_main/exterior)
 "Fw" = (
 /obj/machinery/ai_status_display,
-/turf/simulated/wall,
+/turf/simulated/wall/concrete,
 /area/surface/station/maintenance/substation/medbay/bmt)
 "FA" = (
 /obj/machinery/conveyor{
@@ -15465,7 +15502,7 @@
 /area/surface/station/engineering/auxiliary_engineering)
 "Hi" = (
 /obj/structure/disposalpipe/segment,
-/turf/simulated/wall,
+/turf/simulated/wall/concrete,
 /area/surface/station/maintenance/incinerator)
 "Hj" = (
 /obj/machinery/door/firedoor/border_only,
@@ -15612,7 +15649,7 @@
 /turf/simulated/floor/tiled/old_tile/white,
 /area/surface/station/rnd/mixing)
 "HA" = (
-/turf/simulated/wall,
+/turf/simulated/wall/concrete,
 /area/surface/station/construction/warehouse)
 "HB" = (
 /obj/machinery/door/blast/regular/open{
@@ -15752,7 +15789,7 @@
 /area/surface/station/mining_main/exterior)
 "HQ" = (
 /obj/structure/disposalpipe/segment,
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall/r_concrete,
 /area/surface/station/maintenance/weststairwell/bmt)
 "HS" = (
 /obj/effect/decal/cleanable/cobweb2,
@@ -15824,7 +15861,7 @@
 /turf/simulated/floor/tiled/steel_dirty,
 /area/surface/station/hallway/primary/bmt/east)
 "HX" = (
-/turf/simulated/wall,
+/turf/simulated/wall/concrete,
 /area/surface/station/medical/storage/second_storage)
 "HY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -15887,7 +15924,7 @@
 /area/surface/outpost/research/xenoarcheology/isolation_c)
 "Ig" = (
 /obj/structure/sign/warning/high_voltage,
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall/r_concrete,
 /area/surface/station/maintenance/substation/medbay/bmt)
 "Ih" = (
 /obj/structure/disposalpipe/segment{
@@ -16088,7 +16125,7 @@
 /area/surface/station/mining_main)
 "IG" = (
 /obj/structure/sign/warning/secure_area,
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall/r_concrete,
 /area/surface/station/storage/tech)
 "II" = (
 /obj/structure/ore_box,
@@ -16567,7 +16604,7 @@
 /turf/simulated/floor/tiled,
 /area/surface/station/rnd/storage)
 "JL" = (
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall/r_concrete,
 /area/surface/station/maintenance/substation/engineering/bmt)
 "JM" = (
 /obj/structure/table/rack,
@@ -16623,6 +16660,9 @@
 	},
 /turf/simulated/floor/tiled,
 /area/surface/station/rnd/toxins_launch)
+"JQ" = (
+/turf/simulated/wall/r_concrete,
+/area/surface/station/hallway/primary/bmt/west)
 "JR" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 4
@@ -16869,7 +16909,7 @@
 /area/surface/station/rnd/mixing)
 "Kv" = (
 /obj/structure/sign/warning/high_voltage,
-/turf/simulated/wall,
+/turf/simulated/wall/concrete,
 /area/surface/station/maintenance/engineering/south)
 "Kw" = (
 /obj/machinery/conveyor{
@@ -17033,7 +17073,7 @@
 	},
 /area/surface/station/mining_main/exterior)
 "KO" = (
-/turf/simulated/wall,
+/turf/simulated/wall/concrete,
 /area/surface/station/construction/bar)
 "KP" = (
 /obj/effect/floor_decal/borderfloor,
@@ -17085,7 +17125,7 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/surface/station/mining_main/refinery)
 "KT" = (
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall/r_concrete,
 /area/surface/station/hallway/primary/bmt/west/elevator)
 "KU" = (
 /obj/machinery/conveyor_switch{
@@ -17439,7 +17479,7 @@
 /turf/simulated/wall/r_wall,
 /area/surface/station/engineering/reactor_room)
 "LF" = (
-/turf/simulated/wall,
+/turf/simulated/wall/concrete,
 /area/surface/station/maintenance/eaststairwell)
 "LG" = (
 /obj/effect/floor_decal/steeldecal/steel_decals4{
@@ -17713,7 +17753,7 @@
 /turf/simulated/floor/tiled/white,
 /area/surface/station/rnd/hallway/bmt)
 "Mk" = (
-/turf/simulated/wall,
+/turf/simulated/wall/concrete,
 /area/surface/station/maintenance/engineering/south)
 "Ml" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -17810,7 +17850,7 @@
 /turf/simulated/floor/plating,
 /area/surface/station/maintenance/medical/south)
 "Mv" = (
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall/r_concrete,
 /area/surface/station/construction/warehouse)
 "Mw" = (
 /obj/machinery/conveyor_switch{
@@ -17853,6 +17893,9 @@
 	},
 /turf/simulated/floor/plating,
 /area/surface/station/hallway/primary/bmt/east)
+"MA" = (
+/turf/simulated/wall/r_concrete,
+/area/surface/station/rnd/hallway/bmt)
 "MB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -18076,7 +18119,7 @@
 /area/surface/outpost/research/xenoarcheology)
 "MW" = (
 /obj/machinery/status_display,
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall/r_concrete,
 /area/surface/station/maintenance/substation/cargo/bmt)
 "MX" = (
 /obj/structure/closet/secure_closet/miner,
@@ -18352,8 +18395,11 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/surface/outpost/research/xenoarcheology/analysis)
+"NC" = (
+/turf/simulated/wall/r_concrete,
+/area/surface/station/vault)
 "ND" = (
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall/r_concrete,
 /area/surface/station/construction/bmt/construction4)
 "NE" = (
 /obj/structure/morgue{
@@ -18580,6 +18626,10 @@
 	},
 /obj/effect/map_helper/airlock/sensor/chamber_sensor,
 /turf/simulated/floor/tiled/techfloor/grid,
+/area/surface/station/rnd/hallway/bmt)
+"NX" = (
+/obj/structure/sign/science,
+/turf/simulated/wall/r_concrete,
 /area/surface/station/rnd/hallway/bmt)
 "NY" = (
 /turf/simulated/wall/r_wall,
@@ -18855,7 +18905,7 @@
 /area/surface/station/mining_main/storage)
 "OA" = (
 /obj/structure/disposalpipe/segment,
-/turf/simulated/wall,
+/turf/simulated/wall/concrete,
 /area/surface/station/maintenance/research/east)
 "OB" = (
 /obj/structure/cable{
@@ -19215,7 +19265,7 @@
 /turf/simulated/floor/plating,
 /area/surface/station/maintenance/security)
 "Pf" = (
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall/r_concrete,
 /area/surface/station/engineering/drone_fabrication)
 "Pg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -19405,7 +19455,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/wall,
+/turf/simulated/wall/concrete,
 /area/surface/station/maintenance/research/east)
 "PA" = (
 /obj/effect/floor_decal/industrial/warning/corner{
@@ -19806,7 +19856,7 @@
 /area/surface/station/rnd/mixing)
 "Qk" = (
 /obj/effect/landmark/submap_position/random_subtype/cynosure_medical_basement,
-/turf/simulated/wall,
+/turf/simulated/wall/concrete,
 /area/surface/station/construction/bmt/construction4)
 "Ql" = (
 /obj/machinery/ai_status_display,
@@ -20152,7 +20202,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall/r_concrete,
 /area/surface/station/mining_main/locker)
 "QV" = (
 /obj/structure/cable/cyan{
@@ -20232,7 +20282,7 @@
 	},
 /area/surface/station/mining_main/exterior)
 "Rf" = (
-/turf/simulated/wall,
+/turf/simulated/wall/concrete,
 /area/surface/station/mining_main/storage)
 "Rg" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -20299,7 +20349,7 @@
 /turf/simulated/floor/plating,
 /area/surface/station/rnd/hallway/bmt)
 "Rl" = (
-/turf/simulated/wall,
+/turf/simulated/wall/concrete,
 /area/surface/station/medical/hallway/bmt)
 "Rm" = (
 /obj/machinery/recharge_station,
@@ -20672,7 +20722,7 @@
 	dir = 5;
 	pixel_y = -6
 	},
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall/r_concrete,
 /area/surface/station/hallway/primary/bmt/west/elevator)
 "RY" = (
 /obj/structure/cable/green{
@@ -20912,7 +20962,7 @@
 /area/surface/station/hallway/primary/bmt/west)
 "Su" = (
 /obj/structure/sign/warning/secure_area,
-/turf/simulated/wall,
+/turf/simulated/wall/concrete,
 /area/surface/station/storage/tech)
 "Sv" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
@@ -20947,6 +20997,9 @@
 /obj/random/multiple/voidsuit/mining,
 /turf/simulated/floor/tiled/techmaint,
 /area/surface/station/mining_main/storage)
+"Sx" = (
+/turf/simulated/wall/r_concrete,
+/area/surface/station/mining_main)
 "Sy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -20995,7 +21048,7 @@
 /turf/simulated/floor/tiled/monofloor,
 /area/surface/station/engineering/hallway/bmt)
 "SD" = (
-/turf/simulated/wall,
+/turf/simulated/wall/concrete,
 /area/surface/cave/explored/normal)
 "SF" = (
 /obj/structure/cable{
@@ -21029,7 +21082,7 @@
 /area/surface/station/maintenance/substation/cargo/bmt)
 "SI" = (
 /obj/structure/sign/warning/secure_area,
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall/r_concrete,
 /area/surface/station/vault)
 "SJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/universal,
@@ -21050,7 +21103,7 @@
 /area/surface/outpost/research/xenoarcheology/anomaly)
 "SL" = (
 /obj/machinery/status_display,
-/turf/simulated/wall,
+/turf/simulated/wall/concrete,
 /area/surface/station/storage/tech)
 "SM" = (
 /obj/machinery/atmospherics/pipe/tank/phoron{
@@ -21059,7 +21112,7 @@
 /turf/simulated/floor/tiled/old_tile/gray,
 /area/surface/station/maintenance/incinerator)
 "SO" = (
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall/r_concrete,
 /area/surface/station/maintenance/medical/south)
 "SQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -21463,7 +21516,7 @@
 /turf/simulated/floor/plating,
 /area/surface/station/maintenance/mining)
 "TQ" = (
-/turf/simulated/wall,
+/turf/simulated/wall/concrete,
 /area/surface/station/construction/bmt/construction5)
 "TR" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -22241,7 +22294,7 @@
 /turf/simulated/floor/tiled/steel_dirty,
 /area/surface/station/hallway/primary/bmt/east)
 "Vy" = (
-/turf/simulated/wall,
+/turf/simulated/wall/concrete,
 /area/surface/station/maintenance/substation/engineering/bmt)
 "Vz" = (
 /obj/structure/grille,
@@ -22270,7 +22323,7 @@
 /turf/simulated/floor/tiled,
 /area/surface/station/mining_main)
 "VC" = (
-/turf/simulated/wall,
+/turf/simulated/wall/concrete,
 /area/surface/station/maintenance/substation/cargo/bmt)
 "VE" = (
 /obj/effect/floor_decal/industrial/warning/dust{
@@ -22403,7 +22456,7 @@
 /turf/simulated/floor/tiled,
 /area/surface/outpost/research/xenoarcheology/exp_prep)
 "VS" = (
-/turf/simulated/wall,
+/turf/simulated/wall/concrete,
 /area/surface/station/construction/bmt/construction3)
 "VU" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -22534,7 +22587,7 @@
 /area/surface/station/maintenance/incineratormaint)
 "Wh" = (
 /obj/structure/sign/warning/high_voltage,
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall/r_concrete,
 /area/surface/station/storage/tech)
 "Wk" = (
 /obj/effect/floor_decal/steeldecal/steel_decals4{
@@ -23142,6 +23195,9 @@
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/dark,
 /area/surface/outpost/research/xenoarcheology/longtermstorage)
+"Xu" = (
+/turf/simulated/wall/concrete,
+/area/surface/station/engineering/hallway/bmt)
 "Xv" = (
 /turf/simulated/floor/plating,
 /area/surface/station/construction/basement)
@@ -23305,7 +23361,7 @@
 /turf/simulated/floor/tiled,
 /area/surface/station/hallway/primary/bmt/west)
 "XR" = (
-/turf/simulated/wall,
+/turf/simulated/wall/concrete,
 /area/surface/station/construction/bmt/construction2)
 "XS" = (
 /obj/machinery/sparker{
@@ -23428,7 +23484,7 @@
 /area/surface/station/rnd/mixing)
 "Yg" = (
 /obj/structure/sign/warning/high_voltage,
-/turf/simulated/wall,
+/turf/simulated/wall/concrete,
 /area/surface/station/hallway/primary/bmt/west)
 "Yh" = (
 /obj/structure/table/steel_reinforced,
@@ -23799,7 +23855,7 @@
 /area/surface/station/rnd/mixing)
 "Za" = (
 /obj/effect/zone_divider,
-/turf/simulated/wall,
+/turf/simulated/wall/concrete,
 /area/surface/station/maintenance/engineering/south)
 "Zb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -24126,11 +24182,11 @@
 /turf/simulated/floor/plating,
 /area/surface/station/storage/tech)
 "ZF" = (
-/turf/simulated/wall,
+/turf/simulated/wall/concrete,
 /area/surface/station/construction/basement)
 "ZG" = (
 /obj/effect/landmark/submap_position/random_subtype/cynosure_ten_by_nine_maint,
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall/r_concrete,
 /area/surface/station/construction/warehouse)
 "ZH" = (
 /obj/structure/cable/green{
@@ -42481,7 +42537,7 @@ HE
 HE
 HE
 HE
-IV
+Fp
 HE
 HE
 HE
@@ -42738,7 +42794,7 @@ Kj
 Kj
 Kj
 Kj
-wj
+bM
 Kj
 Kj
 Kj
@@ -43509,7 +43565,7 @@ HE
 HE
 HE
 HE
-IV
+Fp
 HE
 HE
 HE
@@ -46823,11 +46879,11 @@ HE
 HE
 HE
 HE
-IV
+Fp
 qf
 lS
-wj
-IV
+bM
+Fp
 HE
 HE
 HE
@@ -46869,7 +46925,7 @@ Nj
 bZ
 wx
 nR
-Sc
+Sx
 Kp
 Yp
 fR
@@ -47113,7 +47169,7 @@ HE
 zL
 zL
 zL
-Vt
+jG
 sU
 Xp
 ug
@@ -47126,7 +47182,7 @@ Nj
 KT
 BJ
 Wo
-Sc
+Sx
 ii
 cS
 wp
@@ -47640,7 +47696,7 @@ Nj
 KT
 Se
 Ow
-Sc
+Sx
 Ax
 Gi
 ZV
@@ -47897,20 +47953,20 @@ KT
 KT
 XE
 Oc
-Sc
-Sc
+Sx
+Sx
 WE
 sX
 gk
-hc
+oT
 xD
-hc
+oT
 De
 aR
 KS
-hc
-NY
-NY
+oT
+DY
+DY
 HE
 HE
 HE
@@ -48166,7 +48222,7 @@ Kn
 cW
 Qf
 FK
-Sc
+Sx
 HE
 HE
 HE
@@ -48412,7 +48468,7 @@ nY
 hv
 Wg
 HB
-Sc
+Sx
 VB
 ZH
 KM
@@ -48423,7 +48479,7 @@ Ea
 FX
 IE
 Gb
-Sc
+Sx
 HE
 HE
 HE
@@ -48913,7 +48969,7 @@ sJ
 aY
 aY
 aY
-mB
+NX
 qK
 lv
 kx
@@ -49167,9 +49223,9 @@ ZA
 ZA
 iY
 aY
-JV
+MA
 jF
-JV
+MA
 yl
 MH
 vK
@@ -49935,13 +49991,13 @@ Dk
 eX
 mJ
 zx
-JV
+MA
 oK
-JV
-JV
-JV
-JV
-JV
+MA
+MA
+MA
+MA
+MA
 hh
 EQ
 hh
@@ -50191,11 +50247,11 @@ ds
 tO
 pZ
 WI
-JV
+MA
 Tr
 rW
 Tr
-KE
+rH
 EZ
 Rj
 oQ
@@ -50448,7 +50504,7 @@ ds
 qu
 bC
 eh
-JV
+MA
 lI
 HH
 WD
@@ -50630,13 +50686,13 @@ Yq
 sD
 Rw
 XI
-uZ
-uZ
-uZ
-uZ
+zr
+zr
+zr
+zr
 Al
-uZ
-uZ
+zr
+zr
 RM
 wl
 st
@@ -50705,7 +50761,7 @@ ds
 mG
 ok
 dQ
-JV
+MA
 PB
 KD
 gA
@@ -50887,13 +50943,13 @@ Qu
 Hm
 jd
 XI
-uZ
+zr
 Bj
 Bj
 Bj
 Bj
 ZZ
-uZ
+zr
 xM
 AB
 Vc
@@ -50959,10 +51015,10 @@ VW
 tl
 vG
 ds
-JV
-JV
-JV
-JV
+MA
+MA
+MA
+MA
 PB
 yN
 Be
@@ -51144,13 +51200,13 @@ NB
 sD
 OK
 oz
-uZ
+zr
 Bj
 Bj
 Bj
 Bj
 Bj
-uZ
+zr
 DK
 eF
 Mr
@@ -51203,13 +51259,13 @@ mB
 JV
 JV
 JV
-JV
-JV
-JV
-JV
-JV
-JV
-JV
+MA
+MA
+MA
+MA
+MA
+MA
+MA
 iT
 ds
 jb
@@ -51401,13 +51457,13 @@ bJ
 sD
 Ec
 kH
-uZ
+zr
 Bj
 Bj
 Bj
 Bj
 Bj
-uZ
+zr
 pR
 MG
 cj
@@ -51465,7 +51521,7 @@ HE
 HE
 HE
 HE
-JV
+MA
 Tr
 zY
 ds
@@ -51658,13 +51714,13 @@ wb
 sD
 Ec
 PS
-uZ
+zr
 Bj
 Bj
 Bj
 Bj
 Bj
-uZ
+zr
 NI
 MG
 zw
@@ -51915,13 +51971,13 @@ lo
 Ql
 Ec
 af
-uZ
+zr
 Bj
 Bj
 Bj
 Bj
 Bj
-uZ
+zr
 cu
 lQ
 Ak
@@ -52172,13 +52228,13 @@ sD
 sD
 YU
 gE
-uZ
-uZ
+zr
+zr
 Kd
 Ms
 Xb
-uZ
-uZ
+zr
+zr
 MQ
 XP
 dM
@@ -55562,12 +55618,12 @@ HE
 jw
 yS
 GN
-Us
-Us
-Us
-Us
-Us
-Us
+id
+id
+id
+id
+id
+id
 ec
 ec
 ec
@@ -55600,9 +55656,9 @@ HE
 Kj
 Kj
 fk
-kx
+JQ
 qz
-kx
+JQ
 SI
 Kj
 Kj
@@ -55819,17 +55875,17 @@ jw
 jw
 tb
 GN
-Us
+id
 QG
 QG
 QG
 RB
-Us
-UE
+id
+DD
 hJ
 UE
-UE
-UE
+DD
+DD
 nI
 Ug
 cE
@@ -55855,13 +55911,13 @@ HE
 HE
 HE
 Kj
-EN
+NC
 EN
 EN
 Qy
 EN
 EN
-EN
+NC
 Kj
 HE
 HE
@@ -56081,12 +56137,12 @@ QG
 QG
 QG
 QG
-Us
+id
 iU
 Oa
 LK
 oX
-UE
+DD
 pa
 Ug
 cE
@@ -56111,7 +56167,7 @@ fr
 HE
 HE
 HE
-EN
+NC
 EN
 EN
 lu
@@ -56119,7 +56175,7 @@ og
 Nn
 EN
 EN
-EN
+NC
 HE
 HE
 HE
@@ -56333,17 +56389,17 @@ Zf
 jw
 VU
 VU
-Us
+id
 QG
 QG
 QG
 QG
-Us
+id
 iU
 dc
 dc
 oX
-UE
+DD
 oh
 Ug
 cE
@@ -56368,7 +56424,7 @@ fr
 HE
 HE
 HE
-EN
+NC
 EN
 sl
 GE
@@ -56376,7 +56432,7 @@ Pm
 mm
 nm
 EN
-EN
+NC
 HE
 HE
 HE
@@ -56585,22 +56641,22 @@ Nl
 Us
 Us
 Us
-Us
-Us
-Us
+id
+id
+id
 Cb
 Cb
-Us
+id
 QG
 QG
 QG
 QG
-Us
+id
 NE
 FS
 FS
 qw
-UE
+DD
 hj
 Ug
 cE
@@ -56625,7 +56681,7 @@ fr
 HE
 HE
 HE
-EN
+NC
 EN
 MY
 mK
@@ -56633,7 +56689,7 @@ sR
 mK
 jO
 EN
-EN
+NC
 HE
 HE
 HE
@@ -56846,18 +56902,18 @@ xu
 CZ
 Rl
 gz
-Us
-Us
-Us
+id
+id
+id
 vC
 fF
-Us
-Us
+id
+id
 ov
 sq
 gn
 pj
-UE
+DD
 uw
 zf
 cE
@@ -56882,7 +56938,7 @@ fr
 HE
 HE
 HE
-EN
+NC
 EN
 kW
 cA
@@ -56890,7 +56946,7 @@ Rz
 cA
 UW
 EN
-EN
+NC
 HE
 HE
 HE
@@ -57114,7 +57170,7 @@ wN
 CL
 iK
 jY
-UE
+DD
 dg
 Ug
 cE
@@ -57139,7 +57195,7 @@ fr
 HE
 HE
 HE
-EN
+NC
 EN
 lh
 mK
@@ -57147,7 +57203,7 @@ UW
 mK
 Uc
 EN
-EN
+NC
 HE
 HE
 HE
@@ -57371,7 +57427,7 @@ Dj
 Cr
 kd
 vk
-UE
+DD
 cM
 iv
 cE
@@ -57396,7 +57452,7 @@ fr
 HE
 HE
 HE
-EN
+NC
 EN
 jc
 mK
@@ -57404,7 +57460,7 @@ UW
 mK
 iS
 EN
-EN
+NC
 HE
 HE
 HE
@@ -57628,7 +57684,7 @@ yY
 rC
 Ee
 xB
-UE
+DD
 Lv
 Ug
 cE
@@ -57653,7 +57709,7 @@ fr
 HE
 HE
 HE
-EN
+NC
 EN
 EN
 UU
@@ -57661,7 +57717,7 @@ fv
 ID
 EN
 EN
-EN
+NC
 HE
 HE
 HE
@@ -57884,8 +57940,8 @@ pj
 pj
 pj
 pj
-UE
-UE
+DD
+DD
 pU
 Ug
 cE
@@ -57911,13 +57967,13 @@ HE
 HE
 HE
 HE
+NC
 EN
 EN
 EN
 EN
 EN
-EN
-EN
+NC
 HE
 HE
 HE
@@ -58169,11 +58225,11 @@ HE
 HE
 HE
 HE
-EN
-EN
-EN
-EN
-EN
+NC
+NC
+NC
+NC
+NC
 HE
 HE
 HE
@@ -58653,7 +58709,7 @@ Ih
 pS
 CZ
 Rl
-Us
+id
 SO
 SO
 SO
@@ -58910,7 +58966,7 @@ xg
 xU
 Ph
 Kc
-Us
+id
 Am
 GV
 cE
@@ -59706,21 +59762,21 @@ fr
 aH
 JH
 fr
-dX
-dX
-dX
-dX
-dX
-dX
-dX
-dX
-dX
-dX
-dX
-dX
-dX
-dX
-dX
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
 BA
 BA
 BA
@@ -60189,9 +60245,9 @@ HE
 HE
 HE
 HE
-Us
-Us
-Us
+id
+id
+id
 EA
 oL
 oU
@@ -62801,7 +62857,7 @@ LF
 LF
 LF
 LF
-dX
+eE
 rJ
 lO
 hN
@@ -63058,7 +63114,7 @@ HE
 HE
 HE
 HE
-dX
+eE
 rJ
 lj
 zu
@@ -63315,7 +63371,7 @@ HE
 HE
 HE
 HE
-dX
+eE
 rJ
 lj
 hN
@@ -64848,7 +64904,7 @@ HE
 HE
 HE
 HE
-XU
+lk
 QX
 ZF
 cs
@@ -65114,7 +65170,7 @@ Xv
 Pb
 Pb
 Lo
-Na
+uY
 Ap
 Ap
 wV
@@ -65362,7 +65418,7 @@ HE
 HE
 HE
 HE
-XU
+lk
 DQ
 ZF
 wq
@@ -65371,10 +65427,10 @@ Pb
 QK
 GM
 GM
-Na
+uY
 Da
 ti
-Na
+uY
 ww
 ww
 ww
@@ -65619,19 +65675,19 @@ HE
 HE
 HE
 HE
-XU
+lk
 DQ
-Na
-Na
-Na
-Na
-Na
-Na
-Na
-Na
+uY
+uY
+uY
+uY
+uY
+uY
+uY
+uY
 yh
 lE
-Na
+uY
 HE
 HE
 HE
@@ -65875,20 +65931,20 @@ HE
 HE
 HE
 HE
-XU
-XU
+lk
+lk
 DQ
-Na
+uY
 Nt
 Nt
 Nt
 Nt
 us
-Na
+uY
 mU
 Va
 Dp
-Na
+uY
 Pf
 Pf
 Pf
@@ -66132,10 +66188,10 @@ HE
 HE
 HE
 HE
-XU
+lk
 BR
 Me
-Na
+uY
 Nt
 Nt
 Nt
@@ -66389,7 +66445,7 @@ HE
 HE
 HE
 HE
-XU
+lk
 BR
 Me
 dz
@@ -66646,10 +66702,10 @@ HE
 HE
 HE
 HE
-XU
-XU
+lk
+lk
 DQ
-Na
+uY
 Nt
 Nt
 Nt
@@ -66904,15 +66960,15 @@ HE
 HE
 HE
 HE
-XU
+lk
 DQ
-Na
+uY
 Nt
 Nt
 Nt
 Nt
 Nt
-Na
+uY
 tX
 ZR
 ho
@@ -67161,15 +67217,15 @@ HE
 HE
 HE
 HE
-XU
+lk
 DQ
-Na
-Na
-Na
-Na
-Na
-Na
-Na
+uY
+uY
+uY
+uY
+uY
+uY
+uY
 iF
 bq
 Ls
@@ -67416,16 +67472,16 @@ HE
 HE
 HE
 HE
-XU
-XU
-XU
+lk
+lk
+lk
 Me
 JL
 GJ
 ak
 Yi
 Vy
-iF
+Xu
 lA
 ko
 oD
@@ -67673,7 +67729,7 @@ HE
 HE
 HE
 HE
-XU
+lk
 Ny
 Et
 RS
@@ -67930,7 +67986,7 @@ HE
 HE
 HE
 HE
-XU
+lk
 Jr
 cT
 Ff
@@ -68187,7 +68243,7 @@ HE
 HE
 HE
 HE
-XU
+lk
 za
 nF
 rK
@@ -68202,7 +68258,7 @@ Gm
 Bk
 zq
 BZ
-Na
+uY
 HE
 HE
 HE
@@ -68444,22 +68500,22 @@ HE
 HE
 HE
 HE
-XU
+lk
 ao
 Me
-XU
+lk
 JL
 JL
 JL
 JL
 JL
 vp
-Na
-Na
+uY
+uY
 uJ
 cK
 Fk
-Na
+uY
 HE
 HE
 HE
@@ -68691,20 +68747,20 @@ tR
 tR
 tR
 tR
-XU
-XU
-XU
-XU
-XU
-XU
-XU
-XU
-XU
-XU
-XU
+lk
+lk
+lk
+lk
+lk
+lk
+lk
+lk
+lk
+lk
+lk
 BR
 Me
-XU
+lk
 HE
 HE
 HE
@@ -68716,7 +68772,7 @@ Na
 kj
 ep
 JF
-Na
+uY
 HE
 HE
 HE
@@ -68961,7 +69017,7 @@ QY
 QY
 QY
 kQ
-XU
+lk
 HE
 HE
 HE
@@ -69205,20 +69261,20 @@ tR
 tR
 tR
 tR
-XU
-XU
-XU
-XU
-XU
-XU
+lk
+lk
+lk
+lk
+lk
+lk
 Dr
 Oe
 aS
 Sp
 zd
 qZ
-XU
-XU
+lk
+lk
 HE
 HE
 HE
@@ -69467,14 +69523,14 @@ HE
 HE
 HE
 HE
-XU
-XU
+lk
+lk
 tC
 QB
-XU
-XU
-XU
-XU
+lk
+lk
+lk
+lk
 HE
 HE
 HE
@@ -69725,10 +69781,10 @@ HE
 HE
 HE
 HE
-XU
-XU
-XU
-XU
+lk
+lk
+lk
+lk
 HE
 HE
 HE

--- a/maps/cynosure/cynosure-2.dmm
+++ b/maps/cynosure/cynosure-2.dmm
@@ -533,7 +533,7 @@
 /turf/simulated/floor/plating,
 /area/surface/station/maintenance/north/gnd)
 "asQ" = (
-/turf/simulated/wall,
+/turf/simulated/wall/concrete,
 /area/surface/station/maintenance/solars/northeast)
 "asW" = (
 /obj/item/stool/padded{
@@ -1129,7 +1129,7 @@
 /obj/structure/sign/levels/cargo/mining{
 	dir = 9
 	},
-/turf/simulated/wall,
+/turf/simulated/wall/concrete,
 /area/surface/station/hallway/primary/groundfloor/east)
 "aFZ" = (
 /turf/simulated/wall/r_wall,
@@ -2047,7 +2047,7 @@
 /obj/structure/sign/directions/engineering/solars{
 	pixel_y = 6
 	},
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall/r_concrete,
 /area/surface/station/maintenance/solars/west)
 "aZL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -2362,7 +2362,7 @@
 /turf/simulated/floor/carpet,
 /area/surface/station/security/detectives_office)
 "ben" = (
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall/r_concrete,
 /area/surface/station/maintenance/substation/atmospherics)
 "bes" = (
 /obj/machinery/atmospherics/binary/pump{
@@ -3368,6 +3368,9 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/surface/station/medical/etc)
+"bAZ" = (
+/turf/simulated/wall/concrete,
+/area/surface/station/rnd/research_restroom)
 "bBp" = (
 /obj/effect/floor_decal/industrial/warning/corner,
 /obj/machinery/meter,
@@ -3524,7 +3527,7 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/surface/station/ai/upload)
 "bEh" = (
-/turf/simulated/wall,
+/turf/simulated/wall/concrete,
 /area/surface/station/rnd/hallway/stairwell)
 "bEv" = (
 /obj/machinery/door/firedoor/border_only,
@@ -3620,7 +3623,7 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/surface/station/rnd/research_restroom)
 "bHw" = (
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall/r_concrete,
 /area/surface/station/medical/hallway/gnd)
 "bIc" = (
 /obj/structure/railing{
@@ -3665,7 +3668,7 @@
 /turf/simulated/floor/plating,
 /area/surface/station/engineering/atmos)
 "bIC" = (
-/turf/simulated/wall,
+/turf/simulated/wall/concrete,
 /area/surface/station/medical/etc)
 "bIK" = (
 /obj/structure/cable/cyan{
@@ -3951,7 +3954,7 @@
 /turf/simulated/floor/tiled/eris,
 /area/surface/station/rnd/xenobiology)
 "bOG" = (
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall/r_concrete,
 /area/surface/station/maintenance/substation/security/gnd)
 "bPE" = (
 /obj/effect/floor_decal/industrial/outline/grey,
@@ -4319,6 +4322,9 @@
 	},
 /turf/simulated/floor/wood/sif,
 /area/surface/station/chapel/main)
+"bZn" = (
+/turf/simulated/wall/r_concrete,
+/area/surface/station/security/evidence_storage)
 "bZp" = (
 /obj/machinery/camera/network/security{
 	c_tag = "SEC - Evidence Storage";
@@ -4503,6 +4509,9 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
+/area/surface/station/hallway/primary/groundfloor/west/elevator)
+"cdD" = (
+/turf/simulated/wall/r_concrete,
 /area/surface/station/hallway/primary/groundfloor/west/elevator)
 "cdK" = (
 /obj/machinery/door/firedoor/glass,
@@ -4734,6 +4743,9 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/shuttle/exploration/cargo)
+"ckl" = (
+/turf/simulated/wall/concrete,
+/area/surface/outpost/research/xenoarcheology/surface)
 "ckG" = (
 /obj/structure/cable/cyan{
 	d2 = 8;
@@ -4797,6 +4809,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/surface/station/park)
+"cmt" = (
+/turf/simulated/wall/r_concrete,
+/area/surface/station/security/equiptment_storage/ses)
 "cmJ" = (
 /obj/structure/fence{
 	dir = 4
@@ -5168,7 +5183,7 @@
 /area/surface/station/hallway/primary/groundfloor/south)
 "cyo" = (
 /obj/structure/sign/warning/nosmoking_2,
-/turf/simulated/wall,
+/turf/simulated/wall/concrete,
 /area/surface/station/medical/etc)
 "cyO" = (
 /obj/structure/cable/green{
@@ -5460,6 +5475,9 @@
 	},
 /turf/simulated/floor/tiled/old_cargo/gray,
 /area/shuttle/exploration/cockpit)
+"cHa" = (
+/turf/simulated/wall/r_concrete,
+/area/surface/station/rnd/exploration)
 "cHj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -5975,6 +5993,9 @@
 /obj/effect/map_helper/airlock/door/simple,
 /turf/simulated/floor/plating,
 /area/surface/station/quartermaster/storage)
+"cQG" = (
+/turf/simulated/wall/r_concrete,
+/area/surface/station/rnd/research_restroom)
 "cQI" = (
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 1
@@ -6404,7 +6425,7 @@
 /area/surface/station/ai/upload)
 "cXT" = (
 /obj/structure/sign/warning/radioactive,
-/turf/simulated/wall,
+/turf/simulated/wall/concrete,
 /area/surface/outside/plains/station)
 "cXY" = (
 /obj/structure/cable/cyan{
@@ -6478,7 +6499,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
-/turf/simulated/wall,
+/turf/simulated/wall/concrete,
 /area/surface/station/hallway/primary/groundfloor/west/elevator)
 "cZg" = (
 /obj/effect/floor_decal/borderfloorblack{
@@ -6517,6 +6538,9 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/surface/station/medical/reception)
+"cZL" = (
+/turf/simulated/wall/r_concrete,
+/area/surface/station/security/briefing_room)
 "cZO" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -6963,7 +6987,7 @@
 /area/surface/station/hallway/primary/groundfloor/south)
 "dlf" = (
 /obj/structure/sign/warning/high_voltage,
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall/r_concrete,
 /area/surface/station/maintenance/substation/cargo/gnd)
 "dln" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -6995,7 +7019,7 @@
 /turf/simulated/floor/tiled/white,
 /area/surface/station/medical/ward)
 "dlE" = (
-/turf/simulated/wall,
+/turf/simulated/wall/concrete,
 /area/surface/station/maintenance/substation/atmospherics)
 "dlI" = (
 /obj/effect/floor_decal/borderfloor{
@@ -7433,7 +7457,7 @@
 	dir = 8;
 	pixel_y = -6
 	},
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall/r_concrete,
 /area/surface/station/hallway/primary/groundfloor/east)
 "duZ" = (
 /obj/machinery/atmospherics/unary/engine{
@@ -7470,7 +7494,7 @@
 /area/surface/station/quartermaster/storage)
 "dwo" = (
 /obj/structure/sign/level/ground,
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall/r_concrete,
 /area/surface/station/security/equiptment_storage/ses)
 "dwr" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -7545,7 +7569,7 @@
 /obj/structure/sign/directions/ladder_down{
 	pixel_y = 6
 	},
-/turf/simulated/wall,
+/turf/simulated/wall/concrete,
 /area/surface/station/maintenance/north/gnd)
 "dyI" = (
 /obj/structure/ladder/up,
@@ -8402,7 +8426,7 @@
 /turf/simulated/floor/plating,
 /area/surface/station/medical/emt_bay)
 "dTQ" = (
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall/r_concrete,
 /area/surface/station/arrivals/cynosure/cryo)
 "dUv" = (
 /obj/machinery/door/firedoor/glass,
@@ -8506,7 +8530,7 @@
 /turf/simulated/floor/plating,
 /area/surface/station/engineering/atmos)
 "dYh" = (
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall/r_concrete,
 /area/surface/station/maintenance/substation/cargo/gnd)
 "dYO" = (
 /obj/item/radio/intercom{
@@ -8605,6 +8629,9 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled/old_tile/white,
 /area/surface/station/rnd/research_restroom)
+"ebz" = (
+/turf/simulated/wall/concrete,
+/area/surface/station/chapel/office)
 "ebH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -9620,6 +9647,9 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/surface/station/storage/primarytool)
+"ewo" = (
+/turf/simulated/wall/r_concrete,
+/area/surface/station/maintenance/substation/engineering/gnd)
 "ewC" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/yellow{
 	dir = 1
@@ -10153,7 +10183,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/surface/station/security/lobby)
 "eHW" = (
-/turf/simulated/wall,
+/turf/simulated/wall/concrete,
 /area/surface/station/maintenance/substation/engineering/gnd)
 "eIB" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -10190,6 +10220,9 @@
 	},
 /turf/simulated/floor/plating,
 /area/surface/station/crew_quarters/heads/hop)
+"eIR" = (
+/turf/simulated/wall/r_concrete,
+/area/surface/station/security/range)
 "eJn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -10456,7 +10489,7 @@
 	dir = 1;
 	pixel_y = -6
 	},
-/turf/simulated/wall,
+/turf/simulated/wall/concrete,
 /area/surface/station/maintenance/solars/northeast)
 "eOB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/universal,
@@ -11041,6 +11074,9 @@
 /obj/effect/floor_decal/steeldecal/steel_decals4,
 /turf/simulated/floor/tiled/eris/cafe,
 /area/surface/station/crew_quarters/kitchen)
+"eZL" = (
+/turf/simulated/wall/concrete,
+/area/surface/outside/plains/station)
 "eZS" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	dir = 10
@@ -12068,7 +12104,7 @@
 /area/surface/station/hydroponics)
 "fzQ" = (
 /obj/structure/sign/warning/high_voltage,
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall/r_concrete,
 /area/surface/station/maintenance/substation/research/gnd)
 "fzX" = (
 /obj/effect/floor_decal/techfloor{
@@ -12923,7 +12959,7 @@
 /turf/simulated/floor/tiled/white,
 /area/surface/station/medical/storage/primary_storage)
 "fRF" = (
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall/r_concrete,
 /area/surface/station/hallway/primary/groundfloor/east)
 "fRI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -13019,6 +13055,9 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/surface/station/ai/upload)
+"fTD" = (
+/turf/simulated/wall/r_concrete,
+/area/surface/outpost/research/xenoarcheology/surface)
 "fTV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/borderfloorwhite/corner,
@@ -13252,7 +13291,7 @@
 /area/surface/station/maintenance/atmos)
 "gbG" = (
 /obj/structure/sign/warning/high_voltage,
-/turf/simulated/wall,
+/turf/simulated/wall/concrete,
 /area/surface/station/maintenance/substation/research/gnd)
 "gbK" = (
 /obj/effect/floor_decal/borderfloor,
@@ -13565,7 +13604,7 @@
 /turf/simulated/wall/r_wall,
 /area/surface/station/engineering/reactor_room)
 "gjW" = (
-/turf/simulated/floor/plating/sif/planetuse,
+/turf/simulated/floor/concrete/sif/planetuse,
 /area/surface/outside/plains/station)
 "gkB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -14427,7 +14466,7 @@
 /obj/structure/sign/levels/cargo{
 	dir = 1
 	},
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall/r_concrete,
 /area/surface/station/hallway/primary/groundfloor/west/elevator)
 "gDD" = (
 /obj/effect/floor_decal/industrial/warning,
@@ -15045,7 +15084,7 @@
 	dir = 8;
 	pixel_y = 6
 	},
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall/r_concrete,
 /area/surface/station/arrivals/cynosure/cryo)
 "gPO" = (
 /obj/effect/zone_divider,
@@ -16077,7 +16116,7 @@
 /area/surface/station/crew_quarters/pool)
 "hsL" = (
 /obj/structure/sign/warning/high_voltage,
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall/r_concrete,
 /area/surface/station/maintenance/solars/west)
 "hta" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -16811,6 +16850,9 @@
 /obj/effect/floor_decal/corner/yellow/bordercorner,
 /turf/simulated/floor/tiled,
 /area/surface/station/engineering/workshop)
+"hJJ" = (
+/turf/simulated/wall/r_concrete,
+/area/surface/station/crew_quarters/pool)
 "hKf" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -17114,7 +17156,7 @@
 /area/surface/station/security/briefing_room)
 "hSr" = (
 /obj/structure/sign/warning/high_voltage,
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall/r_concrete,
 /area/surface/station/maintenance/substation/medbay/gnd)
 "hSB" = (
 /obj/effect/floor_decal/borderfloor/corner{
@@ -17301,9 +17343,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/surface/station/hallway/primary/groundfloor/north)
-"hXy" = (
-/turf/simulated/wall/r_wall,
-/area/surface/station/maintenance/substation/civilian)
 "hYa" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/industrial/danger,
@@ -17340,6 +17379,9 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/surface/station/rnd/xenobiology)
+"hZm" = (
+/turf/simulated/wall/r_concrete,
+/area/surface/station/security/lobby)
 "hZG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 10
@@ -17659,7 +17701,7 @@
 /area/surface/station/medical/surgeryobs)
 "ihE" = (
 /obj/structure/sign/warning/high_voltage,
-/turf/simulated/wall,
+/turf/simulated/wall/concrete,
 /area/surface/station/medical/etc)
 "ihO" = (
 /obj/machinery/sleeper{
@@ -18814,6 +18856,9 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/surface/station/ai/upload_foyer)
+"iMZ" = (
+/turf/simulated/wall/concrete,
+/area/surface/station/medical/cloning)
 "iNb" = (
 /obj/effect/floor_decal/corner/white/diagonal,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -18994,7 +19039,7 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/shuttle/exploration/cargo)
 "iSh" = (
-/turf/simulated/wall,
+/turf/simulated/wall/concrete,
 /area/surface/station/hallway/primary/groundfloor/east)
 "iSG" = (
 /turf/simulated/wall,
@@ -22451,6 +22496,9 @@
 	},
 /turf/simulated/floor/tiled,
 /area/surface/station/arrivals/cynosure)
+"krp" = (
+/turf/simulated/wall/concrete,
+/area/surface/station/maintenance/north/gnd)
 "krw" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction{
 	dir = 1
@@ -23407,7 +23455,7 @@
 /turf/simulated/floor/carpet,
 /area/surface/station/security/detectives_office)
 "kPd" = (
-/turf/simulated/wall,
+/turf/simulated/wall/concrete,
 /area/surface/station/garage)
 "kPm" = (
 /obj/effect/floor_decal/steeldecal/steel_decals4{
@@ -24004,6 +24052,9 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/surface/station/engineering/storage)
+"lfc" = (
+/turf/simulated/wall/concrete,
+/area/surface/station/maintenance/kitchen)
 "lfk" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/borderfloorwhite,
@@ -25301,6 +25352,9 @@
 /obj/structure/window/reinforced/full,
 /turf/simulated/floor/plating,
 /area/surface/station/storage/primarytool)
+"lJS" = (
+/turf/simulated/wall/r_concrete,
+/area/surface/station/security/hallway/gnd)
 "lKB" = (
 /obj/effect/floor_decal/borderfloor/corner{
 	dir = 1
@@ -25528,7 +25582,7 @@
 	dir = 4;
 	pixel_y = 6
 	},
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall/r_concrete,
 /area/surface/station/security/hallway/gnd)
 "lOW" = (
 /obj/structure/ladder,
@@ -25730,6 +25784,9 @@
 /obj/item/flashlight/lamp,
 /turf/simulated/floor/lino,
 /area/surface/station/chapel/office)
+"lSJ" = (
+/turf/simulated/wall/concrete,
+/area/surface/station/rnd/research_lockerroom)
 "lSV" = (
 /turf/simulated/floor/tiled/techmaint,
 /area/surface/station/security/range)
@@ -26329,7 +26386,7 @@
 /area/surface/station/maintenance/surgery)
 "mdG" = (
 /obj/structure/sign/warning/high_voltage,
-/turf/simulated/wall,
+/turf/simulated/wall/r_concrete,
 /area/surface/station/maintenance/substation/civilian)
 "meb" = (
 /obj/effect/floor_decal/steeldecal/steel_decals4{
@@ -26434,7 +26491,7 @@
 /turf/simulated/floor/tiled/white,
 /area/surface/station/rnd/xenobiology)
 "mgC" = (
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall/r_concrete,
 /area/surface/station/maintenance/substation/arrivals)
 "mgM" = (
 /obj/item/modular_computer/console/preset/security{
@@ -27223,6 +27280,9 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/surface/station/ai/upload)
+"mxb" = (
+/turf/simulated/wall/concrete,
+/area/surface/station/security/interrogation)
 "mxf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -27264,7 +27324,7 @@
 	dir = 9;
 	pixel_y = 6
 	},
-/turf/simulated/wall,
+/turf/simulated/wall/concrete,
 /area/surface/station/rnd/hallway/stairwell)
 "mxT" = (
 /obj/effect/zone_divider,
@@ -27382,7 +27442,7 @@
 /obj/structure/sign/levels/medical/virology{
 	dir = 1
 	},
-/turf/simulated/wall,
+/turf/simulated/wall/concrete,
 /area/surface/station/medical/etc)
 "mAq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -27555,6 +27615,9 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/sif/planetuse,
 /area/surface/outside/station/solar/westsolar)
+"mCs" = (
+/turf/simulated/wall/r_concrete,
+/area/surface/station/quartermaster/storage)
 "mCR" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -28404,6 +28467,9 @@
 	},
 /turf/simulated/floor/tiled,
 /area/surface/station/security/range)
+"mVg" = (
+/turf/simulated/wall/concrete,
+/area/surface/station/hallway/primary/groundfloor/west)
 "mVp" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 6
@@ -28497,6 +28563,9 @@
 /obj/item/folder/red,
 /turf/simulated/floor/plating,
 /area/surface/station/security/briefing_room)
+"mWA" = (
+/turf/simulated/wall/r_concrete,
+/area/surface/station/maintenance/kitchen)
 "mWO" = (
 /obj/machinery/vending/coffee,
 /turf/simulated/floor/tiled/hydro,
@@ -28524,6 +28593,9 @@
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/wood,
 /area/surface/station/crew_quarters/cafeteria)
+"mYb" = (
+/turf/simulated/wall/r_concrete,
+/area/surface/station/engineering/hallway/reactor)
 "mYc" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -28676,7 +28748,7 @@
 /turf/simulated/floor/reinforced/supermatter_core,
 /area/surface/station/engineering/reactor_room)
 "nbV" = (
-/turf/simulated/floor/plating/sif/planetuse,
+/turf/simulated/floor/concrete/sif/planetuse,
 /area/surface/outside/station/shuttle/pad4)
 "nck" = (
 /obj/random/obstruction,
@@ -29367,7 +29439,7 @@
 /turf/simulated/floor/tiled/freezer,
 /area/surface/station/crew_quarters/kitchen)
 "nvX" = (
-/turf/simulated/floor/plating/sif/planetuse,
+/turf/simulated/floor/concrete/sif/planetuse,
 /area/shuttle/arrival/station{
 	dynamic_lighting = 1
 	})
@@ -30191,7 +30263,7 @@
 /area/shuttle/large_escape_pod1/station)
 "nNy" = (
 /obj/effect/shuttle_landmark/cynosure/escape/station,
-/turf/simulated/floor/plating/sif/planetuse,
+/turf/simulated/floor/concrete/sif/planetuse,
 /area/shuttle/escape/station{
 	dynamic_lighting = 1
 	})
@@ -30281,6 +30353,9 @@
 	},
 /turf/simulated/floor/tiled/neutral,
 /area/surface/station/crew_quarters/caferestroom)
+"nPR" = (
+/turf/simulated/wall/concrete,
+/area/surface/outpost/checkpoint)
 "nQi" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -30815,6 +30890,9 @@
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/surface/station/engineering/hallway/reactor)
+"obq" = (
+/turf/simulated/wall/r_concrete,
+/area/surface/station/medical/cloning)
 "obt" = (
 /obj/structure/table/marble,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -31587,6 +31665,9 @@
 /obj/structure/window/reinforced/full,
 /turf/simulated/floor/plating,
 /area/surface/station/hallway/primary/groundfloor/west/elevator)
+"ore" = (
+/turf/simulated/wall/r_concrete,
+/area/surface/station/quartermaster/lockerroom)
 "orl" = (
 /obj/effect/floor_decal/steeldecal/steel_decals_central6{
 	dir = 1
@@ -31776,7 +31857,7 @@
 /area/surface/outside/river/gautelfr)
 "ouz" = (
 /obj/structure/sign/warning/high_voltage,
-/turf/simulated/wall,
+/turf/simulated/wall/concrete,
 /area/surface/station/maintenance/substation/cargo/gnd)
 "ouC" = (
 /obj/effect/floor_decal/borderfloor{
@@ -31920,7 +32001,7 @@
 /area/surface/station/security/lobby)
 "owK" = (
 /obj/structure/sign/warning/high_voltage,
-/turf/simulated/wall,
+/turf/simulated/wall/concrete,
 /area/surface/station/maintenance/substation/security/gnd)
 "owR" = (
 /obj/structure/closet/wardrobe/chaplain_black,
@@ -32711,6 +32792,9 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/surface/station/janitor)
+"oQc" = (
+/turf/simulated/wall/concrete,
+/area/surface/station/engineering/hallway)
 "oQg" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -32849,7 +32933,7 @@
 /turf/simulated/floor/tiled/neutral,
 /area/surface/station/medical/surgeryobs)
 "oTc" = (
-/turf/simulated/wall,
+/turf/simulated/wall/concrete,
 /area/surface/station/maintenance/east/gnd)
 "oTe" = (
 /obj/random/crate{
@@ -33844,7 +33928,7 @@
 /turf/simulated/floor/outdoors/mask,
 /area/surface/outside/plains/station)
 "plP" = (
-/turf/simulated/wall,
+/turf/simulated/wall/r_concrete,
 /area/surface/station/maintenance/substation/civilian)
 "plR" = (
 /obj/effect/floor_decal/borderfloorwhite{
@@ -34260,12 +34344,12 @@
 /area/surface/station/medical/surgery)
 "psJ" = (
 /obj/effect/shuttle_landmark/cynosure/arrivals_station,
-/turf/simulated/floor/plating/sif/planetuse,
+/turf/simulated/floor/concrete/sif/planetuse,
 /area/shuttle/arrival/station{
 	dynamic_lighting = 1
 	})
 "psP" = (
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall/r_concrete,
 /area/surface/station/maintenance/weststairwell/gnd)
 "psX" = (
 /obj/machinery/lapvend,
@@ -34851,6 +34935,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/surface/station/crew_quarters/gym)
+"pGp" = (
+/turf/simulated/wall/r_concrete,
+/area/surface/station/engineering/workshop)
 "pGM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -36842,6 +36929,9 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/surface/station/ai/upload)
+"qyA" = (
+/turf/simulated/wall/r_concrete,
+/area/surface/station/maintenance/solars/west)
 "qyR" = (
 /obj/structure/table/woodentable,
 /obj/item/paicard,
@@ -38101,6 +38191,9 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/shuttle/exploration/cargo)
+"qZp" = (
+/turf/simulated/wall/r_concrete,
+/area/surface/station/rnd/xenobiology)
 "qZB" = (
 /turf/simulated/floor/tiled/white,
 /area/surface/station/medical/etc)
@@ -38775,7 +38868,7 @@
 /area/surface/station/engineering/reactor_room)
 "roL" = (
 /obj/effect/zone_divider,
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall/r_concrete,
 /area/surface/station/crew_quarters/pool)
 "rpd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -38792,6 +38885,9 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/surface/station/medical/reception)
+"rpI" = (
+/turf/simulated/wall/r_concrete,
+/area/surface/station/maintenance/solars/northeast)
 "rpV" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red,
 /obj/machinery/door/firedoor/glass,
@@ -39862,7 +39958,7 @@
 /area/surface/station/security/detectives_office/lab)
 "rPP" = (
 /obj/structure/sign/warning/nosmoking_2,
-/turf/simulated/wall,
+/turf/simulated/wall/concrete,
 /area/surface/station/maintenance/substation/atmospherics)
 "rPT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -40065,6 +40161,9 @@
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/simulated/floor/grass,
 /area/surface/station/hydroponics/garden)
+"rVy" = (
+/turf/simulated/wall/concrete,
+/area/surface/station/quartermaster/storage)
 "rVE" = (
 /turf/simulated/wall/r_wall,
 /area/surface/station/rnd/misc_lab)
@@ -40235,7 +40334,7 @@
 /area/surface/station/engineering/reactor_waste)
 "rZv" = (
 /obj/structure/sign/warning/high_voltage,
-/turf/simulated/wall,
+/turf/simulated/wall/concrete,
 /area/surface/station/maintenance/solars/northeast)
 "rZG" = (
 /obj/machinery/appliance/cooker/oven,
@@ -40248,7 +40347,7 @@
 /area/surface/station/crew_quarters/kitchen)
 "rZW" = (
 /obj/structure/sign/warning/high_voltage,
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall/r_concrete,
 /area/surface/station/maintenance/substation/engineering/gnd)
 "sag" = (
 /obj/effect/floor_decal/steeldecal/steel_decals4{
@@ -40496,7 +40595,7 @@
 /obj/structure/sign/directions/engineering/atmospherics{
 	pixel_y = -6
 	},
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall/r_concrete,
 /area/surface/station/engineering/hallway)
 "sjj" = (
 /obj/structure/disposalpipe/segment{
@@ -41197,6 +41296,9 @@
 	},
 /turf/simulated/floor/tiled,
 /area/surface/station/crew_quarters/heads/hop)
+"sAh" = (
+/turf/simulated/wall/r_concrete,
+/area/surface/station/arrivals/cynosure)
 "sAl" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/machinery/hologram/holopad,
@@ -41831,7 +41933,7 @@
 /turf/simulated/floor/tiled/eris/cafe,
 /area/surface/station/crew_quarters/kitchen)
 "sOv" = (
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall/r_concrete,
 /area/surface/station/maintenance/substation/research/gnd)
 "sOx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -43424,7 +43526,7 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/surface/station/engineering/hallway)
 "tAm" = (
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall/r_concrete,
 /area/surface/station/maintenance/substation/medbay/gnd)
 "tAK" = (
 /obj/effect/floor_decal/borderfloorwhite,
@@ -44269,7 +44371,7 @@
 /turf/simulated/wall/r_wall,
 /area/surface/station/crew_quarters/heads/hos)
 "tVs" = (
-/turf/simulated/wall,
+/turf/simulated/wall/concrete,
 /area/surface/station/maintenance/substation/arrivals)
 "tVA" = (
 /obj/effect/floor_decal/industrial/warning,
@@ -45034,6 +45136,9 @@
 /obj/effect/floor_decal/techfloor,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/surface/station/ai/upload)
+"uoN" = (
+/turf/simulated/wall/concrete,
+/area/surface/station/maintenance/chapel)
 "uoO" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -45906,6 +46011,9 @@
 	},
 /turf/simulated/floor/tiled,
 /area/surface/station/hallway/secondary/groundfloor/civilian)
+"uMS" = (
+/turf/simulated/wall/r_concrete,
+/area/surface/station/janitor)
 "uNc" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
@@ -46055,6 +46163,9 @@
 	},
 /turf/simulated/floor/tiled,
 /area/surface/station/hallway/primary/groundfloor/west)
+"uPj" = (
+/turf/simulated/wall/r_concrete,
+/area/surface/outside/plains/station)
 "uPB" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 6
@@ -46767,7 +46878,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/wall,
+/turf/simulated/wall/concrete,
 /area/surface/station/rnd/xenobiology)
 "vfO" = (
 /obj/structure/cable/green{
@@ -47794,7 +47905,7 @@
 /turf/simulated/floor/plating,
 /area/surface/station/maintenance/chapel)
 "vBC" = (
-/turf/simulated/floor/plating/sif/planetuse,
+/turf/simulated/floor/concrete/sif/planetuse,
 /area/shuttle/escape/station{
 	dynamic_lighting = 1
 	})
@@ -48212,7 +48323,7 @@
 	dir = 1;
 	pixel_y = 6
 	},
-/turf/simulated/wall,
+/turf/simulated/wall/concrete,
 /area/surface/station/rnd/hallway/stairwell)
 "vKa" = (
 /obj/effect/floor_decal/techfloor,
@@ -48229,7 +48340,7 @@
 /turf/simulated/floor/tiled/monotile,
 /area/surface/station/engineering/atmos)
 "vKC" = (
-/turf/simulated/floor/plating/sif/planetuse,
+/turf/simulated/floor/concrete/sif/planetuse,
 /area/surface/outside/station/shuttle/pad3)
 "vKZ" = (
 /obj/structure/cable/green{
@@ -48711,7 +48822,7 @@
 /turf/simulated/floor/plating,
 /area/surface/station/maintenance/north/gnd)
 "vYO" = (
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall/r_concrete,
 /area/surface/station/security/restroom)
 "vYV" = (
 /obj/machinery/door/blast/regular/open{
@@ -49492,7 +49603,7 @@
 /area/surface/station/security/equiptment_storage/ses)
 "wuZ" = (
 /obj/effect/shuttle_landmark/cynosure/pads/pad3,
-/turf/simulated/floor/plating/sif/planetuse,
+/turf/simulated/floor/concrete/sif/planetuse,
 /area/surface/outside/station/shuttle/pad3)
 "wvm" = (
 /obj/machinery/holosign/bar,
@@ -50727,7 +50838,7 @@
 /turf/simulated/floor/plating,
 /area/surface/station/garage)
 "wUn" = (
-/turf/simulated/wall,
+/turf/simulated/wall/concrete,
 /area/surface/station/maintenance/substation/cargo/gnd)
 "wUu" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow{
@@ -51443,7 +51554,7 @@
 	name = "WARNING";
 	pixel_y = -6
 	},
-/turf/simulated/wall,
+/turf/simulated/wall/concrete,
 /area/surface/outside/plains/station)
 "xod" = (
 /obj/structure/cable/green{
@@ -51709,6 +51820,9 @@
 	},
 /turf/simulated/floor/lino,
 /area/surface/station/chapel/office)
+"xuy" = (
+/turf/simulated/wall/r_concrete,
+/area/surface/station/engineering/hallway)
 "xuX" = (
 /obj/effect/floor_decal/borderfloorwhite,
 /obj/effect/floor_decal/corner/purple/border,
@@ -52183,7 +52297,7 @@
 /turf/simulated/floor/wood/sif,
 /area/surface/outpost/checkpoint)
 "xGi" = (
-/turf/simulated/wall,
+/turf/simulated/wall/concrete,
 /area/surface/station/maintenance/substation/security/gnd)
 "xGw" = (
 /obj/structure/cliff/automatic{
@@ -52460,6 +52574,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/hydro,
 /area/surface/station/rnd/xenobiology/xenoflora)
+"xMM" = (
+/turf/simulated/wall/r_concrete,
+/area/surface/station/maintenance/east/gnd)
 "xNj" = (
 /obj/structure/cliff/automatic,
 /obj/effect/zone_divider,
@@ -53627,6 +53744,9 @@
 /obj/structure/window/reinforced/full,
 /turf/simulated/floor/plating,
 /area/surface/station/maintenance/north/gnd)
+"yiE" = (
+/turf/simulated/wall/concrete,
+/area/surface/station/chapel/main)
 "yjC" = (
 /obj/effect/floor_decal/industrial/outline{
 	color = "#D4D4D4"
@@ -53720,6 +53840,9 @@
 	amount = 20
 	},
 /obj/item/stack/rods{
+	amount = 50
+	},
+/obj/item/stack/material/concrete{
 	amount = 50
 	},
 /turf/simulated/floor/tiled,
@@ -55430,12 +55553,12 @@ vwy
 vwy
 vwy
 vwy
-bGA
+nPR
 bGA
 hMY
 hMY
 bGA
-bGA
+nPR
 eKw
 vwy
 fyc
@@ -57486,12 +57609,12 @@ vwy
 vwy
 vwy
 vwy
-bGA
+nPR
 bGA
 hMY
 hMY
 bGA
-bGA
+nPR
 eKw
 vwy
 vwy
@@ -72569,7 +72692,7 @@ xnL
 twu
 twu
 nCe
-sSy
+eZL
 nCe
 nCe
 nCe
@@ -73832,17 +73955,17 @@ nCe
 nCe
 nCe
 aqn
-fHJ
+hJJ
 szA
 ulS
 szA
-fHJ
+hJJ
 roL
-fHJ
+hJJ
 szA
 ulS
 szA
-fHJ
+hJJ
 aqn
 aqn
 nCe
@@ -74085,11 +74208,11 @@ nCe
 nCe
 nCe
 nCe
-fHJ
-fHJ
-fHJ
-fHJ
-fHJ
+hJJ
+hJJ
+hJJ
+hJJ
+hJJ
 aKd
 ldo
 yfz
@@ -74099,10 +74222,10 @@ iuv
 aKd
 ldo
 yfz
-fHJ
-fHJ
-fHJ
-fHJ
+hJJ
+hJJ
+hJJ
+hJJ
 nCe
 nCe
 nCe
@@ -74342,7 +74465,7 @@ nCe
 nCe
 nCe
 nCe
-fHJ
+hJJ
 ihg
 rHf
 qXW
@@ -74359,8 +74482,8 @@ lzq
 dPv
 lzq
 rHf
-fHJ
-fHJ
+hJJ
+hJJ
 nCe
 nCe
 nCe
@@ -74599,7 +74722,7 @@ nCe
 nCe
 nCe
 nCe
-fHJ
+hJJ
 wcF
 lzq
 sLL
@@ -74840,7 +74963,7 @@ aqn
 aqn
 aqn
 aqn
-wzX
+uPj
 fIk
 fIk
 fIk
@@ -74848,7 +74971,7 @@ fIk
 fIk
 fIk
 fIk
-wzX
+uPj
 aqn
 aqn
 aqn
@@ -75091,7 +75214,7 @@ nCe
 vLj
 miC
 hwh
-wzX
+uPj
 eSN
 eSN
 eSN
@@ -75105,8 +75228,8 @@ fIk
 fIk
 fIk
 fIk
-wzX
-wzX
+uPj
+uPj
 eSN
 fIk
 fIk
@@ -75343,7 +75466,7 @@ nCe
 nCe
 nCe
 nCe
-hwh
+qyA
 idS
 haN
 ewJ
@@ -75388,7 +75511,7 @@ syj
 qdF
 rtv
 xgE
-fHJ
+hJJ
 nCe
 nCe
 nCe
@@ -75600,7 +75723,7 @@ nCe
 nCe
 psP
 fdg
-hwh
+qyA
 mrO
 jlb
 kHv
@@ -75627,7 +75750,7 @@ fIk
 fIk
 fIk
 fIk
-fHJ
+hJJ
 btA
 jss
 wzJ
@@ -75645,8 +75768,8 @@ syj
 qdF
 lzq
 oBR
-fHJ
-fHJ
+hJJ
+hJJ
 nCe
 nCe
 nCe
@@ -75861,13 +75984,13 @@ aZD
 opT
 skd
 pIY
-pRP
-pRP
-pRP
-pRP
-pRP
-pRP
-pRP
+cdD
+cdD
+cdD
+cdD
+cdD
+cdD
+cdD
 idr
 idr
 idr
@@ -75876,8 +75999,8 @@ pXz
 pXz
 fIk
 fIk
-wzX
-wzX
+uPj
+uPj
 idr
 idr
 idr
@@ -76118,13 +76241,13 @@ bbT
 lBQ
 cTK
 gEG
-pRP
+cdD
 nPy
 nPy
 nPy
 nPy
 nPy
-pRP
+cdD
 aqn
 aqn
 aqn
@@ -76372,16 +76495,16 @@ fdg
 qXG
 ulb
 hsL
-hwh
-hwh
-hwh
-pRP
+qyA
+qyA
+qyA
+cdD
 nPy
 nPy
 nPy
 nPy
 nPy
-pRP
+cdD
 aqn
 dNR
 tYs
@@ -76632,13 +76755,13 @@ psP
 prA
 qKp
 xRE
-pRP
+cdD
 nPy
 nPy
 nPy
 nPy
 nPy
-pRP
+cdD
 aqn
 wCG
 aWW
@@ -76655,7 +76778,7 @@ aWW
 aWW
 fkd
 aqn
-fHJ
+hJJ
 lbL
 xig
 xig
@@ -76674,7 +76797,7 @@ bvY
 eni
 lzq
 dZT
-fHJ
+hJJ
 nCe
 nCe
 nCe
@@ -76889,13 +77012,13 @@ psP
 prA
 qYz
 owy
-pRP
+cdD
 nPy
 nPy
 nPy
 nPy
 nPy
-pRP
+cdD
 aqn
 wCG
 aWW
@@ -76912,7 +77035,7 @@ aWW
 aWW
 fkd
 aqn
-fHJ
+hJJ
 fHJ
 tWf
 tWf
@@ -77133,11 +77256,11 @@ nCe
 nCe
 nCe
 nCe
-mjQ
-mjQ
-mjQ
-mjQ
-mjQ
+cQG
+cQG
+cQG
+cQG
+cQG
 aqn
 psP
 sGM
@@ -77146,13 +77269,13 @@ wcG
 mqv
 mXo
 jfk
-pRP
+cdD
 nPy
 nPy
 nPy
 nPy
 nPy
-pRP
+cdD
 aqn
 wCG
 aWW
@@ -77390,11 +77513,11 @@ kzM
 kzM
 kzM
 mjQ
-mjQ
+cQG
 oyH
-cFh
+bAZ
 gXJ
-mjQ
+cQG
 sOv
 sOv
 sOv
@@ -77404,12 +77527,12 @@ cYW
 fQI
 tHt
 gDu
-pRP
+cdD
 mHU
 hby
 heZ
 pRP
-pRP
+cdD
 aqn
 wCG
 aWW
@@ -77651,7 +77774,7 @@ cFh
 bHr
 cFh
 vdB
-cFh
+bAZ
 rmN
 wYw
 tgD
@@ -77689,7 +77812,7 @@ vXK
 lSf
 oog
 kHo
-aTi
+ebz
 ayX
 ode
 waK
@@ -77908,7 +78031,7 @@ koY
 chs
 aJK
 hwP
-cFh
+bAZ
 mUu
 dKr
 tNf
@@ -77946,7 +78069,7 @@ bkk
 nhb
 xtS
 dPI
-aTi
+ebz
 jIZ
 aQf
 aOd
@@ -78165,7 +78288,7 @@ fEG
 jon
 soA
 ebn
-cFh
+bAZ
 oZO
 qpj
 dWF
@@ -78203,9 +78326,9 @@ aTi
 bUZ
 tCu
 kbn
-aTi
-bMx
-bMx
+ebz
+yiE
+yiE
 qtN
 sEZ
 stJ
@@ -78422,7 +78545,7 @@ iLk
 kDz
 kwo
 eWv
-cFh
+bAZ
 wIY
 eBp
 rVE
@@ -78679,7 +78802,7 @@ sOE
 aTx
 sOE
 sOE
-sOE
+lSJ
 vCi
 gbG
 rVE
@@ -79376,11 +79499,11 @@ nCe
 nCe
 nCe
 nCe
-jMb
-jMb
-jMb
-jMb
-jMb
+ckl
+ckl
+ckl
+ckl
+ckl
 nCe
 nCe
 nCe
@@ -79633,11 +79756,11 @@ nCe
 nCe
 nCe
 nCe
-jMb
+ckl
 xyV
 oar
 kDX
-jMb
+ckl
 sIs
 nCe
 nCe
@@ -79702,11 +79825,11 @@ kog
 qjg
 qjg
 bEM
-kzM
-sOE
+qZp
+lSJ
 eCn
-sOE
-sOE
+lSJ
+lSJ
 sOE
 hqG
 mNx
@@ -79721,12 +79844,12 @@ rVE
 dJf
 yeD
 jXg
-nub
+mVg
 dYh
 dYh
 dYh
 dYh
-wUn
+dYh
 doW
 joM
 gRB
@@ -79890,7 +80013,7 @@ nCe
 nCe
 nCe
 nCe
-jMb
+ckl
 dSx
 aWH
 bgJ
@@ -80145,13 +80268,13 @@ nCe
 nCe
 nCe
 nCe
-nwG
-nwG
-nwG
-nwG
-nwG
-nwG
-nwG
+fTD
+fTD
+fTD
+fTD
+fTD
+fTD
+fTD
 fqw
 nCe
 nCe
@@ -80249,11 +80372,11 @@ xfp
 oow
 vhL
 egk
-doc
-hXy
-hXy
-hXy
-hXy
+mCs
+plP
+plP
+plP
+plP
 qgI
 wao
 rKD
@@ -80286,7 +80409,7 @@ aqn
 aqn
 aqn
 aqn
-hAR
+sAh
 hAR
 owj
 sUk
@@ -80297,11 +80420,11 @@ hAR
 lzA
 sNQ
 hAR
-hAR
-hAR
-hAR
-hAR
-hAR
+sAh
+sAh
+sAh
+sAh
+sAh
 nCe
 nCe
 nCe
@@ -80402,13 +80525,13 @@ bsh
 bsh
 bsh
 bsh
-nwG
+fTD
 tAU
 tAU
 tAU
 tAU
 tAU
-nwG
+fTD
 dtm
 nCe
 nCe
@@ -80473,7 +80596,7 @@ kzM
 eSK
 spM
 gYe
-kzM
+qZp
 hMh
 aVL
 rnV
@@ -80506,7 +80629,7 @@ jTH
 vhL
 eXm
 dwK
-doc
+rVy
 oiM
 dOT
 jxK
@@ -80541,9 +80664,9 @@ hAR
 xyp
 xyp
 hAR
-hAR
-hAR
-hAR
+sAh
+sAh
+sAh
 pBE
 oTk
 bCh
@@ -80554,7 +80677,7 @@ rza
 qCW
 oav
 qvN
-hAR
+sAh
 ggd
 ggd
 epw
@@ -80659,13 +80782,13 @@ caC
 caC
 caC
 yaa
-nwG
+fTD
 tAU
 tAU
 tAU
 tAU
 tAU
-nwG
+fTD
 dtm
 nCe
 nCe
@@ -80730,7 +80853,7 @@ tzH
 wHU
 uEu
 nig
-kzM
+qZp
 mxK
 dsn
 iZQ
@@ -80763,7 +80886,7 @@ rHJ
 vhL
 eXm
 eQq
-doc
+rVy
 oqv
 kSp
 gLG
@@ -80916,13 +81039,13 @@ coN
 coN
 coN
 nNo
-nwG
+fTD
 tAU
 tAU
 tAU
 tAU
 tAU
-nwG
+fTD
 dtm
 twu
 nCe
@@ -81020,7 +81143,7 @@ rHJ
 vhL
 eXm
 egk
-doc
+rVy
 kdH
 idR
 xmn
@@ -81173,13 +81296,13 @@ cTj
 cGb
 uas
 nNo
-nwG
+fTD
 tAU
 tAU
 tAU
 tAU
 tAU
-nwG
+fTD
 dtm
 twu
 twu
@@ -81277,11 +81400,11 @@ ayH
 swE
 dZZ
 jWC
-doc
+rVy
 plP
 aIa
 mdG
-pgK
+uMS
 lZH
 pQA
 fAU
@@ -81430,13 +81553,13 @@ dCd
 qdT
 vzO
 nNo
-nwG
+fTD
 tAU
 tAU
 tAU
 tAU
 tAU
-nwG
+fTD
 dtm
 twu
 twu
@@ -81534,7 +81657,7 @@ vhL
 vhL
 vhL
 hSB
-doc
+rVy
 whp
 pIz
 dyI
@@ -81687,13 +81810,13 @@ git
 qdT
 auU
 gTs
-nwG
-nwG
+fTD
+fTD
 uBC
 tJk
 lag
-nwG
-nwG
+fTD
+fTD
 gNF
 pKW
 jMb
@@ -81747,10 +81870,10 @@ kzM
 kzM
 kzM
 kzM
-kzM
+qZp
 vfM
-kzM
-kzM
+qZp
+qZp
 cVm
 dKB
 jyy
@@ -81839,7 +81962,7 @@ bDr
 aGW
 wff
 mcO
-hAR
+sAh
 fus
 fus
 jMj
@@ -82007,7 +82130,7 @@ aOC
 kPd
 wTX
 aEj
-xHY
+cHa
 iUj
 uly
 xjm
@@ -82048,8 +82171,8 @@ oWU
 oay
 cRp
 iPB
-doc
-pWW
+rVy
+uoN
 eXX
 vam
 pgK
@@ -82096,11 +82219,11 @@ csg
 fKR
 vZZ
 csg
-hAR
-hAR
-hAR
-hAR
-hAR
+sAh
+sAh
+sAh
+sAh
+sAh
 nCe
 nCe
 nCe
@@ -82264,7 +82387,7 @@ lze
 aOr
 syY
 aOW
-xHY
+cHa
 cFP
 sMu
 iCU
@@ -82299,13 +82422,13 @@ bbi
 ehL
 rAx
 egk
-doc
-doc
+mCs
+mCs
 bSL
 oWj
 oNG
-doc
-doc
+mCs
+mCs
 hgC
 diD
 rMU
@@ -82521,7 +82644,7 @@ qZC
 kPd
 piz
 npd
-xHY
+cHa
 jPx
 sMu
 ayn
@@ -82556,13 +82679,13 @@ ehL
 jPE
 qwb
 lLE
-doc
+mCs
 nGD
 nGD
 nGD
 nGD
 gom
-doc
+mCs
 fuz
 eUO
 rMU
@@ -82778,7 +82901,7 @@ mbv
 kPd
 kPd
 kPd
-xHY
+cHa
 neZ
 vgP
 cGc
@@ -82813,13 +82936,13 @@ gWo
 blU
 sRR
 uTh
-doc
+mCs
 nGD
 nGD
 nGD
 nGD
 nGD
-doc
+mCs
 pIj
 pdg
 rMU
@@ -83070,10 +83193,10 @@ lRO
 tdH
 oov
 hNH
-doc
+mCs
 nGD
 nGD
-nGD
+rVy
 nGD
 nGD
 gDj
@@ -83327,13 +83450,13 @@ pKu
 pKu
 icE
 paJ
-doc
+mCs
 nGD
 nGD
 nGD
 nGD
 nGD
-doc
+mCs
 hMD
 mAt
 rMU
@@ -83577,20 +83700,20 @@ hez
 haB
 lWm
 idf
-imW
+ore
 xWG
 vYX
 msu
 bbk
 cOo
 cNb
-doc
+mCs
 nGD
 nGD
 nGD
 nGD
 nGD
-doc
+mCs
 rNP
 pWW
 rMU
@@ -83777,7 +83900,7 @@ nCe
 flO
 nCe
 nCe
-sSy
+eZL
 nCe
 nCe
 nCe
@@ -83834,20 +83957,20 @@ jtX
 gwo
 jjI
 imW
-imW
-imW
-imW
+ore
+ore
+ore
 imW
 vbc
 oMB
 vbc
-doc
-doc
-doc
-doc
-doc
-doc
-doc
+mCs
+mCs
+mCs
+mCs
+mCs
+mCs
+mCs
 gry
 kVp
 rMU
@@ -88165,7 +88288,7 @@ dSl
 dSl
 bac
 dSl
-dSl
+iMZ
 cyo
 eoN
 eoN
@@ -88422,7 +88545,7 @@ dSl
 eEs
 hpy
 afr
-dSl
+iMZ
 pPr
 pPr
 qEr
@@ -88679,7 +88802,7 @@ dSl
 gwp
 srP
 lip
-dSl
+iMZ
 ooa
 uUU
 naO
@@ -88936,7 +89059,7 @@ dSl
 qzv
 ltg
 hiw
-dSl
+iMZ
 mEz
 qIj
 eKt
@@ -89193,7 +89316,7 @@ oXl
 lBN
 ocq
 mje
-dSl
+iMZ
 bIC
 bIC
 bIC
@@ -89450,7 +89573,7 @@ dSl
 xVF
 vCf
 lVK
-dSl
+iMZ
 rEF
 sGR
 xYP
@@ -89707,7 +89830,7 @@ hfX
 dSl
 dSl
 dSl
-dSl
+iMZ
 hoR
 gQG
 byd
@@ -89964,7 +90087,7 @@ hfX
 rMr
 psl
 qmI
-dSl
+iMZ
 ulR
 pXL
 mnY
@@ -90221,7 +90344,7 @@ hfX
 meH
 rrj
 bDG
-hfX
+obq
 hSr
 kjy
 tAm
@@ -90244,7 +90367,7 @@ nCq
 aDA
 nCq
 ljP
-tgI
+hZm
 flZ
 oSo
 gAK
@@ -90501,7 +90624,7 @@ rBW
 rBW
 rBW
 uSO
-tgI
+hZm
 hAV
 mCR
 lQT
@@ -90758,7 +90881,7 @@ cdW
 cBd
 wnM
 aCw
-tgI
+hZm
 hAV
 mCR
 gLQ
@@ -90801,11 +90924,11 @@ xZB
 yft
 uCo
 oEi
-tew
-tew
+lfc
+lfc
 efj
-erl
-erl
+mWA
+mWA
 aqn
 aqn
 nCe
@@ -90995,9 +91118,9 @@ iLI
 tTa
 iQZ
 dyH
-caA
-caA
-jZP
+krp
+krp
+bZn
 xKl
 gTb
 bZp
@@ -91015,7 +91138,7 @@ eYr
 qBy
 ptC
 ruC
-tgI
+hZm
 oTc
 wSd
 oTc
@@ -91058,11 +91181,11 @@ yft
 yft
 aHL
 pzZ
-tew
+lfc
 xtG
 axx
 fAm
-erl
+mWA
 aqn
 nCe
 nCe
@@ -91254,7 +91377,7 @@ ezk
 arT
 asC
 cVI
-jZP
+bZn
 maD
 hUy
 pYq
@@ -91319,7 +91442,7 @@ dCe
 twb
 luk
 qaq
-erl
+mWA
 aqn
 nCe
 nCe
@@ -91508,10 +91631,10 @@ fIk
 iLI
 nLw
 tTa
-caA
+krp
 sEd
 vYM
-jZP
+bZn
 xXF
 vlK
 oam
@@ -91572,11 +91695,11 @@ efl
 toH
 bSs
 jdw
-tew
+lfc
 gww
 aug
-erl
-erl
+mWA
+mWA
 aqn
 nCe
 nCe
@@ -91765,10 +91888,10 @@ iLI
 iLI
 gPq
 eSX
-vvS
-vvS
-vvS
-jZP
+lJS
+lJS
+lJS
+bZn
 poz
 yfn
 poz
@@ -91794,7 +91917,7 @@ mam
 mam
 mam
 bef
-dBs
+pGp
 rRO
 bIc
 gBL
@@ -91829,10 +91952,10 @@ erl
 aQb
 hdo
 aQb
-erl
-erl
-erl
-erl
+mWA
+mWA
+mWA
+mWA
 aqn
 aqn
 nCe
@@ -92045,13 +92168,13 @@ bQr
 uFp
 ush
 sHJ
-vvS
-vvS
-vvS
+lJS
+lJS
+lJS
 krN
 gRF
 wmF
-dBs
+pGp
 muC
 kGK
 iWy
@@ -92561,7 +92684,7 @@ liB
 bbH
 wRs
 tIX
-vvS
+lJS
 jtd
 aWM
 lWt
@@ -92815,12 +92938,12 @@ tnh
 kNK
 bLZ
 moa
-vvS
-vvS
-vvS
-vvS
-vvS
-vvS
+lJS
+lJS
+lJS
+lJS
+lJS
+lJS
 vvJ
 apr
 hHn
@@ -93077,7 +93200,7 @@ pOC
 pOC
 pOC
 fxr
-vvS
+lJS
 iro
 bDy
 dBs
@@ -93334,7 +93457,7 @@ pOC
 pOC
 pOC
 pOC
-vvS
+lJS
 hSO
 bpJ
 swT
@@ -93843,12 +93966,12 @@ ehV
 iQt
 sPn
 pZo
-vvS
+lJS
 pOC
 pOC
 pOC
 pOC
-vvS
+lJS
 htw
 iQk
 swT
@@ -94100,12 +94223,12 @@ kOV
 jij
 xPr
 clv
-vvS
-vvS
-vvS
-vvS
-vvS
-vvS
+lJS
+lJS
+lJS
+lJS
+lJS
+lJS
 yag
 iPu
 swT
@@ -95128,7 +95251,7 @@ kwE
 rRE
 cia
 liB
-vbM
+mxb
 xGi
 xGi
 xGi
@@ -95136,13 +95259,13 @@ xGi
 bOG
 xGi
 qDs
-wYQ
-wYQ
-wYQ
-wYQ
-wYQ
-wYQ
-wYQ
+xuy
+xuy
+xuy
+xuy
+xuy
+xuy
+xuy
 sik
 owp
 lQi
@@ -95393,13 +95516,13 @@ qpK
 mFU
 qrd
 wOs
-wYQ
+xuy
 ktI
 ktI
 ktI
 ktI
 ktI
-wYQ
+xuy
 mUo
 ouC
 url
@@ -95650,7 +95773,7 @@ lFD
 mFU
 qyi
 ulf
-wYQ
+xuy
 ktI
 ktI
 ktI
@@ -95907,7 +96030,7 @@ rXg
 mFU
 sNB
 ezP
-wYQ
+xuy
 ktI
 ktI
 ktI
@@ -96138,9 +96261,9 @@ dpw
 svh
 vPD
 lsh
-rut
+cmt
 nUw
-uuk
+cZL
 vYO
 wZA
 jQE
@@ -96164,7 +96287,7 @@ dpJ
 mFU
 sNB
 ezP
-wYQ
+xuy
 ktI
 ktI
 ktI
@@ -96391,10 +96514,10 @@ nCe
 nCe
 nCe
 nCe
-rut
-rut
-rut
-rut
+cmt
+cmt
+cmt
+cmt
 dwo
 vSu
 hyZ
@@ -96421,13 +96544,13 @@ iak
 mFU
 sNB
 iDu
-wYQ
+xuy
 ktI
 ktI
 ktI
 ktI
 ktI
-wYQ
+xuy
 vAs
 uFg
 kgL
@@ -96648,14 +96771,14 @@ nCe
 nCe
 nCe
 nCe
-wyf
+rpI
 uaT
 fgg
 asQ
 rzv
 jlo
 gKX
-eCy
+eIR
 sPx
 fVP
 fVP
@@ -96678,14 +96801,14 @@ bFw
 mFU
 sNB
 dmr
-wYQ
-wYQ
-wYQ
-wYQ
-wYQ
-wYQ
-wYQ
-lXO
+xuy
+xuy
+xuy
+xuy
+xuy
+xuy
+xuy
+oQc
 pxZ
 qKr
 nQp
@@ -96912,7 +97035,7 @@ asQ
 rZv
 xmF
 cQJ
-eCy
+eIR
 tOC
 vZO
 vLa
@@ -96935,7 +97058,7 @@ pxp
 mFU
 qio
 cJR
-jyJ
+ewo
 vxR
 lMj
 qmG
@@ -97169,7 +97292,7 @@ iGD
 lrA
 mEG
 nTk
-eCy
+eIR
 tOC
 vLa
 hkX
@@ -97192,7 +97315,7 @@ wPl
 mFU
 xzw
 eYi
-jyJ
+ewo
 miy
 jLC
 dRY
@@ -97419,14 +97542,14 @@ nCe
 nCe
 nCe
 nCe
-wyf
+rpI
 cJQ
 plv
 hCV
 eOu
 tSD
 vjp
-eCy
+eIR
 tOC
 vZO
 vLa
@@ -97449,7 +97572,7 @@ mFU
 mFU
 xzL
 jyJ
-jyJ
+ewo
 prS
 rwH
 tmJ
@@ -97676,14 +97799,14 @@ nCe
 nCe
 nCe
 nCe
-wyf
+rpI
 wyf
 lsR
 qTo
-wyf
+rpI
 pkO
 pkO
-eCy
+eIR
 eCy
 pqe
 uko
@@ -97713,7 +97836,7 @@ wKC
 eHW
 eHW
 eHW
-lXO
+oQc
 bsA
 bMs
 lXO
@@ -98195,7 +98318,7 @@ eTc
 cVc
 ugC
 aqn
-wzX
+uPj
 eSN
 fIk
 fIk
@@ -98220,7 +98343,7 @@ mLd
 cKU
 tVA
 kYb
-jyJ
+ewo
 oeu
 gDR
 dBJ
@@ -98456,7 +98579,7 @@ aqn
 aqn
 aqn
 aqn
-wzX
+uPj
 eSN
 eSN
 eSN
@@ -98477,14 +98600,14 @@ xtH
 iPF
 rYh
 jyJ
-jyJ
-jyJ
-jyJ
-jyJ
-jyJ
-jyJ
-jyJ
-oSl
+ewo
+ewo
+ewo
+ewo
+ewo
+ewo
+ewo
+mYb
 scN
 obk
 oSl
@@ -98726,7 +98849,7 @@ aqn
 rYh
 lCL
 lCL
-rYh
+xMM
 xNJ
 jWf
 rYh
@@ -98983,7 +99106,7 @@ aqn
 aqn
 aqn
 aqn
-rYh
+xMM
 eYZ
 aSI
 rYh
@@ -99240,9 +99363,9 @@ eSN
 eSN
 aqn
 aqn
-rYh
-rYh
-rYh
+xMM
+xMM
+xMM
 rYh
 cVQ
 yjU
@@ -102080,7 +102203,7 @@ nCe
 nCe
 nCe
 nCe
-oSl
+mYb
 bEv
 oSl
 bKN
@@ -103108,7 +103231,7 @@ nCe
 nCe
 nCe
 nCe
-oSl
+mYb
 alK
 keP
 qvb
@@ -105153,7 +105276,7 @@ xBq
 xpd
 xpd
 xpd
-sSy
+eZL
 nCe
 twu
 nCe
@@ -105183,7 +105306,7 @@ nCe
 nCe
 twu
 nCe
-sSy
+eZL
 nCe
 nCe
 nCe

--- a/maps/cynosure/cynosure-3.dmm
+++ b/maps/cynosure/cynosure-3.dmm
@@ -1567,7 +1567,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/surface/station/engineering/hallway/snd)
 "bhC" = (
-/turf/simulated/wall,
+/turf/simulated/wall/concrete,
 /area/surface/station/maintenance/weststairwell/snd)
 "bic" = (
 /obj/effect/floor_decal/borderfloorblack{
@@ -4658,6 +4658,9 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/steel_grid,
 /area/surface/station/maintenance/substation/engineering/snd)
+"dca" = (
+/turf/simulated/wall/r_concrete,
+/area/surface/station/quartermaster/restroom)
 "dcu" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/disposalpipe/segment,
@@ -5088,6 +5091,9 @@
 /obj/machinery/washing_machine,
 /turf/simulated/floor/tiled/techmaint,
 /area/surface/station/hallway/secondary/secondfloor/dormhallway)
+"doV" = (
+/turf/simulated/wall/r_concrete,
+/area/surface/station/crew_quarters/captain)
 "dph" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/machinery/porta_turret/industrial/teleport_defense,
@@ -6103,7 +6109,7 @@
 /turf/simulated/floor/tiled,
 /area/surface/station/engineering/hallway/eva_hallway)
 "dWN" = (
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall/r_concrete,
 /area/surface/station/security/lobby)
 "dWP" = (
 /obj/structure/railing,
@@ -7913,6 +7919,9 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/surface/station/security/prison)
+"fkB" = (
+/turf/simulated/wall/concrete,
+/area/surface/station/security/hallway/stairwell)
 "flb" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/effect/floor_decal/borderfloor/corner{
@@ -8502,7 +8511,7 @@
 /area/surface/station/hallway/secondary/secondfloor/weststairwell)
 "fFc" = (
 /obj/structure/sign/level/two,
-/turf/simulated/wall,
+/turf/simulated/wall/concrete,
 /area/surface/station/maintenance/cargo)
 "fFn" = (
 /obj/structure/disposalpipe/segment{
@@ -8771,6 +8780,9 @@
 "fOc" = (
 /turf/simulated/open,
 /area/surface/station/ai)
+"fOo" = (
+/turf/simulated/wall/r_concrete,
+/area/surface/station/quartermaster/office)
 "fOL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -9527,6 +9539,9 @@
 	},
 /turf/simulated/floor/tiled,
 /area/surface/station/hallway/secondary/secondfloor/civilian)
+"glf" = (
+/turf/simulated/wall/r_concrete,
+/area/surface/station/maintenance/substation/medbay/snd)
 "gmx" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/atmospherics/portables_connector{
@@ -9592,6 +9607,9 @@
 /obj/structure/window/reinforced/full,
 /turf/simulated/floor/plating,
 /area/surface/station/security/hallway/cell_hallway)
+"goE" = (
+/turf/simulated/wall/concrete,
+/area/surface/station/crew_quarters/sleep/Dorm_2)
 "goT" = (
 /obj/structure/closet/lawcloset,
 /obj/item/flash,
@@ -10057,7 +10075,7 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/surface/station/engineering/atmos)
 "gCb" = (
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall/r_concrete,
 /area/surface/station/hallway/primary/secondfloor/west/elevator)
 "gCg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
@@ -10392,6 +10410,9 @@
 "gLr" = (
 /turf/simulated/wall,
 /area/surface/station/medical/lockerroom)
+"gLs" = (
+/turf/simulated/wall/concrete,
+/area/surface/station/security/riot_control)
 "gMa" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -10698,6 +10719,9 @@
 	},
 /turf/simulated/floor/tiled/old_cargo/gray,
 /area/surface/station/security/tactical)
+"gSv" = (
+/turf/simulated/wall/concrete,
+/area/surface/station/rnd/research)
 "gTh" = (
 /obj/structure/table/standard,
 /obj/item/paper_bin,
@@ -10722,7 +10746,7 @@
 /turf/simulated/floor/tiled,
 /area/surface/station/storage/art)
 "gTr" = (
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall/r_concrete,
 /area/surface/station/maintenance/substation/cargo/snd)
 "gTM" = (
 /obj/structure/cable/cyan{
@@ -11857,6 +11881,9 @@
 /obj/structure/window/reinforced/full,
 /turf/simulated/floor/plating,
 /area/surface/station/ai_monitored/storage/eva)
+"hEs" = (
+/turf/simulated/wall/r_concrete,
+/area/surface/station/hallway/primary/secondfloor/east)
 "hEv" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/grille,
@@ -11978,7 +12005,7 @@
 /area/surface/station/engineering/foyer/secondfloor)
 "hGI" = (
 /obj/machinery/status_display,
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall/r_concrete,
 /area/surface/station/hallway/primary/secondfloor/east)
 "hIH" = (
 /obj/effect/floor_decal/borderfloor,
@@ -12598,6 +12625,9 @@
 	},
 /turf/simulated/floor/tiled/old_tile/white,
 /area/surface/station/medical/lockerroom)
+"iaU" = (
+/turf/simulated/wall/concrete,
+/area/surface/station/medical/restroom)
 "ibd" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/grille,
@@ -12829,6 +12859,9 @@
 	},
 /turf/simulated/floor/tiled,
 /area/surface/station/quartermaster/office)
+"iko" = (
+/turf/simulated/wall/concrete,
+/area/surface/station/rnd/workshop)
 "ikv" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -13222,7 +13255,7 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/surface/station/ai)
 "iyT" = (
-/turf/simulated/wall,
+/turf/simulated/wall/concrete,
 /area/surface/station/maintenance/cargo)
 "izh" = (
 /obj/structure/cable{
@@ -13326,6 +13359,9 @@
 	},
 /turf/simulated/floor/tiled,
 /area/surface/station/hallway/primary/secondfloor/east)
+"izU" = (
+/turf/simulated/wall/concrete,
+/area/surface/station/quartermaster/restroom)
 "iAb" = (
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 1
@@ -15538,6 +15574,9 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/surface/station/command/operations)
+"jFu" = (
+/turf/simulated/wall/r_concrete,
+/area/surface/station/quartermaster/qm)
 "jFv" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/effect/floor_decal/steeldecal/steel_decals3{
@@ -15686,6 +15725,9 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/surface/station/rnd/robotics)
+"jIE" = (
+/turf/simulated/wall/r_concrete,
+/area/surface/station/rnd/workshop)
 "jIT" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -15993,6 +16035,9 @@
 	},
 /turf/simulated/floor/plating,
 /area/surface/station/engineering/foyer/secondfloor)
+"jRf" = (
+/turf/simulated/wall/r_concrete,
+/area/surface/station/medical/patient_wing)
 "jRh" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/machinery/hologram/holopad,
@@ -16613,6 +16658,9 @@
 /obj/effect/floor_decal/corner/purple/border,
 /turf/simulated/floor/tiled/white,
 /area/surface/station/rnd/research)
+"kmT" = (
+/turf/simulated/wall/r_concrete,
+/area/surface/station/hallway/secondary/secondfloor/civilian)
 "kny" = (
 /turf/simulated/wall/r_wall,
 /area/surface/station/command/internalaffairs)
@@ -16989,6 +17037,9 @@
 	},
 /turf/simulated/floor/plating,
 /area/surface/station/medical/exam_room)
+"kBb" = (
+/turf/simulated/wall/concrete,
+/area/surface/station/maintenance/substation/medbay/snd)
 "kBk" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -17022,6 +17073,9 @@
 	},
 /turf/simulated/floor/tiled,
 /area/surface/station/hallway/primary/secondfloor/east)
+"kDg" = (
+/turf/simulated/wall/r_concrete,
+/area/surface/station/hallway/secondary/secondfloor/westskybridge)
 "kFf" = (
 /obj/effect/floor_decal/industrial/warning/dust/corner{
 	dir = 1
@@ -17723,8 +17777,11 @@
 /obj/structure/window/reinforced/full,
 /turf/simulated/floor/plating,
 /area/surface/station/engineering/atmos)
+"lnc" = (
+/turf/simulated/wall/r_concrete,
+/area/surface/station/medical/restroom)
 "lnd" = (
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall/r_concrete,
 /area/surface/station/maintenance/cargo)
 "lnL" = (
 /obj/structure/cable/cyan{
@@ -18772,7 +18829,7 @@
 /turf/simulated/floor/tiled/white,
 /area/surface/station/rnd/research_foyer)
 "meJ" = (
-/turf/simulated/wall,
+/turf/simulated/wall/concrete,
 /area/surface/station/maintenance/substation/cargo/snd)
 "meP" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -20658,7 +20715,7 @@
 /area/surface/station/rnd/robotics)
 "npn" = (
 /obj/structure/sign/warning/secure_area,
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall/r_concrete,
 /area/surface/station/security/lobby)
 "npz" = (
 /obj/machinery/porta_turret/ai_defense,
@@ -22182,7 +22239,7 @@
 /area/surface/station/hallway/secondary/secondfloor/civilian)
 "ovY" = (
 /obj/structure/sign/warning/server_room,
-/turf/simulated/wall,
+/turf/simulated/wall/concrete,
 /area/surface/station/rnd/workshop)
 "ows" = (
 /obj/machinery/door/firedoor/border_only,
@@ -23427,7 +23484,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/surface/station/security/equiptment_storage)
 "pmc" = (
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall/r_concrete,
 /area/surface/station/maintenance/substation/engineering/snd)
 "pmn" = (
 /obj/structure/cable/green{
@@ -24472,7 +24529,7 @@
 	dir = 4;
 	pixel_y = -6
 	},
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall/r_concrete,
 /area/surface/station/hallway/secondary/secondfloor/civilian)
 "pXb" = (
 /obj/effect/floor_decal/borderfloor,
@@ -25212,6 +25269,9 @@
 	},
 /turf/simulated/floor/plating,
 /area/surface/station/crew_quarters/captain)
+"qsN" = (
+/turf/simulated/wall/r_concrete,
+/area/surface/station/rnd/research)
 "qtv" = (
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 5
@@ -25736,6 +25796,10 @@
 	},
 /turf/simulated/open,
 /area/surface/station/ai)
+"qLg" = (
+/obj/effect/zone_divider,
+/turf/simulated/wall/concrete,
+/area/surface/station/crew_quarters/sleep/Dorm_4)
 "qLx" = (
 /obj/structure/bed/psych,
 /turf/simulated/floor/carpet/sblucarpet,
@@ -26163,6 +26227,9 @@
 	},
 /turf/simulated/floor/tiled/old_tile/gray,
 /area/surface/station/security/tactical)
+"rac" = (
+/turf/simulated/wall/r_concrete,
+/area/surface/station/engineering/hallway/snd)
 "raX" = (
 /obj/random/crate{
 	dir = 4
@@ -26381,6 +26448,9 @@
 	},
 /turf/simulated/floor/tiled/yellow,
 /area/surface/station/engineering/locker_room)
+"rhQ" = (
+/turf/simulated/wall/r_concrete,
+/area/surface/station/engineering/hallway/sndaccess)
 "rhR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/effect/floor_decal/industrial/warning,
@@ -27208,6 +27278,9 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/surface/station/security/armoury)
+"rPF" = (
+/turf/simulated/wall/r_concrete,
+/area/surface/station/maintenance/substation/security/snd)
 "rQD" = (
 /obj/machinery/door/firedoor/glass,
 /obj/structure/cable/green{
@@ -28425,7 +28498,7 @@
 /turf/simulated/floor/tiled,
 /area/surface/station/hallway/secondary/secondfloor/westskybridge)
 "sFQ" = (
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall/r_concrete,
 /area/surface/station/maintenance/eva)
 "sFT" = (
 /turf/unsimulated/mask,
@@ -28846,6 +28919,9 @@
 	},
 /turf/simulated/floor/tiled,
 /area/surface/station/security/prison)
+"sPJ" = (
+/turf/simulated/wall/concrete,
+/area/surface/station/medical/patient_wing)
 "sPZ" = (
 /obj/machinery/door/firedoor/glass,
 /obj/structure/grille,
@@ -30396,7 +30472,7 @@
 /area/surface/station/maintenance/substation/research/snd)
 "tLL" = (
 /obj/machinery/status_display,
-/turf/simulated/wall,
+/turf/simulated/wall/concrete,
 /area/surface/station/medical/patient_wing)
 "tMd" = (
 /obj/effect/floor_decal/borderfloorwhite{
@@ -30614,6 +30690,9 @@
 /obj/structure/window/reinforced/full,
 /turf/simulated/floor/plating,
 /area/surface/station/security/hallway/stairwell)
+"tTk" = (
+/turf/simulated/wall/concrete,
+/area/surface/station/crew_quarters/sleep/Dorm_4)
 "tTX" = (
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 4
@@ -31303,7 +31382,7 @@
 /turf/simulated/wall,
 /area/surface/station/medical/psych)
 "upv" = (
-/turf/simulated/wall,
+/turf/simulated/wall/concrete,
 /area/surface/station/maintenance/substation/security/snd)
 "upN" = (
 /obj/structure/cable/green{
@@ -32062,7 +32141,7 @@
 /area/surface/station/holodeck_control)
 "uSc" = (
 /obj/structure/sign/warning/high_voltage,
-/turf/simulated/wall,
+/turf/simulated/wall/concrete,
 /area/surface/station/maintenance/substation/engineering/snd)
 "uSB" = (
 /obj/effect/floor_decal/borderfloor{
@@ -32525,6 +32604,9 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/surface/station/security/warden)
+"veS" = (
+/turf/simulated/wall/r_concrete,
+/area/surface/station/maintenance/substation/research/snd)
 "vft" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -33694,6 +33776,9 @@
 "vUp" = (
 /turf/simulated/floor/tiled/white,
 /area/surface/station/rnd/robotics)
+"vVy" = (
+/turf/simulated/wall/r_concrete,
+/area/surface/station/security/riot_control)
 "vWR" = (
 /obj/machinery/hologram/holopad,
 /obj/effect/floor_decal/industrial/outline/grey,
@@ -34919,6 +35004,12 @@
 /obj/item/banner/nt,
 /turf/simulated/floor/tiled/dark,
 /area/surface/station/hallway/primary/secondfloor/east)
+"wKh" = (
+/turf/simulated/wall/r_concrete,
+/area/surface/station/security/hallway/snd)
+"wKI" = (
+/turf/simulated/wall/r_concrete,
+/area/surface/station/maintenance/weststairwell/snd)
 "wLt" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/effect/map_helper/airlock/door/ext_door,
@@ -37372,7 +37463,7 @@
 /area/surface/station/medical/office)
 "ycN" = (
 /obj/machinery/status_display,
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall/r_concrete,
 /area/surface/station/medical/patient_wing)
 "ycO" = (
 /turf/simulated/floor/wood,
@@ -58724,15 +58815,15 @@ ddU
 ddU
 ddU
 ddU
-iLw
+kDg
 jbk
 sfj
 jbk
-iLw
+kDg
 jbk
 sfj
 jbk
-iLw
+kDg
 ddU
 ddU
 ddU
@@ -58740,7 +58831,7 @@ ddU
 ddU
 ddU
 ddU
-pPO
+kmT
 oor
 sQm
 pqN
@@ -58980,8 +59071,8 @@ jbk
 sfj
 jbk
 iLw
-iLw
-iLw
+kDg
+kDg
 xHQ
 esY
 aCF
@@ -58989,15 +59080,15 @@ mYW
 aCF
 esY
 yaG
-iLw
-iLw
+kDg
+kDg
 jbk
 sfj
 jbk
-iLw
+kDg
 jbk
 jbk
-pPO
+kmT
 dQK
 wyu
 jDU
@@ -59482,9 +59573,9 @@ ddU
 ddU
 ddU
 ddU
-cFC
-cFC
-cFC
+wKI
+wKI
+wKI
 jLj
 foJ
 bLl
@@ -59738,10 +59829,10 @@ ddU
 ddU
 ddU
 ddU
-cFC
-cFC
+wKI
+wKI
 nSO
-cFC
+wKI
 kLx
 wPV
 jNR
@@ -59752,20 +59843,20 @@ gCb
 gCb
 gCb
 gCb
-iLw
+kDg
 jbk
 sfj
 jbk
-iLw
+kDg
 jbk
 sfj
 jbk
-iLw
-iLw
+kDg
+kDg
 jbk
 sfj
 jbk
-iLw
+kDg
 jbk
 jbk
 pWP
@@ -59995,10 +60086,10 @@ ddU
 ddU
 ddU
 ddU
-cFC
+wKI
 pBM
 sLp
-cFC
+wKI
 lWb
 lpJ
 xgF
@@ -60025,7 +60116,7 @@ ddU
 ddU
 ddU
 ddU
-pPO
+kmT
 pPO
 qFL
 won
@@ -60766,7 +60857,7 @@ hmc
 hmc
 hmc
 hmc
-cFC
+wKI
 dSM
 kvn
 bhC
@@ -61278,12 +61369,12 @@ sBb
 sBb
 qbU
 sBb
-rlB
-rlB
-rlB
-rlB
-rlB
-rlB
+veS
+veS
+veS
+veS
+veS
+veS
 uyg
 pzK
 qll
@@ -61535,11 +61626,11 @@ eOZ
 abG
 hJt
 eOZ
-rlB
+veS
 gOZ
 vNB
 rnJ
-rlB
+veS
 ifn
 hdD
 kaM
@@ -62086,11 +62177,11 @@ pPO
 vHY
 tws
 cDA
-cDA
-cDA
-cDA
-kYR
-aLp
+goE
+goE
+goE
+tTk
+qLg
 kYR
 kYR
 kYR
@@ -63072,11 +63163,11 @@ sBb
 sBb
 sBb
 sBb
-eOZ
-tWa
+jIE
+iko
 dlr
 ovY
-tWa
+iko
 sHr
 uMb
 uNB
@@ -63329,7 +63420,7 @@ sBb
 sBb
 sBb
 sBb
-gae
+qsN
 vnD
 rLO
 rRh
@@ -63609,7 +63700,7 @@ gTr
 gTr
 gTr
 gTr
-mVy
+dca
 ciZ
 tek
 oVF
@@ -63866,7 +63957,7 @@ mzO
 gTr
 iPO
 uBB
-mya
+izU
 bii
 jJz
 vne
@@ -64123,7 +64214,7 @@ mzO
 lZz
 sZD
 biM
-mya
+izU
 bFn
 bMW
 gUA
@@ -64357,11 +64448,11 @@ sBb
 sBb
 sBb
 sBb
-gae
+qsN
 tXh
 naq
 tXh
-uMb
+gSv
 svX
 aFQ
 hix
@@ -64380,7 +64471,7 @@ mzO
 gTr
 wJp
 tUZ
-mya
+izU
 mya
 bIW
 mya
@@ -64390,7 +64481,7 @@ mAe
 pqi
 ctc
 aSg
-vjy
+jFu
 lnd
 kst
 kst
@@ -64637,7 +64728,7 @@ gTr
 gTr
 hkH
 meJ
-mjy
+fOo
 ofN
 lod
 ofR
@@ -64647,7 +64738,7 @@ cNV
 iqh
 sYT
 iMk
-vjy
+jFu
 ciU
 eIH
 kkr
@@ -64904,7 +64995,7 @@ hgN
 cqr
 hgN
 hgN
-vjy
+jFu
 fFc
 sfy
 ozu
@@ -65161,7 +65252,7 @@ uYI
 lod
 iPC
 ugP
-mjy
+fOo
 ffk
 izk
 pnE
@@ -65675,11 +65766,11 @@ msr
 xlP
 msr
 kOt
-mjy
-nWW
-nWW
-nWW
-nWW
+fOo
+doV
+doV
+doV
+doV
 sVu
 gdk
 imJ
@@ -65932,7 +66023,7 @@ qxd
 ubW
 bqC
 pNl
-mjy
+fOo
 qsp
 vBb
 bHc
@@ -66183,13 +66274,13 @@ iKn
 pYO
 krl
 mJz
-mjy
-mjy
+fOo
+fOo
 wyG
 bUg
 pMU
-mjy
-mjy
+fOo
+fOo
 dgv
 mtd
 ifT
@@ -66440,13 +66531,13 @@ ecx
 rgI
 nuG
 jDc
-mjy
+fOo
 sFT
 sFT
 sFT
 sFT
 sFT
-mjy
+fOo
 gdY
 sTF
 gdY
@@ -66697,13 +66788,13 @@ ecx
 flb
 mSo
 aiC
-mjy
+fOo
 sFT
 sFT
 sFT
 sFT
 sFT
-mjy
+fOo
 fXF
 ezy
 fct
@@ -66954,13 +67045,13 @@ ezx
 bal
 fOL
 uZi
-mjy
+fOo
 sFT
 sFT
 sFT
 sFT
 sFT
-mjy
+fOo
 jHa
 tlW
 jTE
@@ -67211,13 +67302,13 @@ pmW
 pvE
 nbC
 fFT
-mjy
+fOo
 sFT
 sFT
 sFT
 sFT
 sFT
-mjy
+fOo
 lyL
 qVL
 uao
@@ -67468,13 +67559,13 @@ mDw
 hZc
 jQf
 wnL
-mjy
+fOo
 sFT
 sFT
 sFT
 sFT
 sFT
-mjy
+fOo
 kzF
 fnp
 wym
@@ -67725,13 +67816,13 @@ mjy
 tWk
 cnN
 tWk
-mjy
-mjy
-mjy
-mjy
-mjy
-mjy
-mjy
+fOo
+fOo
+fOo
+fOo
+fOo
+fOo
+fOo
 nWW
 nWW
 tJt
@@ -68961,12 +69052,12 @@ sBb
 sBb
 sBb
 sBb
-eMs
-eMs
-eMs
-eMs
-eMs
-eMs
+jRf
+jRf
+jRf
+jRf
+jRf
+jRf
 ddU
 ddU
 ddU
@@ -69218,12 +69309,12 @@ lHE
 qJK
 rGd
 qJK
-eMs
+jRf
 psx
 psx
 psx
 psx
-eMs
+jRf
 hWm
 hWm
 iVl
@@ -69475,12 +69566,12 @@ mce
 iRT
 vzd
 tOU
-eMs
+jRf
 psx
 psx
 psx
 psx
-eMs
+jRf
 ahD
 ahD
 ahD
@@ -69732,12 +69823,12 @@ mce
 xMa
 wZz
 unC
-eMs
+jRf
 psx
 psx
 psx
 psx
-eMs
+jRf
 ahD
 ahD
 ahD
@@ -69989,12 +70080,12 @@ mce
 hat
 wxh
 nRY
-eMs
+jRf
 psx
 psx
 psx
 psx
-eMs
+jRf
 ahD
 ahD
 ahD
@@ -70247,11 +70338,11 @@ avw
 djZ
 avw
 ycN
-eMs
+jRf
 bic
 roC
-eMs
-eMs
+jRf
+jRf
 ahD
 ahD
 ahD
@@ -72564,7 +72655,7 @@ jnI
 xRB
 sDD
 oTv
-hlD
+sPJ
 sYd
 aAo
 cBN
@@ -73078,10 +73169,10 @@ uoM
 ssg
 mDj
 kzq
-ssg
-jBh
-jBh
-jBh
+kBb
+iaU
+iaU
+iaU
 ows
 jBh
 jBh
@@ -73336,7 +73427,7 @@ dBq
 kZO
 ulG
 vTu
-jBh
+iaU
 jLM
 vXN
 wSf
@@ -73593,7 +73684,7 @@ fMD
 gxg
 hON
 oVt
-jBh
+iaU
 oqD
 mCN
 vKv
@@ -73847,10 +73938,10 @@ sBb
 sBb
 sBb
 fMD
-fMD
+glf
 eCT
 spA
-jBh
+iaU
 uFq
 fLc
 jOT
@@ -74104,10 +74195,10 @@ sBb
 sBb
 sBb
 sBb
-fMD
-fMD
-fMD
-fek
+glf
+glf
+glf
+lnc
 fek
 fIl
 jBh
@@ -74133,12 +74224,12 @@ poa
 ahF
 pJK
 pJK
-mCA
-mCA
+hEs
+hEs
 xJX
 vmh
-mCA
-mCA
+hEs
+hEs
 oGF
 fVX
 old
@@ -74390,12 +74481,12 @@ pWG
 ygv
 eTe
 jyY
-mCA
+hEs
 lMh
 lMh
 lMh
 lMh
-mCA
+hEs
 uln
 esP
 xyd
@@ -74647,12 +74738,12 @@ tbh
 lVP
 eTe
 jyY
-mCA
+hEs
 lMh
 lMh
 lMh
 lMh
-mCA
+hEs
 xHg
 ijK
 iQk
@@ -74909,7 +75000,7 @@ lMh
 lMh
 lMh
 lMh
-mCA
+hEs
 tir
 ijt
 eSt
@@ -75161,12 +75252,12 @@ lcv
 qQS
 qQS
 gib
-mCA
+hEs
 lMh
 lMh
 lMh
 lMh
-mCA
+hEs
 uWn
 jqR
 inP
@@ -75417,13 +75508,13 @@ npn
 eum
 wEo
 wEo
-bHi
-mCA
-mCA
-mCA
-mCA
-mCA
-mCA
+fkB
+hEs
+hEs
+hEs
+hEs
+hEs
+hEs
 lRd
 rCp
 dKp
@@ -75677,7 +75768,7 @@ tSm
 mhI
 mhI
 iBx
-cRg
+rhQ
 wGH
 oQm
 kqP
@@ -75934,7 +76025,7 @@ sBi
 muw
 mhI
 raX
-cRg
+rhQ
 eyg
 lqQ
 nYj
@@ -76699,12 +76790,12 @@ fDm
 wTx
 gyp
 xGr
-fDm
-fDm
-fDm
-fDm
-fDm
-fDm
+wKh
+wKh
+wKh
+wKh
+wKh
+wKh
 gdH
 bmR
 fzP
@@ -76956,12 +77047,12 @@ fHd
 hgK
 wdL
 gvR
-fDm
+wKh
 jso
 jso
 jso
 jso
-fDm
+wKh
 rEp
 bmR
 bTE
@@ -77218,7 +77309,7 @@ jso
 jso
 jso
 jso
-fDm
+wKh
 fHn
 eHO
 fzP
@@ -77475,7 +77566,7 @@ jso
 jso
 jso
 jso
-fDm
+wKh
 bvI
 aDS
 fzP
@@ -77727,12 +77818,12 @@ gbs
 nKq
 gBc
 sPt
-fDm
+wKh
 jso
 jso
 jso
 jso
-fDm
+wKh
 rEp
 cim
 fzP
@@ -77984,12 +78075,12 @@ cTr
 uFX
 pdf
 lAM
-fDm
-fDm
-fDm
-fDm
-fDm
-fDm
+wKh
+wKh
+wKh
+wKh
+wKh
+wKh
 uEx
 cbr
 dLD
@@ -78759,7 +78850,7 @@ upv
 ark
 bFV
 nkm
-mFa
+rPF
 kqH
 gMd
 gqJ
@@ -79012,21 +79103,21 @@ pKC
 hWR
 hAZ
 qXc
-qXc
-qXc
+gLs
+gLs
 uVR
-qXc
-ghW
+gLs
+vVy
 mFa
 lys
 lys
-kjd
-kjd
-kjd
-kjd
-kjd
-kjd
-kjd
+rac
+rac
+rac
+rac
+rac
+rac
+rac
 eUC
 gaM
 fXe
@@ -79277,13 +79368,13 @@ xuz
 sBb
 sBb
 sBb
-kjd
+rac
 lNK
 lNK
 lNK
 lNK
 lNK
-kjd
+rac
 rDq
 kao
 din
@@ -79534,7 +79625,7 @@ hFF
 sBb
 sBb
 sBb
-kjd
+rac
 lNK
 lNK
 lNK
@@ -79791,7 +79882,7 @@ xwr
 sBb
 sBb
 sBb
-kjd
+rac
 lNK
 lNK
 lNK
@@ -80048,7 +80139,7 @@ sBb
 sBb
 sBb
 sBb
-kjd
+rac
 lNK
 lNK
 lNK
@@ -80305,13 +80396,13 @@ sBb
 sBb
 sBb
 sBb
-kjd
+rac
 lNK
 lNK
 lNK
 lNK
 lNK
-kjd
+rac
 rDq
 gaM
 cZQ
@@ -80562,13 +80653,13 @@ sBb
 sBb
 sBb
 sBb
-kjd
-kjd
-kjd
-kjd
-kjd
-kjd
-kjd
+rac
+rac
+rac
+rac
+rac
+rac
+rac
 bQS
 bWG
 cZQ

--- a/maps/cynosure/cynosure-7.dmm
+++ b/maps/cynosure/cynosure-7.dmm
@@ -137,7 +137,7 @@
 	icon_state = "wilderness2";
 	pixel_y = -6
 	},
-/turf/simulated/wall/sifwood,
+/turf/simulated/wall/concrete,
 /area/surface/outside/wilderness/normal)
 "tC" = (
 /obj/structure/simple_door/sifwood,


### PR DESCRIPTION
Integrates concrete elements onto the main map levels.

- Basement is MOSTLY concrete, except for airlocks, and a few heat-sensitive areas like Toxins Research.
- The vault is layered with both R conc and R steel.
- Main levels are MOSTLY still steel, except for elevator shafts, stairwells and utility manifolds (mostly substations)
- Various fence pole and wilderness signage elements are concrete.
- Pool is brutalism.
- Landing pads made concrete (unsure about this aesthetically personally, but greenjoe already made the spot the shuttles leave look like that so, consistency one way or the other)
- Concrete stack added to engineering material piles.
- Conk bricks and rebar added to random material spawners.
- Basic type steel/r-steel walls blend "one way" with concrete walls. Full blending and no blending both look kind of bad, this looks structurally nice imo:
![conk](https://i.gyazo.com/4abcf5a4fde29f729ee487254120592d.png)
