### PR TITLE
Fix for custom tail icon layering

### DIFF
--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -261,5 +261,5 @@
 
 /mob/living/carbon/human/set_dir(var/new_dir)
 	. = ..()
-	if(. && species.tail)
+	if(. && (species.tail || tail_style))
 		update_tail_showing()

--- a/code/modules/mob/new_player/preferences_setup.dm
+++ b/code/modules/mob/new_player/preferences_setup.dm
@@ -258,7 +258,6 @@
 	dress_preview_mob(mannequin)
 	mannequin.toggle_tail(setting = TRUE)
 	mannequin.toggle_wing(setting = TRUE)
-	mannequin.update_tail_showing()
 	mannequin.ImmediateOverlayUpdate()
 
 	update_character_previews(new /mutable_appearance(mannequin))


### PR DESCRIPTION
Fixes a bug reported by prismaticgynoid where non-species tails would layer under everything (as if using the E/W/S sprite) when facing north if they icon update was called when they were facing E/W/S which I tryed my darnedest to make happen after this tweak and it wouldn't (thats good). I think they fixed this specific issue downstream by just swapping the defaults but this also works.

Also took out a proc in preferences setup which didn't fix the preview layering (which seems to be caused because the snapshots of the mob are taken before the icon can regenerate because it's non-instant. Shrugs. Also that proc is called by toggle_tail anyway and was totally redundant.