### PR TITLE
Faction Update

### DIFF
--- a/code/modules/client/preference_setup/general/05_background.dm
+++ b/code/modules/client/preference_setup/general/05_background.dm
@@ -24,7 +24,7 @@
 
 /datum/category_item/player_setup_item/general/background/sanitize_character()
 	if(!pref.home_system) pref.home_system = "Unset"
-	if(!pref.citizenship) pref.citizenship = "Sol Confederate Government"
+	if(!pref.citizenship) pref.citizenship = "Solar Confederate Government"
 	if(!pref.faction)     pref.faction =     "NanoTrasen"
 	if(!pref.religion)    pref.religion =    "None"
 

--- a/code/modules/client/preference_setup/general/05_background.dm
+++ b/code/modules/client/preference_setup/general/05_background.dm
@@ -24,8 +24,8 @@
 
 /datum/category_item/player_setup_item/general/background/sanitize_character()
 	if(!pref.home_system) pref.home_system = "Unset"
-	if(!pref.citizenship) pref.citizenship = "None"
-	if(!pref.faction)     pref.faction =     "None"
+	if(!pref.citizenship) pref.citizenship = "Sol Confederate Government"
+	if(!pref.faction)     pref.faction =     "NanoTrasen"
 	if(!pref.religion)    pref.religion =    "None"
 
 	pref.economic_status = sanitize_inlist(pref.economic_status, ECONOMIC_CLASS, initial(pref.economic_status))

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -73,7 +73,7 @@ var/global/list/preferences_datums = list()
 
 		//Some faction information.
 	var/home_system = "Unset"           //System of birth.
-	var/citizenship = "Sol Confederate Government"            //Nation of citizenship
+	var/citizenship = "Solar Confederate Government"            //Nation of citizenship
 	var/faction = "NanoTrasen"                //General associated faction.
 	var/religion = "None"               //Religious association.
 	var/antag_faction = "None"			//Antag associated faction.

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -73,8 +73,8 @@ var/global/list/preferences_datums = list()
 
 		//Some faction information.
 	var/home_system = "Unset"           //System of birth.
-	var/citizenship = "None"            //Current home system.
-	var/faction = "None"                //General associated faction.
+	var/citizenship = "Sol Confederate Government"            //Nation of citizenship
+	var/faction = "NanoTrasen"                //General associated faction.
 	var/religion = "None"               //Religious association.
 	var/antag_faction = "None"			//Antag associated faction.
 	var/antag_vis = "Hidden"			//How visible antag association is to others.

--- a/code/modules/client/preferences_factions.dm
+++ b/code/modules/client/preferences_factions.dm
@@ -51,7 +51,11 @@ var/global/list/faction_choices = list(
 	"Zeng-Hu Pharmaceuticals",
 	"Hephaestus Industries",
 	"Morpheus Cyberkinetics",
-	"Xion Manufacturing Group"
+	"Xion Manufacturing Group",
+	"Hedberg-Hammarstrom",
+	"Kaleidoscope Cosmetics",
+	"Stealth Assault Enterprises",
+	"Proxima Centauri Risk Control",
 	)
 
 var/global/list/antag_faction_choices = list(

--- a/code/modules/client/preferences_factions.dm
+++ b/code/modules/client/preferences_factions.dm
@@ -55,7 +55,7 @@ var/global/list/faction_choices = list(
 	"Hedberg-Hammarstrom",
 	"Kaleidoscope Cosmetics",
 	"Stealth Assault Enterprises",
-	"Proxima Centauri Risk Control",
+	"Proxima Centauri Risk Control"
 	)
 
 var/global/list/antag_faction_choices = list(
@@ -92,7 +92,7 @@ var/global/list/religion_choices = list(
 	"Nock",
 	"Starlit Path",
 	"Singulitarian Worship",
-	"The Unity,"
+	"The Unity",
 	"Xilar Qall",
 	"Tajr-kii Rarkajar",
 	"Agnosticism",

--- a/code/modules/client/preferences_factions.dm
+++ b/code/modules/client/preferences_factions.dm
@@ -14,23 +14,28 @@ var/global/list/seen_religions = list()
 	return
 
 var/global/list/citizenship_choices = list(
-	"Earth",
-	"Mars",
-	"Sif",
-	"Binma",
-	"Moghes",
-	"Meralar",
-	"Qerr'balak"
+	"Solar Confederate Government",
+	"Almach Protectorate",
+	"Five Arrows",
+	"Pearlshield Coalition",
+	"Moghes Hegemony",
+	"Skrellian Kingdoms",
+	"Stateless" //Sol might automatically cover stateless humans/maybe posis but this is probably common for teshari/zaddat and ubiqtuous for drones
 	)
 
 var/global/list/home_system_choices = list(
 	"Sol",
 	"Vir",
-	"Nyx",
+	"Alpha Centauri",
 	"Tau Ceti",
+	"El",
+	"New Seoul",
+	"Relan",
+	"Vounna",
 	"Qerr'valis",
-	"Epsilon Ursae Minoris",
-	"Rarkajar"
+	"Rarkajar",
+	"Uueoa-Esa",
+	"Spacer"
 	)
 
 var/global/list/faction_choices = list(
@@ -71,7 +76,9 @@ var/global/list/religion_choices = list(
 	"Kishari Faith",
 	"Hauler Faith",
 	"Nock",
+	"Starlit Path",
 	"Singulitarian Worship",
+	"The Unity,"
 	"Xilar Qall",
 	"Tajr-kii Rarkajar",
 	"Agnosticism",

--- a/code/modules/client/preferences_factions.dm
+++ b/code/modules/client/preferences_factions.dm
@@ -54,7 +54,17 @@ var/global/list/faction_choices = list(
 	"Xion Manufacturing Group"
 	)
 
-var/global/list/antag_faction_choices = list()	//Should be populated after brainstorming. Leaving as blank in case brainstorming does not occur.
+var/global/list/antag_faction_choices = list(
+	"Nos Amis",
+	"Russian Mafia",
+	"Sampatti",
+	"Xin Cohong",
+	"Golden Tiger Syndicate",
+	"Jaguar Gang",
+	"Revolutionary Solar People's Party",
+	"Vystholm",
+	"Qerr-Glia"
+	)
 
 var/global/list/antag_visiblity_choices = list(
 	"Hidden",


### PR DESCRIPTION
- Citizenship now points at what country you hold citizenship in. Default is SCG.
- Home System updated to include major human population  / cultural centers. I resisted the mighty urge to add Zhu Que. EUM removed because nobody is actually from there.
- Some "new" corporations from the brainstorming session like 6 years ago added to factions, a selector whose very existence I continue to protest. Default faction is now NT.
- Starlit Path and the Unity added to religion selector.
- "Antag Factions" populated with our list of criminals + Vystholm. Resisted the urge to add foreign governments and shady state departments despite many characters covertly working for them.

Changes to the default or the selector list will not impact existing character slots. 