### PR TITLE
Fixes a bug with deleted disposal outlets

### DIFF
--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -1530,6 +1530,12 @@
 	if(trunk)
 		trunk.linked = src	// link the pipe trunk to self
 
+/obj/structure/disposaloutlet/Destroy()
+	var/obj/structure/disposalpipe/trunk/trunk = locate() in loc
+	if(trunk)
+		trunk.linked = null
+	return ..()
+
 	// expel the contents of the holder object, then delete it
 	// called when the holder exits the outlet
 /obj/structure/disposaloutlet/proc/expel(var/obj/structure/disposalholder/H)


### PR DESCRIPTION
Fixes deleted disposal outlets not unlinking their trunks, causing anything that the bare trunk tries to eject to runtime and get qdel'd instead.