### PR TITLE
Consolidates Loadout Lists

### DIFF
--- a/code/modules/client/preference_setup/loadout/loadout_accessories.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_accessories.dm
@@ -1,9 +1,9 @@
 /datum/gear/accessory
-	display_name = "accessory"
+	display_name = "locket"
 	slot = slot_tie
 	sort_category = "Accessories"
 	type_category = /datum/gear/accessory
-	path = /obj/item/clothing/accessory
+	path = /obj/item/clothing/accessory/locket
 	cost = 1
 
 /datum/gear/accessory/armband
@@ -19,7 +19,7 @@
 	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(armbands))
 
 /datum/gear/accessory/armband/colored
-	display_name = "armband"
+	display_name = "armband (colorable)"
 	path = /obj/item/clothing/accessory/armband/med/color
 
 /datum/gear/accessory/armband/colored/New()
@@ -35,7 +35,7 @@
 	path = /obj/item/storage/wallet/poly
 
 /datum/gear/accessory/wallet/womens
-	display_name = "wallet, women's"
+	display_name = "wallet, women's (colorable)"
 	path = /obj/item/storage/wallet/womens
 
 /datum/gear/accessory/wallet/womens/New()
@@ -147,38 +147,35 @@
 	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(jackets))
 
 /datum/gear/accessory/suitvest
-	display_name = "suit vest"
+	display_name = "suit vest, black"
 	path = /obj/item/clothing/accessory/vest
 
-/datum/gear/accessory/brown_vest
-	display_name = "webbing, brown"
+/datum/gear/accessory/webbing_vest
+	display_name = "webbing vest selection (Engineering, Security, Medical)"
 	path = /obj/item/clothing/accessory/storage/brown_vest
 	allowed_roles = list("Station Engineer","Atmospheric Technician","Chief Engineer","Security Officer","Detective","Head of Security","Warden","Paramedic","Chief Medical Officer","Medical Doctor", "Search and Rescue")
 
-/datum/gear/accessory/black_vest
-	display_name = "webbing, black"
-	path = /obj/item/clothing/accessory/storage/black_vest
-	allowed_roles = list("Station Engineer","Atmospheric Technician","Chief Engineer","Security Officer","Detective","Head of Security","Warden","Paramedic","Chief Medical Officer","Medical Doctor", "Search and Rescue")
+/datum/gear/accessory/webbing_vest/New()
+	..()
+	var/webbingtype = list()
+	webbingtype["webbing, brown"] = /obj/item/clothing/accessory/storage/brown_vest
+	webbingtype["webbing, black"] = /obj/item/clothing/accessory/storage/black_vest
+	webbingtype["webbing, white"] = /obj/item/clothing/accessory/storage/white_vest
+	webbingtype["webbing, simple"] = /obj/item/clothing/accessory/storage/webbing
+	gear_tweaks += new/datum/gear_tweak/path(webbingtype)
 
-/datum/gear/accessory/white_vest
-	display_name = "webbing, white"
-	path = /obj/item/clothing/accessory/storage/white_vest
-	allowed_roles = list("Station Engineer","Atmospheric Technician","Chief Engineer","Security Officer","Detective","Head of Security","Warden","Paramedic","Chief Medical Officer","Medical Doctor", "Search and Rescue")
-
-/datum/gear/accessory/brown_drop_pouches
-	display_name = "drop pouches, brown"
+/datum/gear/accessory/drop_pouches
+	display_name = "drop pouches selection (Engineering, Security, Medical)"
 	path = /obj/item/clothing/accessory/storage/brown_drop_pouches
 	allowed_roles = list("Station Engineer","Atmospheric Technician","Chief Engineer","Security Officer","Detective","Head of Security","Warden","Paramedic","Chief Medical Officer","Medical Doctor", "Search and Rescue")
 
-/datum/gear/accessory/black_drop_pouches
-	display_name = "drop pouches, black"
-	path = /obj/item/clothing/accessory/storage/black_drop_pouches
-	allowed_roles = list("Station Engineer","Atmospheric Technician","Chief Engineer","Security Officer","Detective","Head of Security","Warden","Paramedic","Chief Medical Officer","Medical Doctor", "Search and Rescue")
-
-/datum/gear/accessory/white_drop_pouches
-	display_name = "drop pouches, white"
-	path = /obj/item/clothing/accessory/storage/white_drop_pouches
-	allowed_roles = list("Station Engineer","Atmospheric Technician","Chief Engineer","Security Officer","Detective","Head of Security","Warden","Paramedic","Chief Medical Officer","Medical Doctor", "Search and Rescue")
+/datum/gear/accessory/drop_pouches/New()
+	..()
+	var/pouchtype = list()
+	pouchtype["drop pouches, brown"] = /obj/item/clothing/accessory/storage/brown_drop_pouches
+	pouchtype["drop pouches, black"] = /obj/item/clothing/accessory/storage/black_drop_pouches
+	pouchtype["drop pouches, white"] = /obj/item/clothing/accessory/storage/white_drop_pouches
+	gear_tweaks += new/datum/gear_tweak/path(pouchtype)
 
 /datum/gear/accessory/fannypack
 	display_name = "fannypack selection"
@@ -192,12 +189,6 @@
 		var/obj/item/storage/belt/fannypack/fanny_type = fanny
 		fannys[initial(fanny_type.name)] = fanny_type
 	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(fannys))
-
-/datum/gear/accessory/webbing
-	display_name = "webbing, simple"
-	path = /obj/item/clothing/accessory/storage/webbing
-	cost = 2
-
 /datum/gear/accessory/chaps
 	display_name = "chaps, brown"
 	path = /obj/item/clothing/accessory/chaps
@@ -217,7 +208,6 @@
 	shirts["red hawaii shirt"] = /obj/item/clothing/accessory/hawaii/red
 	shirts["random colored hawaii shirt"] = /obj/item/clothing/accessory/hawaii/random
 	gear_tweaks += new/datum/gear_tweak/path(shirts)
-
 
 /datum/gear/accessory/sweater
 	display_name = "sweater selection"
@@ -251,14 +241,11 @@
 	bracelettype["bracelet, plastic"] = /obj/item/clothing/accessory/bracelet/material/plastic
 	bracelettype["bracelet, copper"] = /obj/item/clothing/accessory/bracelet/material/copper
 	bracelettype["bracelet, bronze"] = /obj/item/clothing/accessory/bracelet/material/bronze
+	bracelettype["bracelet, friendship"] = /obj/item/clothing/accessory/bracelet/friendship
 	gear_tweaks += new/datum/gear_tweak/path(bracelettype)
 
-/datum/gear/accessory/bracelet/friendship
-	display_name = "bracelet, friendship"
-	path = /obj/item/clothing/accessory/bracelet/friendship
-
 /datum/gear/accessory/bracelet/slap
-	display_name = "bracelet, slap (recolorable)"
+	display_name = "bracelet, slap (colorable)"
 	path = /obj/item/clothing/accessory/bracelet/slap
 
 /datum/gear/accessory/bracelet/slap/New()
@@ -266,7 +253,7 @@
 	gear_tweaks += gear_tweak_free_color_choice
 
 /datum/gear/accessory/bracelet/beaded
-	display_name = "bracelet, beaded (recolorable)"
+	display_name = "bracelet, beaded (colorable)"
 	path = /obj/item/clothing/accessory/bracelet/beaded
 
 /datum/gear/accessory/bracelet/beaded/New()
@@ -277,10 +264,6 @@
 	display_name = "stethoscope"
 	path = /obj/item/clothing/accessory/stethoscope
 	allowed_roles = list("Chief Medical Officer","Medical Doctor","Chemist","Psychiatrist","Paramedic", "Search and Rescue")
-
-/datum/gear/accessory/locket
-	display_name = "locket"
-	path = /obj/item/clothing/accessory/locket
 
 /datum/gear/accessory/halfcape
 	display_name = "cape, half"
@@ -345,11 +328,11 @@
 	allowed_roles = list("Internal affairs agent")
 
 /datum/gear/accessory/pressbadge
-	display_name = "corporate press pass"
+	display_name = "press pass, corporate"
 	path = /obj/item/clothing/accessory/badge/press
 
-/datum/gear/accessory/pressbadge
-	display_name = "freelance press pass"
+/datum/gear/accessory/pressbadgefreelance
+	display_name = "press pass, freelance"
 	path = /obj/item/clothing/accessory/badge/press/independent
 
 /datum/gear/accessory/legbrace

--- a/code/modules/client/preference_setup/loadout/loadout_cyberware.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_cyberware.dm
@@ -9,6 +9,7 @@
 
 /datum/gear/utility/implant/tracking
 	display_name = "implant, tracking"
+	description = "An implanted chip allowing authorities to pinpoint the location of an individual at all times. Primarily given as a condition of a criminal sentence."
 	path = /obj/item/implant/tracking/weak
 	cost = 10
 

--- a/code/modules/client/preference_setup/loadout/loadout_eyes.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_eyes.dm
@@ -36,16 +36,31 @@
 	gear_tweaks += gear_tweak_free_color_choice
 
 /datum/gear/eyes/glasses
-	display_name = "glasses, prescription"
+	display_name = "glasses, prescription selection"
 	path = /obj/item/clothing/glasses/regular
+	cost = 1
 
-/datum/gear/eyes/glasses/green
-	display_name = "glasses, green"
+/datum/gear/eyes/glasses/New()
+	..()
+	var/glassestype = list()
+	glassestype["prescription glasses, standard"] = /obj/item/clothing/glasses/regular
+	glassestype["prescription glasses, hipster"] = /obj/item/clothing/glasses/regular/hipster
+	glassestype["prescription glasses, rimless"] = /obj/item/clothing/glasses/regular/rimless
+	glassestype["prescription glasses, thin frame"] = /obj/item/clothing/glasses/regular/thin
+	gear_tweaks += new/datum/gear_tweak/path(glassestype)
+
+/datum/gear/eyes/glassesfake
+	display_name = "glasses, non-prescription selection"
 	path = /obj/item/clothing/glasses/gglasses
+	cost = 1
 
-/datum/gear/eyes/glasses/prescriptionhipster
-	display_name = "glasses, hipster"
-	path = /obj/item/clothing/glasses/regular/hipster
+/datum/gear/eyes/glassesfake/New()
+	..()
+	var/glassestype = list()
+	glassestype["glasses, green"] = /obj/item/clothing/glasses/gglasses
+	glassestype["glasses, rimless"] = /obj/item/clothing/glasses/rimless
+	glassestype["glasses, thin frame"] = /obj/item/clothing/glasses/thin
+	gear_tweaks += new/datum/gear_tweak/path(glassestype)
 
 /datum/gear/eyes/glasses/monocle
 	display_name = "monocle"
@@ -64,51 +79,47 @@
 	path = /obj/item/clothing/glasses/science
 
 /datum/gear/eyes/security
-	display_name = "security HUD (Security)"
+	display_name = "security HUD selection (Security)"
 	path = /obj/item/clothing/glasses/hud/security
 	allowed_roles = list("Security Officer","Head of Security","Warden", "Detective")
 
-/datum/gear/eyes/security/prescriptionsec
-	display_name = "security HUD, prescription (Security)"
-	path = /obj/item/clothing/glasses/hud/security/prescription
+/datum/gear/eyes/security/New()
+	..()
+	var/hudtype = list()
+	hudtype["security hud, standard"] = /obj/item/clothing/glasses/hud/security
+	hudtype["security hud, standard prescription"] = /obj/item/clothing/glasses/hud/security/prescription
+	hudtype["security hud, sunglasses"] = /obj/item/clothing/glasses/sunglasses/sechud
+	hudtype["security hud, sunglasses prescription"] = /obj/item/clothing/glasses/sunglasses/sechud/prescription
+	hudtype["security hud, aviators"] = /obj/item/clothing/glasses/sunglasses/sechud/aviator
+	hudtype["security hud, aviators prescription"] = /obj/item/clothing/glasses/sunglasses/sechud/aviator/prescription
 
-/datum/gear/eyes/security/sunglasshud
-	display_name = "security HUD, sunglasses (Security)"
-	path = /obj/item/clothing/glasses/sunglasses/sechud
-
-/datum/gear/eyes/security/aviator
-	display_name = "security HUD Aviators (Security)"
-	path = /obj/item/clothing/glasses/sunglasses/sechud/aviator
-
-/datum/gear/eyes/security/aviator/prescription
-	display_name = "security HUD Aviators, prescription (Security)"
-	path = /obj/item/clothing/glasses/sunglasses/sechud/aviator/prescription
+	gear_tweaks += new/datum/gear_tweak/path(hudtype)
 
 /datum/gear/eyes/medical
-	display_name = "medical HUD (Medical)"
+	display_name = "medical HUD selection (Medical)"
 	path = /obj/item/clothing/glasses/hud/health
 	allowed_roles = list("Medical Doctor","Chief Medical Officer","Chemist","Paramedic","Geneticist", "Psychiatrist", "Search and Rescue")
 
-/datum/gear/eyes/medical/prescriptionmed
-	display_name = "medical HUD, prescription (Medical)"
-	path = /obj/item/clothing/glasses/hud/health/prescription
-
-/datum/gear/eyes/medical/aviator
-	display_name = "medical HUD Aviators (Medical)"
-	path = /obj/item/clothing/glasses/hud/health/aviator
-
-/datum/gear/eyes/medical/aviator/prescription
-	display_name = "medical HUD Aviators, prescription (Medical)"
-	path = /obj/item/clothing/glasses/hud/health/aviator/prescription
+/datum/gear/eyes/medical/New()
+	..()
+	var/list/huds = list()
+	for(var/hud in typesof(/obj/item/clothing/glasses/hud/health))
+		var/obj/item/clothing/glasses/hud/hud_type = hud
+		huds[initial(hud_type.name)] = hud_type
+	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(huds))
 
 /datum/gear/eyes/meson
-	display_name = "optical meson scanners (Engineering, Science, Mining)"
+	display_name = "optical meson scanners selection (Engineering, Science, Mining)"
 	path = /obj/item/clothing/glasses/meson
 	allowed_roles = list("Station Engineer","Chief Engineer","Atmospheric Technician", "Scientist", "Research Director", "Shaft Miner")
 
-/datum/gear/eyes/meson/prescription
-	display_name = "optical meson scanners, prescription (Engineering, Science, Mining)"
-	path = /obj/item/clothing/glasses/meson/prescription
+/datum/gear/eyes/meson/New()
+	..()
+	var/list/mesons = list()
+	for(var/meson in typesof(/obj/item/clothing/glasses/meson))
+		var/obj/item/clothing/glasses/meson_type = meson
+		mesons[initial(meson_type.name)] = meson_type
+	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(mesons))
 
 /datum/gear/eyes/material
 	display_name = "optical material scanners (Mining)"
@@ -119,13 +130,6 @@
 	display_name = "optical material scanners, prescription (Mining)"
 	path = /obj/item/clothing/glasses/material/prescription
 
-/datum/gear/eyes/meson/aviator
-	display_name = "optical meson aviators (Engineering, Science, Mining)"
-	path = /obj/item/clothing/glasses/meson/aviator
-
-/datum/gear/eyes/meson/aviator/prescription
-	display_name = "optical meson aviators, prescription (Engineering, Science, Mining)"
-	path = /obj/item/clothing/glasses/meson/aviator/prescription
 
 /datum/gear/eyes/glasses/fakesun
 	display_name = "sunglasses, stylish"
@@ -136,38 +140,20 @@
 	path = /obj/item/clothing/glasses/fakesunglasses/aviator
 
 /datum/gear/eyes/sun
-	display_name = "sunglasses (Security/Command)"
+	display_name = "sunglasses, protective selection (Security/Command)"
 	path = /obj/item/clothing/glasses/sunglasses
 	allowed_roles = list("Security Officer","Head of Security","Warden","Site Manager","Head of Personnel","Quartermaster","Internal Affairs Agent","Detective")
 
-/datum/gear/eyes/sun/shades
-	display_name = "sunglasses, fat (Security/Command)"
-	path = /obj/item/clothing/glasses/sunglasses/big
+/datum/gear/eyes/sun/New()
+	..()
+	var/hudtype = list()
+	hudtype["sunglasses, standard"] = /obj/item/clothing/glasses/sunglasses
+	hudtype["sunglasses, big"] = /obj/item/clothing/glasses/sunglasses/big
+	hudtype["sunglasses, aviators"] = /obj/item/clothing/glasses/sunglasses/aviator
+	hudtype["sunglasses, prescription"] = /obj/item/clothing/glasses/sunglasses/prescription
 
-/datum/gear/eyes/sun/aviators
-	display_name = "sunglasses, aviators (Security/Command)"
-	path = /obj/item/clothing/glasses/sunglasses/aviator
-
-/datum/gear/eyes/sun/prescriptionsun
-	display_name = "sunglasses, presciption (Security/Command)"
-	path = /obj/item/clothing/glasses/sunglasses/prescription
+	gear_tweaks += new/datum/gear_tweak/path(hudtype)
 
 /datum/gear/eyes/circuitry
 	display_name = "goggles, circuitry (empty)"
 	path = /obj/item/clothing/glasses/circuitry
-
-/datum/gear/eyes/glasses/rimless
-	display_name = "glasses, rimless"
-	path = /obj/item/clothing/glasses/rimless
-
-/datum/gear/eyes/glasses/prescriptionrimless
-	display_name = "glasses, prescription rimless"
-	path = /obj/item/clothing/glasses/regular/rimless
-
-/datum/gear/eyes/glasses/thin
-	display_name = "glasses, thin frame"
-	path = /obj/item/clothing/glasses/thin
-
-/datum/gear/eyes/glasses/prescriptionthin
-	display_name = "glasses, prescription thin frame"
-	path = /obj/item/clothing/glasses/regular/thin

--- a/code/modules/client/preference_setup/loadout/loadout_gloves.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_gloves.dm
@@ -6,30 +6,26 @@
 	slot = slot_gloves
 	sort_category = "Gloves and Handwear"
 
-/datum/gear/gloves/blue
-	display_name = "gloves, blue"
-	path = /obj/item/clothing/gloves/blue
+/datum/gear/gloves/color
+	display_name = "gloves, colored selection"
+	path = /obj/item/clothing/gloves/black
 	cost = 1
 
-/datum/gear/gloves/brown
-	display_name = "gloves, brown"
-	path = /obj/item/clothing/gloves/brown
-	cost = 1
-
-/datum/gear/gloves/light_brown
-	display_name = "gloves, light-brown"
-	path = /obj/item/clothing/gloves/light_brown
-	cost = 1
-
-/datum/gear/gloves/green
-	display_name = "gloves, green"
-	path = /obj/item/clothing/gloves/green
-	cost = 1
-
-/datum/gear/gloves/grey
-	display_name = "gloves, grey"
-	path = /obj/item/clothing/gloves/grey
-	cost = 1
+/datum/gear/gloves/color/New()
+	..()
+	var/glovetype = list()
+	glovetype["gloves, black"] = /obj/item/clothing/gloves/black
+	glovetype["gloves, blue"] = path = /obj/item/clothing/gloves/blue
+	glovetype["gloves, brown"] = /obj/item/clothing/gloves/brown
+	glovetype["gloves, light-brown"] = /obj/item/clothing/gloves/light_brown
+	glovetype["gloves, green"] = /obj/item/clothing/gloves/green
+	glovetype["gloves, grey"] = /obj/item/clothing/gloves/grey
+	glovetype["gloves, orange"] = /obj/item/clothing/gloves/orange
+	glovetype["gloves, purple"] = /obj/item/clothing/gloves/purple
+	glovetype["gloves, rainbow"] = /obj/item/clothing/gloves/rainbow
+	glovetype["gloves, red"] = /obj/item/clothing/gloves/red
+	glovetype["gloves, white"] = /obj/item/clothing/gloves/white
+	gear_tweaks += new/datum/gear_tweak/path(glovetype)
 
 /datum/gear/gloves/latex
 	display_name = "gloves, latex"
@@ -40,32 +36,6 @@
 	display_name = "gloves, nitrile"
 	path = /obj/item/clothing/gloves/sterile/nitrile
 	cost = 2
-
-/datum/gear/gloves/orange
-	display_name = "gloves, orange"
-	path = /obj/item/clothing/gloves/orange
-	cost = 1
-
-/datum/gear/gloves/purple
-	display_name = "gloves, purple"
-	path = /obj/item/clothing/gloves/purple
-	cost = 1
-
-/datum/gear/gloves/rainbow
-	display_name = "gloves, rainbow"
-	path = /obj/item/clothing/gloves/rainbow
-	cost = 1
-
-/datum/gear/gloves/red
-	display_name = "gloves, red"
-	path = /obj/item/clothing/gloves/red
-	cost = 1
-
-/datum/gear/gloves/white
-	display_name = "gloves, white"
-	path = /obj/item/clothing/gloves/white
-	cost = 1
-
 /datum/gear/gloves/evening
 	display_name = "gloves, evening"
 	path = /obj/item/clothing/gloves/evening

--- a/code/modules/client/preference_setup/loadout/loadout_head.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_head.dm
@@ -1,122 +1,94 @@
 /datum/gear/head
-	display_name = "bandana, pirate-red"
-	path = /obj/item/clothing/head/bandana
+	display_name = "hat, boatsman"
+	path = /obj/item/clothing/head/boaterhat
 	slot = slot_head
 	sort_category = "Hats and Headwear"
 
-/datum/gear/head/bandana_green
-	display_name = "bandana, green"
-	path = /obj/item/clothing/head/greenbandana
 
-/datum/gear/head/bandana_orange
-	display_name = "bandana, orange"
-	path = /obj/item/clothing/head/orangebandana
+/datum/gear/head/bandanas
+	display_name = "bandana selection"
+	path = /obj/item/clothing/head/bandana
+
+/datum/gear/head/bandanas/New()
+	..()
+	var/bandanatype = list()
+	bandanatype["bandana, pirate-red"] = /obj/item/clothing/head/bandana
+	bandanatype["bandana, green"] = /obj/item/clothing/head/greenbandana
+	bandanatype["bandana, orange"] = /obj/item/clothing/head/orangebandana
+	gear_tweaks += new/datum/gear_tweak/path(bandanatype)
 
 /datum/gear/head/beret
-	display_name = "beret, red"
+	display_name = "beret, colored selection"
 	path = /obj/item/clothing/head/beret
 
-/datum/gear/head/beret/bsec
-	display_name = "beret, navy (officer)"
+/datum/gear/head/beret/New()
+	..()
+	var/berettype = list()
+	berettype["beret, engineering orange"] = /obj/item/clothing/head/beret/engineering
+	berettype["beret, purple"] = /obj/item/clothing/head/beret/purple
+	berettype["beret, red"] = /obj/item/clothing/head/beret
+	gear_tweaks += new/datum/gear_tweak/path(berettype)
+
+/datum/gear/head/beretsec
+	display_name = "beret, security selection (Security)"
 	path = /obj/item/clothing/head/beret/sec/navy/officer
 	allowed_roles = list("Security Officer","Head of Security","Warden")
 
-/datum/gear/head/beret/bsec_warden
-	display_name = "beret, navy (warden)"
-	path = /obj/item/clothing/head/beret/sec/navy/warden
-	allowed_roles = list("Head of Security","Warden")
-
-/datum/gear/head/beret/bsec_hos
-	display_name = "beret, navy (hos)"
-	path = /obj/item/clothing/head/beret/sec/navy/hos
-	allowed_roles = list("Head of Security")
-
-/datum/gear/head/beret/csec
-	display_name = "beret, corporate (officer)"
-	path = /obj/item/clothing/head/beret/sec/corporate/officer
-	allowed_roles = list("Security Officer","Head of Security","Warden", "Detective")
-
-/datum/gear/head/beret/csec_warden
-	display_name = "beret, corporate (warden)"
-	path = /obj/item/clothing/head/beret/sec/corporate/warden
-	allowed_roles = list("Head of Security","Warden")
-
-/datum/gear/head/beret/csec_hos
-	display_name = "beret, corporate (hos)"
-	path = /obj/item/clothing/head/beret/sec/corporate/hos
-	allowed_roles = list("Head of Security")
-
-/datum/gear/head/beret/eng
-	display_name = "beret, engie-orange"
-	path = /obj/item/clothing/head/beret/engineering
-
-/datum/gear/head/beret/purp
-	display_name = "beret, purple"
-	path = /obj/item/clothing/head/beret/purple
-
-/datum/gear/head/beret/sec
-	display_name = "beret, red (security)"
-	path = /obj/item/clothing/head/beret/sec
-	allowed_roles = list("Security Officer","Head of Security","Warden", "Detective")
+/datum/gear/head/beretsec/New()
+	..()
+	var/berettype = list()
+	berettype["officer beret, navy"] = /obj/item/clothing/head/beret/sec/navy/officer
+	berettype["officer beret, corporate"] = /obj/item/clothing/head/beret/sec/corporate/officer
+	berettype["officer beret, red"] = /obj/item/clothing/head/beret/sec
+	berettype["HoS beret, navy"] = /obj/item/clothing/head/beret/sec/navy/hos
+	berettype["HoS beret, corporate"] = /obj/item/clothing/head/beret/sec/corporate/hos
+	berettype["warden beret, navy"] = /obj/item/clothing/head/beret/sec/navy/warden
+	berettype["warden beret, corporate"] = /obj/item/clothing/head/beret/sec/corporate/warden
+	gear_tweaks += new/datum/gear_tweak/path(berettype)
 
 /datum/gear/head/cap
-	display_name = "cap, black"
+	display_name = "cap, soft selection"
 	path = /obj/item/clothing/head/soft/black
 
-/datum/gear/head/cap/blue
-	display_name = "cap, blue"
-	path = /obj/item/clothing/head/soft/blue
+/datum/gear/head/cap/New()
+	..()
+	var/captype = list()
+	captype["soft cap, black"] = /obj/item/clothing/head/soft/black
+	captype["soft cap, blue"] = /obj/item/clothing/head/soft/blue
+	captype["soft cap, green"] = /obj/item/clothing/head/soft/green
+	captype["soft cap, grey"] = /obj/item/clothing/head/soft/grey
+	captype["soft cap, major bill's"] = /obj/item/clothing/head/soft/mbill
+	captype["soft cap, orange"] = /obj/item/clothing/head/soft/orange
+	captype["soft cap, purple"] = /obj/item/clothing/head/soft/purple
+	captype["soft cap, rainbow"] = /obj/item/clothing/head/soft/rainbow
+	captype["soft cap, red"] = /obj/item/clothing/head/soft/red
+	captype["soft cap, solgov"] = /obj/item/clothing/head/soft/solgov
+	captype["soft cap, white"] = /obj/item/clothing/head/soft/mime
+	captype["soft cap, yellow"] = /obj/item/clothing/head/soft/yellow
+	captype["station cap, blue"] = /obj/item/clothing/head/mailman
+	gear_tweaks += new/datum/gear_tweak/path(captype)
 
-/datum/gear/head/cap/mailman
-	display_name = "cap, blue station"
-	path = /obj/item/clothing/head/mailman
-
-/datum/gear/head/cap/flat
-	display_name = "cap, brown-flat"
-	path = /obj/item/clothing/head/flatcap
-
-/datum/gear/head/cap/corp
-	display_name = "cap, corporate (Security)"
+/datum/gear/head/sec_cap
+	display_name = "cap, soft security selection (Security)"
 	path = /obj/item/clothing/head/soft/sec/corp
 	allowed_roles = list("Security Officer","Head of Security","Warden", "Detective")
 
-/datum/gear/head/cap/green
-	display_name = "cap, green"
-	path = /obj/item/clothing/head/soft/green
+/datum/gear/head/sec_cap/New()
+	..()
+	var/list/caps = list()
+	for(var/cap in typesof(/obj/item/clothing/head/soft/sec))
+		var/obj/item/clothing/head/soft/cap_type = cap
+		caps[initial(cap_type.name)] = cap_type
+	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(caps))
 
-/datum/gear/head/cap/grey
-	display_name = "cap, grey"
-	path = /obj/item/clothing/head/soft/grey
+/datum/gear/head/cap/flat
+	display_name = "cap, flat brown"
+	path = /obj/item/clothing/head/flatcap
 
 /datum/gear/head/cap/med
 	display_name = "cap, medical (Medical)"
 	path = /obj/item/clothing/head/soft/med
 	allowed_roles = list("Chief Medical Officer","Medical Doctor","Chemist","Psychiatrist","Paramedic","Search and Rescue")
-
-/datum/gear/head/cap/orange
-	display_name = "cap, orange"
-	path = /obj/item/clothing/head/soft/orange
-
-/datum/gear/head/cap/purple
-	display_name = "cap, purple"
-	path = /obj/item/clothing/head/soft/purple
-
-/datum/gear/head/cap/rainbow
-	display_name = "cap, rainbow"
-	path = /obj/item/clothing/head/soft/rainbow
-
-/datum/gear/head/cap/red
-	display_name = "cap, red"
-	path = /obj/item/clothing/head/soft/red
-
-/datum/gear/head/cap/sec
-	display_name = "cap, security (Security)"
-	path = /obj/item/clothing/head/soft/sec
-	allowed_roles = list("Security Officer","Head of Security","Warden", "Detective")
-
-/datum/gear/head/cap/yellow
-	display_name = "cap, yellow"
-	path = /obj/item/clothing/head/soft/yellow
 
 /datum/gear/head/cap/white
 	display_name = "cap (colorable)"
@@ -126,25 +98,17 @@
 	..()
 	gear_tweaks += gear_tweak_free_color_choice
 
-/datum/gear/head/cap/mbill
-	display_name = "cap, bill"
-	path = /obj/item/clothing/head/soft/mbill
-
-/datum/gear/head/cap/sol
-	display_name = "cap, solgov"
-	path = /obj/item/clothing/head/soft/solgov
-
 /datum/gear/head/cowboy
-	display_name = "cowboy hat, rodeo"
+	display_name = "cowboy hat selection"
 	path = /obj/item/clothing/head/cowboy_hat
 
-/datum/gear/head/cowboy/black
-	display_name = "cowboy hat, black"
-	path = /obj/item/clothing/head/cowboy_hat/black
-
-/datum/gear/head/cowboy/wide
-	display_name = "cowboy hat, wide"
-	path = /obj/item/clothing/head/cowboy_hat/wide
+/datum/gear/head/cowboy/New()
+	..()
+	var/list/hats = list()
+	for(var/hat in typesof(/obj/item/clothing/head/cowboy_hat))
+		var/obj/item/clothing/head/hat_type = hat
+		hats[initial(hat_type.name)] = hat_type
+	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(hats))
 
 /datum/gear/head/fedora
 	display_name = "fedora, brown"
@@ -187,10 +151,6 @@
 		hardhats[initial(hardhat_type.name)] = hardhat_type
 	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(hardhats))
 
-/datum/gear/head/boater
-	display_name = "hat, boatsman"
-	path = /obj/item/clothing/head/boaterhat
-
 /datum/gear/head/bowler
 	display_name = "hat, bowler"
 	path = /obj/item/clothing/head/bowler
@@ -208,16 +168,24 @@
 	path = /obj/item/clothing/head/panama
 
 /datum/gear/head/wig/philosopher
-	display_name = "natural philosopher's wig"
+	display_name = "wig, natural philosopher"
 	path = /obj/item/clothing/head/philosopher_wig
 
 /datum/gear/head/wig
-	display_name = "powdered wig"
+	display_name = "wig, powdered"
 	path = /obj/item/clothing/head/powdered_wig
 
 /datum/gear/head/ushanka
-	display_name = "ushanka"
+	display_name = "ushanka selection"
 	path = /obj/item/clothing/head/ushanka
+
+/datum/gear/head/ushanka/New()
+	..()
+	var/list/ushankas = list()
+	for(var/ushanka in typesof(/obj/item/clothing/head/ushanka))
+		var/obj/item/clothing/head/ushanka/ushanka_type = ushanka
+		ushankas[initial(ushanka_type.name)] = ushanka_type
+	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(ushankas))
 
 /datum/gear/head/santahat
 	display_name = "santa hat"
@@ -289,7 +257,7 @@
 	gear_tweaks += gear_tweak_free_color_choice
 
 /datum/gear/head/beretg
-	display_name = "beret"
+	display_name = "beret (colorable)"
 	path = /obj/item/clothing/head/beretg
 
 /datum/gear/head/beretg/New()
@@ -301,7 +269,7 @@
 	path = /obj/item/clothing/head/sombrero
 
 /datum/gear/head/flatcapg
-	display_name = "cap, flat"
+	display_name = "cap, flat (colorable)"
 	path = /obj/item/clothing/head/flatcap/grey
 
 /datum/gear/head/flatcapg/New()
@@ -317,29 +285,21 @@
 	gear_tweaks += gear_tweak_free_color_choice
 
 /datum/gear/head/welding/
-	display_name = "welding, normal (engineering/robotics)"
+	display_name = "welding helmet selection (engineering/robotics)"
 	path = /obj/item/clothing/head/welding
 	cost = 2
 	allowed_roles = list("Chief Engineer","Station Engineer","Atmospheric Technician","Research Director","Roboticist")
 
-/datum/gear/head/welding/demon
-	display_name = "welding, demon (engineering/robotics)"
-	path = /obj/item/clothing/head/welding/demon
-
-/datum/gear/head/welding/knight
-	display_name = "welding, knight (engineering/robotics)"
-	path = /obj/item/clothing/head/welding/knight
-
-/datum/gear/head/welding/fancy
-	display_name = "welding, fancy (engineering/robotics)"
-	path = /obj/item/clothing/head/welding/fancy
-
-/datum/gear/head/welding/engie
-	display_name = "welding, engie (engineering/robotics)"
-	path = /obj/item/clothing/head/welding/engie
+/datum/gear/head/welding/New()
+	..()
+	var/list/welding_helmets = list()
+	for(var/welding_helmet in typesof(/obj/item/clothing/head/welding))
+		var/obj/item/clothing/head/welding/welding_helmet_type = welding_helmet
+		welding_helmets[initial(welding_helmet_type.name)] = welding_helmet_type
+	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(welding_helmets))
 
 /datum/gear/head/beret/solgov
-	display_name = "beret, solgov selection"
+	display_name = "beret, government selection"
 	path = /obj/item/clothing/head/beret/solgov
 
 /datum/gear/head/beret/solgov/New()

--- a/code/modules/client/preference_setup/loadout/loadout_mask.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_mask.dm
@@ -1,26 +1,21 @@
 // Mask
 /datum/gear/mask
-	display_name = "bandana, blue"
-	path = /obj/item/clothing/mask/bandana/blue
+	display_name = "mask, sterile"
+	path = /obj/item/clothing/mask/surgical
 	slot = slot_wear_mask
 	sort_category = "Masks and Facewear"
 
-/datum/gear/mask/gold
-	display_name = "bandana, gold"
-	path = /obj/item/clothing/mask/bandana/gold
+/datum/gear/mask/bandanas
+	display_name = "face bandana selection"
+	path = /obj/item/clothing/mask/bandana/blue
 
-/datum/gear/mask/green
-	display_name = "bandana, green 2"
-	path = /obj/item/clothing/mask/bandana/green
-
-/datum/gear/mask/red
-	display_name = "bandana, red"
-	path = /obj/item/clothing/mask/bandana/red
-
-/datum/gear/mask/sterile
-	display_name = "mask, sterile"
-	path = /obj/item/clothing/mask/surgical
-	cost = 2
+/datum/gear/mask/bandanas/New()
+	..()
+	var/list/bandanas = list()
+	for(var/bandana in typesof(/obj/item/clothing/mask/bandana))
+		var/obj/item/clothing/mask/bandana/bandana_type = bandana
+		bandanas[initial(bandana_type.name)] = bandana_type
+	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(bandanas))
 
 /datum/gear/mask/veil
 	display_name = "black veil"
@@ -41,7 +36,7 @@
 	gear_tweaks += new/datum/gear_tweak/path(masks)
 
 /datum/gear/mask/cloth
-	display_name = "mask, cloth (recolorable)"
+	display_name = "mask, cloth (colorable)"
 	path = /obj/item/clothing/mask/surgical/cloth
 	cost = 2
 

--- a/code/modules/client/preference_setup/loadout/loadout_shoes.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_shoes.dm
@@ -6,10 +6,9 @@
 	sort_category = "Shoes and Footwear"
 
 /datum/gear/shoes/jackboots
-	display_name = "jackboots selection (Security)"
+	display_name = "jackboots selection"
 	path = /obj/item/clothing/shoes/boots/jackboots
 	cost = 2
-	allowed_roles = list("Security Officer","Head of Security","Warden", "Detective")
 
 /datum/gear/shoes/jackboots/New()
 	..()
@@ -106,16 +105,16 @@
 	gear_tweaks += gear_tweak_free_color_choice
 
 /datum/gear/shoes/cowboy
-	display_name = "boots, cowboy"
+	display_name = "boots, cowboy selection"
 	path = /obj/item/clothing/shoes/boots/cowboy
 
-/datum/gear/shoes/cowboy/classic
-	display_name = "boots, cowboy classic"
-	path = /obj/item/clothing/shoes/boots/cowboy/classic
-
-/datum/gear/shoes/cowboy/snakeskin
-	display_name = "boots, cowboy snakeskin"
-	path = /obj/item/clothing/shoes/boots/cowboy/snakeskin
+/datum/gear/shoes/cowboy/New()
+	..()
+	var/list/cowboys = list()
+	for(var/cowboy in typesof(/obj/item/clothing/shoes/boots/cowboy))
+		var/obj/item/clothing/shoes/boots/cowboy/cowboy_type = cowboy
+		cowboys[initial(cowboy_type.name)] = cowboy_type
+	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(cowboys))
 
 /datum/gear/shoes/jungle
 	display_name = "boots, jungle"
@@ -148,7 +147,7 @@
 	path = /obj/item/clothing/shoes/slippers
 
 /datum/gear/shoes/boots/winter
-	display_name = "winter boots selection"
+	display_name = "boots, winter selection"
 	path = /obj/item/clothing/shoes/boots/winter
 
 /datum/gear/shoes/boots/winter/New()

--- a/code/modules/client/preference_setup/loadout/loadout_shoes.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_shoes.dm
@@ -6,19 +6,18 @@
 	sort_category = "Shoes and Footwear"
 
 /datum/gear/shoes/jackboots
-	display_name = "jackboots"
+	display_name = "jackboots selection (Security)"
 	path = /obj/item/clothing/shoes/boots/jackboots
 	cost = 2
+	allowed_roles = list("Security Officer","Head of Security","Warden", "Detective")
 
-/datum/gear/shoes/kneeboots
-	display_name = "jackboots, knee-length"
-	path = /obj/item/clothing/shoes/boots/jackboots/knee
-	cost = 2
-
-/datum/gear/shoes/thighboots
-	display_name = "jackboots, thigh-length"
-	path = /obj/item/clothing/shoes/boots/jackboots/thigh
-	cost = 2
+/datum/gear/shoes/jackboots/New()
+	..()
+	var/list/jacks = list()
+	for(var/jack in typesof(/obj/item/clothing/shoes/boots/jackboots))
+		var/obj/item/clothing/shoes/boots/jackboots/jack_type = jack
+		jacks[initial(jack_type.name)] = jack_type
+	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(jacks))
 
 /datum/gear/shoes/workboots
 	display_name = "workboots"
@@ -30,17 +29,25 @@
 	path = /obj/item/clothing/shoes/boots/workboots/toeless
 	cost = 2
 
-/datum/gear/shoes/black
-	display_name = "shoes, black"
+/datum/gear/shoes/colored
+	display_name = "shoes, colored selection"
 	path = /obj/item/clothing/shoes/black
 
-/datum/gear/shoes/blue
-	display_name = "shoes, blue"
-	path = /obj/item/clothing/shoes/blue
+/datum/gear/shoes/colored/New()
+	..()
+	var/shoetype = list()
+	shoetype["shoes, black"] = /obj/item/clothing/shoes/black
+	shoetype["shoes, blue"] = /obj/item/clothing/shoes/blue
+	shoetype["shoes, brown"] = /obj/item/clothing/shoes/brown
+	shoetype["shoes, green"] = /obj/item/clothing/shoes/green
+	shoetype["shoes, orange"] = /obj/item/clothing/shoes/orange
+	shoetype["shoes, purple"] = /obj/item/clothing/shoes/purple
+	shoetype["shoes, rainbow"] = /obj/item/clothing/shoes/rainbow
+	shoetype["shoes, red"] = /obj/item/clothing/shoes/red
+	shoetype["shoes, white"] = /obj/item/clothing/shoes/white
+	shoetype["shoes, yellow"] = /obj/item/clothing/shoes/yellow
 
-/datum/gear/shoes/brown
-	display_name = "shoes, brown"
-	path = /obj/item/clothing/shoes/brown
+	gear_tweaks += new/datum/gear_tweak/path(shoetype)
 
 /datum/gear/shoes/lacey
 	display_name = "shoes, oxford selection"
@@ -53,34 +60,6 @@
         var/obj/item/clothing/shoes/laceup/lace_type = lace
         laces[initial(lace_type.name)] = lace_type
     gear_tweaks += new/datum/gear_tweak/path(sortAssoc(laces))
-
-/datum/gear/shoes/green
-	display_name = "shoes, green"
-	path = /obj/item/clothing/shoes/green
-
-/datum/gear/shoes/orange
-	display_name = "shoes, orange"
-	path = /obj/item/clothing/shoes/orange
-
-/datum/gear/shoes/purple
-	display_name = "shoes, purple"
-	path = /obj/item/clothing/shoes/purple
-
-/datum/gear/shoes/rainbow
-	display_name = "shoes, rainbow"
-	path = /obj/item/clothing/shoes/rainbow
-
-/datum/gear/shoes/red
-	display_name = "shoes, red"
-	path = /obj/item/clothing/shoes/red
-
-/datum/gear/shoes/white
-	display_name = "shoes, white"
-	path = /obj/item/clothing/shoes/white
-
-/datum/gear/shoes/yellow
-	display_name = "shoes, yellow"
-	path = /obj/item/clothing/shoes/yellow
 
 /datum/gear/shoes/hitops
 	display_name = "shoes, high-top selection"
@@ -119,7 +98,7 @@
 	gear_tweaks += gear_tweak_free_color_choice
 
 /datum/gear/shoes/flats
-	display_name = "flats"
+	display_name = "shoes, flats (colorable)"
 	path = /obj/item/clothing/shoes/flats/white/color
 
 /datum/gear/shoes/flats/New()
@@ -169,47 +148,24 @@
 	path = /obj/item/clothing/shoes/slippers
 
 /datum/gear/shoes/boots/winter
-	display_name = "winter boots"
+	display_name = "winter boots selection"
 	path = /obj/item/clothing/shoes/boots/winter
 
-/datum/gear/shoes/boots/winter/security
-	display_name = "winter boots, security"
-	path = /obj/item/clothing/shoes/boots/winter/security
-	allowed_roles = list("Security Officer", "Head of Security", "Warden", "Detective")
+/datum/gear/shoes/boots/winter/New()
+	..()
+	var/boottype = list()
+	boottype["winter boots, atmospherics"] = /obj/item/clothing/shoes/boots/winter/atmos
+	boottype["winter boots, brown"] = /obj/item/clothing/shoes/boots/winter
+	boottype["winter boots, engineering"] = /obj/item/clothing/shoes/boots/winter/engineering
+	boottype["winter boots, hydroponics"] = /obj/item/clothing/shoes/boots/winter/hydro
+	boottype["winter boots, management"] = /obj/item/clothing/shoes/boots/winter/command
+	boottype["winter boots, medical"] = /obj/item/clothing/shoes/boots/winter/medical
+	boottype["winter boots, mining"] = /obj/item/clothing/shoes/boots/winter/mining
+	boottype["winter boots, science"] = /obj/item/clothing/shoes/boots/winter/science
+	boottype["winter boots, security"] = /obj/item/clothing/shoes/boots/winter/security
+	boottype["winter boots, supply"] = /obj/item/clothing/shoes/boots/winter/supply
 
-/datum/gear/shoes/boots/winter/science
-	display_name = "winter boots, science"
-	path = /obj/item/clothing/shoes/boots/winter/science
-
-/datum/gear/shoes/boots/winter/command
-	display_name = "winter boots, site manager"
-	path = /obj/item/clothing/shoes/boots/winter/command
-	allowed_roles = list("Site Manager")
-
-/datum/gear/shoes/boots/winter/engineering
-	display_name = "winter boots, engineering"
-	path = /obj/item/clothing/shoes/boots/winter/engineering
-
-/datum/gear/shoes/boots/winter/atmos
-	display_name = "winter boots, atmospherics"
-	path = /obj/item/clothing/shoes/boots/winter/atmos
-
-/datum/gear/shoes/boots/winter/medical
-	display_name = "winter boots, medical"
-	path = /obj/item/clothing/shoes/boots/winter/medical
-
-/datum/gear/shoes/boots/winter/mining
-	display_name = "winter boots, mining"
-	path = /obj/item/clothing/shoes/boots/winter/mining
-
-/datum/gear/shoes/boots/winter/supply
-	display_name = "winter boots, supply"
-	path = /obj/item/clothing/shoes/boots/winter/supply
-
-/datum/gear/shoes/boots/winter/hydro
-	display_name = "winter boots, hydroponics"
-	path = /obj/item/clothing/shoes/boots/winter/hydro
-
+	gear_tweaks += new/datum/gear_tweak/path(boottype)
 /datum/gear/shoes/circuitry
 	display_name = "boots, circuitry (empty)"
 	path = /obj/item/clothing/shoes/circuitry

--- a/code/modules/client/preference_setup/loadout/loadout_suit.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_suit.dm
@@ -353,7 +353,7 @@
 	path = /obj/item/clothing/suit/storage/insulated
 	cost = 2
 
-/datum/gear/suit/insulted/New()
+/datum/gear/suit/insulated/New()
 	..()
 	var/list/insulated_jackets = list()
 	for(var/insulated_jacket_style in typesof(/obj/item/clothing/suit/storage/insulated))

--- a/code/modules/client/preference_setup/loadout/loadout_suit.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_suit.dm
@@ -33,55 +33,44 @@
 	cost = 2
 
 /datum/gear/suit/bomber
-	display_name = "bomber jacket"
+	display_name = "jacket, bomber selection"
 	path = /obj/item/clothing/suit/storage/toggle/bomber
 	cost = 2
 
-/datum/gear/suit/bomber_alt
-	display_name = "bomber jacket 2"
-	path = /obj/item/clothing/suit/storage/bomber/alt
-	cost = 2
-
-/datum/gear/suit/bomber_retro
-	display_name = "bomber jacket, retro"
-	path = /obj/item/clothing/suit/storage/toggle/bomber/retro
-	cost = 2
+/datum/gear/suit/bomber/New()
+	..()
+	var/bombertype = list()
+	bombertype["bomber jacket"] = /obj/item/clothing/suit/storage/toggle/bomber
+	bombertype["bomber jacket, alternate"] = /obj/item/clothing/suit/storage/bomber/alt
+	bombertype["bomber jacket, retro"] = /obj/item/clothing/suit/storage/toggle/bomber/retro
+	gear_tweaks += new/datum/gear_tweak/path(bombertype)
 
 /datum/gear/suit/leather_jacket
-	display_name = "leather jacket, black"
+	display_name = "jacket, leather selection"
 	path = /obj/item/clothing/suit/storage/toggle/leather_jacket
 
-/datum/gear/suit/leather_jacket_sleeveless
-	display_name = "leather vest, black"
+/datum/gear/suit/leather_jacket/New()
+	..()
+	var/ljtype = list()
+	ljtype["leather jacket, black"] = /obj/item/clothing/suit/storage/toggle/leather_jacket
+	ljtype["leather jacket, alternate black"] = /obj/item/clothing/suit/storage/leather_jacket_alt
+	ljtype["leather jacket, corporate black"] = /obj/item/clothing/suit/storage/toggle/leather_jacket/nanotrasen
+	ljtype["leather jacket, brown"] = /obj/item/clothing/suit/storage/toggle/brown_jacket
+	ljtype["leather jacket, corporate brown"] = /obj/item/clothing/suit/storage/toggle/brown_jacket/nanotrasen
+	gear_tweaks += new/datum/gear_tweak/path(ljtype)
+
+/datum/gear/suit/leather_vest
+	display_name = "jacket, leather vest selection"
 	path = /obj/item/clothing/suit/storage/toggle/leather_jacket/sleeveless
 
-/datum/gear/suit/leather_jacket_alt
-	display_name = "leather jacket 2, black"
-	path = /obj/item/clothing/suit/storage/leather_jacket_alt
-
-/datum/gear/suit/leather_jacket_nt
-	display_name = "leather jacket, corporate, black"
-	path = /obj/item/clothing/suit/storage/toggle/leather_jacket/nanotrasen
-
-/datum/gear/suit/leather_jacket_nt/sleeveless
-	display_name = "leather vest, corporate, black"
-	path = /obj/item/clothing/suit/storage/toggle/leather_jacket/nanotrasen/sleeveless
-
-/datum/gear/suit/brown_jacket
-	display_name = "leather jacket, brown"
-	path = /obj/item/clothing/suit/storage/toggle/brown_jacket
-
-/datum/gear/suit/brown_jacket_sleeveless
-	display_name = "leather vest, brown"
-	path = /obj/item/clothing/suit/storage/toggle/brown_jacket/sleeveless
-
-/datum/gear/suit/brown_jacket_nt
-	display_name = "leather jacket, corporate, brown"
-	path = /obj/item/clothing/suit/storage/toggle/brown_jacket/nanotrasen
-
-/datum/gear/suit/brown_jacket_nt/sleeveless
-	display_name = "leather vest, corporate, brown"
-	path = /obj/item/clothing/suit/storage/toggle/brown_jacket/nanotrasen/sleeveless
+/datum/gear/suit/leather_vest/New()
+	..()
+	var/lvtype = list()
+	lvtype["leather vest, black"] = /obj/item/clothing/suit/storage/toggle/leather_jacket/sleeveless
+	lvtype["leather vest, corporate black"] = /obj/item/clothing/suit/storage/toggle/leather_jacket/nanotrasen/sleeveless
+	lvtype["leather vest, brown"] = /obj/item/clothing/suit/storage/toggle/brown_jacket/sleeveless
+	lvtype["leather vest, corporate brown"] = /obj/item/clothing/suit/storage/toggle/brown_jacket/nanotrasen/sleeveless
+	gear_tweaks += new/datum/gear_tweak/path(lvtype)
 
 /datum/gear/suit/mil
 	display_name = "military jacket selection"
@@ -99,16 +88,19 @@
 	display_name = "jacket, grey"
 	path = /obj/item/clothing/suit/storage/greyjacket
 
-/datum/gear/suit/brown_trenchcoat
-	display_name = "trenchcoat, brown"
+/datum/gear/suit/trenchcoat
+	display_name = "trenchcoat selection"
 	path = /obj/item/clothing/suit/storage/trench
 
-/datum/gear/suit/grey_trenchcoat
-	display_name = "trenchcoat, grey"
-	path = /obj/item/clothing/suit/storage/trench/grey
+/datum/gear/suit/trenchcoat/New()
+	..()
+	var/coattype = list()
+	coattype["trenchcoat, brown"] = /obj/item/clothing/suit/storage/trench
+	coattype["trenchcoat, grey"] = /obj/item/clothing/suit/storage/trench/grey
+	gear_tweaks += new/datum/gear_tweak/path(coattype)
 
 /datum/gear/suit/duster
-	display_name = "cowboy duster"
+	display_name = "cowboy duster (colorable)"
 	path = /obj/item/clothing/suit/storage/duster
 
 /datum/gear/suit/duster/New()
@@ -141,41 +133,23 @@
 	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(hoodies))
 
 /datum/gear/suit/labcoat
-	display_name = "labcoat"
+	display_name = "labcoat, colored selection"
 	path = /obj/item/clothing/suit/storage/toggle/labcoat
 	cost = 2
 
-/datum/gear/suit/labcoat/blue
-	display_name = "labcoat, blue"
-	path = /obj/item/clothing/suit/storage/toggle/labcoat/blue
-
-/datum/gear/suit/labcoat/blue_edge
-	display_name = "labcoat, blue-edged"
-	path = /obj/item/clothing/suit/storage/toggle/labcoat/blue_edge
-
-/datum/gear/suit/labcoat/green
-	display_name = "labcoat, green"
-	path = /obj/item/clothing/suit/storage/toggle/labcoat/green
-
-/datum/gear/suit/labcoat/orange
-	display_name = "labcoat, orange"
-	path = /obj/item/clothing/suit/storage/toggle/labcoat/orange
-
-/datum/gear/suit/labcoat/purple
-	display_name = "labcoat, purple"
-	path = /obj/item/clothing/suit/storage/toggle/labcoat/purple
-
-/datum/gear/suit/labcoat/pink
-	display_name = "labcoat, pink"
-	path = /obj/item/clothing/suit/storage/toggle/labcoat/pink
-
-/datum/gear/suit/labcoat/red
-	display_name = "labcoat, red"
-	path = /obj/item/clothing/suit/storage/toggle/labcoat/red
-
-/datum/gear/suit/labcoat/yellow
-	display_name = "labcoat, yellow"
-	path = /obj/item/clothing/suit/storage/toggle/labcoat/yellow
+/datum/gear/suit/labcoat/New()
+	..()
+	var/labcoattype = list()
+	labcoattype["labcoat, white"] = /obj/item/clothing/suit/storage/toggle/labcoat
+	labcoattype["labcoat, blue"] = /obj/item/clothing/suit/storage/toggle/labcoat/blue
+	labcoattype["labcoat, blue-edged"] = /obj/item/clothing/suit/storage/toggle/labcoat/blue_edge
+	labcoattype["labcoat, green"] = /obj/item/clothing/suit/storage/toggle/labcoat/green
+	labcoattype["labcoat, orange"] = /obj/item/clothing/suit/storage/toggle/labcoat/orange
+	labcoattype["labcoat, pink"] = /obj/item/clothing/suit/storage/toggle/labcoat/pink
+	labcoattype["labcoat, purple"] = /obj/item/clothing/suit/storage/toggle/labcoat/purple
+	labcoattype["labcoat, red"] = /obj/item/clothing/suit/storage/toggle/labcoat/red
+	labcoattype["labcoat, yellow"] = /obj/item/clothing/suit/storage/toggle/labcoat/yellow
+	gear_tweaks += new/datum/gear_tweak/path(labcoattype)
 
 /datum/gear/suit/labcoat/rd
 	display_name = "labcoat, research director (RD)"
@@ -208,97 +182,22 @@
 /datum/gear/suit/poncho/New()
 	..()
 	var/list/ponchos = list()
-	for(var/poncho_style in (typesof(/obj/item/clothing/accessory/poncho) - typesof(/obj/item/clothing/accessory/poncho/roles)))
+	for(var/poncho_style in (typesof(/obj/item/clothing/accessory/poncho) - typesof(/obj/item/clothing/accessory/poncho/roles/cloak)))
 		var/obj/item/clothing/accessory/poncho/poncho = poncho_style
 		ponchos[initial(poncho.name)] = poncho
 	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(ponchos))
 
-/datum/gear/suit/roles/poncho
-	display_name = "poncho, cargo"
-	path = /obj/item/clothing/accessory/poncho/roles/cargo
-
-/datum/gear/suit/roles/poncho/security
-	display_name = "poncho, security"
-	path = /obj/item/clothing/accessory/poncho/roles/security
-
-/datum/gear/suit/roles/poncho/medical
-	display_name = "poncho, medical"
-	path = /obj/item/clothing/accessory/poncho/roles/medical
-
-/datum/gear/suit/roles/poncho/engineering
-	display_name = "poncho, engineering"
-	path = /obj/item/clothing/accessory/poncho/roles/engineering
-
-/datum/gear/suit/roles/poncho/science
-	display_name = "poncho, science"
-	path = /obj/item/clothing/accessory/poncho/roles/science
-
-/datum/gear/suit/roles/poncho/cloak/hos
-	display_name = "cloak, head of security"
-	path = /obj/item/clothing/accessory/poncho/roles/cloak/hos
-	allowed_roles = list("Head of Security")
-
-/datum/gear/suit/roles/poncho/cloak/cmo
-	display_name = "cloak, chief medical officer"
-	path = /obj/item/clothing/accessory/poncho/roles/cloak/cmo
-	allowed_roles = list("Chief Medical Officer")
-
-/datum/gear/suit/roles/poncho/cloak/ce
-	display_name = "cloak, chief engineer"
-	path = /obj/item/clothing/accessory/poncho/roles/cloak/ce
-	allowed_roles = list("Chief Engineer")
-
-/datum/gear/suit/roles/poncho/cloak/rd
-	display_name = "cloak, research director"
-	path = /obj/item/clothing/accessory/poncho/roles/cloak/rd
-	allowed_roles = list("Research Director")
-
-/datum/gear/suit/roles/poncho/cloak/qm
-	display_name = "cloak, quartermaster"
-	path = /obj/item/clothing/accessory/poncho/roles/cloak/qm
-	allowed_roles = list("Quartermaster")
-
-/datum/gear/suit/roles/poncho/cloak/captain
-	display_name = "cloak, site manager"
-	path = /obj/item/clothing/accessory/poncho/roles/cloak/captain
-	allowed_roles = list("Site Manager")
-
-/datum/gear/suit/roles/poncho/cloak/hop
-	display_name = "cloak, head of personnel"
-	path = /obj/item/clothing/accessory/poncho/roles/cloak/hop
-	allowed_roles = list("Head of Personnel")
-
-/datum/gear/suit/roles/poncho/cloak/cargo
-	display_name = "cloak, cargo"
+/datum/gear/suit/roles/poncho/cloak
+	display_name = "cloak, departmental selection"
 	path = /obj/item/clothing/accessory/poncho/roles/cloak/cargo
 
-/datum/gear/suit/roles/poncho/cloak/mining
-	display_name = "cloak, mining"
-	path = /obj/item/clothing/accessory/poncho/roles/cloak/mining
-
-/datum/gear/suit/roles/poncho/cloak/security
-	display_name = "cloak, security"
-	path = /obj/item/clothing/accessory/poncho/roles/cloak/security
-
-/datum/gear/suit/roles/poncho/cloak/service
-	display_name = "cloak, service"
-	path = /obj/item/clothing/accessory/poncho/roles/cloak/service
-
-/datum/gear/suit/roles/poncho/cloak/engineer
-	display_name = "cloak, engineer"
-	path = /obj/item/clothing/accessory/poncho/roles/cloak/engineer
-
-/datum/gear/suit/roles/poncho/cloak/atmos
-	display_name = "cloak, atmos"
-	path = /obj/item/clothing/accessory/poncho/roles/cloak/atmos
-
-/datum/gear/suit/roles/poncho/cloak/research
-	display_name = "cloak, science"
-	path = /obj/item/clothing/accessory/poncho/roles/cloak/research
-
-/datum/gear/suit/roles/poncho/cloak/medical
-	display_name = "cloak, medical"
-	path = /obj/item/clothing/accessory/poncho/roles/cloak/medical
+/datum/gear/suit/roles/poncho/cloak/New()
+	..()
+	var/list/cloaks = list()
+	for(var/cloak_style in (typesof(/obj/item/clothing/accessory/poncho/roles/cloak)))
+		var/obj/item/clothing/accessory/poncho/roles/cloak/cloak = cloak_style
+		cloaks[initial(cloak.name)] = cloak
+	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(cloaks))
 
 /datum/gear/suit/roles/poncho/cloak/custom //A colorable cloak
 	display_name = "cloak (colorable)"
@@ -312,181 +211,48 @@
 	display_name = "roughspun robe"
 	path = /obj/item/clothing/suit/unathi/robe
 
-/datum/gear/suit/black_lawyer_jacket
-	display_name = "suit jacket, black"
+/datum/gear/suit/suit_jackets
+	display_name = "suit jacket selection"
 	path = /obj/item/clothing/suit/storage/toggle/internalaffairs
 
-/datum/gear/suit/blue_lawyer_jacket
-	display_name = "suit jacket, blue"
-	path = /obj/item/clothing/suit/storage/toggle/lawyer/bluejacket
-
-/datum/gear/suit/purple_lawyer_jacket
-	display_name = "suit jacket, purple"
-	path = /obj/item/clothing/suit/storage/toggle/lawyer/purpjacket
+/datum/gear/suit/suit_jackets/New()
+	..()
+	var/jackettype = list()
+	jackettype["suit jacket, black"] = /obj/item/clothing/suit/storage/toggle/internalaffairs
+	jackettype["suit jacket, blue"] = /obj/item/clothing/suit/storage/toggle/lawyer/bluejacket
+	jackettype["suit jacket, purple"] = /obj/item/clothing/suit/storage/toggle/lawyer/purpjacket
+	gear_tweaks += new/datum/gear_tweak/path(jackettype)
 
 /datum/gear/suit/suspenders
 	display_name = "suspenders"
 	path = /obj/item/clothing/suit/suspenders
 
 /datum/gear/suit/forensics
-	display_name = "forensics long, red"
+	display_name = "jacket, forensics selection (Detective)"
 	path = /obj/item/clothing/suit/storage/forensics/red/long
 	allowed_roles = list("Detective")
 
-/datum/gear/suit/forensics/blue
-	display_name = "forensics long, blue"
-	path = /obj/item/clothing/suit/storage/forensics/blue/long
-	allowed_roles = list("Detective")
-
-/datum/gear/suit/forensics/blue/short
-	display_name = "forensics, blue"
-	path = /obj/item/clothing/suit/storage/forensics/blue
-	allowed_roles = list("Detective")
-
-/datum/gear/suit/forensics/red/short
-	display_name = "forensics, red"
-	path = /obj/item/clothing/suit/storage/forensics/red
-	allowed_roles = list("Detective")
-
-// winter coats go here
+/datum/gear/suit/forensics/New()
+	..()
+	var/jackettype = list()
+	jackettype["forensics jacket, red long"] = /obj/item/clothing/suit/storage/forensics/red/long
+	jackettype["forensics jacket, red short"] = /obj/item/clothing/suit/storage/forensics/red
+	jackettype["forensics jacket, blue long"] = /obj/item/clothing/suit/storage/forensics/blue/long
+	jackettype["forensics jacket, blue short"] = /obj/item/clothing/suit/storage/forensics/blue
+	gear_tweaks += new/datum/gear_tweak/path(jackettype)
 
 /datum/gear/suit/wintercoat
-	display_name = "winter coat"
+	display_name = "winter coat selection"
 	path = /obj/item/clothing/suit/storage/hooded/wintercoat
 	cost = 2
 
-/datum/gear/suit/wintercoat/captain
-	display_name = "winter coat, site manager"
-	path = /obj/item/clothing/suit/storage/hooded/wintercoat/captain
-	allowed_roles = list("Site Manager")
-
-/datum/gear/suit/wintercoat/hop
-	display_name = "winter coat, head of personnel"
-	path = /obj/item/clothing/suit/storage/hooded/wintercoat/hop
-	allowed_roles = list("Head of Personnel")
-
-/datum/gear/suit/wintercoat/security
-	display_name = "winter coat, security"
-	path = /obj/item/clothing/suit/storage/hooded/wintercoat/security
-	allowed_roles = list("Security Officer", "Head of Security", "Warden", "Detective")
-
-/datum/gear/suit/wintercoat/security/hos
-	display_name = "winter coat, head of security"
-	path = /obj/item/clothing/suit/storage/hooded/wintercoat/security/hos
-	allowed_roles = list("Head of Security")
-
-/datum/gear/suit/wintercoat/medical
-	display_name = "winter coat, medical"
-	path = /obj/item/clothing/suit/storage/hooded/wintercoat/medical
-	allowed_roles = list("Medical Doctor","Chief Medical Officer","Chemist","Paramedic","Geneticist", "Psychiatrist", "Field Medic")
-
-/datum/gear/suit/wintercoat/medical/alt
-	display_name = "winter coat, medical alt"
-	path = /obj/item/clothing/suit/storage/hooded/wintercoat/medical/alt
-	allowed_roles = list("Medical Doctor","Chief Medical Officer","Chemist","Paramedic","Geneticist", "Psychiatrist", "Field Medic")
-
-/datum/gear/suit/wintercoat/medical/viro
-	display_name = "winter coat, virologist"
-	path = /obj/item/clothing/suit/storage/hooded/wintercoat/medical/viro
-	allowed_roles = list("Medical Doctor","Chief Medical Officer")
-
-/datum/gear/suit/wintercoat/medical/para
-	display_name = "winter coat, paramedic"
-	path = /obj/item/clothing/suit/storage/hooded/wintercoat/medical/para
-	allowed_roles = list("Medical Doctor","Chief Medical Officer","Paramedic")
-
-/datum/gear/suit/wintercoat/medical/chemist
-	display_name = "winter coat, chemist"
-	path = /obj/item/clothing/suit/storage/hooded/wintercoat/medical/chemist
-	allowed_roles = list("Chief Medical Officer","Chemist")
-
-/datum/gear/suit/wintercoat/medical/cmo
-	display_name = "winter coat, chief medical officer"
-	path = /obj/item/clothing/suit/storage/hooded/wintercoat/medical/cmo
-	allowed_roles = list("Chief Medical Officer")
-
-/datum/gear/suit/wintercoat/medical/sar
-	display_name = "winter coat, search and rescue"
-	path = /obj/item/clothing/suit/storage/hooded/wintercoat/medical/sar
-	allowed_roles = list("Chief Medical Officer", "Field Medic")
-
-/datum/gear/suit/wintercoat/science
-	display_name = "winter coat, science"
-	path = /obj/item/clothing/suit/storage/hooded/wintercoat/science
-	allowed_roles = list("Research Director","Scientist", "Roboticist", "Xenobiologist", "Xenobotanist")
-
-/datum/gear/suit/wintercoat/science/robotics
-	display_name = "winter coat, robotics"
-	path = /obj/item/clothing/suit/storage/hooded/wintercoat/science/robotics
-	allowed_roles = list("Research Director", "Roboticist")
-
-/datum/gear/suit/wintercoat/science/rd
-	display_name = "winter coat, research director"
-	path = /obj/item/clothing/suit/storage/hooded/wintercoat/science/rd
-	allowed_roles = list("Research Director")
-
-/datum/gear/suit/wintercoat/engineering
-	display_name = "winter coat, engineering"
-	path = /obj/item/clothing/suit/storage/hooded/wintercoat/engineering
-	allowed_roles = list("Chief Engineer","Atmospheric Technician", "Station Engineer")
-
-/datum/gear/suit/wintercoat/engineering/atmos
-	display_name = "winter coat, atmospherics"
-	path = /obj/item/clothing/suit/storage/hooded/wintercoat/engineering/atmos
-	allowed_roles = list("Chief Engineer", "Atmospheric Technician")
-
-/datum/gear/suit/wintercoat/engineering/ce
-	display_name = "winter coat, chief engineer"
-	path = /obj/item/clothing/suit/storage/hooded/wintercoat/engineering/ce
-	allowed_roles = list("Chief Engineer")
-
-/datum/gear/suit/wintercoat/hydro
-	display_name = "winter coat, hydroponics"
-	path = /obj/item/clothing/suit/storage/hooded/wintercoat/hydro
-	allowed_roles = list("Botanist", "Xenobotanist")
-
-/datum/gear/suit/wintercoat/cargo
-	display_name = "winter coat, cargo"
-	path = /obj/item/clothing/suit/storage/hooded/wintercoat/cargo
-	allowed_roles = list("Quartermaster","Cargo Technician")
-
-/datum/gear/suit/wintercoat/miner
-	display_name = "winter coat, mining"
-	path = /obj/item/clothing/suit/storage/hooded/wintercoat/miner
-	allowed_roles = list("Shaft Miner")
-
-/datum/gear/suit/wintercoat/cargo/qm
-	display_name = "winter coat, quartermaster"
-	path = /obj/item/clothing/suit/storage/hooded/wintercoat/cargo/qm
-	allowed_roles = list("Quartermaster")
-
-/datum/gear/suit/wintercoat/bar
-	display_name = "winter coat, bartender"
-	path = /obj/item/clothing/suit/storage/hooded/wintercoat/bar
-	allowed_roles = list("Bartender")
-
-/datum/gear/suit/wintercoat/janitor
-	display_name = "winter coat, janitor"
-	path = /obj/item/clothing/suit/storage/hooded/wintercoat/janitor
-	allowed_roles = list("Janitor")
-
-/datum/gear/suit/wintercoat/aformal
-	display_name = "winter coat, assistant formal"
-	path = /obj/item/clothing/suit/storage/hooded/wintercoat/aformal
-
-/datum/gear/suit/wintercoat/ratvar
-	display_name = "winter coat, brassy"
-	path = /obj/item/clothing/suit/storage/hooded/wintercoat/ratvar
-
-/datum/gear/suit/wintercoat/narsie
-	display_name = "winter coat, runed"
-	path = /obj/item/clothing/suit/storage/hooded/wintercoat/narsie
-
-/datum/gear/suit/wintercoat/cosmic
-	display_name = "winter coat, cosmic"
-	path = /obj/item/clothing/suit/storage/hooded/wintercoat/cosmic
-
-// winter coats end here
+/datum/gear/suit/wintercoat/New()
+	..()
+	var/list/wintercoats = list()
+	for(var/wintercoat_style in (typesof(/obj/item/clothing/suit/storage/hooded/wintercoat)))
+		var/obj/item/clothing/suit/storage/hooded/wintercoat/wintercoat = wintercoat_style
+		wintercoats[initial(wintercoat.name)] = wintercoat
+	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(wintercoats))
 
 /datum/gear/suit/varsity
 	display_name = "jacket, varsity selection"
@@ -513,36 +279,28 @@
 	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(tracks))
 
 /datum/gear/suit/flannel
-	display_name = "flannel, grey"
+	display_name = "flannel selection"
 	path = /obj/item/clothing/suit/storage/flannel
 
-/datum/gear/suit/flannel/red
-	display_name = "flannel, red"
-	path = /obj/item/clothing/suit/storage/flannel/red
-
-/datum/gear/suit/flannel/aqua
-	display_name = "flannel, aqua"
-	path = /obj/item/clothing/suit/storage/flannel/aqua
-
-/datum/gear/suit/flannel/brown
-	display_name = "flannel, brown"
-	path = /obj/item/clothing/suit/storage/flannel/brown
+/datum/gear/suit/flannel/New()
+	..()
+	var/list/flannels = list()
+	for(var/flannel_style in typesof(/obj/item/clothing/suit/storage/flannel))
+		var/obj/item/clothing/suit/storage/flannel/flannel = flannel_style
+		flannels[initial(flannel.name)] = flannel
+	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(flannels))
 
 /datum/gear/suit/denim_jacket
-	display_name = "denim jacket"
+	display_name = "jacket, denim selection"
 	path = /obj/item/clothing/suit/storage/toggle/denim_jacket
 
-/datum/gear/suit/denim_jacket/corporate
-	display_name = "denim jacket, corporate"
-	path = /obj/item/clothing/suit/storage/toggle/denim_jacket/nanotrasen
-
-/datum/gear/suit/denim_vest
-	display_name = "denim vest"
-	path = /obj/item/clothing/suit/storage/toggle/denim_jacket/sleeveless
-
-/datum/gear/suit/denim_vest/corporate
-	display_name = "denim vest, corporate"
-	path = /obj/item/clothing/suit/storage/toggle/denim_jacket/nanotrasen/sleeveless
+/datum/gear/suit/denim_jacket/New()
+	..()
+	var/list/denim_jackets = list()
+	for(var/denim_jacket_style in typesof(/obj/item/clothing/suit/storage/toggle/denim_jacket))
+		var/obj/item/clothing/suit/storage/toggle/denim_jacket/denim_jacket = denim_jacket_style
+		denim_jackets[initial(denim_jacket.name)] = denim_jacket
+	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(denim_jackets))
 
 /datum/gear/suit/miscellaneous/kimono
 	display_name = "kimono"
@@ -552,28 +310,22 @@
 	..()
 	gear_tweaks += gear_tweak_free_color_choice
 
-/datum/gear/suit/miscellaneous/sec_dep_jacket
-	display_name = "department jacket, security"
+/datum/gear/suit/miscellaneous/dep_jacket
+	display_name = "jacket, departmental selection"
 	path = /obj/item/clothing/suit/storage/toggle/sec_dep_jacket
 
-/datum/gear/suit/miscellaneous/engi_dep_jacket
-	display_name = "department jacket, engineering"
-	path = /obj/item/clothing/suit/storage/toggle/engi_dep_jacket
-
-/datum/gear/suit/miscellaneous/supply_dep_jacket
-	display_name = "department jacket, supply"
-	path = /obj/item/clothing/suit/storage/toggle/supply_dep_jacket
-
-/datum/gear/suit/miscellaneous/sci_dep_jacket
-	display_name = "department jacket, science"
-	path = /obj/item/clothing/suit/storage/toggle/sci_dep_jacket
-
-/datum/gear/suit/miscellaneous/med_dep_jacket
-	display_name = "department jacket, medical"
-	path = /obj/item/clothing/suit/storage/toggle/med_dep_jacket
+/datum/gear/suit/miscellaneous/dep_jacket/New()
+	..()
+	var/jackettype = list()
+	jackettype["department jacket, engineering"] = /obj/item/clothing/suit/storage/toggle/engi_dep_jacket
+	jackettype["department jacket, medical"] = /obj/item/clothing/suit/storage/toggle/med_dep_jacket
+	jackettype["department jacket, security"] = /obj/item/clothing/suit/storage/toggle/sec_dep_jacket
+	jackettype["department jacket, science"] = /obj/item/clothing/suit/storage/toggle/sci_dep_jacket
+	jackettype["department jacket, supply"] = /obj/item/clothing/suit/storage/toggle/supply_dep_jacket
+	gear_tweaks += new/datum/gear_tweak/path(jackettype)
 
 /datum/gear/suit/miscellaneous/light_jacket
-	display_name = "light jacket selection"
+	display_name = "jacket, light selection"
 	path = /obj/item/clothing/suit/storage/toggle/light_jacket
 
 /datum/gear/suit/miscellaneous/light_jacket/New()
@@ -596,40 +348,18 @@
 	display_name = "kamishimo"
 	path = /obj/item/clothing/suit/kamishimo
 
-/datum/gear/suit/snowsuit
-	display_name = "snowsuit"
-	path = /obj/item/clothing/suit/storage/snowsuit
+/datum/gear/suit/insulted
+	display_name = "insulted jacket selection"
+	path = /obj/item/clothing/suit/storage/insulated
 	cost = 2
 
-/datum/gear/suit/snowsuit/command
-	display_name = "snowsuit, command"
-	path = /obj/item/clothing/suit/storage/snowsuit/command
-	allowed_roles = list("Site Manager","Research Director","Head of Personnel","Head of Security","Chief Engineer","Command Secretary")
-
-/datum/gear/suit/snowsuit/security
-	display_name = "snowsuit, security"
-	path = /obj/item/clothing/suit/storage/snowsuit/security
-	allowed_roles = list("Security Officer", "Head of Security", "Warden", "Detective")
-
-/datum/gear/suit/snowsuit/medical
-	display_name = "snowsuit, medical"
-	path = /obj/item/clothing/suit/storage/snowsuit/medical
-	allowed_roles = list("Medical Doctor","Chief Medical Officer","Chemist","Paramedic","Geneticist", "Psychiatrist", "Search and Rescue")
-
-/datum/gear/suit/snowsuit/science
-	display_name = "snowsuit, science"
-	path = /obj/item/clothing/suit/storage/snowsuit/science
-	allowed_roles = list("Research Director","Scientist", "Roboticist", "Xenobiologist")
-
-/datum/gear/suit/snowsuit/engineering
-	display_name = "snowsuit, engineering"
-	path = /obj/item/clothing/suit/storage/snowsuit/engineering
-	allowed_roles = list("Chief Engineer","Atmospheric Technician", "Station Engineer")
-
-/datum/gear/suit/snowsuit/cargo
-	display_name = "snowsuit, supply"
-	path = /obj/item/clothing/suit/storage/snowsuit/cargo
-	allowed_roles = list("Quartermaster","Shaft Miner","Cargo Technician","Head of Personnel")
+/datum/gear/suit/insulted/New()
+	..()
+	var/list/insulated_jackets = list()
+	for(var/insulated_jacket_style in typesof(/obj/item/clothing/suit/storage/insulated))
+		var/obj/item/clothing/suit/storage/insulated/insulated_jacket = insulated_jacket_style
+		insulated_jackets[initial(insulated_jacket.name)] = insulated_jacket
+	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(insulated_jackets))
 
 /datum/gear/suit/miscellaneous/cardigan
 	display_name = "cardigan"

--- a/code/modules/client/preference_setup/loadout/loadout_uniform.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_uniform.dm
@@ -303,7 +303,6 @@
 	var/hosunitype = list()
 	hosunitype["HoS uniform, corporate"] = /obj/item/clothing/under/rank/head_of_security/corp
 	hosunitype["HoS uniform, navy"] = /obj/item/clothing/under/rank/head_of_security/navyblue
-	hosunitype["detective uniform, corporate"] = /obj/item/clothing/under/det/corporate
 	gear_tweaks += new/datum/gear_tweak/path(hosunitype)
 
 /datum/gear/uniform/uniform_hop
@@ -397,7 +396,7 @@
 /datum/gear/uniform/brandsuit/New()
 	..()
 	var/list/brandsuits = list()
-	for(var/brandsuit in typesof(/obj/item/clothing/under/corp))
+	for(var/brandsuit in typesof(/obj/item/clothing/under/corp, /obj/item/clothing/under/hedbergtech))
 		var/obj/item/clothing/under/corp/brandsuit_type = brandsuit
 		brandsuits[initial(brandsuit_type.name)] = brandsuit_type
 	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(brandsuits))

--- a/code/modules/client/preference_setup/loadout/loadout_uniform.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_uniform.dm
@@ -102,7 +102,7 @@
 	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(pants))
 
 /datum/gear/uniform/shorts
-	display_name = "shorts selection"
+	display_name = "shorts, selection"
 	path = /obj/item/clothing/under/shorts/jeans
 
 /datum/gear/uniform/shorts/New()
@@ -113,60 +113,26 @@
 		shorts[initial(short_type.name)] = short_type
 	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(shorts))
 
-/datum/gear/uniform/job_skirt/ce
-	display_name = "skirt, ce"
+/datum/gear/uniform/job_skirt
+	display_name = "skirt, job selection"
+	description = "Skirt options for standard job uniforms."
 	path = /obj/item/clothing/under/rank/chief_engineer/skirt
-	allowed_roles = list("Chief Engineer")
 
-/datum/gear/uniform/job_skirt/atmos
-	display_name = "skirt, atmos"
-	path = /obj/item/clothing/under/rank/atmospheric_technician/skirt
-	allowed_roles = list("Chief Engineer","Atmospheric Technician")
-
-/datum/gear/uniform/job_skirt/eng
-	display_name = "skirt, engineer"
-	path = /obj/item/clothing/under/rank/engineer/skirt
-	allowed_roles = list("Chief Engineer","Station Engineer")
-
-/datum/gear/uniform/job_skirt/roboticist
-	display_name = "skirt, roboticist"
-	path = /obj/item/clothing/under/rank/roboticist/skirt
-	allowed_roles = list("Research Director","Roboticist")
-
-/datum/gear/uniform/job_skirt/cmo
-	display_name = "skirt, cmo"
-	path = /obj/item/clothing/under/rank/chief_medical_officer/skirt
-	allowed_roles = list("Chief Medical Officer")
-
-/datum/gear/uniform/job_skirt/chem
-	display_name = "skirt, chemist"
-	path = /obj/item/clothing/under/rank/chemist/skirt
-	allowed_roles = list("Chief Medical Officer","Chemist")
-
-/datum/gear/uniform/job_skirt/viro
-	display_name = "skirt, virologist"
-	path = /obj/item/clothing/under/rank/virologist/skirt
-	allowed_roles = list("Chief Medical Officer","Medical Doctor")
-
-/datum/gear/uniform/job_skirt/med
-	display_name = "skirt, medical"
-	path = /obj/item/clothing/under/rank/medical/skirt
-	allowed_roles = list("Chief Medical Officer","Medical Doctor","Chemist","Psychiatrist","Paramedic")
-
-/datum/gear/uniform/job_skirt/sci
-	display_name = "skirt, scientist"
-	path = /obj/item/clothing/under/rank/scientist/skirt
-	allowed_roles = list("Research Director","Scientist", "Xenobiologist")
-
-/datum/gear/uniform/job_skirt/cargo
-	display_name = "skirt, cargo"
-	path = /obj/item/clothing/under/rank/cargotech/skirt
-	allowed_roles = list("Quartermaster","Cargo Technician")
-
-/datum/gear/uniform/job_skirt/qm
-	display_name = "skirt, QM"
-	path = /obj/item/clothing/under/rank/cargo/skirt
-	allowed_roles = list("Quartermaster")
+/datum/gear/uniform/job_skirt/New()
+	..()
+	var/skirttype = list()
+	skirttype["skirt, chief engineer"] = /obj/item/clothing/under/rank/chief_engineer/skirt
+	skirttype["skirt, atmospheric technician"] = /obj/item/clothing/under/rank/atmospheric_technician/skirt
+	skirttype["skirt, engineer"] = /obj/item/clothing/under/rank/engineer/skirt
+	skirttype["skirt, roboticist"] = /obj/item/clothing/under/rank/roboticist/skirt
+	skirttype["skirt, CMO"] = /obj/item/clothing/under/rank/chief_medical_officer/skirt
+	skirttype["skirt, chemist"] = /obj/item/clothing/under/rank/chemist/skirt
+	skirttype["skirt, virologist"] = /obj/item/clothing/under/rank/virologist/skirt
+	skirttype["skirt, medical"] = /obj/item/clothing/under/rank/medical/skirt
+	skirttype["skirt, scientist"] = /obj/item/clothing/under/rank/scientist/skirt
+	skirttype["skirt, cargo"] = /obj/item/clothing/under/rank/cargotech/skirt
+	skirttype["skirt, quartermaster"] = /obj/item/clothing/under/rank/cargotech/skirt
+	gear_tweaks += new/datum/gear_tweak/path(skirttype)
 
 /datum/gear/uniform/job_skirt/warden
 	display_name = "skirt, warden"
@@ -183,25 +149,18 @@
 	path = /obj/item/clothing/under/rank/head_of_security/skirt
 	allowed_roles = list("Head of Security")
 
-/datum/gear/uniform/job_turtle/science
-	display_name = "turtleneck, science"
+/datum/gear/uniform/job_turtle
+	display_name = "turtleneck, departmental selection"
 	path = /obj/item/clothing/under/rank/scientist/turtleneck
-	allowed_roles = list("Research Director", "Scientist", "Roboticist", "Xenobiologist")
 
-/datum/gear/uniform/job_turtle/security
-	display_name = "turtleneck, security"
-	path = /obj/item/clothing/under/rank/security/turtleneck
-	allowed_roles = list("Head of Security", "Warden", "Detective", "Security Officer")
-
-/datum/gear/uniform/job_turtle/engineering
-	display_name = "turtleneck, engineering"
-	path = /obj/item/clothing/under/rank/engineer/turtleneck
-	allowed_roles = list("Chief Engineer", "Atmospheric Technician", "Station Engineer")
-
-/datum/gear/uniform/job_turtle/medical
-	display_name = "turtleneck, medical"
-	path = /obj/item/clothing/under/rank/medical/turtleneck
-	allowed_roles = list("Chief Medical Officer", "Paramedic", "Medical Doctor", "Psychiatrist", "Search and Rescue", "Chemist")
+/datum/gear/uniform/job_turtle/New()
+	..()
+	var/turtletype = list()
+	turtletype["turtleneck, science"] = /obj/item/clothing/under/rank/scientist/turtleneck
+	turtletype["turtleneck, engineering"] = /obj/item/clothing/under/rank/engineer/turtleneck
+	turtletype["turtleneck, security"] = /obj/item/clothing/under/rank/security/turtleneck
+	turtletype["turtleneck, medical"] = /obj/item/clothing/under/rank/medical/turtleneck
+	gear_tweaks += new/datum/gear_tweak/path(turtletype)
 
 /datum/gear/uniform/jeans_qm
 	display_name = "jeans, QM"
@@ -209,7 +168,7 @@
 	allowed_roles = list("Quartermaster")
 
 /datum/gear/uniform/jeans_qmf
-	display_name = "female jeans, QM"
+	display_name = "jeans, feminine QM"
 	path = /obj/item/clothing/under/rank/cargo/jeans/female
 	allowed_roles = list("Quartermaster")
 
@@ -219,7 +178,7 @@
 	allowed_roles = list("Quartermaster","Cargo Technician")
 
 /datum/gear/uniform/jeans_cargof
-	display_name = "female jeans, cargo"
+	display_name = "jeans, feminine cargo"
 	path = /obj/item/clothing/under/rank/cargotech/jeans/female
 	allowed_roles = list("Quartermaster","Cargo Technician")
 
@@ -230,8 +189,8 @@
 /datum/gear/uniform/suit/lawyer/New()
 	..()
 	var/list/lsuits = list()
-	for(var/lsuit in typesof(/obj/item/clothing/under/lawyer))
-		var/obj/item/clothing/suit/lsuit_type = lsuit
+	for(var/lsuit in typesof(/obj/item/clothing/under/lawyer, /obj/item/clothing/under/sl_suit, /obj/item/clothing/under/gentlesuit))
+		var/obj/item/clothing/under/lsuit_type = lsuit
 		lsuits[initial(lsuit_type.name)] = lsuit_type
 	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(lsuits))
 
@@ -246,26 +205,6 @@
 		var/obj/item/clothing/suit/msuit_type = msuit
 		msuits[initial(msuit_type.name)] = msuit_type
 	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(msuits))
-
-/datum/gear/uniform/suit/amish  //amish
-	display_name = "suit, amish"
-	path = /obj/item/clothing/under/sl_suit
-
-/datum/gear/uniform/suit/gentle
-	display_name = "suit, gentlemen"
-	path = /obj/item/clothing/under/gentlesuit
-
-/datum/gear/uniform/suit/gentleskirt
-	display_name = "suit, lady"
-	path = /obj/item/clothing/under/gentlesuit/skirt
-
-/datum/gear/uniform/suit/white
-	display_name = "suit, white"
-	path = /obj/item/clothing/under/scratch
-
-/datum/gear/uniform/suit/whiteskirt
-	display_name = "suit, white skirt"
-	path = /obj/item/clothing/under/scratch/skirt
 
 /datum/gear/uniform/suit/detectiveblack
 	display_name = "suit, detective black (Detective)"
@@ -300,16 +239,24 @@
 	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(scrubs))
 
 /datum/gear/uniform/oldwoman
-	display_name = "old woman attire"
+	display_name = "outfit, old woman"
 	path = /obj/item/clothing/under/oldwoman
 
 /datum/gear/uniform/sundress
-	display_name = "sundress"
+	display_name = "sundress selection"
 	path = /obj/item/clothing/under/sundress
 
-/datum/gear/uniform/sundress/white
-	display_name = "sundress, white"
-	path = /obj/item/clothing/under/sundress_white
+/datum/gear/uniform/sundress/New()
+	..()
+	var/sdresstype = list()
+	sdresstype["sundress"] = /obj/item/clothing/under/sundress
+	sdresstype["sundress, long blue"] = /obj/item/clothing/under/dress/sundress_blue
+	sdresstype["sundress, pink"] = /obj/item/clothing/under/dress/sundress_pink
+	sdresstype["sundress, pink with bow"] = /obj/item/clothing/under/dress/sundress_pinkbow
+	sdresstype["sundress, short pink"] = /obj/item/clothing/under/dress/sundress_pinkshort
+	sdresstype["sundress, white"] = /obj/item/clothing/under/sundress_white
+	sdresstype["sundress, white alt"] = /obj/item/clothing/under/dress/sundress_white
+	gear_tweaks += new/datum/gear_tweak/path(sdresstype)
 
 /datum/gear/uniform/dress_fire
 	display_name = "dress, flame"
@@ -320,54 +267,59 @@
 	path = /obj/item/clothing/under/dress/dress_cap
 	allowed_roles = list("Site Manager")
 
-/datum/gear/uniform/corpdetsuit
-	display_name = "uniform, corporate (Detective)"
-	path = /obj/item/clothing/under/det/corporate
-	allowed_roles = list("Detective","Head of Security")
-
-/datum/gear/uniform/corpsecsuit
-	display_name = "uniform, corporate (Security)"
+/datum/gear/uniform/uniform_security
+	display_name = "uniform, security selection"
 	path = /obj/item/clothing/under/rank/security/corp
-	allowed_roles = list("Security Officer","Head of Security","Warden")
+	allowed_roles = list("Security Officer","Head of Security","Warden", "Detective")
 
-/datum/gear/uniform/corpwarsuit
-	display_name = "uniform, corporate (Warden)"
+/datum/gear/uniform/uniform_security/New()
+	..()
+	var/secunitype = list()
+	secunitype["officer uniform, corporate"] = /obj/item/clothing/under/rank/security/corp
+	secunitype["officer uniform, navy"] = /obj/item/clothing/under/rank/security/navyblue
+	secunitype["officer uniform, hedberg-hammarstrom"] = /obj/item/clothing/under/hedberg
+	secunitype["detective uniform, corporate"] = /obj/item/clothing/under/det/corporate
+	gear_tweaks += new/datum/gear_tweak/path(secunitype)
+
+/datum/gear/uniform/uniform_warden
+	display_name = "uniform, warden selection"
 	path = /obj/item/clothing/under/rank/warden/corp
 	allowed_roles = list("Head of Security","Warden")
 
-/datum/gear/uniform/corphossuit
-	display_name = "uniform, corporate (Head of Security)"
-	path = /obj/item/clothing/under/rank/head_of_security/corp
+/datum/gear/uniform/uniform_warden/New()
+	..()
+	var/warunitype = list()
+	warunitype["warden uniform, corporate"] = /obj/item/clothing/under/rank/warden/corp
+	warunitype["warden uniform, navy"] = /obj/item/clothing/under/rank/warden/navyblue
+	gear_tweaks += new/datum/gear_tweak/path(warunitype)
+
+/datum/gear/uniform/uniform_hos
+	display_name = "uniform, head of security selection"
+	path = /obj/item/clothing/under/rank/security/corp
 	allowed_roles = list("Head of Security")
+
+/datum/gear/uniform/uniform_hos/New()
+	..()
+	var/hosunitype = list()
+	hosunitype["HoS uniform, corporate"] = /obj/item/clothing/under/rank/head_of_security/corp
+	hosunitype["HoS uniform, navy"] = /obj/item/clothing/under/rank/head_of_security/navyblue
+	hosunitype["detective uniform, corporate"] = /obj/item/clothing/under/det/corporate
+	gear_tweaks += new/datum/gear_tweak/path(hosunitype)
 
 /datum/gear/uniform/uniform_hop
-	display_name = "uniform, HoP's dress"
-	path = /obj/item/clothing/under/dress/dress_hop
+	display_name = "uniform, head of personnel selection"
+	path = /obj/item/clothing/under/rank/security/corp
 	allowed_roles = list("Head of Personnel")
 
-/datum/gear/uniform/uniform_hr
-	display_name = "uniform, HR director (HoP)"
-	path = /obj/item/clothing/under/dress/dress_hr
-
-	allowed_roles = list("Head of Personnel")
-
-/datum/gear/uniform/navysecsuit
-	display_name = "uniform, navy blue (Security)"
-	path = /obj/item/clothing/under/rank/security/navyblue
-	allowed_roles = list("Security Officer","Head of Security","Warden")
-
-/datum/gear/uniform/navywarsuit
-	display_name = "uniform, navy blue (Warden)"
-	path = /obj/item/clothing/under/rank/warden/navyblue
-	allowed_roles = list("Head of Security","Warden")
-
-/datum/gear/uniform/navyhossuit
-	display_name = "uniform, navy blue (Head of Security)"
-	path = /obj/item/clothing/under/rank/head_of_security/navyblue
-	allowed_roles = list("Head of Security")
+/datum/gear/uniform/uniform_hop/New()
+	..()
+	var/hopunitype = list()
+	hopunitype["HoP dress"] = /obj/item/clothing/under/dress/dress_hop
+	hopunitype["HR director"] = /obj/item/clothing/under/dress/dress_hr
+	gear_tweaks += new/datum/gear_tweak/path(hopunitype)
 
 /datum/gear/uniform/shortplaindress
-	display_name = "dress, plain"
+	display_name = "dress, plain (colorable)"
 	path = /obj/item/clothing/under/dress/white3
 
 /datum/gear/uniform/shortplaindress/New()
@@ -375,7 +327,7 @@
 	gear_tweaks += gear_tweak_free_color_choice
 
 /datum/gear/uniform/longdress
-	display_name = "dress, long"
+	display_name = "dress, long (colorable)"
 	path = /obj/item/clothing/under/dress/white2
 
 /datum/gear/uniform/longdress/New()
@@ -383,7 +335,7 @@
 	gear_tweaks += gear_tweak_free_color_choice
 
 /datum/gear/uniform/longwidedress
-	display_name = "dress, long and wide"
+	display_name = "dress, long and wide (colorable)"
 	path = /obj/item/clothing/under/dress/white4
 
 /datum/gear/uniform/longwidedress/New()
@@ -397,10 +349,6 @@
 /datum/gear/uniform/whitewedding
 	display_name = "dress, white wedding"
 	path = /obj/item/clothing/under/wedding/bride_white
-
-/datum/gear/uniform/skirts
-	display_name = "skirt, executive"
-	path = /obj/item/clothing/under/suit_jacket/female/skirt
 
 /datum/gear/uniform/dresses
 	display_name = "dress, sailor"
@@ -423,24 +371,16 @@
 	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(maids))
 
 /datum/gear/uniform/utility
-	display_name = "utility, black"
+	display_name = "jumpsuit, utility selection"
 	path = /obj/item/clothing/under/utility
 
-/datum/gear/uniform/utility/blue
-	display_name = "utility, blue"
-	path = /obj/item/clothing/under/utility/blue
-
-/datum/gear/uniform/utility/grey
-	display_name = "utility, grey"
-	path = /obj/item/clothing/under/utility/grey
-
-/datum/gear/uniform/utility/gsa
-	display_name = "utility, galactic survey"
-	path = /obj/item/clothing/under/gsa
-
-/datum/gear/uniform/utility/gsa_work
-	display_name = "heavy utility, galactic survey"
-	path = /obj/item/clothing/under/gsa_work
+/datum/gear/uniform/utility/New()
+	..()
+	var/list/utils = list()
+	for(var/util in typesof(/obj/item/clothing/under/utility, /obj/item/clothing/under/gsa_work, /obj/item/clothing/under/gsa))
+		var/obj/item/clothing/under/util_type = util
+		utils[initial(util_type.name)] = util_type
+	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(utils))
 
 /datum/gear/uniform/sweater
 	display_name = "sweater, grey"
@@ -450,84 +390,24 @@
 	display_name = "sweater, retro"
 	path = /obj/item/clothing/under/retrosweater
 
-/datum/gear/uniform/brandsuit/aether
-	display_name = "jumpsuit, aether"
+/datum/gear/uniform/brandsuit
+	display_name = "jumpsuit/uniform, corporate selection"
 	path = /obj/item/clothing/under/corp/aether
 
-/datum/gear/uniform/brandsuit/centauri
-	display_name = "jumpsuit, centauri provisions"
-	path = /obj/item/clothing/under/corp/centauri
-
-/datum/gear/uniform/brandsuit/focal
-	display_name = "jumpsuit, focal point"
-	path = /obj/item/clothing/under/corp/focal
-
-/datum/gear/uniform/brandsuit/grayson
-	display_name = "outfit, grayson"
-	path = /obj/item/clothing/under/corp/grayson
-
-/datum/gear/uniform/brandsuit/grayson_jump
-	display_name = "jumpsuit, grayson"
-	path = /obj/item/clothing/under/corp/grayson
-
-/datum/gear/uniform/brandsuit/hedberg
-	display_name = "uniform, hedberg officer (Security)"
-	path = 	/obj/item/clothing/under/hedberg
-	allowed_roles = list("Security Officer","Head of Security","Warden")
-
-/datum/gear/uniform/brandsuit/hedbergtech
-	display_name = "jumpsuit, hedberg technician"
-	path = 	/obj/item/clothing/under/hedbergtech
-
-/datum/gear/uniform/brandsuit/hephaestus
-	display_name = "jumpsuit, hephaestus"
-	path = 	/obj/item/clothing/under/corp/hephaestus
-
-/datum/gear/uniform/brandsuit/kaleidoscope
-	display_name = "outfit, kaleidoscope (Science)"
-	path = 	/obj/item/clothing/under/corp/kaleidoscope
-	allowed_roles = list("Research Director","Scientist","Xenobiologist")
-
-/datum/gear/uniform/mbill
-	display_name = "outfit, major bill's"
-	path = /obj/item/clothing/under/corp/mbill
-
-/datum/gear/uniform/mbill_flight
-	display_name = "flight suit, major bill's"
-	path = /obj/item/clothing/under/corp/mbill_flight
-
-/datum/gear/uniform/brandsuit/morpheus
-	display_name = "jumpsuit, morpheus"
-	path = /obj/item/clothing/under/corp/morpheus
-
-/datum/gear/uniform/pcrc
-	display_name = "uniform, PCRC (Security)"
-	path = /obj/item/clothing/under/corp/pcrc
-	allowed_roles = list("Security Officer","Head of Security","Warden")
-
-/datum/gear/uniform/brandsuit/wardt
-	display_name = "jumpsuit, ward-takahashi"
-	path = /obj/item/clothing/under/corp/wardt
-
-/datum/gear/uniform/brandsuit/wulf
-	display_name = "jumpsuit, wulf"
-	path = /obj/item/clothing/under/corp/wulf
-
-/datum/gear/uniform/brandsuit/vedmed
-	display_name = "jumpsuit, vey-med (Medical)"
-	path = /obj/item/clothing/under/corp/veymed
-	allowed_roles = list("Chief Medical Officer","Medical Doctor","Chemist","Psychiatrist","Paramedic")
-
-/datum/gear/uniform/brandsuit/zenghu
-	display_name = "jumpsuit, zeng-hu"
-	path = /obj/item/clothing/under/corp/zenghu
+/datum/gear/uniform/brandsuit/New()
+	..()
+	var/list/brandsuits = list()
+	for(var/brandsuit in typesof(/obj/item/clothing/under/corp))
+		var/obj/item/clothing/under/corp/brandsuit_type = brandsuit
+		brandsuits[initial(brandsuit_type.name)] = brandsuit_type
+	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(brandsuits))
 
 /datum/gear/uniform/frontier
 	display_name = "outfit, frontier"
 	path = 	/obj/item/clothing/under/frontier
 
 /datum/gear/uniform/yogapants
-	display_name = "pants, yoga"
+	display_name = "pants, yoga (colorable)"
 	path = /obj/item/clothing/under/pants/yogapants
 
 /datum/gear/uniform/yogapants/New()
@@ -651,7 +531,7 @@
 	path = /obj/item/clothing/under/dress/revealingdress
 
 /datum/gear/uniform/rippedpunk
-	display_name = "ripped punk jeans"
+	display_name = "jeans, ripped punk"
 	path = /obj/item/clothing/under/rippedpunk
 
 /datum/gear/uniform/gothic
@@ -671,11 +551,11 @@
 	path = /obj/item/clothing/under/dress/yellowswoop
 
 /datum/gear/uniform/greenasym
-	display_name = "green asymmetrical jumpsuit"
+	display_name = "jumpsuit, green asymmetrical"
 	path = /obj/item/clothing/under/greenasym
 
 /datum/gear/uniform/cyberpunkharness
-	display_name = "cyberpunk strapped harness"
+	display_name = "outfit, cyberpunk strapped harness"
 	path = /obj/item/clothing/under/cyberpunkharness
 
 /datum/gear/uniform/whitegown
@@ -699,32 +579,12 @@
 	path = /obj/item/clothing/under/sheerblue
 
 /datum/gear/uniform/disheveled
-	display_name = "disheveled suit"
+	display_name = "suit, disheveled"
 	path = /obj/item/clothing/under/disheveled
 
 /datum/gear/uniform/orangedress
 	display_name = "dress, orange"
 	path = /obj/item/clothing/under/dress/dress_orange
-
-/datum/gear/uniform/sundress_pink
-	display_name = "sundress, pink"
-	path = /obj/item/clothing/under/dress/sundress_pink
-
-/datum/gear/uniform/sundress_white
-	display_name = "sundress, white"
-	path = /obj/item/clothing/under/dress/sundress_white
-
-/datum/gear/uniform/sundress_pinkbow
-	display_name = "sundress, bowed pink"
-	path = /obj/item/clothing/under/dress/sundress_pinkbow
-
-/datum/gear/uniform/sundress_blue
-	display_name = "sundress, long blue"
-	path = /obj/item/clothing/under/dress/sundress_blue
-
-/datum/gear/uniform/sundress_pinkshort
-	display_name = "sundress, short pink"
-	path = /obj/item/clothing/under/dress/sundress_pinkshort
 
 /datum/gear/uniform/twopiece
 	display_name = "dress, two-piece"
@@ -747,5 +607,5 @@
 	path = /obj/item/clothing/under/dress/countess
 
 /datum/gear/uniform/vampire
-	display_name = "high-waisted trousers"
+	display_name = "pants, high-waisted trousers"
 	path = /obj/item/clothing/under/hightrousers

--- a/code/modules/client/preference_setup/loadout/loadout_xeno.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_xeno.dm
@@ -93,7 +93,7 @@
 	gear_tweaks += gear_tweak_free_color_choice
 
 /datum/gear/uniform/smock
-	display_name = "smock selection (Teshari)"
+	display_name = "Teshari smock selection"
 	path = /obj/item/clothing/under/teshari/smock
 	whitelisted = SPECIES_TESHARI
 	sort_category = "Xenowear"
@@ -107,7 +107,7 @@
 	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(smocks))
 
 /datum/gear/uniform/undercoat
-	display_name = "undercoat selection (Teshari)"
+	display_name = "Teshari undercoat selection"
 	path = /obj/item/clothing/under/teshari/undercoat/standard
 	whitelisted = SPECIES_TESHARI
 	sort_category = "Xenowear"
@@ -121,7 +121,7 @@
 	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(undercoats))
 
 /datum/gear/suit/cloak
-	display_name = "cloak selection (Teshari)"
+	display_name = "Teshari cloak selection"
 	path = /obj/item/clothing/suit/storage/teshari/cloak/standard
 	whitelisted = SPECIES_TESHARI
 	sort_category = "Xenowear"
@@ -166,358 +166,33 @@
 	whitelisted = SPECIES_TESHARI
 	sort_category = "Xenowear"
 
-/datum/gear/uniform/dept/undercoat/cap
-	display_name = "undercoat, facility director (Teshari)"
-	path = /obj/item/clothing/under/teshari/undercoat/jobs/cap
-	allowed_roles = list("Facility Director")
-
-/datum/gear/uniform/dept/undercoat/hop
-	display_name = "undercoat, head of personnel (Teshari)"
+/datum/gear/uniform/dept/undercoat
+	display_name = "Teshari undercoat selection"
 	path = /obj/item/clothing/under/teshari/undercoat/jobs/hop
-	allowed_roles = list("Head of Personnel")
 
-/datum/gear/uniform/dept/undercoat/rd
-	display_name = "undercoat, research director (Teshari)"
-	path = /obj/item/clothing/under/teshari/undercoat/jobs/rd
-	allowed_roles = list("Research Director")
-
-/datum/gear/uniform/dept/undercoat/hos
-	display_name = "undercoat, head of security (Teshari)"
-	path = /obj/item/clothing/under/teshari/undercoat/jobs/hos
-	allowed_roles = list("Head of Security")
-
-/datum/gear/uniform/dept/undercoat/ce
-	display_name = "undercoat, chief engineer (Teshari)"
-	path = /obj/item/clothing/under/teshari/undercoat/jobs/ce
-	allowed_roles = list("Chief Engineer")
-
-/datum/gear/uniform/dept/undercoat/cmo
-	display_name = "undercoat, chief medical officer (Teshari)"
-	path = /obj/item/clothing/under/teshari/undercoat/jobs/cmo
-	allowed_roles = list("Chief Medical Officer")
-
-/datum/gear/uniform/dept/undercoat/qm
-	display_name = "undercoat, quartermaster (Teshari)"
-	path = /obj/item/clothing/under/teshari/undercoat/jobs/qm
-	allowed_roles = list("Quartermaster")
-
-/datum/gear/uniform/dept/undercoat/cargo
-	display_name = "undercoat, cargo (Teshari)"
-	path = /obj/item/clothing/under/teshari/undercoat/jobs/cargo
-	allowed_roles = list("Cargo Technician","Quartermaster","Shaft Miner")
-
-/datum/gear/uniform/dept/undercoat/mining
-	display_name = "undercoat, mining (Teshari)"
-	path = /obj/item/clothing/under/teshari/undercoat/jobs/mining
-	allowed_roles = list("Quartermaster","Shaft Miner")
-
-/datum/gear/uniform/dept/undercoat/security
-	display_name = "undercoat, security (Teshari)"
-	path = /obj/item/clothing/under/teshari/undercoat/jobs/sec
-	allowed_roles = list("Head of Security","Detective","Warden","Security Officer",)
-
-/datum/gear/uniform/dept/undercoat/service
-	display_name = "undercoat, service (Teshari)"
-	path = /obj/item/clothing/under/teshari/undercoat/jobs/service
-	allowed_roles = list("Head of Personnel","Bartender","Botanist","Janitor","Chef","Librarian","Chaplain")
-
-/datum/gear/uniform/dept/undercoat/engineer
-	display_name = "undercoat, engineering (Teshari)"
-	path = /obj/item/clothing/under/teshari/undercoat/jobs/engineer
-	allowed_roles = list("Chief Engineer","Station Engineer")
-
-/datum/gear/uniform/dept/undercoat/atmos
-	display_name = "undercoat, atmospherics (Teshari)"
-	path = /obj/item/clothing/under/teshari/undercoat/jobs/atmos
-	allowed_roles = list("Chief Engineer","Atmospheric Technician")
-
-/datum/gear/uniform/dept/undercoat/research
-	display_name = "undercoat, scientist (Teshari)"
-	path = /obj/item/clothing/under/teshari/undercoat/jobs/sci
-	allowed_roles = list("Research Director","Scientist", "Roboticist", "Xenobiologist")
-
-/datum/gear/uniform/dept/undercoat/robo
-	display_name = "undercoat, roboticist (Teshari)"
-	path = /obj/item/clothing/under/teshari/undercoat/jobs/robo
-	allowed_roles = list("Research Director","Roboticist")
-
-/datum/gear/uniform/dept/undercoat/medical
-	display_name = "undercoat, medical (Teshari)"
-	path = /obj/item/clothing/under/teshari/undercoat/jobs/medical
-	allowed_roles = list("Chief Medical Officer","Medical Doctor","Chemist","Paramedic","Geneticist","Psychiatrist")
-
-/datum/gear/uniform/dept/undercoat/chemistry
-	display_name = "undercoat, chemist (Teshari)"
-	path = /obj/item/clothing/under/teshari/undercoat/jobs/chemistry
-	allowed_roles = list("Chief Medical Officer","Chemist")
-
-/datum/gear/uniform/dept/undercoat/virology
-	display_name = "undercoat, virologist (Teshari)"
-	path = /obj/item/clothing/under/teshari/undercoat/jobs/viro
-	allowed_roles = list("Chief Medical Officer","Medical Doctor")
-
-/datum/gear/uniform/dept/undercoat/psych
-	display_name = "undercoat, psychiatrist (Teshari)"
-	path = /obj/item/clothing/under/teshari/undercoat/jobs/psych
-	allowed_roles = list("Chief Medical Officer","Psychiatrist")
-
-/datum/gear/uniform/dept/undercoat/paramedic
-	display_name = "undercoat, paramedic (Teshari)"
-	path = /obj/item/clothing/under/teshari/undercoat/jobs/para
-	allowed_roles = list("Chief Medical Officer","Paramedic")
-
-/datum/gear/uniform/dept/undercoat/iaa
-	display_name = "undercoat, internal affairs (Teshari)"
-	path = /obj/item/clothing/under/teshari/undercoat/jobs/iaa
-	allowed_roles = list("Internal Affairs Agent")
+/datum/gear/uniform/dept/undercoat/New()
+	..()
+	var/list/teshundercoats = list()
+	for(var/teshundercoat_style in typesof(/obj/item/clothing/under/teshari/undercoat/jobs))
+		var/obj/item/clothing/under/teshari/undercoat/jobs/teshundercoat = teshundercoat_style
+		teshundercoats[initial(teshundercoat.name)] = teshundercoat
+	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(teshundercoats))
 
 /datum/gear/suit/dept/cloak
+	display_name = "Teshari cloak selection, jobs"
 	whitelisted = SPECIES_TESHARI
 	sort_category = "Xenowear"
 
-/datum/gear/suit/dept/cloak/cap
-	display_name = "cloak, facility director (Teshari)"
-	path = /obj/item/clothing/suit/storage/teshari/cloak/jobs
-	allowed_roles = list("Facility Director")
-
-/datum/gear/suit/dept/cloak/hop
-	display_name = "cloak, head of personnel (Teshari)"
-	path = /obj/item/clothing/suit/storage/teshari/cloak/jobs/hop
-	allowed_roles = list("Head of Personnel")
-
-/datum/gear/suit/dept/cloak/rd
-	display_name = "cloak, research director (Teshari)"
-	path = /obj/item/clothing/suit/storage/teshari/cloak/jobs/rd
-	allowed_roles = list("Research Director")
-
-/datum/gear/suit/dept/cloak/hos
-	display_name = "cloak, head of security (Teshari)"
-	path = /obj/item/clothing/suit/storage/teshari/cloak/jobs/hos
-	allowed_roles = list("Head of Security")
-
-/datum/gear/suit/dept/cloak/hos/New()
+/datum/gear/suit/dept/cloak/New()
 	..()
-	var/list/cloaks = list()
-	for(var/cloak in typesof(/obj/item/clothing/suit/storage/teshari/cloak/jobs/hos,/obj/item/clothing/suit/storage/teshari/beltcloak/jobs/hos))
-		var/obj/item/clothing/suit/storage/teshari/beltcloak/jobs/cloak_type = cloak
-		cloaks[initial(cloak_type.name)] = cloak_type
-	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(cloaks))
-
-/datum/gear/suit/cloak/dept/ce
-	display_name = "cloak, chief engineer (Teshari)"
-	path = /obj/item/clothing/suit/storage/teshari/cloak/jobs/ce
-	allowed_roles = list("Chief Engineer")
-
-/datum/gear/suit/dept/cloak/ce/New()
-	..()
-	var/list/cloaks = list()
-	for(var/cloak in typesof(/obj/item/clothing/suit/storage/teshari/cloak/jobs/ce,/obj/item/clothing/suit/storage/teshari/beltcloak/jobs/ce))
-		var/obj/item/clothing/suit/storage/teshari/beltcloak/jobs/cloak_type = cloak
-		cloaks[initial(cloak_type.name)] = cloak_type
-	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(cloaks))
-
-/datum/gear/suit/dept/cloak/cmo
-	display_name = "cloak, chief medical officer (Teshari)"
-	path = /obj/item/clothing/suit/storage/teshari/cloak/jobs/cmo
-	allowed_roles = list("Chief Medical Officer")
-
-/datum/gear/suit/dept/cloak/cmo/New()
-	..()
-	var/list/cloaks = list()
-	for(var/cloak in typesof(/obj/item/clothing/suit/storage/teshari/cloak/jobs/cmo,/obj/item/clothing/suit/storage/teshari/beltcloak/jobs/cmo))
-		var/obj/item/clothing/suit/storage/teshari/beltcloak/jobs/cloak_type = cloak
-		cloaks[initial(cloak_type.name)] = cloak_type
-	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(cloaks))
-
-/datum/gear/suit/dept/cloak/qm
-	display_name = "cloak, quartermaster (Teshari)"
-	path = /obj/item/clothing/suit/storage/teshari/cloak/jobs/qm
-	allowed_roles = list("Chief Medical Officer")
-
-/datum/gear/suit/dept/cloak/qm/New()
-	..()
-	var/list/cloaks = list()
-	for(var/cloak in typesof(/obj/item/clothing/suit/storage/teshari/cloak/jobs/qm,/obj/item/clothing/suit/storage/teshari/beltcloak/jobs/qm))
-		var/obj/item/clothing/suit/storage/teshari/beltcloak/jobs/cloak_type = cloak
-		cloaks[initial(cloak_type.name)] = cloak_type
-	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(cloaks))
-
-/datum/gear/suit/dept/cloak/cargo
-	display_name = "cloak, cargo (Teshari)"
-	path = /obj/item/clothing/suit/storage/teshari/cloak/jobs/cargo
-	allowed_roles = list("Quartermaster","Shaft Miner","Cargo Technician")
-
-/datum/gear/suit/dept/cloak/cargo/New()
-	..()
-	var/list/cloaks = list()
-	for(var/cloak in typesof(/obj/item/clothing/suit/storage/teshari/cloak/jobs/cargo,/obj/item/clothing/suit/storage/teshari/beltcloak/jobs/cargo))
-		var/obj/item/clothing/suit/storage/teshari/beltcloak/jobs/cloak_type = cloak
-		cloaks[initial(cloak_type.name)] = cloak_type
-	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(cloaks))
-
-/datum/gear/suit/dept/cloak/mining
-	display_name = "cloak, mining (Teshari)"
-	path = /obj/item/clothing/suit/storage/teshari/cloak/jobs/mining
-	allowed_roles = list("Quartermaster","Shaft Miner")
-
-/datum/gear/suit/dept/cloak/mining/New()
-	..()
-	var/list/cloaks = list()
-	for(var/cloak in typesof(/obj/item/clothing/suit/storage/teshari/cloak/jobs/mining,/obj/item/clothing/suit/storage/teshari/beltcloak/jobs/mining))
-		var/obj/item/clothing/suit/storage/teshari/beltcloak/jobs/cloak_type = cloak
-		cloaks[initial(cloak_type.name)] = cloak_type
-	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(cloaks))
-
-/datum/gear/suit/dept/cloak/security
-	display_name = "cloak, security (Teshari)"
-	path = /obj/item/clothing/suit/storage/teshari/cloak/jobs/sec
-	allowed_roles = list("Head of Security","Detective","Warden","Security Officer")
-
-/datum/gear/suit/dept/cloak/security/New()
-	..()
-	var/list/cloaks = list()
-	for(var/cloak in typesof(/obj/item/clothing/suit/storage/teshari/cloak/jobs/sec,/obj/item/clothing/suit/storage/teshari/beltcloak/jobs/sec))
-		var/obj/item/clothing/suit/storage/teshari/beltcloak/jobs/cloak_type = cloak
-		cloaks[initial(cloak_type.name)] = cloak_type
-	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(cloaks))
-
-/datum/gear/suit/dept/cloak/service
-	display_name = "cloak, service (Teshari)"
-	path = /obj/item/clothing/suit/storage/teshari/cloak/jobs/service
-	allowed_roles = list("Head of Personnel","Bartender","Botanist","Janitor","Chef","Librarian","Chaplain")
-
-/datum/gear/suit/dept/cloak/service/New()
-	..()
-	var/list/cloaks = list()
-	for(var/cloak in typesof(/obj/item/clothing/suit/storage/teshari/cloak/jobs/service,/obj/item/clothing/suit/storage/teshari/beltcloak/jobs/service))
-		var/obj/item/clothing/suit/storage/teshari/beltcloak/jobs/cloak_type = cloak
-		cloaks[initial(cloak_type.name)] = cloak_type
-	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(cloaks))
-
-/datum/gear/suit/dept/cloak/engineer
-	display_name = "cloak, engineering (Teshari)"
-	path = /obj/item/clothing/suit/storage/teshari/cloak/jobs/engineer
-	allowed_roles = list("Chief Engineer","Station Engineer")
-
-/datum/gear/suit/dept/cloak/engineer/New()
-	..()
-	var/list/cloaks = list()
-	for(var/cloak in typesof(/obj/item/clothing/suit/storage/teshari/cloak/jobs/engineer,/obj/item/clothing/suit/storage/teshari/beltcloak/jobs/engineer))
-		var/obj/item/clothing/suit/storage/teshari/beltcloak/jobs/cloak_type = cloak
-		cloaks[initial(cloak_type.name)] = cloak_type
-	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(cloaks))
-
-/datum/gear/suit/dept/cloak/atmos
-	display_name = "cloak, atmospherics (Teshari)"
-	path = /obj/item/clothing/suit/storage/teshari/cloak/jobs/atmos
-	allowed_roles = list("Chief Engineer","Atmospheric Technician")
-
-/datum/gear/suit/dept/cloak/atmos/New()
-	..()
-	var/list/cloaks = list()
-	for(var/cloak in typesof(/obj/item/clothing/suit/storage/teshari/cloak/jobs/atmos,/obj/item/clothing/suit/storage/teshari/beltcloak/jobs/atmos))
-		var/obj/item/clothing/suit/storage/teshari/beltcloak/jobs/cloak_type = cloak
-		cloaks[initial(cloak_type.name)] = cloak_type
-	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(cloaks))
-
-/datum/gear/suit/dept/cloak/research
-	display_name = "cloak, scientist (Teshari)"
-	path = /obj/item/clothing/suit/storage/teshari/cloak/jobs/sci
-	allowed_roles = list("Research Director","Scientist","Roboticist","Xenobiologist")
-
-/datum/gear/suit/dept/cloak/research/New()
-	..()
-	var/list/cloaks = list()
-	for(var/cloak in typesof(/obj/item/clothing/suit/storage/teshari/cloak/jobs/sci,/obj/item/clothing/suit/storage/teshari/beltcloak/jobs/sci))
-		var/obj/item/clothing/suit/storage/teshari/beltcloak/jobs/cloak_type = cloak
-		cloaks[initial(cloak_type.name)] = cloak_type
-	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(cloaks))
-
-/datum/gear/suit/dept/cloak/robo
-	display_name = "cloak, roboticist (Teshari)"
-	path = /obj/item/clothing/suit/storage/teshari/cloak/jobs/robo
-	allowed_roles = list("Research Director","Roboticist")
-
-/datum/gear/suit/dept/cloak/robo/New()
-	..()
-	var/list/cloaks = list()
-	for(var/cloak in typesof(/obj/item/clothing/suit/storage/teshari/cloak/jobs/robo,/obj/item/clothing/suit/storage/teshari/beltcloak/jobs/robo))
-		var/obj/item/clothing/suit/storage/teshari/beltcloak/jobs/cloak_type = cloak
-		cloaks[initial(cloak_type.name)] = cloak_type
-	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(cloaks))
-
-/datum/gear/suit/dept/cloak/medical
-	display_name = "cloak, medical (Teshari)"
-	path = /obj/item/clothing/suit/storage/teshari/cloak/jobs/medical
-	allowed_roles = list("Chief Medical Officer","Medical Doctor","Chemist","Paramedic","Geneticist", "Psychiatrist")
-
-/datum/gear/suit/dept/cloak/medical/New()
-	..()
-	var/list/cloaks = list()
-	for(var/cloak in typesof(/obj/item/clothing/suit/storage/teshari/cloak/jobs/medical,/obj/item/clothing/suit/storage/teshari/beltcloak/jobs/medical))
-		var/obj/item/clothing/suit/storage/teshari/beltcloak/jobs/cloak_type = cloak
-		cloaks[initial(cloak_type.name)] = cloak_type
-	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(cloaks))
-
-/datum/gear/suit/dept/cloak/chemistry
-	display_name = "cloak, chemist (Teshari)"
-	path = /obj/item/clothing/suit/storage/teshari/cloak/jobs/chemistry
-	allowed_roles = list("Chemist")
-
-/datum/gear/suit/dept/cloak/chemistry/New()
-	..()
-	var/list/cloaks = list()
-	for(var/cloak in typesof(/obj/item/clothing/suit/storage/teshari/cloak/jobs/chemistry,/obj/item/clothing/suit/storage/teshari/beltcloak/jobs/chemistry))
-		var/obj/item/clothing/suit/storage/teshari/beltcloak/jobs/cloak_type = cloak
-		cloaks[initial(cloak_type.name)] = cloak_type
-	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(cloaks))
-
-/datum/gear/suit/dept/cloak/virology
-	display_name = "cloak, virologist (Teshari)"
-	path = /obj/item/clothing/suit/storage/teshari/cloak/jobs/viro
-	allowed_roles = list("Medical Doctor")
-
-/datum/gear/suit/dept/cloak/virology/New()
-	..()
-	var/list/cloaks = list()
-	for(var/cloak in typesof(/obj/item/clothing/suit/storage/teshari/cloak/jobs/viro,/obj/item/clothing/suit/storage/teshari/beltcloak/jobs/viro))
-		var/obj/item/clothing/suit/storage/teshari/beltcloak/jobs/cloak_type = cloak
-		cloaks[initial(cloak_type.name)] = cloak_type
-	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(cloaks))
-
-/datum/gear/suit/dept/cloak/psych
-	display_name = "cloak, psychiatrist (Teshari)"
-	path = /obj/item/clothing/suit/storage/teshari/cloak/jobs/psych
-	allowed_roles = list("Chief Medical Officer","Psychiatrist")
-
-/datum/gear/suit/dept/cloak/paramedic
-	display_name = "cloak, paramedic (Teshari)"
-	path = /obj/item/clothing/suit/storage/teshari/cloak/jobs/para
-	allowed_roles = list("Chief Medical Officer","Paramedic")
-
-/datum/gear/suit/dept/cloak/paramedic/New()
-	..()
-	var/list/cloaks = list()
-	for(var/cloak in typesof(/obj/item/clothing/suit/storage/teshari/cloak/jobs/para,/obj/item/clothing/suit/storage/teshari/beltcloak/jobs/para))
-		var/obj/item/clothing/suit/storage/teshari/beltcloak/jobs/cloak_type = cloak
-		cloaks[initial(cloak_type.name)] = cloak_type
-	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(cloaks))
-
-/datum/gear/suit/dept/cloak/iaa
-	display_name = "cloak, internal affairs (Teshari)"
-	path = /obj/item/clothing/suit/storage/teshari/cloak/jobs/iaa
-	allowed_roles = list("Internal Affairs Agent")
-
-/datum/gear/suit/dept/cloak/iaa/New()
-	..()
-	var/list/cloaks = list()
-	for(var/cloak in typesof(/obj/item/clothing/suit/storage/teshari/cloak/jobs/iaa,/obj/item/clothing/suit/storage/teshari/beltcloak/jobs/iaa))
-		var/obj/item/clothing/suit/storage/teshari/beltcloak/jobs/cloak_type = cloak
-		cloaks[initial(cloak_type.name)] = cloak_type
-	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(cloaks))
+	var/list/teshcloaks = list()
+	for(var/teshcloak_style in typesof(/obj/item/clothing/suit/storage/teshari/cloak/jobs, /obj/item/clothing/suit/storage/teshari/beltcloak/jobs))
+		var/obj/item/clothing/suit/storage/teshari/cloak/jobs/teshcloak = teshcloak_style
+		teshcloaks[initial(teshcloak.name)] = teshcloak
+	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(teshcloaks))
 
 /datum/gear/uniform/smockcolor
-	display_name = "smock, recolorable (Teshari)"
+	display_name = "Teshari smock (colorable)"
 	path = /obj/item/clothing/under/teshari/smock/white
 	whitelisted = SPECIES_TESHARI
 	sort_category = "Xenowear"
@@ -527,7 +202,7 @@
 	gear_tweaks += gear_tweak_free_color_choice
 
 /datum/gear/suit/beltcloak
-	display_name = "belted cloak, selection (Teshari)"
+	display_name = "Teshari cloak selection, belted"
 	path = /obj/item/clothing/suit/storage/teshari/beltcloak/standard
 	whitelisted = SPECIES_TESHARI
 	sort_category = "Xenowear"
@@ -541,7 +216,7 @@
 	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(cloaks))
 
 /datum/gear/suit/beltcloak_color
-	display_name = "belted cloak, recolorable (Teshari)"
+	display_name = "Teshari cloak, belted (colorable)"
 	path = /obj/item/clothing/suit/storage/teshari/beltcloak/standard/white_grey
 	whitelisted = SPECIES_TESHARI
 	sort_category = "Xenowear"
@@ -550,23 +225,8 @@
 	..()
 	gear_tweaks += gear_tweak_free_color_choice
 
-/datum/gear/suit/dept/beltcloak/wrdn
-	display_name = "belted cloak, warden (Teshari)"
-	path = /obj/item/clothing/suit/storage/teshari/beltcloak/jobs/wrdn
-	allowed_roles = list("Head of Security","Warden")
-
-/datum/gear/suit/dept/beltcloak/jani
-	display_name = "belted cloak, janitor (Teshari)"
-	path = /obj/item/clothing/suit/storage/teshari/beltcloak/jobs/jani
-	allowed_roles = list("Janitor")
-
-/datum/gear/suit/dept/beltcloak/cmd
-	display_name = "belted cloak, command (Teshari)"
-	path = /obj/item/clothing/suit/storage/teshari/beltcloak/jobs/command
-	allowed_roles = list("Site Manager","Head of Personnel","Head of Security","Chief Engineer","Chief Medical Officer","Research Director")
-
 /datum/gear/suit/cloak_hood
-	display_name = "hooded cloak selection (Teshari)"
+	display_name = "Teshari cloak selection, hooded"
 	path = /obj/item/clothing/suit/storage/hooded/teshari/standard
 	whitelisted = SPECIES_TESHARI
 	sort_category = "Xenowear"
@@ -580,7 +240,7 @@
 	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(cloaks))
 
 /datum/gear/uniform/worksuit
-	display_name = "worksuit selection (Teshari)"
+	display_name = "Teshari worksuit selection"
 	path = /obj/item/clothing/under/teshari/undercoat/standard/worksuit
 	whitelisted = SPECIES_TESHARI
 	sort_category = "Xenowear"
@@ -594,7 +254,7 @@
 	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(worksuits))
 
 /datum/gear/uniform/undercoatcolor
-	display_name = "undercoat, recolorable (Teshari)"
+	display_name = "Teshari undercoat (colorable)"
 	path = /obj/item/clothing/under/teshari/undercoat/standard/white_grey
 	whitelisted = SPECIES_TESHARI
 	sort_category = "Xenowear"
@@ -604,7 +264,7 @@
 	gear_tweaks += gear_tweak_free_color_choice
 
 /datum/gear/suit/cloakcolor
-	display_name = "cloak, recolorable (Teshari)"
+	display_name = "Teshari cloak (colorable)"
 	path = /obj/item/clothing/suit/storage/teshari/cloak/standard/white_grey
 	whitelisted = SPECIES_TESHARI
 	sort_category = "Xenowear"
@@ -614,7 +274,7 @@
 	gear_tweaks += gear_tweak_free_color_choice
 
 /datum/gear/suit/labcoat_tesh
-	display_name = "labcoat, colorable (Teshari)"
+	display_name = "Teshari labcoat (colorable)"
 	path = /obj/item/clothing/suit/storage/toggle/labcoat/teshari
 	whitelisted = SPECIES_TESHARI
 	sort_category = "Xenowear"
@@ -624,7 +284,7 @@
 	gear_tweaks += gear_tweak_free_color_choice
 
 /datum/gear/suit/teshcoat
-	display_name = "small black coat, recolorable stripes (Teshari)"
+	display_name = "Teshari smallcoat, (colorable stripes)"
 	path = /obj/item/clothing/suit/storage/toggle/tesharicoat
 	whitelisted = SPECIES_TESHARI
 	sort_category = "Xenowear"
@@ -634,7 +294,7 @@
 	gear_tweaks += gear_tweak_free_color_choice
 
 /datum/gear/suit/teshcoatwhite
-	display_name = "smallcoat, recolorable (Teshari)"
+	display_name = "Teshari smallcoat (colorable)"
 	path = /obj/item/clothing/suit/storage/toggle/tesharicoatwhite
 	whitelisted = SPECIES_TESHARI
 	sort_category = "Xenowear"
@@ -644,7 +304,7 @@
 	gear_tweaks += gear_tweak_free_color_choice
 
 /datum/gear/accessory/teshneckscarf
-	display_name = "neckscarf, recolorable (Teshari)"
+	display_name = "Teshari neckscarf, (colorable)"
 	path = /obj/item/clothing/accessory/scarf/teshari/neckscarf
 	whitelisted = SPECIES_TESHARI
 	sort_category = "Xenowear"
@@ -653,23 +313,8 @@
 	..()
 	gear_tweaks += gear_tweak_free_color_choice
 
-/datum/gear/shoes/toelessjack
-	display_name = "jackboots, toe-less"
-	path = /obj/item/clothing/shoes/boots/jackboots/toeless
-	cost = 2
-
-/datum/gear/shoes/toelessknee
-	display_name = "jackboots, toe-less, knee-length"
-	path = /obj/item/clothing/shoes/boots/jackboots/toeless/knee
-	cost = 2
-
-/datum/gear/shoes/toelessthigh
-	display_name = "jackboots, toe-less, thigh-length"
-	path = /obj/item/clothing/shoes/boots/jackboots/toeless/thigh
-	cost = 2
-
 /datum/gear/eyes/aerogelgoggles
-	display_name = "airtight orange goggles (Teshari)"
+	display_name = "Teshari airtight orange goggles"
 	path = /obj/item/clothing/glasses/aerogelgoggles
 	whitelisted = SPECIES_TESHARI
 	sort_category = "Xenowear"

--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -437,6 +437,11 @@ BLIND     // can't see anything
 	icon_state = "sunSecHud"
 	enables_planes = list(VIS_CH_ID,VIS_CH_WANTED,VIS_CH_IMPTRACK,VIS_CH_IMPLOYAL,VIS_CH_IMPCHEM)
 
+/obj/item/clothing/glasses/sunglasses/sechud/prescription
+	name = "prescription HUD sunglasses"
+	desc = "Sunglasses with a HUD and modified prescription lenses."
+	prescription = 6
+
 /obj/item/clothing/glasses/sunglasses/sechud/tactical
 	name = "tactical HUD"
 	desc = "Flash-resistant goggles with inbuilt combat and security information."

--- a/code/modules/clothing/suits/miscellaneous.dm
+++ b/code/modules/clothing/suits/miscellaneous.dm
@@ -568,12 +568,13 @@
 	item_state_slots = list(slot_r_hand_str = "denim_jacket", slot_l_hand_str = "denim_jacket")
 
 /obj/item/clothing/suit/storage/toggle/denim_jacket/nanotrasen
+	name = "corporate denim jacket"
 	desc = "A denim coat. A corporate logo is proudly displayed on the back."
 	icon_state = "denim_jacket_nt"
 	item_state_slots = list(slot_r_hand_str = "denim_jacket", slot_l_hand_str = "denim_jacket")
 
 /obj/item/clothing/suit/storage/toggle/denim_jacket/nanotrasen/sleeveless
-	name = "denim vest"
+	name = "corporate denim vest"
 	desc = "A denim vest. A corporate logo is proudly displayed on the back."
 	icon_state = "denim_jacket_nt_sleeveless"
 	body_parts_covered = UPPER_TORSO
@@ -872,9 +873,9 @@
 	body_parts_covered = UPPER_TORSO|ARMS
 	flags_inv = HIDEHOLSTER
 
-/obj/item/clothing/suit/storage/snowsuit
-	name = "snowsuit"
-	desc = "A suit made to keep you nice and toasty on cold winter days. Or at least alive."
+/obj/item/clothing/suit/storage/insulated
+	name = "insulted jacket"
+	desc = "A jacket made to keep you nice and toasty on cold winter days. Or at least alive."
 	icon_state = "snowsuit"
 	item_state_slots = list(slot_r_hand_str = "labcoat", slot_l_hand_str = "labcoat")
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|ARMS
@@ -884,28 +885,28 @@
 	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 10, rad = 0)
 	allowed = list (/obj/item/pen, /obj/item/paper, /obj/item/flashlight,/obj/item/tank/emergency/oxygen, /obj/item/storage/fancy/cigarettes, /obj/item/storage/box/matches, /obj/item/reagent_containers/food/drinks/flask)
 
-/obj/item/clothing/suit/storage/snowsuit/command
-	name = "command snowsuit"
+/obj/item/clothing/suit/storage/insulated/command
+	name = "command insulted jacket"
 	icon_state = "snowsuit_command"
 
-/obj/item/clothing/suit/storage/snowsuit/security
-	name = "security snowsuit"
+/obj/item/clothing/suit/storage/insulated/security
+	name = "security insulted jacket"
 	icon_state = "snowsuit_security"
 
-/obj/item/clothing/suit/storage/snowsuit/medical
-	name = "medical snowsuit"
+/obj/item/clothing/suit/storage/insulated/medical
+	name = "medical insulted jacket"
 	icon_state = "snowsuit_medical"
 
-/obj/item/clothing/suit/storage/snowsuit/engineering
-	name = "engineering snowsuit"
+/obj/item/clothing/suit/storage/insulated/engineering
+	name = "engineering insulted jacket"
 	icon_state = "snowsuit_engineering"
 
-/obj/item/clothing/suit/storage/snowsuit/cargo
-	name = "cargo snowsuit"
+/obj/item/clothing/suit/storage/insulated/cargo
+	name = "cargo insulted jacket"
 	icon_state = "snowsuit_cargo"
 
-/obj/item/clothing/suit/storage/snowsuit/science
-	name = "science snowsuit"
+/obj/item/clothing/suit/storage/insulated/science
+	name = "science insulted jacket"
 	icon_state = "snowsuit_science"
 
 /obj/item/clothing/suit/caution

--- a/code/modules/clothing/suits/miscellaneous.dm
+++ b/code/modules/clothing/suits/miscellaneous.dm
@@ -874,7 +874,7 @@
 	flags_inv = HIDEHOLSTER
 
 /obj/item/clothing/suit/storage/insulated
-	name = "insulted jacket"
+	name = "insulated jacket"
 	desc = "A jacket made to keep you nice and toasty on cold winter days. Or at least alive."
 	icon_state = "snowsuit"
 	item_state_slots = list(slot_r_hand_str = "labcoat", slot_l_hand_str = "labcoat")
@@ -886,27 +886,27 @@
 	allowed = list (/obj/item/pen, /obj/item/paper, /obj/item/flashlight,/obj/item/tank/emergency/oxygen, /obj/item/storage/fancy/cigarettes, /obj/item/storage/box/matches, /obj/item/reagent_containers/food/drinks/flask)
 
 /obj/item/clothing/suit/storage/insulated/command
-	name = "command insulted jacket"
+	name = "command insulated jacket"
 	icon_state = "snowsuit_command"
 
 /obj/item/clothing/suit/storage/insulated/security
-	name = "security insulted jacket"
+	name = "security insulated jacket"
 	icon_state = "snowsuit_security"
 
 /obj/item/clothing/suit/storage/insulated/medical
-	name = "medical insulted jacket"
+	name = "medical insulated jacket"
 	icon_state = "snowsuit_medical"
 
 /obj/item/clothing/suit/storage/insulated/engineering
-	name = "engineering insulted jacket"
+	name = "engineering insulated jacket"
 	icon_state = "snowsuit_engineering"
 
 /obj/item/clothing/suit/storage/insulated/cargo
-	name = "cargo insulted jacket"
+	name = "cargo insulated jacket"
 	icon_state = "snowsuit_cargo"
 
 /obj/item/clothing/suit/storage/insulated/science
-	name = "science insulted jacket"
+	name = "science insulated jacket"
 	icon_state = "snowsuit_science"
 
 /obj/item/clothing/suit/caution

--- a/code/modules/clothing/under/solgov.dm
+++ b/code/modules/clothing/under/solgov.dm
@@ -43,7 +43,7 @@
 //Utility
 //These are just colored
 /obj/item/clothing/under/utility
-	name = "utility uniform"
+	name = "black utility uniform"
 	desc = "A comfortable turtleneck and black utility trousers."
 	icon_state = "blackutility"
 	worn_state = "blackutility"
@@ -52,13 +52,13 @@
 	siemens_coefficient = 0.9
 
 /obj/item/clothing/under/utility/blue
-	name = "utility uniform"
+	name = "blue utility uniform"
 	desc = "A comfortable blue utility jumpsuit."
 	icon_state = "navyutility"
 	worn_state = "navyutility"
 
 /obj/item/clothing/under/utility/grey
-	name = "utility uniform"
+	name = "grey utility uniform"
 	desc = "A comfortable grey utility jumpsuit."
 	icon_state = "greyutility"
 	worn_state = "greyutility"

--- a/maps/cynosure/loadout/loadout_accessories.dm
+++ b/maps/cynosure/loadout/loadout_accessories.dm
@@ -1,34 +1,11 @@
-/datum/gear/accessory/brown_vest
-	display_name = "webbing, brown"
-	path = /obj/item/clothing/accessory/storage/brown_vest
+/datum/gear/accessory/webbing_vest/
+	display_name = "webbing vest selection (Engineering, Security, Medical, Miner, Explorer)"
 	allowed_roles = list("Station Engineer","Atmospheric Technician","Chief Engineer","Security Officer","Detective","Head of Security","Warden","Paramedic","Chief Medical Officer","Medical Doctor","Search and Rescue","Explorer","Shaft Miner")
 
-/datum/gear/accessory/black_vest
-	display_name = "webbing, black"
-	path = /obj/item/clothing/accessory/storage/black_vest
+/datum/gear/accessory/drop_pouches
+	display_name = "drop pouches selection, (Engineering, Security, Medical, Miner, Explorer)"
 	allowed_roles = list("Station Engineer","Atmospheric Technician","Chief Engineer","Security Officer","Detective","Head of Security","Warden","Paramedic","Chief Medical Officer","Medical Doctor","Search and Rescue","Explorer","Shaft Miner")
-
-/datum/gear/accessory/white_vest
-	display_name = "webbing, white"
-	path = /obj/item/clothing/accessory/storage/white_vest
-	allowed_roles = list("Station Engineer","Atmospheric Technician","Chief Engineer","Security Officer","Detective","Head of Security","Warden","Paramedic","Chief Medical Officer","Medical Doctor","Search and Rescue","Explorer","Shaft Miner")
-
-/datum/gear/accessory/brown_drop_pouches
-	display_name = "drop pouches, brown"
-	path = /obj/item/clothing/accessory/storage/brown_drop_pouches
-	allowed_roles = list("Station Engineer","Atmospheric Technician","Chief Engineer","Security Officer","Detective","Head of Security","Warden","Paramedic","Chief Medical Officer","Medical Doctor","Search and Rescue","Explorer","Shaft Miner")
-
-/datum/gear/accessory/black_drop_pouches
-	display_name = "drop pouches, black"
-	path = /obj/item/clothing/accessory/storage/black_drop_pouches
-	allowed_roles = list("Station Engineer","Atmospheric Technician","Chief Engineer","Security Officer","Detective","Head of Security","Warden","Paramedic","Chief Medical Officer","Medical Doctor","Search and Rescue","Explorer","Shaft Miner")
-
-/datum/gear/accessory/white_drop_pouches
-	display_name = "drop pouches, white"
-	path = /obj/item/clothing/accessory/storage/white_drop_pouches
-	allowed_roles = list("Station Engineer","Atmospheric Technician","Chief Engineer","Security Officer","Detective","Head of Security","Warden","Paramedic","Chief Medical Officer","Medical Doctor","Search and Rescue","Explorer","Shaft Miner")
-
 /datum/gear/accessory/holster
-	display_name = "holster selection (Security, CD, HoP)"
+	display_name = "holster selection (Security, CD, HoP, Explorer)"
 	path = /obj/item/clothing/accessory/holster
 	allowed_roles = list("Site Manager","Head of Personnel","Security Officer","Warden","Head of Security","Detective","Explorer")

--- a/maps/cynosure/loadout/loadout_suit.dm
+++ b/maps/cynosure/loadout/loadout_suit.dm
@@ -2,8 +2,3 @@
 	display_name = "bomber jacket, pilot"
 	path = /obj/item/clothing/suit/storage/toggle/bomber/pilot
 	cost = 2
-
-/datum/gear/suit/wintercoat/medical/sar
-	display_name = "winter coat, search and rescue"
-	path = /obj/item/clothing/suit/storage/hooded/wintercoat/medical/sar
-	allowed_roles = list("Medical Doctor", "Chief Medical Officer", "Paramedic", "Psychiatrist", "Field Medic")


### PR DESCRIPTION
Fixed up a lot of shit in the loadout menus to make it more readable and easier to find shit.

- Colorable items are more consistently labelled
- Very similar/recoloured items generally grouped into 'selections'
- Some items that were already in selections removed from the main lists
- Xenowear tab made readable by grouping all the Teshari items and putting most into selections
- Moved some job options (e.g. security uniforms) into role-based selections
- Moved some other options that were previously job-locked into 'public' selections within reason and trusting people not to be weird about it (hats, winter coats, shit that isn't STRICTLY "uniform" and mostly just looks nice)
- Consolidated skirt-uniforms in the same way, anybody can take them in theory, except for security uniforms.
- Re-sorted a bunch of stuff that was inconsistent from #8695 sorry you might have to set up loadout AGAIN.
- ~~Jackboots are sec-only again maybe?~~ nope
- Renamed snowsuits to insulated jackets because they're... They're just jackets.
- Tweaked some other item names so they'd autopopulate the type lists properly.
- Fixed the tracking implant description being inherited from the neural web
- Ushanka variants are in.
- The dummy 'accessory' item is OUT.

To do after this: Nuke some items that are terrible/ancient/nobody has used in 10 years??