### PR TITLE
Deconstructive Analyzer Tweak

### DIFF
--- a/code/modules/research/destructive_analyzer.dm
+++ b/code/modules/research/destructive_analyzer.dm
@@ -61,11 +61,8 @@ Note: Must be placed within 3 tiles of the R&D Console
 	if(!loaded_item)
 		if(isrobot(user)) //Don't put your module items in there!
 			return
-		if(!O.origin_tech)
-			to_chat(user, "<span class='notice'>This doesn't seem to have a tech origin.</span>")
-			return
-		if(O.origin_tech.len == 0)
-			to_chat(user, "<span class='notice'>You cannot deconstruct this item.</span>")
+		if(istype(O,/obj/item/ammo_magazine/clip) || istype(O,/obj/item/ammo_magazine/s357) || istype(O,/obj/item/ammo_magazine/s38)) // Prevents ammo recycling exploit with speedloaders.
+			to_chat(user, "<span class='notice'>\The [O] is too hazardous to recycle with the autolathe!</span>")
 			return
 		busy = 1
 		loaded_item = O

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -493,7 +493,10 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 			dat += "Updating Database..."
 
 		if(0.1)
-			dat += "Processing and Updating Database..."
+			if(linked_lathe)
+				dat += "Processing; Updating Database and Recycling Materials to Protolathe..."
+			else
+				dat += "Processing; Updating Database..."
 
 		if(0.2)
 			dat += "SYSTEM LOCKED<BR><BR>"
@@ -645,12 +648,15 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 			dat += "Name: [linked_destroy.loaded_item.name]<BR>"
 			dat += "Origin Tech:"
 			dat += "<UL>"
-			for(var/T in linked_destroy.loaded_item.origin_tech)
-				dat += "<LI>[CallTechName(T)] [linked_destroy.loaded_item.origin_tech[T]]"
-				for(var/datum/tech/F in files.known_tech)
-					if(F.name == CallTechName(T))
-						dat += " (Current: [F.level])"
-						break
+			if(!linked_destroy.loaded_item.origin_tech || linked_destroy.loaded_item.origin_tech.len == 0)
+				dat += "No Tech origin detected. Deconstruct anyway?"
+			else
+				for(var/T in linked_destroy.loaded_item.origin_tech)
+					dat += "<LI>[CallTechName(T)] [linked_destroy.loaded_item.origin_tech[T]]"
+					for(var/datum/tech/F in files.known_tech)
+						if(F.name == CallTechName(T))
+							dat += " (Current: [F.level])"
+							break
 			dat += "</UL>"
 			dat += "<HR><A href='?src=\ref[src];deconstruct=1'>Deconstruct Item</A> || "
 			dat += "<A href='?src=\ref[src];eject_item=1'>Eject Item</A> || "


### PR DESCRIPTION
- Allows the Deconstructive Analyzer to destroy items with no tech origin
- Prevents ammo from being deconstructed
- Modifies UI to clue in players that the Analyzer Recycles parts to the protolathe.

Essentially, allows for the creation of small amounts of materials through the existing recycling system in the Deconstructive Analyzer. This can be used for getting a small amount of materials from items like coins.