### PR TITLE
Hotfix for moving pulled objects

### DIFF
--- a/code/game/turfs/simulated/floor_attackby.dm
+++ b/code/game/turfs/simulated/floor_attackby.dm
@@ -136,12 +136,13 @@
 						to_chat(user, "<span class='warning'>You need more welding fuel to complete this task.</span>")
 
 /turf/simulated/floor/attack_hand(mob/user)
-	if (has_snow())
+	if (!user.pulling && has_snow())
 		visible_message(SPAN_NOTICE("[user] starts scooping up some snow..."), SPAN_NOTICE("You start scooping up some snow..."))
 		if(do_after(user, 1 SECOND))
 			var/obj/S = new /obj/item/stack/material/snow(user.loc)
 			user.put_in_hands(S)
 			visible_message(SPAN_NOTICE("[user] scoops up a pile of snow."), SPAN_NOTICE("You scoop up a pile of snow."))
+	return ..()
 
 /turf/simulated/floor/proc/try_deconstruct_tile(obj/item/W as obj, mob/user as mob)
 	if(W.is_crowbar())

--- a/code/game/turfs/simulated/floor_attackby.dm
+++ b/code/game/turfs/simulated/floor_attackby.dm
@@ -142,6 +142,7 @@
 			var/obj/S = new /obj/item/stack/material/snow(user.loc)
 			user.put_in_hands(S)
 			visible_message(SPAN_NOTICE("[user] scoops up a pile of snow."), SPAN_NOTICE("You scoop up a pile of snow."))
+		return
 	return ..()
 
 /turf/simulated/floor/proc/try_deconstruct_tile(obj/item/W as obj, mob/user as mob)


### PR DESCRIPTION
Closes #9037

#8970 accidentally didn't include a `..()` call on floor's `attack_hand`, and so the base `/turf` call was being ignored. this prevented pulled objects from being moved with clicking. I'm sorry! this is a hotfix for that.

quickly tested on the example map; I used click-dragging to move stuff around both before and after setting all the turfs to be snowy. also now tested on cynosure as a survivalist by dragging around an umbrella in the wilderness.