### PR TITLE
Child organs can't robotize() if they're already robotic

### DIFF
--- a/code/modules/client/preference_setup/general/03_body.dm
+++ b/code/modules/client/preference_setup/general/03_body.dm
@@ -345,7 +345,7 @@ var/global/list/valid_bloodtypes = list("A+", "A-", "B+", "B-", "AB+", "AB-", "O
 
 	// Destroy/cyborgize organs and limbs.
 	character.synthetic = null //Clear the existing var.
-	for(var/name in BP_ALL)
+	for(var/name in list(BP_HEAD, BP_L_HAND, BP_R_HAND, BP_L_ARM, BP_R_ARM, BP_L_FOOT, BP_R_FOOT, BP_L_LEG, BP_R_LEG, BP_GROIN, BP_TORSO))
 		var/status = pref.organ_data[name]
 		var/obj/item/organ/external/O = character.organs_by_name[name]
 		if(O)


### PR DESCRIPTION
I looked at `robotize()` when I reviewd #8911 to make sure the changes made sense. I missed a very important line:
https://github.com/PolarisSS13/Polaris/blob/master/code/modules/organs/organ_external.dm#L1101-L1102

If the child limb is already robotic, it will not update the brand. Hence, the issue stated as fixed was actually _introduced_ by the changes implemented.