### PR TITLE
Removes BluSD and DJOutpost4 from spawning

### DIFF
--- a/maps/submaps/surface_submaps/mountains/mountains.dm
+++ b/maps/submaps/surface_submaps/mountains/mountains.dm
@@ -352,5 +352,5 @@
 	name = "spatial anomaly"
 	desc = "A strange section of the caves that seems twist and turn in ways that shouldn't be physically possible."
 	mappath = 'maps/submaps/surface_submaps/mountains/spatial_anomaly.dmm'
-	cost = 20
+	cost = INFINITY /// Prevent spawning.
 	fixed_orientation = TRUE

--- a/maps/submaps/surface_submaps/wilderness/wilderness.dm
+++ b/maps/submaps/surface_submaps/wilderness/wilderness.dm
@@ -171,7 +171,7 @@
 	desc = "The surprisingly high-tech home of Sif Free Radio, the only radio station run by mindless clones."
 	mappath = 'maps/submaps/surface_submaps/wilderness/DJOutpost4.dmm'
 	template_group = "Sif Free Radio"
-	cost = 10
+	cost = INFINITY /// Prevent spawning.
 
 /datum/map_template/surface/wilderness/deep/Boombase
 	name = "Boombase"
@@ -190,7 +190,7 @@
 	name = "Blue Shuttle Down"
 	desc = "You REALLY shouldn't be near this. Mostly because they're SolGov."
 	mappath = 'maps/submaps/surface_submaps/wilderness/Blueshuttledown.dmm'
-	cost = 50
+	cost = INFINITY /// Prevent spawning.
 	template_group = "Shuttle Down"
 
 /datum/map_template/surface/wilderness/deep/Rockybase


### PR DESCRIPTION
Reason for BluSD: The IC implications of killing literal government officials is really weird and bad and shouldn't be encouraged. It just eats a spawn chance for something to logically clear out.

Reason for DJOutpost4: Replicants have weird IC implications as well and are very, VERY strange to rp around. 

Neither of these PoIs have a place in HRP on our server. Both should still be spawnable if an EM wants them for w/e reason.