### PR TITLE
Flesh Repair respects Blood Pump

### DIFF
--- a/code/game/machinery/oxygen_pump.dm
+++ b/code/game/machinery/oxygen_pump.dm
@@ -311,7 +311,7 @@
 							H.adjustOxyLoss(-(rand(1,8)))
 
 				if(H.stat == DEAD)
-					H.add_modifier(/datum/modifier/bloodpump_corpse, 6 SECONDS)
+					H.add_modifier(/datum/modifier/bloodpump/corpse, 6 SECONDS)
 
 				else
 					H.add_modifier(/datum/modifier/bloodpump, 6 SECONDS)

--- a/code/modules/mob/_modifiers/medical.dm
+++ b/code/modules/mob/_modifiers/medical.dm
@@ -18,7 +18,7 @@
 	if(holder.stat == DEAD)
 		src.expire()
 
-/datum/modifier/bloodpump_corpse
+/datum/modifier/bloodpump/corpse
 	name = "forced blood pumping"
 	desc = "Your blood flows thanks to the wonderful power of science."
 

--- a/code/modules/reagents/reagents/medicine.dm
+++ b/code/modules/reagents/reagents/medicine.dm
@@ -421,7 +421,7 @@
 	scannable = 1
 
 /datum/reagent/mortiferin/on_mob_life(var/mob/living/carbon/M, var/alien, var/datum/reagents/metabolism/location)
-	if(M.stat == DEAD && M.has_modifier_of_type(/datum/modifier/bloodpump_corpse))
+	if(M.stat == DEAD && M.has_modifier_of_type(/datum/modifier/bloodpump/corpse))
 		affects_dead = TRUE
 	else
 		affects_dead = FALSE
@@ -429,7 +429,7 @@
 	. = ..(M, alien, location)
 
 /datum/reagent/mortiferin/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
-	if(M.bodytemperature < (T0C - 10) || (M.stat == DEAD && M.has_modifier_of_type(/datum/modifier/bloodpump_corpse)))
+	if(M.bodytemperature < (T0C - 10) || (M.stat == DEAD && M.has_modifier_of_type(/datum/modifier/bloodpump/corpse)))
 		var/chem_effective = 1 * M.species.chem_strength_heal
 		if(alien == IS_SLIME)
 			if(prob(10))
@@ -466,7 +466,7 @@
 
 /datum/reagent/necroxadone/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	var/chem_effective = 1 * M.species.chem_strength_heal
-	if(M.bodytemperature < 170 || (M.stat == DEAD && M.has_modifier_of_type(/datum/modifier/bloodpump_corpse)))
+	if(M.bodytemperature < 170 || (M.stat == DEAD && M.has_modifier_of_type(/datum/modifier/bloodpump/corpse)))
 		if(alien == IS_SLIME)
 			if(prob(10))
 				to_chat(M, "<span class='danger'>It's so cold. Something causes your cellular mass to harden sporadically, resulting in seizure-like twitching.</span>")

--- a/code/modules/surgery/external_repair.dm
+++ b/code/modules/surgery/external_repair.dm
@@ -9,7 +9,7 @@
 	req_open = 1
 
 /datum/surgery_step/repairflesh/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
-	if (target.stat == DEAD) // Sorry defibs, your subjects need to have pumping fluids for these to work.
+	if (target.stat == DEAD && !target.has_modifier_of_type(/datum/modifier/bloodpump/corpse)) // Sorry defibs, your subjects need to have pumping fluids for these to work.
 		return 0
 	if (isslime(target))
 		return 0


### PR DESCRIPTION
Flesh repair surgery now works on corpses with the bloodpump modifier, typically from the patient stabilizer.

A surgeon with enough time can stitch a corpse back together to try and defib them, as long as the corpse's blood is being pumped.