### PR TITLE
Adds departmental cloaks to lockers, cleans closet list formatting

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/bar.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/bar.dm
@@ -6,4 +6,5 @@
 	close_sound = 'sound/machines/closet/closet_wood_close.ogg'
 
 	starts_with = list(
-		/obj/item/reagent_containers/food/drinks/bottle/small/beer = 10)
+		/obj/item/reagent_containers/food/drinks/bottle/small/beer = 10
+	)

--- a/code/game/objects/structures/crates_lockers/closets/secure/cargo.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/cargo.dm
@@ -12,7 +12,9 @@
 		/obj/item/radio/headset/headset_cargo/alt,
 		/obj/item/clothing/gloves/duty,
 		/obj/item/clothing/gloves/fingerless,
-		/obj/item/clothing/head/soft)
+		/obj/item/clothing/head/soft,
+		/obj/item/clothing/accessory/storage/poncho/roles/cloak/cargo
+	)
 
 /obj/structure/closet/secure_closet/cargotech/Initialize()
 	if(prob(75))
@@ -42,7 +44,9 @@
 		/obj/item/clothing/head/soft,
 		/obj/item/clothing/suit/storage/hooded/wintercoat/cargo,
 		/obj/item/clothing/suit/storage/hooded/wintercoat/cargo/qm,
-		/obj/item/clothing/shoes/boots/winter/supply)
+		/obj/item/clothing/shoes/boots/winter/supply,
+		/obj/item/clothing/accessory/storage/poncho/roles/cloak/cargo
+	)
 
 /obj/structure/closet/secure_closet/quartermaster/Initialize()
 	if(prob(75))
@@ -72,7 +76,9 @@
 		/obj/item/clothing/glasses/material,
 		/obj/item/clothing/suit/storage/hooded/wintercoat/miner,
 		/obj/item/clothing/shoes/boots/winter/mining,
-		/obj/item/stack/marker_beacon/thirty)
+		/obj/item/stack/marker_beacon/thirty,
+		/obj/item/clothing/accessory/storage/poncho/roles/cloak/mining
+	)
 
 /obj/structure/closet/secure_closet/miner/Initialize()
 	if(prob(50))

--- a/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
@@ -31,7 +31,9 @@
 		/obj/item/taperoll/engineering,
 		/obj/item/clothing/suit/storage/hooded/wintercoat/engineering,
 		/obj/item/clothing/shoes/boots/winter/engineering,
-		/obj/item/tank/emergency/oxygen/engi)
+		/obj/item/tank/emergency/oxygen/engi,
+		/obj/item/clothing/accessory/storage/poncho/roles/cloak/ce
+	)
 
 /obj/structure/closet/secure_closet/engineering_chief/Initialize()
 	if(prob(50))
@@ -51,7 +53,8 @@
 		/obj/item/clothing/gloves/yellow = 2,
 		/obj/item/storage/toolbox/electrical = 3,
 		/obj/item/module/power_control = 3,
-		/obj/item/multitool = 3)
+		/obj/item/multitool = 3
+	)
 
 
 /obj/structure/closet/secure_closet/engineering_welding
@@ -63,7 +66,8 @@
 		/obj/item/clothing/head/welding = 3,
 		/obj/item/weldingtool/largetank = 3,
 		/obj/item/weldpack = 3,
-		/obj/item/clothing/glasses/welding = 3)
+		/obj/item/clothing/glasses/welding = 3
+	)
 
 /obj/structure/closet/secure_closet/engineering_personal
 	name = "engineer's locker"
@@ -85,7 +89,8 @@
 		/obj/item/clothing/head/hardhat,
 		/obj/item/clothing/suit/storage/hooded/wintercoat/engineering,
 		/obj/item/clothing/shoes/boots/winter/engineering,
-		/obj/item/tank/emergency/oxygen/engi)
+		/obj/item/tank/emergency/oxygen/engi
+	)
 
 /obj/structure/closet/secure_closet/engineering_personal/Initialize()
 	if(prob(50))
@@ -117,7 +122,9 @@
 		/obj/item/taperoll/atmos,
 		/obj/item/clothing/suit/storage/hooded/wintercoat/engineering/atmos,
 		/obj/item/clothing/shoes/boots/winter/atmos,
-		/obj/item/tank/emergency/oxygen/engi)
+		/obj/item/tank/emergency/oxygen/engi,
+		/obj/item/clothing/accessory/storage/poncho/roles/cloak/atmos
+	)
 
 /obj/structure/closet/secure_closet/atmos_personal/Initialize()
 	if(prob(50))

--- a/code/game/objects/structures/crates_lockers/closets/secure/freezer.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/freezer.dm
@@ -9,7 +9,7 @@
 		/obj/item/reagent_containers/food/condiment/carton/flour/rustic = 1,
 		/obj/item/reagent_containers/food/condiment/carton/sugar/rustic = 1,
 		/obj/item/reagent_containers/food/condiment/spacespice = 2
-		)
+	)
 
 /obj/structure/closet/secure_closet/freezer/kitchen/mining
 	req_access = list()
@@ -22,7 +22,8 @@
 	door_anim_time = 0 //Unsupported
 
 	starts_with = list(
-		/obj/item/reagent_containers/food/snacks/meat/monkey = 10)
+		/obj/item/reagent_containers/food/snacks/meat/monkey = 10
+	)
 
 
 /obj/structure/closet/secure_closet/freezer/fridge
@@ -35,7 +36,8 @@
 		/obj/item/reagent_containers/food/drinks/milk = 6,
 		/obj/item/reagent_containers/food/drinks/soymilk = 4,
 		/obj/item/storage/fancy/egg_box = 4,
-		/obj/item/reagent_containers/hypospray/autoinjector/biginjector/glucose = 2)
+		/obj/item/reagent_containers/hypospray/autoinjector/biginjector/glucose = 2
+	)
 
 
 /obj/structure/closet/secure_closet/freezer/money
@@ -45,8 +47,8 @@
 	req_access = list(access_heads_vault)
 	door_anim_time = 0 //Unsupported
 
-
 	starts_with = list(
 		/obj/item/spacecash/c1000 = 3,
 		/obj/item/spacecash/c500 = 4,
-		/obj/item/spacecash/c200 = 5)
+		/obj/item/spacecash/c200 = 5
+	)

--- a/code/game/objects/structures/crates_lockers/closets/secure/hydroponics.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/hydroponics.dm
@@ -15,7 +15,8 @@
 		/obj/item/tool/wirecutters/clippers/trimmers,
 		/obj/item/reagent_containers/spray/plantbgone,
 		/obj/item/clothing/suit/storage/hooded/wintercoat/hydro,
-		/obj/item/clothing/shoes/boots/winter/hydro)
+		/obj/item/clothing/shoes/boots/winter/hydro
+	)
 
 /obj/structure/closet/secure_closet/hydroponics/Initialize()
 	if(prob(50))

--- a/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
@@ -44,7 +44,9 @@
 		/obj/item/clothing/shoes/boots/winter/medical,
 		/obj/item/clothing/under/rank/nursesuit,
 		/obj/item/clothing/head/nursehat,
-		/obj/item/storage/box/freezer = 3)
+		/obj/item/storage/box/freezer = 3,
+		/obj/item/clothing/accessory/storage/poncho/roles/cloak/medical
+	)
 
 /obj/structure/closet/secure_closet/medical3/Initialize()
 	if(prob(50))
@@ -121,8 +123,9 @@
 		/obj/item/clothing/accessory/storage/white_vest,
 		/obj/item/taperoll/medical,
 		/obj/item/gps/medical,
-		/obj/item/geiger
-		)
+		/obj/item/geiger,
+		/obj/item/clothing/accessory/storage/poncho/roles/cloak/medical
+	)
 
 /obj/structure/closet/secure_closet/CMO
 	name = "chief medical officer's locker"
@@ -150,7 +153,9 @@
 		/obj/item/clothing/suit/bio_suit/cmo,
 		/obj/item/clothing/head/bio_hood/cmo,
 		/obj/item/clothing/shoes/white,
-		/obj/item/gps/medical/cmo)
+		/obj/item/gps/medical/cmo,
+		/obj/item/clothing/accessory/storage/poncho/roles/cloak/cmo
+	)
 
 /obj/structure/closet/secure_closet/CMO/Initialize()
 	if(prob(50))
@@ -224,7 +229,9 @@
 		/obj/item/taperecorder,
 		/obj/item/cassette_tape/random = 3,
 		/obj/item/camera,
-		/obj/item/toy/plushie/therapy/blue)
+		/obj/item/toy/plushie/therapy/blue,
+		/obj/item/clothing/accessory/storage/poncho/roles/cloak/medical
+	)
 
 
 /obj/structure/closet/secure_closet/medical_wall
@@ -246,7 +253,8 @@
 		/obj/item/storage/pill_bottle/tramadol,
 		/obj/item/storage/pill_bottle/antitox,
 		/obj/item/storage/pill_bottle/carbon,
-		/obj/random/medical/pillbottle)
+		/obj/random/medical/pillbottle
+	)
 
 
 /obj/structure/closet/secure_closet/medical_wall/anesthetics
@@ -256,4 +264,5 @@
 
 	starts_with = list(
 		/obj/item/tank/anesthetic = 3,
-		/obj/item/clothing/mask/breath/medical = 3)
+		/obj/item/clothing/mask/breath/medical = 3
+	)

--- a/code/game/objects/structures/crates_lockers/closets/secure/personal.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/personal.dm
@@ -5,7 +5,8 @@
 	var/registered_name = null
 
 	starts_with = list(
-		/obj/item/radio/headset)
+		/obj/item/radio/headset
+	)
 
 /obj/structure/closet/secure_closet/personal/Initialize()
 	if(prob(50))
@@ -21,7 +22,8 @@
 	starts_with = list(
 		/obj/item/clothing/under/medigown,
 		/obj/item/clothing/under/color/white,
-		/obj/item/clothing/shoes/white)
+		/obj/item/clothing/shoes/white
+	)
 
 
 /obj/structure/closet/secure_closet/personal/cabinet
@@ -33,7 +35,7 @@
 	starts_with = list(
 		/obj/item/storage/backpack/satchel/withwallet,
 		/obj/item/radio/headset
-		)
+	)
 
 /obj/structure/closet/secure_closet/personal/attackby(obj/item/W as obj, mob/user as mob)
 	if (src.opened)

--- a/code/game/objects/structures/crates_lockers/closets/secure/scientist.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/scientist.dm
@@ -11,7 +11,8 @@
 		/obj/item/tank/air,
 		/obj/item/clothing/mask/gas,
 		/obj/item/clothing/suit/storage/hooded/wintercoat/science,
-		/obj/item/clothing/shoes/boots/winter/science)
+		/obj/item/clothing/shoes/boots/winter/science
+	)
 
 /obj/structure/closet/secure_closet/scientist/Initialize()
 	if(prob(50))
@@ -45,7 +46,9 @@
 		/obj/item/flash,
 		/obj/item/clothing/suit/storage/hooded/wintercoat/science,
 		/obj/item/clothing/suit/storage/hooded/wintercoat/science/rd,
-		/obj/item/clothing/shoes/boots/winter/science)
+		/obj/item/clothing/shoes/boots/winter/science,
+		/obj/item/clothing/accessory/storage/poncho/roles/cloak/rd
+	)
 
 /obj/structure/closet/secure_closet/xenoarchaeologist
 	name = "Xenoarchaeologist Locker"
@@ -60,7 +63,8 @@
 		/obj/item/clothing/glasses/science,
 		/obj/item/radio/headset/headset_sci,
 		/obj/item/storage/belt/archaeology,
-		/obj/item/storage/excavation)
+		/obj/item/storage/excavation
+	)
 
 /obj/structure/closet/excavation
 	name = "Excavation tools"
@@ -81,4 +85,5 @@
 		/obj/item/measuring_tape,
 		/obj/item/pickaxe/hand,
 		/obj/item/storage/bag/fossils,
-		/obj/item/hand_labeler)
+		/obj/item/hand_labeler
+	)

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -14,7 +14,9 @@
 		/obj/item/gun/energy/gun,
 		/obj/item/melee/telebaton,
 		/obj/item/flash,
-		/obj/item/storage/box/ids)
+		/obj/item/storage/box/ids,
+		/obj/item/clothing/accessory/storage/poncho/roles/cloak/captain
+	)
 
 
 /obj/structure/closet/secure_closet/hop
@@ -31,7 +33,8 @@
 		/obj/item/storage/box/ids = 2,
 		/obj/item/gun/energy/gun,
 		/obj/item/gun/projectile/sec/flash,
-		/obj/item/flash)
+		/obj/item/flash
+	)
 
 /obj/structure/closet/secure_closet/hop2
 	name = "head of personnel's attire"
@@ -58,7 +61,9 @@
 		/obj/item/clothing/under/gimmick/rank/head_of_personnel/suit,
 		/obj/item/clothing/under/gimmick/rank/head_of_personnel/suit/skirt,
 		/obj/item/clothing/suit/storage/hooded/wintercoat/hop,
-		/obj/item/clothing/glasses/sunglasses)
+		/obj/item/clothing/glasses/sunglasses,
+		/obj/item/clothing/accessory/storage/poncho/roles/cloak/hop
+	)
 
 
 /obj/structure/closet/secure_closet/hos
@@ -102,7 +107,9 @@
 		/obj/item/clothing/shoes/boots/winter/security,
 		/obj/item/flashlight/maglight,
 		/obj/item/clothing/mask/gas/half,
-		/obj/item/clothing/mask/gas/sechailer/swat/hos)
+		/obj/item/clothing/mask/gas/sechailer/swat/hos,
+		/obj/item/clothing/accessory/storage/poncho/roles/cloak/hos
+	)
 
 /obj/structure/closet/secure_closet/hos/Initialize()
 	if(prob(50))
@@ -148,7 +155,8 @@
 		/obj/item/flashlight/maglight,
 		/obj/item/megaphone,
 		/obj/item/clothing/mask/gas/half,
-		/obj/item/clothing/mask/gas/sechailer/swat/warden)
+		/obj/item/clothing/mask/gas/sechailer/swat/warden,
+	)
 
 /obj/structure/closet/secure_closet/warden/Initialize()
 	if(prob(50))
@@ -187,7 +195,8 @@
 		/obj/item/cell/device/weapon,
 		/obj/item/clothing/suit/storage/hooded/wintercoat/security,
 		/obj/item/clothing/shoes/boots/winter/security,
-		/obj/item/flashlight/maglight)
+		/obj/item/flashlight/maglight
+	)
 
 /obj/structure/closet/secure_closet/security/Initialize()
 	if(prob(50))
@@ -246,7 +255,8 @@
 		/obj/item/storage/briefcase/crimekit,
 		/obj/item/taperecorder,
 		/obj/item/storage/bag/detective,
-		/obj/item/cassette_tape/random = 3)
+		/obj/item/cassette_tape/random = 3
+	)
 
 /obj/structure/closet/secure_closet/injection
 	name = "lethal injections locker"
@@ -254,7 +264,8 @@
 	closet_appearance = /decl/closet_appearance/secure_closet/courtroom
 
 	starts_with = list(
-		/obj/item/reagent_containers/syringe/ld50_syringe/choral = 2)
+		/obj/item/reagent_containers/syringe/ld50_syringe/choral = 2
+	)
 
 GLOBAL_LIST_BOILERPLATE(all_brig_closets, /obj/structure/closet/secure_closet/brig)
 
@@ -267,7 +278,8 @@ GLOBAL_LIST_BOILERPLATE(all_brig_closets, /obj/structure/closet/secure_closet/br
 
 	starts_with = list(
 		/obj/item/clothing/under/color/prison,
-		/obj/item/clothing/shoes/orange)
+		/obj/item/clothing/shoes/orange
+	)
 
 /obj/structure/closet/secure_closet/posters
 	name = "morale storage"
@@ -279,7 +291,8 @@ GLOBAL_LIST_BOILERPLATE(all_brig_closets, /obj/structure/closet/secure_closet/br
 		/obj/item/poster/nanotrasen,
 		/obj/item/poster/nanotrasen,
 		/obj/item/poster/nanotrasen,
-		/obj/item/poster/nanotrasen)
+		/obj/item/poster/nanotrasen
+	)
 
 /obj/structure/closet/secure_closet/courtroom
 	name = "courtroom locker"
@@ -292,7 +305,8 @@ GLOBAL_LIST_BOILERPLATE(all_brig_closets, /obj/structure/closet/secure_closet/br
 		/obj/item/pen,
 		/obj/item/clothing/suit/costume/judgerobe,
 		/obj/item/clothing/head/powdered_wig,
-		/obj/item/storage/briefcase)
+		/obj/item/storage/briefcase
+	)
 
 
 /obj/structure/closet/secure_closet/wall


### PR DESCRIPTION
Cloaks are good, so why not make prefab departmental ones available within their respective department lockers?
They can be worn over winter coats too, so you can really keep warm by putting on those extra layers!

I originally intended to just add cloaks to the Head of Staff closets, but once I realised there were other departmental prefabs I figured they might as well be added too.

Adds departmental cloaks to the following lockers:
- Site Manager
- Head of Personnel
- Research Director
- Chief Medical Officer
- Chief Engineer
- Quartermaster
- Atmospherics
- Cargo / Mining
- Medical / Paramedic / Psychiatrist

Also fixes some weird list formatting across closets for consistency.

🆑
rscadd: Departmental cloaks have been added to their respective lockers.
/🆑