### PR TITLE
Cargonia Buff

### DIFF
--- a/code/modules/persistence/storage/smartfridge.dm
+++ b/code/modules/persistence/storage/smartfridge.dm
@@ -48,8 +48,8 @@
 
 		// Delete some stacks if we want
 		if(stacks_go_missing)
-			var/fuzzy = rand(55,65)
-			count = round(count*0.01*fuzzy) // loss of 35-45% with rounding down
+			var/fuzzy = rand(65,75)
+			count = round(count*0.01*fuzzy) // loss of 25-35% with rounding down
 			if(count <= 0)
 				continue
 

--- a/maps/cynosure/cynosure-2.dmm
+++ b/maps/cynosure/cynosure-2.dmm
@@ -13617,10 +13617,14 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/surface/station/security/restroom)
 "gjB" = (
-/obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 9
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
 	},
-/turf/simulated/wall/r_wall,
+/obj/machinery/atmospherics/pipe/manifold/visible/green{
+	dir = 8
+	},
+/obj/machinery/meter,
+/turf/simulated/floor/plating,
 /area/surface/station/engineering/reactor_room)
 "gjW" = (
 /turf/simulated/floor/concrete/sif/planetuse,
@@ -14332,10 +14336,6 @@
 	},
 /obj/item/stack/material/phoron{
 	pixel_y = 2
-	},
-/obj/item/stack/material/phoron{
-	pixel_x = 1;
-	pixel_y = 3
 	},
 /turf/simulated/floor/tiled/white,
 /area/surface/station/medical/chemistry)
@@ -18371,12 +18371,6 @@
 /obj/item/stack/material/glass{
 	amount = 50
 	},
-/obj/item/stack/material/glass{
-	amount = 50
-	},
-/obj/item/stack/material/glass/reinforced{
-	amount = 20
-	},
 /obj/machinery/alarm{
 	pixel_y = 22
 	},
@@ -19731,6 +19725,13 @@
 /obj/structure/window/reinforced/full,
 /turf/simulated/floor/plating,
 /area/surface/station/library)
+"jkO" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/machinery/atmospherics/valve,
+/turf/simulated/floor/plating,
+/area/surface/station/engineering/reactor_room)
 "jkY" = (
 /obj/structure/cable/yellow{
 	d1 = 2;
@@ -22451,6 +22452,12 @@
 /obj/structure/window/reinforced/full,
 /turf/simulated/floor/plating,
 /area/surface/station/medical/storage/primary_storage)
+"kpQ" = (
+/obj/machinery/atmospherics/pipe/simple/visible/green{
+	dir = 9
+	},
+/turf/simulated/floor/plating,
+/area/surface/station/engineering/reactor_room)
 "kqa" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -22785,12 +22792,6 @@
 /obj/structure/table/steel_reinforced,
 /obj/item/stack/material/plasteel{
 	amount = 15
-	},
-/obj/item/stack/material/plasteel{
-	amount = 15
-	},
-/obj/item/stack/material/steel{
-	amount = 50
 	},
 /obj/item/stack/material/steel{
 	amount = 50
@@ -30616,6 +30617,15 @@
 /obj/effect/floor_decal/steeldecal/steel_decals7,
 /turf/simulated/floor/tiled,
 /area/surface/station/engineering/foyer)
+"nTX" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/green{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/surface/station/engineering/reactor_room)
 "nTZ" = (
 /obj/structure/bed/chair/shuttle{
 	dir = 1
@@ -34875,13 +34885,13 @@
 /turf/simulated/floor/plating,
 /area/surface/station/engineering/reactor_room)
 "pDQ" = (
-/obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 6
-	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
 /obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/green{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
@@ -43987,7 +43997,12 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/surface/station/hallway/secondary/groundfloor/civilian)
 "tJR" = (
-/obj/machinery/atmospherics/pipe/simple/visible/green,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/green{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/surface/station/engineering/reactor_room)
 "tJS" = (
@@ -45861,7 +45876,6 @@
 /turf/simulated/floor/tiled/hydro,
 /area/surface/station/hydroponics)
 "uHq" = (
-/obj/machinery/atmospherics/pipe/simple/visible/green,
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 4
 	},
@@ -46677,6 +46691,13 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/surface/station/hallway/primary/groundfloor/east)
+"vaW" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/atmospherics/pipe/simple/visible/green{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/surface/station/engineering/reactor_room)
 "vbc" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/grille,
@@ -53897,7 +53918,7 @@
 	amount = 20
 	},
 /obj/item/stack/rods{
-	amount = 50
+	amount = 25
 	},
 /obj/item/stack/material/concrete{
 	amount = 50
@@ -105354,8 +105375,8 @@ lpT
 jbt
 nAa
 sTX
-jEw
-jEw
+gjB
+jkO
 pwl
 qWU
 bkB
@@ -105611,7 +105632,7 @@ hrd
 yda
 itt
 jaY
-bcX
+tJR
 nZP
 eBc
 pCl
@@ -105868,7 +105889,7 @@ aZv
 aZv
 udx
 lxx
-lxx
+vaW
 lxx
 jWD
 rDt
@@ -106125,7 +106146,7 @@ hHt
 hKN
 tgg
 vwK
-uwn
+nTX
 uwn
 wMM
 pCl
@@ -106382,7 +106403,7 @@ wnA
 sPH
 nKU
 jaY
-bcX
+tJR
 nZP
 eBc
 oRg
@@ -106639,7 +106660,7 @@ bkB
 pYG
 hFe
 lxx
-lxx
+vaW
 lxx
 jWD
 uCG
@@ -106896,10 +106917,10 @@ vZV
 pyL
 jIS
 vwK
-uwn
+nTX
 uwn
 wMM
-pCl
+kpQ
 bkB
 nCe
 twu
@@ -107155,8 +107176,8 @@ bcX
 bcX
 pDQ
 uHq
-tJR
-gjB
+aZv
+bkB
 xTx
 nCe
 twu

--- a/maps/cynosure/cynosure-3.dmm
+++ b/maps/cynosure/cynosure-3.dmm
@@ -13762,8 +13762,6 @@
 	dir = 1
 	},
 /obj/structure/table/standard,
-/obj/fiftyspawner/steel,
-/obj/fiftyspawner/steel,
 /obj/item/stack/material/plasteel{
 	amount = 10;
 	pixel_x = -2;
@@ -23213,22 +23211,6 @@
 	},
 /obj/item/stack/material/steel{
 	amount = 50
-	},
-/obj/item/stack/material/steel{
-	amount = 50
-	},
-/obj/item/stack/material/steel{
-	amount = 50
-	},
-/obj/item/stack/material/glass{
-	amount = 50;
-	pixel_x = 2;
-	pixel_y = -2
-	},
-/obj/item/stack/material/glass{
-	amount = 50;
-	pixel_x = 2;
-	pixel_y = -2
 	},
 /obj/item/stack/material/glass{
 	amount = 50;


### PR DESCRIPTION
Reduced the sheet storage vendor loss per round to 25% to 35%

Reduced the amount of materials over the entire station

Engineering

20 Sheets of Reinforced Glass removed
50 Sheets of Glass removed
50 Sheets of Metal removed
15 Sheets of Plasteel Removed
25 Stack of Rods removed

Medical

1 Sheet of Phoron Removed

Robotics

100 Sheets of Metal Removed
100 Sheets of Glass Removed

EVA

100 Sheets of Metal Removed

--

Fixed a stupid piping bug in the Reactor Core