### PR TITLE
Refluff space bats and space bears

### DIFF
--- a/code/modules/mob/living/simple_mob/subtypes/animal/space/bats.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/space/bats.dm
@@ -10,22 +10,6 @@
 
 	faction = "scarybat"
 
-/datum/category_item/catalogue/fauna/razor_bat
-	name = "Nispean Fauna - Razor Bat"
-	desc = "These sharp-toothed flying mammalian animals are adapted to the oxygen-deficient \
-	and hostile jungles of Nisp, and as a result are frightening capable of surviving in harsh, \
-	even near-airless environments. In higher-oxygen environments, these bats can reach the size \
-	of a human head, though they struggle to thrive in low temperatures without proper shelter.\
-	<br><br>\
-	The Razor Bat is exclusively carnivorous, feeding on the blood of prey of all sizes, an\
-	act which often proves fatal to smaller targets. Remarkably, the bat can survive up to a\
-	week without feeding, though underfed specimens are notoriously aggressive.\
-	<br><br>\
-	With the human colonisation of Kess-Gendar, the Razor Bat gained a bad habit of stowing \
-	away undetected in the maintenance spaces of ships departing Nisp, and have become a minor\
-	invasive pest on several human worlds."
-	value = CATALOGUER_REWARD_EASY
-
 	maxHealth = 20
 	health = 20
 
@@ -73,3 +57,19 @@
 	maxHealth = 60
 	health = 60
 	melee_damage_upper = 10
+
+/datum/category_item/catalogue/fauna/razor_bat
+	name = "Nispean Fauna - Razor Bat"
+	desc = "These sharp-toothed flying mammalian animals are adapted to the oxygen-deficient \
+	and hostile jungles of Nisp, and as a result are frightening capable of surviving in harsh, \
+	even near-airless environments. In higher-oxygen environments, these bats can reach the size \
+	of a human head, though they struggle to thrive in low temperatures without proper shelter.\
+	<br><br>\
+	The Razor Bat is exclusively carnivorous, feeding on the blood of prey of all sizes, an\
+	act which often proves fatal to smaller targets. Remarkably, the bat can survive up to a\
+	week without feeding, though underfed specimens are notoriously aggressive.\
+	<br><br>\
+	With the human colonisation of Kess-Gendar, the Razor Bat gained a bad habit of stowing \
+	away undetected in the maintenance spaces of ships departing Nisp, and have become a minor\
+	invasive pest on several human worlds."
+	value = CATALOGUER_REWARD_EASY

--- a/code/modules/mob/living/simple_mob/subtypes/animal/space/bats.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/space/bats.dm
@@ -61,13 +61,14 @@
 /datum/category_item/catalogue/fauna/razor_bat
 	name = "Nispean Fauna - Razor Bat"
 	desc = "These sharp-toothed flying mammalian animals are adapted to the oxygen-deficient \
-	and hostile jungles of Nisp, and as a result are frightening capable of surviving in harsh, \
+	and hostile jungles of Nisp, and as a result are frighteningly capable of surviving in harsh, \
 	even near-airless environments. In higher-oxygen environments, these bats can reach the size \
 	of a human head, though they struggle to thrive in low temperatures without proper shelter.\
 	<br><br>\
-	The Razor Bat is exclusively carnivorous, feeding on the blood of prey of all sizes, an\
-	act which often proves fatal to smaller targets. Remarkably, the bat can survive up to a\
-	week without feeding, though underfed specimens are notoriously aggressive.\
+	The Razor Bat is exclusively carnivorous, feeding on the blood of prey of all sizes by inflicting\
+	cuts with its eponymous razor-sharp fangs, an act which often proves fatal to smaller targets.\
+	Remarkably, the bat can survive up to a week without feeding, though underfed specimens are \
+	notoriously aggressive.\
 	<br><br>\
 	With the human colonisation of Kess-Gendar, the Razor Bat gained a bad habit of stowing \
 	away undetected in the maintenance spaces of ships departing Nisp, and have become a minor\

--- a/code/modules/mob/living/simple_mob/subtypes/animal/space/bats.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/space/bats.dm
@@ -60,9 +60,9 @@
 
 /datum/category_item/catalogue/fauna/razor_bat
 	name = "Nispean Fauna - Razor Bat"
-	desc = "These sharp-toothed flying mammalian animals are adapted to the oxygen-deficient \
+	desc = "These sharp-toothed flying mammalian animals are adapted to the nitrous-oxide rich \
 	and hostile jungles of Nisp, and as a result are frighteningly capable of surviving in harsh, \
-	even near-airless environments. In higher-oxygen environments, these bats can reach the size \
+	even near-airless environments. In high oxygen environments, these bats can reach the size \
 	of a human head, though they struggle to thrive in low temperatures without proper shelter.\
 	<br><br>\
 	The Razor Bat is exclusively carnivorous, feeding on the blood of prey of all sizes by inflicting\

--- a/code/modules/mob/living/simple_mob/subtypes/animal/space/bats.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/space/bats.dm
@@ -1,6 +1,6 @@
 /mob/living/simple_mob/animal/space/bats
-	name = "space bat swarm"
-	desc = "A swarm of cute little blood sucking bats that looks pretty upset."
+	name = "razor bats"
+	desc = "A swarm of cute little blood sucking bats that look pretty upset."
 	tt_desc = "N Bestia gregaria" //Nispean swarm bats, because of course Nisp has swarm bats
 	icon = 'icons/mob/bats.dmi'
 	icon_state = "bat"
@@ -9,6 +9,22 @@
 	icon_gib = "bat_dead"
 
 	faction = "scarybat"
+
+/datum/category_item/catalogue/fauna/razor_bat
+	name = "Nispean Fauna - Razor Bat"
+	desc = "These sharp-toothed flying mammalian animals are adapted to the oxygen-deficient \
+	and hostile jungles of Nisp, and as a result are frightening capable of surviving in harsh, \
+	even near-airless environments. In higher-oxygen environments, these bats can reach the size \
+	of a human head, though they struggle to thrive in low temperatures without proper shelter.\
+	<br><br>\
+	The Razor Bat is exclusively carnivorous, feeding on the blood of prey of all sizes, an\
+	act which often proves fatal to smaller targets. Remarkably, the bat can survive up to a\
+	week without feeding, though underfed specimens are notoriously aggressive.\
+	<br><br>\
+	With the human colonisation of Kess-Gendar, the Razor Bat gained a bad habit of stowing \
+	away undetected in the maintenance spaces of ships departing Nisp, and have become a minor\
+	invasive pest on several human worlds."
+	value = CATALOGUER_REWARD_EASY
 
 	maxHealth = 20
 	health = 20

--- a/code/modules/mob/living/simple_mob/subtypes/animal/space/bear.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/space/bear.dm
@@ -1,13 +1,13 @@
 /mob/living/simple_mob/animal/space/bear
-	name = "space bear"
-	desc = "A product of Space Russia?"
-	tt_desc = "U Ursinae aetherius" //...bearspace? Maybe.
+	name = "shimmer bear"
+	desc = "Its fur glimmers in even the slightest light."
+	tt_desc = "N Ursinae fulgeo" //bear glisten...
 	icon_state = "bear"
 	icon_living = "bear"
 	icon_dead = "bear_dead"
 	icon_gib = "bear_gib"
 
-	faction = "russian"
+	faction = "bear"
 
 	maxHealth = 125
 	health = 125


### PR DESCRIPTION
Space bats are regularly used in PoIs of all sorts so its a little odd that they have a goofy joke name from a decade ago. Also: Holy echolocation batman, it's batlore!

Space bears aren't used anywhere where they show up For Realises because they're very silly, but renamed them for the rare occasion they do show up.