### PR TITLE
Fixes a small hiccup in cable coil examine text

### DIFF
--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -498,6 +498,7 @@ var/global/list/possible_cable_coil_colours = list(
 	amount = MAXCOIL
 	max_amount = MAXCOIL
 	color = COLOR_RED
+	gender = NEUTER
 	desc = "A coil of power cable."
 	throwforce = 10
 	w_class = ITEMSIZE_SMALL
@@ -508,6 +509,7 @@ var/global/list/possible_cable_coil_colours = list(
 	item_state = "coil"
 	attack_verb = list("whipped", "lashed", "disciplined", "flogged")
 	stacktype = /obj/item/stack/cable_coil
+	singular_name = "length"
 	drop_sound = 'sound/items/drop/accessory.ogg'
 	pickup_sound = 'sound/items/pickup/accessory.ogg'
 	tool_qualities = list(TOOL_CABLE_COIL)
@@ -589,15 +591,6 @@ var/global/list/possible_cable_coil_colours = list(
 		w_class = ITEMSIZE_TINY
 	else
 		w_class = ITEMSIZE_SMALL
-
-/obj/item/stack/cable_coil/examine(mob/user)
-	. = ..()
-	if(get_amount() == 1)
-		. += "Just a short piece remains."
-	else if(get_amount() == 2)
-		. += "Just a couple of short pieces remain."
-	else if(Adjacent(user))
-		. += "There are [get_amount()] lengths of cable in the coil."
 
 /obj/item/stack/cable_coil/attackby(obj/item/W, mob/user)
 	if(istype(W, /obj/item/multitool))


### PR DESCRIPTION
reeeeally tiny change, just made because I kept noticing it and it was annoying me. basically: cable coils had a unique `examine()` that added extra information about the amount of cable in them, which comboed with the base /stack's examine to make it look weird. this PR fixes some things with the cable coil def and removes the unique examine logic to let it just use the base stack logic instead. includes no other changes, no matter how sorely tempting they were.

before:
![dreamseeker_LNj38CTaKE](https://user-images.githubusercontent.com/47678781/223086472-9bb07996-33c1-4f15-91ca-40b7129fa75a.png)
after:
![dreamseeker_oKy3n99i8T](https://user-images.githubusercontent.com/47678781/223086489-29f37b6a-6192-4079-ab02-5cce32e3030c.png)
