### PR TITLE
Preventing bot AI from stalling SSmobs hopefully.

### DIFF
--- a/code/modules/mob/living/bot/bot.dm
+++ b/code/modules/mob/living/bot/bot.dm
@@ -191,6 +191,7 @@
 		handleFrustrated(0)
 
 /mob/living/bot/proc/handleAI()
+	set waitfor = FALSE
 	if(ignore_list.len)
 		for(var/atom/A in ignore_list)
 			if(!A || !A.loc || prob(1))


### PR DESCRIPTION
SSmobs stalls appear to be due to bots. This may help with the SSmobs stall at the cost of high CPU usage by whatever is causing the extended stalls.