### PR TITLE
Random Rig spawner no longer spawns access locked rigs.

### DIFF
--- a/code/game/objects/random/spacesuits.dm
+++ b/code/game/objects/random/spacesuits.dm
@@ -276,9 +276,9 @@
 	icon_state = "generic"
 
 /obj/random/rigsuit/item_to_spawn()
-	return pick(prob(4);/obj/item/rig/light/hacker,
+	return pick(prob(4);/obj/item/rig/light/hacker/poi,
 				prob(5);/obj/item/rig/industrial,
 				prob(5);/obj/item/rig/eva,
-				prob(4);/obj/item/rig/light/stealth,
+				prob(4);/obj/item/rig/light/stealth/poi,
 				prob(3);/obj/item/rig/hazard,
-				prob(1);/obj/item/rig/merc/empty)
+				prob(1);/obj/item/rig/merc/empty/poi)

--- a/code/modules/clothing/spacesuits/rig/rig_attackby.dm
+++ b/code/modules/clothing/spacesuits/rig/rig_attackby.dm
@@ -194,5 +194,6 @@
 		LAZYCLEARLIST(req_one_access)
 		locked = 0
 		subverted = 1
-		to_chat(user, "<span class='danger'>You short out the access protocol for the suit.</span>")
+		if(user)
+			to_chat(user, "<span class='danger'>You short out the access protocol for the suit.</span>")
 		return 1

--- a/code/modules/clothing/spacesuits/rig/suits/light.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/light.dm
@@ -68,6 +68,11 @@
 		/obj/item/rig_module/vision,
 		)
 
+/obj/item/rig/light/hacker/poi/Initialize()
+	. = ..()
+	if(!QDELETED(src))
+		emag_act()
+
 //The cybersuit is not space-proof. It does however, have good siemens_coefficient values
 /obj/item/clothing/head/helmet/space/rig/light/hacker
 	name = "headgear"
@@ -138,3 +143,8 @@
 		/obj/item/rig_module/stealth_field,
 		/obj/item/rig_module/vision
 		)
+
+/obj/item/rig/light/stealth/poi/Initialize()
+	. = ..()
+	if(!QDELETED(src))
+		emag_act()

--- a/code/modules/clothing/spacesuits/rig/suits/merc.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/merc.dm
@@ -44,3 +44,8 @@
 		/obj/item/rig_module/ai_container,
 		/obj/item/rig_module/electrowarfare_suite, //might as well
 		)
+
+/obj/item/rig/merc/empty/poi/Initialize()
+	. = ..()
+	if(!QDELETED(src))
+		emag_act()


### PR DESCRIPTION
Tin. The hacker, stealth, and empty merc rig spawned with access_syndicate, while the others lack any requirements at all. This brings them in line with the others.