### PR TITLE
different voidsuits!

### DIFF
--- a/maps/cynosure/cynosure-2.dmm
+++ b/maps/cynosure/cynosure-2.dmm
@@ -12548,7 +12548,7 @@
 	dir = 1
 	},
 /obj/machinery/power/emitter{
-	desc = "It is a heavy duty industrial laser. Someone has stencilled a pair of tiny skulls onto the side."
+	desc = "It is a heavy duty industrial laser. This one seems a little more ominous than the rest, somehow..."
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1

--- a/maps/cynosure/cynosure-2.dmm
+++ b/maps/cynosure/cynosure-2.dmm
@@ -12547,7 +12547,9 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
-/obj/machinery/power/emitter,
+/obj/machinery/power/emitter{
+	desc = "It is a heavy duty industrial laser. Someone has stencilled a pair of tiny skulls onto the side."
+	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
@@ -52174,6 +52176,10 @@
 /obj/item/storage/pill_bottle/spaceacillin,
 /obj/item/roller,
 /obj/item/storage/firstaid/regular,
+/obj/machinery/camera/network/civilian{
+	c_tag = "CIV - Pool East";
+	dir = 8
+	},
 /turf/simulated/floor/tiled/freezer,
 /area/surface/station/crew_quarters/pool)
 "xAM" = (

--- a/maps/cynosure/cynosure-3.dmm
+++ b/maps/cynosure/cynosure-3.dmm
@@ -14492,8 +14492,8 @@
 	name = "Medical Suits";
 	req_one_access = list(5)
 	},
-/obj/item/clothing/suit/space/void/medical,
-/obj/item/clothing/head/helmet/space/void/medical,
+/obj/item/clothing/suit/space/void/medical/emt,
+/obj/item/clothing/head/helmet/space/void/medical/emt,
 /turf/simulated/floor/tiled/dark,
 /area/surface/station/ai_monitored/storage/eva)
 "jbk" = (
@@ -30246,8 +30246,8 @@
 	},
 /obj/item/clothing/shoes/magboots,
 /obj/item/clothing/mask/breath,
-/obj/item/clothing/suit/space/void/security,
-/obj/item/clothing/head/helmet/space/void/security,
+/obj/item/clothing/suit/space/void/security/riot,
+/obj/item/clothing/head/helmet/space/void/security/riot,
 /obj/structure/table/rack{
 	layer = 2.6
 	},
@@ -30436,8 +30436,8 @@
 	name = "Engineering Suits";
 	req_one_access = list(11,24)
 	},
-/obj/item/clothing/suit/space/void/engineering,
-/obj/item/clothing/head/helmet/space/void/engineering,
+/obj/item/clothing/suit/space/void/engineering/hazmat,
+/obj/item/clothing/head/helmet/space/void/engineering/hazmat,
 /turf/simulated/floor/tiled/dark,
 /area/surface/station/engineering/engine_eva)
 "tJt" = (
@@ -35085,6 +35085,26 @@
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/surface/station/hallway/secondary/secondfloor/command)
+"wMC" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/item/clothing/shoes/magboots,
+/obj/item/clothing/mask/breath,
+/obj/structure/table/rack{
+	layer = 2.6
+	},
+/obj/machinery/door/window/southright{
+	name = "Engineering Suits";
+	req_one_access = list(11,24)
+	},
+/obj/item/clothing/suit/space/void/engineering/construction,
+/obj/item/clothing/head/helmet/space/void/engineering/construction,
+/turf/simulated/floor/tiled/dark,
+/area/surface/station/engineering/engine_eva)
 "wMP" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/cable/green{
@@ -74792,7 +74812,7 @@ ixp
 mhw
 dWs
 hWE
-gKO
+wMC
 njp
 ono
 grT


### PR DESCRIPTION
the voidsuits in EVA have been adjusted slightly! 
engineering goes from four Engineering suits, to two Engineering suits, a Construction Engineering suit and a HAZMAT Engineering suit. 
security goes from two Security suits, to one Security suit and one Riot Control Security suit. 
medical goes from two Medical suits, to one Medical suit and one EMT Medical suit. 

they're all basically just sidegrades of each other tbh (riot control has increased melee but reduced bullet/laser, etc) but we never see the special ones used which is a shame because the sprites are gorgeous,,

(also a couple of very tiny tweaks while i was there: )
- a single-tile camera blind spot has been fixed with the addition of an east pool camera. this changes absolutely nothing.
- That One Hyperlethal Emitter K/D is now ascended canon...

this pr is mostly just "oh hey vea knows how to use strongdmm now" but it's a lil change that might be nice!