### PR TITLE
Standardized area flag defines, added vendor rampancy flag check.

### DIFF
--- a/code/__defines/misc.dm
+++ b/code/__defines/misc.dm
@@ -46,8 +46,10 @@
 #define CLIENT_FROM_VAR(I) (ismob(I) ? I:client : (isclient(I) ? I : null))
 
 
-//Persistence
-#define AREA_FLAG_IS_NOT_PERSISTENT 8 // SSpersistence will not track values from this area.
+//Area flags, possibly more to come
+#define AREA_FLAG_IS_RAD_SHIELDED   1 //shielded from radiation, clearly
+#define AREA_FLAG_IS_NOT_PERSISTENT 2 // SSpersistence will not track values from this area.
+#define AREA_FLAG_IS_STATION_AREA   4 // This area is valid for the purposes of vending machine rampancy (for now)
 
 //	Shuttles.
 
@@ -94,9 +96,6 @@
 #define HYDRO_SPEED_MULTIPLIER 1
 
 #define DEFAULT_JOB_TYPE /datum/job/assistant
-
-//Area flags, possibly more to come
-#define RAD_SHIELDED 1 //shielded from radiation, clearly
 
 // OnTopic return values
 #define TOPIC_NOACTION 0

--- a/code/controllers/subsystems/radiation.dm
+++ b/code/controllers/subsystems/radiation.dm
@@ -73,7 +73,7 @@ SUBSYSTEM_DEF(radiation)
 
 		if(source.respect_maint)
 			var/area/A = T.loc
-			if(A.atom_flags & RAD_SHIELDED)
+			if(A.atom_flags & AREA_FLAG_IS_RAD_SHIELDED)
 				continue // In shielded area
 
 		var/dist = get_dist(source.source_turf, T)

--- a/code/game/area/Space Station 13 areas.dm
+++ b/code/game/area/Space Station 13 areas.dm
@@ -54,6 +54,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 /area/arrival/start
 	name = "\improper Arrival Area"
 	icon_state = "start"
+	area_flags = AREA_FLAG_IS_STATION_AREA
 
 /area/admin
 	name = "\improper Admin room"
@@ -69,7 +70,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 
 /area/shuttle
 	requires_power = 0
-	area_flags = RAD_SHIELDED | AREA_FLAG_IS_NOT_PERSISTENT
+	area_flags = AREA_FLAG_IS_RAD_SHIELDED | AREA_FLAG_IS_NOT_PERSISTENT
 	sound_env = SMALL_ENCLOSED
 	base_turf = /turf/space
 	forbid_events = TRUE
@@ -363,7 +364,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	name = "\improper Independent Station"
 	icon_state = "yellow"
 	requires_power = 0
-	area_flags = AREA_FLAG_IS_NOT_PERSISTENT | RAD_SHIELDED
+	area_flags = AREA_FLAG_IS_NOT_PERSISTENT | AREA_FLAG_IS_RAD_SHIELDED
 	base_turf = /turf/space
 	ambience = AMBIENCE_HIGHSEC
 
@@ -554,7 +555,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 //Maintenance
 
 /area/maintenance
-	area_flags = RAD_SHIELDED
+	area_flags = AREA_FLAG_IS_RAD_SHIELDED | AREA_FLAG_IS_STATION_AREA
 	sound_env = TUNNEL_ENCLOSED
 	turf_initializer = new /datum/turf_initializer/maintenance()
 	ambience = AMBIENCE_MAINTENANCE
@@ -650,7 +651,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 /area/maintenance/disposal
 	name = "Waste Disposal"
 	icon_state = "disposal"
-	area_flags = AREA_FLAG_IS_NOT_PERSISTENT //If trash items got this far, they can be safely deleted.
+	area_flags = AREA_FLAG_IS_NOT_PERSISTENT | AREA_FLAG_IS_STATION_AREA //If trash items got this far, they can be safely deleted.
 
 /area/maintenance/engineering
 	name = "Engineering Maintenance"
@@ -965,12 +966,12 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 /area/crew_quarters/heads/hop
 	name = "\improper Command - HoP's Office"
 	icon_state = "head_quarters"
-	area_flags = AREA_FLAG_IS_NOT_PERSISTENT
+	area_flags = AREA_FLAG_IS_NOT_PERSISTENT | AREA_FLAG_IS_STATION_AREA
 
 /area/crew_quarters/heads/hor
 	name = "\improper Research - RD's Office"
 	icon_state = "head_quarters"
-	area_flags = AREA_FLAG_IS_NOT_PERSISTENT
+	area_flags = AREA_FLAG_IS_NOT_PERSISTENT | AREA_FLAG_IS_STATION_AREA
 
 /area/crew_quarters/heads/chief
 	name = "\improper Engineering - CE's Office"
@@ -1006,7 +1007,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 /area/crew_quarters
 	name = "\improper Dormitories"
 	icon_state = "Sleep"
-	area_flags = RAD_SHIELDED
+	area_flags = AREA_FLAG_IS_RAD_SHIELDED | AREA_FLAG_IS_STATION_AREA
 	ambience = AMBIENCE_GENERIC
 	forbid_events = TRUE
 
@@ -1311,7 +1312,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	dynamic_lighting = 0
 	sound_env = LARGE_ENCLOSED
 	forbid_events = TRUE
-	area_flags = AREA_FLAG_IS_NOT_PERSISTENT
+	area_flags = AREA_FLAG_IS_NOT_PERSISTENT | AREA_FLAG_IS_STATION_AREA
 
 /area/holodeck/alphadeck
 	name = "\improper Holodeck Alpha"
@@ -1381,10 +1382,11 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 
 //Engineering
 
-/area/engineering/
+/area/engineering
 	name = "\improper Engineering"
 	icon_state = "engineering"
 	ambience = AMBIENCE_ENGINEERING
+	area_flags = AREA_FLAG_IS_STATION_AREA
 
 /area/engineering/atmos
  	name = "\improper Atmospherics"
@@ -1521,6 +1523,9 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	icon_state = "SolarcontrolA"
 	sound_env = SMALL_ENCLOSED
 
+/area/assembly
+	area_flags = AREA_FLAG_IS_STATION_AREA
+
 /area/assembly/chargebay
 	name = "\improper Mech Bay"
 	icon_state = "mechbay"
@@ -1546,11 +1551,13 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	name = "\improper Teleporter"
 	icon_state = "teleporter"
 	music = "signal"
+	area_flags = AREA_FLAG_IS_STATION_AREA
 
 /area/gateway
 	name = "\improper Gateway"
 	icon_state = "teleporter"
 	music = "signal"
+	area_flags = AREA_FLAG_IS_STATION_AREA
 
 /area/AIsattele
 	name = "\improper AI Satellite Teleporter Room"
@@ -1558,6 +1565,8 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	music = "signal"
 
 //MedBay
+/area/medical
+	area_flags = AREA_FLAG_IS_STATION_AREA
 
 /area/medical/medbay
 	name = "\improper Medbay Hallway - Port"
@@ -1674,12 +1683,12 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 /area/medical/surgery
 	name = "\improper Operating Theatre 1"
 	icon_state = "surgery"
-	area_flags = AREA_FLAG_IS_NOT_PERSISTENT //This WOULD become a filth pit
+	area_flags = AREA_FLAG_IS_NOT_PERSISTENT | AREA_FLAG_IS_STATION_AREA //This WOULD become a filth pit
 
 /area/medical/surgery2
 	name = "\improper Operating Theatre 2"
 	icon_state = "surgery"
-	area_flags = AREA_FLAG_IS_NOT_PERSISTENT
+	area_flags = AREA_FLAG_IS_NOT_PERSISTENT | AREA_FLAG_IS_STATION_AREA
 
 /area/medical/surgeryobs
 	name = "\improper Operation Observation Room"
@@ -1716,7 +1725,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 /area/medical/sleeper
 	name = "\improper Emergency Treatment Centre"
 	icon_state = "exam_room"
-	area_flags = AREA_FLAG_IS_NOT_PERSISTENT //Trust me.
+	area_flags = AREA_FLAG_IS_NOT_PERSISTENT | AREA_FLAG_IS_STATION_AREA //Trust me.
 
 /area/medical/first_aid_station_starboard
 	name = "\improper Starboard First-Aid Station"
@@ -1729,6 +1738,8 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 
 
 //Security
+/area/security
+	area_flags = AREA_FLAG_IS_STATION_AREA
 
 /area/security/main
 	name = "\improper Security Office"
@@ -1871,10 +1882,12 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 /area/janitor/
 	name = "\improper Custodial Closet"
 	icon_state = "janitor"
+	area_flags = AREA_FLAG_IS_STATION_AREA
 
 /area/hydroponics
 	name = "\improper Hydroponics"
 	icon_state = "hydro"
+	area_flags = AREA_FLAG_IS_STATION_AREA
 
 /area/hydroponics/cafegarden
 	name = "\improper Cafeteria Garden"
@@ -1889,6 +1902,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 /area/quartermaster
 	name = "\improper Quartermasters"
 	icon_state = "quart"
+	area_flags = AREA_FLAG_IS_STATION_AREA
 
 /area/quartermaster/office
 	name = "\improper Cargo Office"
@@ -1914,7 +1928,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 /area/quartermaster/delivery
 	name = "\improper Cargo - Delivery Office"
 	icon_state = "quart"
-	area_flags = AREA_FLAG_IS_NOT_PERSISTENT //So trash doesn't pile up too hard.
+	area_flags = AREA_FLAG_IS_NOT_PERSISTENT | AREA_FLAG_IS_STATION_AREA //So trash doesn't pile up too hard.
 
 /area/quartermaster/miningdock
 	name = "\improper Cargo Mining Dock"
@@ -1922,6 +1936,8 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 
 
 // SCIENCE
+/area/rnd
+	area_flags = AREA_FLAG_IS_STATION_AREA
 
 /area/rnd/research
 	name = "\improper Research and Development"
@@ -1955,7 +1971,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 /area/rnd/rdoffice
 	name = "\improper Research Director's Office"
 	icon_state = "head_quarters"
-	area_flags = AREA_FLAG_IS_NOT_PERSISTENT
+	area_flags = AREA_FLAG_IS_NOT_PERSISTENT | AREA_FLAG_IS_STATION_AREA
 
 /area/rnd/supermatter
 	name = "\improper Supermatter Lab"
@@ -1998,6 +2014,8 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	icon_state = "server"
 
 //Storage
+/area/storage
+	area_flags = AREA_FLAG_IS_STATION_AREA
 
 /area/storage/tools
 	name = "Auxiliary Tool Storage"
@@ -2292,39 +2310,46 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	name = "\improper AI Upload Chamber"
 	icon_state = "ai_upload"
 	ambience = AMBIENCE_AI
+	area_flags = AREA_FLAG_IS_STATION_AREA
 
 /area/ai_upload_foyer
 	name = "AI Upload Access"
 	icon_state = "ai_foyer"
 	sound_env = SMALL_ENCLOSED
 	ambience = AMBIENCE_AI
+	area_flags = AREA_FLAG_IS_STATION_AREA
 
 /area/ai_server_room
 	name = "Messaging Server Room"
 	icon_state = "ai_server"
 	sound_env = SMALL_ENCLOSED
 	ambience = AMBIENCE_AI
+	area_flags = AREA_FLAG_IS_STATION_AREA
 
 /area/ai
 	name = "\improper AI Chamber"
 	icon_state = "ai_chamber"
 	ambience = AMBIENCE_AI
+	area_flags = AREA_FLAG_IS_STATION_AREA
 
 /area/ai_cyborg_station
 	name = "\improper Cyborg Station"
 	icon_state = "ai_cyborg"
 	sound_env = SMALL_ENCLOSED
 	ambience = AMBIENCE_AI
+	area_flags = AREA_FLAG_IS_STATION_AREA
 
 /area/aisat
 	name = "\improper AI Satellite"
 	icon_state = "ai"
 	ambience = AMBIENCE_AI
+	area_flags = AREA_FLAG_IS_STATION_AREA
 
 /area/aisat_interior
 	name = "\improper AI Satellite"
 	icon_state = "ai"
 	ambience = AMBIENCE_AI // The lack of inheritence hurts my soul.
+	area_flags = AREA_FLAG_IS_STATION_AREA
 
 /area/AIsatextFP
 	name = "\improper AI Sat Ext"
@@ -2332,6 +2357,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	luminosity = 1
 	dynamic_lighting = 0
 	ambience = AMBIENCE_AI
+	area_flags = AREA_FLAG_IS_STATION_AREA
 
 /area/AIsatextFS
 	name = "\improper AI Sat Ext"
@@ -2339,6 +2365,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	luminosity = 1
 	dynamic_lighting = 0
 	ambience = AMBIENCE_AI
+	area_flags = AREA_FLAG_IS_STATION_AREA
 
 /area/AIsatextAS
 	name = "\improper AI Sat Ext"
@@ -2346,6 +2373,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	luminosity = 1
 	dynamic_lighting = 0
 	ambience = AMBIENCE_AI
+	area_flags = AREA_FLAG_IS_STATION_AREA
 
 /area/AIsatextAP
 	name = "\improper AI Sat Ext"
@@ -2353,11 +2381,13 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	luminosity = 1
 	dynamic_lighting = 0
 	ambience = AMBIENCE_AI
+	area_flags = AREA_FLAG_IS_STATION_AREA
 
 /area/NewAIMain
 	name = "\improper AI Main New"
 	icon_state = "storage"
 	ambience = AMBIENCE_AI
+	area_flags = AREA_FLAG_IS_STATION_AREA
 
 
 
@@ -2395,46 +2425,56 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 // Telecommunications Satellite
 /area/tcommsat/
 	ambience = AMBIENCE_ENGINEERING
+	area_flags = AREA_FLAG_IS_STATION_AREA
 
 /area/tcommsat/entrance
 	name = "\improper Telecomms Teleporter"
 	icon_state = "tcomsatentrance"
+	area_flags = AREA_FLAG_IS_STATION_AREA
 
 /area/tcommsat/chamber
 	name = "\improper Telecomms Central Compartment"
 	icon_state = "tcomsatcham"
+	area_flags = AREA_FLAG_IS_STATION_AREA
 
 /area/tcomsat
 	name = "\improper Telecomms Satellite"
 	icon_state = "tcomsatlob"
 	ambience = AMBIENCE_ENGINEERING
+	area_flags = AREA_FLAG_IS_STATION_AREA
 
 /area/tcomfoyer
 	name = "\improper Telecomms Foyer"
 	icon_state = "tcomsatfoyer"
 	ambience = AMBIENCE_ENGINEERING
+	area_flags = AREA_FLAG_IS_STATION_AREA
 
 /area/tcomwest
 	name = "\improper Telecommunications Satellite West Wing"
 	icon_state = "tcomsatwest"
 	ambience = AMBIENCE_ENGINEERING
+	area_flags = AREA_FLAG_IS_STATION_AREA
 
 /area/tcomeast
 	name = "\improper Telecommunications Satellite East Wing"
 	icon_state = "tcomsateast"
 	ambience = AMBIENCE_ENGINEERING
+	area_flags = AREA_FLAG_IS_STATION_AREA
 
 /area/tcommsat/computer
 	name = "\improper Telecomms Control Room"
 	icon_state = "tcomsatcomp"
+	area_flags = AREA_FLAG_IS_STATION_AREA
 
 /area/tcommsat/lounge
 	name = "\improper Telecommunications Satellite Lounge"
 	icon_state = "tcomsatlounge"
+	area_flags = AREA_FLAG_IS_STATION_AREA
 
 /area/tcommsat/powercontrol
 	name = "\improper Telecommunications Power Control"
 	icon_state = "tcomsatwest"
+	area_flags = AREA_FLAG_IS_STATION_AREA
 
 
 // Away Missions

--- a/code/game/area/ai_monitored.dm
+++ b/code/game/area/ai_monitored.dm
@@ -1,5 +1,6 @@
 /area/ai_monitored
 	name = "AI Monitored Area"
+	area_flags = AREA_FLAG_IS_STATION_AREA
 	var/obj/machinery/camera/motioncamera = null
 
 /area/ai_monitored/LateInitialize()

--- a/code/game/area/asteroid_areas.dm
+++ b/code/game/area/asteroid_areas.dm
@@ -43,7 +43,7 @@
 // Main mining outpost
 /area/outpost/mining_main
 	icon_state = "outpost_mine_main"
-	area_flags = AREA_FLAG_IS_NOT_PERSISTENT
+	area_flags = AREA_FLAG_IS_NOT_PERSISTENT | AREA_FLAG_IS_STATION_AREA
 
 /area/outpost/mining_main/airlock
 	name = "Mining Outpost Airlock"
@@ -95,7 +95,7 @@
 // Engineering Outpost
 /area/outpost/engineering
 	icon_state = "outpost_engine"
-	area_flags = AREA_FLAG_IS_NOT_PERSISTENT
+	area_flags = AREA_FLAG_IS_NOT_PERSISTENT | AREA_FLAG_IS_STATION_AREA
 
 /area/outpost/engineering/hallway
 	name = "Engineering Outpost Hallway"
@@ -169,7 +169,7 @@
 // Research Outpost
 /area/outpost/research
 	icon_state = "outpost_research"
-	area_flags = AREA_FLAG_IS_NOT_PERSISTENT
+	area_flags = AREA_FLAG_IS_NOT_PERSISTENT | AREA_FLAG_IS_STATION_AREA
 
 /area/outpost/research/hallway
 	name = "Research Outpost Hallway"

--- a/code/modules/events/brand_intelligence.dm
+++ b/code/modules/events/brand_intelligence.dm
@@ -14,7 +14,11 @@
 
 /datum/event/brand_intelligence/start()
 	for(var/obj/machinery/vending/V in machines)
-		if(isNotStationLevel(V.z))	continue
+		if(isNotStationLevel(V.z))
+			continue
+		var/area/A = get_area(V)
+		if(!(A?.area_flags & AREA_FLAG_IS_STATION_AREA))
+			continue
 		vendingMachines.Add(V)
 
 	if(!vendingMachines.len)

--- a/code/modules/events/ion_storm.dm
+++ b/code/modules/events/ion_storm.dm
@@ -37,7 +37,7 @@
 		if(!(S.z in affecting_z))
 			continue
 		var/area/A = get_area(S)
-		if(!A || A.area_flags & RAD_SHIELDED) // Rad shielding will protect from ions too
+		if(!A || A.area_flags & AREA_FLAG_IS_RAD_SHIELDED) // Rad shielding will protect from ions too
 			continue
 		to_chat(S, "<span class='warning'>Your integrated sensors detect an ionospheric anomaly. Your systems will be impacted as you begin a partial restart.</span>")
 		var/ionbug = rand(3, 9)

--- a/code/modules/events/radiation_storm.dm
+++ b/code/modules/events/radiation_storm.dm
@@ -37,7 +37,7 @@
 		var/area/A = get_area(C)
 		if(!A)
 			continue
-		if(A.area_flags & RAD_SHIELDED)
+		if(A.area_flags & AREA_FLAG_IS_RAD_SHIELDED)
 			continue
 		if(istype(C,/mob/living/carbon/human))
 			var/mob/living/carbon/human/H = C

--- a/code/modules/radiation/radiation.dm
+++ b/code/modules/radiation/radiation.dm
@@ -4,7 +4,7 @@
 	var/turf/source_turf		// Location of the radiation source.
 	var/rad_power				// Strength of the radiation being emitted.
 	var/decay = TRUE			// True for automatic decay.  False if owner promises to handle it (i.e. supermatter)
-	var/respect_maint = FALSE	// True for not affecting RAD_SHIELDED areas.
+	var/respect_maint = FALSE	// True for not affecting AREA_FLAG_IS_RAD_SHIELDED areas.
 	var/flat = FALSE			// True for power falloff with distance.
 	var/range					// Cached maximum range, used for quick checks against mobs.
 

--- a/maps/cynosure/cynosure_areas.dm
+++ b/maps/cynosure/cynosure_areas.dm
@@ -2,7 +2,7 @@
 
 /area/surface
 	name = "The Surface (Don't Use)"
-	area_flags = RAD_SHIELDED
+	area_flags = AREA_FLAG_IS_RAD_SHIELDED
 
 /area/surface/center
 	name = "Center"
@@ -43,7 +43,7 @@
 /area/surface/outside
 	ambience = AMBIENCE_SIF
 	always_unpowered = TRUE
-	area_flags = RAD_SHIELDED | AREA_FLAG_IS_NOT_PERSISTENT
+	area_flags = AREA_FLAG_IS_RAD_SHIELDED | AREA_FLAG_IS_NOT_PERSISTENT
 	outdoors = OUTDOORS_YES
 
 // The area near the station, so POIs don't show up right next to the outpost.
@@ -102,7 +102,7 @@
 	name = "Gautelfr River"
 
 /area/surface/cave
-	area_flags = RAD_SHIELDED | AREA_FLAG_IS_NOT_PERSISTENT
+	area_flags = AREA_FLAG_IS_RAD_SHIELDED | AREA_FLAG_IS_NOT_PERSISTENT
 	always_unpowered = TRUE
 
 // The bottom half that connects to the outpost and is safer.
@@ -128,6 +128,7 @@
 /area/surface/station
 	ambience = AMBIENCE_GENERIC
 	outdoors = OUTDOORS_NO
+	area_flags = AREA_FLAG_IS_STATION_AREA
 
 //AI
 
@@ -509,13 +510,13 @@
 /area/surface/station/crew_quarters/heads/cmo
 	name = "\improper Medbay - CMO's Office"
 	icon_state = "head_quarters"
-	area_flags = RAD_SHIELDED | AREA_FLAG_IS_NOT_PERSISTENT
+	area_flags = AREA_FLAG_IS_RAD_SHIELDED | AREA_FLAG_IS_NOT_PERSISTENT | AREA_FLAG_IS_STATION_AREA
 	holomap_color = HOLOMAP_AREACOLOR_MEDICAL
 
 /area/surface/station/crew_quarters/heads/hop
 	name = "\improper Head of Personnel's Office"
 	icon_state = "head_quarters"
-	area_flags = RAD_SHIELDED | AREA_FLAG_IS_NOT_PERSISTENT
+	area_flags = AREA_FLAG_IS_RAD_SHIELDED | AREA_FLAG_IS_NOT_PERSISTENT | AREA_FLAG_IS_STATION_AREA
 	holomap_color = HOLOMAP_AREACOLOR_COMMAND
 
 /area/surface/station/crew_quarters/heads/hos
@@ -669,7 +670,7 @@
 //Maintenance
 
 /area/surface/station/maintenance
-	area_flags = RAD_SHIELDED
+	area_flags = AREA_FLAG_IS_RAD_SHIELDED | AREA_FLAG_IS_STATION_AREA
 	sound_env = TUNNEL_ENCLOSED
 	turf_initializer = new /datum/turf_initializer/maintenance()
 	ambience = AMBIENCE_MAINTENANCE
@@ -803,7 +804,7 @@
 /area/surface/station/construction
 	name = "\improper Engineering Construction Area"
 	icon_state = "yellow"
-	area_flags = RAD_SHIELDED | AREA_FLAG_IS_NOT_PERSISTENT
+	area_flags = AREA_FLAG_IS_RAD_SHIELDED | AREA_FLAG_IS_NOT_PERSISTENT | AREA_FLAG_IS_STATION_AREA
 
 /area/surface/station/construction/bar
 	name = "\improper Bar Basement"
@@ -865,7 +866,7 @@
 /area/surface/station/medical/etc
 	name = "\improper Medical - Emergency Treatment Centre"
 	icon_state = "exam_room"
-	area_flags = RAD_SHIELDED | AREA_FLAG_IS_NOT_PERSISTENT //Trust me.
+	area_flags = AREA_FLAG_IS_RAD_SHIELDED | AREA_FLAG_IS_NOT_PERSISTENT | AREA_FLAG_IS_STATION_AREA //Trust me.
 
 /area/surface/station/medical/hallway
 	name = "\improper Medbay - Hallway"
@@ -937,12 +938,12 @@
 /area/surface/station/medical/surgery
 	name = "\improper Medbay - Operating Theatre 1"
 	icon_state = "surgery"
-	area_flags = RAD_SHIELDED | AREA_FLAG_IS_NOT_PERSISTENT //This WOULD become a filth pit
+	area_flags = AREA_FLAG_IS_RAD_SHIELDED | AREA_FLAG_IS_NOT_PERSISTENT | AREA_FLAG_IS_STATION_AREA //This WOULD become a filth pit
 
 /area/surface/station/medical/surgery2
 	name = "\improper Medbay - Operating Theatre 2"
 	icon_state = "surgery"
-	area_flags = RAD_SHIELDED | AREA_FLAG_IS_NOT_PERSISTENT
+	area_flags = AREA_FLAG_IS_RAD_SHIELDED | AREA_FLAG_IS_NOT_PERSISTENT | AREA_FLAG_IS_STATION_AREA
 
 /area/surface/station/medical/surgeryobs
 	name = "\improper Medbay - Operation Observation"
@@ -990,7 +991,7 @@
 /area/surface/outside/station
 	name = "\improper Station"
 	ambience = AMBIENCE_SIF
-	area_flags = RAD_SHIELDED | AREA_FLAG_IS_NOT_PERSISTENT
+	area_flags = AREA_FLAG_IS_RAD_SHIELDED | AREA_FLAG_IS_NOT_PERSISTENT | AREA_FLAG_IS_STATION_AREA
 
 /area/surface/outside/station/roof
 	name = "\improper Roof"
@@ -1067,7 +1068,7 @@
 
 /area/surface/station/quartermaster/delivery
 	name = "\improper Cargo - Delivery Office"
-	area_flags = RAD_SHIELDED | AREA_FLAG_IS_NOT_PERSISTENT //So trash doesn't pile up too hard.
+	area_flags = AREA_FLAG_IS_RAD_SHIELDED | AREA_FLAG_IS_NOT_PERSISTENT | AREA_FLAG_IS_STATION_AREA //So trash doesn't pile up too hard.
 
 /area/surface/station/quartermaster/lockerroom
 	name = "\improper Cargo Locker Room"
@@ -1344,7 +1345,7 @@
 	icon_state = "shuttle"
 	requires_power = 0
 	dynamic_lighting = 1
-	area_flags = RAD_SHIELDED | AREA_FLAG_IS_NOT_PERSISTENT
+	area_flags = AREA_FLAG_IS_RAD_SHIELDED | AREA_FLAG_IS_NOT_PERSISTENT | AREA_FLAG_IS_STATION_AREA
 
 /area/turbolift/start
 	name = "\improper Turbolift Start"
@@ -1493,6 +1494,7 @@
 	name = "\improper Telecomms Satellite"
 	icon_state = "tcomsatcham"
 	ambience = AMBIENCE_ENGINEERING
+	area_flags = AREA_FLAG_IS_STATION_AREA
 
 /area/tcommsat/cynosure/entrance
 	name = "\improper Telecomms Entrance"
@@ -1551,7 +1553,7 @@
 	name = "\improper Response Team Ship"
 	icon_state = "centcom"
 	requires_power = 0
-	area_flags = RAD_SHIELDED
+	area_flags = AREA_FLAG_IS_RAD_SHIELDED
 	ambience = AMBIENCE_HIGHSEC
 
 /area/shuttle/response_ship/start
@@ -1631,7 +1633,7 @@
 	icon_state = "syndie-ship"
 	requires_power = 0
 	dynamic_lighting = 0
-	area_flags = RAD_SHIELDED
+	area_flags = AREA_FLAG_IS_RAD_SHIELDED
 	ambience = AMBIENCE_HIGHSEC
 
 /area/syndicate_station
@@ -1639,7 +1641,7 @@
 	icon_state = "syndie-ship"
 	requires_power = 0
 	dynamic_lighting = 0
-	area_flags = RAD_SHIELDED
+	area_flags = AREA_FLAG_IS_RAD_SHIELDED
 	ambience = AMBIENCE_HIGHSEC
 
 /area/syndicate_station/start
@@ -1700,7 +1702,7 @@
 	icon_state = "yellow"
 	requires_power = 0
 	dynamic_lighting = 0
-	area_flags = RAD_SHIELDED
+	area_flags = AREA_FLAG_IS_RAD_SHIELDED
 	ambience = AMBIENCE_HIGHSEC
 
 /area/skipjack_station/transit
@@ -1754,7 +1756,7 @@
 	name = "\improper Ninja Base"
 	icon_state = "green"
 	requires_power = 0
-	area_flags = RAD_SHIELDED
+	area_flags = AREA_FLAG_IS_RAD_SHIELDED
 	ambience = AMBIENCE_HIGHSEC
 
 /area/ninja_dojo/dojo

--- a/maps/southern_cross/southern_cross_areas.dm
+++ b/maps/southern_cross/southern_cross_areas.dm
@@ -19,7 +19,7 @@
 
 /area/surface
 	name = "The Surface (Don't Use)"
-	flags = RAD_SHIELDED
+	flags = AREA_FLAG_IS_RAD_SHIELDED
 
 /area/surface/center
 	name = "Center"
@@ -125,7 +125,7 @@
 
 
 /area/surface/cave
-	flags = RAD_SHIELDED | AREA_FLAG_IS_NOT_PERSISTENT
+	flags = AREA_FLAG_IS_RAD_SHIELDED | AREA_FLAG_IS_NOT_PERSISTENT
 	always_unpowered = TRUE
 
 /area/surface/cave
@@ -154,6 +154,7 @@
 
 /area/surface/outpost
 	ambience = AMBIENCE_GENERIC
+	area_flags = AREA_FLAG_IS_STATION_AREA
 
 //Wilderness Shuttle Shelter
 
@@ -413,7 +414,7 @@
 	icon_state = "shuttle"
 	requires_power = 0
 	dynamic_lighting = 1
-	flags = RAD_SHIELDED | AREA_FLAG_IS_NOT_PERSISTENT
+	flags = AREA_FLAG_IS_RAD_SHIELDED | AREA_FLAG_IS_NOT_PERSISTENT
 
 /area/turbolift/start
 	name = "\improper Turbolift Start"
@@ -658,7 +659,7 @@
 	name = "\improper First Deck First-Aid Station"
 
 /area/storage/emergency_storage/
-	flags = RAD_SHIELDED
+	flags = AREA_FLAG_IS_RAD_SHIELDED
 	name = "Emergency Storage"
 	icon_state = "emergencystorage"
 
@@ -762,7 +763,7 @@
 /area/crew_quarters/heads/sc/
 	name = "\improper Command - Head Office"
 	icon_state = "head_quarters"
-	flags = RAD_SHIELDED
+	flags = AREA_FLAG_IS_RAD_SHIELDED
 	sound_env = MEDIUM_SOFTFLOOR
 
 /area/crew_quarters/heads/sc/hop
@@ -800,7 +801,7 @@
 /area/engineering/engi_restroom
 	name = "\improper Engineering Restroom"
 	icon_state = "toilet"
-	flags = RAD_SHIELDED
+	flags = AREA_FLAG_IS_RAD_SHIELDED
 	sound_env = SMALL_ENCLOSED
 
 /area/engineering/hallway/atmos_hallway
@@ -878,7 +879,7 @@
 /area/medical/medical_restroom
 	name = "\improper Medbay Restroom"
 	icon_state = "medbay_restroom"
-	flags = RAD_SHIELDED
+	flags = AREA_FLAG_IS_RAD_SHIELDED
 	sound_env = SMALL_ENCLOSED
 
 /area/security/aid_station
@@ -892,7 +893,7 @@
 /area/security/security_restroom
 	name = "\improper Security - Restroom"
 	icon_state = "security_bathroom"
-	flags = RAD_SHIELDED
+	flags = AREA_FLAG_IS_RAD_SHIELDED
 	sound_env = SMALL_ENCLOSED
 
 /area/storage/emergency_storage/seconddeck/ap_emergency
@@ -916,7 +917,7 @@
 /area/rnd/research_restroom_sc
 	name = "\improper Research Restroom"
 	icon_state = "research_restroom"
-	flags = RAD_SHIELDED
+	flags = AREA_FLAG_IS_RAD_SHIELDED
 	sound_env = SMALL_ENCLOSED
 
 /area/rnd/research_lockerroom
@@ -1081,7 +1082,7 @@
 	name = "\improper Response Team Ship"
 	icon_state = "centcom"
 	requires_power = 0
-	flags = RAD_SHIELDED
+	flags = AREA_FLAG_IS_RAD_SHIELDED
 	ambience = AMBIENCE_HIGHSEC
 
 /area/shuttle/response_ship/start
@@ -1142,7 +1143,7 @@
 	icon_state = "yellow"
 	requires_power = 0
 	dynamic_lighting = 1
-	flags = RAD_SHIELDED
+	flags = AREA_FLAG_IS_RAD_SHIELDED
 
 /area/shuttle/shuttle1/start
 	name = "Shuttle One"
@@ -1192,7 +1193,7 @@
 	icon_state = "yellow"
 	requires_power = 0
 	dynamic_lighting = 1
-	flags = RAD_SHIELDED
+	flags = AREA_FLAG_IS_RAD_SHIELDED
 
 /area/shuttle/shuttle2/start
 	name = "Shuttle Two"
@@ -1261,7 +1262,7 @@
 	icon_state = "syndie-ship"
 	requires_power = 0
 	dynamic_lighting = 0
-	flags = RAD_SHIELDED
+	flags = AREA_FLAG_IS_RAD_SHIELDED
 	ambience = AMBIENCE_HIGHSEC
 
 /area/syndicate_station
@@ -1269,7 +1270,7 @@
 	icon_state = "syndie-ship"
 	requires_power = 0
 	dynamic_lighting = 0
-	flags = RAD_SHIELDED
+	flags = AREA_FLAG_IS_RAD_SHIELDED
 	ambience = AMBIENCE_HIGHSEC
 
 /area/syndicate_station/start
@@ -1330,7 +1331,7 @@
 	icon_state = "yellow"
 	requires_power = 0
 	dynamic_lighting = 0
-	flags = RAD_SHIELDED
+	flags = AREA_FLAG_IS_RAD_SHIELDED
 	ambience = AMBIENCE_HIGHSEC
 
 /area/skipjack_station/transit
@@ -1384,7 +1385,7 @@
 	name = "\improper Ninja Base"
 	icon_state = "green"
 	requires_power = 0
-	flags = RAD_SHIELDED
+	flags = AREA_FLAG_IS_RAD_SHIELDED
 	ambience = AMBIENCE_HIGHSEC
 
 /area/ninja_dojo/dojo

--- a/maps/submaps/surface_submaps/wilderness/wilderness_areas.dm
+++ b/maps/submaps/surface_submaps/wilderness/wilderness_areas.dm
@@ -4,7 +4,7 @@
 	ambience = AMBIENCE_RUINS
 	secret_name = TRUE
 	forbid_events = TRUE
-	area_flags = AREA_FLAG_IS_NOT_PERSISTENT | RAD_SHIELDED
+	area_flags = AREA_FLAG_IS_NOT_PERSISTENT | AREA_FLAG_IS_RAD_SHIELDED
 
 /area/submap/event //To be used for Events not for regular PoIs
 	name = "Unknown"


### PR DESCRIPTION
Should prevent vendors in PoIs or other inaccessible sites being infected for the event.