### PR TITLE
Menthol doesn't kill you at 7 units

### DIFF
--- a/code/modules/reagents/reagents/medicine.dm
+++ b/code/modules/reagents/reagents/medicine.dm
@@ -1405,5 +1405,5 @@
 	reagent_state = LIQUID
 	color = "#80af9c"
 	metabolism = REM * 0.002
-	overdose = REAGENTS_OVERDOSE * 0.25
+	overdose = REAGENTS_OVERDOSE
 	scannable = 1


### PR DESCRIPTION
You would start getting poisoned from a couple of menthol cigarettes. Overdose is now 30 (the baseline) instead of a quarter of the baseline.