### PR TITLE
Restores the missing agent card UI template

### DIFF
--- a/nano/templates/agent_id_card.tmpl
+++ b/nano/templates/agent_id_card.tmpl
@@ -1,0 +1,21 @@
+<!-- 
+Title: Syndicate Uplink, uses some javascript to change nanoUI up a bit.
+Used In File(s): \code\game\objects\items\devices\uplinks.dm
+ -->
+{{:helper.syndicateMode()}}
+<H1>Available Entries</H1>
+<table>
+{{for data.entries}}
+    <tr>
+		<td>{{:helper.link('', 'gear', {'set' : value.name})}}</td><td>{{:value.name}}</td><td>{{:value.value}}</td>
+	</tr>
+{{/for}}
+</table>
+
+<table>
+    <tr>
+        <td>Electronic warfare:</td>
+        <td>{{:helper.link('Enabled', null, {'electronic_warfare' : 1}, data.electronic_warfare ? 'selected' : null)}}</td>
+        <td>{{:helper.link('Disabled',null, {'electronic_warfare' : 0}, data.electronic_warfare ? null : 'selected')}}</td>
+    </tr>
+</table>


### PR DESCRIPTION
#### purpose

Fixes #8877 

#### details

agent cards, as it turns out, have been bugged for goodness knows how long. they were coded to use nano, but the .tmpl file they were looking for doesn't actually exist, so it just shows a blank page.

this PR reimplements the missing template by way of pulling it from Nebula's code and putting it here. no other changes are made. unfortunately, I'm not sure if this keeps the authorship history or not, but we'll see

#### testing

spawn in a card, or grab one from an uplink/job loadout. edit stuff, scan cards, be gay, do crime

#### media

![7S5QHHaxq3](https://user-images.githubusercontent.com/47678781/227110088-bd44aa0a-9ad8-48d8-b3a2-8609413e23be.png)
