### PR TITLE
Hydroponics - Braincaps, two* new Traits.

### DIFF
--- a/code/datums/supplypacks/contraband.dm
+++ b/code/datums/supplypacks/contraband.dm
@@ -44,15 +44,28 @@
 	contraband = 1
 
 /datum/supply_pack/munitions/bolt_rifles_militia
- 	name = "Weapon - Surplus militia rifles"
- 	contains = list(
- 			/obj/item/gun/projectile/shotgun/pump/rifle = 3,
- 			/obj/item/ammo_magazine/clip/c762 = 6
- 			)
- 	cost = 50
- 	contraband = 1
- 	containertype = /obj/structure/closet/crate/hedberg
- 	containername = "Ballistic weapons crate"
+	name = "Weapon - Surplus militia rifles"
+	contains = list(
+			/obj/item/gun/projectile/shotgun/pump/rifle = 3,
+			/obj/item/ammo_magazine/clip/c762 = 6
+			)
+	cost = 50
+	contraband = 1
+	containertype = /obj/structure/closet/crate/hedberg
+	containername = "Ballistic weapons crate"
+
+/datum/supply_pack/hydro/fungus
+	name = "Fungal Crate"
+	contains = list(
+			/obj/item/seeds/braincapmycelium = 3,
+			/obj/item/seeds/sporemycelium = 3,
+			/obj/item/seeds/angelmycelium = 1
+			)
+	cost = 50
+	contraband = 1
+	containertype = /obj/structure/closet/crate/carp
+	containername = "Hydroponics crate"
+	access = access_hydroponics
 
 /datum/supply_pack/randomised/misc/telecrate //you get something awesome, a couple of decent things, and a few weak/filler things
 	name = "ERR_NULL_ENTRY" //null crate! also dream maker is hell,

--- a/code/modules/hydroponics/_hydro_setup.dm
+++ b/code/modules/hydroponics/_hydro_setup.dm
@@ -62,6 +62,8 @@
 #define TRAIT_BENEFICIAL_REAG      41
 #define TRAIT_MUTAGENIC_REAG       42
 #define TRAIT_TOXIC_REAG           43
+#define TRAIT_UNIQUE_PRODUCT       44
+#define TRAIT_SPEAKING             45
 
 // Global list initialization for plants.
 

--- a/code/modules/hydroponics/seed_gene_mut.dm
+++ b/code/modules/hydroponics/seed_gene_mut.dm
@@ -139,3 +139,15 @@
 /decl/plantgene/special/mutate(var/datum/seed/S)
 	if(prob(65))
 		S.set_trait(TRAIT_TELEPORTING, !S.get_trait(TRAIT_TELEPORTING))
+
+	if(prob(20))
+		var/unique_product_path
+		if(prob(30))
+			unique_product_path = pickweight(GLOB.plant_mob_products)
+		else
+			unique_product_path = pickweight(GLOB.plant_item_products)
+
+		S.set_trait(TRAIT_UNIQUE_PRODUCT, unique_product_path)
+
+	if(prob(20))
+		S.set_trait(TRAIT_SPEAKING, !S.get_trait(TRAIT_SPEAKING))

--- a/code/modules/hydroponics/seed_mobs.dm
+++ b/code/modules/hydroponics/seed_mobs.dm
@@ -20,3 +20,34 @@
 				var/obj/item/seeds/S = new(get_turf(host))
 				S.seed_type = name
 				S.update_seed()
+
+// Returns null, if the plant doesn't produce mobs, or the mob produced.
+/datum/seed/proc/create_hostile_mob(var/turf/T)
+	if(!T)
+		return
+
+	if(ispath(get_trait(TRAIT_UNIQUE_PRODUCT), /mob/living))
+		var/MobPath = get_trait(TRAIT_UNIQUE_PRODUCT)
+		var/mob/living/L = new MobPath(T)
+		L.faction = "plant"	// Plants together strong.
+
+		if(!L.ai_holder)
+			if(ishuman(L))	// By default, the only humanoid that plants can make is a monkey. Hence, prior reference.
+				L.ai_holder = new /datum/ai_holder/simple_mob/humanoid/hostile(L)
+				L.a_intent = I_HURT
+				if(!L.hud_used)
+					L.hud_used = new /datum/hud(L)
+					L.create_mob_hud(L.hud_used)
+			else
+				L.ai_holder = new /datum/ai_holder/simple_mob/guard(L)
+			L.ai_holder.hostile = TRUE
+		else
+			L.ai_holder.hostile = TRUE
+
+		if(ishuman(L))
+			var/mob/living/carbon/human/H = L
+			H.real_name = "[display_name] [H.real_name]"
+
+		L.name = "[display_name] [L.name]"
+
+		return L

--- a/code/modules/hydroponics/seed_packets.dm
+++ b/code/modules/hydroponics/seed_packets.dm
@@ -187,6 +187,9 @@ GLOBAL_LIST_BOILERPLATE(all_seed_packs, /obj/item/seeds)
 /obj/item/seeds/plumpmycelium
 	seed_type = "plumphelmet"
 
+/obj/item/seeds/brainmycelium
+	seed_type = "braincap"
+
 /obj/item/seeds/plastellmycelium
 	seed_type = "plastic"
 

--- a/code/modules/hydroponics/seed_packets.dm
+++ b/code/modules/hydroponics/seed_packets.dm
@@ -187,7 +187,7 @@ GLOBAL_LIST_BOILERPLATE(all_seed_packs, /obj/item/seeds)
 /obj/item/seeds/plumpmycelium
 	seed_type = "plumphelmet"
 
-/obj/item/seeds/brainmycelium
+/obj/item/seeds/braincapmycelium
 	seed_type = "braincap"
 
 /obj/item/seeds/plastellmycelium

--- a/code/modules/hydroponics/seedtypes/diona.dm
+++ b/code/modules/hydroponics/seedtypes/diona.dm
@@ -18,4 +18,4 @@
 	set_trait(TRAIT_PRODUCT_COLOUR,"#799957")
 	set_trait(TRAIT_PLANT_COLOUR,"#66804B")
 	set_trait(TRAIT_PLANT_ICON,"alien4")
-	set_trait(TRAIT_UNIQUE_PRODUCT, /mob/living/carbon/alien/diona)
+	set_trait(TRAIT_UNIQUE_PRODUCT, /mob/living/carbon/diona)

--- a/code/modules/hydroponics/seedtypes/diona.dm
+++ b/code/modules/hydroponics/seedtypes/diona.dm
@@ -5,7 +5,6 @@
 	display_name = "replicant pods"
 	can_self_harvest = 1
 	apply_color_to_mob = FALSE
-	has_mob_product = /mob/living/carbon/alien/diona
 
 /datum/seed/diona/New()
 	..()
@@ -19,3 +18,4 @@
 	set_trait(TRAIT_PRODUCT_COLOUR,"#799957")
 	set_trait(TRAIT_PLANT_COLOUR,"#66804B")
 	set_trait(TRAIT_PLANT_ICON,"alien4")
+	set_trait(TRAIT_UNIQUE_PRODUCT, /mob/living/carbon/alien/diona)

--- a/code/modules/hydroponics/seedtypes/eggplant.dm
+++ b/code/modules/hydroponics/seedtypes/eggplant.dm
@@ -28,4 +28,7 @@
 	kitchen_tag = "egg-plant"
 	mutants = null
 	chems = list("nutriment" = list(1,5), "egg" = list(3,12))
-	has_item_product = /obj/item/reagent_containers/food/snacks/egg/purple
+
+/datum/seed/eggplant/egg/New()
+	..()
+	set_trait(TRAIT_UNIQUE_PRODUCT, /obj/item/reagent_containers/food/snacks/egg/purple)

--- a/code/modules/hydroponics/seedtypes/mushrooms.dm
+++ b/code/modules/hydroponics/seedtypes/mushrooms.dm
@@ -214,8 +214,8 @@
 	name = "braincap"
 	seed_name = "brain cap"
 	display_name = "brain cap sporangium"
-	mutants = list("walkingmushroom","towercap", "braincap")
-	chems = list("nutriment" = list(2,10), )
+	mutants = null
+	chems = list("nutriment" = list(2,10), "braindance" = list(2,4), "dmt" = list(3,6))
 	kitchen_tag = "braincap"
 
 /datum/seed/mushroom/thinker/New()

--- a/code/modules/hydroponics/seedtypes/mushrooms.dm
+++ b/code/modules/hydroponics/seedtypes/mushrooms.dm
@@ -43,7 +43,7 @@
 	name = "plumphelmet"
 	seed_name = "plump helmet"
 	display_name = "plump helmet mushrooms"
-	mutants = list("walkingmushroom","towercap")
+	mutants = list("walkingmushroom","towercap", "braincap")
 	chems = list("nutriment" = list(2,10))
 	kitchen_tag = "plumphelmet"
 
@@ -132,7 +132,6 @@
 	display_name = "tower caps"
 	chems = list("woodpulp" = list(10,1))
 	mutants = list("redcap")
-	has_item_product = /obj/item/stack/material/log
 
 /datum/seed/mushroom/towercap/New()
 	..()
@@ -141,18 +140,18 @@
 	set_trait(TRAIT_PRODUCT_COLOUR,"#79A36D")
 	set_trait(TRAIT_PLANT_COLOUR,"#857F41")
 	set_trait(TRAIT_PLANT_ICON,"mushroom8")
-
+	set_trait(TRAIT_UNIQUE_PRODUCT, /obj/item/stack/material/log)
 /datum/seed/mushroom/towercap/red
 	name = "redcap"
 	seed_name = "red cap"
 	display_name = "red caps"
 	chems = list("woodpulp" = list(10,1), "tannin" = list(1,10))
 	mutants = null
-	has_item_product = null
 
 /datum/seed/mushroom/towercap/red/New()
 	..()
 	set_trait(TRAIT_PRODUCT_COLOUR,"#b81414")
+	set_trait(TRAIT_UNIQUE_PRODUCT, null)
 
 /datum/seed/mushroom/glowshroom
 	name = "glowshroom"
@@ -210,3 +209,23 @@
 	set_trait(TRAIT_PLANT_COLOUR,"#f8e6f4")
 	set_trait(TRAIT_PLANT_ICON,"mushroom9")
 	set_trait(TRAIT_SPORING, TRUE)
+
+/datum/seed/mushroom/thinker
+	name = "braincap"
+	seed_name = "brain cap"
+	display_name = "brain cap sporangium"
+	mutants = list("walkingmushroom","towercap", "braincap")
+	chems = list("nutriment" = list(2,10), )
+	kitchen_tag = "braincap"
+
+/datum/seed/mushroom/thinker/New()
+	..()
+	set_trait(TRAIT_MATURATION,7)
+	set_trait(TRAIT_YIELD,3)
+	set_trait(TRAIT_POTENCY,5)
+	set_trait(TRAIT_PRODUCT_ICON,"mushroom9")
+	set_trait(TRAIT_PRODUCT_COLOUR,"#b33b55")
+	set_trait(TRAIT_PLANT_COLOUR,"#92002c")
+	set_trait(TRAIT_PLANT_ICON,"mushroom7")
+	set_trait(TRAIT_LIGHT_TOLERANCE, 3)
+	set_trait(TRAIT_SPEAKING, TRUE)

--- a/code/modules/hydroponics/seedtypes/tomatoes.dm
+++ b/code/modules/hydroponics/seedtypes/tomatoes.dm
@@ -41,10 +41,10 @@
 	display_name = "killer tomato plant"
 	mutants = null
 	can_self_harvest = 1
-	has_mob_product = /mob/living/simple_mob/tomato
 
 /datum/seed/tomato/killer/New()
 	..()
+	set_trait(TRAIT_UNIQUE_PRODUCT, /mob/living/simple_mob/tomato)
 	set_trait(TRAIT_YIELD,2)
 	set_trait(TRAIT_PRODUCT_COLOUR,"#A86747")
 

--- a/code/modules/hydroponics/seedtypes/wabback.dm
+++ b/code/modules/hydroponics/seedtypes/wabback.dm
@@ -7,7 +7,6 @@
 	chems = list("nutriment" = list(1,10), "protein" = list(1,5), "enzyme" = list(0,3))
 	kitchen_tag = "wabback"
 	mutants = list("blackwabback","wildwabback")
-	has_item_product = /obj/item/stack/material/cloth
 
 /datum/seed/wabback/New()
 	..()
@@ -25,7 +24,7 @@
 	set_trait(TRAIT_CARNIVOROUS,1)
 	set_trait(TRAIT_HARVEST_REPEAT,1)
 	set_trait(TRAIT_SPREAD,1)
-
+	set_trait(TRAIT_UNIQUE_PRODUCT, /obj/item/stack/material/cloth)
 /datum/seed/wabback/vine
 	name = "blackwabback"
 	seed_name = "black wabback"
@@ -43,7 +42,6 @@
 	seed_name = "wild wabback"
 	display_name = "wild wabback"
 	mutants = list("whitewabback")
-	has_item_product = null
 	chems = list("nutriment" = list(1,15), "protein" = list(0,2), "enzyme" = list(0,1))
 
 /datum/seed/wabback/wild/New()
@@ -52,3 +50,4 @@
 	set_trait(TRAIT_WATER_CONSUMPTION, 7)
 	set_trait(TRAIT_NUTRIENT_CONSUMPTION, 0.1)
 	set_trait(TRAIT_YIELD,5)
+	set_trait(TRAIT_UNIQUE_PRODUCT, null)

--- a/code/modules/hydroponics/spreading/spreading_growth.dm
+++ b/code/modules/hydroponics/spreading/spreading_growth.dm
@@ -41,6 +41,12 @@
 		if(neighbor.seed == src.seed)
 			neighbor.neighbors -= T
 
+/obj/effect/plant/proc/count_nearby_mobs()
+	. = 0
+	for(var/mob/living/L in range(world.view, src))
+		if(L.stat != DEAD)
+			. += 1
+
 /obj/effect/plant/process()
 
 	// Something is very wrong, kill ourselves.
@@ -94,12 +100,34 @@
 		if(!has_buckled_mobs())
 			for(var/turf/neighbor in neighbors)
 				for(var/mob/living/M in neighbor)
-					if(seed.get_trait(TRAIT_SPREAD) >= 2 && (M.lying || prob(round(seed.get_trait(TRAIT_POTENCY)))))
+					if(seed.get_trait(TRAIT_SPREAD) >= 2 && (M.faction != "plant") &&(M.lying || prob(round(seed.get_trait(TRAIT_POTENCY)))) && (!M.faction != "plant"))
 						entangle(M)
 
 		if(seed.get_trait(TRAIT_SPORING) && prob(1))
 			visible_message(SPAN_WARNING("\The [src] hisses, releasing a cloud of spores!"), SPAN_WARNING("Something nearby hisses loudly!"))
 			seed.create_spores(get_turf(src))
+
+		if(prob(1) && (ispath(seed.get_trait(TRAIT_UNIQUE_PRODUCT), /mob/living)) && (count_nearby_mobs() < 3))
+			var/mob/living/Offspring = seed.create_hostile_mob(get_turf(src))
+			if(istype(Offspring))
+				visible_message(SPAN_DANGER("\The [src] disgorges \the [Offspring]!"))
+
+		if(seed.get_trait(TRAIT_SPEAKING) && prob(5))
+			visible_message(SPAN_OCCULT("\The [src] whispers [pick("strangely","uncomfortably","disturbingly","serenely")]."), SPAN_WARNING("Something nearby mumbles."))
+			visible_message(SPAN_NOTICE("\The [src] whispers,")+ SPAN_OCCULT("[pick(\
+			"\"You smell nice...\"",\
+			"\"I see you...\"",\
+			"\"Stop and smell \the [seed.display_name]s...\"",\
+			"\"Are you still there...\"",\
+			"\"Come back...\"",\
+			"\"Don't fight...\"",\
+			"\"A fine garden...\"",\
+			"\"Too much..?\"",\
+			"\"We'll be here...\"",\
+			"\"To the stars...\"",\
+			"\"They're just [seed.seed_noun]\"",\
+			"\"Bones are great fertilizer...\""\
+			)]."), SPAN_OCCULT("Something's whispering to you."), range = 2)
 
 		if(length(neighbors) && prob(spread_chance))
 			//spread to 1-3 adjacent turfs depending on yield trait.

--- a/code/modules/hydroponics/spreading/spreading_response.dm
+++ b/code/modules/hydroponics/spreading/spreading_response.dm
@@ -93,7 +93,7 @@
 	if(has_buckled_mobs())
 		return
 
-	if(victim.buckled || victim.anchored)
+	if(victim.buckled || victim.anchored || victim.faction == "plant")
 		return
 
 	//grabbing people

--- a/code/modules/hydroponics/trays/tray.dm
+++ b/code/modules/hydroponics/trays/tray.dm
@@ -136,7 +136,7 @@
 
 /obj/machinery/portable_atmospherics/hydroponics/attack_ghost(var/mob/observer/dead/user)
 
-	if(!(harvest && seed && seed.has_mob_product))
+	if(!(harvest && seed && istype(seed.get_trait(TRAIT_UNIQUE_PRODUCT), /mob/living)))
 		return
 
 	var/datum/ghosttrap/plant/G = get_ghost_trap("living plant")
@@ -234,6 +234,9 @@
 	update_icon()
 
 /obj/machinery/portable_atmospherics/hydroponics/proc/die()
+	if(seed.get_trait(TRAIT_SPEAKING))
+		visible_message("\The [seed.display_name] whimpers," + SPAN_OCCULT("[pick(" \"Sorry.. we're sorry..\""," \"It's quiet...\""," \"So it goes...\"")]"), SPAN_NOTICE("Something mumbles nearby."))
+
 	dead = 1
 	mutation_level = 0
 	harvest = 0
@@ -320,6 +323,11 @@
 		seed.harvest(user,yield_mod)
 	else
 		seed.harvest(get_turf(src),yield_mod)
+
+	if(seed.get_trait(TRAIT_SPEAKING) && prob(80))
+		visible_message("\The [seed.display_name] [pick("whines","mumbles","mutters")], " + SPAN_OCCULT("[pick("\"That's not yours...\"", "\"Why..?\"", "\"Okay...\"", "\"Stop it...\"")]"), range = 2)
+
+
 	// Reset values.
 	harvest = 0
 	lastproduce = age
@@ -359,7 +367,10 @@
 /obj/machinery/portable_atmospherics/hydroponics/proc/weed_invasion()
 
 	//Remove the seed if something is already planted.
-	if(seed) seed = null
+	if(seed)
+		if(!dead && seed.get_trait(TRAIT_SPEAKING))
+			visible_message("\The [seed.display_name] whimpers," + SPAN_OCCULT("[pick(" \"Sorry.. we're sorry..\""," \"It hurts...\""," \"So it goes...\"")]"), SPAN_NOTICE("Something mumbles nearby."))
+		seed = null
 	seed = plant_controller.seeds[pick(list("reishi","nettle","amanita","mushrooms","plumphelmet","towercap","harebells","weeds"))]
 	if(!seed) return //Weed does not exist, someone fucked up.
 
@@ -453,6 +464,10 @@
 
 	dead = 0
 	mutate(1)
+
+	if(seed.get_trait(TRAIT_SPEAKING) && prob(90))
+		visible_message("\The [seed.display_name] mutters," + SPAN_OCCULT("[pick(" \"Good as new...\""," \"Right as rain...\""," \"Yaay...\"")]"), SPAN_NOTICE("Something mumbles nearby."), range = 2)
+
 	age = 0
 	health = seed.get_trait(TRAIT_ENDURANCE)
 	lastcycle = world.time
@@ -484,6 +499,9 @@
 			return
 
 		// Create a sample.
+		if(seed.get_trait(TRAIT_SPEAKING) && prob(30))
+			visible_message("\The [seed.display_name] growls," + SPAN_OCCULT("[pick(" \"What is that for..\""," \"It hurts...\""," \"Mean...\"")]"), SPAN_NOTICE("Something mumbles nearby."), range = 2)
+
 		seed.harvest(user,yield_mod,1)
 		health -= (rand(3,5)*10)
 
@@ -531,7 +549,10 @@
 			plant_seeds(S)
 
 		else
-			to_chat(user, "<span class='danger'>\The [src] already has seeds in it!</span>")
+			if(seed.get_trait(TRAIT_SPEAKING) && prob(20))
+				visible_message("\The [seed.display_name] mumbles," + SPAN_OCCULT("[pick(" \"Occupied..\""," \"We're here already...\""," \"Stop it...\"")]"), SPAN_NOTICE("Something mumbles nearby."), range = 2)
+			else
+				to_chat(user, "<span class='danger'>\The [src] already has seeds in it!</span>")
 
 	else if (istype(O, /obj/item/material/minihoe))  // The minihoe
 
@@ -539,6 +560,11 @@
 			user.visible_message("<span class='danger'>[user] starts uprooting the weeds.</span>", "<span class='danger'>You remove the weeds from the [src].</span>")
 			weedlevel = 0
 			update_icon()
+			if(seed.get_trait(TRAIT_SPEAKING) && prob(70))
+				visible_message("\The [seed.display_name] sighs," + SPAN_OCCULT("[pick(" \"Thank you...\""," \"...Nice...\""," \"Thanks...\"")]"), SPAN_NOTICE("Something mumbles nearby."), range = 2)
+				for(var/obj/machinery/portable_atmospherics/hydroponics/Hydro in oview(world.view, get_turf(src)))
+					if(Hydro.seed && Hydro.seed.get_trait(TRAIT_SPEAKING) && Hydro.weedlevel > 0 && prob(10))
+						Hydro.visible_message("\The [seed.display_name] whines," + SPAN_OCCULT("[pick(" \"Us too..\""," \"It's cramped...\""," \"Help...\"")]"), SPAN_NOTICE("Something mumbles nearby."), range = 2)
 		else
 			to_chat(user, "<span class='danger'>This plot is completely devoid of weeds. It doesn't need uprooting.</span>")
 
@@ -553,7 +579,8 @@
 			S.handle_item_insertion(G, 1)
 
 	else if ( istype(O, /obj/item/plantspray) )
-
+		if(seed && !dead && seed.get_trait(TRAIT_SPEAKING) && prob(30))
+			visible_message("\The [seed.display_name] hisses," + SPAN_OCCULT("[pick(" \"Gross..\""," \"It hurts...\""," \"Regret it...\"")]"), SPAN_NOTICE("Something mumbles nearby."), range = 2)
 		var/obj/item/plantspray/spray = O
 		user.remove_from_mob(O)
 		toxins += spray.toxicity
@@ -590,6 +617,8 @@
 		user.setClickCooldown(user.get_attack_speed(O))
 		user.visible_message("<span class='danger'>\The [seed.display_name] has been attacked by [user] with \the [O]!</span>")
 		if(!dead)
+			if(seed.get_trait(TRAIT_SPEAKING) && prob(10))
+				visible_message("\The [seed.display_name] whimpers," + SPAN_OCCULT("[pick(" \"Sorry.. we're sorry..\""," \"It hurts...\""," \"No..!\"")]"), SPAN_NOTICE("Something mumbles nearby."), range = 2)
 			health -= O.force
 			check_health()
 

--- a/code/modules/hydroponics/trays/tray_process.dm
+++ b/code/modules/hydroponics/trays/tray_process.dm
@@ -62,8 +62,15 @@
 	var/healthmod = rand(1,3) * HYDRO_SPEED_MULTIPLIER
 	if(seed.get_trait(TRAIT_REQUIRES_NUTRIENTS) && prob(35))
 		health += (nutrilevel < 2 ? -healthmod : healthmod)
+
+		if(seed.get_trait(TRAIT_SPEAKING) && nutrilevel < 2 && prob(20))
+			visible_message("\The [seed.display_name] mumbles," + SPAN_OCCULT("[pick(" \"Hungry..\""," \"Food..?\""," \"Help...\"")]"), SPAN_NOTICE("Something mumbles nearby."), range = 2)
+
 	if(seed.get_trait(TRAIT_REQUIRES_WATER) && prob(35))
 		health += (waterlevel < 10 ? -healthmod : healthmod)
+
+		if(seed.get_trait(TRAIT_SPEAKING) && waterlevel < 10 && prob(20))
+			visible_message("\The [seed.display_name] mumbles," + SPAN_OCCULT("[pick(" \"Thirsty..\""," \"Water..?\""," \"Help...\"")]"), SPAN_NOTICE("Something mumbles nearby."), range = 2)
 
 	// Check that pressure, heat and light are all within bounds.
 	// First, handle an open system or an unconnected closed system.
@@ -92,6 +99,10 @@
 		var/toxin_uptake = max(1,round(toxins/10))
 		if(toxins > seed.get_trait(TRAIT_TOXINS_TOLERANCE))
 			health -= toxin_uptake
+
+			if(seed.get_trait(TRAIT_SPEAKING) && prob(10))
+				visible_message("\The [seed.display_name] mumbles," + SPAN_OCCULT("[pick(" \"Gross..\""," \"Not tasty...\""," \"Eww...\"")]"), SPAN_NOTICE("Something mumbles nearby."), range = 2)
+
 		toxins -= toxin_uptake
 
 	// Check for pests and weeds.
@@ -100,16 +111,29 @@
 		if(seed.get_trait(TRAIT_CARNIVOROUS))
 			health += HYDRO_SPEED_MULTIPLIER
 			pestlevel -= HYDRO_SPEED_MULTIPLIER
+
+			if(seed.get_trait(TRAIT_SPEAKING) && prob(5))
+				visible_message("\The [seed.display_name] mumbles," + SPAN_OCCULT("[pick(" \"Munch...\""," \"Crunch...\""," \"Haha...\"")]"), SPAN_NOTICE("Something mumbles nearby."), range = 2)
 		else if (pestlevel >= seed.get_trait(TRAIT_PEST_TOLERANCE))
 			health -= HYDRO_SPEED_MULTIPLIER
+
+			if(seed.get_trait(TRAIT_SPEAKING) && prob(5))
+				visible_message("\The [seed.display_name] mumbles," + SPAN_OCCULT("[pick(" \"Ow...\""," \"Biting...\""," \"Help...\"")]"), SPAN_NOTICE("Something mumbles nearby."), range = 2)
 
 	// Some plants thrive and live off of weeds.
 	if(weedlevel > 0)
 		if(seed.get_trait(TRAIT_PARASITE))
 			health += HYDRO_SPEED_MULTIPLIER
 			weedlevel -= HYDRO_SPEED_MULTIPLIER
+
+			if(seed.get_trait(TRAIT_SPEAKING) && prob(5))
+				visible_message("\The [seed.display_name] mumbles," + SPAN_OCCULT("[pick(" \"Sip...\""," \"Sup...\""," \"Haha...\"")]"), SPAN_NOTICE("Something mumbles nearby."), range = 2)
+
 		else if (weedlevel >= seed.get_trait(TRAIT_WEED_TOLERANCE))
 			health -= HYDRO_SPEED_MULTIPLIER
+
+			if(seed.get_trait(TRAIT_SPEAKING) && prob(5))
+				visible_message("\The [seed.display_name] mumbles," + SPAN_OCCULT("[pick(" \"Cramped...\""," \"Occupied...\""," \"Help...\"")]"), SPAN_NOTICE("Something mumbles nearby."), range = 2)
 
 	// Handle life and death.
 	// When the plant dies, weeds thrive and pests die off.

--- a/code/modules/reagents/reagents/drugs.dm
+++ b/code/modules/reagents/reagents/drugs.dm
@@ -171,6 +171,76 @@
 			M.emote(pick("twitch", "giggle"))
 			prob_proc = FALSE
 
+/datum/reagent/drugs/braindance
+	name = "Braindance"
+	id = "braindance"
+	description = "A strange fluid typically derived from a sentient fungus. It sometimes moves on its own."
+	taste_description = "nostalgia"
+	color = "#9f6db6"
+	high_message_list = list("Your mind drifts to a time long ago...",
+	"You've been here before...",
+	"It's all so familiar...",
+	"It feels like you've fallen through time...")
+	sober_message_list = list("Where did the time go?", "You feel painfully nostalgic.", "You feel.. homesick.")
+
+	affects_robots = TRUE	// Sapient fungus goo, interacts with robots.
+	affects_dead = TRUE
+
+/datum/reagent/drugs/braindance/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
+	..()
+
+	var/threshold = 5 * M.species.chem_strength_tox
+	if(alien == IS_SKRELL)
+		threshold = 1.2
+
+	if(alien == IS_SLIME)
+		threshold = 0.8
+
+	M.druggy = max(M.druggy, 30)
+
+	var/effective_dose = dose
+	if(issmall(M))
+		effective_dose *= 2
+	if(effective_dose < 1 * threshold)
+		M.apply_effect(3, DROWSY)
+		if(prob(5))
+			M.Move(get_step(M, M.dir))
+		if(prob(1) && prob_proc == TRUE)
+			to_chat(M, SPAN_OCCULT("[pick("Drifting", "Floating", "Walking", "Flying", "Hovering")] away, on a [pick("cold", "warm", "mild", "chilly", "hot")] [pick("Summer", "Winter", "Autumnal", "Spring")] [pick("Day","Morning","Noon","Afternoon","Evening","Night","Midnight")]...."))
+			prob_proc = FALSE
+	else if(effective_dose < 2 * threshold)
+		M.apply_effect(4, DROWSY)
+		if(prob(7))
+			M.Move(get_step(M, M.dir))
+		if(prob(1) && prob_proc == TRUE)
+			to_chat(M, SPAN_OCCULT("Just like yesterday... [pick("everything changed...","they left...","they arrived...","it started...","it began...")]"))
+			prob_proc = FALSE
+	else
+		M.apply_effect(5, DROWSY)
+		M.make_dizzy(3)
+		M.adjustHalLoss(effective_dose / 10 * removed)
+		if(prob(10))
+			M.Move(get_step(M, M.dir))
+		if(prob(1) && prob_proc == TRUE)
+			to_chat(M, SPAN_OCCULT("Then everything [pick("flew", "moved", "bounced", "jolted")] [pick("up","down","left","right","forward","backward","that way","this way")] and [pick("started over", "changed again", "reset", "ended")] that day.."))
+			prob_proc = FALSE
+
+/datum/reagent/drugs/braindance/overdose(var/mob/living/M as mob)
+	if(prob_proc == TRUE && prob(40))
+		M.hallucination = max(M.hallucination, round(dose * REM))
+		prob_proc = FALSE
+
+	M.apply_effect(3, EYE_BLUR)
+
+	if(!M.isSynthetic(M))
+		M.adjustBrainLoss(-0.1 * REM)
+		M.adjustToxLoss(0.5*REM)
+
+	else
+		M.adjustToxLoss(REM)
+
+	..()
+
 /datum/reagent/drugs/talum_quem
 	name = "Talum-quem"
 	id = "talum_quem"


### PR DESCRIPTION
Plant item and mob products reworked to use a proper gene, TRAIT_UNIQUE_PRODUCT.

Vines can rarely spawn up to 3 mobs in sightline of eachother, on the incredibly rare chance they have a mob product. These will always be hostile, in comparison to the player-controlled ones spawned from harvest.

Braincaps added, which use the speaking gene, TRAIT_SPEAKING. TRAIT_SPEAKING makes plants babble about their status; starving, dehydrated, attacked, etcetera; and causes the product, if it is not a mob, to rarely become talkative, akin to xenoarch baubles. Except these ones you can kill.
Braincaps also (will when PR finished momentarily) contain a (illegal? it is a talking plant with some sense of pain and thought) psychoactive drug due to the method they store their memories.

TRAIT_UNIQUE_PRODUCT and TRAIT_SPEAKING are both on the Special allele, making TRAIT_TELEPORTING no longer alone.

Braincaps, Sporeshrooms, and a Destroying Angel seedpack, have been added to cargo in a contraband crate.