### PR TITLE
Fixes overlooked invisible spawner when mapping

### DIFF
--- a/code/game/objects/random/guns_and_ammo.dm
+++ b/code/game/objects/random/guns_and_ammo.dm
@@ -564,7 +564,6 @@
 /obj/random/projectile/scrapped_gun
 	name = "broken gun spawner"
 	desc = "Spawns a random broken gun, or rarely a fully functional one."
-	icon = 'icons/obj/gun.dmi'
 	icon_state = "gun_scrap"
 
 /obj/random/projectile/scrapped_gun/item_to_spawn()


### PR DESCRIPTION
Was going to put this into the gun sprite PR but I forgot to commit it hee hoo.
Is technically an oversight from forever ago when I did a random spawner overhaul and not that PR! All it did was made scrap gun part spawners invisible in the map editor for the past while but nobody's been messing with PoIs much lately.