### PR TITLE
Further loadout tweaks and fixes

### DIFF
--- a/code/modules/client/preference_setup/loadout/loadout_accessories.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_accessories.dm
@@ -161,8 +161,11 @@
 	webbingtype["webbing, brown"] = /obj/item/clothing/accessory/storage/brown_vest
 	webbingtype["webbing, black"] = /obj/item/clothing/accessory/storage/black_vest
 	webbingtype["webbing, white"] = /obj/item/clothing/accessory/storage/white_vest
-	webbingtype["webbing, simple"] = /obj/item/clothing/accessory/storage/webbing
 	gear_tweaks += new/datum/gear_tweak/path(webbingtype)
+
+/datum/gear/accessory/webbing_simple
+	display_name = "webbing, simple"
+	path = /obj/item/clothing/accessory/storage/webbing
 
 /datum/gear/accessory/drop_pouches
 	display_name = "drop pouches selection (Engineering, Security, Medical)"

--- a/code/modules/client/preference_setup/loadout/loadout_eyes.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_eyes.dm
@@ -62,7 +62,7 @@
 	glassestype["glasses, thin frame"] = /obj/item/clothing/glasses/thin
 	gear_tweaks += new/datum/gear_tweak/path(glassestype)
 
-/datum/gear/eyes/glasses/monocle
+/datum/gear/eyes/monocle
 	display_name = "monocle"
 	path = /obj/item/clothing/glasses/monocle
 
@@ -130,12 +130,11 @@
 	display_name = "optical material scanners, prescription (Mining)"
 	path = /obj/item/clothing/glasses/material/prescription
 
-
-/datum/gear/eyes/glasses/fakesun
+/datum/gear/eyes/fakesun
 	display_name = "sunglasses, stylish"
 	path = /obj/item/clothing/glasses/fakesunglasses
 
-/datum/gear/eyes/glasses/fakeaviator
+/datum/gear/eyes/fakeaviator
 	display_name = "sunglasses, stylish aviators"
 	path = /obj/item/clothing/glasses/fakesunglasses/aviator
 

--- a/code/modules/client/preference_setup/loadout/loadout_gloves.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_gloves.dm
@@ -37,7 +37,7 @@
 	path = /obj/item/clothing/gloves/sterile/nitrile
 	cost = 2
 /datum/gear/gloves/evening
-	display_name = "gloves, evening"
+	display_name = "gloves, evening (colorable)"
 	path = /obj/item/clothing/gloves/evening
 	cost = 1
 
@@ -57,7 +57,7 @@
 	cost = 1
 
 /datum/gear/gloves/fingerless
-	display_name = "gloves, fingerless"
+	display_name = "gloves, fingerless (colorable)"
 	path = /obj/item/clothing/gloves/fingerless
 	cost = 1
 

--- a/code/modules/client/preference_setup/loadout/loadout_head.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_head.dm
@@ -81,20 +81,20 @@
 		caps[initial(cap_type.name)] = cap_type
 	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(caps))
 
-/datum/gear/head/cap/flat
+/datum/gear/head/cap_flat
 	display_name = "cap, flat brown"
 	path = /obj/item/clothing/head/flatcap
 
-/datum/gear/head/cap/med
+/datum/gear/head/cap_med
 	display_name = "cap, medical (Medical)"
 	path = /obj/item/clothing/head/soft/med
 	allowed_roles = list("Chief Medical Officer","Medical Doctor","Chemist","Psychiatrist","Paramedic","Search and Rescue")
 
-/datum/gear/head/cap/white
+/datum/gear/head/cap_colorable
 	display_name = "cap (colorable)"
 	path = /obj/item/clothing/head/soft/mime
 
-/datum/gear/head/cap/white/New()
+/datum/gear/head/cap_colorable/New()
 	..()
 	gear_tweaks += gear_tweak_free_color_choice
 
@@ -298,11 +298,11 @@
 		welding_helmets[initial(welding_helmet_type.name)] = welding_helmet_type
 	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(welding_helmets))
 
-/datum/gear/head/beret/solgov
+/datum/gear/head/beret_gov
 	display_name = "beret, government selection"
 	path = /obj/item/clothing/head/beret/solgov
 
-/datum/gear/head/beret/solgov/New()
+/datum/gear/head/beret_gov/New()
 	..()
 	var/list/sols = list()
 	for(var/sol_style in typesof(/obj/item/clothing/head/beret/solgov))

--- a/code/modules/client/preference_setup/loadout/loadout_shoes.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_shoes.dm
@@ -26,7 +26,6 @@
 /datum/gear/shoes/workboots/toeless
 	display_name = "workboots, toe-less"
 	path = /obj/item/clothing/shoes/boots/workboots/toeless
-	cost = 2
 
 /datum/gear/shoes/colored
 	display_name = "shoes, colored selection"
@@ -73,7 +72,7 @@
 	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(hitops))
 
 /datum/gear/shoes/flipflops
-	display_name = "flip flops"
+	display_name = "flip flops (colorable)"
 	path = /obj/item/clothing/shoes/flipflop
 
 /datum/gear/shoes/flipflops/New()
@@ -81,7 +80,7 @@
 	gear_tweaks += gear_tweak_free_color_choice
 
 /datum/gear/shoes/athletic
-	display_name = "shoes, athletic"
+	display_name = "shoes, athletic (colorable)"
 	path = /obj/item/clothing/shoes/athletic
 
 /datum/gear/shoes/athletic/New()
@@ -89,7 +88,7 @@
 	gear_tweaks += gear_tweak_free_color_choice
 
 /datum/gear/shoes/skater
-	display_name = "shoes, skater"
+	display_name = "shoes, skater (colorable)"
 	path = /obj/item/clothing/shoes/skater
 
 /datum/gear/shoes/skater/New()
@@ -135,7 +134,7 @@
 	path = 	/obj/item/clothing/shoes/dress/white
 
 /datum/gear/shoes/heels
-	display_name = "high heels"
+	display_name = "high heels (colorable)"
 	path = /obj/item/clothing/shoes/heels
 
 /datum/gear/shoes/heels/New()
@@ -146,11 +145,11 @@
 	display_name = "bunny slippers"
 	path = /obj/item/clothing/shoes/slippers
 
-/datum/gear/shoes/boots/winter
+/datum/gear/shoes/winter_boots
 	display_name = "boots, winter selection"
 	path = /obj/item/clothing/shoes/boots/winter
 
-/datum/gear/shoes/boots/winter/New()
+/datum/gear/shoes/winter_boots/New()
 	..()
 	var/boottype = list()
 	boottype["winter boots, atmospherics"] = /obj/item/clothing/shoes/boots/winter/atmos

--- a/code/modules/client/preference_setup/loadout/loadout_suit.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_suit.dm
@@ -349,7 +349,7 @@
 	path = /obj/item/clothing/suit/kamishimo
 
 /datum/gear/suit/insulated
-	display_name = "insulated jacket selection"
+	display_name = "jacket, insulated selection"
 	path = /obj/item/clothing/suit/storage/insulated
 	cost = 2
 

--- a/code/modules/client/preference_setup/loadout/loadout_suit.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_suit.dm
@@ -151,21 +151,21 @@
 	labcoattype["labcoat, yellow"] = /obj/item/clothing/suit/storage/toggle/labcoat/yellow
 	gear_tweaks += new/datum/gear_tweak/path(labcoattype)
 
-/datum/gear/suit/labcoat/rd
+/datum/gear/suit/labcoat_rd
 	display_name = "labcoat, research director (RD)"
 	path = /obj/item/clothing/suit/storage/toggle/labcoat/rd
 	allowed_roles = list("Research Director")
 
-/datum/gear/suit/labcoat/emt
+/datum/gear/suit/labcoat_emt
 	display_name = "labcoat, EMT (Medical)"
 	path = /obj/item/clothing/suit/storage/toggle/labcoat/emt
 	allowed_roles = list("Medical Doctor","Chief Medical Officer","Chemist","Paramedic","Geneticist", "Psychiatrist")
 
-/datum/gear/suit/miscellaneous/labcoat
+/datum/gear/suit/plague_coat
 	display_name = "plague doctor's coat"
 	path = /obj/item/clothing/suit/storage/toggle/labcoat/plaguedoctor
 
-/datum/gear/suit/roles/surgical_apron
+/datum/gear/suit/surgical_apron
 	display_name = "apron, surgical"
 	path = /obj/item/clothing/suit/surgicalapron
 	allowed_roles = list("Medical Doctor","Chief Medical Officer")
@@ -187,11 +187,11 @@
 		ponchos[initial(poncho.name)] = poncho
 	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(ponchos))
 
-/datum/gear/suit/roles/poncho/cloak
+/datum/gear/suit/cloak
 	display_name = "cloak, departmental selection"
 	path = /obj/item/clothing/accessory/poncho/roles/cloak/cargo
 
-/datum/gear/suit/roles/poncho/cloak/New()
+/datum/gear/suit/cloak/New()
 	..()
 	var/list/cloaks = list()
 	for(var/cloak_style in (typesof(/obj/item/clothing/accessory/poncho/roles/cloak)))
@@ -199,7 +199,7 @@
 		cloaks[initial(cloak.name)] = cloak
 	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(cloaks))
 
-/datum/gear/suit/roles/poncho/cloak/custom //A colorable cloak
+/datum/gear/suit/cloak_custom //A colorable cloak
 	display_name = "cloak (colorable)"
 	path = /obj/item/clothing/accessory/poncho/roles/cloak/custom
 
@@ -302,19 +302,19 @@
 		denim_jackets[initial(denim_jacket.name)] = denim_jacket
 	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(denim_jackets))
 
-/datum/gear/suit/miscellaneous/kimono
+/datum/gear/suit/kimono
 	display_name = "kimono"
 	path = /obj/item/clothing/suit/kimono
 
-/datum/gear/suit/miscellaneous/kimono/New()
+/datum/gear/suit/kimono/New()
 	..()
 	gear_tweaks += gear_tweak_free_color_choice
 
-/datum/gear/suit/miscellaneous/dep_jacket
+/datum/gear/suit/dep_jacket
 	display_name = "jacket, departmental selection"
 	path = /obj/item/clothing/suit/storage/toggle/sec_dep_jacket
 
-/datum/gear/suit/miscellaneous/dep_jacket/New()
+/datum/gear/suit/dep_jacket/New()
 	..()
 	var/jackettype = list()
 	jackettype["department jacket, engineering"] = /obj/item/clothing/suit/storage/toggle/engi_dep_jacket
@@ -324,11 +324,11 @@
 	jackettype["department jacket, supply"] = /obj/item/clothing/suit/storage/toggle/supply_dep_jacket
 	gear_tweaks += new/datum/gear_tweak/path(jackettype)
 
-/datum/gear/suit/miscellaneous/light_jacket
+/datum/gear/suit/light_jacket
 	display_name = "jacket, light selection"
 	path = /obj/item/clothing/suit/storage/toggle/light_jacket
 
-/datum/gear/suit/miscellaneous/light_jacket/New()
+/datum/gear/suit/light_jacket/New()
 	..()
 	var/list/jacket = list(
 		"grey light jacket" = /obj/item/clothing/suit/storage/toggle/light_jacket,
@@ -336,15 +336,15 @@
 	)
 	gear_tweaks += new/datum/gear_tweak/path(jacket)
 
-/datum/gear/suit/miscellaneous/peacoat
-	display_name = "peacoat"
+/datum/gear/suit/peacoat
+	display_name = "peacoat (colorable)"
 	path = /obj/item/clothing/suit/storage/toggle/peacoat
 
-/datum/gear/suit/miscellaneous/peacoat/New()
+/datum/gear/suit/peacoat/New()
 	..()
 	gear_tweaks += gear_tweak_free_color_choice
 
-/datum/gear/suit/miscellaneous/kamishimo
+/datum/gear/suit/kamishimo
 	display_name = "kamishimo"
 	path = /obj/item/clothing/suit/kamishimo
 
@@ -361,10 +361,10 @@
 		insulated_jackets[initial(insulated_jacket.name)] = insulated_jacket
 	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(insulated_jackets))
 
-/datum/gear/suit/miscellaneous/cardigan
-	display_name = "cardigan"
+/datum/gear/suit/cardigan
+	display_name = "cardigan (colorable)"
 	path = /obj/item/clothing/suit/storage/toggle/cardigan
 
-/datum/gear/suit/miscellaneous/cardigan/New()
+/datum/gear/suit/cardigan/New()
 	..()
 	gear_tweaks += gear_tweak_free_color_choice

--- a/code/modules/client/preference_setup/loadout/loadout_suit.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_suit.dm
@@ -348,8 +348,8 @@
 	display_name = "kamishimo"
 	path = /obj/item/clothing/suit/kamishimo
 
-/datum/gear/suit/insulted
-	display_name = "insulted jacket selection"
+/datum/gear/suit/insulated
+	display_name = "insulated jacket selection"
 	path = /obj/item/clothing/suit/storage/insulated
 	cost = 2
 

--- a/code/modules/client/preference_setup/loadout/loadout_uniform.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_uniform.dm
@@ -134,21 +134,6 @@
 	skirttype["skirt, quartermaster"] = /obj/item/clothing/under/rank/cargotech/skirt
 	gear_tweaks += new/datum/gear_tweak/path(skirttype)
 
-/datum/gear/uniform/job_skirt/warden
-	display_name = "skirt, warden"
-	path = /obj/item/clothing/under/rank/warden/skirt
-	allowed_roles = list("Head of Security", "Warden")
-
-/datum/gear/uniform/job_skirt/security
-	display_name = "skirt, security"
-	path = /obj/item/clothing/under/rank/security/skirt
-	allowed_roles = list("Head of Security", "Warden", "Detective", "Security Officer")
-
-/datum/gear/uniform/job_skirt/head_of_security
-	display_name = "skirt, hos"
-	path = /obj/item/clothing/under/rank/head_of_security/skirt
-	allowed_roles = list("Head of Security")
-
 /datum/gear/uniform/job_turtle
 	display_name = "turtleneck, departmental selection"
 	path = /obj/item/clothing/under/rank/scientist/turtleneck
@@ -182,11 +167,11 @@
 	path = /obj/item/clothing/under/rank/cargotech/jeans/female
 	allowed_roles = list("Quartermaster","Cargo Technician")
 
-/datum/gear/uniform/suit/lawyer
+/datum/gear/uniform/suit_lawyer
 	display_name = "suit, one-piece selection"
 	path = /obj/item/clothing/under/lawyer
 
-/datum/gear/uniform/suit/lawyer/New()
+/datum/gear/uniform/suit_lawyer/New()
 	..()
 	var/list/lsuits = list()
 	for(var/lsuit in typesof(/obj/item/clothing/under/lawyer, /obj/item/clothing/under/sl_suit, /obj/item/clothing/under/gentlesuit))
@@ -194,11 +179,11 @@
 		lsuits[initial(lsuit_type.name)] = lsuit_type
 	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(lsuits))
 
-/datum/gear/uniform/suit/suit_jacket
+/datum/gear/uniform/suit_jacket
 	display_name = "suit, modular selection"
 	path = /obj/item/clothing/under/suit_jacket
 
-/datum/gear/uniform/suit/suit_jacket/New()
+/datum/gear/uniform/suit_jacket/New()
 	..()
 	var/list/msuits = list()
 	for(var/msuit in typesof(/obj/item/clothing/under/suit_jacket))
@@ -206,22 +191,22 @@
 		msuits[initial(msuit_type.name)] = msuit_type
 	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(msuits))
 
-/datum/gear/uniform/suit/detectiveblack
+/datum/gear/uniform/detectiveblack
 	display_name = "suit, detective black (Detective)"
 	path = /obj/item/clothing/under/det/black_alt
 	allowed_roles = list("Detective")
 
-/datum/gear/uniform/suit/detectiveskirt
+/datum/gear/uniform/detectiveskirt
 	display_name = "suit, detective skirt (Detective)"
 	path = /obj/item/clothing/under/det/skirt
 	allowed_roles = list("Detective")
 
-/datum/gear/uniform/suit/iaskirt
+/datum/gear/uniform/iaskirt
 	display_name = "suit, Internal Affairs skirt (Internal Affairs)"
 	path = /obj/item/clothing/under/rank/internalaffairs/skirt
 	allowed_roles = list("Internal Affairs Agent")
 
-/datum/gear/uniform/suit/bartenderskirt
+/datum/gear/uniform/bartenderskirt
 	display_name = "suit, bartender skirt (Bartender)"
 	path = /obj/item/clothing/under/rank/bartender/skirt
 	allowed_roles = list("Bartender")
@@ -278,6 +263,7 @@
 	secunitype["officer uniform, corporate"] = /obj/item/clothing/under/rank/security/corp
 	secunitype["officer uniform, navy"] = /obj/item/clothing/under/rank/security/navyblue
 	secunitype["officer uniform, hedberg-hammarstrom"] = /obj/item/clothing/under/hedberg
+	secunitype["officer uniform, red skirt"] = /obj/item/clothing/under/rank/security/skirt
 	secunitype["detective uniform, corporate"] = /obj/item/clothing/under/det/corporate
 	gear_tweaks += new/datum/gear_tweak/path(secunitype)
 
@@ -291,6 +277,7 @@
 	var/warunitype = list()
 	warunitype["warden uniform, corporate"] = /obj/item/clothing/under/rank/warden/corp
 	warunitype["warden uniform, navy"] = /obj/item/clothing/under/rank/warden/navyblue
+	warunitype["warden uniform, red skirt"] = /obj/item/clothing/under/rank/warden/skirt
 	gear_tweaks += new/datum/gear_tweak/path(warunitype)
 
 /datum/gear/uniform/uniform_hos
@@ -303,6 +290,7 @@
 	var/hosunitype = list()
 	hosunitype["HoS uniform, corporate"] = /obj/item/clothing/under/rank/head_of_security/corp
 	hosunitype["HoS uniform, navy"] = /obj/item/clothing/under/rank/head_of_security/navyblue
+	hosunitype["HoS Uniform, red skirt"] = /obj/item/clothing/under/rank/head_of_security/skirt
 	gear_tweaks += new/datum/gear_tweak/path(hosunitype)
 
 /datum/gear/uniform/uniform_hop
@@ -530,7 +518,7 @@
 	path = /obj/item/clothing/under/dress/revealingdress
 
 /datum/gear/uniform/rippedpunk
-	display_name = "jeans, ripped punk"
+	display_name = "outfit, ripped punk"
 	path = /obj/item/clothing/under/rippedpunk
 
 /datum/gear/uniform/gothic


### PR DESCRIPTION
Overlooked fixes to https://github.com/PolarisSS13/Polaris/pull/8714

- Apologizes further to insulted jackets.
- Simple webbing is available to everybody again.
- Fixed numerous problems with unnecessary inheritance causing problems with selections/colourables. The datum path does not need to match the gear typepath which I think a lot of people assumed over the years.
- More consistent colourable labelling
- Rolled security skirts into the security uniform selections
- Renamed the punk jeans to an outfit because they also include a bra and shirt!
