### PR TITLE
Genericise some cult stuff

### DIFF
--- a/code/game/gamemodes/cult/cult_items.dm
+++ b/code/game/gamemodes/cult/cult_items.dm
@@ -1,6 +1,6 @@
 /obj/item/melee/cultblade
 	name = "cult blade"
-	desc = "An arcane weapon wielded by the followers of Nar-Sie."
+	desc = "An arcane weapon wielded by the followers of an unknown god."
 	icon_state = "cultblade"
 	origin_tech = list(TECH_COMBAT = 1, TECH_ARCANE = 1)
 	w_class = ITEMSIZE_LARGE
@@ -51,7 +51,7 @@
 /obj/item/clothing/head/culthood
 	name = "cult hood"
 	icon_state = "culthood"
-	desc = "A hood worn by the followers of Nar-Sie."
+	desc = "A hood worn by the followers of an unknown god."
 	origin_tech = list(TECH_MATERIAL = 3, TECH_ARCANE = 1)
 	flags_inv = HIDEFACE
 	body_parts_covered = HEAD
@@ -66,7 +66,7 @@
 /obj/item/clothing/head/culthood/magus
 	name = "magus helm"
 	icon_state = "magus"
-	desc = "A helm worn by the followers of Nar-Sie."
+	desc = "A helm worn by the followers of an unknown god."
 	flags_inv = HIDEFACE | BLOCKHAIR
 	body_parts_covered = HEAD|FACE|EYES
 
@@ -75,7 +75,7 @@
 
 /obj/item/clothing/suit/cultrobes
 	name = "cult robes"
-	desc = "A set of armored robes worn by the followers of Nar-Sie."
+	desc = "A set of armored robes worn by the followers of an unknown god."
 	icon_state = "cultrobes"
 	origin_tech = list(TECH_MATERIAL = 3, TECH_ARCANE = 1)
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
@@ -92,14 +92,14 @@
 
 /obj/item/clothing/suit/cultrobes/magusred
 	name = "magus robes"
-	desc = "A set of armored robes worn by the followers of Nar-Sie."
+	desc = "A set of armored robes worn by the followers of an unknown god."
 	icon_state = "magusred"
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|FEET|ARMS|HANDS
 	flags_inv = HIDEGLOVES|HIDESHOES|HIDEJUMPSUIT
 
 /obj/item/clothing/head/helmet/space/cult
 	name = "cult helmet"
-	desc = "A space worthy helmet used by the followers of Nar-Sie."
+	desc = "A space worthy helmet used by the followers of an unknown god."
 	icon_state = "cult_helmet"
 	origin_tech = list(TECH_MATERIAL = 3, TECH_ARCANE = 1)
 	armor = list(melee = 60, bullet = 50, laser = 30, energy = 80, bomb = 30, bio = 30, rad = 30)

--- a/code/game/gamemodes/cult/cult_structures.dm
+++ b/code/game/gamemodes/cult/cult_structures.dm
@@ -8,13 +8,13 @@
 
 /obj/structure/cult/talisman
 	name = "Altar"
-	desc = "A bloodstained altar dedicated to Nar-Sie."
+	desc = "A bloodstained altar dedicated to an unknown god."
 	icon_state = "talismanaltar"
 
 
 /obj/structure/cult/forge
 	name = "Daemon forge"
-	desc = "A forge used in crafting the unholy weapons used by the armies of Nar-Sie."
+	desc = "A forge used in crafting the sacred weapons used in service of an unknown god."
 	icon_state = "forge"
 
 /obj/structure/cult/pylon

--- a/code/modules/clothing/shoes/miscellaneous.dm
+++ b/code/modules/clothing/shoes/miscellaneous.dm
@@ -80,7 +80,7 @@
 
 /obj/item/clothing/shoes/cult
 	name = "boots"
-	desc = "A pair of boots worn by the followers of Nar-Sie."
+	desc = "A pair of boots worn by the followers of an unknown god."
 	icon_state = "cult"
 	item_state_slots = list(slot_r_hand_str = "cult", slot_l_hand_str = "cult")
 	force = 2

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -66,7 +66,7 @@
 		"Koi" = "koi-swim",
 		"Carp" = "carp",
 		"Red Robes" = "robe_red",
-		"Faithless" = "faithless",
+		"Miasmic Entity" = "faithless",
 		"Shadowform" = "forgotten",
 		"Dark Ethereal" = "bloodguardian",
 		"Holy Ethereal" = "lightguardian",

--- a/code/modules/mob/living/simple_mob/subtypes/occult/constructs/juggernaut.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/occult/constructs/juggernaut.dm
@@ -6,7 +6,7 @@
 	name = "Juggernaut"
 	real_name = "Juggernaut"
 	construct_type = "juggernaut"
-	desc = "A possessed suit of armour driven by the will of the restless dead"
+	desc = "A possessed suit of armour driven by the will of the restless dead."
 	icon = 'icons/mob/mob.dmi'
 	icon_state = "behemoth"
 	icon_living = "behemoth"

--- a/code/modules/mob/living/simple_mob/subtypes/occult/constructs/shade.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/occult/constructs/shade.dm
@@ -5,7 +5,7 @@
 /mob/living/simple_mob/construct/shade
 	name = "Shade"
 	real_name = "Shade"
-	desc = "A bound spirit"
+	desc = "A bound spirit."
 	icon = 'icons/mob/mob.dmi'
 	icon_state = "shade"
 	icon_living = "shade"

--- a/code/modules/mob/living/simple_mob/subtypes/occult/creature.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/occult/creature.dm
@@ -1,6 +1,6 @@
 /mob/living/simple_mob/creature
 	name = "creature"
-	desc = "A sanity-destroying otherthing."
+	desc = "An unrecognisable biological otherthing."
 	icon = 'icons/mob/critter.dmi'
 	icon_state = "otherthing"
 	icon_living = "otherthing"

--- a/code/modules/mob/living/simple_mob/subtypes/occult/faithless.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/occult/faithless.dm
@@ -1,6 +1,6 @@
 /mob/living/simple_mob/faithless
-	name = "Faithless"
-	desc = "The Wish Granter's faith in humanity, incarnate"
+	name = "miasmic entity"
+	desc = "Malignant energy given physical form by phenomena unknown."
 	icon_state = "faithless"
 	icon_living = "faithless"
 	icon_dead = "faithless_dead"

--- a/maps/submaps/surface_submaps/wilderness/demonpool.dmm
+++ b/maps/submaps/surface_submaps/wilderness/demonpool.dmm
@@ -305,7 +305,7 @@
 	health = 250;
 	melee_damage_lower = 20;
 	melee_damage_upper = 30;
-	name = "Recursive faithless"
+	name = "Recursive entity"
 	},
 /turf/simulated/floor/cult,
 /area/submap/DemonPool)


### PR DESCRIPTION
De-"cults" some stuff that consistently shows up outside the context of Cult Rounds/events, especially in what should just be weird-anomaly-shit situations where it should be up to interpretation.

- Faithless -> miasmic entity
- "Creature" and faithless descriptions are less explicitly supernatural.
- References to Nar-Sie in items that are used outside of cult rounds removed.
- No change to explicitly spooky scary shit related to/exclusively used in cult round gameplay. That stuff is supposed to be explicitly supernatural!