### PR TITLE
Adds a morgue access corridor

### DIFF
--- a/maps/cynosure/cynosure-1.dmm
+++ b/maps/cynosure/cynosure-1.dmm
@@ -248,6 +248,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/surface/station/maintenance/medical/south)
+"aE" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/paleblue/border,
+/obj/machinery/door/airlock/medical{
+	name = "Morgue Access";
+	req_one_access = list(5, 6, 12, 47)
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/simulated/floor/tiled/steel_dirty,
+/area/surface/station/maintenance/medical/south)
 "aF" = (
 /obj/machinery/door/airlock/maintenance/engi{
 	icon_state = "door_locked";
@@ -1864,12 +1874,14 @@
 /turf/simulated/floor/plating,
 /area/surface/station/hallway/secondary/bmt/weststairwell)
 "ec" = (
-/obj/machinery/door/blast/regular/open{
-	id = "medbayquar";
-	layer = 3.3;
-	name = "Medbay Lockdown"
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12
 	},
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/spline/plain{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/old_tile/gray,
 /area/surface/station/medical/morgue)
 "ee" = (
 /obj/structure/disposalpipe/segment{
@@ -2048,6 +2060,19 @@
 /obj/item/stack/tile/floor,
 /turf/simulated/floor/plating,
 /area/surface/station/hallway/primary/bmt/east)
+"ev" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 10
+	},
+/obj/structure/closet/crate/medical,
+/obj/random/medical,
+/obj/random/medical,
+/obj/random/firstaid,
+/turf/simulated/floor/tiled/steel_dirty,
+/area/surface/station/maintenance/medical/south)
 "ew" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
@@ -2183,6 +2208,9 @@
 	},
 /turf/simulated/floor/plating,
 /area/surface/station/hallway/primary/bmt/east)
+"eN" = (
+/turf/simulated/floor/tiled/steel_dirty,
+/area/surface/station/maintenance/eaststairwell)
 "eO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
@@ -2215,9 +2243,14 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/surface/station/engineering/drone_fabrication)
 "eR" = (
-/obj/structure/loot_pile/maint/technical,
-/turf/simulated/floor/plating,
-/area/surface/station/maintenance/eaststairwell)
+/obj/structure/morgue{
+	dir = 2
+	},
+/obj/effect/floor_decal/spline/plain{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/old_cargo/gray,
+/area/surface/station/medical/morgue)
 "eT" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -3228,12 +3261,19 @@
 /turf/simulated/floor/plating,
 /area/surface/station/maintenance/research/east)
 "hj" = (
-/obj/structure/closet/crate/medical,
-/obj/random/medical,
-/obj/random/medical,
-/obj/random/firstaid,
-/turf/simulated/floor/plating,
-/area/surface/station/maintenance/medical/south)
+/obj/machinery/door/blast/regular/open{
+	id = "medbayquar";
+	layer = 3.3;
+	name = "Medbay Lockdown"
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel_dirty,
+/area/surface/station/medical/morgue)
 "hk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/universal,
 /obj/effect/floor_decal/industrial/warning{
@@ -3511,9 +3551,9 @@
 /area/surface/station/mining_main/refinery)
 "hJ" = (
 /obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/maintenance{
-	name = "Medbay Maintenance Access";
-	req_access = list(5)
+/obj/machinery/door/airlock/medical{
+	name = "Morgue";
+	req_one_access = list(4,6)
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/surface/station/medical/morgue)
@@ -3852,6 +3892,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
+/obj/effect/catwalk_plated/dark,
 /turf/simulated/floor/plating,
 /area/surface/station/maintenance/medical/south)
 "iw" = (
@@ -4135,6 +4176,9 @@
 /obj/structure/morgue{
 	dir = 2
 	},
+/obj/effect/floor_decal/spline/plain{
+	dir = 9
+	},
 /turf/simulated/floor/tiled/old_cargo/gray,
 /area/surface/station/medical/morgue)
 "iY" = (
@@ -4315,6 +4359,12 @@
 	outdoors = 0
 	},
 /area/surface/cave/explored/normal)
+"jq" = (
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/steel_dirty,
+/area/surface/station/maintenance/eaststairwell)
 "jr" = (
 /obj/machinery/power/apc{
 	name = "south bump";
@@ -4630,6 +4680,10 @@
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/plating,
 /area/surface/station/medical/hallway/bmt)
+"jU" = (
+/obj/structure/sign/warning/caution,
+/turf/simulated/wall/concrete,
+/area/surface/station/medical/morgue)
 "jV" = (
 /obj/machinery/ai_status_display,
 /turf/simulated/wall/r_wall,
@@ -4798,13 +4852,16 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/surface/station/engineering/hallway/bmt)
 "kl" = (
-/obj/effect/floor_decal/industrial/warning/corner,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/door/airlock/maintenance{
+	req_one_access = list(5,12,47)
+	},
+/obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/plating,
 /area/surface/station/maintenance/medical/south)
 "km" = (
@@ -5586,6 +5643,18 @@
 	},
 /turf/simulated/floor/tiled,
 /area/surface/station/engineering/auxiliary_engineering)
+"lU" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel_dirty,
+/area/surface/station/maintenance/eaststairwell)
 "lV" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -6369,17 +6438,11 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/surface/station/hallway/primary/bmt/south)
 "nC" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
+/obj/effect/floor_decal/spline/plain{
+	dir = 8
 	},
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/surface/station/maintenance/medical/south)
+/turf/simulated/floor/tiled/old_tile/gray,
+/area/surface/station/medical/morgue)
 "nD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
@@ -6429,8 +6492,8 @@
 /turf/simulated/floor/tiled/old_tile/gray,
 /area/surface/station/rnd/mixing)
 "nI" = (
-/obj/structure/reagent_dispensers/watertank,
-/turf/simulated/floor/plating,
+/obj/structure/reagent_dispensers/fueltank,
+/turf/simulated/floor/tiled/steel_dirty,
 /area/surface/station/maintenance/medical/south)
 "nJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -6606,13 +6669,22 @@
 /turf/simulated/floor/plating,
 /area/surface/station/vault)
 "oh" = (
-/obj/random/crate{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/random/maintenance/medical,
-/obj/random/maintenance/medical,
-/obj/random/maintenance/clean,
-/obj/random/maintenance/clean,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/catwalk_plated/dark,
+/obj/structure/sign/directions/medical/morgue{
+	dir = 1;
+	pixel_y = 32
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 1
+	},
 /turf/simulated/floor/plating,
 /area/surface/station/maintenance/medical/south)
 "oi" = (
@@ -6841,6 +6913,18 @@
 	},
 /turf/simulated/floor/tiled,
 /area/surface/station/hallway/primary/bmt/west)
+"oI" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 4
+	},
+/obj/machinery/light/small/flicker{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel_dirty,
+/area/surface/station/maintenance/medical/south)
 "oJ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -7017,6 +7101,9 @@
 /obj/structure/morgue{
 	dir = 1
 	},
+/obj/effect/floor_decal/spline/plain{
+	dir = 10
+	},
 /turf/simulated/floor/tiled/old_cargo/gray,
 /area/surface/station/medical/morgue)
 "oY" = (
@@ -7034,8 +7121,8 @@
 	},
 /area/surface/station/mining_main/exterior)
 "pa" = (
-/obj/structure/reagent_dispensers/fueltank,
-/turf/simulated/floor/plating,
+/obj/structure/reagent_dispensers/watertank,
+/turf/simulated/floor/tiled/steel_dirty,
 /area/surface/station/maintenance/medical/south)
 "pb" = (
 /obj/structure/cable{
@@ -7052,7 +7139,8 @@
 "pc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/dark,
+/obj/effect/catwalk_plated/dark,
+/turf/simulated/floor/plating,
 /area/surface/station/hallway/primary/bmt/north)
 "pd" = (
 /turf/simulated/wall/concrete,
@@ -7405,10 +7493,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/maintenance{
-	req_one_access = list(5,12,47)
+/obj/machinery/door/airlock/medical{
+	name = "Morgue Access";
+	req_one_access = list(5, 6, 12, 47)
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/steel_dirty,
 /area/surface/station/maintenance/eaststairwell)
 "pQ" = (
 /obj/effect/floor_decal/industrial/warning/dust{
@@ -7695,13 +7784,16 @@
 /turf/simulated/floor/tiled/dark,
 /area/surface/station/rnd/storage)
 "qw" = (
-/obj/structure/morgue{
-	dir = 1
-	},
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/old_cargo/gray,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/old_tile/gray,
 /area/surface/station/medical/morgue)
 "qx" = (
 /obj/structure/table/rack,
@@ -7848,6 +7940,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
+/obj/effect/catwalk_plated/dark,
 /turf/simulated/floor/plating,
 /area/surface/station/maintenance/eaststairwell)
 "qK" = (
@@ -8287,6 +8380,21 @@
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
+	},
+/turf/simulated/floor/plating,
+/area/surface/station/maintenance/medical/south)
+"rF" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/catwalk_plated/dark,
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/surface/station/maintenance/medical/south)
@@ -9180,6 +9288,10 @@
 	},
 /turf/simulated/floor/tiled,
 /area/surface/station/hallway/primary/bmt/north)
+"tw" = (
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor/tiled/steel_dirty,
+/area/surface/station/maintenance/medical/south)
 "tx" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -9568,6 +9680,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/surface/station/maintenance/eaststairwell)
+"um" = (
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/steel_dirty,
+/area/surface/station/maintenance/medical/south)
 "un" = (
 /obj/item/frame/light,
 /turf/simulated/floor/tiled/white,
@@ -9577,6 +9698,7 @@
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/catwalk_plated/dark,
 /turf/simulated/floor/plating,
 /area/surface/station/maintenance/eaststairwell)
 "up" = (
@@ -9624,8 +9746,16 @@
 /turf/simulated/floor/tiled/old_tile/white,
 /area/surface/station/rnd/mixing)
 "uw" = (
-/obj/machinery/floodlight,
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/paleblue/border,
+/obj/random/crate{
+	dir = 4
+	},
+/obj/random/maintenance/medical,
+/obj/random/maintenance/medical,
+/obj/random/maintenance/clean,
+/obj/random/maintenance/clean,
+/turf/simulated/floor/tiled/steel_dirty,
 /area/surface/station/maintenance/medical/south)
 "ux" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -9821,10 +9951,8 @@
 "uU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/airlock/maintenance{
-	req_one_access = list(5,12,47)
-	},
 /obj/machinery/door/firedoor/border_only,
+/obj/effect/catwalk_plated/dark,
 /turf/simulated/floor/plating,
 /area/surface/station/maintenance/medical/south)
 "uV" = (
@@ -9873,9 +10001,14 @@
 /turf/simulated/wall/r_wall,
 /area/surface/outpost/research/xenoarcheology/entrance)
 "va" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/borderfloor{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 5
+	},
+/obj/machinery/floodlight,
+/turf/simulated/floor/tiled/steel_dirty,
 /area/surface/station/maintenance/medical/south)
 "vb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -10764,6 +10897,21 @@
 	},
 /turf/simulated/floor/plating,
 /area/surface/station/maintenance/engineering/south)
+"wQ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/effect/catwalk_plated/dark,
+/turf/simulated/floor/plating,
+/area/surface/station/maintenance/medical/south)
 "wR" = (
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 4
@@ -11688,6 +11836,16 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled,
 /area/surface/station/hallway/secondary/bmt/eaststairwell)
+"yP" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/simulated/floor/tiled/steel_dirty,
+/area/surface/station/maintenance/medical/south)
 "yQ" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/airlock/maintenance{
@@ -11726,6 +11884,15 @@
 /obj/item/stock_parts/console_screen,
 /turf/simulated/floor/plating,
 /area/surface/station/storage/tech)
+"yU" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel_dirty,
+/area/surface/station/maintenance/eaststairwell)
 "yV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -12218,6 +12385,13 @@
 /area/surface/cave/explored/normal)
 "Aa" = (
 /obj/machinery/portable_atmospherics/powered/scrubber,
+/obj/structure/sign/directions/medical/morgue{
+	dir = 1;
+	pixel_y = 32
+	},
+/obj/effect/floor_decal/spline/plain{
+	dir = 5
+	},
 /turf/simulated/floor/tiled/dark,
 /area/surface/station/hallway/primary/bmt/north)
 "Ab" = (
@@ -14177,6 +14351,14 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/surface/outpost/research/xenoarcheology)
+"Ed" = (
+/obj/effect/floor_decal/borderfloor/corner,
+/obj/effect/floor_decal/corner/paleblue/bordercorner,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/steel_dirty,
+/area/surface/station/maintenance/medical/south)
 "Ee" = (
 /obj/machinery/optable{
 	name = "Morgue Table"
@@ -14366,6 +14548,9 @@
 "Ex" = (
 /obj/machinery/alarm{
 	pixel_y = 22
+	},
+/obj/machinery/door/airlock/maintenance{
+	req_one_access = list(5,12,47)
 	},
 /turf/simulated/floor/plating,
 /area/surface/station/maintenance/eaststairwell)
@@ -14607,6 +14792,23 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/monotile,
 /area/surface/outpost/research/xenoarcheology/anomaly)
+"EY" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/catwalk_plated/dark,
+/obj/machinery/door/airlock/medical{
+	name = "Morgue Access";
+	req_one_access = list(5, 6, 12, 47)
+	},
+/turf/simulated/floor/plating,
+/area/surface/station/maintenance/medical/south)
 "EZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -14804,6 +15006,12 @@
 /obj/machinery/ai_status_display,
 /turf/simulated/wall/concrete,
 /area/surface/station/maintenance/substation/medbay/bmt)
+"Fx" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/paleblue/border,
+/obj/machinery/light/small,
+/turf/simulated/floor/tiled/steel_dirty,
+/area/surface/station/maintenance/medical/south)
 "FA" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -15488,6 +15696,10 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/surface/station/rnd/mixing)
+"Hd" = (
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor/tiled/steel_dirty,
+/area/surface/station/maintenance/eaststairwell)
 "Hf" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -15895,6 +16107,16 @@
 /obj/structure/window/reinforced/full,
 /turf/simulated/floor/plating,
 /area/surface/outpost/research/xenoarcheology)
+"Id" = (
+/obj/structure/sign/directions/medical/morgue{
+	dir = 8;
+	pixel_x = -32
+	},
+/obj/structure/table/rack/shelf/steel,
+/obj/random/maintenance/medical,
+/obj/random/maintenance/clean,
+/turf/simulated/floor/plating,
+/area/surface/station/maintenance/medical/south)
 "Ie" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/borderfloor{
@@ -16992,6 +17214,7 @@
 	dir = 9
 	},
 /obj/machinery/meter,
+/obj/effect/catwalk_plated/dark,
 /turf/simulated/floor/plating,
 /area/surface/station/maintenance/eaststairwell)
 "KD" = (
@@ -17030,6 +17253,11 @@
 	},
 /turf/simulated/floor/tiled/old_tile/white,
 /area/surface/station/rnd/mixing)
+"KI" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/paleblue/border,
+/turf/simulated/floor/tiled/steel_dirty,
+/area/surface/station/maintenance/medical/south)
 "KJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/universal,
 /obj/machinery/atmospherics/pipe/simple/visible/purple{
@@ -17413,21 +17641,6 @@
 /obj/machinery/meter,
 /turf/simulated/floor/tiled/old_tile/white,
 /area/surface/station/rnd/mixing)
-"Lz" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/surface/station/maintenance/medical/south)
 "LA" = (
 /obj/machinery/door/airlock/maintenance/engi{
 	icon_state = "door_locked";
@@ -17508,13 +17721,6 @@
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/surface/station/mining_main/storage)
-"LK" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -12
-	},
-/turf/simulated/floor/tiled/old_tile/gray,
-/area/surface/station/medical/morgue)
 "LL" = (
 /obj/structure/table/rack{
 	layer = 2.6
@@ -18094,6 +18300,10 @@
 	},
 /turf/simulated/floor/tiled,
 /area/surface/station/hallway/primary/bmt/west)
+"MU" = (
+/obj/structure/loot_pile/maint/technical,
+/turf/simulated/floor/plating,
+/area/surface/station/maintenance/eaststairwell)
 "MV" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
@@ -18406,6 +18616,9 @@
 	dir = 2
 	},
 /obj/effect/floor_decal/industrial/warning/corner,
+/obj/effect/floor_decal/spline/plain{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/old_cargo/gray,
 /area/surface/station/medical/morgue)
 "NF" = (
@@ -18634,15 +18847,6 @@
 "NY" = (
 /turf/simulated/wall/r_wall,
 /area/surface/station/mining_main/refinery)
-"Oa" = (
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 1
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/old_tile/gray,
-/area/surface/station/medical/morgue)
 "Ob" = (
 /obj/structure/ore_box,
 /obj/effect/floor_decal/borderfloor{
@@ -21254,7 +21458,11 @@
 /obj/random/maintenance/medical,
 /obj/random/maintenance/clean,
 /obj/random/maintenance/clean,
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/rust,
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/steel_dirty,
 /area/surface/station/maintenance/medical/south)
 "Tg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -21715,6 +21923,7 @@
 "Uo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/catwalk_plated/dark,
 /turf/simulated/floor/plating,
 /area/surface/station/maintenance/eaststairwell)
 "Up" = (
@@ -21873,8 +22082,15 @@
 /turf/simulated/floor/plating,
 /area/surface/station/maintenance/substation/engineering/bmt)
 "UE" = (
-/turf/simulated/wall/r_wall,
-/area/surface/station/medical/morgue)
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner{
+	dir = 4
+	},
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor/tiled/steel_dirty,
+/area/surface/station/maintenance/medical/south)
 "UF" = (
 /obj/effect/floor_decal/borderfloor/corner{
 	dir = 1
@@ -21884,6 +22100,13 @@
 	},
 /turf/simulated/floor/tiled,
 /area/surface/station/hallway/primary/bmt/west/elevator)
+"UG" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/item/clothing/head/cone,
+/turf/simulated/floor/plating,
+/area/surface/station/maintenance/medical/south)
 "UH" = (
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 9
@@ -22195,6 +22418,15 @@
 	},
 /turf/simulated/floor/tiled,
 /area/surface/station/hallway/primary/bmt/west)
+"Vo" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel_dirty,
+/area/surface/station/maintenance/medical/south)
 "Vp" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -22949,7 +23181,11 @@
 /obj/random/maintenance/medical,
 /obj/random/maintenance/clean,
 /obj/random/maintenance/clean,
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/rust,
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/steel_dirty,
 /area/surface/station/maintenance/medical/south)
 "WU" = (
 /turf/simulated/wall/r_wall,
@@ -23055,6 +23291,16 @@
 	},
 /turf/simulated/floor/tiled,
 /area/surface/station/mining_main/storage)
+"Xd" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 4
+	},
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor/tiled/steel_dirty,
+/area/surface/station/maintenance/medical/south)
 "Xg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/wall/r_wall,
@@ -23644,6 +23890,15 @@
 	},
 /turf/simulated/floor/tiled,
 /area/surface/station/hallway/primary/bmt/west/elevator)
+"Yy" = (
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -22
+	},
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/paleblue/border,
+/turf/simulated/floor/tiled/steel_dirty,
+/area/surface/station/maintenance/medical/south)
 "Yz" = (
 /obj/effect/floor_decal/borderfloorwhite/corner{
 	dir = 8
@@ -23821,21 +24076,12 @@
 /turf/simulated/floor/tiled,
 /area/surface/station/medical/hallway/bmt)
 "YX" = (
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 4
+/obj/structure/morgue{
+	dir = 1
 	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/maintenance{
-	req_one_access = list(5,12,47)
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/surface/station/maintenance/medical/south)
+/obj/effect/floor_decal/spline/plain,
+/turf/simulated/floor/tiled/old_cargo/gray,
+/area/surface/station/medical/morgue)
 "YY" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -55367,10 +55613,10 @@ Ps
 Gj
 Ps
 kl
-nC
-Lz
-nC
-YX
+Ps
+Ps
+Ps
+Ps
 Ps
 FT
 iv
@@ -55624,15 +55870,15 @@ id
 id
 id
 id
-ec
-ec
-ec
-pj
-Mu
-Mu
-Ug
+DD
+DD
+DD
+DD
+va
+UE
+bu
+ev
 cE
-HE
 HE
 HE
 HE
@@ -55881,15 +56127,15 @@ QG
 QG
 RB
 id
-DD
-hJ
-UE
+iU
+nC
+ec
 DD
 DD
 nI
-Ug
+bu
+uw
 cE
-HE
 HE
 HE
 HE
@@ -56138,15 +56384,15 @@ QG
 QG
 QG
 id
-iU
-Oa
-LK
+eR
+dc
+dc
 oX
 DD
 pa
-Ug
+bu
+Fx
 cE
-HE
 HE
 HE
 HE
@@ -56395,15 +56641,15 @@ QG
 QG
 QG
 id
-iU
+eR
 dc
 dc
-oX
+YX
 DD
-oh
-Ug
+jU
+rF
+KI
 cE
-HE
 HE
 HE
 HE
@@ -56656,11 +56902,11 @@ NE
 FS
 FS
 qw
-DD
+hJ
 hj
-Ug
+wQ
+KI
 cE
-HE
 HE
 HE
 HE
@@ -56914,10 +57160,10 @@ sq
 gn
 pj
 DD
-uw
-zf
+pj
+oh
+Yy
 cE
-HE
 HE
 HE
 HE
@@ -57172,9 +57418,9 @@ iK
 jY
 DD
 dg
-Ug
+bu
+KI
 cE
-HE
 HE
 HE
 HE
@@ -57430,8 +57676,8 @@ vk
 DD
 cM
 iv
+KI
 cE
-HE
 HE
 HE
 HE
@@ -57686,9 +57932,9 @@ Ee
 xB
 DD
 Lv
-Ug
+bu
+Fx
 cE
-HE
 HE
 HE
 HE
@@ -57943,9 +58189,9 @@ pj
 DD
 DD
 pU
-Ug
+bu
+KI
 cE
-HE
 HE
 HE
 HE
@@ -58199,10 +58445,10 @@ GQ
 Mu
 cE
 Tf
-Mu
-Ug
+tw
+bu
+KI
 cE
-HE
 HE
 HE
 HE
@@ -58456,10 +58702,10 @@ ni
 Am
 cE
 WT
-Mu
-Ug
+tw
+bu
+KI
 cE
-HE
 HE
 HE
 HE
@@ -58714,9 +58960,9 @@ SO
 SO
 SO
 cE
-wI
+EY
+aE
 cE
-HE
 HE
 HE
 HE
@@ -58970,10 +59216,10 @@ id
 Am
 GV
 cE
-Mu
-Ug
+Id
+bu
+KI
 cE
-HE
 HE
 HE
 HE
@@ -59227,9 +59473,9 @@ EA
 uQ
 cE
 cE
-Mu
+UG
 bu
-cE
+um
 cE
 cE
 cE
@@ -59486,20 +59732,20 @@ aD
 JB
 Hl
 bW
-va
-va
-va
 Yb
 Yb
 Yb
-va
-va
-va
+Yb
+Yb
+Yb
+Yb
+Yb
+Yb
 uU
 uo
 KC
-Qg
-py
+jq
+eN
 LF
 Aa
 yC
@@ -59743,20 +59989,20 @@ SJ
 Bg
 Hl
 zH
-cE
-cE
-cE
-cE
-cE
-cE
-cE
-cE
-cE
-cE
-LF
-LF
-LF
-py
+Ed
+Vo
+Vo
+Xd
+Vo
+oI
+Vo
+Vo
+Vo
+yP
+yU
+yU
+lU
+Hd
 LF
 fr
 aH
@@ -60001,20 +60247,20 @@ cE
 cE
 wI
 cE
-HE
-HE
-HE
-HE
-HE
-HE
-HE
-HE
-HE
-HE
-HE
+cE
+cE
+cE
+cE
+cE
+cE
+cE
+cE
+cE
+LF
+LF
 LF
 Ex
-eR
+LF
 fr
 uG
 KB
@@ -60528,7 +60774,7 @@ HE
 HE
 LF
 py
-py
+MU
 fr
 RU
 vT


### PR DESCRIPTION
Converts one of the narrow maintenance hallways into a slightly wider semi-maintenance gloomy medical access corridor (Med, maint and R&D access, same as the prior maint hallway + morgue access. Morgue rear door itself now has med, morgue, forensics access the same as the front door, instead of being med only) for the purposes of ~~shady corpse exchanges~~ those with morgue access actually having access to the morgue without going through medical which they may **not** have access to, in a slightly more immerseful way than just hauling a corpse through straight up maintenance.

Layout of the morgue changed very slightly to accomodate new south-facing door.