### PR TITLE
Card fixes and QOL

### DIFF
--- a/code/datums/supplypacks/misc.dm
+++ b/code/datums/supplypacks/misc.dm
@@ -15,8 +15,7 @@
 	num_contained = 5
 	contains = list(
 			/obj/item/pack/cardemon,
-			/obj/item/pack/spaceball,
-			/obj/item/deck/holder
+			/obj/item/pack/spaceball
 			)
 	name = "Trading Card Crate"
 	cost = 10

--- a/code/datums/supplypacks/misc.dm
+++ b/code/datums/supplypacks/misc.dm
@@ -10,18 +10,6 @@
 /datum/supply_pack/randomised/misc
 	group = "Miscellaneous"
 
-
-/datum/supply_pack/randomised/misc/card_packs
-	num_contained = 5
-	contains = list(
-			/obj/item/pack/cardemon,
-			/obj/item/pack/spaceball
-			)
-	name = "Trading Card Crate"
-	cost = 10
-	containertype = /obj/structure/closet/crate/oculum
-	containername = "cards crate"
-
 /datum/supply_pack/randomised/misc/dnd
 	num_contained = 4
 	contains = list(

--- a/code/datums/supplypacks/recreation.dm
+++ b/code/datums/supplypacks/recreation.dm
@@ -105,3 +105,15 @@
 			/obj/machinery/porta_turret/lasertag/blue,
 			/obj/machinery/porta_turret/lasertag/red
 			)
+
+/datum/supply_pack/recreation/card_packs
+	contains = list(
+			/obj/item/pack/cardemon = 4,
+			/obj/item/pack/spaceball = 4,
+			/obj/item/deck/cardemon = 2,
+			/obj/item/deck/spaceball = 2
+			)
+	name = "Trading Card Crate"
+	cost = 15
+	containertype = /obj/structure/closet/crate/oculum
+	containername = "cards crate"

--- a/code/game/objects/items/weapons/storage/wallets.dm
+++ b/code/game/objects/items/weapons/storage/wallets.dm
@@ -24,7 +24,7 @@
 		/obj/item/forensics,
 		/obj/item/glass_extra,
 		/obj/item/haircomb,
-		/obj/item/hand,
+		/obj/item/cardhand,
 		/obj/item/key,
 		/obj/item/lipstick,
 		/obj/item/paper,

--- a/code/modules/client/preference_setup/loadout/loadout_general.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_general.dm
@@ -33,10 +33,6 @@
 	display_name = "deck of tarot cards"
 	path = /obj/item/deck/tarot
 
-/datum/gear/holder
-	display_name = "card holder"
-	path = /obj/item/deck/holder
-
 /datum/gear/cardemon_pack
 	display_name = "Cardemon booster pack"
 	path = /obj/item/pack/cardemon

--- a/code/modules/games/cah.dm
+++ b/code/modules/games/cah.dm
@@ -6,17 +6,23 @@
 	name = "\improper CAG deck (white)"
 	desc = "The ever-popular Cards Against The Galaxy word game. Warning: may include traces of broken fourth wall. This is the white deck."
 	icon_state = "cag_white"
+	decktype = /datum/playingcard/cah/white
 	var/blanks = 5
+
+/datum/playingcard/cah/white
 
 /obj/item/deck/cah/black
 	name = "\improper CAG deck (black)"
 	desc = "The ever-popular Cards Against The Galaxy word game. Warning: may include traces of broken fourth wall. This is the black deck."
 	icon_state = "cag_black"
+	decktype = /datum/playingcard/cah/black
 	blanks = 0
+
+/datum/playingcard/cah/black
 
 /obj/item/deck/cah/Initialize()
 	. = ..()
-	var/datum/playingcard/P
+	var/datum/playingcard/P = new decktype
 	for(var/cardtext in card_text_list)
 		P = new()
 		P.name = "[cardtext]"

--- a/code/modules/games/cardemon.dm
+++ b/code/modules/games/cardemon.dm
@@ -1,32 +1,40 @@
+/obj/item/deck/cardemon
+	name = "\improper Cardemon deck box"
+	desc = "A deck box for carrying your Cardemon cards. Fun for all ages!"
+	icon_state = "card_holder_cardemon"
+	decktype = /datum/playingcard/cardemon
+	decklimit = 20
+
 /obj/item/pack/cardemon
 	name = "cardemon booster pack"
 	desc = "Finally! A children's card game in space!"
 	icon_state = "card_pack_cardemon"
-	parentdeck = "cardemon"
+	decktype = /datum/playingcard/cardemon
 
 /obj/item/pack/cardemon/Initialize()
 	. = ..()
-	var/datum/playingcard/P
+	var/datum/playingcard/cardemon/P
 	var/i
 	for(i=0; i<5; i++)
-		var/rarity
-		if(prob(10))
-			if(prob(5))
-				if(prob(5))
-					rarity = "Plasteel"
-				else
-					rarity = "Platinum"
-			else
-				rarity = "Silver"
-
-		var/nam = pick("Death","Life","Plant","Leaf","Air","Earth","Fire","Water","Killer","Holy", "God", "Ordinary","Demon","Angel", "Plasteel", "Phoron", "Mad", "Insane", "Metal", "Steel", "Secret")
-		var/nam2 = pick("Carp", "Corgi", "Cat", "Mouse", "Octopus", "Lizard", "Monkey", "Plant", "Duck", "Demon", "Spider", "Bird", "Slime", "Sheep", "Fish")
-
 		P = new()
-		P.name = "[nam] [nam2]"
-		P.card_icon = "card_cardemon"
-		if(rarity)
-			P.name = "[rarity] [P.name]"
-			P.card_icon += "_[rarity]"
-		P.back_icon = "card_back_cardemon"
 		cards += P
+
+/datum/playingcard/cardemon
+
+/datum/playingcard/cardemon/New()
+
+	var/list/static/nam = list("Death","Life","Plant","Leaf","Air","Earth","Fire","Water","Killer","Holy", "God", "Ordinary","Demon","Angel", "Plasteel", "Phoron", "Mad", "Insane", "Metal", "Steel", "Secret", "Science")
+	var/list/static/nam2 = list("Carp", "Corgi", "Cat", "Mouse", "Octopus", "Lizard", "Monkey", "Plant", "Duck", "Demon", "Spider", "Bird", "Slime", "Sheep", "Fish", "Siffet", "Goose")
+
+	var/rarity = pick("",
+			prob(10); "Silver",
+			prob(0.5); "Platinum",
+			prob(0.025); "Plasteel"
+		)
+
+	name = "[pick(nam)] [pick(nam2)]"
+	card_icon = "card_cardemon"
+	if(rarity)
+		name = "[rarity] [name]"
+		card_icon += "_[rarity]"
+	back_icon = "card_back_cardemon"

--- a/code/modules/games/cards.dm
+++ b/code/modules/games/cards.dm
@@ -347,7 +347,7 @@
 				user.put_in_hands(src)
 	return
 
-/obj/item/pack/ /// Put new packs in random spawner in code/game/objects/random/misc.dm
+/obj/item/pack/
 	name = "Card Pack"
 	desc = "For those with disposible income."
 

--- a/code/modules/games/cards.dm
+++ b/code/modules/games/cards.dm
@@ -148,6 +148,7 @@
 		if(!islist(pickablecards[P.name]))
 			pickablecards[P.name] = list()
 		pickablecards[P.name] += P
+	sortTim(pickablecards, /proc/cmp_text_asc)
 	var/pickedcard = input("Which card do you want to remove from the deck?")	as null|anything in pickablecards
 	if(!pickedcard || !LAZYLEN(pickablecards[pickedcard]) || !usr || !src)
 		return
@@ -230,6 +231,29 @@
 		user.visible_message("<span class = 'notice'>\The [user] deals [dcard] card(s) to \the [target].</span>")
 	H.throw_at(get_step(target,target.dir),10,1,H)
 
+
+/obj/item/deck/verb/cheater_deal() /// Takes from the bottom of the deck, chance to expose your cheat.
+	set category = "Object"
+	set name = "Deal From Bottom"
+	set desc = "Deal a card from the bottom of a deck, like a cheater."
+	set src in view(1)
+
+	if(!cards.len)
+		to_chat(usr,"<span class='notice'>There are no cards in the deck.</span>")
+		return
+
+	var/list/players = list()
+	for(var/mob/living/player in viewers(3))
+		if(!player.stat)
+			players += player
+	var/mob/living/M = input("Who do you wish to deal a card?") as null|anything in players
+	if(!usr || !src || !M) return
+
+	if(prob(30))
+		usr.visible_message("<span class = 'warning'>\The [usr] dealt from the bottom of the deck!</span>")
+
+	moveElement(cards, cards.len, 1) /// Deal_at moves the first card in the list.
+	deal_at(usr, M, 1)
 
 /obj/item/cardhand/attackby(obj/O as obj, mob/user as mob)
 	if(cards.len == 1 && istype(O, /obj/item/pen))

--- a/code/modules/games/cards.dm
+++ b/code/modules/games/cards.dm
@@ -1,5 +1,6 @@
 /datum/playingcard
 	var/name = "playing card"
+	var/desc
 	var/card_icon = "card_back"
 	var/back_icon = "card_back"
 
@@ -8,11 +9,8 @@
 	icon = 'icons/obj/playing_cards.dmi'
 	var/list/cards = list()
 	var/cooldown = 0 // to prevent spam shuffle
-
-/obj/item/deck/holder
-	name = "card box"
-	desc = "A small leather case to show how classy you are compared to everyone else."
-	icon_state = "card_holder"
+	var/decklimit = null // For giving a deck a max card count.
+	var/decktype
 
 /obj/item/deck/cards
 	name = "deck of cards"
@@ -20,6 +18,7 @@
 	icon_state = "deck"
 	drop_sound = 'sound/items/drop/paper.ogg'
 	pickup_sound = 'sound/items/pickup/paper.ogg'
+	decktype = /datum/playingcard
 
 /obj/item/deck/cards/Initialize()
 	. = ..()
@@ -53,10 +52,20 @@
 		cards += P
 
 /obj/item/deck/attackby(obj/O as obj, mob/user as mob)
-	if(istype(O,/obj/item/hand))
-		var/obj/item/hand/H = O
-		if(H.parentdeck == src)
+	if(istype(O,/obj/item/cardhand))
+		var/obj/item/cardhand/H = O
+		if(decklimit && (decklimit <= cards.len))
+			to_chat(user,"<span class='warning'>This deck is full!</span>")
+			return
+		if(ispath(H.cardtype, decktype))
+			var/i = 0
 			for(var/datum/playingcard/P in H.cards)
+				if(decklimit && (decklimit <= cards.len)) /// Stop placing the cards
+					to_chat(user,"<span class='notice'>You place [i] cards on the bottom of \the [src]</span>.")
+					H.update_icon()
+					return
+				i++
+				H.cards -= P
 				cards += P
 			qdel(H)
 			to_chat(user,"<span class='notice'>You place your cards on the bottom of \the [src]</span>.")
@@ -95,8 +104,8 @@
 		to_chat(user,"<span class='notice'>There are no cards in the deck.</span>")
 		return
 
-	var/obj/item/hand/H = user.get_type_in_hands(/obj/item/hand)
-	if(H && !(H.parentdeck == src))
+	var/obj/item/cardhand/H = user.get_active_hand(/obj/item/cardhand)
+	if(H && !ispath(H.cardtype, decktype))
 		to_chat(user,"<span class='warning'>You can't mix cards from different decks!</span>")
 		return
 
@@ -109,10 +118,50 @@
 	var/datum/playingcard/P = cards[1]
 	H.cards += P
 	cards -= P
-	H.parentdeck = src
+	H.cardtype = src.decktype
 	H.update_icon()
 	user.visible_message("<span class='notice'>\The [user] draws a card.</span>")
 	to_chat(user,"<span class='notice'>It's the [P].</span>")
+
+/obj/item/deck/verb/find_card()
+	set category = "Object"
+	set name = "Find Card"
+	set desc = "Find a specific card from a deck."
+	set src in view(1)
+
+	if(!ishuman(usr))
+		return
+	var/mob/living/carbon/user = usr
+	if(user.incapacitated() || !Adjacent(user))
+		return
+
+	if(user.hands_are_full())
+		to_chat(user,"<span class='notice'>Your hands are full!</span>")
+		return
+
+	if(!cards.len)
+		to_chat(user,"<span class='notice'>There are no cards in the deck.</span>")
+		return
+
+	var/list/pickablecards = list()
+	for(var/datum/playingcard/P in cards)
+		if(!islist(pickablecards[P.name]))
+			pickablecards[P.name] = list()
+		pickablecards[P.name] += P
+	var/pickedcard = input("Which card do you want to remove from the deck?")	as null|anything in pickablecards
+	if(!pickedcard || !LAZYLEN(pickablecards[pickedcard]) || !usr || !src)
+		return
+
+	var/datum/playingcard/card = pick(pickablecards[pickedcard])
+	user.visible_message("<span class = 'notice'>\The [user] searches the [src] for a card.</span>") /// To help catch any cheaters.
+	var/obj/item/cardhand/H = new(get_turf(src))
+	if(!istype(H, /obj/item/cardhand))
+		return
+	user.put_in_hands(H)
+	H.cards += card
+	cards -= card
+	H.cardtype = src.decktype
+	H.update_icon()
 
 /obj/item/deck/verb/deal_card()
 
@@ -166,12 +215,12 @@
 	deal_at(usr, M, dcard)
 
 /obj/item/deck/proc/deal_at(mob/user, mob/target, dcard) // Take in the no. of card to be dealt
-	var/obj/item/hand/H = new(get_step(user, user.dir))
+	var/obj/item/cardhand/H = new(get_step(user, user.dir))
 	var/i
 	for(i = 0, i < dcard, i++)
 		H.cards += cards[1]
 		cards -= cards[1]
-		H.parentdeck = src
+		H.cardtype = src.decktype
 		H.concealed = 1
 		H.update_icon()
 	if(user==target)
@@ -182,7 +231,7 @@
 	H.throw_at(get_step(target,target.dir),10,1,H)
 
 
-/obj/item/hand/attackby(obj/O as obj, mob/user as mob)
+/obj/item/cardhand/attackby(obj/O as obj, mob/user as mob)
 	if(cards.len == 1 && istype(O, /obj/item/pen))
 		var/datum/playingcard/P = cards[1]
 		if(P.name != "Blank Card")
@@ -195,9 +244,9 @@
 		// SNOWFLAKE FOR CAG, REMOVE IF OTHER CARDS ARE ADDED THAT USE THIS.
 		P.card_icon = "cag_white_card"
 		update_icon()
-	else if(istype(O,/obj/item/hand))
-		var/obj/item/hand/H = O
-		if(H.parentdeck == src.parentdeck) // Prevent cardmixing
+	else if(istype(O,/obj/item/cardhand))
+		var/obj/item/cardhand/H = O
+		if(H.cardtype == src.cardtype) // Prevent cardmixing
 			for(var/datum/playingcard/P in cards)
 				H.cards += P
 			H.concealed = src.concealed
@@ -274,7 +323,7 @@
 				user.put_in_hands(src)
 	return
 
-/obj/item/pack/
+/obj/item/pack/ /// Put new packs in random spawner in code/game/objects/random/misc.dm
 	name = "Card Pack"
 	desc = "For those with disposible income."
 
@@ -282,17 +331,17 @@
 	icon = 'icons/obj/playing_cards.dmi'
 	w_class = ITEMSIZE_TINY
 	var/list/cards = list()
-	var/parentdeck = null // This variable is added here so that card pack dependent card can be mixed together by defining a "parentdeck" for them
+	var/decktype = null // For defining their decktype.
 	drop_sound = 'sound/items/drop/paper.ogg'
 	pickup_sound = 'sound/items/pickup/paper.ogg'
 
 
 /obj/item/pack/attack_self(var/mob/user as mob)
 	user.visible_message("<span class ='danger'>[user] rips open \the [src]!</span>")
-	var/obj/item/hand/H = new()
+	var/obj/item/cardhand/H = new()
 
 	H.cards += cards
-	H.parentdeck = src.parentdeck
+	H.cardtype = decktype
 	cards.Cut();
 	user.drop_item()
 	qdel(src)
@@ -300,7 +349,7 @@
 	H.update_icon()
 	user.put_in_active_hand(H)
 
-/obj/item/hand
+/obj/item/cardhand
 	name = "hand of cards"
 	desc = "Some playing cards."
 	icon = 'icons/obj/playing_cards.dmi'
@@ -311,9 +360,9 @@
 
 	var/concealed = 0
 	var/list/cards = list()
-	var/parentdeck = null
+	var/cardtype
 
-/obj/item/hand/verb/discard()
+/obj/item/cardhand/verb/discard()
 
 	set category = "Object"
 	set name = "Discard"
@@ -335,13 +384,13 @@
 		var/datum/playingcard/card = to_discard[discarding]
 		to_discard.Cut()
 
-		var/obj/item/hand/H = new(src.loc)
+		var/obj/item/cardhand/H = new(src.loc)
 		H.cards += card
 		cards -= card
 		H.concealed = 0
-		H.parentdeck = src.parentdeck
+		H.cardtype = src.cardtype
 		H.update_icon()
-		src.update_icon()
+		src.update_icon() /// Calls for qdel if no cards
 		usr.visible_message("<span class = 'notice'>\The [usr] plays \the [discarding].</span>")
 		H.loc = get_turf(usr)
 		H.Move(get_step(usr,usr.dir))
@@ -349,19 +398,22 @@
 	if(!cards.len)
 		qdel(src)
 
-/obj/item/hand/attack_self(var/mob/user as mob)
+/obj/item/cardhand/attack_self(var/mob/user as mob)
 	concealed = !concealed
 	update_icon()
 	user.visible_message("<span class = 'notice'>\The [user] [concealed ? "conceals" : "reveals"] their hand.</span>")
 
-/obj/item/hand/examine(mob/user)
+/obj/item/cardhand/examine(mob/user)
 	. = ..()
 	if((!concealed) && cards.len)
 		. += "It contains: "
 		for(var/datum/playingcard/P in cards)
-			. += "\The [P.name]."
+			if(!P.desc)
+				. += "\The [P.name]."
+			else
+				. += "[P.name]: [P.desc]"
 
-/obj/item/hand/verb/Removecard()
+/obj/item/cardhand/verb/Removecard()
 
 	set category = "Object"
 	set name = "Remove card"
@@ -376,20 +428,23 @@
 		to_chat(usr,"<span class='danger'>Your hands are full!</span>")
 		return
 
-	var/pickablecards = list()
+	var/list/pickablecards = list() /// Make it so duplicates don't cause runtimes
 	for(var/datum/playingcard/P in cards)
+		if(!islist(pickablecards[P.name]))
+			pickablecards[P.name] += list()
 		pickablecards[P.name] += P
 	var/pickedcard = input("Which card do you want to remove from the hand?")	as null|anything in pickablecards
 
-	if(!pickedcard || !pickablecards[pickedcard] || !usr || !src) return
+	if(!pickedcard || !LAZYLEN(pickablecards[pickedcard]) || !usr || !src)
+		return
 
-	var/datum/playingcard/card = pickablecards[pickedcard]
+	var/datum/playingcard/card = pick(pickablecards[pickedcard])
 
-	var/obj/item/hand/H = new(get_turf(src))
+	var/obj/item/cardhand/H = new(get_turf(src))
 	user.put_in_hands(H)
 	H.cards += card
 	cards -= card
-	H.parentdeck = src.parentdeck
+	H.cardtype = src.cardtype
 	H.concealed = src.concealed
 	H.update_icon()
 	src.update_icon()
@@ -398,7 +453,7 @@
 		qdel(src)
 	return
 
-/obj/item/hand/update_icon(var/direction = 0)
+/obj/item/cardhand/update_icon(var/direction = 0)
 
 	if(!cards.len)
 		qdel(src)
@@ -407,7 +462,7 @@
 		name = "hand of cards"
 		desc = "Some playing cards."
 	else
-		name = "a playing card"
+		name = "playing card"
 		desc = "A playing card."
 
 	cut_overlays()
@@ -421,7 +476,7 @@
 		add_overlay(I)
 		return
 
-	var/offset = FLOOR(20/cards.len, 1)
+	var/offset = max(FLOOR(20/cards.len, 1), 1) /// Keeps +20 cards from shifting back into one.
 
 	var/matrix/M = matrix()
 	if(direction)
@@ -440,6 +495,8 @@
 	for(var/datum/playingcard/P in cards)
 		var/image/I = new(src.icon, (concealed ? "[P.back_icon]" : "[P.card_icon]") )
 		//I.pixel_x = origin+(offset*i)
+		if(i>20)
+			return
 		switch(direction)
 			if(SOUTH)
 				I.pixel_x = 8-(offset*i)
@@ -453,12 +510,10 @@
 		add_overlay(I)
 		i++
 
-/obj/item/hand/dropped(mob/user as mob)
+/obj/item/cardhand/dropped(mob/user as mob)
 	if(locate(/obj/structure/table, loc))
 		src.update_icon(user.dir)
-	else
-		update_icon()
 
-/obj/item/hand/pickup(mob/user as mob)
+/obj/item/cardhand/pickup(mob/user as mob)
 	..()
 	src.update_icon()

--- a/code/modules/games/spaceball_cards.dm
+++ b/code/modules/games/spaceball_cards.dm
@@ -1,25 +1,33 @@
+/obj/item/deck/spaceball
+	name = "\improper Spaceball deck box"
+	desc = "A deck box for carrying your Spaceball cards."
+	icon_state = "card_holder"
+	decktype = /datum/playingcard/spaceball_cards
+	decklimit = 20
+
 /obj/item/pack/spaceball
 	name = "spaceball booster pack"
 	desc = "Officially licensed to take your money."
 	icon_state = "card_pack_spaceball"
-	parentdeck = "spaceball"
+	decktype = /datum/playingcard/spaceball_cards
 
 /obj/item/pack/spaceball/Initialize()
 	. = ..()
-	var/datum/playingcard/P
+	var/datum/playingcard/spaceball_cards/P
 	var/i
-	var/year = 554 + text2num(time2text(world.timeofday, "YYYY"))
 	for(i=0;i<5;i++)
 		P = new()
-		if(prob(1))
-			P.name = "Spaceball Jones, [year] Brickburn Galaxy Trekers"
-			P.card_icon = "spaceball_jones"
-		else
-			var/language_type = pick(/datum/language/human,/datum/language/diona_local,/datum/language/tajaran,/datum/language/unathi)
-			var/datum/language/L = new language_type()
-			var/team = pick("Brickburn Galaxy Trekers","Mars Rovers", "Qerrbalak Saints", "Moghes Rockets", "Meralar Lightning", "[using_map.starsys_name] Vixens", "Euphoric-Earth Alligators")
-			P.name = "[L.get_random_name(pick(MALE,FEMALE))], [year - rand(0,50)] [team]"
-			P.card_icon = "spaceball_standard"
-		P.back_icon = "card_back_spaceball"
-
 		cards += P
+
+/datum/playingcard/spaceball_cards/New() /// This is all very silly but I don't care enough about sports to refluff it.
+	var/year = 554 + text2num(time2text(world.timeofday, "YYYY"))
+	if(prob(1))
+		name = "Spaceball Jones, [year] Brickburn Galaxy Trekers"
+		card_icon = "spaceball_jones"
+	else
+		var/language_type = pick(/datum/language/human,/datum/language/skrell,/datum/language/tajaran,/datum/language/unathi,/datum/language/diona_local) /// Keeping diona because it's hilarious, though.
+		var/datum/language/L = new language_type()
+		var/team = pick("Brickburn Galaxy Trekers","Mars Rovers", "Qerrbalak Saints", "Moghes Rockets", "Meralar Lightning", "[using_map.starsys_name] Vixens", "Euphoric-Earth Alligators")
+		name = "[L.get_random_name(pick(MALE,FEMALE))], [year - rand(0,50)] [team]"
+		card_icon = "spaceball_standard"
+	back_icon = "card_back_spaceball"

--- a/code/modules/games/tarot.dm
+++ b/code/modules/games/tarot.dm
@@ -5,11 +5,14 @@
 	name = "deck of tarot cards"
 	desc = "For all your occult needs!"
 	icon_state = "deck_tarot"
+	decktype = /datum/playingcard/tarot
+
+/datum/playingcard/tarot/
 
 /obj/item/deck/tarot/Initialize()
 	. = ..()
 
-	var/datum/playingcard/P
+	var/datum/playingcard/tarot/P
 	for(var/name in list("Fool","Magician","High Priestess","Empress","Emperor","Hierophant","Lovers","Chariot","Strength","Hermit","Wheel of Fortune","Justice","Hanged Man","Death","Temperance","Devil","Tower","Star","Moon","Sun","Judgement","World"))
 		P = new()
 		P.name = "[name]"
@@ -29,7 +32,7 @@
 	if (cooldown < world.time - 10)
 		var/list/newcards = list()
 		while(cards.len)
-			var/datum/playingcard/P = pick(cards)
+			var/datum/playingcard/tarot/P = pick(cards)
 			P.name = replacetext(P.name," reversed","")
 			if(prob(50))
 				P.name += " reversed"


### PR DESCRIPTION
Fixes a lot of the messy backend for cards and their decks so I can add my MtG clone later. Should fix a few bugs that happen with dupe cards and clarifies the hand of cards obj. A lot of this was already done in an old PR that got closed and I've included the original requested changes for the most part.

Also adds find card, which gives an alphabetized list of the deck to find a specific card, and deal from bottom, which will deal a card from the bottom of a deck with a chance to announce you cheated.

Also also adds deck boxes for Cardemon and Spaceball so they can be stored!

Also also ALSO tweaks the cargo order for trading cards.