### PR TITLE
Enforcing no sleep during mob/Life(), tick checking AStar().

### DIFF
--- a/code/defines/procs/AStar.dm
+++ b/code/defines/procs/AStar.dm
@@ -134,7 +134,10 @@ length to avoid portals or something i guess?? Not that they're counted right no
 
 	open.Enqueue(new /PathNode(start, null, 0, call(start, dist)(end), 0))
 
-	while(!open.IsEmpty() && !path)
+	var/how_many_iter = 0
+	var/sanity = 500 // From some local testing, AStar() tends to hit tick check or succeed around the 450 mark.
+	while(!open.IsEmpty() && !path && sanity)
+		sanity--
 		var/PathNode/current = open.Dequeue()
 		closed.Add(current.position)
 
@@ -177,5 +180,8 @@ length to avoid portals or something i guess?? Not that they're counted right no
 
 			if(max_nodes && open.Length() > max_nodes)
 				open.Remove(open.Length())
+
+		if(TICK_CHECK)
+			return // Took too long, give up.
 
 	return path

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -721,15 +721,10 @@ GLOBAL_DATUM(autospeaker, /mob/living/silicon/ai/announcer)
 			src.syndie = 1
 
 	for (var/ch_name in src.channels)
-		if(!radio_controller)
-			sleep(30) // Waiting for the radio_controller to be created.
-		if(!radio_controller)
+		if(!radio_controller) // Should be exceedingly unlikely following New() => Initialize() changes.
 			src.name = "broken radio"
 			return
-
 		secure_radio_connections[ch_name] = radio_controller.add_object(src, radiochannels[ch_name],  RADIO_CHAT)
-
-	return
 
 /obj/item/radio/proc/config(op)
 	if(radio_controller)

--- a/code/modules/blob2/blobs/base_blob.dm
+++ b/code/modules/blob2/blobs/base_blob.dm
@@ -182,22 +182,23 @@ GLOBAL_LIST_EMPTY(all_blobs)
 			B.overmind = overmind
 		B.density = TRUE
 		if(T.Enter(B,src)) //NOW we can attempt to move into the tile
-			sleep(1) // To have the slide animation work.
-			B.density = initial(B.density)
-			B.forceMove(T)
-			B.update_icon()
-			if(B.overmind && expand_reaction)
-				B.overmind.blob_type.on_expand(src, B, T, B.overmind)
+			do_slide_animation(B, T, expand_reaction)
 			return B
-
-		else
-			blob_attack_animation(T, controller)
-			T.blob_act(src) //if we can't move in hit the turf again
-			qdel(B) //we should never get to this point, since we checked before moving in. destroy the blob so we don't have two blobs on one tile
-			return null
+		blob_attack_animation(T, controller)
+		T.blob_act(src) //if we can't move in hit the turf again
+		qdel(B) //we should never get to this point, since we checked before moving in. destroy the blob so we don't have two blobs on one tile
+		return null
 	else
 		blob_attack_animation(T, controller) //if we can't, animate that we attacked
-	return null
+
+/obj/structure/blob/proc/do_slide_animation(var/obj/structure/blob/B, var/turf/T, var/expand_reaction)
+	set waitfor = FALSE
+	sleep(1) // To have the slide animation work.
+	B.density = initial(B.density)
+	B.forceMove(T)
+	B.update_icon()
+	if(B.overmind && expand_reaction)
+		B.overmind.blob_type.on_expand(src, B, T, B.overmind)
 
 /obj/structure/blob/proc/consume_tile()
 	for(var/atom/A in loc)

--- a/code/modules/blob2/overmind/powers.dm
+++ b/code/modules/blob2/overmind/powers.dm
@@ -86,7 +86,8 @@
 			B = temp
 			break
 
-		CHECK_TICK // Iterating over a list containing hundreds of blobs can get taxing.
+		if(TICK_CHECK) // Iterating over a list containing hundreds of blobs can get taxing.
+			return // Swapped to TICK_CHECK because previous usage was sleeping entire mob subsystem.
 
 	if(B)
 		forceMove(B.loc)
@@ -129,7 +130,8 @@
 			B = temp
 			break
 
-		CHECK_TICK
+		if(TICK_CHECK)
+			return // Blobs are tick checked but this while loop is not. Previous usage was sleeping the entire mob subsystem.
 
 	if(B)
 		forceMove(B.loc)
@@ -171,7 +173,8 @@
 			B = temp
 			break
 
-		CHECK_TICK
+		if(TICK_CHECK)
+			return // Do not sleep the entire mob subsystem pls.
 
 	if(B)
 		forceMove(B.loc)

--- a/code/modules/emotes/emote_mob.dm
+++ b/code/modules/emotes/emote_mob.dm
@@ -146,6 +146,8 @@
 
 /mob/proc/custom_emote(var/m_type = VISIBLE_MESSAGE, var/message, var/range = world.view)
 
+	set waitfor = FALSE // Due to input() below and this being used in Life() procs.
+
 	if((usr && stat) || (!use_me && usr == src))
 		to_chat(src, "You are unable to emote.")
 		return

--- a/code/modules/mob/living/bot/bot.dm
+++ b/code/modules/mob/living/bot/bot.dm
@@ -37,6 +37,7 @@
 	var/max_target_dist = 50 // How far we are willing to go
 	var/max_patrol_dist = 250
 
+	var/started_moving_along_path = 0
 	var/target_patience = 5
 	var/frustration = 0
 	var/max_frustration = 0
@@ -70,8 +71,7 @@
 	SetParalysis(0)
 
 	if(on && !client && !busy)
-		spawn(0)
-			handleAI()
+		handleAI()
 
 /mob/living/bot/updatehealth()
 	if(status_flags & GODMODE)
@@ -158,6 +158,38 @@
 /mob/living/bot/emag_act(var/remaining_charges, var/mob/user)
 	return 0
 
+// Some boilerplate here and below, but this is a quickfix to stop Ater nuking the mob type, so heigh ho.
+/mob/living/bot/proc/stepTowardsTarget(var/delay, var/panic_speed_mod)
+	set waitfor = FALSE
+	var/started_moving_at = world.time
+	started_moving_along_path = started_moving_at
+	if(!wait_if_pulled || !pulledby)
+		for(var/i = 1 to (target_speed + panic_speed_mod))
+			sleep(delay)
+			if(started_moving_along_path != started_moving_at)
+				return // We have started another move iteration.
+			stepToTarget() // Calls A*, very expensive; is not necessarily safe. In a perfect world this would
+			if(TICK_CHECK) // not be behind a set waitfor = FALSE, but we do not live in a perfect world and
+				break      // SSmobs fires too slowly for chases to work using A* without sleeping.
+	if(started_moving_along_path != started_moving_at)
+		return // We have started another move iteration.
+	if(max_frustration && frustration > max_frustration * target_speed)
+		handleFrustrated(1)
+
+/mob/living/bot/proc/stepAlongPatrol(var/delay, var/panic_speed_mod)
+	set waitfor = FALSE
+	var/started_moving_at = world.time
+	started_moving_along_path = started_moving_at
+	for(var/i = 1 to (patrol_speed + panic_speed_mod))
+		sleep(delay)
+		if(started_moving_along_path != started_moving_at)
+			return // We have started another move iteration.
+		handlePatrol() // Does not call A*; is more or less safe.
+	if(started_moving_along_path != started_moving_at)
+		return // We have started another move iteration.
+	if(max_frustration && frustration > max_frustration * patrol_speed)
+		handleFrustrated(0)
+
 /mob/living/bot/proc/handleAI()
 	if(ignore_list.len)
 		for(var/atom/A in ignore_list)
@@ -165,41 +197,28 @@
 				ignore_list -= A
 	handleRegular()
 
-	var/panic_speed_mod = 0
-
-	if(panic_on_alert)
-		panic_speed_mod = handlePanic()
-
 	if(target && confirmTarget(target))
 		if(Adjacent(target))
 			handleAdjacentTarget()
 		else
 			handleRangedTarget()
-		if(!wait_if_pulled || !pulledby)
-			for(var/i = 1 to (target_speed + panic_speed_mod))
-				sleep(20 / (target_speed + panic_speed_mod + 1))
-				stepToTarget()
-		if(max_frustration && frustration > max_frustration * target_speed)
-			handleFrustrated(1)
-	else
-		resetTarget()
-		lookForTargets()
-		if(will_patrol && !pulledby && !target)
-			if(patrol_path && patrol_path.len)
-				for(var/i = 1 to (patrol_speed + panic_speed_mod))
-					sleep(20 / (patrol_speed + 1))
-					handlePatrol()
-				if(max_frustration && frustration > max_frustration * patrol_speed)
-					handleFrustrated(0)
-			else
-				startPatrol()
-		else
-			if((locate(/obj/machinery/door) in loc) && !pulledby) //Don't hang around blocking doors, but don't run off if someone tries to pull us through one.
-				var/turf/my_turf = get_turf(src)
-				var/list/can_go = my_turf.CardinalTurfsWithAccess(botcard)
-				if(LAZYLEN(can_go))
-					if(step_towards(src, pick(can_go)))
-						return
+		var/panic_speed_mod = panic_on_alert ? handlePanic() : 0
+		stepTowardsTarget(round(20 / (target_speed + panic_speed_mod + 1)), panic_speed_mod)
+		return
+
+	resetTarget()
+	lookForTargets()
+	if(will_patrol && !pulledby && !target)
+		if(patrol_path && patrol_path.len)
+			stepAlongPatrol(round(20 / (patrol_speed + 1)), (panic_on_alert ? handlePanic() : 0))
+			return
+		startPatrol()
+		return
+
+	if((locate(/obj/machinery/door) in loc) && !pulledby) //Don't hang around blocking doors, but don't run off if someone tries to pull us through one.
+		var/turf/my_turf = get_turf(src)
+		var/list/can_go = my_turf.CardinalTurfsWithAccess(botcard)
+		if(!LAZYLEN(can_go) || !step_towards(src, pick(can_go)))
 			handleIdle()
 
 /mob/living/bot/proc/handleRegular()

--- a/code/modules/mob/living/simple_mob/life.dm
+++ b/code/modules/mob/living/simple_mob/life.dm
@@ -142,7 +142,6 @@
 /mob/living/simple_mob/proc/handle_guts()
 	for(var/obj/item/organ/OR in internal_organs)
 		OR.process()
-
 	for(var/obj/item/organ/OR in organs)
 		OR.process()
 

--- a/code/modules/mob/living/simple_mob/subtypes/animal/pets/dog.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/pets/dog.dm
@@ -114,6 +114,52 @@
 	icon_dead = "ian_dead"
 	var/turns_since_scan = 0
 	var/obj/movement_target
+	var/moving_to_lunch = FALSE
+
+/mob/living/simple_mob/animal/passive/dog/corgi/Ian/proc/move_to_lunch()
+	set waitfor = FALSE
+	if(!movement_target || moving_to_lunch)
+		return
+	moving_to_lunch = TRUE
+	step_to(src,movement_target,1)
+	sleep(3)
+	if(QDELETED(src) || !movement_target || incapacitated())
+		moving_to_lunch = FALSE
+		return
+	step_to(src,movement_target,1)
+	sleep(3)
+	if(QDELETED(src) || !movement_target || incapacitated())
+		moving_to_lunch = FALSE
+		return
+	step_to(src,movement_target,1)
+	if(QDELETED(src) || !movement_target || incapacitated())
+		moving_to_lunch = FALSE
+		return
+	moving_to_lunch = FALSE
+
+	if(movement_target)		//Not redundant due to sleeps, Item can be gone in 6 decisecomds
+		if (movement_target.loc.x < src.x)
+			set_dir(WEST)
+		else if (movement_target.loc.x > src.x)
+			set_dir(EAST)
+		else if (movement_target.loc.y < src.y)
+			set_dir(SOUTH)
+		else if (movement_target.loc.y > src.y)
+			set_dir(NORTH)
+		else
+			set_dir(SOUTH)
+
+		if(isturf(movement_target.loc) )
+			UnarmedAttack(movement_target)
+		else if(ishuman(movement_target.loc) && prob(20))
+			visible_emote("stares at the [movement_target] that [movement_target.loc] has with sad puppy eyes.")
+
+/mob/living/simple_mob/animal/passive/dog/corgi/Ian/proc/dance()
+	set waitfor = FALSE
+	visible_emote(pick("dances around","chases their tail"))
+	for(var/i in list(1,2,4,8,4,2,1,2,4,8,4,2,1,2,4,8,4,2))
+		set_dir(i)
+		sleep(1)
 
 /mob/living/simple_mob/animal/passive/dog/corgi/Ian/Life()
 	..()
@@ -134,35 +180,10 @@
 						movement_target = S
 						break
 			if(movement_target)
-				step_to(src,movement_target,1)
-				sleep(3)
-				step_to(src,movement_target,1)
-				sleep(3)
-				step_to(src,movement_target,1)
-
-				if(movement_target)		//Not redundant due to sleeps, Item can be gone in 6 decisecomds
-					if (movement_target.loc.x < src.x)
-						set_dir(WEST)
-					else if (movement_target.loc.x > src.x)
-						set_dir(EAST)
-					else if (movement_target.loc.y < src.y)
-						set_dir(SOUTH)
-					else if (movement_target.loc.y > src.y)
-						set_dir(NORTH)
-					else
-						set_dir(SOUTH)
-
-					if(isturf(movement_target.loc) )
-						UnarmedAttack(movement_target)
-					else if(ishuman(movement_target.loc) && prob(20))
-						visible_emote("stares at the [movement_target] that [movement_target.loc] has with sad puppy eyes.")
+				move_to_lunch()
 
 		if(prob(1))
-			visible_emote(pick("dances around","chases their tail"))
-			spawn(0)
-				for(var/i in list(1,2,4,8,4,2,1,2,4,8,4,2,1,2,4,8,4,2))
-					set_dir(i)
-					sleep(1)
+			dance()
 
 //LISA! SQUEEEEEEEEE~
 /mob/living/simple_mob/animal/passive/dog/corgi/Lisa

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -142,8 +142,7 @@
 	return 0
 
 /mob/proc/Life()
-//	if(organStructure)
-//		organStructure.ProcessOrgans()
+	SHOULD_NOT_SLEEP(TRUE)
 	return
 
 #define UNBUCKLED 0


### PR DESCRIPTION
Alternative to #8787. Opening for diff, still need to test bot pathfinding changes.

- Adds linter instruction to mob/Life() to issue a warning on sleep. Sleeping during Life() sleeps the entire SSmobs subsystem and is undesirable in the first place.
- Removes a `spawn(0)` from `bot/Life()` that was preventing it from being tick checked properly at all.
- Adds various `set waitfor = FALSE` alternatives to sleeps in Life().
- Removes a check against `radio_controller` being null - this should no longer be relevant as `New()` isn't firing any code and SSatoms will initialize long after the startup hook.
- Adds a sanity counter and tick checking to A* as it can't reasonably be factored into bot pathing due to the spaghetti.

One possible issue that will need testing will be whether blobs now spread too fast - when we fixed the sleep() issue in blobcode on Neb, they started expanding more aggressively than intended since they were previously limited by their own sleep() proc (which was also limiting _every other mob in the game_).

The bot pathfinding solution is absolutely horrible, but a more reasonable implementation using movement callbacks or `walk_to` is not something I am interested in committing to for Polaris. This should (still need to test) at least prevent it from locking the server up.


ed:
closes #8787 (for now, if accepted)