### PR TITLE
Adds a proc to fix player notes listings

### DIFF
--- a/code/modules/admin/fix_player_notes_listing.dm
+++ b/code/modules/admin/fix_player_notes_listing.dm
@@ -1,0 +1,16 @@
+/proc/fix_player_notes_listing()
+	var/list/has_notes = list()
+	// flist() dir names include the /
+	for(var/subdir in flist("data/player_saves/"))
+		for(var/ckey in flist("data/player_saves/[subdir]"))
+			if(fexists("data/player_saves/[subdir][ckey]info.sav"))
+				has_notes += copytext(ckey, 1, -1) // Trim the tailing /
+
+	//Updating list of keys with notes on them
+	var/savefile/note_list = new("data/player_notes.sav")
+	var/list/note_keys
+	note_list >> note_keys
+	if(!note_keys) note_keys = list()
+	note_keys |= has_notes
+	note_list << note_keys
+	del(note_list) // savefile, so NOT qdel

--- a/polaris.dme
+++ b/polaris.dme
@@ -1357,6 +1357,7 @@
 #include "code\modules\admin\create_mob.dm"
 #include "code\modules\admin\create_object.dm"
 #include "code\modules\admin\create_turf.dm"
+#include "code\modules\admin\fix_player_notes_listing.dm"
 #include "code\modules\admin\holder2.dm"
 #include "code\modules\admin\IsBanned.dm"
 #include "code\modules\admin\map_capture.dm"


### PR DESCRIPTION
This gets called manually by ~enterprising admins who've realized something is wrong~ Ater after lazy admins complain about everything being wrong.
I tested this locally, it works.