### PR TITLE
Survivalist no longer announces arrivals or departures.

### DIFF
--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -3,39 +3,37 @@
 	//The name of the job
 	var/title = "NOPE"
 	//Job access. The use of minimal_access or access is determined by a config setting: config.jobs_have_minimal_access
-	var/list/minimal_access = list()      // Useful for servers which prefer to only have access given to the places a job absolutely needs (Larger server population)
-	var/list/access = list()              // Useful for servers which either have fewer players, so each person needs to fill more than one role, or servers which like to give more access, so players can't hide forever in their super secure departments (I'm looking at you, chemistry!)
-	var/flag = 0 	                      // Bitflags for the job
+	var/list/minimal_access = list()        // Useful for servers which prefer to only have access given to the places a job absolutely needs (Larger server population)
+	var/list/access = list()                // Useful for servers which either have fewer players, so each person needs to fill more than one role, or servers which like to give more access, so players can't hide forever in their super secure departments (I'm looking at you, chemistry!)
+	var/flag = 0 	                        // Bitflags for the job
 	var/department_flag = 0
-	var/faction = "None"	              // Players will be allowed to spawn in as jobs that are set to "Station"
-	var/total_positions = 0               // How many players can be this job
-	var/spawn_positions = 0               // How many players can spawn in as this job
-	var/current_positions = 0             // How many players have this job
-	var/supervisors = null                // Supervisors, who this person answers to directly
+	var/faction = "None"	                // Players will be allowed to spawn in as jobs that are set to "Station"
+	var/total_positions = 0                 // How many players can be this job
+	var/spawn_positions = 0                 // How many players can spawn in as this job
+	var/current_positions = 0               // How many players have this job
+	var/supervisors = null                  // Supervisors, who this person answers to directly
 	var/selection_color = "#ffffff"       // Selection screen color
-	var/list/alt_titles = null            // List of alternate titles; There is no need for an alt-title datum for the base job title.
-	var/req_admin_notify                  // If this is set to 1, a text is printed to the player when jobs are assigned, telling him that he should let admins know that he has to disconnect.
-	var/minimal_player_age = 0            // If you have use_age_restriction_for_jobs config option enabled and the database set up, this option will add a requirement for players to be at least minimal_player_age days old. (meaning they first signed in at least that many days before.)
-	var/list/departments = list()         // List of departments this job belongs to, if any. The first one on the list will be the 'primary' department.
-	var/sorting_order = 0                 // Used for sorting jobs so boss jobs go above regular ones, and their boss's boss is above that. Higher numbers = higher in sorting.
-	var/departments_managed = null        // Is this a management position?  If yes, list of departments managed.  Otherwise null.
-	var/department_accounts = null        // Which department accounts should people with this position be given the pin for?
-	var/assignable = TRUE                 // Should it show up on things like the ID computer?
+	var/list/alt_titles = null              // List of alternate titles; There is no need for an alt-title datum for the base job title.
+	var/req_admin_notify                    // If this is set to 1, a text is printed to the player when jobs are assigned, telling him that he should let admins know that he has to disconnect.
+	var/minimal_player_age = 0              // If you have use_age_restriction_for_jobs config option enabled and the database set up, this option will add a requirement for players to be at least minimal_player_age days old. (meaning they first signed in at least that many days before.)
+	var/list/departments = list()           // List of departments this job belongs to, if any. The first one on the list will be the 'primary' department.
+	var/sorting_order = 0                   // Used for sorting jobs so boss jobs go above regular ones, and their boss's boss is above that. Higher numbers = higher in sorting.
+	var/departments_managed = null          // Is this a management position?  If yes, list of departments managed.  Otherwise null.
+	var/department_accounts = null          // Which department accounts should people with this position be given the pin for?
+	var/assignable = TRUE                   // Should it show up on things like the ID computer?
 	var/minimum_character_age = 0
 	var/list/min_age_by_species = null
 	var/ideal_character_age = 30
 	var/list/ideal_age_by_species = null
 	var/list/banned_job_species = list(SPECIES_VOX)
-	var/has_headset = TRUE                //Do people with this job need to be given headsets and told how to use them?  E.g. Cyborgs don't.
-
-	var/account_allowed = 1				  // Does this job type come with a station account?
-	var/economic_modifier = 2			  // With how much does this job modify the initial account amount?
-
-	var/outfit_type						  // What outfit datum does this job use in its default title?
-
-	var/offmap_spawn = FALSE			  // Do we require weird and special spawning and datacore handling?
-	var/substitute_announce_title         // Set this to replace the actual job title in join/leave messages (for 'gamey' jobs like Survivalist)
-	var/mob_type = JOB_CARBON 		      // Bitflags representing mob type this job spawns
+	var/has_headset = TRUE                  // Do people with this job need to be given headsets and told how to use them?  E.g. Cyborgs don't.
+	var/account_allowed = 1                 // Does this job type come with a station account?
+	var/economic_modifier = 2               // With how much does this job modify the initial account amount?
+	var/outfit_type                         // What outfit datum does this job use in its default title?
+	var/offmap_spawn = FALSE                // Do we require weird and special spawning and datacore handling?
+	var/substitute_announce_title           // Set this to replace the actual job title in join/leave messages (for 'gamey' jobs like Survivalist)
+	var/announce_arrival_and_despawn = TRUE // Set this to false to skip announcing arrivals or departures for this job.
+	var/mob_type = JOB_CARBON               // Bitflags representing mob type this job spawns
 
 	// Description of the job's role and minimum responsibilities.
 	var/job_description = "This Job doesn't have a description! Please report it!"

--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -627,8 +627,8 @@ var/global/datum/controller/occupations/job_master
 		else
 			spawnpos = spawntypes[C.prefs.spawnpoint]
 
-	//We will return a list key'd by "turf" and "msg"
-	. = list("turf","msg")
+	//We will return a list of various properties useful to the caller.
+	. = list("announce" = !J || J.announce_arrival_and_despawn)
 	if(spawnpos && istype(spawnpos) && spawnpos.turfs.len)
 		if(spawnpos.check_job_spawning(rank))
 			.["turf"] =     spawnpos.get_spawn_position()

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -484,8 +484,9 @@
 	log_and_message_admins("[key_name(to_despawn)] ([to_despawn.mind.role_alt_title]) entered cryostorage.")
 
 	var/datum/job/J = SSjob.get_job(job)
-	announce.autosay("[to_despawn.real_name], [J?.substitute_announce_title || to_despawn.mind.role_alt_title], [on_store_message]", "[on_store_name]", announce_channel, using_map.get_map_levels(z, TRUE, om_range = DEFAULT_OVERMAP_RANGE))
-	visible_message("<span class='notice'>\The [initial(name)] [on_store_visible_message_1] [to_despawn.real_name] [on_store_visible_message_2]</span>", 3)
+	if(!J || J.announce_arrival_and_despawn)
+		announce.autosay("[to_despawn.real_name], [J?.substitute_announce_title || to_despawn.mind.role_alt_title], [on_store_message]", "[on_store_name]", announce_channel, using_map.get_map_levels(z, TRUE, om_range = DEFAULT_OVERMAP_RANGE))
+	visible_message(SPAN_NOTICE("\The [initial(name)] [on_store_visible_message_1] [to_despawn.real_name] [on_store_visible_message_2]"), VISIBLE_MESSAGE)
 
 	//This should guarantee that ghosts don't spawn.
 	to_despawn.ckey = null

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -450,11 +450,12 @@
 
 	ticker.mode.latespawn(character)
 
+	var/do_announce = join_props["announce"] && join_message && announce_channel
 	if(J.mob_type & JOB_SILICON)
-		if(join_message && announce_channel)
+		if(do_announce)
 			AnnounceCyborg(character, rank, join_message, announce_channel, character.z)
 	else
-		if(join_message && announce_channel)
+		if(do_announce)
 			AnnounceArrival(character, J?.substitute_announce_title || rank, join_message, announce_channel, character.z)
 		data_core.manifest_inject(character)
 		ticker.minds += character.mind//Cyborgs and AIs handle this in the transform proc.	//TODO!!!!! ~Carn

--- a/maps/cynosure/cynosure_jobs.dm
+++ b/maps/cynosure/cynosure_jobs.dm
@@ -87,6 +87,7 @@ var/global/const/access_explorer = 43
 	offmap_spawn = TRUE
 	substitute_announce_title = "Colonist"
 	banned_job_species = null
+	announce_arrival_and_despawn = FALSE
 	alt_titles = list(
 		CRASH_SURVIVOR_TITLE = /datum/alt_title/crash_survivor,
 		DRAKE_SURVIVOR_TITLE = /datum/alt_title/working_drake


### PR DESCRIPTION
Also tidies the whitespace in the base job definition.