### PR TITLE
Click catchers no longer display as Darkness

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -337,7 +337,6 @@
 		facedir(direction)
 
 /obj/screen/click_catcher
-	name = "Darkness"
 	icon = 'icons/mob/screen_gen.dmi'
 	icon_state = "click_catcher"
 	plane = CLICKCATCHER_PLANE

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -344,6 +344,10 @@
 	mouse_opacity = 2
 	screen_loc = "SOUTHWEST to NORTHEAST"
 
+/obj/screen/click_catcher/Initialize(mapload, ...)
+	. = ..()
+	verbs.Cut()
+
 /obj/screen/click_catcher/Click(location, control, params)
 	var/list/modifiers = params2list(params)
 	if(modifiers["middle"] && istype(usr, /mob/living/carbon))


### PR DESCRIPTION
see title. these are the things that let you, for instance, fire a gun at an enemy by clicking on an empty tile that you otherwise can't see; however, right now, they display as `Darkness` on every single right click menu. this PR just removes their `name` variable so that they don't do that anymore, and their behavior still seems to function correctly.