### PR TITLE
Synthetics can have antennas (also humans if they want?)

### DIFF
--- a/code/modules/mob/new_player/sprite_accessories_ear.dm
+++ b/code/modules/mob/new_player/sprite_accessories_ear.dm
@@ -47,15 +47,17 @@
 /datum/sprite_accessory/ears/dual_robot
 	name = "synth antennae"
 	icon_state = "dual_robot_antennae"
+	species_allowed = list(SPECIES_HUMAN, SPECIES_HUMAN_VATBORN, SPECIES_EVENT1, SPECIES_EVENT2, SPECIES_EVENT3)
 
 /datum/sprite_accessory/ears/right_robot
 	name = "right synth"
-
 	icon_state = "right_robot_antennae"
+	species_allowed = list(SPECIES_HUMAN, SPECIES_HUMAN_VATBORN, SPECIES_EVENT1, SPECIES_EVENT2, SPECIES_EVENT3)
 
 /datum/sprite_accessory/ears/left_robot
 	name = "left synth"
 	icon_state = "left_robot_antennae"
+	species_allowed = list(SPECIES_HUMAN, SPECIES_HUMAN_VATBORN, SPECIES_EVENT1, SPECIES_EVENT2, SPECIES_EVENT3)
 
 /datum/sprite_accessory/ears/oni_h1
 	name = "oni horns"


### PR DESCRIPTION
Enables the dual, left, and right synth antenna sprite accessories for the human, vatborn, and event species (don't know what those are, just copied the line from the elf ears for parity with other universally accessible eartypes). There was a conversation on the Discord the other day that I could whitelist to get these, but it was also mentioned that there's no real reason that these aren't universally accessible anyways (both for the use of synthetics using the Human/Vatborn species as a baseline, and just "as augments" for those who are _actual_ humans). So instead of playing enough that I'm trusted for a whitelist I just PR'ed them. This was ostensibly the better option anyways.

![image](https://user-images.githubusercontent.com/32314478/218273103-066bd1ff-bbe4-4c3b-bdc2-aa901413303c.png)

Have I mentioned how disconcerting it is that this codebase doesn't seem to have a PR body text format?