### PR TITLE
Removes a leftover reference to forum applications

### DIFF
--- a/code/modules/client/preference_setup/general/03_body.dm
+++ b/code/modules/client/preference_setup/general/03_body.dm
@@ -1297,7 +1297,7 @@ var/global/list/valid_bloodtypes = list("A+", "A-", "B+", "B-", "AB+", "AB-", "O
 
 	if(restricted)
 		if(restricted == 1)
-			dat += "<font color='red'><b>You cannot play as this species.</br><small>If you wish to be whitelisted, you can make an application post on <a href='?src=\ref[user];preference=open_whitelist_forum'>the forums</a>.</small></b></font></br>"
+			dat += "<font color='red'><b>You cannot play as this species.</br><small>If you wish to be whitelisted, you can make an application on <a href='?src=\ref[user];preference=open_whitelist_discord'>the Discord</a>.</small></b></font></br>"
 		else if(restricted == 2)
 			dat += "<font color='red'><b>You cannot play as this species.</br><small>This species is not available for play as a station race..</small></b></font></br>"
 	if(!restricted || check_rights(R_ADMIN|R_EVENT, 0))

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -308,11 +308,11 @@ var/global/list/preferences_datums = list()
 
 	if(!istype(user, /mob/new_player))	return
 
-	if(href_list["preference"] == "open_whitelist_forum")
-		if(config.forumurl)
-			user << link(config.forumurl)
+	if(href_list["preference"] == "open_whitelist_discord")
+		if(config.discordurl)
+			user << link(config.discordurl)
 		else
-			to_chat(user, "<span class='danger'>The forum URL is not set in the server configuration.</span>")
+			to_chat(user, "<span class='danger'>The Discord server invite is not set in the server configuration.</span>")
 			return
 	ShowChoices(usr)
 	return 1


### PR DESCRIPTION
Species popups now advise players to apply on the Discord, instead of the forums, as this is where applications have been migrated to for a while.