### PR TITLE
Typing say into the input control will activate typing indicators

### DIFF
--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -125,7 +125,7 @@
 			add_overlay(H.overlays_standing)
 		default_pixel_x = body.default_pixel_x
 		default_pixel_y = body.default_pixel_y
-	if(!T && length(latejoin))	
+	if(!T && length(latejoin))
 		T = pick(latejoin)			//Safety in case we cannot find the body's position
 	if(T)
 		forceMove(T)
@@ -167,10 +167,10 @@
 		I = getFlatIcon(src, defdir = SOUTH, no_anim = TRUE)
 		set_cached_examine_icon(src, I, 200 SECONDS)
 	return I
-	
+
 /mob/observer/dead/examine(mob/user)
 	. = ..()
-	
+
 	if(is_admin(user))
 		. += "\t><span class='admin'>[ADMIN_FULLMONTY(src)]</span>"
 
@@ -186,6 +186,7 @@ Works together with spawning an observer, noted above.
 
 	handle_regular_hud_updates()
 	handle_vision()
+	handle_input_typing_indicator()
 
 /mob/proc/ghostize(var/can_reenter_corpse = 1)
 	if(key)
@@ -342,7 +343,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	for(var/area/A as anything in areas)
 		if(A.z in using_map?.secret_levels)
 			areas -= A
-	return areas				
+	return areas
 
 /mob/observer/dead/proc/jumpable_mobs()
 	var/list/mobs = getmobs()
@@ -368,7 +369,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		A = input(usr, "Select an area:", "Ghost Teleport") as null|anything in jumpable_areas()
 	if(!A)
 		return
-	
+
 	usr.forceMove(pick(get_area_turfs(A)))
 	usr.on_mob_jump()
 
@@ -381,7 +382,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		input = input(usr, "Select a mob:", "Ghost Follow") as null|anything in jumpable_mobs()
 	if(!input)
 		return
-	
+
 	var/target = jumpable_mobs()[input]
 	if(!target) return
 	ManualFollow(target)
@@ -929,7 +930,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	set category = "Ghost"
 	set name = "Blank pAI alert"
 	set desc = "Flash an indicator light on available blank pAI devices for a smidgen of hope."
-	
+
 	if(usr.client.prefs?.be_special & BE_PAI)
 		var/count = 0
 		for(var/obj/item/paicard/p in all_pai_cards)

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -41,10 +41,10 @@
 
 	//Check if we're on fire
 	handle_fire()
-	
+
 	if(client && !(client.prefs.ambience_freq == 0))	// Handle re-running ambience to mobs if they've remained in an area, AND have an active client assigned to them, and do not have repeating ambience disabled.
 		handle_ambience()
-	
+
 	//stuff in the stomach
 	handle_stomach()
 
@@ -66,6 +66,9 @@
 	handle_regular_hud_updates()
 
 	handle_vision()
+
+	handle_input_typing_indicator()
+
 
 /mob/living/proc/handle_breathing()
 	return

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -139,8 +139,6 @@
 	return 0
 
 /mob/proc/Life()
-//	if(organStructure)
-//		organStructure.ProcessOrgans()
 	return
 
 #define UNBUCKLED 0

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -213,6 +213,7 @@
 	var/get_rig_stats = 0 //Moved from computer.dm
 
 	var/typing
+	var/textbox_typing // Typing messages in a textbox will keep the typing indicator active.
 	var/obj/effect/decal/typing_indicator
 
 	var/low_priority = FALSE //Skip processing life() if there's just no players on this Z-level

--- a/code/modules/mob/typing_indicator.dm
+++ b/code/modules/mob/typing_indicator.dm
@@ -63,16 +63,16 @@
 		me_verb(message)
 
 /mob/proc/handle_input_typing_indicator()
+	set waitfor=FALSE
 	if(!is_preference_enabled(/datum/client_preference/show_typing_indicator))
 		return
 
 	// winget() has to contact the client, so could block the rest of life() for poorer connections
 	// If a textbox has already latched this up, don't bother checking.
 	if(!textbox_typing)
-		spawn()
-			var/t = winget(src, "mainwindow.input", "text")
-			if(cmptext(copytext(t, 1, 6), "say \"") && length(copytext(t, 6)))
-				set_typing_indicator(TRUE)
-			// Could have changed during the winget()
-			else if(!textbox_typing)
-				set_typing_indicator(FALSE)
+		var/t = winget(src, "mainwindow.input", "text")
+		if(cmptext(copytext(t, 1, 6), "say \"") && length(copytext(t, 6)))
+			set_typing_indicator(TRUE)
+		// Could have changed during the winget()
+		else if(!textbox_typing)
+			set_typing_indicator(FALSE)


### PR DESCRIPTION
For the folks like me that don't hit f3 every time they want to say something, but still would appreciate being able to use the typing indicator: https://puu.sh/Jn4ar/6e18129a22.mp4

Putting a `winget()` in Life() is probably a mistake, but that's why I wrapped it in a spawn. It does give a little bit of lag before it'll update, compared to using the `.say()` verb, but wyd. I had to add a latch around the `.say()` and `.me()` verbs to make sure the input checker wouldn't just disable the overlay immediately, because those only apply/remove it once, where the checker has to constantly watch the input control.

I made an attempt at checking to see if the input windows for `.say()` and `.me()` exist, and was utterly foiled by the available methods to determine if a control element exists (I guess `input()` does something else under the hood?). Honestly, that would've required another `winexists()` call or similar, which'd require another round-trip message to the client and back, so this implementation is probably for the best.

I'm admittedly wary of the `winget()` so kinda tempted to testmerge, but if other folks think it's fine as is, there's always the revert button (Plus trying to get a round going can be hard)