### PR TITLE
Fixes Electrical Fault and Containment Subroutine events

### DIFF
--- a/code/modules/gamemaster/event2/events/engineering/wallrot.dm
+++ b/code/modules/gamemaster/event2/events/engineering/wallrot.dm
@@ -8,9 +8,6 @@
 /datum/event2/meta/wallrot/get_weight()
 	return (10 + metric.count_people_in_department(DEPARTMENT_ENGINEERING) * 10) / (times_ran + 1)
 
-
-
-
 /datum/event2/event/wallrot
 	var/turf/simulated/wall/origin = null
 
@@ -42,6 +39,3 @@
 					rot_count++
 			if(rot_count >= target_rot)
 				break
-
-
-

--- a/code/modules/gamemaster/event2/events/everyone/electrical_fault.dm
+++ b/code/modules/gamemaster/event2/events/everyone/electrical_fault.dm
@@ -35,12 +35,10 @@
 	to cause voltage spikes and other electrical issues very soon. Please secure sensitive electrical equipment until the situation passes.", "[location_name()] Sensor Array")
 
 /datum/event2/event/electrical_fault/set_up()
-	valid_z_levels = get_location_z_levels()
-	valid_z_levels -= using_map.sealed_levels // Space levels only please!
 
 	valid_apcs = list()
-	for(var/obj/machinery/power/apc/A in global.machines)
-		if(A.z in valid_z_levels)
+	for(var/obj/machinery/power/apc/A in machines)
+		if(A.z in using_map.station_levels)
 			valid_apcs += A
 
 /datum/event2/event/electrical_fault/start()
@@ -97,4 +95,3 @@
 //		log_debug("ELECTRICAL EVENT: Emagged \the [A].")
 		playsound(A, 'sound/machines/chime.ogg', 50, 1)
 		apcs_emagged++
-

--- a/maps/cynosure/cynosure_events.dm
+++ b/maps/cynosure/cynosure_events.dm
@@ -1,11 +1,10 @@
-// The Station Director's office is specific to the Southern Cross, so this needs to go here.
+// Area defines on Cynosure differ from previous maps, so these have to be overriden with map-specific lists.
 /datum/event2/event/prison_break/bridge
 	area_types_to_break = list(
 		/area/surface/station/command/operations,
 		/area/surface/station/crew_quarters/captain
 	)
 
-// So is xenoflora isolation it seems.
 /datum/event2/meta/prison_break/xenobio
 	irrelevant_areas = list(
 		/area/surface/station/rnd/xenobiology/xenoflora,
@@ -13,8 +12,50 @@
 	)
 
 /datum/event2/event/prison_break/xenobio
+	area_types_to_break = list(/area/surface/station/rnd/xenobiology)
 	area_types_to_ignore = list(
 		/area/surface/station/rnd/xenobiology/xenoflora,
 		/area/surface/station/rnd/xenobiology/xenoflora_isolation
 	)
 	ignore_blast_doors = TRUE // Needed to avoid a breach.
+
+/datum/event2/meta/prison_break/brig
+	relevant_areas = list(
+		/area/surface/station/security/prison,
+		/area/surface/station/security/hallway,
+		/area/surface/station/security/processing,
+		/area/surface/station/security/interrogation
+	)
+
+/datum/event2/event/prison_break/brig
+	area_types_to_break = list(
+		/area/surface/station/security/prison,
+		/area/surface/station/security/hallway/cell_hallway,
+		/area/surface/station/security/hallway/stairwell,
+		/area/surface/station/maintenance/substation/security,
+		/area/surface/station/security/lobby,
+		/area/surface/station/security/processing,
+		/area/surface/station/security/interrogation
+	)
+
+/datum/event2/event/prison_break/armory
+	area_types_to_break = list(
+		/area/surface/station/security/brig,
+		/area/surface/station/security/warden,
+		/area/surface/station/security/evidence_storage,
+		/area/surface/station/security/equiptment_storage,
+		/area/surface/station/security/armoury,
+		/area/surface/station/security/tactical
+	)
+
+/datum/event2/meta/prison_break/virology
+	relevant_areas = list(
+		/area/surface/station/medical/virology
+	)
+
+/datum/event2/event/prison_break/virology
+	area_types_to_break = list(
+		/area/surface/station/medical/virology,
+		/area/surface/station/medical/patient_wing,
+		/area/surface/station/medical/office
+	)


### PR DESCRIPTION
Containment break events had incomplete map-specific overrides, and electrical faults were using a "space only" z-level selection.
PoIs in the plains don't typically use APCs so using z-level select is fine. I spent a weird amount of time trying to redo it based on station areas but there wasn't really a point.
This should give engineers more to do again than a million rogue vending machines.

Observations during testing: Event selection weights seem really suspicious but it would take a lot of digging to get to the bottom of why the code loves comms blackouts and weather shifts above all else and seems to explicitly "filter out" other events that should be valid to fire at "any time" (vermin infestations and wallrot especially).