### PR TITLE
Adds Sivian Creole Language

### DIFF
--- a/code/__defines/species_languages.dm
+++ b/code/__defines/species_languages.dm
@@ -96,6 +96,7 @@
 #define LANGUAGE_ZADDAT "Vedahq"
 #define LANGUAGE_PROMETHEAN "Promethean Biolinguistics"
 #define LANGUAGE_BLOB "Chemosense Transmission"
+#define LANGUAGE_SIVIAN "Sivian Creole"
 #define LANGUAGE_GIBBERISH "Babel"
 
 // Language flags.

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -200,6 +200,7 @@
 
 	R.add_language(LANGUAGE_SOL_COMMON, 1)
 	R.add_language(LANGUAGE_TRADEBAND, 1)
+	R.add_language(LANGUAGE_SIVIAN, 1)
 	R.add_language(LANGUAGE_UNATHI, 1)
 	R.add_language(LANGUAGE_SIIK, 1)
 	R.add_language(LANGUAGE_AKHANI, 1)

--- a/code/modules/mob/language/generic.dm
+++ b/code/modules/mob/language/generic.dm
@@ -26,7 +26,7 @@
 	syllables = list(
 "vol", "zum", "coo","zoo","bi","do","ooz","ite","og","re","si","ite","ish",
 "ar","at","on","ee","east","ma","da", "rim")
-	partial_understanding = list(LANGUAGE_SKRELLIAN = 30, LANGUAGE_SOL_COMMON = 30)
+	partial_understanding = list(LANGUAGE_SKRELLIAN = 30, LANGUAGE_SOL_COMMON = 30, LANGUAGE_SIVIAN = 40)
 
 //TODO flag certain languages to use the mob-type specific say_quote and then get rid of these.
 /datum/language/common/get_spoken_verb(var/msg_end)
@@ -125,6 +125,26 @@
 "ve", "wa", "all", "and", "are", "but", "ent", "era", "ere", "eve", "for", "had", "hat", "hen", "her", "hin",
 "his", "ing", "ion", "ith", "not", "ome", "oul", "our", "sho", "ted", "ter", "tha", "the", "thi")
 
+//Local language
+/datum/language/sivian
+	name = LANGUAGE_SIVIAN
+	desc = "A hybrid language local to the Vir system, heavily incorporating elements from the languages of early Scandinavian colonists into a form of Galactic Common."
+	speech_verb = "says"
+	whisper_verb = "whispers"
+	colour = "sivian"
+	key = "7"
+	partial_understanding = list(LANGUAGE_SOL_COMMON = 20, LANGUAGE_GALCOM = 40)
+	space_chance = 45
+	syllables = list (
+	"all", "are", "det", "enn", "ere", "hen", "kan", "lig", "men", "ren", "som", "ver", "vir", "var", "vis", "ikk", "ter", "ork",
+	"den", "ing", "jeg", "jag", "han", "hir", "hil", "ans", "kan", "kir", "bor", "bir", "um", "om", "ve", "ur", "ha", "he", "hyu",
+	"er", "ad", "ath", "bjo,", "gun", "gur", "gir", "fyr", "thar", "thir", "thad", "thei", "ayr", "for", "fjo", "jor", "jik", "jar",
+	"yor", "yar", "yik", "rik", "os", "olm", "erm", "ferk", "borg", "bork", "smorg", // Scandi
+	"meng", "tao", "bu", "qu", "ai", "xin", "pin", "wa", "cang", "chun", "ding", "gang", "ling", "gao", "jian", "sun", "tong",
+	"xie", "zu", "miao", "po", "nu", // Chinese (galcom)
+	"our", "oul", "tou", "eve", "ome", "ion", "ais", // Romance (galcom)
+	"zaoo", "zix", "vol") //Skrell (galcom)
+
 /datum/language/sign
 	name = LANGUAGE_SIGN
 	desc = "A sign language commonly used for those who are deaf or mute."
@@ -146,7 +166,7 @@
 /datum/language/sign/broadcast(var/mob/living/speaker, var/message, var/speaker_mask)
 	log_say("(SIGN) [message]", speaker)
 	speaker.say_signlang(message, pick(signlang_verb), src)
-	
+
 
 // Silly language for those times when you try to talk a languague you normally can't
 /datum/language/gibberish

--- a/code/modules/mob/language/monkey.dm
+++ b/code/modules/mob/language/monkey.dm
@@ -18,7 +18,7 @@
 /datum/language/unathi/monkey
 	name = "Stok"
 	desc = "Hiss hiss hiss."
-	key = "7"
+	key = "S"
 	syllables = list("squick","croak")
 	machine_understands = 0
 

--- a/code/modules/mob/language/station.dm
+++ b/code/modules/mob/language/station.dm
@@ -150,6 +150,7 @@
 	colour = "solcom"
 	key = "1"
 	flags = WHITELISTED
+	partial_understanding = list(LANGUAGE_SIVIAN = 20)
 	//syllables are at the bottom of the file
 
 /datum/language/human/get_spoken_verb(var/msg_end)

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -87,7 +87,7 @@ var/global/list/ai_verbs_default = list(
 	var/datum/ai_icon/selected_sprite			// The selected icon set
 	var/custom_sprite 	= 0 					// Whether the selected icon is custom
 	var/carded
-	
+
 	// Multicam Vars
 	var/multicam_allowed = TRUE
 	var/multicam_on = FALSE
@@ -160,6 +160,7 @@ var/global/list/ai_verbs_default = list(
 	add_language("Robot Talk", 1)
 	add_language(LANGUAGE_GALCOM, 1)
 	add_language(LANGUAGE_SOL_COMMON, 1)
+	add_language(LANGUAGE_SIVIAN, 1)
 	add_language(LANGUAGE_UNATHI, 1)
 	add_language(LANGUAGE_SIIK, 1)
 	add_language(LANGUAGE_AKHANI, 1)
@@ -486,7 +487,7 @@ var/global/list/ai_verbs_default = list(
 		else
 			to_chat(src, "<font color='red'>System error. Cannot locate [html_decode(href_list["trackname"])].</font>")
 		return
-		
+
 	if(href_list["trackbot"])
 		var/mob/living/bot/target = locate(href_list["trackbot"]) in mob_list
 		if(target)
@@ -814,21 +815,21 @@ var/global/list/ai_verbs_default = list(
 
 /mob/living/silicon/ai/proc/check_unable(var/flags = 0, var/feedback = 1)
 	if(stat == DEAD)
-		if(feedback) 
+		if(feedback)
 			to_chat(src, "<span class='warning'>You are dead!</span>")
 		return 1
 
 	if(aiRestorePowerRoutine)
-		if(feedback) 
+		if(feedback)
 			to_chat(src, "<span class='warning'>You lack power!</span>")
 		return 1
 
 	if((flags & AI_CHECK_WIRELESS) && src.control_disabled)
-		if(feedback) 
+		if(feedback)
 			to_chat(src, "<span class='warning'>Wireless control is disabled!</span>")
 		return 1
 	if((flags & AI_CHECK_RADIO) && src.aiRadio.disabledAi)
-		if(feedback) 
+		if(feedback)
 			to_chat(src, "<span class='warning'>System Error - Transceiver Disabled!</span>")
 		return 1
 	return 0
@@ -972,7 +973,7 @@ var/global/list/ai_verbs_default = list(
 	//This communication is imperfect because the holopad "filters" voices and is only designed to connect to the master only.
 	var/rendered = "<i><span class='game say'>Relayed Speech: <span class='name'>[name_used]</span> [message]</span></i>"
 	show_message(rendered, 2)
-	
+
 /mob/living/silicon/ai/proc/toggle_multicam_verb()
 	set name = "Toggle Multicam"
 	set category = "AI Commands"

--- a/code/modules/mob/living/silicon/robot/robot_modules/station.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules/station.dm
@@ -21,7 +21,7 @@ var/global/list/robot_modules = list(
 	var/hide_on_manifest = FALSE
 	var/channels = list()
 	var/networks = list()
-	var/languages = list(LANGUAGE_SOL_COMMON = 1, LANGUAGE_TRADEBAND = 1, LANGUAGE_UNATHI = 0, LANGUAGE_SIIK = 0, LANGUAGE_AKHANI = 0, LANGUAGE_SKRELLIAN = 0, LANGUAGE_GUTTER = 0, LANGUAGE_SCHECHI = 0, LANGUAGE_SIGN = 0, LANGUAGE_TERMINUS = 1, LANGUAGE_ZADDAT = 0)
+	var/languages = list(LANGUAGE_SOL_COMMON = 1, LANGUAGE_SIVIAN= 0, LANGUAGE_TRADEBAND = 1, LANGUAGE_UNATHI = 0, LANGUAGE_SIIK = 0, LANGUAGE_AKHANI = 0, LANGUAGE_SKRELLIAN = 0, LANGUAGE_GUTTER = 0, LANGUAGE_SCHECHI = 0, LANGUAGE_SIGN = 0, LANGUAGE_TERMINUS = 1, LANGUAGE_ZADDAT = 0)
 	var/sprites = list()
 	var/can_be_pushed = 1
 	var/no_slip = 0
@@ -611,6 +611,7 @@ var/global/list/robot_modules = list(
 		)
 	languages = list(
 					LANGUAGE_SOL_COMMON	= 1,
+					LANGUAGE_SIVIAN 	= 1,
 					LANGUAGE_UNATHI		= 1,
 					LANGUAGE_SIIK		= 1,
 					LANGUAGE_AKHANI		= 1,

--- a/code/modules/mob/living/silicon/robot/robot_modules/syndicate.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules/syndicate.dm
@@ -5,6 +5,7 @@
 	hide_on_manifest = TRUE
 	languages = list(
 					LANGUAGE_SOL_COMMON = 1,
+					LANGUAGE_SIVIAN = 0,
 					LANGUAGE_TRADEBAND = 1,
 					LANGUAGE_UNATHI = 0,
 					LANGUAGE_SIIK	= 0,

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -105,6 +105,7 @@
 	add_language("Robot Talk", 1)
 	add_language(LANGUAGE_GALCOM, 1)
 	add_language(LANGUAGE_SOL_COMMON, 1)
+	add_language(LANGUAGE_SIVIAN, 1)
 	add_language(LANGUAGE_UNATHI, 1)
 	add_language(LANGUAGE_SIIK, 1)
 	add_language(LANGUAGE_AKHANI, 1)

--- a/code/modules/vchat/css/ss13styles.css
+++ b/code/modules/vchat/css/ss13styles.css
@@ -153,6 +153,7 @@ h1.alert, h2.alert		{color: #000000;}
 .tajaran				{color: #803B56;}
 .tajaran_signlang		{color: #941C1C;}
 .akhani					{color: #AC398C;}
+.sivian					{color: #6666bb;}
 .skrell					{color: #00B0B3;}
 .skrellfar				{color: #70FCFF;}
 .soghun					{color: #50BA6C;}

--- a/code/stylesheet.dm
+++ b/code/stylesheet.dm
@@ -94,6 +94,7 @@ h1.alert, h2.alert		{color: #000000;}
 .tajaran				{color: #803B56;}
 .tajaran_signlang		{color: #941C1C;}
 .akhani					{color: #AC398C;}
+.sivian					{color: #6666bb;}
 .skrell					{color: #00B0B3;}
 .skrellfar				{color: #70FCFF;}
 .soghun					{color: #50BA6C;}


### PR DESCRIPTION
Adds Sivian Creole.
Lore:

- Local language derived from a blend of GalCom and Scandinavian languages and spoken almost exclusively in Vir, particularly on Sif where the majority of original colonists settled and developed the local culture.
- No longer an "official language" that anybody is _expected_ to speak on a national scale, but still holding on among Vir Natives and probably something VirGov sticks on road signs in a smaller font to keep it alive.
- Hundreds of such languages probably exist in the galaxy, but it only makes sense to individually represent The Local One for people who want to play Locals or we'd be here all day to no mechanical benefit.

Mechanically:

- Language key is ,7
- Stok language has been moved to upper-case S (when has anybody spoken Stok ever anyway)
- About 40% understandable to speakers of GalCom or SolCom, as would be expected from a creole.
- Sounds like a mix of Swedish, Norwegian and Icelandic, with elements from Chinese and French, and a hint of Skrellian.
- Most borgs don't speak it by default.
- A desaturated cold blue colour that should show up well on light and dark modes. Geddit, because ice.

Spookerton pelase don't speedmerge people may have input on this one.