### PR TITLE
Plains POI - Rest Stop

### DIFF
--- a/maps/submaps/surface_submaps/plains/plains.dm
+++ b/maps/submaps/surface_submaps/plains/plains.dm
@@ -288,3 +288,9 @@
 	desc = "A temporarily abandoned VR den, still functional."
 	mappath = 'maps/submaps/surface_submaps/plains/VRDen.dmm'
 	cost = 10
+
+/datum/map_template/surface/reststop
+	name = "Rest Stop"
+	desc = "Once this place was a nice spot to take a load off, now the wildlife call it home."
+	mappath = 'maps/submaps/cave_submaps/reststop.dmm'
+	cost = 20

--- a/maps/submaps/surface_submaps/plains/plains.dm
+++ b/maps/submaps/surface_submaps/plains/plains.dm
@@ -292,5 +292,5 @@
 /datum/map_template/surface/reststop
 	name = "Rest Stop"
 	desc = "Once this place was a nice spot to take a load off, now the wildlife call it home."
-	mappath = 'maps/submaps/cave_submaps/reststop.dmm'
+	mappath = 'maps/submaps/surface_submaps/plains/reststop.dmm'
 	cost = 15

--- a/maps/submaps/surface_submaps/plains/plains.dm
+++ b/maps/submaps/surface_submaps/plains/plains.dm
@@ -293,4 +293,4 @@
 	name = "Rest Stop"
 	desc = "Once this place was a nice spot to take a load off, now the wildlife call it home."
 	mappath = 'maps/submaps/cave_submaps/reststop.dmm'
-	cost = 20
+	cost = 15

--- a/maps/submaps/surface_submaps/plains/plains_areas.dm
+++ b/maps/submaps/surface_submaps/plains/plains_areas.dm
@@ -134,3 +134,7 @@
 /area/submap/VRDen
 	name = "POI - VR Den"
 	ambience = AMBIENCE_TECH_RUINS
+	
+/area/submap/reststop
+	name = "POI - Rest Stop"
+	ambience = AMBIENCE_SIF

--- a/maps/submaps/surface_submaps/plains/reststop.dmm
+++ b/maps/submaps/surface_submaps/plains/reststop.dmm
@@ -9,6 +9,7 @@
 	},
 /obj/item/flame/lighter/random,
 /obj/item/flame/lighter/random,
+/obj/effect/floor_decal/corner_oldtile/red/diagonal,
 /turf/simulated/floor/tiled/hydro,
 /area/submap/reststop)
 "bs" = (
@@ -16,6 +17,7 @@
 /obj/random/cigarettes,
 /obj/random/cigarettes,
 /obj/machinery/light/small,
+/obj/effect/floor_decal/corner_oldtile/red/diagonal,
 /turf/simulated/floor/tiled/hydro,
 /area/submap/reststop)
 "bv" = (
@@ -25,7 +27,7 @@
 /area/submap/reststop)
 "bw" = (
 /obj/random/junk,
-/turf/simulated/floor/tiled/neutral,
+/turf/simulated/floor/tiled/freezer,
 /area/submap/reststop)
 "bS" = (
 /obj/structure/simple_door/wood,
@@ -42,7 +44,7 @@
 /obj/machinery/door/window/eastleft,
 /obj/structure/table/rack,
 /obj/random/drinksoft,
-/turf/simulated/floor/tiled/neutral,
+/turf/simulated/floor/tiled/freezer,
 /area/submap/reststop)
 "dR" = (
 /obj/structure/flora/grass/green,
@@ -50,7 +52,7 @@
 /area/submap/reststop)
 "ee" = (
 /obj/machinery/door/airlock/maintenance,
-/turf/simulated/floor/tiled/eris/dark/techfloor_grid,
+/turf/simulated/floor/tiled/techmaint,
 /area/submap/reststop)
 "eu" = (
 /obj/item/stack/medical/ointment,
@@ -62,7 +64,7 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/neutral,
+/turf/simulated/floor/tiled/freezer,
 /area/submap/reststop)
 "fO" = (
 /obj/machinery/light{
@@ -73,7 +75,7 @@
 /area/submap/reststop)
 "fS" = (
 /obj/machinery/door/airlock/freezer,
-/turf/simulated/floor/tiled/neutral,
+/turf/simulated/floor/tiled/freezer,
 /area/submap/reststop)
 "io" = (
 /obj/structure/table/standard,
@@ -81,11 +83,14 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/eris/dark/techfloor_grid,
+/obj/item/frame/apc,
+/obj/item/module/power_control,
+/turf/simulated/floor/tiled/techmaint,
 /area/submap/reststop)
 "iR" = (
 /obj/structure/table/standard,
 /obj/random/cigarettes,
+/obj/effect/floor_decal/corner_oldtile/red/diagonal,
 /turf/simulated/floor/tiled/hydro,
 /area/submap/reststop)
 "iU" = (
@@ -153,7 +158,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/neutral,
+/turf/simulated/floor/tiled/freezer,
 /area/submap/reststop)
 "qj" = (
 /obj/structure/curtain/open/shower,
@@ -170,7 +175,7 @@
 /area/submap/reststop)
 "qv" = (
 /obj/machinery/door/airlock/freezer,
-/turf/simulated/floor/tiled/eris/dark/techfloor_grid,
+/turf/simulated/floor/tiled/techmaint,
 /area/submap/reststop)
 "qz" = (
 /obj/machinery/power/port_gen/pacman,
@@ -178,7 +183,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/turf/simulated/floor/tiled/eris/dark/techfloor_grid,
+/turf/simulated/floor/tiled/techmaint,
 /area/submap/reststop)
 "qI" = (
 /obj/effect/floor_decal/rust,
@@ -192,7 +197,7 @@
 "uh" = (
 /obj/machinery/door/window/eastleft,
 /obj/structure/table/rack,
-/turf/simulated/floor/tiled/neutral,
+/turf/simulated/floor/tiled/freezer,
 /area/submap/reststop)
 "vf" = (
 /obj/machinery/light{
@@ -204,18 +209,19 @@
 /area/submap/reststop)
 "wj" = (
 /obj/random/vendorfood,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark,
 /area/submap/reststop)
 "yz" = (
 /obj/structure/table/standard,
 /obj/structure/window/reinforced{
 	dir = 1
 	},
+/obj/effect/floor_decal/corner_oldtile/red/diagonal,
 /turf/simulated/floor/tiled/hydro,
 /area/submap/reststop)
 "zD" = (
 /obj/structure/reagent_dispensers/coolanttank,
-/turf/simulated/floor/tiled/neutral,
+/turf/simulated/floor/tiled/freezer,
 /area/submap/reststop)
 "Ab" = (
 /obj/random/powercell,
@@ -242,11 +248,10 @@
 /obj/structure/window/basic,
 /obj/structure/table/standard,
 /obj/item/toy/plushie/marble_fox,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark,
 /area/submap/reststop)
 "Cy" = (
 /obj/structure/table/rack/shelf,
-/obj/random/maintenance/clean,
 /turf/simulated/floor/tiled,
 /area/submap/reststop)
 "Ei" = (
@@ -256,6 +261,7 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
+/obj/effect/floor_decal/corner_oldtile/red/diagonal,
 /turf/simulated/floor/tiled/hydro,
 /area/submap/reststop)
 "Ej" = (
@@ -269,6 +275,7 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
+/obj/effect/floor_decal/corner_oldtile/red/diagonal,
 /turf/simulated/floor/tiled/hydro,
 /area/submap/reststop)
 "ED" = (
@@ -276,11 +283,15 @@
 /obj/structure/window/reinforced/full,
 /turf/simulated/floor,
 /area/submap/reststop)
+"Ff" = (
+/turf/simulated/floor/tiled/freezer,
+/area/submap/reststop)
 "FJ" = (
 /mob/living/simple_mob/animal/passive/hare,
-/turf/simulated/floor/outdoors/dirt/sif,
+/turf/simulated/floor/tiled,
 /area/submap/reststop)
 "FM" = (
+/obj/effect/floor_decal/corner_oldtile/red/diagonal,
 /turf/simulated/floor/tiled/hydro,
 /area/submap/reststop)
 "FP" = (
@@ -295,6 +306,7 @@
 "Gf" = (
 /obj/structure/table/standard,
 /obj/random/drinkbottle,
+/obj/effect/floor_decal/corner_oldtile/red/diagonal,
 /turf/simulated/floor/tiled/hydro,
 /area/submap/reststop)
 "GS" = (
@@ -303,18 +315,19 @@
 /area/submap/reststop)
 "Hj" = (
 /obj/structure/table/standard,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark,
 /area/submap/reststop)
 "IF" = (
 /obj/machinery/door/window/eastleft,
 /obj/structure/table/rack,
 /obj/random/snack,
-/turf/simulated/floor/tiled/neutral,
+/turf/simulated/floor/tiled/freezer,
 /area/submap/reststop)
 "IQ" = (
 /obj/structure/table/standard,
 /obj/machinery/cash_register,
 /obj/machinery/door/window/northleft,
+/obj/effect/floor_decal/corner_oldtile/red/diagonal,
 /turf/simulated/floor/tiled/hydro,
 /area/submap/reststop)
 "Jd" = (
@@ -325,18 +338,11 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	nightshift_setting = 2;
-	pixel_y = 24;
-	start_charge = -1
-	},
-/turf/simulated/floor/tiled/eris/dark/techfloor_grid,
+/turf/simulated/floor/tiled/techmaint,
 /area/submap/reststop)
 "KT" = (
 /obj/random/vendordrink,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark,
 /area/submap/reststop)
 "Lz" = (
 /obj/structure/closet/crate/trashcart,
@@ -349,7 +355,7 @@
 /area/submap/reststop)
 "Mh" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/neutral,
+/turf/simulated/floor/tiled/freezer,
 /area/submap/reststop)
 "Na" = (
 /obj/structure/flora/sif/frostbelle,
@@ -357,7 +363,7 @@
 /area/submap/reststop)
 "Oo" = (
 /obj/structure/loot_pile/maint/trash,
-/turf/simulated/floor/tiled/neutral,
+/turf/simulated/floor/tiled/freezer,
 /area/submap/reststop)
 "OM" = (
 /obj/random/soap,
@@ -405,25 +411,26 @@
 /obj/structure/table/standard,
 /obj/random/plushie,
 /obj/random/plushie,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark,
 /area/submap/reststop)
 "WR" = (
 /obj/random/trash,
-/turf/simulated/floor/tiled/eris/dark/techfloor_grid,
+/turf/simulated/floor/tiled/techmaint,
 /area/submap/reststop)
 "Xm" = (
 /obj/structure/table/rack,
 /obj/machinery/door/window/eastleft,
 /obj/random/drinksoft,
-/turf/simulated/floor/tiled/neutral,
+/turf/simulated/floor/tiled/freezer,
 /area/submap/reststop)
 "XM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/assembly/mousetrap/armed,
-/turf/simulated/floor/tiled/neutral,
+/turf/simulated/floor/tiled/freezer,
 /area/submap/reststop)
 "Ym" = (
 /obj/machinery/door/window/westright,
+/obj/effect/floor_decal/corner_oldtile/red/diagonal,
 /turf/simulated/floor/tiled/hydro,
 /area/submap/reststop)
 "Zd" = (
@@ -436,12 +443,10 @@
 /turf/simulated/floor/tiled/neutral,
 /area/submap/reststop)
 "ZE" = (
-/obj/structure/toilet,
 /obj/machinery/light/small{
-	dir = 1
+	dir = 4
 	},
-/obj/random/maintenance,
-/turf/simulated/floor/tiled/neutral,
+/turf/simulated/floor/outdoors/dirt/sif,
 /area/submap/reststop)
 "ZN" = (
 /obj/effect/floor_decal/rust,
@@ -516,7 +521,7 @@ pi
 Jd
 Jd
 Jd
-Jd
+ZE
 Jd
 pi
 pi
@@ -597,13 +602,13 @@ kJ
 qz
 io
 kJ
-bh
+Ff
 bw
 Mh
-bh
-bh
+Ff
+Ff
 Mh
-bh
+Ff
 bw
 kJ
 pi
@@ -625,11 +630,11 @@ Jp
 WR
 qv
 Mh
-bh
-bh
+Ff
+Ff
 bw
-bh
-bh
+Ff
+Ff
 qa
 XM
 kJ
@@ -698,7 +703,7 @@ lh
 pi
 pi
 kJ
-ZE
+cQ
 bS
 bh
 kJ
@@ -729,7 +734,7 @@ kJ
 kJ
 OM
 bS
-iU
+kq
 iU
 iU
 ZN

--- a/maps/submaps/surface_submaps/plains/reststop.dmm
+++ b/maps/submaps/surface_submaps/plains/reststop.dmm
@@ -19,8 +19,8 @@
 /turf/simulated/floor/tiled/hydro,
 /area/submap/reststop)
 "bv" = (
-/obj/structure/table/rack,
 /obj/item/cell/high,
+/obj/structure/table/rack/shelf,
 /turf/simulated/floor/tiled,
 /area/submap/reststop)
 "bw" = (
@@ -53,8 +53,8 @@
 /turf/simulated/floor/tiled/eris/dark/techfloor_grid,
 /area/submap/reststop)
 "eu" = (
-/obj/structure/table/rack,
 /obj/item/stack/medical/ointment,
+/obj/structure/table/rack/shelf,
 /turf/simulated/floor/tiled,
 /area/submap/reststop)
 "fq" = (
@@ -115,8 +115,8 @@
 /turf/simulated/floor/tiled,
 /area/submap/reststop)
 "mS" = (
-/obj/structure/table/rack,
 /obj/item/clothing/suit/storage/hooded/wintercoat,
+/obj/structure/table/rack/shelf,
 /turf/simulated/floor/tiled,
 /area/submap/reststop)
 "nO" = (
@@ -181,8 +181,8 @@
 /turf/simulated/floor/tiled/eris/dark/techfloor_grid,
 /area/submap/reststop)
 "qI" = (
-/obj/structure/table/rack,
 /obj/effect/floor_decal/rust,
+/obj/structure/table/rack/shelf,
 /turf/simulated/floor/tiled,
 /area/submap/reststop)
 "qR" = (
@@ -213,9 +213,13 @@
 	},
 /turf/simulated/floor/tiled/hydro,
 /area/submap/reststop)
+"zD" = (
+/obj/structure/reagent_dispensers/coolanttank,
+/turf/simulated/floor/tiled/neutral,
+/area/submap/reststop)
 "Ab" = (
-/obj/structure/table/rack,
 /obj/random/powercell,
+/obj/structure/table/rack/shelf,
 /turf/simulated/floor/tiled,
 /area/submap/reststop)
 "Aw" = (
@@ -241,7 +245,7 @@
 /turf/simulated/floor/tiled,
 /area/submap/reststop)
 "Cy" = (
-/obj/structure/table/rack,
+/obj/structure/table/rack/shelf,
 /turf/simulated/floor/tiled,
 /area/submap/reststop)
 "Ei" = (
@@ -374,9 +378,13 @@
 	},
 /turf/simulated/floor/tiled/neutral,
 /area/submap/reststop)
+"SF" = (
+/obj/machinery/space_heater,
+/turf/simulated/floor/outdoors/dirt/sif,
+/area/submap/reststop)
 "SH" = (
-/obj/structure/table/rack,
 /obj/random/mre,
+/obj/structure/table/rack/shelf,
 /turf/simulated/floor/tiled,
 /area/submap/reststop)
 "TJ" = (
@@ -385,10 +393,6 @@
 /area/submap/reststop)
 "TK" = (
 /obj/structure/flora/tree/sif,
-/turf/simulated/floor/outdoors/dirt/sif,
-/area/submap/reststop)
-"Uj" = (
-/obj/machinery/space_heater,
 /turf/simulated/floor/outdoors/dirt/sif,
 /area/submap/reststop)
 "UM" = (
@@ -434,9 +438,9 @@
 /turf/simulated/floor/tiled/neutral,
 /area/submap/reststop)
 "ZN" = (
-/obj/structure/table/rack,
 /obj/random/maintenance,
 /obj/effect/floor_decal/rust,
+/obj/structure/table/rack/shelf,
 /turf/simulated/floor/tiled,
 /area/submap/reststop)
 
@@ -566,7 +570,7 @@ fq
 Oo
 Oo
 Oo
-bh
+zD
 kJ
 kJ
 pi
@@ -729,7 +733,7 @@ iU
 fO
 iU
 qR
-Uj
+SF
 kJ
 Ba
 Ba

--- a/maps/submaps/surface_submaps/plains/reststop.dmm
+++ b/maps/submaps/surface_submaps/plains/reststop.dmm
@@ -100,7 +100,7 @@
 /turf/simulated/floor/tiled,
 /area/submap/reststop)
 "kJ" = (
-/turf/simulated/wall/wood,
+/turf/simulated/wall/concrete,
 /area/submap/reststop)
 "kY" = (
 /obj/structure/girder,
@@ -271,7 +271,8 @@
 /turf/simulated/floor/tiled/hydro,
 /area/submap/reststop)
 "ED" = (
-/obj/effect/wingrille_spawn,
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
 /turf/simulated/floor,
 /area/submap/reststop)
 "FJ" = (
@@ -326,7 +327,8 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
-	pixel_y = 24
+	pixel_y = 24;
+	start_charge = 0
 	},
 /turf/simulated/floor/tiled/eris/dark/techfloor_grid,
 /area/submap/reststop)
@@ -380,7 +382,7 @@
 /area/submap/reststop)
 "SF" = (
 /obj/machinery/space_heater,
-/turf/simulated/floor/outdoors/dirt/sif,
+/turf/simulated/floor/tiled,
 /area/submap/reststop)
 "SH" = (
 /obj/random/mre,
@@ -434,7 +436,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/random/plushie,
+/obj/random/maintenance,
 /turf/simulated/floor/tiled/neutral,
 /area/submap/reststop)
 "ZN" = (
@@ -692,7 +694,7 @@ lh
 pi
 pi
 kJ
-cQ
+ZE
 bS
 bh
 kJ
@@ -746,7 +748,7 @@ lh
 pi
 pi
 kJ
-ZE
+cQ
 bS
 bh
 kJ

--- a/maps/submaps/surface_submaps/plains/reststop.dmm
+++ b/maps/submaps/surface_submaps/plains/reststop.dmm
@@ -246,6 +246,7 @@
 /area/submap/reststop)
 "Cy" = (
 /obj/structure/table/rack/shelf,
+/obj/random/maintenance/clean,
 /turf/simulated/floor/tiled,
 /area/submap/reststop)
 "Ei" = (
@@ -327,8 +328,9 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
+	nightshift_setting = 2;
 	pixel_y = 24;
-	start_charge = 0
+	start_charge = -1
 	},
 /turf/simulated/floor/tiled/eris/dark/techfloor_grid,
 /area/submap/reststop)
@@ -341,7 +343,8 @@
 /obj/random/trash,
 /obj/random/trash,
 /obj/random/trash,
-/obj/random/maintenance/clean,
+/obj/random/junk,
+/obj/random/junk,
 /turf/simulated/floor/outdoors/dirt/sif,
 /area/submap/reststop)
 "Mh" = (
@@ -401,6 +404,7 @@
 /obj/structure/window/basic,
 /obj/structure/table/standard,
 /obj/random/plushie,
+/obj/random/plushie,
 /turf/simulated/floor/tiled,
 /area/submap/reststop)
 "WR" = (
@@ -440,9 +444,9 @@
 /turf/simulated/floor/tiled/neutral,
 /area/submap/reststop)
 "ZN" = (
-/obj/random/maintenance,
 /obj/effect/floor_decal/rust,
 /obj/structure/table/rack/shelf,
+/obj/random/maintenance/clean,
 /turf/simulated/floor/tiled,
 /area/submap/reststop)
 
@@ -623,7 +627,7 @@ qv
 Mh
 bh
 bh
-bh
+bw
 bh
 bh
 qa
@@ -836,7 +840,7 @@ kJ
 kJ
 UM
 iU
-iU
+qq
 iU
 kq
 iU

--- a/maps/submaps/surface_submaps/plains/reststop.dmm
+++ b/maps/submaps/surface_submaps/plains/reststop.dmm
@@ -1,0 +1,109 @@
+"bq" = (/obj/structure/toilet,/obj/machinery/light/small{dir = 1},/obj/random/plushie,/turf/simulated/floor/tiled/neutral,/area/submap/reststop)
+"bC" = (/obj/structure/girder,/turf/simulated/floor,/area/submap/reststop)
+"bN" = (/obj/random/soap,/turf/simulated/floor/tiled/neutral,/area/submap/reststop)
+"cq" = (/obj/machinery/light/small{dir = 8},/turf/simulated/floor/tiled/neutral,/area/submap/reststop)
+"ct" = (/obj/machinery/door/window/eastleft,/obj/structure/table/rack,/obj/random/drinksoft,/turf/simulated/floor/tiled/neutral,/area/submap/reststop)
+"cZ" = (/obj/item/material/shard,/turf/simulated/floor/tiled,/area/submap/reststop)
+"dq" = (/obj/structure/table/rack,/obj/random/maintenance,/obj/effect/floor_decal/rust,/turf/simulated/floor/tiled,/area/submap/reststop)
+"dv" = (/obj/structure/loot_pile/maint/junk,/turf/simulated/floor/outdoors/dirt/sif,/area/submap/reststop)
+"em" = (/obj/structure/table/rack,/obj/random/powercell,/turf/simulated/floor/tiled,/area/submap/reststop)
+"fh" = (/obj/structure/flora/tree/sif,/turf/template_noop,/area/submap/reststop)
+"fJ" = (/obj/machinery/light{dir = 8; icon_state = "tube1"; pixel_y = 0},/turf/simulated/floor/tiled,/area/submap/reststop)
+"gQ" = (/obj/random/junk,/turf/simulated/floor/tiled/neutral,/area/submap/reststop)
+"gV" = (/obj/structure/toilet,/obj/machinery/light/small{dir = 1},/turf/simulated/floor/tiled/neutral,/area/submap/reststop)
+"hd" = (/obj/structure/sink{dir = 4; icon_state = "sink"; pixel_x = 11; pixel_y = 0},/turf/simulated/floor/tiled/neutral,/area/submap/reststop)
+"iO" = (/obj/machinery/power/port_gen/pacman,/obj/structure/cable{d2 = 4; icon_state = "0-4"},/turf/simulated/floor/tiled/eris/dark/techfloor_grid,/area/submap/reststop)
+"iV" = (/obj/structure/sink{dir = 8; icon_state = "sink"; pixel_x = -12; pixel_y = 2},/turf/simulated/floor/tiled/neutral,/area/submap/reststop)
+"jb" = (/obj/structure/flora/grass/green,/turf/template_noop,/area/submap/reststop)
+"ka" = (/obj/structure/table/rack,/obj/item/cell/high,/turf/simulated/floor/tiled,/area/submap/reststop)
+"kM" = (/obj/structure/window/reinforced{dir = 8},/turf/simulated/floor/tiled/hydro,/area/submap/reststop)
+"kZ" = (/obj/structure/table/standard,/obj/structure/window/reinforced{dir = 1},/turf/simulated/floor/tiled/hydro,/area/submap/reststop)
+"lc" = (/obj/machinery/light{dir = 4; icon_state = "tube1"},/turf/simulated/floor/tiled,/area/submap/reststop)
+"lk" = (/obj/machinery/light/small{dir = 8},/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/tiled/neutral,/area/submap/reststop)
+"nd" = (/turf/simulated/floor/tiled/hydro,/area/submap/reststop)
+"nj" = (/obj/machinery/door/window/eastleft,/obj/structure/table/rack,/obj/random/snack,/turf/simulated/floor/tiled/neutral,/area/submap/reststop)
+"nS" = (/obj/structure/window/basic{dir = 8; layer = 2.8},/obj/structure/window/basic,/obj/structure/table/standard,/obj/item/toy/plushie/marble_fox,/turf/simulated/floor/tiled,/area/submap/reststop)
+"pv" = (/obj/structure/table/rack,/obj/item/clothing/suit/storage/hooded/wintercoat/parka/green,/turf/simulated/floor/tiled,/area/submap/reststop)
+"qm" = (/obj/structure/toilet,/obj/random/contraband,/obj/machinery/light/small{dir = 1},/turf/simulated/floor/tiled/neutral,/area/submap/reststop)
+"qC" = (/obj/structure/window/basic,/obj/structure/table/standard,/obj/random/plushie,/turf/simulated/floor/tiled,/area/submap/reststop)
+"sz" = (/obj/structure/table/standard,/obj/structure/flora/pottedplant,/obj/item/gun/projectile/revolver/webley,/obj/structure/window/reinforced{dir = 1},/turf/simulated/floor/tiled/hydro,/area/submap/reststop)
+"sB" = (/obj/effect/floor_decal/rust,/turf/simulated/floor/tiled,/area/submap/reststop)
+"tW" = (/obj/random/mob/mouse,/turf/simulated/floor/outdoors/dirt/sif,/area/submap/reststop)
+"uv" = (/turf/simulated/wall/wood,/area/submap/reststop)
+"uy" = (/obj/structure/curtain/open/shower,/obj/machinery/shower{dir = 8; pixel_x = -5; pixel_y = -1},/obj/item/towel/random,/turf/simulated/floor/tiled/neutral,/area/submap/reststop)
+"vT" = (/obj/machinery/door/airlock/glass,/turf/simulated/floor/tiled,/area/submap/reststop)
+"wj" = (/obj/machinery/door/window/eastleft,/obj/structure/table/rack,/turf/simulated/floor/tiled/neutral,/area/submap/reststop)
+"wN" = (/obj/structure/table/standard,/obj/random/cigarettes,/turf/simulated/floor/tiled/hydro,/area/submap/reststop)
+"xb" = (/obj/random/vendordrink,/turf/simulated/floor/tiled,/area/submap/reststop)
+"xL" = (/obj/structure/table/rack,/obj/item/stack/medical/ointment,/turf/simulated/floor/tiled,/area/submap/reststop)
+"yj" = (/obj/random/vendorfood,/turf/simulated/floor/tiled,/area/submap/reststop)
+"yq" = (/obj/structure/loot_pile/maint/trash,/turf/simulated/floor/tiled/neutral,/area/submap/reststop)
+"zW" = (/obj/structure/table/rack,/turf/simulated/floor/tiled,/area/submap/reststop)
+"Ap" = (/obj/effect/decal/cleanable/dirt,/obj/effect/floor_decal/rust,/turf/simulated/floor/tiled,/area/submap/reststop)
+"BH" = (/obj/structure/table/standard,/turf/simulated/floor/tiled,/area/submap/reststop)
+"Ce" = (/turf/template_noop,/area/submap/reststop)
+"Ch" = (/obj/structure/flora/tree/sif,/turf/simulated/floor/outdoors/dirt/sif,/area/submap/reststop)
+"CE" = (/obj/machinery/door/airlock/freezer,/turf/simulated/floor/tiled/eris/dark/techfloor_grid,/area/submap/reststop)
+"CY" = (/obj/machinery/light{dir = 4},/obj/random/junk,/turf/simulated/floor/tiled,/area/submap/reststop)
+"Dh" = (/obj/structure/table/standard,/obj/random/tech_supply/nofail,/obj/machinery/light/small{dir = 8},/turf/simulated/floor/tiled/eris/dark/techfloor_grid,/area/submap/reststop)
+"Ey" = (/obj/structure/table/standard,/obj/structure/window/reinforced{dir = 1},/obj/item/flame/lighter/random,/obj/item/flame/lighter/random,/turf/simulated/floor/tiled/hydro,/area/submap/reststop)
+"ED" = (/obj/structure/closet/crate/trashcart,/obj/random/trash,/obj/random/trash,/obj/random/trash,/obj/random/maintenance/clean,/turf/simulated/floor/outdoors/dirt/sif,/area/submap/reststop)
+"EV" = (/obj/machinery/door/airlock/maintenance,/turf/simulated/floor/tiled/neutral,/area/submap/reststop)
+"Gq" = (/obj/structure/animal_den,/turf/simulated/floor/outdoors/grass/sif,/area/submap/reststop)
+"GF" = (/obj/machinery/light/small{dir = 4},/turf/simulated/floor/tiled/neutral,/area/submap/reststop)
+"GZ" = (/obj/structure/table/standard,/obj/random/cigarettes,/obj/random/cigarettes,/obj/machinery/light/small,/turf/simulated/floor/tiled/hydro,/area/submap/reststop)
+"HM" = (/obj/effect/floor_decal/rust,/obj/structure/girder/displaced,/turf/simulated/floor/plating/sif/planetuse,/area/submap/reststop)
+"It" = (/obj/machinery/door/airlock/maintenance,/turf/simulated/floor/tiled/eris/dark/techfloor_grid,/area/submap/reststop)
+"IP" = (/turf/simulated/floor/outdoors/grass/sif,/area/submap/reststop)
+"Jd" = (/obj/structure/table/rack,/obj/random/mre,/turf/simulated/floor/tiled,/area/submap/reststop)
+"Kp" = (/obj/random/junk,/obj/machinery/light/small{dir = 4},/turf/simulated/floor/tiled/neutral,/area/submap/reststop)
+"LB" = (/obj/structure/cable{d2 = 8; icon_state = "0-8"},/obj/machinery/power/apc{dir = 1; name = "north bump"; pixel_y = 24},/turf/simulated/floor/tiled/eris/dark/techfloor_grid,/area/submap/reststop)
+"Ma" = (/obj/structure/table/rack,/obj/machinery/door/window/eastleft,/obj/random/drinksoft,/turf/simulated/floor/tiled/neutral,/area/submap/reststop)
+"Mi" = (/obj/structure/curtain/open/shower,/obj/machinery/shower{dir = 4; pixel_x = 5; pixel_y = -1},/turf/simulated/floor/tiled/neutral,/area/submap/reststop)
+"Oh" = (/obj/structure/table/standard,/obj/machinery/cash_register,/obj/machinery/door/window/northleft,/turf/simulated/floor/tiled/hydro,/area/submap/reststop)
+"OO" = (/obj/random/trash,/turf/simulated/floor/tiled/eris/dark/techfloor_grid,/area/submap/reststop)
+"Pm" = (/turf/template_noop,/area/template_noop)
+"QN" = (/turf/simulated/floor/tiled/neutral,/area/submap/reststop)
+"Rs" = (/obj/effect/decal/cleanable/dirt,/obj/item/assembly/mousetrap/armed,/turf/simulated/floor/tiled/neutral,/area/submap/reststop)
+"RC" = (/obj/random/trash,/turf/simulated/floor/tiled,/area/submap/reststop)
+"UJ" = (/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/tiled/neutral,/area/submap/reststop)
+"Vj" = (/obj/machinery/door/window/westright,/turf/simulated/floor/tiled/hydro,/area/submap/reststop)
+"WS" = (/obj/machinery/door/airlock/freezer,/turf/simulated/floor/tiled/neutral,/area/submap/reststop)
+"Xi" = (/obj/structure/table/rack,/obj/effect/floor_decal/rust,/turf/simulated/floor/tiled,/area/submap/reststop)
+"Xz" = (/obj/structure/simple_door/wood,/turf/simulated/floor/tiled/neutral,/area/submap/reststop)
+"XD" = (/obj/structure/flora/sif/frostbelle,/turf/simulated/floor/outdoors/grass/sif,/area/submap/reststop)
+"XF" = (/turf/simulated/floor/tiled,/area/submap/reststop)
+"Yh" = (/obj/effect/wingrille_spawn,/turf/simulated/floor,/area/submap/reststop)
+"Yr" = (/obj/random/junk,/turf/simulated/floor/tiled,/area/submap/reststop)
+"YB" = (/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/tiled,/area/submap/reststop)
+"Zc" = (/turf/simulated/floor/outdoors/dirt/sif,/area/submap/reststop)
+"Zm" = (/obj/structure/table/standard,/obj/random/drinkbottle,/turf/simulated/floor/tiled/hydro,/area/submap/reststop)
+"ZO" = (/obj/structure/flora/grass/both,/turf/template_noop,/area/submap/reststop)
+
+(1,1,1) = {"
+PmPmPmPmPmPmPmPmPmPmPmPmPmPmPmPmPmPmPmPmPmPmPmPmPm
+PmCeCeCeCeCeCeCeCeCeCeCeCeCeCeCeCeCeCeCeZcCeCeCePm
+PmCeCefhCeCeCeCeCeCeCeCeCeCeCeCeCeCeCeCeZcCeCeCePm
+PmCeCeCeCeCeCeCeuvuvuvuvuvuvuvCeCeCeCeCeCeCeCeCePm
+PmCeCeCeCeuvuvuvuvgVuvbquvqmuvCeCeCeCeZcCeCeCeCePm
+PmCeCeCeCeuvMiuyuvXzuvXzuvXzuvCefhCeZcCeCeCeCeCePm
+PmCeCeCeCeuvcqQNQNQNbNQNQNGFuvCeCeCeCeCeCeCeCeCePm
+PmCeCeZcuvuvuvuvuvuvXzuviVhduvCeCeCeZOCeZcCeCeCePm
+PmCeZcdvuviOLBuvxbyjXFuvuvuvuvuvCeCeCeZcCeCeCeCePm
+PmCeZcEDuvDhOOItXFXFXFnSqCBHqCuvuvCeCeZcCeCefhCePm
+PmCeZcdvuvuvCEuvfJRCXFXFXFcZXFCYuvCeCeZcZcCeCeCePm
+PmZcZcuvuvQNUJuvXFsBdqpvemzWXFXFYhCeZcZcZcCeCeCePm
+PmCeZcEVUJgQQNnjsBIPChsBXFXFXFYBvTZcZcZcZcCeCeCePm
+PmCeCeuvlkUJQNwjsBGqXikaJdxLYBXFvTZcZcZcZcZcCeCePm
+PmCeCeuvyqQNQNnjtWsBXFXFXFXFXFRCYhCeZcZcZcZcCeCePm
+PmCeCeuvyqQNQNctsBXFlcuvszOhkZEyuvCeZcZcZcZcCeCePm
+PmCeCeuvyqUJQNMaXFYrXFkMndndndnduvCeZcZcZcZcCeCePm
+PmCeCeuvQNQNKpuvfJXFsBVjndndndnduvCeZcZcZcZcCeCePm
+PmCeCeuvuvgQRsWSYBApZckMwNGZZmZmuvCeZcZcZcCejbCePm
+PmCeCeCeuvuvuvuvbCHMuvuvuvuvuvuvuvCeCeZcZcCeCeCePm
+PmCeCeCeCeCeCeIPIPXDIPCeCeCeCeCeCeCeCeZcCeCeCeCePm
+PmCeCefhCeCeCeCeCeIPIPIPCeCeCeCeCeCeZcCeCeCeCeCePm
+PmCeCeCefhCeCeCeCeCeCeCeCeCeCeCefhCeCeCeZcCeCeCePm
+PmCeCeCeCeCeCeCeCeCeCeCeCeCeCeCeCeCeCeCeZcCeCeCePm
+PmPmPmPmPmPmPmPmPmPmPmPmPmPmPmPmPmPmPmPmPmPmPmPmPm
+"}

--- a/maps/submaps/surface_submaps/plains/reststop.dmm
+++ b/maps/submaps/surface_submaps/plains/reststop.dmm
@@ -1,109 +1,1113 @@
-"bq" = (/obj/structure/toilet,/obj/machinery/light/small{dir = 1},/obj/random/plushie,/turf/simulated/floor/tiled/neutral,/area/submap/reststop)
-"bC" = (/obj/structure/girder,/turf/simulated/floor,/area/submap/reststop)
-"bN" = (/obj/random/soap,/turf/simulated/floor/tiled/neutral,/area/submap/reststop)
-"cq" = (/obj/machinery/light/small{dir = 8},/turf/simulated/floor/tiled/neutral,/area/submap/reststop)
-"ct" = (/obj/machinery/door/window/eastleft,/obj/structure/table/rack,/obj/random/drinksoft,/turf/simulated/floor/tiled/neutral,/area/submap/reststop)
-"cZ" = (/obj/item/material/shard,/turf/simulated/floor/tiled,/area/submap/reststop)
-"dq" = (/obj/structure/table/rack,/obj/random/maintenance,/obj/effect/floor_decal/rust,/turf/simulated/floor/tiled,/area/submap/reststop)
-"dv" = (/obj/structure/loot_pile/maint/junk,/turf/simulated/floor/outdoors/dirt/sif,/area/submap/reststop)
-"em" = (/obj/structure/table/rack,/obj/random/powercell,/turf/simulated/floor/tiled,/area/submap/reststop)
-"fh" = (/obj/structure/flora/tree/sif,/turf/template_noop,/area/submap/reststop)
-"fJ" = (/obj/machinery/light{dir = 8; icon_state = "tube1"; pixel_y = 0},/turf/simulated/floor/tiled,/area/submap/reststop)
-"gQ" = (/obj/random/junk,/turf/simulated/floor/tiled/neutral,/area/submap/reststop)
-"gV" = (/obj/structure/toilet,/obj/machinery/light/small{dir = 1},/turf/simulated/floor/tiled/neutral,/area/submap/reststop)
-"hd" = (/obj/structure/sink{dir = 4; icon_state = "sink"; pixel_x = 11; pixel_y = 0},/turf/simulated/floor/tiled/neutral,/area/submap/reststop)
-"iO" = (/obj/machinery/power/port_gen/pacman,/obj/structure/cable{d2 = 4; icon_state = "0-4"},/turf/simulated/floor/tiled/eris/dark/techfloor_grid,/area/submap/reststop)
-"iV" = (/obj/structure/sink{dir = 8; icon_state = "sink"; pixel_x = -12; pixel_y = 2},/turf/simulated/floor/tiled/neutral,/area/submap/reststop)
-"jb" = (/obj/structure/flora/grass/green,/turf/template_noop,/area/submap/reststop)
-"ka" = (/obj/structure/table/rack,/obj/item/cell/high,/turf/simulated/floor/tiled,/area/submap/reststop)
-"kM" = (/obj/structure/window/reinforced{dir = 8},/turf/simulated/floor/tiled/hydro,/area/submap/reststop)
-"kZ" = (/obj/structure/table/standard,/obj/structure/window/reinforced{dir = 1},/turf/simulated/floor/tiled/hydro,/area/submap/reststop)
-"lc" = (/obj/machinery/light{dir = 4; icon_state = "tube1"},/turf/simulated/floor/tiled,/area/submap/reststop)
-"lk" = (/obj/machinery/light/small{dir = 8},/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/tiled/neutral,/area/submap/reststop)
-"nd" = (/turf/simulated/floor/tiled/hydro,/area/submap/reststop)
-"nj" = (/obj/machinery/door/window/eastleft,/obj/structure/table/rack,/obj/random/snack,/turf/simulated/floor/tiled/neutral,/area/submap/reststop)
-"nS" = (/obj/structure/window/basic{dir = 8; layer = 2.8},/obj/structure/window/basic,/obj/structure/table/standard,/obj/item/toy/plushie/marble_fox,/turf/simulated/floor/tiled,/area/submap/reststop)
-"pv" = (/obj/structure/table/rack,/obj/item/clothing/suit/storage/hooded/wintercoat/parka/green,/turf/simulated/floor/tiled,/area/submap/reststop)
-"qm" = (/obj/structure/toilet,/obj/random/contraband,/obj/machinery/light/small{dir = 1},/turf/simulated/floor/tiled/neutral,/area/submap/reststop)
-"qC" = (/obj/structure/window/basic,/obj/structure/table/standard,/obj/random/plushie,/turf/simulated/floor/tiled,/area/submap/reststop)
-"sz" = (/obj/structure/table/standard,/obj/structure/flora/pottedplant,/obj/item/gun/projectile/revolver/webley,/obj/structure/window/reinforced{dir = 1},/turf/simulated/floor/tiled/hydro,/area/submap/reststop)
-"sB" = (/obj/effect/floor_decal/rust,/turf/simulated/floor/tiled,/area/submap/reststop)
-"tW" = (/obj/random/mob/mouse,/turf/simulated/floor/outdoors/dirt/sif,/area/submap/reststop)
-"uv" = (/turf/simulated/wall/wood,/area/submap/reststop)
-"uy" = (/obj/structure/curtain/open/shower,/obj/machinery/shower{dir = 8; pixel_x = -5; pixel_y = -1},/obj/item/towel/random,/turf/simulated/floor/tiled/neutral,/area/submap/reststop)
-"vT" = (/obj/machinery/door/airlock/glass,/turf/simulated/floor/tiled,/area/submap/reststop)
-"wj" = (/obj/machinery/door/window/eastleft,/obj/structure/table/rack,/turf/simulated/floor/tiled/neutral,/area/submap/reststop)
-"wN" = (/obj/structure/table/standard,/obj/random/cigarettes,/turf/simulated/floor/tiled/hydro,/area/submap/reststop)
-"xb" = (/obj/random/vendordrink,/turf/simulated/floor/tiled,/area/submap/reststop)
-"xL" = (/obj/structure/table/rack,/obj/item/stack/medical/ointment,/turf/simulated/floor/tiled,/area/submap/reststop)
-"yj" = (/obj/random/vendorfood,/turf/simulated/floor/tiled,/area/submap/reststop)
-"yq" = (/obj/structure/loot_pile/maint/trash,/turf/simulated/floor/tiled/neutral,/area/submap/reststop)
-"zW" = (/obj/structure/table/rack,/turf/simulated/floor/tiled,/area/submap/reststop)
-"Ap" = (/obj/effect/decal/cleanable/dirt,/obj/effect/floor_decal/rust,/turf/simulated/floor/tiled,/area/submap/reststop)
-"BH" = (/obj/structure/table/standard,/turf/simulated/floor/tiled,/area/submap/reststop)
-"Ce" = (/turf/template_noop,/area/submap/reststop)
-"Ch" = (/obj/structure/flora/tree/sif,/turf/simulated/floor/outdoors/dirt/sif,/area/submap/reststop)
-"CE" = (/obj/machinery/door/airlock/freezer,/turf/simulated/floor/tiled/eris/dark/techfloor_grid,/area/submap/reststop)
-"CY" = (/obj/machinery/light{dir = 4},/obj/random/junk,/turf/simulated/floor/tiled,/area/submap/reststop)
-"Dh" = (/obj/structure/table/standard,/obj/random/tech_supply/nofail,/obj/machinery/light/small{dir = 8},/turf/simulated/floor/tiled/eris/dark/techfloor_grid,/area/submap/reststop)
-"Ey" = (/obj/structure/table/standard,/obj/structure/window/reinforced{dir = 1},/obj/item/flame/lighter/random,/obj/item/flame/lighter/random,/turf/simulated/floor/tiled/hydro,/area/submap/reststop)
-"ED" = (/obj/structure/closet/crate/trashcart,/obj/random/trash,/obj/random/trash,/obj/random/trash,/obj/random/maintenance/clean,/turf/simulated/floor/outdoors/dirt/sif,/area/submap/reststop)
-"EV" = (/obj/machinery/door/airlock/maintenance,/turf/simulated/floor/tiled/neutral,/area/submap/reststop)
-"Gq" = (/obj/structure/animal_den,/turf/simulated/floor/outdoors/grass/sif,/area/submap/reststop)
-"GF" = (/obj/machinery/light/small{dir = 4},/turf/simulated/floor/tiled/neutral,/area/submap/reststop)
-"GZ" = (/obj/structure/table/standard,/obj/random/cigarettes,/obj/random/cigarettes,/obj/machinery/light/small,/turf/simulated/floor/tiled/hydro,/area/submap/reststop)
-"HM" = (/obj/effect/floor_decal/rust,/obj/structure/girder/displaced,/turf/simulated/floor/plating/sif/planetuse,/area/submap/reststop)
-"It" = (/obj/machinery/door/airlock/maintenance,/turf/simulated/floor/tiled/eris/dark/techfloor_grid,/area/submap/reststop)
-"IP" = (/turf/simulated/floor/outdoors/grass/sif,/area/submap/reststop)
-"Jd" = (/obj/structure/table/rack,/obj/random/mre,/turf/simulated/floor/tiled,/area/submap/reststop)
-"Kp" = (/obj/random/junk,/obj/machinery/light/small{dir = 4},/turf/simulated/floor/tiled/neutral,/area/submap/reststop)
-"LB" = (/obj/structure/cable{d2 = 8; icon_state = "0-8"},/obj/machinery/power/apc{dir = 1; name = "north bump"; pixel_y = 24},/turf/simulated/floor/tiled/eris/dark/techfloor_grid,/area/submap/reststop)
-"Ma" = (/obj/structure/table/rack,/obj/machinery/door/window/eastleft,/obj/random/drinksoft,/turf/simulated/floor/tiled/neutral,/area/submap/reststop)
-"Mi" = (/obj/structure/curtain/open/shower,/obj/machinery/shower{dir = 4; pixel_x = 5; pixel_y = -1},/turf/simulated/floor/tiled/neutral,/area/submap/reststop)
-"Oh" = (/obj/structure/table/standard,/obj/machinery/cash_register,/obj/machinery/door/window/northleft,/turf/simulated/floor/tiled/hydro,/area/submap/reststop)
-"OO" = (/obj/random/trash,/turf/simulated/floor/tiled/eris/dark/techfloor_grid,/area/submap/reststop)
-"Pm" = (/turf/template_noop,/area/template_noop)
-"QN" = (/turf/simulated/floor/tiled/neutral,/area/submap/reststop)
-"Rs" = (/obj/effect/decal/cleanable/dirt,/obj/item/assembly/mousetrap/armed,/turf/simulated/floor/tiled/neutral,/area/submap/reststop)
-"RC" = (/obj/random/trash,/turf/simulated/floor/tiled,/area/submap/reststop)
-"UJ" = (/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/tiled/neutral,/area/submap/reststop)
-"Vj" = (/obj/machinery/door/window/westright,/turf/simulated/floor/tiled/hydro,/area/submap/reststop)
-"WS" = (/obj/machinery/door/airlock/freezer,/turf/simulated/floor/tiled/neutral,/area/submap/reststop)
-"Xi" = (/obj/structure/table/rack,/obj/effect/floor_decal/rust,/turf/simulated/floor/tiled,/area/submap/reststop)
-"Xz" = (/obj/structure/simple_door/wood,/turf/simulated/floor/tiled/neutral,/area/submap/reststop)
-"XD" = (/obj/structure/flora/sif/frostbelle,/turf/simulated/floor/outdoors/grass/sif,/area/submap/reststop)
-"XF" = (/turf/simulated/floor/tiled,/area/submap/reststop)
-"Yh" = (/obj/effect/wingrille_spawn,/turf/simulated/floor,/area/submap/reststop)
-"Yr" = (/obj/random/junk,/turf/simulated/floor/tiled,/area/submap/reststop)
-"YB" = (/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/tiled,/area/submap/reststop)
-"Zc" = (/turf/simulated/floor/outdoors/dirt/sif,/area/submap/reststop)
-"Zm" = (/obj/structure/table/standard,/obj/random/drinkbottle,/turf/simulated/floor/tiled/hydro,/area/submap/reststop)
-"ZO" = (/obj/structure/flora/grass/both,/turf/template_noop,/area/submap/reststop)
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"bh" = (
+/turf/simulated/floor/tiled/neutral,
+/area/submap/reststop)
+"bi" = (
+/obj/structure/table/standard,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/item/flame/lighter/random,
+/obj/item/flame/lighter/random,
+/turf/simulated/floor/tiled/hydro,
+/area/submap/reststop)
+"bs" = (
+/obj/structure/table/standard,
+/obj/random/cigarettes,
+/obj/random/cigarettes,
+/obj/machinery/light/small,
+/turf/simulated/floor/tiled/hydro,
+/area/submap/reststop)
+"bv" = (
+/obj/structure/table/rack,
+/obj/item/cell/high,
+/turf/simulated/floor/tiled,
+/area/submap/reststop)
+"bw" = (
+/obj/random/junk,
+/turf/simulated/floor/tiled/neutral,
+/area/submap/reststop)
+"bS" = (
+/obj/structure/simple_door/wood,
+/turf/simulated/floor/tiled/neutral,
+/area/submap/reststop)
+"cQ" = (
+/obj/structure/toilet,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/submap/reststop)
+"dc" = (
+/obj/machinery/door/window/eastleft,
+/obj/structure/table/rack,
+/obj/random/drinksoft,
+/turf/simulated/floor/tiled/neutral,
+/area/submap/reststop)
+"dR" = (
+/obj/structure/flora/grass/green,
+/turf/template_noop,
+/area/submap/reststop)
+"ee" = (
+/obj/machinery/door/airlock/maintenance,
+/turf/simulated/floor/tiled/eris/dark/techfloor_grid,
+/area/submap/reststop)
+"eu" = (
+/obj/structure/table/rack,
+/obj/item/stack/medical/ointment,
+/turf/simulated/floor/tiled,
+/area/submap/reststop)
+"fq" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/neutral,
+/area/submap/reststop)
+"fO" = (
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1"
+	},
+/turf/simulated/floor/tiled,
+/area/submap/reststop)
+"fS" = (
+/obj/machinery/door/airlock/freezer,
+/turf/simulated/floor/tiled/neutral,
+/area/submap/reststop)
+"io" = (
+/obj/structure/table/standard,
+/obj/random/tech_supply/nofail,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/eris/dark/techfloor_grid,
+/area/submap/reststop)
+"iR" = (
+/obj/structure/table/standard,
+/obj/random/cigarettes,
+/turf/simulated/floor/tiled/hydro,
+/area/submap/reststop)
+"iU" = (
+/turf/simulated/floor/tiled,
+/area/submap/reststop)
+"jx" = (
+/obj/structure/flora/grass/both,
+/turf/template_noop,
+/area/submap/reststop)
+"kq" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled,
+/area/submap/reststop)
+"kJ" = (
+/turf/simulated/wall/wood,
+/area/submap/reststop)
+"kY" = (
+/obj/structure/girder,
+/turf/simulated/floor,
+/area/submap/reststop)
+"lh" = (
+/turf/template_noop,
+/area/template_noop)
+"lw" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor/tiled,
+/area/submap/reststop)
+"mS" = (
+/obj/structure/table/rack,
+/obj/item/clothing/suit/storage/hooded/wintercoat/parka/green,
+/turf/simulated/floor/tiled,
+/area/submap/reststop)
+"nO" = (
+/obj/structure/loot_pile/maint/junk,
+/turf/simulated/floor/outdoors/dirt/sif,
+/area/submap/reststop)
+"nW" = (
+/obj/structure/toilet,
+/obj/random/contraband,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/submap/reststop)
+"oD" = (
+/obj/random/trash,
+/turf/simulated/floor/tiled,
+/area/submap/reststop)
+"pi" = (
+/turf/template_noop,
+/area/submap/reststop)
+"pr" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/submap/reststop)
+"pD" = (
+/obj/machinery/door/airlock/glass,
+/turf/simulated/floor/tiled,
+/area/submap/reststop)
+"qa" = (
+/obj/random/junk,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/submap/reststop)
+"qj" = (
+/obj/structure/curtain/open/shower,
+/obj/machinery/shower{
+	dir = 4;
+	pixel_x = 5;
+	pixel_y = -1
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/submap/reststop)
+"qq" = (
+/obj/random/junk,
+/turf/simulated/floor/tiled,
+/area/submap/reststop)
+"qv" = (
+/obj/machinery/door/airlock/freezer,
+/turf/simulated/floor/tiled/eris/dark/techfloor_grid,
+/area/submap/reststop)
+"qz" = (
+/obj/machinery/power/port_gen/pacman,
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/tiled/eris/dark/techfloor_grid,
+/area/submap/reststop)
+"qI" = (
+/obj/structure/table/rack,
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor/tiled,
+/area/submap/reststop)
+"qR" = (
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor/tiled,
+/area/submap/reststop)
+"uh" = (
+/obj/machinery/door/window/eastleft,
+/obj/structure/table/rack,
+/turf/simulated/floor/tiled/neutral,
+/area/submap/reststop)
+"vf" = (
+/obj/machinery/light{
+	dir = 8;
+	icon_state = "tube1";
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled,
+/area/submap/reststop)
+"wj" = (
+/obj/random/vendorfood,
+/turf/simulated/floor/tiled,
+/area/submap/reststop)
+"yz" = (
+/obj/structure/table/standard,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/hydro,
+/area/submap/reststop)
+"Ab" = (
+/obj/structure/table/rack,
+/obj/random/powercell,
+/turf/simulated/floor/tiled,
+/area/submap/reststop)
+"Aw" = (
+/obj/structure/sink{
+	dir = 4;
+	icon_state = "sink";
+	pixel_x = 11;
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/submap/reststop)
+"Ba" = (
+/turf/simulated/floor/outdoors/grass/sif,
+/area/submap/reststop)
+"Co" = (
+/obj/structure/window/basic{
+	dir = 8;
+	layer = 2.8
+	},
+/obj/structure/window/basic,
+/obj/structure/table/standard,
+/obj/item/toy/plushie/marble_fox,
+/turf/simulated/floor/tiled,
+/area/submap/reststop)
+"Cy" = (
+/obj/structure/table/rack,
+/turf/simulated/floor/tiled,
+/area/submap/reststop)
+"Ei" = (
+/obj/structure/table/standard,
+/obj/structure/flora/pottedplant,
+/obj/item/gun/projectile/revolver/webley,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/hydro,
+/area/submap/reststop)
+"Ej" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/random/junk,
+/turf/simulated/floor/tiled,
+/area/submap/reststop)
+"Eo" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/hydro,
+/area/submap/reststop)
+"ED" = (
+/obj/effect/wingrille_spawn,
+/turf/simulated/floor,
+/area/submap/reststop)
+"FJ" = (
+/obj/random/mob/mouse,
+/turf/simulated/floor/outdoors/dirt/sif,
+/area/submap/reststop)
+"FM" = (
+/turf/simulated/floor/tiled/hydro,
+/area/submap/reststop)
+"FP" = (
+/obj/machinery/door/airlock/maintenance,
+/turf/simulated/floor/tiled/neutral,
+/area/submap/reststop)
+"FT" = (
+/obj/effect/floor_decal/rust,
+/obj/structure/girder/displaced,
+/turf/simulated/floor/plating/sif/planetuse,
+/area/submap/reststop)
+"Gf" = (
+/obj/structure/table/standard,
+/obj/random/drinkbottle,
+/turf/simulated/floor/tiled/hydro,
+/area/submap/reststop)
+"GS" = (
+/obj/structure/flora/tree/sif,
+/turf/template_noop,
+/area/submap/reststop)
+"Hj" = (
+/obj/structure/table/standard,
+/turf/simulated/floor/tiled,
+/area/submap/reststop)
+"IF" = (
+/obj/machinery/door/window/eastleft,
+/obj/structure/table/rack,
+/obj/random/snack,
+/turf/simulated/floor/tiled/neutral,
+/area/submap/reststop)
+"IQ" = (
+/obj/structure/table/standard,
+/obj/machinery/cash_register,
+/obj/machinery/door/window/northleft,
+/turf/simulated/floor/tiled/hydro,
+/area/submap/reststop)
+"Jd" = (
+/turf/simulated/floor/outdoors/dirt/sif,
+/area/submap/reststop)
+"Jp" = (
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_y = 24
+	},
+/turf/simulated/floor/tiled/eris/dark/techfloor_grid,
+/area/submap/reststop)
+"KT" = (
+/obj/random/vendordrink,
+/turf/simulated/floor/tiled,
+/area/submap/reststop)
+"Lz" = (
+/obj/structure/closet/crate/trashcart,
+/obj/random/trash,
+/obj/random/trash,
+/obj/random/trash,
+/obj/random/maintenance/clean,
+/turf/simulated/floor/outdoors/dirt/sif,
+/area/submap/reststop)
+"Mh" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/neutral,
+/area/submap/reststop)
+"Na" = (
+/obj/structure/flora/sif/frostbelle,
+/turf/simulated/floor/outdoors/grass/sif,
+/area/submap/reststop)
+"Oo" = (
+/obj/structure/loot_pile/maint/trash,
+/turf/simulated/floor/tiled/neutral,
+/area/submap/reststop)
+"OM" = (
+/obj/random/soap,
+/turf/simulated/floor/tiled/neutral,
+/area/submap/reststop)
+"Pp" = (
+/obj/structure/curtain/open/shower,
+/obj/machinery/shower{
+	dir = 8;
+	pixel_x = -5;
+	pixel_y = -1
+	},
+/obj/item/towel/random,
+/turf/simulated/floor/tiled/neutral,
+/area/submap/reststop)
+"PE" = (
+/obj/structure/animal_den,
+/turf/simulated/floor/outdoors/grass/sif,
+/area/submap/reststop)
+"Sz" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/submap/reststop)
+"SH" = (
+/obj/structure/table/rack,
+/obj/random/mre,
+/turf/simulated/floor/tiled,
+/area/submap/reststop)
+"TJ" = (
+/obj/item/material/shard,
+/turf/simulated/floor/tiled,
+/area/submap/reststop)
+"TK" = (
+/obj/structure/flora/tree/sif,
+/turf/simulated/floor/outdoors/dirt/sif,
+/area/submap/reststop)
+"UM" = (
+/obj/structure/window/basic,
+/obj/structure/table/standard,
+/obj/random/plushie,
+/turf/simulated/floor/tiled,
+/area/submap/reststop)
+"WR" = (
+/obj/random/trash,
+/turf/simulated/floor/tiled/eris/dark/techfloor_grid,
+/area/submap/reststop)
+"Xm" = (
+/obj/structure/table/rack,
+/obj/machinery/door/window/eastleft,
+/obj/random/drinksoft,
+/turf/simulated/floor/tiled/neutral,
+/area/submap/reststop)
+"XM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/assembly/mousetrap/armed,
+/turf/simulated/floor/tiled/neutral,
+/area/submap/reststop)
+"Ym" = (
+/obj/machinery/door/window/westright,
+/turf/simulated/floor/tiled/hydro,
+/area/submap/reststop)
+"Zd" = (
+/obj/structure/sink{
+	dir = 8;
+	icon_state = "sink";
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/submap/reststop)
+"ZE" = (
+/obj/structure/toilet,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/random/plushie,
+/turf/simulated/floor/tiled/neutral,
+/area/submap/reststop)
+"ZN" = (
+/obj/structure/table/rack,
+/obj/random/maintenance,
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor/tiled,
+/area/submap/reststop)
 
 (1,1,1) = {"
-PmPmPmPmPmPmPmPmPmPmPmPmPmPmPmPmPmPmPmPmPmPmPmPmPm
-PmCeCeCeCeCeCeCeCeCeCeCeCeCeCeCeCeCeCeCeZcCeCeCePm
-PmCeCefhCeCeCeCeCeCeCeCeCeCeCeCeCeCeCeCeZcCeCeCePm
-PmCeCeCeCeCeCeCeuvuvuvuvuvuvuvCeCeCeCeCeCeCeCeCePm
-PmCeCeCeCeuvuvuvuvgVuvbquvqmuvCeCeCeCeZcCeCeCeCePm
-PmCeCeCeCeuvMiuyuvXzuvXzuvXzuvCefhCeZcCeCeCeCeCePm
-PmCeCeCeCeuvcqQNQNQNbNQNQNGFuvCeCeCeCeCeCeCeCeCePm
-PmCeCeZcuvuvuvuvuvuvXzuviVhduvCeCeCeZOCeZcCeCeCePm
-PmCeZcdvuviOLBuvxbyjXFuvuvuvuvuvCeCeCeZcCeCeCeCePm
-PmCeZcEDuvDhOOItXFXFXFnSqCBHqCuvuvCeCeZcCeCefhCePm
-PmCeZcdvuvuvCEuvfJRCXFXFXFcZXFCYuvCeCeZcZcCeCeCePm
-PmZcZcuvuvQNUJuvXFsBdqpvemzWXFXFYhCeZcZcZcCeCeCePm
-PmCeZcEVUJgQQNnjsBIPChsBXFXFXFYBvTZcZcZcZcCeCeCePm
-PmCeCeuvlkUJQNwjsBGqXikaJdxLYBXFvTZcZcZcZcZcCeCePm
-PmCeCeuvyqQNQNnjtWsBXFXFXFXFXFRCYhCeZcZcZcZcCeCePm
-PmCeCeuvyqQNQNctsBXFlcuvszOhkZEyuvCeZcZcZcZcCeCePm
-PmCeCeuvyqUJQNMaXFYrXFkMndndndnduvCeZcZcZcZcCeCePm
-PmCeCeuvQNQNKpuvfJXFsBVjndndndnduvCeZcZcZcZcCeCePm
-PmCeCeuvuvgQRsWSYBApZckMwNGZZmZmuvCeZcZcZcCejbCePm
-PmCeCeCeuvuvuvuvbCHMuvuvuvuvuvuvuvCeCeZcZcCeCeCePm
-PmCeCeCeCeCeCeIPIPXDIPCeCeCeCeCeCeCeCeZcCeCeCeCePm
-PmCeCefhCeCeCeCeCeIPIPIPCeCeCeCeCeCeZcCeCeCeCeCePm
-PmCeCeCefhCeCeCeCeCeCeCeCeCeCeCefhCeCeCeZcCeCeCePm
-PmCeCeCeCeCeCeCeCeCeCeCeCeCeCeCeCeCeCeCeZcCeCeCePm
-PmPmPmPmPmPmPmPmPmPmPmPmPmPmPmPmPmPmPmPmPmPmPmPmPm
+lh
+lh
+lh
+lh
+lh
+lh
+lh
+lh
+lh
+lh
+lh
+lh
+lh
+lh
+lh
+lh
+lh
+lh
+lh
+lh
+lh
+lh
+lh
+lh
+lh
+"}
+(2,1,1) = {"
+lh
+pi
+pi
+pi
+pi
+pi
+pi
+pi
+pi
+pi
+pi
+Jd
+pi
+pi
+pi
+pi
+pi
+pi
+pi
+pi
+pi
+pi
+pi
+pi
+lh
+"}
+(3,1,1) = {"
+lh
+pi
+pi
+pi
+pi
+pi
+pi
+pi
+Jd
+Jd
+Jd
+Jd
+Jd
+pi
+pi
+pi
+pi
+pi
+pi
+pi
+pi
+pi
+pi
+pi
+lh
+"}
+(4,1,1) = {"
+lh
+pi
+GS
+pi
+pi
+pi
+pi
+Jd
+nO
+Lz
+nO
+kJ
+FP
+kJ
+kJ
+kJ
+kJ
+kJ
+kJ
+pi
+pi
+GS
+pi
+pi
+lh
+"}
+(5,1,1) = {"
+lh
+pi
+pi
+pi
+pi
+pi
+pi
+kJ
+kJ
+kJ
+kJ
+kJ
+Mh
+fq
+Oo
+Oo
+Oo
+bh
+kJ
+kJ
+pi
+pi
+GS
+pi
+lh
+"}
+(6,1,1) = {"
+lh
+pi
+pi
+pi
+kJ
+kJ
+kJ
+kJ
+qz
+io
+kJ
+bh
+bw
+Mh
+bh
+bh
+Mh
+bh
+bw
+kJ
+pi
+pi
+pi
+pi
+lh
+"}
+(7,1,1) = {"
+lh
+pi
+pi
+pi
+kJ
+qj
+Sz
+kJ
+Jp
+WR
+qv
+Mh
+bh
+bh
+bh
+bh
+bh
+qa
+XM
+kJ
+pi
+pi
+pi
+pi
+lh
+"}
+(8,1,1) = {"
+lh
+pi
+pi
+pi
+kJ
+Pp
+bh
+kJ
+kJ
+ee
+kJ
+kJ
+IF
+uh
+IF
+dc
+Xm
+kJ
+fS
+kJ
+Ba
+pi
+pi
+pi
+lh
+"}
+(9,1,1) = {"
+lh
+pi
+pi
+kJ
+kJ
+kJ
+bh
+kJ
+KT
+iU
+vf
+iU
+qR
+qR
+FJ
+qR
+iU
+vf
+kq
+kY
+Ba
+pi
+pi
+pi
+lh
+"}
+(10,1,1) = {"
+lh
+pi
+pi
+kJ
+cQ
+bS
+bh
+kJ
+wj
+iU
+oD
+qR
+Ba
+PE
+qR
+iU
+qq
+iU
+lw
+FT
+Na
+Ba
+pi
+pi
+lh
+"}
+(11,1,1) = {"
+lh
+pi
+pi
+kJ
+kJ
+kJ
+OM
+bS
+iU
+iU
+iU
+ZN
+TK
+qI
+iU
+fO
+iU
+qR
+Jd
+kJ
+Ba
+Ba
+pi
+pi
+lh
+"}
+(12,1,1) = {"
+lh
+pi
+pi
+kJ
+ZE
+bS
+bh
+kJ
+kJ
+Co
+iU
+mS
+qR
+bv
+iU
+kJ
+Eo
+Ym
+Eo
+kJ
+pi
+Ba
+pi
+pi
+lh
+"}
+(13,1,1) = {"
+lh
+pi
+pi
+kJ
+kJ
+kJ
+bh
+Zd
+kJ
+UM
+iU
+Ab
+iU
+SH
+iU
+Ei
+FM
+FM
+iR
+kJ
+pi
+pi
+pi
+pi
+lh
+"}
+(14,1,1) = {"
+lh
+pi
+pi
+kJ
+nW
+bS
+pr
+Aw
+kJ
+Hj
+TJ
+Cy
+iU
+eu
+iU
+IQ
+FM
+FM
+bs
+kJ
+pi
+pi
+pi
+pi
+lh
+"}
+(15,1,1) = {"
+lh
+pi
+pi
+kJ
+kJ
+kJ
+kJ
+kJ
+kJ
+UM
+iU
+iU
+iU
+kq
+iU
+yz
+FM
+FM
+Gf
+kJ
+pi
+pi
+pi
+pi
+lh
+"}
+(16,1,1) = {"
+lh
+pi
+pi
+pi
+pi
+pi
+pi
+pi
+kJ
+kJ
+Ej
+iU
+kq
+iU
+oD
+bi
+FM
+FM
+Gf
+kJ
+pi
+pi
+pi
+pi
+lh
+"}
+(17,1,1) = {"
+lh
+pi
+pi
+pi
+pi
+GS
+pi
+pi
+pi
+kJ
+kJ
+ED
+pD
+pD
+ED
+kJ
+kJ
+kJ
+kJ
+kJ
+pi
+pi
+GS
+pi
+lh
+"}
+(18,1,1) = {"
+lh
+pi
+pi
+pi
+pi
+pi
+pi
+pi
+pi
+pi
+pi
+pi
+Jd
+Jd
+pi
+pi
+pi
+pi
+pi
+pi
+pi
+pi
+pi
+pi
+lh
+"}
+(19,1,1) = {"
+lh
+pi
+pi
+pi
+pi
+Jd
+pi
+jx
+pi
+pi
+pi
+Jd
+Jd
+Jd
+Jd
+Jd
+Jd
+Jd
+Jd
+pi
+pi
+Jd
+pi
+pi
+lh
+"}
+(20,1,1) = {"
+lh
+pi
+pi
+pi
+Jd
+pi
+pi
+pi
+Jd
+Jd
+Jd
+Jd
+Jd
+Jd
+Jd
+Jd
+Jd
+Jd
+Jd
+Jd
+Jd
+pi
+pi
+pi
+lh
+"}
+(21,1,1) = {"
+lh
+Jd
+Jd
+pi
+pi
+pi
+pi
+Jd
+pi
+pi
+Jd
+Jd
+Jd
+Jd
+Jd
+Jd
+Jd
+Jd
+Jd
+Jd
+pi
+pi
+Jd
+Jd
+lh
+"}
+(22,1,1) = {"
+lh
+pi
+pi
+pi
+pi
+pi
+pi
+pi
+pi
+pi
+pi
+pi
+pi
+Jd
+Jd
+Jd
+Jd
+Jd
+pi
+pi
+pi
+pi
+pi
+pi
+lh
+"}
+(23,1,1) = {"
+lh
+pi
+pi
+pi
+pi
+pi
+pi
+pi
+pi
+GS
+pi
+pi
+pi
+pi
+pi
+pi
+pi
+pi
+dR
+pi
+pi
+pi
+pi
+pi
+lh
+"}
+(24,1,1) = {"
+lh
+pi
+pi
+pi
+pi
+pi
+pi
+pi
+pi
+pi
+pi
+pi
+pi
+pi
+pi
+pi
+pi
+pi
+pi
+pi
+pi
+pi
+pi
+pi
+lh
+"}
+(25,1,1) = {"
+lh
+lh
+lh
+lh
+lh
+lh
+lh
+lh
+lh
+lh
+lh
+lh
+lh
+lh
+lh
+lh
+lh
+lh
+lh
+lh
+lh
+lh
+lh
+lh
+lh
 "}

--- a/maps/submaps/surface_submaps/plains/reststop.dmm
+++ b/maps/submaps/surface_submaps/plains/reststop.dmm
@@ -275,7 +275,7 @@
 /turf/simulated/floor,
 /area/submap/reststop)
 "FJ" = (
-/obj/random/mob/mouse,
+/mob/living/simple_mob/animal/passive/hare,
 /turf/simulated/floor/outdoors/dirt/sif,
 /area/submap/reststop)
 "FM" = (

--- a/maps/submaps/surface_submaps/plains/reststop.dmm
+++ b/maps/submaps/surface_submaps/plains/reststop.dmm
@@ -116,7 +116,7 @@
 /area/submap/reststop)
 "mS" = (
 /obj/structure/table/rack,
-/obj/item/clothing/suit/storage/hooded/wintercoat/parka/green,
+/obj/item/clothing/suit/storage/hooded/wintercoat,
 /turf/simulated/floor/tiled,
 /area/submap/reststop)
 "nO" = (
@@ -385,6 +385,10 @@
 /area/submap/reststop)
 "TK" = (
 /obj/structure/flora/tree/sif,
+/turf/simulated/floor/outdoors/dirt/sif,
+/area/submap/reststop)
+"Uj" = (
+/obj/machinery/space_heater,
 /turf/simulated/floor/outdoors/dirt/sif,
 /area/submap/reststop)
 "UM" = (
@@ -725,7 +729,7 @@ iU
 fO
 iU
 qR
-Jd
+Uj
 kJ
 Ba
 Ba


### PR DESCRIPTION
Adds a relatively simple POI to the plains pool: an ambitious 'rest stop' that once resupplied explorers and travelers before being ultimately abandoned. The goal was for this to not only be a fun location to explore and scavenge, but its multiple modes of entry and exit make it an interesting base for antags, drakes, and survivalists alike.

My first map! Assistance and feedback is appreciated.

![image](https://github.com/PolarisSS13/Polaris/assets/11377530/7a660825-74f0-4204-be1e-9ac7291483df)
