### PR TITLE
speculative fix for obj/random's not being deleted

### DIFF
--- a/code/game/objects/random/_random.dm
+++ b/code/game/objects/random/_random.dm
@@ -7,12 +7,14 @@
 	var/drop_get_turf = TRUE
 	var/start_anomalous = FALSE
 
-// creates a new object and deletes itself
+
 /obj/random/Initialize()
+	. = INITIALIZE_HINT_QDEL
 	..()
-	if(!prob(spawn_nothing_percentage))
-		try_spawn_item()
-	return INITIALIZE_HINT_QDEL
+	if (prob(spawn_nothing_percentage))
+		return
+	try_spawn_item()
+
 
 /obj/random/proc/try_spawn_item()
 	var/atom/result = spawn_item()


### PR DESCRIPTION
I suspect these are failing to be deleted because of crashes in the try_spawn_item calls; this may resolve that by simply making sure Initialize has a good return value beforehand.