### PR TITLE
Suit kits no longer set item_state on hooded clothes

### DIFF
--- a/code/game/objects/items/paintkit.dm
+++ b/code/game/objects/items/paintkit.dm
@@ -129,10 +129,8 @@
 			suit.desc = new_desc
 			suit.icon_state = "[new_icon]_suit"
 			suit.toggleicon = "[new_icon]_suit"
-			suit.item_state = "[new_icon]_suit"
 			var/obj/item/clothing/head/hood/S = suit.hood
 			S.icon_state = "[new_icon]_helmet"
-			S.item_state = "[new_icon]_helmet"
 			if(new_icon_file)
 				suit.icon = new_icon_file
 				S.icon = new_icon_file


### PR DESCRIPTION
Players reported issues with custom item kits for modifying hooded clothing as not properly updating the worn icon. I suspect that's because the hooded clothes update their `icon_state` with the toggled value, but the kits are setting `item_state`, which overrides the value in worn icon generation.
Totally untested, this could break everything, but should only affect custom items and might fix the issue. I will provide continued support for the issue post-merge.