### PR TITLE
Justice for AcmeCo

### DIFF
--- a/code/game/objects/items/weapons/storage/fancy.dm
+++ b/code/game/objects/items/weapons/storage/fancy.dm
@@ -269,18 +269,18 @@
 		..()
 
 /obj/item/storage/fancy/cigarettes/dromedaryco
-	name = "\improper DromedaryCo packet"
+	name = "\improper pack of DromedaryCos"
 	desc = "A packet of six Earth-export DromedaryCo cancer sticks. A label on the packaging reads, \"Wouldn't a slow death make a change?\""
 	description_fluff = "DromedaryCo is one of Sol's oldest cigarette brands, and takes pride in having sourced tobcacco from the same Indian plantations since 2044. Popular with those willing to pay extra for a little nostalgia."
 	icon_state = "Dpacket"
-	brand = "\improper Dromedary Co. cigarette"
+	brand = "\improper Dromedary Co."
 
 /obj/item/storage/fancy/cigarettes/killthroat
-	name = "\improper AcmeCo packet"
+	name = "\improper pack of AcmeCos"
 	desc = "A packet of six AcmeCo cigarettes. For those who want to obtain a record for the most cancerous tumors on a budget."
 	description_fluff = "Available anywhere people breathe and want to breathe less, AcmeCo is the cheapest, most widespread cigarette brand in the galaxy. They taste like trash, but when you're keeping them inside your jumpsuit on a 16 hour shift, you're probably not too concerned with flavour."
 	icon_state = "Apacket"
-	brand = "\improper Acme Co. cigarette"
+	brand = "\improper Acme Co."
 
 // New exciting ways to kill your lungs! - Earthcrusher //
 

--- a/code/modules/client/preference_setup/loadout/loadout_smoking.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_smoking.dm
@@ -46,7 +46,7 @@
 /datum/gear/cigarettes/New()
 	..()
 	var/list/cigarettes = list()
-	for(var/cigarette in (typesof(/obj/item/storage/fancy/cigarettes) - typesof(/obj/item/storage/fancy/cigarettes/killthroat)))
+	for(var/cigarette in (typesof(/obj/item/storage/fancy/cigarettes)))
 		var/obj/item/storage/fancy/cigarettes/cigarette_brand = cigarette
 		cigarettes[initial(cigarette_brand.name)] = cigarette_brand
 	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(cigarettes))


### PR DESCRIPTION
Shortly prior to Polaris being forked, Bay added joke cigarettes that exploded. Naturally, these weren't in loadout.

Over the years, refluffs and code cleanups and desire for sanity removed the danger... But they were never removed from being excluded from loadout. Which is a pretty funny oversight, but these things are literally in vending machines and every random spawner because they're JUST cigarettes. Shit cheap cigarettes named Acme so they come first alphabetically. Fully circle babey.