### PR TITLE
Printable Mops

### DIFF
--- a/code/datums/autolathe/general.dm
+++ b/code/datums/autolathe/general.dm
@@ -2,6 +2,10 @@
 	name = "bucket"
 	path =/obj/item/reagent_containers/glass/bucket
 
+/datum/category_item/autolathe/general/mop
+	name = "mop"
+	path =/obj/item/mop
+
 /datum/category_item/autolathe/general/cooler_bottle
 	name = "water-cooler bottle"
 	path =/obj/item/reagent_containers/glass/cooler_bottle


### PR DESCRIPTION
Adds mops to the list of things that the autolathe can print. This allows for the easy construction of ED-CLN Cleaning Robot in robotics.