### PR TITLE
Fixes move intent switching for living but non-carbon mobs

### DIFF
--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -274,15 +274,16 @@
 				L.resist()
 
 		if("mov_intent")
-			if(iscarbon(usr))
-				var/mob/living/carbon/C = usr
-				if(C.legcuffed)
-					to_chat(C, "<span class='notice'>You are legcuffed! You cannot run until you get [C.legcuffed] removed!</span>")
-					C.set_move_intent(/decl/move_intent/walk) // Just incase.
-					return 1
-				else
-					var/next_move_intent = next_in_list(C.move_intent.type, C.move_intents)
-					C.set_move_intent(next_move_intent)
+			if(isliving(usr))
+				var/mob/living/L = usr
+				if(iscarbon(usr))
+					var/mob/living/carbon/C = L
+					if(C.legcuffed)
+						to_chat(C, "<span class='notice'>You are legcuffed! You cannot run until you get [C.legcuffed] removed!</span>")
+						C.set_move_intent(/decl/move_intent/walk) // Just incase.
+						return 1
+				var/next_move_intent = next_in_list(L.move_intent.type, L.move_intents)
+				L.set_move_intent(next_move_intent)
 
 		if("Reset Machine")
 			usr.unset_machine()


### PR DESCRIPTION
This is half a small cleanup but half an emergency hotfix.

The aim here is to update the movement intent HUD `Topic()` check so that `/mob/living` that aren't `/mob/living/carbon`-subtypes can actually swap their move intent.

🆑
bugfix: Living but non-carbon mobs (IE Drakes) can now actually change their movement intent, oopsie.
/🆑