### PR TITLE
Removing unnecessary usage of icon_override for Teshari cloaks.

### DIFF
--- a/code/game/objects/items/paintkit.dm
+++ b/code/game/objects/items/paintkit.dm
@@ -72,7 +72,6 @@
 		if(istype(I, /obj/item/clothing/accessory/storage/poncho))
 			var/obj/item/clothing/accessory/storage/poncho/P = I
 			P.icon_override_state = new_icon_override_file
-			LAZYSET(P.sprite_sheets, SPECIES_TESHARI, new_icon_override_file)  /// Will look the same on Teshari and other species.
 			P.item_state = new_icon
 			to_chat(user, "You set about modifying the poncho into [new_name].")
 		return ..()
@@ -84,7 +83,6 @@
 
 /obj/item/kit/clothing/customize(var/obj/item/clothing/I, var/mob/user)
 	if(istype(I) && can_customize(I))
-		LAZYSET(I.sprite_sheets, SPECIES_TESHARI, new_icon_override_file)  /// Will look the same on Teshari and other species.
 		I.item_state = new_icon
 		return ..()
 

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -191,7 +191,8 @@ var/global/list/light_overlay_cache = list() //see get_worn_overlay() on helmets
 	throwforce = 2
 	slot_flags = SLOT_EARS
 	sprite_sheets = list(
-		SPECIES_TESHARI = 'icons/mob/species/teshari/ears.dmi')
+		SPECIES_TESHARI = 'icons/mob/species/teshari/ears.dmi'
+	)
 
 /obj/item/clothing/ears/attack_hand(mob/user as mob)
 	if (!user) return

--- a/code/modules/clothing/suits/aliens/teshari.dm
+++ b/code/modules/clothing/suits/aliens/teshari.dm
@@ -1,27 +1,11 @@
-// Placeholders to force Teshari cloaks to use sprite_sheets to avoid erroneous pixel shifting.
-/obj/item/clothing/suit/storage/teshari/Initialize()
-	. = ..()
-	if(. != INITIALIZE_HINT_QDEL)
-		LAZYSET(sprite_sheets, SPECIES_TESHARI, icon)
-
-/obj/item/clothing/suit/storage/hooded/teshari/Initialize()
-	. = ..()
-	if(. != INITIALIZE_HINT_QDEL)
-		LAZYSET(sprite_sheets, SPECIES_TESHARI, icon)
-
-/obj/item/clothing/head/tesh_hood/Initialize()
-	. = ..()
-	if(. != INITIALIZE_HINT_QDEL)
-		LAZYSET(sprite_sheets, SPECIES_TESHARI, icon)
-// End placeholders.
-
 // Standard Cloaks
-
 /obj/item/clothing/suit/storage/teshari/cloak
 	name = "black cloak"
 	desc = "It drapes over a Teshari's shoulders and closes at the neck with pockets convienently placed inside."
 	icon = 'icons/mob/species/teshari/teshari_cloak.dmi'
-	icon_override = 'icons/mob/species/teshari/teshari_cloak.dmi'
+	sprite_sheets = list(
+			SPECIES_TESHARI = 'icons/mob/species/teshari/teshari_cloak.dmi'
+	)
 	icon_state = "tesh_cloak_bn"
 	item_state = "tesh_cloak_bn"
 	species_restricted = list(SPECIES_TESHARI)
@@ -151,7 +135,9 @@
 // Job Cloaks
 /obj/item/clothing/suit/storage/teshari/cloak/jobs
 	icon = 'icons/mob/species/teshari/deptcloak.dmi'
-	icon_override = 'icons/mob/species/teshari/deptcloak.dmi'
+	sprite_sheets = list(
+		SPECIES_TESHARI = 'icons/mob/species/teshari/deptcloak.dmi'
+	)
 
 /obj/item/clothing/suit/storage/teshari/cloak/jobs/cap
 	name = "facility director cloak"
@@ -232,7 +218,7 @@
 	item_state = "tesh_cloak_para"
 
 /obj/item/clothing/suit/storage/teshari/cloak/jobs/psych
-	name = " psychiatrist cloak"
+	name = "psychiatrist cloak"
 	desc = "A soft Teshari cloak made for the Psychiatrist"
 	icon_state = "tesh_cloak_psych"
 	item_state = "tesh_cloak_psych"
@@ -294,10 +280,12 @@
 //Misc
 
 /obj/item/clothing/suit/storage/toggle/labcoat/teshari
-	name = "Teshari labcoat"
+	name = "small labcoat"
 	desc = "A small suit that protects against minor chemical spills. This one is a good fit on Teshari."
 	icon = 'icons/obj/clothing/species/teshari/suits.dmi'
-	icon_override = 'icons/mob/species/teshari/suit.dmi'
+	sprite_sheets = list(
+		SPECIES_TESHARI = 'icons/mob/species/teshari/suit.dmi'
+	)
 	icon_state = "tesh_labcoat"
 	species_restricted = list(SPECIES_TESHARI)
 
@@ -305,7 +293,9 @@
 	name = "small black coat"
 	desc = "A coat that seems too small to fit a human."
 	icon = 'icons/obj/clothing/species/teshari/suits.dmi'
-	icon_override = 'icons/mob/species/teshari/suit.dmi'
+	sprite_sheets = list(
+		SPECIES_TESHARI = 'icons/mob/species/teshari/suit.dmi'
+	)
 	icon_state = "tesharicoat"
 	body_parts_covered = UPPER_TORSO|ARMS|LOWER_TORSO|LEGS
 	species_restricted = list(SPECIES_TESHARI)
@@ -314,16 +304,20 @@
 	name = "small coat"
 	desc = "A coat that seems too small to fit a human."
 	icon = 'icons/obj/clothing/species/teshari/suits.dmi'
-	icon_override = 'icons/mob/species/teshari/suit.dmi'
+	sprite_sheets = list(
+		SPECIES_TESHARI = 'icons/mob/species/teshari/suit.dmi'
+	)
 	icon_state = "tesharicoatwhite"
 	body_parts_covered = UPPER_TORSO|ARMS|LOWER_TORSO|LEGS
 	species_restricted = list(SPECIES_TESHARI)
 
 //Hooded teshari cloaks
 /obj/item/clothing/suit/storage/hooded/teshari
-	name = "Hooded Teshari Cloak"
-	desc = "A soft teshari cloak with an added hood."
-	icon_override = 'icons/mob/species/teshari/teshari_hood.dmi'
+	name = "hooded cloak"
+	desc = "A soft Teshari cloak with an added hood."
+	sprite_sheets = list(
+		SPECIES_TESHARI = 'icons/mob/species/teshari/teshari_hood.dmi'
+	)
 	icon = 'icons/mob/species/teshari/teshari_hood.dmi'
 	icon_state = "tesh_hcloak_bo"
 	item_state_slots = list(slot_r_hand_str = "tesh_hcloak_bo", slot_l_hand_str = "tesh_hcloak_bo")
@@ -335,9 +329,11 @@
 	allowed = list (/obj/item/pen, /obj/item/paper, /obj/item/flashlight,/obj/item/tank/emergency/oxygen, /obj/item/storage/fancy/cigarettes, /obj/item/storage/box/matches, /obj/item/reagent_containers/food/drinks/flask)
 
 /obj/item/clothing/head/tesh_hood
-	name = "Cloak Hood"
+	name = "cloak hood"
 	desc = "A hood attached to a teshari cloak."
-	icon_override = 'icons/mob/species/teshari/teshari_hood.dmi'
+	sprite_sheets = list(
+		SPECIES_TESHARI = 'icons/mob/species/teshari/teshari_hood.dmi'
+	)
 	icon = 'icons/mob/species/teshari/teshari_hood.dmi'
 	icon_state = "tesh_hood_bo"
 	item_state_slots = list(slot_r_hand_str = "tesh_hood_bo", slot_l_hand_str = "tesh_hood_bo")
@@ -625,7 +621,9 @@
 	name = "belted cloak"
 	desc = "A more ridged and stylized Teshari cloak."
 	icon = 'icons/mob/species/teshari/teshari_cloak.dmi'
-	icon_override = 'icons/mob/species/teshari/teshari_cloak.dmi'
+	sprite_sheets = list(
+		SPECIES_TESHARI = 'icons/mob/species/teshari/teshari_cloak.dmi'
+	)
 	icon_state = "tesh_beltcloak_bo"
 	item_state = "tesh_beltcloak_bo"
 	species_restricted = list(SPECIES_TESHARI)
@@ -759,7 +757,9 @@
 //Belted job cloaks
 /obj/item/clothing/suit/storage/teshari/beltcloak/jobs
 	icon = 'icons/mob/species/teshari/deptcloak.dmi'
-	icon_override = 'icons/mob/species/teshari/deptcloak.dmi'
+	sprite_sheets = list(
+		SPECIES_TESHARI = 'icons/mob/species/teshari/deptcloak.dmi'
+	)
 
 /obj/item/clothing/suit/storage/teshari/beltcloak/jobs/cargo
 	name = "cargo belted cloak"

--- a/code/modules/clothing/suits/utility.dm
+++ b/code/modules/clothing/suits/utility.dm
@@ -101,7 +101,9 @@
 	name = "Small radiation suit"
 	desc = "A specialist suit that protects against radiation, designed specifically for use by Teshari. Made to order by Aether."
 	icon = 'icons/obj/clothing/species/teshari/suits.dmi'
-	icon_override = 'icons/mob/species/teshari/suit.dmi'
+	sprite_sheets = list(
+		SPECIES_TESHARI = 'icons/mob/species/teshari/suit.dmi'
+	)
 	icon_state = "rad_fitted"
 	species_restricted = list(SPECIES_TESHARI)
 
@@ -109,6 +111,8 @@
 	name = "Small radiation hood"
 	desc = "A specialist hood with radiation protective properties, designed specifically for use by Teshari. Made to order by Aether."
 	icon = 'icons/obj/clothing/species/teshari/hats.dmi'
-	icon_override = 'icons/mob/species/teshari/head.dmi'
+	sprite_sheets = list(
+		SPECIES_TESHARI = 'icons/mob/species/teshari/head.dmi'
+	)
 	icon_state = "rad_fitted"
 	species_restricted = list(SPECIES_TESHARI)

--- a/code/modules/clothing/under/accessories/clothing.dm
+++ b/code/modules/clothing/under/accessories/clothing.dm
@@ -67,9 +67,7 @@
 	..()
 	var/mob/living/carbon/human/H = loc
 	if(istype(H) && H.wear_suit == src)
-		if(H.species.name == SPECIES_TESHARI)
-			icon_override = LAZYACCESS(sprite_sheets, SPECIES_TESHARI)
-		else if(icon_override_state)
+		if(icon_override_state)
 			icon_override = icon_override_state
 		else
 			icon_override = initial(icon_override)
@@ -85,10 +83,6 @@
 	. = ..()
 	if(icon_override_state)
 		icon_override = icon_override_state
-	else if(ishuman(user))
-		var/mob/living/carbon/human/H = user
-		if(H.species.name == SPECIES_TESHARI)
-			icon_override = LAZYACCESS(sprite_sheets, SPECIES_TESHARI)
 	else
 		icon_override = initial(icon_override)
 

--- a/code/modules/clothing/under/xenos/teshari.dm
+++ b/code/modules/clothing/under/xenos/teshari.dm
@@ -135,7 +135,9 @@
 	name = "Undercoat"
 	desc =  "Teshari traditional garb, with a modern twist! Made of nanofibres to make it light and billowy, perfect for going fast and stylishly!"
 	icon = 'icons/mob/species/teshari/teshari_uniform.dmi'
-	icon_override = 'icons/mob/species/teshari/teshari_uniform.dmi'
+	sprite_sheets = list(
+		SPECIES_TESHARI = 'icons/mob/species/teshari/teshari_uniform.dmi'
+	)
 	icon_state = "tesh_uniform_bo"
 	item_state = "tesh_uniform_bo"
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO
@@ -259,7 +261,9 @@
 
 /obj/item/clothing/under/teshari/undercoat/jobs
 	icon = 'icons/mob/species/teshari/deptjacket.dmi'
-	icon_override = 'icons/mob/species/teshari/deptjacket.dmi'
+	sprite_sheets = list(
+		SPECIES_TESHARI = 'icons/mob/species/teshari/deptjacket.dmi'
+	)
 
 /obj/item/clothing/under/teshari/undercoat/jobs/cap
 	name = "facility director undercoat"


### PR DESCRIPTION
If anyone on Virgo has any context for why these weird Teshari-specific overrides in place for kits/cloaks, please let me know. `icon_override` was not meant to be used for this kind of thing generally.