### PR TITLE
Sanity check for shredding ID's in the Autolathe

### DIFF
--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -186,6 +186,16 @@
 			to_chat(user, "\The [mag] is too hazardous to put back into the autolathe while there's ammunition inside of it!")
 			return*/
 
+	if(istype(O,/obj/item/pda))
+		var/obj/item/pda/pda=O
+		if(!isnull(pda.id))
+			if(alert(user, "This PDA holds an ID card, are you sure you wish to destroy it?", "Destroy PDA","No","Yes") == "No")
+				return
+	else if(istype(O, /obj/item/card/id))
+		if(alert(user, "Are you sure you wish to destroy this ID?", "Destroy ID","No","Yes") == "No")
+			return
+
+
 	//Resources are being loaded.
 	var/obj/item/eating = O
 	if(!eating.matter)


### PR DESCRIPTION
Prompts the user if they are sure about feeding ID-bearing items into the Autolathe. Prevents a simple miss-click from locking someone in a room until they can break out.