### PR TITLE
Admin Build Mode Agony Removal

### DIFF
--- a/code/modules/admin/verbs/buildmode.dm
+++ b/code/modules/admin/verbs/buildmode.dm
@@ -189,6 +189,7 @@
 	var/atom/movable/throw_atom = null
 	var/list/selected_mobs = list()
 	var/copied_faction = null
+	var/warned = 0
 
 /obj/effect/bmode/buildholder/Destroy()
 	qdel(builddir)
@@ -219,7 +220,7 @@
 	screen_loc = "NORTH,WEST+2"
 	var/varholder = "name"
 	var/valueholder = "derp"
-	var/objholder = /obj/structure/closet
+	var/objholder = null
 	var/objsay = 1
 
 	var/wall_holder = /turf/simulated/wall
@@ -252,7 +253,7 @@
 
 				return 1
 			if(BUILDMODE_ADVANCED)
-				objholder = get_path_from_partial_text(/obj/structure/closet)
+				objholder = get_path_from_partial_text()
 
 			if(BUILDMODE_EDIT)
 				var/list/locked = list("vars", "key", "ckey", "client", "firemut", "ishulk", "telekinesis", "xray", "virus", "viruses", "cuffed", "ka", "last_eaten", "urine")
@@ -330,7 +331,13 @@
 					return
 				else if(istype(object,/turf/simulated/floor))
 					var/turf/T = object
-					T.ChangeTurf(/turf/space)
+					if(!holder.warned)
+						var/warning = tgui_alert(user, "Are you -sure- you want to delete this turf and make it the base turf for this Z level?", "GRIEF ALERT", list("No", "Yes"))
+						if(warning == "Yes")
+							holder.warned = 1
+						else
+							return
+					T.ChangeTurf(get_base_turf_by_area(T)) //Defaults to Z if area does not have a special base turf.
 					return
 				else if(istype(object,/turf/simulated/wall/r_wall))
 					var/turf/T = object
@@ -644,8 +651,6 @@
 		result = matches[1]
 	else
 		result = input("Select an atom type", "Spawn Atom", matches[1]) as null|anything in matches
-		if(!objholder)
-			result = default_path
 	return result
 
 /obj/effect/bmode/buildmode/proc/make_rectangle(var/turf/A, var/turf/B, var/turf/wall_type, var/turf/floor_type)

--- a/code/modules/admin/verbs/buildmode.dm
+++ b/code/modules/admin/verbs/buildmode.dm
@@ -332,7 +332,7 @@
 				else if(istype(object,/turf/simulated/floor))
 					var/turf/T = object
 					if(!holder.warned)
-						var/warning = tgui_alert(user, "Are you -sure- you want to delete this turf and make it the base turf for this Z level?", "GRIEF ALERT", list("No", "Yes"))
+						var/warning = alert("Are you -sure- you want to delete this turf and make it the base turf for this Z level?", "GRIEF ALERT", "No", "Yes")
 						if(warning == "Yes")
 							holder.warned = 1
 						else


### PR DESCRIPTION
Finally, you'll never know you're being meddled with by the sudden presence of random lockers!

> - Makes Basic build mode warn you before you delete the ground and space everyone
> - Makes Basic build mode turn the turf you deleted into the base turf for the area. If area base turf is not available, it goes with the base turf of the Z level.
> - Makes Advanced build mode start with Null. No more spawning lockers and qdel()ing players!
> - Fixes a longstanding bug where if you cancelled selection in build mode and then tried to select something from the list, it defaulted to a locker. Instead, if you cancel it, it defaults back to null and lists work like normal.


via https://github.com/VOREStation/VOREStation/pull/13820