### PR TITLE
Fix some coffee mugs not using the correct sprites

### DIFF
--- a/code/modules/food/drinkingglass/mugs.dm
+++ b/code/modules/food/drinkingglass/mugs.dm
@@ -52,12 +52,12 @@
 /obj/item/reagent_containers/food/drinks/glass2/coffeemug/alma
 	name = "\improper Almach Association coffee cup"
 	desc = "A grey coffee cup emblazoned with the star of the Almach Association."
-	icon_state = "coffeecup_alma"
+	base_icon = "coffeecup_alma"
 
 /obj/item/reagent_containers/food/drinks/glass2/coffeemug/almp
 	name = "\improper Almach Protectorate coffee cup"
 	desc = "A purple coffee cup emblazoned with the star of the Almach Protectorate."
-	icon_state = "coffeecup_almp"
+	base_icon = "coffeecup_almp"
 
 /obj/item/reagent_containers/food/drinks/glass2/coffeemug/psc
 	name = "\improper Pearlshield coffee mug"
@@ -93,7 +93,7 @@
 /obj/item/reagent_containers/food/drinks/glass2/coffeemug/zeng
 	name = "\improper Zeng-Hu coffee cup"
 	desc = "A coffee cup bearing the Zeng-Hu logo."
-	icon_state = "coffeecup_zeng"
+	base_icon = "coffeecup_zeng"
 
 /obj/item/reagent_containers/food/drinks/glass2/coffeemug/bishop
 	name = "\improper Bishop coffee mug"
@@ -139,7 +139,7 @@
 /obj/item/reagent_containers/food/drinks/glass2/coffeemug/flame
 	name = "flame coffee cup"
 	desc = "A coffee cup with the a flame emblazoned on it."
-	icon_state = "coffeecup_flame"
+	base_icon = "coffeecup_flame"
 
 /obj/item/reagent_containers/food/drinks/glass2/coffeemug/tourist
 	name = "\improper Northern Star coffee mug"


### PR DESCRIPTION
Fixes #9010

Turns out they're generated sprites because they're subtypes of glasses or whatever so I reflexively put in icon_state sometimes!