### PR TITLE
allows soap and showers to clean toes, and space cleaner to actually clean synthetic toes

### DIFF
--- a/code/game/objects/items/weapons/clown_items.dm
+++ b/code/game/objects/items/weapons/clown_items.dm
@@ -54,7 +54,7 @@
 		wet()
 	else
 		to_chat(user, "<span class='notice'>You clean \the [target.name].</span>")
-		target.clean_blood()
+		target.clean_blood(TRUE)
 	return
 
 //attack_as_weapon

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -197,7 +197,7 @@
 			wash(M)
 			process_heat(M)
 		for (var/atom/movable/G in src.loc)
-			G.clean_blood()
+			G.clean_blood(TRUE)
 	else
 		soundloop.stop()
 

--- a/code/modules/reagents/reagents/other.dm
+++ b/code/modules/reagents/reagents/other.dm
@@ -452,7 +452,7 @@
 	..()
 	if(iscarbon(M))
 		var/mob/living/carbon/C = M
-		C.clean_blood()
+		C.clean_blood(TRUE)
 
 /datum/reagent/space_cleaner/touch_obj(var/obj/O)
 	..()


### PR DESCRIPTION
title

so, synths don't process reagents so they don't get affect_touch called on them, only touch_mob
but touch mob doesn't have washshoes set to yes, so they never get cleaned
(I think that's why affect_touch isn't called anyway, haven't actually looked into the code too much, just know this fixes it)

could probably remove soap from this list and make just showers and space cleaner do it instead but it's really fucking annoying having to find space cleaner just to clean my goddamn blood stained feet