### PR TITLE
Sheet storage has different caps per type.

### DIFF
--- a/code/game/objects/effects/decals/crayon.dm
+++ b/code/game/objects/effects/decals/crayon.dm
@@ -6,8 +6,7 @@
 	anchored = 1
 
 /obj/effect/decal/cleanable/crayon/Initialize(var/ml, main = "#FFFFFF",shade = "#000000",var/type = "rune")
-	. = ..()
-
+	. = ..(ml, 0) // mapload, age
 	name = type
 	desc = "A [type] drawn in crayon."
 

--- a/code/modules/food/kitchen/smartfridge/engineering.dm
+++ b/code/modules/food/kitchen/smartfridge/engineering.dm
@@ -1,4 +1,4 @@
-/obj/machinery/smartfridge/sheets //Is this used anywhere? It's not secure.
+/obj/machinery/smartfridge/sheets
 	name = "\improper Smart Sheet Storage"
 	desc = "A storage unit for metals."
 	icon_state = "fridge_dark"
@@ -10,7 +10,7 @@
 	persistent = /datum/persistent/storage/smartfridge/sheet_storage
 
 /obj/machinery/smartfridge/sheets/persistent_lossy
-	persistent = /datum/persistent/storage/smartfridge/sheet_storage/lossy
+	persistent = /datum/persistent/storage/smartfridge/sheet_storage/variable_max
 
 /obj/machinery/smartfridge/sheets/accept_check(var/obj/item/O)
 	return istype(O, /obj/item/stack/material)
@@ -29,6 +29,6 @@
 
 /obj/machinery/smartfridge/sheets/find_record(var/obj/item/O)
 	for(var/datum/stored_item/stack/I as anything in item_records)
-		if(istype(O, I.item_path)) // Typecheck should evaluate material-specific subtype
+		if(O.type == I.item_path) // Typecheck should evaluate material-specific subtype
 			return I
 	return null

--- a/code/modules/persistence/storage/smartfridge.dm
+++ b/code/modules/persistence/storage/smartfridge.dm
@@ -34,10 +34,8 @@
 	max_storage = list(
 		/obj/item/stack/material/steel =     150,
 		/obj/item/stack/material/glass =     150,
-		/obj/item/stack/material/rglass =    150,
 		/obj/item/stack/material/copper =    150,
 		/obj/item/stack/material/wood =      150,
-		/obj/item/stack/material/sifwood =   150,
 		/obj/item/stack/material/plastic =   150,
 		/obj/item/stack/material/phoron =    100,
 		/obj/item/stack/material/plasteel =  50,

--- a/code/modules/persistence/storage/smartfridge.dm
+++ b/code/modules/persistence/storage/smartfridge.dm
@@ -29,6 +29,22 @@
 	max_storage = 150
 	stacks_go_missing = TRUE
 
+/datum/persistent/storage/smartfridge/sheet_storage/variable_max
+	name = "variable max storage"
+	max_storage = list(
+		/obj/item/stack/material/steel =     150,
+		/obj/item/stack/material/glass =     150,
+		/obj/item/stack/material/rglass =    150,
+		/obj/item/stack/material/copper =    150,
+		/obj/item/stack/material/wood =      150,
+		/obj/item/stack/material/sifwood =   150,
+		/obj/item/stack/material/plastic =   150,
+		/obj/item/stack/material/phoron =    100,
+		/obj/item/stack/material/plasteel =  50,
+		/obj/item/stack/material/cardboard = 50,
+		"default" = 10
+	)
+
 /datum/persistent/storage/smartfridge/sheet_storage/generate_items(var/list/L)
 	. = list()
 	for(var/obj/item/stack/material/S as anything in L)

--- a/code/modules/persistence/storage/storage.dm
+++ b/code/modules/persistence/storage/storage.dm
@@ -2,7 +2,7 @@
 	name = "storage"
 	entries_expire_at = 1
 	has_admin_data = TRUE
-	
+
 	// Don't use these for storage persistence. If someone takes some sheets out and puts them back in mixed in with
 	// new sheets, how do you know the age of the stack? If you want sheets to 'decay', see go_missing_chance
 	entries_decay_at = 0
@@ -28,15 +28,21 @@
 	var/list/item_list = get_storage_list(entry)
 	var/list/storage_list = list()
 	for(var/item in item_list)
-		storage_list[item] = min(stored, storage_list[item] + item_list[item]) // Can't store more than max_storage
-		
-		// stored gets reduced by qty stored, if greater than stored,
-		// previous assignment will handle overage, and we set to 0
-		if(!store_per_type)
-			stored = max(stored - item_list[item], 0) 
-	
+		if(islist(max_storage))
+			if(!is_path_in_list(item, stored))
+				stored[item] = stored["default"]
+			storage_list[item] = min(stored[item], storage_list[item] + item_list[item]) // Can't store more than max_storage
+
+		else
+			storage_list[item] = min(stored, storage_list[item] + item_list[item]) // Can't store more than max_storage
+
+			// stored gets reduced by qty stored, if greater than stored,
+			// previous assignment will handle overage, and we set to 0
+			if(!store_per_type)
+				stored = max(stored - item_list[item], 0)
+
 	LAZYADDASSOC(., "items", storage_list)
-	
+
 // Usage: returns list with structure:
 //  list(
 //      [type1] = [stored_quantity],


### PR DESCRIPTION
Balance pass to sheet storage: it's too easy to max out research and build death-murder-kill mechs. We have more consistent pop, so mining is pretty regularly available right now. If that changes in the future, this may be reconsidered.
Removes the round-to-round decay, sets high caps for building materials, and low caps for rarer stuff.
The following input was persisted to the following output:
Input:
![input](https://puu.sh/JATLQ/5ef7c131d4.png)
Output:
(I needed to add an entry to the list for sifwood, it's not a subtype of regular wood.
![output](https://puu.sh/JATMI/6faf8b1f77.png)

Full list is visible in the diff, any types that are not explicitly called out get the "default" limit of 10.
Drive-by changes: fixed an issue where crayon decal initialization tries to set the `age` var used by persistence to the `color` var used by the crayon decal, causing a runtime when persistence tries to compile it into an entry.