### PR TITLE
Stuff dview back into nullspace

### DIFF
--- a/code/modules/lighting/lighting_source.dm
+++ b/code/modules/lighting/lighting_source.dm
@@ -222,6 +222,7 @@ var/global/total_lighting_sources = 0
 
 		T.affecting_lights += src
 		affecting_turfs    += T
+	END_FOR_DVIEW
 
 	update_gen++
 
@@ -257,6 +258,7 @@ var/global/total_lighting_sources = 0
 			T.generate_missing_corners()
 		corners |= T.get_corners()
 		turfs   += T
+	END_FOR_DVIEW
 
 	var/list/L = turfs - affecting_turfs // New turfs, add us to the affecting lights of them.
 	affecting_turfs += L


### PR DESCRIPTION
It apparently is not being put away when lighting finishes with it. This is wrong.