### PR TITLE
Cleans up the storage accessory attackby path and prevents double insertion of items into storage accessories.

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -261,18 +261,18 @@
 		R.activate_module(src)
 		R.hud_used.update_robot_modules_display()
 
-/obj/item/attackby(obj/item/W as obj, mob/user as mob)
+/obj/item/attackby(obj/item/W, mob/user)
 	. = ..()
-	if(istype(W, /obj/item/storage))
+	if(!. && istype(W, /obj/item/storage))
 		var/obj/item/storage/S = W
 		if(S.use_to_pickup)
 			if(S.collection_mode) //Mode is set to collect all items
 				if(isturf(src.loc))
 					S.gather_all(src.loc, user)
-
-			else if(S.can_be_inserted(src))
-				S.handle_item_insertion(src)
-	return
+					return TRUE
+		if(S.can_be_inserted(src))
+			S.handle_item_insertion(src)
+			return TRUE
 
 /obj/item/proc/talk_into(mob/M as mob, text)
 	return

--- a/code/game/objects/items/paintkit.dm
+++ b/code/game/objects/items/paintkit.dm
@@ -51,13 +51,12 @@
 		use(1, user)
 
 // Generic use
-/obj/item/attackby(obj/item/W as obj, mob/user as mob)
+/obj/item/attackby(obj/item/W, mob/user)
 	if(istype(W, /obj/item/kit))
 		var/obj/item/kit/K = W
 		K.customize(src, user)
-		return
-
-	..()
+		return TRUE
+	return ..()
 
 /// Ponchos specifically, but other accessories may eventually need this.
 /// Consequence of snowflake-y teshari code.

--- a/code/game/objects/items/weapons/storage/bags.dm
+++ b/code/game/objects/items/weapons/storage/bags.dm
@@ -242,7 +242,8 @@
 // Modified handle_item_insertion.  Would prefer not to, but...
 /obj/item/storage/bag/sheetsnatcher/handle_item_insertion(obj/item/W as obj, prevent_warning = 0)
 	var/obj/item/stack/material/S = W
-	if(!istype(S)) return 0
+	if(!istype(S))
+		return FALSE
 
 	var/amount
 	var/inserted = 0
@@ -276,7 +277,7 @@
 	if(usr.s_active)
 		usr.s_active.show_to(usr)
 	update_icon()
-	return 1
+	return TRUE
 
 // Sets up numbered display to show the stack size of each stored mineral
 // NOTE: numbered display is turned off currently because it's broken

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -353,7 +353,8 @@
 //The stop_warning parameter will stop the insertion message from being displayed. It is intended for cases where you are inserting multiple items at once,
 //such as when picking up all the items on a tile with one click.
 /obj/item/storage/proc/handle_item_insertion(obj/item/W as obj, prevent_warning = 0)
-	if(!istype(W)) return 0
+	if(!istype(W))
+		return FALSE
 
 	if(usr)
 		usr.remove_from_mob(W,target = src) //If given a target, handles forceMove()
@@ -382,7 +383,7 @@
 		W.on_enter_storage(src)
 
 	update_icon()
-	return 1
+	return TRUE
 
 //Call this proc to handle the removal of an item from the storage item. The item will be moved to the atom sent as new_target
 /obj/item/storage/proc/remove_from_storage(obj/item/W as obj, atom/new_location)
@@ -420,10 +421,14 @@
 
 //This proc is called when you want to place an item into the storage item.
 /obj/item/storage/attackby(obj/item/W as obj, mob/user as mob, silent)
-	..()
 
+	. = ..()
+	if(.)
+		return
+
+	//Robots can't interact with storage items.
 	if(isrobot(user))
-		return //Robots can't interact with storage items.
+		return FALSE
 
 	if(istype(W, /obj/item/lightreplacer))
 		var/obj/item/lightreplacer/LP = W
@@ -439,10 +444,10 @@
 		if(amt_inserted)
 			if (!silent)
 				to_chat(user, "You inserted [amt_inserted] light\s into \the [LP.name]. You have [LP.uses] light\s remaining.")
-			return
+		return TRUE
 
 	if(!can_be_inserted(W))
-		return
+		return FALSE
 
 	if(istype(W, /obj/item/tray))
 		var/obj/item/tray/T = W
@@ -450,14 +455,14 @@
 			if(prob(85))
 				if (!silent)
 					to_chat(user, "<span class='warning'>The tray won't fit in [src].</span>")
-				return
-			else
-				W.forceMove(get_turf(user))
-				if ((user.client && user.s_active != src))
-					user.client.screen -= W
-				W.dropped(user)
-				if (!silent)
-					to_chat(user, "<span class='warning'>God damn it!</span>")
+				return TRUE
+			W.forceMove(get_turf(user))
+			if ((user.client && user.s_active != src))
+				user.client.screen -= W
+			W.dropped(user)
+			if (!silent)
+				to_chat(user, "<span class='warning'>God damn it!</span>")
+			return TRUE
 
 	W.add_fingerprint(user)
 	return handle_item_insertion(W, silent)

--- a/code/game/objects/items/weapons/storage/wallets.dm
+++ b/code/game/objects/items/weapons/storage/wallets.dm
@@ -56,11 +56,10 @@
 
 /obj/item/storage/wallet/handle_item_insertion(obj/item/W as obj, prevent_warning = 0)
 	. = ..(W, prevent_warning)
-	if(.)
-		if(!front_id && istype(W, /obj/item/card/id))
-			front_id = W
-			name = "[name] ([front_id])"
-			update_icon()
+	if(. && !front_id && istype(W, /obj/item/card/id))
+		front_id = W
+		name = "[name] ([front_id])"
+		update_icon()
 
 /obj/item/storage/wallet/update_icon()
 	cut_overlays()

--- a/code/modules/clothing/clothing_accessories.dm
+++ b/code/modules/clothing/clothing_accessories.dm
@@ -26,14 +26,14 @@
 	if(istype(I, /obj/item/clothing/accessory))
 		var/obj/item/clothing/accessory/A = I
 		if(attempt_attach_accessory(A, user))
-			return
-
+			return TRUE
 	if(LAZYLEN(accessories))
 		for(var/obj/item/clothing/accessory/A in accessories)
 			A.attackby(I, user)
-		return
-
-	..()
+			if(QDELETED(I) || I.loc != user)
+				break
+		return TRUE
+	return ..()
 
 /obj/item/clothing/attack_hand(var/mob/user)
 	//only forward to the attached accessory if the clothing is equipped (not in a storage)

--- a/code/modules/clothing/suits/storage.dm
+++ b/code/modules/clothing/suits/storage.dm
@@ -20,8 +20,9 @@
 		..(over_object)
 
 /obj/item/clothing/suit/storage/attackby(obj/item/W as obj, mob/user as mob)
-	..()
-	pockets.attackby(W, user)
+	. = ..()
+	if(!.)
+		return pockets.attackby(W, user)
 
 /obj/item/clothing/suit/storage/emp_act(severity)
 	pockets.emp_act(severity)

--- a/code/modules/clothing/under/accessories/accessory.dm
+++ b/code/modules/clothing/under/accessories/accessory.dm
@@ -97,10 +97,6 @@
 	else if(get_turf(src))		//We actually exist in space
 		forceMove(get_turf(src))
 
-//default attackby behaviour
-/obj/item/clothing/accessory/attackby(obj/item/I, mob/user)
-	..()
-
 //default attack_hand behaviour
 /obj/item/clothing/accessory/attack_hand(mob/user as mob)
 	if(has_suit)

--- a/code/modules/clothing/under/accessories/storage.dm
+++ b/code/modules/clothing/under/accessories/storage.dm
@@ -34,8 +34,10 @@
 	if (hold.handle_mousedrop(usr, over_object))
 		..(over_object)
 
-/obj/item/clothing/accessory/storage/attackby(obj/item/W as obj, mob/user as mob)
-	return hold.attackby(W, user)
+/obj/item/clothing/accessory/storage/attackby(obj/item/W, mob/user)
+	. = ..()
+	if(!.)
+		return hold.attackby(W, user)
 
 /obj/item/clothing/accessory/storage/emp_act(severity)
 	hold.emp_act(severity)

--- a/code/modules/reagents/hoses/connector.dm
+++ b/code/modules/reagents/hoses/connector.dm
@@ -1,38 +1,29 @@
 
 /obj/attackby(var/obj/item/O, var/mob/user)
-	. = ..()
-
-	if(locate(/obj/item/hose_connector) in src)
-		if(O.is_wirecutter())
-			var/list/available_sockets = list()
-
-			for(var/obj/item/hose_connector/HC in src)
-				if(HC.my_hose)
-					available_sockets |= HC
-
-			if(LAZYLEN(available_sockets))
-				if(available_sockets.len == 1)
-					var/obj/item/hose_connector/AC = available_sockets[1]
-					var/choice = alert("Are you sure you want to disconnect [AC]?", "Confirm", "Yes", "No")
-
-					if(choice == "Yes" && Adjacent(user))
-						visible_message("[user] disconnects \the hose from \the [src].")
-						AC.my_hose.disconnect()
-					return
-
+	if(O.is_wirecutter() && (locate(/obj/item/hose_connector) in src))
+		var/list/available_sockets = list()
+		for(var/obj/item/hose_connector/HC in src)
+			if(HC.my_hose)
+				available_sockets |= HC
+		if(LAZYLEN(available_sockets))
+			if(available_sockets.len == 1)
+				var/obj/item/hose_connector/AC = available_sockets[1]
+				var/choice = alert("Are you sure you want to disconnect [AC]?", "Confirm", "Yes", "No")
+				if(choice == "Yes" && Adjacent(user))
+					visible_message("[user] disconnects \the hose from \the [src].")
+					AC.my_hose.disconnect()
 			else
-
 				var/choice = input("Select a target hose connector.", "Socket Disconnect", null) as null|anything in available_sockets
-
-				if(choice)
-					var/obj/item/hose_connector/AC = choice
-					var/confirm = alert("Are you sure you want to disconnect [AC]?", "Confirm", "Yes", "No")
-
-					if(confirm == "Yes" && Adjacent(user))
-						visible_message("[user] disconnects \the hose from \the [src].")
-						AC.my_hose.disconnect()
-
-				return
+				if(!choice || QDELETED(user) || QDELETED(O) || O.loc != user || user.incapacitated() || (loc != user && !user.Adjacent(src)))
+					return TRUE
+				var/obj/item/hose_connector/AC = choice
+				var/confirm = alert("Are you sure you want to disconnect [AC]?", "Confirm", "Yes", "No")
+				if(confirm == "No" || QDELETED(user) || QDELETED(O) || O.loc != user || user.incapacitated() || (loc != user && !user.Adjacent(src)))
+					return TRUE
+				visible_message("[user] disconnects \the hose from \the [src].")
+				AC.my_hose.disconnect()
+		return TRUE
+	return ..()
 
 /obj/item/hose_connector
 	name = "hose connector"

--- a/code/modules/xenoarcheaology/tools/tools_pickaxe.dm
+++ b/code/modules/xenoarcheaology/tools/tools_pickaxe.dm
@@ -139,8 +139,9 @@
 	new /obj/item/pickaxe/six_pick(src)
 
 /obj/item/storage/excavation/handle_item_insertion()
-	..()
-	sort_picks()
+	. = ..()
+	if(.)
+		sort_picks()
 
 /obj/item/storage/excavation/proc/sort_picks()
 	var/list/obj/item/pickaxe/picksToSort = list()


### PR DESCRIPTION
`attackby()` should always return `TRUE` if it has handled the attackby.