### PR TITLE
Phoron Bore Adjustment Take 2

### DIFF
--- a/code/modules/projectiles/guns/magnetic/bore.dm
+++ b/code/modules/projectiles/guns/magnetic/bore.dm
@@ -176,6 +176,8 @@
 
 	action_button_name = "Toggle internal generator"
 
+	var/winding = FALSE	// Are we winding up to fire?
+
 	var/generator_state = GEN_OFF
 	var/datum/looping_sound/small_motor/soundloop
 	var/time_started //to keep the soundloop from being "stopped" too soon and playing indefinitely
@@ -267,6 +269,15 @@
 		soundloop.stop()
 		audible_message(SPAN_NOTICE("\The [src] goes quiet."),SPAN_NOTICE("A motor noise cuts out."), runemessage = "goes quiet")
 		generator_state = GEN_OFF
+
+/obj/item/gun/magnetic/matfed/phoronbore/special_check(mob/user)
+	if(!winding)
+		winding = TRUE
+		if(do_after(user, 1 SECOND, src) && ..())	// Super after do_after, due to clumsy check force-firing.
+			winding = FALSE
+			return TRUE
+		winding = FALSE
+	return FALSE
 
 /obj/item/gun/magnetic/matfed/phoronbore/loaded
 	cell = /obj/item/cell/apc

--- a/code/modules/projectiles/projectile/magnetic.dm
+++ b/code/modules/projectiles/projectile/magnetic.dm
@@ -171,7 +171,7 @@
 	penetrating = 0
 	check_armour = "melee"
 	irradiate = 20
-	range = 6
+	range = 3
 	hud_state = "plasma_rifle_blast"
 
 /obj/item/projectile/bullet/magnetic/bore/Initialize(loc, range_mod) // i'm gonna be real honest i dunno how this works but it does


### PR DESCRIPTION
Phoron bore given a windup of 1 second before firing. Moving or interacting otherwise cancels this.
Phoron bore range dropped to 3 tiles base, instead of 6.