### PR TITLE
Safes Move Objects In Late Initialize.

### DIFF
--- a/code/game/objects/structures/safe.dm
+++ b/code/game/objects/structures/safe.dm
@@ -29,7 +29,10 @@ FLOOR SAFES
 	tumbler_2_pos = rand(0, 72)
 	tumbler_2_open = rand(0, 72)
 
-/obj/structure/safe/Initialize()
+	if(. != INITIALIZE_HINT_QDEL)
+		return INITIALIZE_HINT_LATELOAD
+
+/obj/structure/safe/LateInitialize()
 	. = ..()
 	for(var/obj/item/I in loc)
 		if(space >= maxspace)
@@ -114,7 +117,7 @@ FLOOR SAFES
 				if(canhear)
 					to_chat(user, "<span class='notice'>You hear a [pick("click", "chink", "clink")] from \the [src].</span>")
 					playsound(src, 'sound/machines/click.ogg', 20, 1)
-			check_unlocked(user, canhear)		
+			check_unlocked(user, canhear)
 
 		updateUsrDialog()
 		return


### PR DESCRIPTION
Not all safes (saves?) seem to have this issue, but occasionally in PoIs, safes will for some reason not consume their items.