### PR TITLE
unuses DS2NEARESTTICK, fixes a diagonal snafu

### DIFF
--- a/code/modules/mob/living/living_movement.dm
+++ b/code/modules/mob/living/living_movement.dm
@@ -155,7 +155,7 @@ default behaviour is:
 			now_pushing = 0
 			return
 		var/move_time = movement_delay(loc, t) * SQRT_TWO
-		move_time = DS2NEARESTTICK(move_time)
+		//move_time = DS2NEARESTTICK(move_time)
 		if(AM.Move(T2, t, move_time))
 			Move(T, t, move_time)
 

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -285,7 +285,7 @@
 					direct = turn(direct, pick(90, -90))
 					n = get_step(my_mob, direct)
 
-	total_delay = DS2NEARESTTICK(total_delay) //Rounded to the next tick in equivalent ds
+	//total_delay = DS2NEARESTTICK(total_delay) //Rounded to the next tick in equivalent ds
 	my_mob.setMoveCooldown(total_delay)
 
 	if(istype(my_mob.pulledby, /obj/structure/bed/chair/wheelchair))
@@ -297,7 +297,7 @@
 
 	// If we ended up moving diagonally, increase delay.
 	if((direct & (direct - 1)) && mob.loc == n)
-		my_mob.setMoveCooldown(total_delay * 2)
+		my_mob.setMoveCooldown(total_delay * SQRT_TWO)
 
 	// If we have a grab
 	var/list/grablist = my_mob.ret_grab()


### PR DESCRIPTION
1. Diagonal movement has speed parity with cardinal movement.

2. Comments out nearest-tick rounding for movement delays.
This rounding exists to attempt to make movement visually smoother but badly impacts movement speed nuance, *especially* after calculations like nutrition, damage, and non-cardinal movement are applied.

Video is a quickie with corrected diagonal cooldown and removed rounding, showing better grading of speed changes.

https://user-images.githubusercontent.com/918997/197525425-e9800416-79b8-4aa5-a14d-34bdc62f9717.mp4

A look at speed rebalances might be necessary after this - since they will actually be possible and meaningful now.