### PR TITLE
Nudges sif's resting temperature

### DIFF
--- a/code/game/turfs/unsimulated/planetary.dm
+++ b/code/game/turfs/unsimulated/planetary.dm
@@ -59,7 +59,7 @@
 /turf/unsimulated/wall/planetary/sif
 	oxygen		= 114.50978 * 0.181
 	nitrogen	= 114.50978 * 0.819
-	temperature	= 243.15 // Roughly -30C / -22F
+	temperature	= 273.15 // 0C
 
 //High Alt Sif
 /turf/unsimulated/wall/planetary/sif/alt

--- a/maps/cynosure/turfs/outdoors.dm
+++ b/maps/cynosure/turfs/outdoors.dm
@@ -7,7 +7,7 @@
 #define MOLES_O2SIF (MOLES_CELLSIF * O2SIF) // O2 value on Sif(18%)
 #define MOLES_N2SIF (MOLES_CELLSIF * N2SIF) // N2 value on Sif(82%)
 
-#define TEMPERATURE_SIF 243.15 // Roughly -30C / -22F
+#define TEMPERATURE_SIF 273.15 // 0C
 #define TEMPERATURE_ALTSIF 225.15
 
 /turf/simulated/floor/outdoors/mud/sif/planetuse


### PR DESCRIPTION
I previously made it so that pressure from planetary railroading turfs would scale inversely with temperature.
I did not account for the part where sif's default temperature was _-30C_. This means that all of our weather is _warmer_ than this value, such that the pressure is expected to _decrease_.

Let's move the base temperature to 0C and see if that helps to fix the issue of poplung.