### PR TITLE
Axe player-facing references to 'biological gender'

### DIFF
--- a/code/__defines/mobs.dm
+++ b/code/__defines/mobs.dm
@@ -461,8 +461,8 @@
 /// Used by human/get_visible_gender(user, force) to return the mob's identifying gender
 #define VISIBLE_GENDER_FORCE_IDENTIFYING 2
 
-/// Used by human/get_visible_gender(user, force) to return the mob's biological gender
-#define VISIBLE_GENDER_FORCE_BIOLOGICAL 3
+/// Used by human/get_visible_gender(user, force) to return the mob's body type
+#define VISIBLE_GENDER_FORCE_BODYTPE 3
 
 
 // Dexterity levels for mob/proc/check_dexterity

--- a/code/__defines/mobs.dm
+++ b/code/__defines/mobs.dm
@@ -462,7 +462,7 @@
 #define VISIBLE_GENDER_FORCE_IDENTIFYING 2
 
 /// Used by human/get_visible_gender(user, force) to return the mob's body type
-#define VISIBLE_GENDER_FORCE_BODYTPE 3
+#define VISIBLE_GENDER_FORCE_BODYTYPE 3
 
 
 // Dexterity levels for mob/proc/check_dexterity

--- a/code/modules/client/preference_setup/general/01_basic.dm
+++ b/code/modules/client/preference_setup/general/01_basic.dm
@@ -71,7 +71,7 @@
 	. += "<b>Nickname:</b> "
 	. += "<a href='?src=\ref[src];nickname=1'><b>[pref.nickname]</b></a>"
 	. += "<br>"
-	. += "<b>Biological Sex:</b> <a href='?src=\ref[src];bio_gender=1'><b>[gender2text(pref.biological_gender)]</b></a><br>"
+	. += "<b>Body Type:</b> <a href='?src=\ref[src];bio_gender=1'><b>[gender2text(pref.biological_gender)]</b></a><br>"
 	. += "<b>Pronouns:</b> <a href='?src=\ref[src];id_gender=1'><b>[gender2text(pref.identifying_gender)]</b></a><br>"
 	. += "<b>Age:</b> <a href='?src=\ref[src];age=1'>[pref.age]</a><br>"
 	. += "<b>Spawn Point</b>: <a href='?src=\ref[src];spawnpoint=1'>[pref.spawnpoint]</a><br>"
@@ -111,7 +111,7 @@
 				return TOPIC_NOACTION
 
 	else if(href_list["bio_gender"])
-		var/new_gender = input(user, "Choose your character's biological sex:", "Character Preference", pref.biological_gender) as null|anything in get_genders()
+		var/new_gender = input(user, "Choose your character's body type:", "Character Preference", pref.biological_gender) as null|anything in get_genders()
 		if(new_gender && CanUseTopic(user))
 			pref.set_biological_gender(new_gender)
 		return TOPIC_REFRESH_UPDATE_PREVIEW

--- a/code/modules/lore_codex/lore_data/species.dm
+++ b/code/modules/lore_codex/lore_data/species.dm
@@ -137,8 +137,7 @@
 	is an obnoxiously warm, humid planet requiring structures to be built within large, atmospherically-filtered 'tent-like' domes. \
 	Prometheans take on vague visual and vocal features of the species they cohabitate with, sharing their predecessors' tendency to mimic nearby entities, \
 	though in physical form additionally; this is seemingly more important in their own development, as well. Despite their taken appearances, \
-	there is no known existence of a divergence between a biologically 'male' or 'female' form of the species, leading most to believe they are in fact asexual, \
-	as their predecessors are."
+	there is no known sexual differentiation between individuals, are are widely accepted to be an asexual species, as their predecessors are."
 
 // Vatborn Lore
 /datum/lore/codex/page/vatborn/add_content()

--- a/code/modules/lore_codex/lore_data/species.dm
+++ b/code/modules/lore_codex/lore_data/species.dm
@@ -137,7 +137,7 @@
 	is an obnoxiously warm, humid planet requiring structures to be built within large, atmospherically-filtered 'tent-like' domes. \
 	Prometheans take on vague visual and vocal features of the species they cohabitate with, sharing their predecessors' tendency to mimic nearby entities, \
 	though in physical form additionally; this is seemingly more important in their own development, as well. Despite their taken appearances, \
-	there is no known sexual differentiation between individuals, are are widely accepted to be an asexual species, as their predecessors are."
+	there is no known sexual differentiation between individuals, and they are widely accepted to be an asexual species, as their predecessors are."
 
 // Vatborn Lore
 /datum/lore/codex/page/vatborn/add_content()

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -866,7 +866,7 @@
 			return PLURAL
 		if (VISIBLE_GENDER_FORCE_IDENTIFYING)
 			return get_gender()
-		if (VISIBLE_GENDER_FORCE_BIOLOGICAL)
+		if (VISIBLE_GENDER_FORCE_BODYTYPE)
 			return gender
 		else
 			if ((wear_mask || (head?.flags_inv & HIDEMASK)) && (wear_suit?.flags_inv & HIDEJUMPSUIT))

--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -101,7 +101,7 @@
 	mob_push_flags = ~HEAVY
 	mob_swap_flags = ~HEAVY
 
-	var/identifying_gender // In case the human identifies as another gender than it's biological
+	var/identifying_gender // In case the human identifies as another gender than it's base body type
 
 	var/list/descriptors	// For comparative examine code
 


### PR DESCRIPTION
Um, what are your BIOLOGICAL pronouns?

When body-pronoun split was done 5 years ago, this terminology was less cringe-ass-shit, so no hard feelings y'know?
Doesn't actually change (most) code-side var names because most of them are in regards to save files, this is all UI stuff, mostly character setup text. Actually making the options not literally the BYOND grammar structure is beyond the scope of me slapping this up in 5 minutes.