### PR TITLE
AlienObjects tm are once again alien objects

### DIFF
--- a/code/game/objects/structures/props/alien_props.dm
+++ b/code/game/objects/structures/props/alien_props.dm
@@ -101,7 +101,6 @@
 /obj/item/prop/alien/junk
 	name = "alien object"
 	desc = "You have no idea what this thing does."
-	icon = 'icons/obj/device.dmi'
 	pickup_sound = 'sound/items/pickup/device.ogg'
 	drop_sound = 'sound/items/drop/device.ogg'
 	icon_state = "health"


### PR DESCRIPTION
At some point, alien objects were given the icon override of `device.dmi`. This fixes that so they aren't invisible anymore.