### PR TITLE
Fixes Simplemob Movement Delay

### DIFF
--- a/code/modules/mob/living/simple_mob/simple_mob.dm
+++ b/code/modules/mob/living/simple_mob/simple_mob.dm
@@ -247,9 +247,9 @@
 	if(m_intent == "walk")
 		. *= 1.5
 
-	 . += config.animal_delay
+	. += config.animal_delay
 
-	 . += ..()
+	. += ..()
 
 
 /mob/living/simple_mob/Stat()


### PR DESCRIPTION
Ever since #7174 was introduced, perhaps earlier, the following two lines have been indented with a space.

Erroneous or not, this meant that config.animal_delay and the parent were never checked UNLESS the simplemob was using walk intent.

Funny thing, this came about bc I was working on adding movement delays for injuries on simplemobs, and then discovered this in VSCode, thanks to the highlight.
See here:
![](https://i.imgur.com/S1DbkHS.png)