### PR TITLE
correct uplink item cost behavior

### DIFF
--- a/code/datums/uplink/badassery.dm
+++ b/code/datums/uplink/badassery.dm
@@ -32,13 +32,10 @@
 	name = "Random Items"
 	desc = "Buys you as many random items you can afford. Convenient packaging NOT included."
 
-/datum/uplink_item/item/badassery/random_many/cost(obj/item/uplink/U, mob/M)
-	if(istype(M))
-		return max(1, M.mind?.tcrystals)
-	if(istype(M, /datum/mind))
-		var/datum/mind/m = M
-		return max(1, m.tcrystals)
-	return max(1, M)
+
+/datum/uplink_item/item/badassery/random_many/cost(obj/item/uplink/U, available_telecrystals)
+	return max(1, available_telecrystals)
+
 
 /datum/uplink_item/item/badassery/random_many/get_goods(var/obj/item/uplink/U, var/loc, var/mob/M)
 	var/list/bought_items = list()

--- a/code/datums/uplink/telecrystals.dm
+++ b/code/datums/uplink/telecrystals.dm
@@ -35,5 +35,5 @@
 /datum/uplink_item/item/telecrystal/all
 	name = "Telecrystals - Empty Uplink"
 
-/datum/uplink_item/item/telecrystal/all/cost(obj/item/uplink/U, mob/M)
-	return max(1, M.mind.tcrystals)
+/datum/uplink_item/item/telecrystal/all/cost(obj/item/uplink/uplink, available_telecrystals)
+	return max(1, available_telecrystals)

--- a/code/datums/uplink/uplink_items.dm
+++ b/code/datums/uplink/uplink_items.dm
@@ -75,10 +75,10 @@ var/global/datum/uplink/uplink = new()
 
 	return TRUE
 
-/datum/uplink_item/proc/cost(obj/item/uplink/U, mob/M)
-	. = item_cost
-	if(U)
-		. = U.get_item_cost(src, .)
+/datum/uplink_item/proc/cost(obj/item/uplink/uplink, available_telecrystals)
+	if (uplink)
+		return uplink.GetAdjustedCost(src, item_cost)
+	return item_cost
 
 /datum/uplink_item/proc/description()
 	return desc

--- a/code/game/objects/items/devices/uplink.dm
+++ b/code/game/objects/items/devices/uplink.dm
@@ -27,8 +27,12 @@
 	. = ..()
 	addtimer(CALLBACK(src, .proc/next_offer), offer_time) //It seems like only the /hidden type actually makes use of this...
 
-/obj/item/uplink/get_item_cost(var/item_type, var/item_cost)
-	return (discount_item && (item_type == discount_item)) ? max(1, round(item_cost*discount_amount)) : item_cost
+
+/obj/item/uplink/proc/GetAdjustedCost(datum/uplink_item/item, current_cost)
+	if (item == discount_item)
+		return max(1, round(current_cost * discount_amount))
+	return current_cost
+
 
 /obj/item/uplink/proc/next_offer()
 	return //Stub, used on children.
@@ -169,7 +173,7 @@
 				"items" = (category == selected_cat ? list() : null)
 			)
 		for(var/datum/uplink_item/item in category.items)
-			var/cost = item.cost(src, user) || "???"
+			var/cost = item.cost(src, user.mind.tcrystals) || "???"
 			cat["items"] += list(list(
 				"name" = item.name,
 				"cost" = cost,

--- a/code/game/objects/items/devices/uplink_random_lists.dm
+++ b/code/game/objects/items/devices/uplink_random_lists.dm
@@ -34,7 +34,7 @@ var/global/datum/uplink_random_selection/all_uplink_selection = new/datum/uplink
 		if(!prob(RI.keep_probability))
 			continue
 		var/datum/uplink_item/I = uplink.items_assoc[RI.uplink_item]
-		if(I.cost(U) > telecrystals)
+		if(I.cost(U, telecrystals) > telecrystals)
 			continue
 		if(bought_items && (I in bought_items) && !prob(RI.reselect_probability))
 			continue


### PR DESCRIPTION
This does *not* fix uplink item costs not updating in the UI if they are dynamic or currently discounted. As a workaround, locking and re-opening the uplink will push the new cost data. This occurs because item costs are all written as static tgui data when the UI is first opened. I'm not refactoring that.