### PR TITLE
Tank gauge overlays initialize correctly

### DIFF
--- a/code/game/objects/items/weapons/tanks/tanks.dm
+++ b/code/game/objects/items/weapons/tanks/tanks.dm
@@ -58,12 +58,17 @@ var/global/list/tank_gauge_cache = list()
 
 
 /obj/item/tank/Initialize()
-	. = ..()
-
+	..()
 	src.init_proxy()
 	src.air_contents = new /datum/gas_mixture()
 	src.air_contents.volume = volume //liters
 	src.air_contents.temperature = T20C
+	return INITIALIZE_HINT_LATELOAD
+
+/obj/item/tank/LateInitialize()
+	// Running this in Initialize() won't work for subtypes, which run their own override of Initialize() (for initial contents etc) *after* the base one
+	// Since air_contents is created in the base init, we can't just move the order of operations either (i.e. for subtypes, calling update_gauge() before the base proc)
+	// Thus, we defer it to later so that the gauge only updates after everything else is done
 	update_gauge()
 
 /obj/item/tank/Destroy()


### PR DESCRIPTION
#### purpose

oxygen tanks (and other air tanks, of course) have a visible gauge that shows roughly how full they are. right now, though, the gauge overlays are generated *before* the tanks are actually filled up, meaning that they'll show with no overlay by default until something is done with them.

#### details
* moved the `update_gauge()` call from `Initialize()` into `LateInitialize()`.

#### testing

spawn in on an unfixed server. open your box and see a tank with no gauge. fall to your knees, weeping in despair and wailing to the cold and unfeeling sky at the futility of your existence.

spawn in on a server with the fix. open your box and see a tank with a gauge. success!

#### media

internals box, before fix:
![image](https://user-images.githubusercontent.com/47678781/229274287-6d2d5138-6f51-48a2-a67c-7dad95ae42d9.png)

internals box, after fix:
![image](https://user-images.githubusercontent.com/47678781/229274168-8d16d0e1-d348-4c45-a3d1-d0650708a65e.png)

