### PR TITLE
Updates text sanitization

### DIFF
--- a/code/_helpers/text.dm
+++ b/code/_helpers/text.dm
@@ -54,6 +54,9 @@
 	if(extra)
 		input = replace_characters(input, list("\n"=" ","\t"=" "))
 
+	input = html_decode(input) 	//this prevents double-encoding, but does nothing if it's not encoded already.
+								//For sending text to HTML UIs (eg browse() ), ensure encode = 1.
+
 	if(encode)
 		// The below \ escapes have a space inserted to attempt to enable CI auto-checking of span class usage. Please do not remove the space.
 		//In addition to processing html, html_encode removes byond formatting codes like "\ red", "\ i" and other.

--- a/code/datums/uplink/announcements.dm
+++ b/code/datums/uplink/announcements.dm
@@ -16,10 +16,10 @@
 	item_cost = 20
 
 /datum/uplink_item/abstract/announcements/fake_centcom/extra_args(var/mob/user)
-	var/title = sanitize(input("Enter your announcement title.", "Announcement Title") as null|text)
+	var/title = html_decode(sanitize(input("Enter your announcement title.", "Announcement Title") as null|text))
 	if(!title)
 		return
-	var/message = sanitize(input("Enter your announcement message.", "Announcement Title") as null|text)
+	var/message = html_decode(sanitize(input("Enter your announcement message.", "Announcement Title") as message|null, extra = 0))
 	if(!message)
 		return
 	return list("title" = title, "message" = message)

--- a/code/game/machinery/requests_console.dm
+++ b/code/game/machinery/requests_console.dm
@@ -152,7 +152,7 @@ var/global/list/obj/machinery/requests_console/allConsoles = list()
 			reset_message(1)
 
 	if(href_list["writeAnnouncement"])
-		var/new_message = sanitize(input("Write your message:", "Awaiting Input", ""))
+		var/new_message = sanitize(input("Write your message:", "Awaiting Input", "") as message|null, extra = 0) //Lets you write longer announcements.
 		if(new_message)
 			message = new_message
 		else
@@ -204,13 +204,14 @@ var/global/list/obj/machinery/requests_console/allConsoles = list()
 	if(computer_deconstruction_screwdriver(user, O))
 		return
 	if(istype(O, /obj/item/multitool))
-		var/input = sanitize(input(usr, "What Department ID would you like to give this request console?", "Multitool-Request Console Interface", department))
+		var/input = html_decode(sanitize(input(usr, "What Department ID would you like to give this request console?", "Multitool-Request Console Interface", department)))
 		if(!input)
 			to_chat(usr, "No input found. Please hang up and try your call again.")
 			return
 		department = input
 		announcement.title = "[department] announcement"
 		announcement.newscast = 1
+		announcementConsole = 1 //2023-03-20, fixes deconstruction breaking announcement function
 
 		name = "[department] Requests Console"
 		allConsoles += src

--- a/code/game/objects/items/devices/uplink.dm
+++ b/code/game/objects/items/devices/uplink.dm
@@ -135,22 +135,22 @@
 				data["exploit"] = list()  // Setting this to equal L.fields passes it's variables that are lists as reference instead of value.
 								 // We trade off being able to automatically add shit for more control over what gets passed to json
 								 // and if it's sanitized for html.
-				data["exploit"]["nanoui_exploit_record"] = html_encode(L.fields["exploit_record"])                         		// Change stuff into html
-				data["exploit"]["nanoui_exploit_record"] = replacetext(data["exploit"]["nanoui_exploit_record"], "\n", "<br>")    // change line breaks into <br>
-				data["exploit"]["name"] =  html_encode(L.fields["name"])
-				data["exploit"]["sex"] =  html_encode(L.fields["sex"])
-				data["exploit"]["age"] =  html_encode(L.fields["age"])
-				data["exploit"]["species"] =  html_encode(L.fields["species"])
-				data["exploit"]["rank"] =  html_encode(L.fields["rank"])
-				data["exploit"]["home_system"] =  html_encode(L.fields["home_system"])
-				data["exploit"]["citizenship"] =  html_encode(L.fields["citizenship"])
-				data["exploit"]["faction"] =  html_encode(L.fields["faction"])
-				data["exploit"]["religion"] =  html_encode(L.fields["religion"])
-				data["exploit"]["fingerprint"] =  html_encode(L.fields["fingerprint"])
+				data["exploit"]["nanoui_exploit_record"] = html_decode(L.fields["exploit_record"])                         		// This is all sanitized and encoded when it's entered.
+//				data["exploit"]["nanoui_exploit_record"] = replacetext(data["exploit"]["nanoui_exploit_record"], "\n", "<br>")    // We want to keep line breaks, though.
+				data["exploit"]["name"] =  html_decode(L.fields["name"])
+				data["exploit"]["sex"] =  html_decode(L.fields["sex"])
+				data["exploit"]["age"] =  html_decode(L.fields["age"])
+				data["exploit"]["species"] =  html_decode(L.fields["species"])
+				data["exploit"]["rank"] =  html_decode(L.fields["rank"])
+				data["exploit"]["home_system"] =  html_decode(L.fields["home_system"])
+				data["exploit"]["citizenship"] =  html_decode(L.fields["citizenship"])
+				data["exploit"]["faction"] =  html_decode(L.fields["faction"])
+				data["exploit"]["religion"] =  html_decode(L.fields["religion"])
+				data["exploit"]["fingerprint"] =  html_decode(L.fields["fingerprint"])
 				if(L.fields["antagvis"] == ANTAG_KNOWN || (faction == L.fields["antagfac"] && (L.fields["antagvis"] == ANTAG_SHARED)))
-					data["exploit"]["antagfaction"] = html_encode(L.fields["antagfac"])
+					data["exploit"]["antagfaction"] = html_decode(L.fields["antagfac"])
 				else
-					data["exploit"]["antagfaction"] = html_encode("None")
+					data["exploit"]["antagfaction"] = html_decode("None")
 				break
 	else
 		var/list/permanentData = list()

--- a/code/modules/client/preference_setup/antagonism/01_basic.dm
+++ b/code/modules/client/preference_setup/antagonism/01_basic.dm
@@ -44,11 +44,11 @@ var/global/list/uplink_locations = list("PDA", "Headset", "None")
 		return TOPIC_REFRESH
 
 	if(href_list["exploitable_record"])
-		var/exploitmsg = sanitize(input(user,"Set exploitable information about you here.","Exploitable Information", html_decode(pref.exploit_record)) as message|null, MAX_RECORD_LENGTH, extra = 0)
+		var/exploitmsg = html_decode(sanitizeSafe(input(user,"Set exploitable information about you here.","Exploitable Information", html_decode(pref.exploit_record)) as message|null, MAX_RECORD_LENGTH, extra = 0))
 		if(!isnull(exploitmsg) && !jobban_isbanned(user, "Records") && CanUseTopic(user))
 			pref.exploit_record = exploitmsg
 			return TOPIC_REFRESH
-			
+
 	if(href_list["antagfaction"])
 		var/choice = input(user, "Please choose an antagonistic faction to work for.", "Character Preference", pref.antag_faction) as null|anything in antag_faction_choices + list("None","Other")
 		if(!choice || !CanUseTopic(user))
@@ -60,7 +60,7 @@ var/global/list/uplink_locations = list("PDA", "Headset", "None")
 		else
 			pref.antag_faction = choice
 		return TOPIC_REFRESH
-		
+
 	if(href_list["antagvis"])
 		var/choice = input(user, "Please choose an antagonistic visibility level.", "Character Preference", pref.antag_vis) as null|anything in antag_visiblity_choices
 		if(!choice || !CanUseTopic(user))

--- a/code/modules/client/preference_setup/general/05_background.dm
+++ b/code/modules/client/preference_setup/general/05_background.dm
@@ -107,27 +107,27 @@
 		if(!choice || !CanUseTopic(user))
 			return TOPIC_NOACTION
 		if(choice == "Other")
-			var/raw_choice = sanitize(input(user, "Please enter a religon.", "Character Preference")  as text|null, MAX_NAME_LEN)
+			var/raw_choice = sanitize(input(user, "Please enter a religion.", "Character Preference")  as text|null, MAX_NAME_LEN)
 			if(raw_choice)
 				pref.religion = sanitize(raw_choice)
 		else
 			pref.religion = choice
 		return TOPIC_REFRESH
 
-	else if(href_list["set_medical_records"])
-		var/new_medical = sanitize(input(user,"Enter medical information here.","Character Preference", html_decode(pref.med_record)) as message|null, MAX_RECORD_LENGTH, extra = 0)
+	else if(href_list["set_medical_records"]) //2023-03-18, we're using sanitizeSafe() in order to remove <> entirely, allowing us to safely decode it on the pref screen
+		var/new_medical = html_decode(sanitizeSafe(input(user,"Enter medical information here.","Character Preference", html_decode(pref.med_record)) as message|null, MAX_RECORD_LENGTH, extra = 0))
 		if(!isnull(new_medical) && !jobban_isbanned(user, "Records") && CanUseTopic(user))
 			pref.med_record = new_medical
 		return TOPIC_REFRESH
 
-	else if(href_list["set_general_records"])
-		var/new_general = sanitize(input(user,"Enter employment information here.","Character Preference", html_decode(pref.gen_record)) as message|null, MAX_RECORD_LENGTH, extra = 0)
+	else if(href_list["set_general_records"]) //2023-03-20, this allows people to use apostrophes in their records!
+		var/new_general = html_decode(sanitizeSafe(input(user,"Enter employment information here.","Character Preference", html_decode(pref.gen_record)) as message|null, MAX_RECORD_LENGTH, extra = 0))
 		if(!isnull(new_general) && !jobban_isbanned(user, "Records") && CanUseTopic(user))
 			pref.gen_record = new_general
 		return TOPIC_REFRESH
 
-	else if(href_list["set_security_records"])
-		var/sec_medical = sanitize(input(user,"Enter security information here.","Character Preference", html_decode(pref.sec_record)) as message|null, MAX_RECORD_LENGTH, extra = 0)
+	else if(href_list["set_security_records"]) //Note that html exploits still won't work here because we removed <> earlier.
+		var/sec_medical = html_decode(sanitizeSafe(input(user,"Enter security information here.","Character Preference", html_decode(pref.sec_record)) as message|null, MAX_RECORD_LENGTH, extra = 0))
 		if(!isnull(sec_medical) && !jobban_isbanned(user, "Records") && CanUseTopic(user))
 			pref.sec_record = sec_medical
 		return TOPIC_REFRESH

--- a/code/modules/emotes/emote_mob.dm
+++ b/code/modules/emotes/emote_mob.dm
@@ -152,7 +152,7 @@
 			to_chat(src, "You are unable to emote.")
 			return
 
-	message = sanitize(message, encode = FALSE) // This is getting double-encoded somewhere along the line.
+	message = html_decode(sanitize(message))
 	if(!message)
 		return
 

--- a/code/modules/paperwork/handlabeler.dm
+++ b/code/modules/paperwork/handlabeler.dm
@@ -72,8 +72,8 @@
 	icon_state = "labeler[mode]"
 	if(mode)
 		to_chat(user, SPAN_NOTICE("You turn on \the [src]."))
-		//Now let them chose the text.
-		var/str = sanitizeSafe(input(user,"Label text?","Set label",""), MAX_NAME_LEN)
+		//Now let them choose the text.
+		var/str = html_decode(sanitizeSafe(input(user,"Label text?","Set label",""), MAX_NAME_LEN))
 		if(!str || !length(str))
 			to_chat(user, SPAN_WARNING("Invalid text."))
 			return


### PR DESCRIPTION
ok i have
absolutely 0 guarantees this won't like, turbofuck something if someone comes up with a html exploit but ??? i have tried my own html exploits and they don't seem to be working so i'm like 80% sure this is safe ,, ,

amway this pr does the following things:

- lets you use apostrophes in your records and in labellers
- lets you use new lines in traitor fake command announcements, and in request console announcements, and in exploitables
- fixes the bug where if a request console is damaged or deconned and you put it back together you can't use it any more
- adds a check to prevent double-encoding in sanitization

basically the most important part is that it unfucks records tbh
at what cost???