### PR TITLE
Move intent tweaks.

### DIFF
--- a/code/__defines/movement.dm
+++ b/code/__defines/movement.dm
@@ -1,3 +1,6 @@
-// Move intent decl helpers.
-#define IS_WALKING(X) istype(X.move_intent, /decl/move_intent/walk)
-#define IS_RUNNING(X) istype(X.move_intent, /decl/move_intent/run)
+// Defines used for movement state evaluation.
+#define MOVEMENT_INTENT_WALKING 1
+#define MOVEMENT_INTENT_RUNNING 2
+
+#define IS_WALKING(X) (X?.move_intent?.flags & MOVEMENT_INTENT_WALKING)
+#define IS_RUNNING(X) (X?.move_intent?.flags & MOVEMENT_INTENT_RUNNING)

--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -280,7 +280,7 @@
 					var/mob/living/carbon/C = L
 					if(C.legcuffed)
 						to_chat(C, "<span class='notice'>You are legcuffed! You cannot run until you get [C.legcuffed] removed!</span>")
-						C.set_move_intent(/decl/move_intent/walk) // Just incase.
+						C.set_move_intent(C.get_movement_intent_with_flag(MOVEMENT_INTENT_WALKING)) // Just incase.
 						return 1
 				var/next_move_intent = next_in_list(L.move_intent.type, L.move_intents)
 				L.set_move_intent(next_move_intent)

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -181,9 +181,6 @@ var/global/list/gamemode_cache = list()
 	//Mob specific modifiers. NOTE: These will affect different mob types in different ways
 	var/human_delay = 0
 	var/robot_delay = 0
-	var/monkey_delay = 0
-	var/alien_delay = 0
-	var/slime_delay = 0
 	var/animal_delay = 0
 
 	var/footstep_volume = 0
@@ -998,12 +995,6 @@ var/global/list/gamemode_cache = list()
 					config.human_delay = value
 				if("robot_delay")
 					config.robot_delay = value
-				if("monkey_delay")
-					config.monkey_delay = value
-				if("alien_delay")
-					config.alien_delay = value
-				if("slime_delay")
-					config.slime_delay = value
 				if("animal_delay")
 					config.animal_delay = value
 

--- a/code/datums/move_intent.dm
+++ b/code/datums/move_intent.dm
@@ -2,11 +2,13 @@
 	var/name
 	var/move_delay = 1
 	var/hud_icon_state
+	var/flags = 0
 
 // Walking
 /decl/move_intent/walk
 	name = "Walk"
 	hud_icon_state = "walking"
+	flags = MOVEMENT_INTENT_WALKING
 
 /decl/move_intent/walk/Initialize()
 	. = ..()
@@ -16,7 +18,34 @@
 /decl/move_intent/run
 	name = "Run"
 	hud_icon_state = "running"
+	flags = MOVEMENT_INTENT_RUNNING
 
 /decl/move_intent/run/Initialize()
 	. = ..()
 	move_delay = config.run_speed
+
+// Simplemob movement intents.
+/decl/move_intent/animal_walk
+	name = "Walk"
+	hud_icon_state = "walking"
+	flags = MOVEMENT_INTENT_WALKING
+
+/decl/move_intent/animal_walk/Initialize()
+	. = ..()
+	move_delay = config.animal_delay + 1
+
+/decl/move_intent/animal_run
+	name = "Run"
+	hud_icon_state = "running"
+	flags = MOVEMENT_INTENT_RUNNING
+
+/decl/move_intent/animal_run/Initialize()
+	. = ..()
+	move_delay = config.animal_delay
+
+// Ghost movement intent.
+/decl/move_intent/no_delay
+	name = "Move"
+	hud_icon_state = "running"
+	flags = MOVEMENT_INTENT_WALKING | MOVEMENT_INTENT_RUNNING
+	move_delay = 0

--- a/code/datums/move_intent.dm
+++ b/code/datums/move_intent.dm
@@ -49,3 +49,12 @@
 	hud_icon_state = "running"
 	flags = MOVEMENT_INTENT_WALKING | MOVEMENT_INTENT_RUNNING
 	move_delay = 0
+
+// Robot movement intents.
+/decl/move_intent/walk/robot/Initialize()
+	. = ..()
+	move_delay += config.robot_delay
+
+/decl/move_intent/run/robot/Initialize()
+	. = ..()
+	move_delay += config.robot_delay

--- a/code/game/gamemodes/changeling/powers/visible_camouflage.dm
+++ b/code/game/gamemodes/changeling/powers/visible_camouflage.dm
@@ -42,7 +42,7 @@
 			to_chat(src, "<span class='notice'>We may move at our normal speed while hidden.</span>")
 
 		if(must_walk)
-			H.set_move_intent(/decl/move_intent/walk)
+			H.set_move_intent(H.get_movement_intent_with_flag(MOVEMENT_INTENT_WALKING))
 
 		var/remain_cloaked = TRUE
 		while(remain_cloaked) //This loop will keep going until the player uncloaks.
@@ -66,7 +66,7 @@
 		H.invisibility = initial(invisibility)
 		visible_message("<span class='warning'>[src] suddenly fades in, seemingly from nowhere!</span>",
 		"<span class='notice'>We revert our camouflage, revealing ourselves.</span>")
-		H.set_move_intent(/decl/move_intent/run)
+		H.set_move_intent(H.get_movement_intent_with_flag(MOVEMENT_INTENT_RUNNING))
 		H.mind.changeling.cloaked = 0
 		H.mind.changeling.chem_recharge_rate = old_regen_rate
 

--- a/code/game/objects/items/weapons/handcuffs.dm
+++ b/code/game/objects/items/weapons/handcuffs.dm
@@ -274,14 +274,14 @@ var/global/last_chew = 0
 	target.legcuffed = lcuffs
 	target.update_inv_legcuffed()
 	if(!IS_WALKING(target))
-		target.set_move_intent(/decl/move_intent/walk)
+		target.set_move_intent(target.get_movement_intent_with_flag(MOVEMENT_INTENT_WALKING))
 	return 1
 
 /obj/item/handcuffs/legcuffs/equipped(var/mob/living/user,var/slot)
 	. = ..()
 	if(slot == slot_legcuffed)
 		if(!IS_WALKING(user))
-			user.set_move_intent(/decl/move_intent/walk)
+			user.set_move_intent(user.get_movement_intent_with_flag(MOVEMENT_INTENT_WALKING))
 
 
 /obj/item/handcuffs/legcuffs/bola
@@ -321,5 +321,5 @@ var/global/last_chew = 0
 	target.legcuffed = lcuffs
 	target.update_inv_legcuffed()
 	if(!IS_WALKING(target))
-		target.set_move_intent(/decl/move_intent/walk)
+		target.set_move_intent(target.get_movement_intent_with_flag(MOVEMENT_INTENT_WALKING))
 	return 1

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -2,6 +2,7 @@
 	name = "observer"
 	desc = "This shouldn't appear"
 	density = 0
+	move_intents = list(/decl/move_intent/no_delay)
 
 /mob/observer/dead
 	name = "ghost"

--- a/code/modules/mob/living/silicon/robot/robot_movement.dm
+++ b/code/modules/mob/living/silicon/robot/robot_movement.dm
@@ -35,8 +35,6 @@
 	if(get_restraining_bolt())	// Borgs with Restraining Bolts move slower.
 		. += 1
 
-	. += config.robot_delay
-
 	. += ..()
 
 // NEW: Use power while moving.

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -1,13 +1,18 @@
 /mob/living/silicon
 	gender = NEUTER
 	voice_name = "synthesized voice"
+	has_huds = TRUE
+	move_intents = list(
+		/decl/move_intent/run/robot,
+		/decl/move_intent/walk/robot
+	)
+
 	var/syndicate = 0
 	var/const/MAIN_CHANNEL = "Main Frequency"
 	var/lawchannel = MAIN_CHANNEL // Default channel on which to state laws
 	var/list/stating_laws = list()// Channels laws are currently being stated on
 	var/obj/item/radio/common_radio
 
-	has_huds = TRUE
 	var/list/speech_synthesizer_langs = list()	//which languages can be vocalized by the speech synthesizer
 
 	//Used in say.dm.

--- a/code/modules/mob/living/simple_mob/simple_mob.dm
+++ b/code/modules/mob/living/simple_mob/simple_mob.dm
@@ -17,6 +17,11 @@
 
 	has_huds = TRUE // We do show AI status huds for buildmode players
 
+	move_intents = list(
+		/decl/move_intent/animal_run,
+		/decl/move_intent/animal_walk
+	)
+
 	var/tt_desc = null //Tooltip description
 
 	//Settings for played mobs
@@ -225,17 +230,17 @@
 	return ..()
 */
 /mob/living/simple_mob/movement_delay()
-	. = movement_cooldown
 
 	if(force_max_speed)
 		return -3
-
+	. = 0
 	for(var/datum/modifier/M in modifiers)
 		if(!isnull(M.haste) && M.haste == TRUE)
 			return -3
 		if(!isnull(M.slowdown))
 			. += M.slowdown
 
+	. += ..() + movement_cooldown
 	// Turf related slowdown
 	var/turf/T = get_turf(src)
 	if(T && T.get_movement_cost() && !hovering) // Flying mobs ignore turf-based slowdown. Aquatic mobs ignore water slowdown, and can gain bonus speed in it.
@@ -251,8 +256,6 @@
 
 	if(IS_WALKING(src))
 		. *= 1.5
-
-	. += config.animal_delay
 
 	. += ..()
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -34,7 +34,7 @@
 	zone_sel = null
 
 /mob/Initialize()
-	move_intent = GET_DECL(/decl/move_intent/run) // Sets the initial move_intent.
+	move_intent = GET_DECL(move_intents[1]) // Sets the initial move_intent.
 	mob_list += src
 	if(stat == DEAD)
 		dead_mob_list += src

--- a/code/modules/organs/internal/intestine.dm
+++ b/code/modules/organs/internal/intestine.dm
@@ -17,7 +17,7 @@
 		if(prob(1))
 			owner.custom_pain("Your abdomen feels like it's tearing itself apart!",1)
 			if(!IS_WALKING(owner))
-				owner.set_move_intent(/decl/move_intent/walk)
+				owner.set_move_intent(owner.get_movement_intent_with_flag(MOVEMENT_INTENT_WALKING))
 
 /obj/item/organ/internal/intestine/xeno
 	color = "#555555"

--- a/code/modules/organs/internal/kidneys.dm
+++ b/code/modules/organs/internal/kidneys.dm
@@ -39,7 +39,7 @@
 		if(prob(1))
 			owner.custom_pain("You feel extremely tired, like you can't move!",1)
 			if(!IS_WALKING(owner))
-				owner.set_move_intent(/decl/move_intent/walk)
+				owner.set_move_intent(owner.get_movement_intent_with_flag(MOVEMENT_INTENT_WALKING))
 
 /obj/item/organ/internal/kidneys/grey
 	icon_state = "kidneys_grey"

--- a/code/modules/projectiles/targeting/targeting_mob.dm
+++ b/code/modules/projectiles/targeting/targeting_mob.dm
@@ -58,13 +58,18 @@
 		trigger_aiming(TARGET_CAN_MOVE)
 
 /mob/living/proc/set_move_intent(decl/move_intent/intent)
-	if(move_intent.type == intent)
-		return
-
 	var/new_intent = GET_DECL(intent)
 	if(isnull(new_intent))
 		return
+	if(move_intent != new_intent)
+		move_intent = new_intent
+		if(hud_used?.move_intent)
+			hud_used.move_intent.icon_state = move_intent.hud_icon_state
 
-	move_intent = new_intent
-	if(hud_used?.move_intent)
-		hud_used.move_intent.icon_state = move_intent.hud_icon_state
+/mob/living/proc/get_movement_intent_with_flag(var/flag_to_check = MOVEMENT_INTENT_WALKING)
+	if(!flag_to_check || !length(move_intents))
+		return
+	for(var/move_intent_type in move_intents)
+		var/decl/move_intent/check_intent = GET_DECL(move_intent_type)
+		if(check_intent.flags & flag_to_check)
+			return move_intent_type

--- a/config/example/game_options.txt
+++ b/config/example/game_options.txt
@@ -45,7 +45,7 @@ ALLOW_HEADGIBS
 ## These values get directly added to values and totals in-game. To speed things up make the number negative, to slow things down, make the number positive.
 
 
-## These modify the run/walk speed of all mobs before the mob-specific modifiers are applied. 
+## These modify the run/walk speed of all mobs before the mob-specific modifiers are applied.
 RUN_SPEED 2
 WALK_SPEED 5
 
@@ -53,9 +53,6 @@ WALK_SPEED 5
 ## The variables below affect the movement of specific mob types.
 HUMAN_DELAY 0
 ROBOT_DELAY 0
-MONKEY_DELAY 0
-ALIEN_DELAY 0
-METROID_DELAY 0
 ANIMAL_DELAY 0
 
 ## Volume of footstep sound effects.  Range: 1-100, Set to 0 to disable footstep sounds.


### PR DESCRIPTION
- Move intents now use flags and generalized getter logic instead of hard types.
- Simple mobs are no longer hardcoded to use human move delays. This fixes drakes being very slow.
- Removed several unused delay vars.

I have tried to keep this as close to 1:1 with the timings prior to the move intent update but it may need testing and config tweaks on live.