### PR TITLE
Siege Hivebots Use Proper Projectile

### DIFF
--- a/code/modules/mob/living/simple_mob/subtypes/mechanical/hivebot/ranged_damage.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/mechanical/hivebot/ranged_damage.dm
@@ -113,7 +113,7 @@
 /mob/living/simple_mob/mechanical/hivebot/ranged_damage/siege
 	name = "siege engine hivebot"
 	desc = "A large robot capable of delivering long range bombardment."
-	projectiletype = /obj/item/projectile/arc/test
+	projectiletype = /obj/item/projectile/arc/fragmentation/mortar
 	projectilesound = 'sound/weapons/mech_mortar.ogg'
 	icon_scale_x = 2
 	icon_scale_y = 2


### PR DESCRIPTION
Removes the usage of the test projectile from the siege hivebot.