### PR TITLE
Revert "fixes a memory leak with mannequins and the issue that then comes with fixing it"

### DIFF
--- a/code/_helpers/global_lists.dm
+++ b/code/_helpers/global_lists.dm
@@ -23,6 +23,8 @@ var/global/list/joblist = list()					//list of all jobstypes, minus borg and AI
 #define all_genders_define_list list(MALE,FEMALE,PLURAL,NEUTER)
 #define all_genders_text_list list("Male","Female","Plural","Neuter")
 
+var/global/list/mannequins_
+
 // Times that players are allowed to respawn ("ckey" = world.time)
 GLOBAL_LIST_EMPTY(respawn_timers)
 
@@ -102,13 +104,13 @@ var/global/list/string_slot_flags = list(
 	"holster" = SLOT_HOLSTER
 )
 
-GLOBAL_LIST_EMPTY(mannequins)
-/proc/get_mannequin(var/ckey = "NULL")
-	var/mob/living/carbon/human/dummy/mannequin/M = GLOB.mannequins[ckey]
-	if(!istype(M))
-		GLOB.mannequins[ckey] = new /mob/living/carbon/human/dummy/mannequin(null)
-		M = GLOB.mannequins[ckey]
-	return M
+/proc/get_mannequin(var/ckey)
+	if(!mannequins_)
+		mannequins_ = new()
+ 	. = mannequins_[ckey]
+	if(!.)
+		. = new/mob/living/carbon/human/dummy/mannequin()
+		mannequins_[ckey] = .
 
 //////////////////////////
 /////Initial Building/////

--- a/code/modules/client/preference_setup/general/03_body.dm
+++ b/code/modules/client/preference_setup/general/03_body.dm
@@ -373,9 +373,7 @@ var/global/list/valid_bloodtypes = list("A+", "A-", "B+", "B-", "AB+", "AB-", "O
 		var/status = pref.organ_data[name]
 		var/obj/item/organ/external/O = character.organs_by_name[name]
 		if(O)
-			if(status == null)
-				O.derobotize()
-			else if(status == "amputated")
+			if(status == "amputated")
 				O.remove_rejuv()
 			else if(status == "cyborg")
 				if(pref.rlimb_data[name])
@@ -385,15 +383,15 @@ var/global/list/valid_bloodtypes = list("A+", "A-", "B+", "B-", "AB+", "AB-", "O
 
 	for(var/name in list(O_HEART,O_EYES,O_VOICE,O_LUNGS,O_LIVER,O_KIDNEYS,O_SPLEEN,O_STOMACH,O_INTESTINE,O_BRAIN))
 		var/status = pref.organ_data[name]
+		if(!status)
+			continue
 		var/obj/item/organ/I = character.internal_organs_by_name[name]
 		if(istype(I, /obj/item/organ/internal/brain))
 			var/obj/item/organ/external/E = character.get_organ(I.parent_organ)
 			if(E.robotic < ORGAN_ASSISTED)
 				continue
 		if(I)
-			if(status == null)
-				I.derobotize()
-			else if(status == "assisted")
+			if(status == "assisted")
 				I.mechassist()
 			else if(status == "mechanical")
 				I.robotize()

--- a/code/modules/organs/internal/_organ_internal.dm
+++ b/code/modules/organs/internal/_organ_internal.dm
@@ -40,13 +40,6 @@
 	if(dead_icon)
 		dead_icon = "[initial(dead_icon)]_prosthetic"
 
-/obj/item/organ/internal/derobotize()
-	. = ..()
-	if (!.) return
-	name = initial(name)
-	icon_state = initial(icon_state)
-	dead_icon = initial(dead_icon)
-
 /obj/item/organ/internal/mechassist()
 	..()
 	name = "assisted [initial(name)]"

--- a/code/modules/organs/internal/brain.dm
+++ b/code/modules/organs/internal/brain.dm
@@ -52,12 +52,6 @@ GLOBAL_LIST_BOILERPLATE(all_brain_organs, /obj/item/organ/internal/brain)
 /obj/item/organ/internal/brain/robotize()
 	replace_self_with(/obj/item/organ/internal/mmi_holder/posibrain)
 
-/obj/item/organ/internal/brain/derobotize()
-	if (ispath(owner?.species?.has_organ?[O_BRAIN], /obj/item/organ/internal/brain))
-		replace_self_with(owner.species.has_organ[O_BRAIN])
-	else
-		replace_self_with(/obj/item/organ/internal/brain)
-
 /obj/item/organ/internal/brain/mechassist()
 	replace_self_with(/obj/item/organ/internal/mmi_holder)
 

--- a/code/modules/organs/internal/eyes.dm
+++ b/code/modules/organs/internal/eyes.dm
@@ -12,10 +12,6 @@
 	name = "optical sensor"
 	verbs |= /obj/item/organ/internal/eyes/proc/change_eye_color
 
-/obj/item/organ/internal/eyes/derobotize()
-	. = ..()
-	verbs -= /obj/item/organ/internal/eyes/proc/change_eye_color
-
 /obj/item/organ/internal/eyes/robot
 	name = "optical sensor"
 

--- a/code/modules/organs/internal/heart.dm
+++ b/code/modules/organs/internal/heart.dm
@@ -24,11 +24,6 @@
 	..()
 	standard_pulse_level = PULSE_NONE
 
-/obj/item/organ/internal/heart/derobotize()
-	. = ..()
-	if (!.) return
-	standard_pulse_level = initial(standard_pulse_level)
-
 /obj/item/organ/internal/heart/grey
 	icon_state = "heart_grey-on"
 	dead_icon = "heart_grey-off"

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -274,9 +274,7 @@ var/global/list/organ_cache = list()
 		handle_organ_mod_special()
 	if(!ignore_prosthetic_prefs && owner && owner.client && owner.client.prefs && owner.client.prefs.real_name == owner.real_name)
 		var/status = owner.client.prefs.organ_data[organ_tag]
-		if(status == null)
-			derobotize()
-		else if(status == "assisted")
+		if(status == "assisted")
 			mechassist()
 		else if(status == "mechanical")
 			robotize()
@@ -340,15 +338,6 @@ var/global/list/organ_cache = list()
 	src.status &= ~ORGAN_BROKEN
 	src.status &= ~ORGAN_BLEEDING
 	src.status &= ~ORGAN_CUT_AWAY
-
-/obj/item/organ/proc/derobotize()
-	if (robotic < ORGAN_ROBOT)
-		return FALSE//already flesh
-	robotic = ORGAN_FLESH
-	min_bruised_damage = initial(min_bruised_damage)
-	min_broken_damage = initial(min_broken_damage)
-	butcherable = initial(butcherable)
-	return TRUE
 
 /obj/item/organ/proc/mechassist() //Used to add things like pacemakers, etc
 	robotize()

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -480,9 +480,7 @@ This function completely restores a damaged organ to perfect condition.
 	if(owner && !ignore_prosthetic_prefs)
 		if(owner.client && owner.client.prefs && owner.client.prefs.real_name == owner.real_name)
 			var/status = owner.client.prefs.organ_data[organ_tag]
-			if(status == null)
-				derobotize()
-			else if(status == "amputated")
+			if(status == "amputated")
 				remove_rejuv()
 			else if(status == "cyborg")
 				var/robodata = owner.client.prefs.rlimb_data[organ_tag]
@@ -1151,47 +1149,6 @@ Note that amputating the affected organ does in fact remove the infection from t
 			owner.internal_organs -= null
 		owner.refresh_modular_limb_verbs()
 	return 1
-
-/obj/item/organ/external/derobotize(var/restore_organs = TRUE)
-	. = ..()
-	if (!.) return
-	var/obj/item/organ/external/parent = owner?.organs_by_name[parent_organ]
-	if (parent && parent.robotic) return FALSE
-	var/datum/robolimb/R = all_robolimbs[model]
-	if (R)
-		brute_mod /= R.robo_brute_mod
-		burn_mod /= R.robo_burn_mod
-	else
-		brute_mod = initial(brute_mod)
-		burn_mod = initial(burn_mod)
-	model = null
-	force_icon = initial(force_icon)
-	name = initial(name)
-	desc = initial(desc)
-	dislocated = initial(dislocated)
-	cannot_break = initial(cannot_break)
-	drop_sound = initial(drop_sound)
-	pickup_sound = initial(pickup_sound)
-	if (restore_organs && LAZYLEN(owner?.species?.has_organ))
-		for(var/obj/item/organ/thing in internal_organs)
-			if(istype(thing))
-				if (!(thing.organ_tag in owner.species.has_organ) && !istype(thing, /obj/item/organ/internal/brain))
-					internal_organs -= thing
-					owner.internal_organs_by_name[thing.organ_tag] = null
-					owner.internal_organs_by_name -= thing.organ_tag
-					owner.internal_organs.Remove(thing)
-					qdel(thing)
-				else
-					thing.derobotize()
-		for (var/organ_area in owner.species.has_organ)
-			if (owner.internal_organs_by_name[organ_area])
-				continue
-			var/obj/item/organ/internal/organtype = owner.species.has_organ[organ_area]
-			if (initial(organtype.parent_organ) == organ_tag)
-				owner.internal_organs_by_name[organ_area] = new organtype(owner, TRUE)
-		while(null in owner.internal_organs)
-			owner.internal_organs -= null
-		owner.refresh_modular_limb_verbs()
 
 /obj/item/organ/external/proc/mutate()
 	if(src.robotic >= ORGAN_ROBOT)

--- a/code/modules/organs/subtypes/standard.dm
+++ b/code/modules/organs/subtypes/standard.dm
@@ -39,11 +39,6 @@
 		owner.synthetic = R
 	return FALSE
 
-/obj/item/organ/external/chest/derobotize()
-	. = ..()
-	if (!.) return
-	owner?.synthetic = null
-
 /obj/item/organ/external/chest/handle_germ_effects()
 	. = ..() //Should return an infection level
 	if(!. || (status & ORGAN_DEAD)) return //If it's already above 2, it's become necrotic and we can just not worry about it.
@@ -297,12 +292,6 @@
 		else
 			LAZYREMOVE(organ_verbs, /mob/living/carbon/human/proc/setmonitor_state)
 		handle_organ_mod_special()
-
-/obj/item/organ/external/head/derobotize()
-	. = ..()
-	if (!.) return
-	LAZYREMOVE(organ_verbs, /mob/living/carbon/human/proc/setmonitor_state)
-	handle_organ_mod_special()
 
 /obj/item/organ/external/head/removed()
 	if(owner)


### PR DESCRIPTION
Reverts PolarisSS13/Polaris#8942

@Seris02 multiple complaints from players after updating to the fixed behaviour. I tried looking a bit last night, and a fix did not seem trivial or obvious, so moving to revert and reattempt the fixes later, rather than forward-fixing.
> Okay, really weird bug. I was rolling a new character. I set one of the arms as amputated to see what it was like, but it won't reset and the arms are amputated on all the characters now.

> and Latee's showing as having cenilimi prosthetics, despite having unbranded tesh ones

> oh this happened with remi but instead it was displaying half his limbs with unbranded prosthetics while still listing them as cremilimi...which is less cursed than this. did correct after switching to another character then back again 

> first of all those aren't even spectre's prosthetics and second of all WHY DOES IT HAVE HUMAN LEGS
![image](https://cdn.discordapp.com/attachments/182550163263324160/1077054595668385802/image.png)