### PR TITLE
Attempting to prevent overlapping blob chunks.

### DIFF
--- a/code/modules/blob2/blobs/base_blob.dm
+++ b/code/modules/blob2/blobs/base_blob.dm
@@ -148,16 +148,17 @@ GLOBAL_LIST_EMPTY(all_blobs)
 			var/dirn = pick(dirs)
 			dirs.Remove(dirn)
 			T = get_step(src, dirn)
-			var/obj/structure/blob/B = locate(/obj/structure/blob) in T
+			if(!T)
+				continue
+			var/obj/structure/blob/B = locate() in T
 			if(!B || B.faction != faction)	// Allow opposing blobs to fight.
 				break
-			else
-				T = null
+			T = null
+
 	if(!T)
 		return FALSE
 
 	var/make_blob = TRUE //can we make a blob?
-
 	if(istype(T, /turf/space) && !(locate(/obj/structure/lattice) in T) && prob(80))
 		make_blob = FALSE
 		playsound(src, 'sound/effects/splat.ogg', 50, 1) //Let's give some feedback that we DID try to spawn in space, since players are used to it
@@ -183,7 +184,7 @@ GLOBAL_LIST_EMPTY(all_blobs)
 		B.density = TRUE
 		if(T.Enter(B,src)) //NOW we can attempt to move into the tile
 			do_slide_animation(B, T, expand_reaction)
-			return B
+			return QDELETED(B) ? null : B
 		blob_attack_animation(T, controller)
 		T.blob_act(src) //if we can't move in hit the turf again
 		qdel(B) //we should never get to this point, since we checked before moving in. destroy the blob so we don't have two blobs on one tile
@@ -194,6 +195,9 @@ GLOBAL_LIST_EMPTY(all_blobs)
 /obj/structure/blob/proc/do_slide_animation(var/obj/structure/blob/B, var/turf/T, var/expand_reaction)
 	set waitfor = FALSE
 	sleep(1) // To have the slide animation work.
+	if(locate(/obj/structure/blob) in T)
+		qdel(B)
+		return
 	B.density = initial(B.density)
 	B.forceMove(T)
 	B.update_icon()

--- a/code/modules/gamemaster/event2/events/engineering/blob.dm
+++ b/code/modules/gamemaster/event2/events/engineering/blob.dm
@@ -106,11 +106,15 @@
 /datum/event2/event/blob/start()
 	if(!open_turfs.len)
 		set_up()
-	for(var/i = 1 to number_of_blobs)
+	var/i = number_of_blobs
+	while(i && length(open_turfs))
 		var/turf/T = pick(open_turfs)
+		open_turfs -= T // So we can't put two cores on the same tile if doing multiblob.
+		if(locate(/obj/structure/blob) in T)
+			continue
+		i--
 		var/obj/structure/blob/core/new_blob = new spawn_blob_type(T)
 		blobs += weakref(new_blob)
-		open_turfs -= T // So we can't put two cores on the same tile if doing multiblob.
 		log_debug("Spawned [new_blob.overmind.blob_type.name] blob at [get_area(new_blob)].")
 
 /datum/event2/event/blob/should_end()


### PR DESCRIPTION
Blob spawn animation previously ran synchronously, when I did the Life() sleep changes I didn't account for the 1ds slide animation now potentially running alongside multiple blob segments.