### PR TITLE
Adds flasks to the forensic belt allowed items

### DIFF
--- a/code/defines/procs/AStar.dm
+++ b/code/defines/procs/AStar.dm
@@ -134,7 +134,6 @@ length to avoid portals or something i guess?? Not that they're counted right no
 
 	open.Enqueue(new /PathNode(start, null, 0, call(start, dist)(end), 0))
 
-	var/how_many_iter = 0
 	var/sanity = 500 // From some local testing, AStar() tends to hit tick check or succeed around the 450 mark.
 	while(!open.IsEmpty() && !path && sanity)
 		sanity--

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -235,7 +235,8 @@
 		/obj/item/reagent_containers/food/snacks/donut/,
 		/obj/item/ammo_magazine,
 		/obj/item/gun/projectile/colt/detective,
-		/obj/item/holowarrant
+		/obj/item/holowarrant,
+		/obj/item/reagent_containers/food/drinks/flask
 		)
 
 /obj/item/storage/belt/soulstone


### PR DESCRIPTION
Ensure your forensic supply of coffee, alcohol, or water.