### PR TITLE
Naming Food & Blood Cakes

### DIFF
--- a/code/modules/food/food.dm
+++ b/code/modules/food/food.dm
@@ -12,14 +12,19 @@
 	drop_sound = 'sound/items/drop/food.ogg'
 	pickup_sound = 'sound/items/pickup/food.ogg'
 
-/obj/item/reagent_containers/food/AltClick(mob/user)
-	. = ..()
-	if(Adjacent(src))
-		var/n_name = sanitizeSafe(input(usr, "What would you like to name \the [src]? Leave blank to reset.", "Food Naming", null) as text, MAX_NAME_LEN)
-		if(!n_name)
-			n_name = initial(name)
+/obj/item/reagent_containers/food/verb/change_name()
+	set name = "Rename Food"
+	set category = "Object"
+	set src in view(0)
 
-		name = n_name
+	handle_name_change(usr)
+
+/obj/item/reagent_containers/food/proc/handle_name_change(var/mob/living/user)
+	var/n_name = sanitizeSafe(input(user, "What would you like to name \the [src]? Leave blank to reset.", "Food Naming", null) as text, MAX_NAME_LEN)
+	if(!n_name)
+		n_name = initial(name)
+
+	name = n_name
 
 /obj/item/reagent_containers/food/Initialize()
 	. = ..()

--- a/code/modules/food/food.dm
+++ b/code/modules/food/food.dm
@@ -7,9 +7,19 @@
 /obj/item/reagent_containers/food
 	possible_transfer_amounts = null
 	volume = 50 //Sets the default container amount for all food items.
-	var/filling_color = "#FFFFFF" //Used by sandwiches.
+	description_info = "Food can be alt-clicked to rename it."
+	var/filling_color = "#FFFFFF" //Used by sandwiches and custom food.
 	drop_sound = 'sound/items/drop/food.ogg'
 	pickup_sound = 'sound/items/pickup/food.ogg'
+
+/obj/item/reagent_containers/food/AltClick(mob/user)
+	. = ..()
+	if(Adjacent(src))
+		var/n_name = sanitizeSafe(input(usr, "What would you like to name \the [src]? Leave blank to reset.", "Food Naming", null) as text, MAX_NAME_LEN)
+		if(!n_name)
+			n_name = initial(name)
+
+		name = n_name
 
 /obj/item/reagent_containers/food/Initialize()
 	. = ..()

--- a/code/modules/food/food.dm
+++ b/code/modules/food/food.dm
@@ -7,7 +7,7 @@
 /obj/item/reagent_containers/food
 	possible_transfer_amounts = null
 	volume = 50 //Sets the default container amount for all food items.
-	description_info = "Food can be alt-clicked to rename it."
+	description_info = "Food can use the Rename Food verb in the Object Tab to rename it."
 	var/filling_color = "#FFFFFF" //Used by sandwiches and custom food.
 	drop_sound = 'sound/items/drop/food.ogg'
 	pickup_sound = 'sound/items/pickup/food.ogg'

--- a/code/modules/food/kitchen/cooking_machines/_appliance.dm
+++ b/code/modules/food/kitchen/cooking_machines/_appliance.dm
@@ -471,6 +471,10 @@
 	var/list/cooktypes = list()
 	var/datum/reagents/buffer = new /datum/reagents(1000)
 	var/totalcolour
+	var/reagents_determine_color
+
+	if(!LAZYLEN(CI.container.contents))	// It's possible to make something, such as a cake in the oven, with only reagents. This stops them from being grey and sad.
+		reagents_determine_color = TRUE
 
 	for (var/obj/item/I in CI.container)
 		var/obj/item/reagent_containers/food/snacks/S
@@ -508,6 +512,10 @@
 	var/obj/item/reagent_containers/food/snacks/result = new cook_path(CI.container)
 	buffer.trans_to_holder(result.reagents, buffer.total_volume) //trans_to doesn't handle food items well, so
 																 //just call trans_to_holder instead
+
+	// Reagent-only foods.
+	if(reagents_determine_color)
+		totalcolour = result.reagents.get_color()
 
 	//Filling overlay
 	var/image/I = image(result.icon, "[result.icon_state]_filling")

--- a/code/modules/food/kitchen/cooking_machines/_appliance.dm
+++ b/code/modules/food/kitchen/cooking_machines/_appliance.dm
@@ -517,6 +517,9 @@
 	if(reagents_determine_color)
 		totalcolour = result.reagents.get_color()
 
+		for(var/datum/reagent/reag in result.reagents.reagent_list)
+			words |= text2list(reag.name, " ")
+
 	//Filling overlay
 	var/image/I = image(result.icon, "[result.icon_state]_filling")
 	I.color = totalcolour


### PR DESCRIPTION
:cl:
bugfix - Fix reagent-only custom foods being grey and nameless. Down with grey cake. In with blood cake.
adds - Ability to Alt-Click food items to rename them. Giving an invalid or blank name will reset it.
/:cl:

<img src="https://i.imgur.com/3EB2WYE.png">