### PR TITLE
Fixes powersink having no sprite

### DIFF
--- a/code/game/objects/items/devices/powersink.dm
+++ b/code/game/objects/items/devices/powersink.dm
@@ -4,6 +4,7 @@
 	name = "power sink"
 	desc = "A nulling power sink which drains energy from electrical systems."
 	icon_state = "powersink0"
+	icon = 'icons/obj/device.dmi'
 	w_class = ITEMSIZE_LARGE
 	throwforce = 5
 	throw_speed = 1


### PR DESCRIPTION
Was missed when /devices/ was removed apparently.