### PR TITLE
re-enabled DS2NEARESTTICK

### DIFF
--- a/code/modules/mob/living/living_movement.dm
+++ b/code/modules/mob/living/living_movement.dm
@@ -155,7 +155,7 @@ default behaviour is:
 			now_pushing = 0
 			return
 		var/move_time = movement_delay(loc, t) * SQRT_TWO
-		//move_time = DS2NEARESTTICK(move_time)
+		move_time = DS2NEARESTTICK(move_time)
 		if(AM.Move(T2, t, move_time))
 			Move(T, t, move_time)
 

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -285,7 +285,7 @@
 					direct = turn(direct, pick(90, -90))
 					n = get_step(my_mob, direct)
 
-	//total_delay = DS2NEARESTTICK(total_delay) //Rounded to the next tick in equivalent ds
+	total_delay = DS2NEARESTTICK(total_delay) //Rounded to the next tick in equivalent ds
 	my_mob.setMoveCooldown(total_delay)
 
 	if(istype(my_mob.pulledby, /obj/structure/bed/chair/wheelchair))


### PR DESCRIPTION
Turning this off has created stop-start movement I can't replicate but with more than one sufferer. Needs more work and leaving it WIP is a bad plan with my workloads.

Updating glide size according to time is probably a viable correction, but not one I want to experiment with while people are having bad experiences.