### PR TITLE
Fixes produce harvest applying double color

### DIFF
--- a/code/modules/hydroponics/seed.dm
+++ b/code/modules/hydroponics/seed.dm
@@ -814,7 +814,7 @@
 				product = new /obj/item/reagent_containers/food/snacks/grown(get_turf(user),name)
 			if(get_trait(TRAIT_PRODUCT_COLOUR))
 				if(!istype(product, /mob))
-					product.color = get_trait(TRAIT_PRODUCT_COLOUR)
+					//product.color = get_trait(TRAIT_PRODUCT_COLOUR) //Already applied correctly on overlays in icon_update, no need to double color over all overlays
 					if(istype(product,/obj/item/reagent_containers/food))
 						var/obj/item/reagent_containers/food/food = product
 						food.filling_color = get_trait(TRAIT_PRODUCT_COLOUR)


### PR DESCRIPTION
Fixes harvested produce getting the produce color (meant for the produce part of the icon overlay and not the leaf part, which uses its own color) applied on top of both already colored overlays for a second time, most visible on mushrooms, which have ended up with hypersaturated caps and incorrect underside colors.