### PR TITLE
Cleans up drop_from_inventory(), fixes drake harness population.

### DIFF
--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -149,10 +149,8 @@ var/global/list/slot_equipment_priority = list( \
 /mob/proc/drop_from_inventory(var/obj/item/W, var/atom/target)
 	if(W)
 		remove_from_mob(W, target)
-		if(!(W && W.loc))
-			return 1 // self destroying objects (tk, grabs)
-		return 1
-	return 0
+		return TRUE
+	return FALSE
 
 //Drops the item in our left hand
 /mob/proc/drop_l_hand(var/atom/Target)
@@ -222,8 +220,7 @@ var/global/list/slot_equipment_priority = list( \
 		else
 			I.dropInto(drop_location())
 		I.dropped(src)
-	return 1
-
+	return TRUE
 
 //Returns the item equipped to the specified slot, if any.
 /mob/proc/get_equipped_item(var/slot)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1387,10 +1387,8 @@
 		to_chat(S, "<span class='danger'>[U] pops your [current_limb.joint] back in!</span>")
 	current_limb.relocate()
 
-/mob/living/carbon/human/drop_from_inventory(var/obj/item/W, var/atom/Target = null)
-	if(W in organs)
-		return
-	..()
+/mob/living/carbon/human/drop_from_inventory(var/obj/item/W, var/atom/target = null)
+	return !(W in organs) && ..()
 
 /mob/living/carbon/human/reset_view(atom/A, update_hud = 1)
 	..()

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -714,10 +714,8 @@
 /mob/living/proc/slip(var/slipped_on,stun_duration=8)
 	return FALSE
 
-/mob/living/carbon/drop_from_inventory(var/obj/item/W, var/atom/Target = null)
-	if(W in internal_organs)
-		return
-	..()
+/mob/living/carbon/drop_from_inventory(var/obj/item/W, var/atom/target = null)
+	return !(W in internal_organs) && ..()
 
 /mob/living/touch_map_edge()
 

--- a/code/modules/mob/living/simple_mob/hands.dm
+++ b/code/modules/mob/living/simple_mob/hands.dm
@@ -135,13 +135,6 @@
 		to_chat(src, "<span class='danger'>Your [hand_form] are not fit for use of \the [display_name].</span>")
 	return humanoid_hands
 
-/mob/living/simple_mob/drop_from_inventory(var/obj/item/W, var/atom/target = null)
-	. = ..(W, target)
-	if(!target)
-		target = src.loc
-	if(.)
-		W.forceMove(src.loc)
-
 /mob/living/simple_mob/is_holding_item_of_type(typepath)
 	for(var/obj/item/I in list(l_hand, r_hand))
 		if(istype(I, typepath))

--- a/code/modules/mob/living/simple_mob/subtypes/animal/sif/grafadreka/grafadreka_harness.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/sif/grafadreka/grafadreka_harness.dm
@@ -24,39 +24,34 @@
 		/obj/item/flashlight = ATTACHED_LIGHT
 	)
 
-	/// The drake that owns this harness.
-	var/mob/living/simple_mob/animal/sif/grafadreka/trained/owner
-
-
 /obj/item/storage/internal/animal_harness/grafadreka/Destroy()
 	attachable_types = null
-	owner = null
 	return ..()
 
 
 /obj/item/storage/internal/animal_harness/grafadreka/Initialize(mapload)
 	attachable_types = grafadreka_attachable_types
 	. = ..()
-	owner = loc
-	if (!istype(owner))
-		log_debug("Drake harness created without a drake!")
-		return INITIALIZE_HINT_QDEL
 
 
 /obj/item/storage/internal/animal_harness/grafadreka/proc/UpdateArmor()
-	if (!owner)
+	var/mob/living/simple_mob/animal/sif/grafadreka/drake = loc
+	if (!istype(drake))
 		return
 	var/obj/item/clothing/accessory/armor = attached_items[ATTACHED_ARMOR]
 	if (!armor)
-		owner.armor = owner.original_armor
+		drake.armor = drake.original_armor
 		return
 	for (var/key in armor.armor)
-		armor[key] = max(owner.original_armor[key], armor.armor[key])
+		armor[key] = max(drake.original_armor[key], armor.armor[key])
 
 
 // Basic trained drake harness contents on spawn
 /obj/item/storage/internal/animal_harness/grafadreka/trained/CreateAttachments()
-	attached_items[ATTACHED_RADIO] = new /obj/item/radio (owner)
+	var/mob/living/owner = loc
+	if (!istype(owner))
+		return
+	attached_items[ATTACHED_RADIO] = new /obj/item/radio(owner)
 	new /obj/item/stack/medical/bruise_pack (src)
 	new /obj/item/stack/medical/ointment (src)
 	var/obj/item/storage/mre/mre_type = pick(typesof(/obj/item/storage/mre) - list(
@@ -69,6 +64,9 @@
 
 // Station/Science drake harness contents on spawn
 /obj/item/storage/internal/animal_harness/grafadreka/expedition/CreateAttachments()
+	var/mob/living/owner = loc
+	if (!istype(owner))
+		return
 	attached_items[ATTACHED_RADIO] = new /obj/item/radio (owner)
 	new /obj/item/stack/medical/bruise_pack (src)
 	new /obj/item/stack/medical/ointment (src)


### PR DESCRIPTION
- Cleans up `drop_from_inventory` overrides.
- Removes owner set from drake harness init since it was not being set by the time equipment was created.