### PR TITLE
Make tape recorders record voices not faces

### DIFF
--- a/code/game/objects/items/devices/taperecorder.dm
+++ b/code/game/objects/items/devices/taperecorder.dm
@@ -92,7 +92,7 @@
 /obj/item/taperecorder/hear_talk(mob/M, list/message_pieces, verb)
 	var/msg = multilingual_to_message(message_pieces, requires_machine_understands = TRUE, with_capitalization = TRUE)
 	if(mytape && recording)
-		mytape.record_speech("[M.name] [verb], \"[msg]\"")
+		mytape.record_speech("[M.voice] [verb], \"[msg]\"")
 
 
 /obj/item/taperecorder/see_emote(mob/M as mob, text, var/emote_type)


### PR DESCRIPTION
Changes tape-recorders so they record the person's voice, not their visible face. This makes it so voice changers affect the recordings.