### PR TITLE
Removes HoP

### DIFF
--- a/code/game/jobs/job/captain.dm
+++ b/code/game/jobs/job/captain.dm
@@ -56,7 +56,7 @@ var/global/datum/announcement/minor/captain_announcement = new(do_newscast = 1)
 /datum/job/hop
 	title = "Head of Personnel"
 	flag = HOP
-	departments = list(DEPARTMENT_COMMAND, DEPARTMENT_CIVILIAN, DEPARTMENT_CARGO)
+	departments = list(DEPARTMENT_COMMAND, DEPARTMENT_CIVILIAN)
 	sorting_order = 2 // Above the QM, below captain.
 	departments_managed = list(DEPARTMENT_CIVILIAN, DEPARTMENT_CARGO)
 	department_flag = CIVILIAN


### PR DESCRIPTION
Dethrone the Triumvirate

HoP now appears twice on the manifest like every other head (command + main dept) instead of _three_ times, because Cargo already has a sub-head and it's the QM, and when somebody is playing HoP and it looks like there's three entire people on it's misleading and a little annoying.
HoP IS still listed as manager of cargo. Just not triplefest.