### PR TITLE
The cloner no longer misgenders you

### DIFF
--- a/code/game/dna/dna_modifier.dm
+++ b/code/game/dna/dna_modifier.dm
@@ -24,6 +24,7 @@
 	var/languages=null
 	var/list/flavor=null
 	var/gender = null
+	var/identifying_gender = null
 	var/list/body_descriptors = null
 	var/list/genetic_modifiers = list() // Modifiers with the MODIFIER_GENETIC flag are saved.  Note that only the type is saved, not an instance.
 
@@ -54,6 +55,7 @@
 	newrecord.implant = implant
 	newrecord.flavor = flavor
 	newrecord.gender = gender
+	newrecord.identifying_gender = identifying_gender
 	newrecord.body_descriptors = body_descriptors.Copy()
 	newrecord.genetic_modifiers = genetic_modifiers.Copy()
 	return newrecord

--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -110,6 +110,7 @@
 		R.dna.real_name = "clone ([rand(0,999)])"
 	H.real_name = R.dna.real_name
 	H.gender = R.gender
+	H.identifying_gender = R.identifying_gender
 	H.descriptors = R.body_descriptors
 
 	//Get the clone body ready

--- a/code/game/machinery/computer/cloning.dm
+++ b/code/game/machinery/computer/cloning.dm
@@ -432,6 +432,7 @@
 	R.gender = subject.gender
 	R.body_descriptors = subject.descriptors
 	R.flavor = subject.flavor_texts.Copy()
+	R.identifying_gender = subject.identifying_gender
 	for(var/datum/modifier/mod in subject.modifiers)
 		if(mod.flags & MODIFIER_GENETIC)
 			R.genetic_modifiers.Add(mod.type)


### PR DESCRIPTION
Fixes #8848. DNA now transmits gender identity along with the rest of the stuff it transmits, so your pronouns are preserved upon cloning.