### PR TITLE
Reworks mech repair loop to avoid infinite loops.

### DIFF
--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -1636,26 +1636,52 @@
 		return
 
 	else if(istype(W,/obj/item/stack/nanopaste))
-		if(state >= MECHA_PANEL_LOOSE)
-			var/obj/item/stack/nanopaste/NP = W
+		if(state < MECHA_PANEL_LOOSE)
+			to_chat(user, SPAN_WARNING("You can't reach \the [src]'s internal components."))
+			return
 
+		var/obj/item/stack/nanopaste/nanopaste = W
+		while(!QDELETED(user) && !QDELETED(src) && do_after(user, 1 SECOND, src))
+
+			// Get a component to attempt a repair on.
+			var/obj/item/mecha_parts/component/component
 			for(var/slot in internal_components)
-				var/obj/item/mecha_parts/component/C = internal_components[slot]
+				var/obj/item/mecha_parts/component/check_component = internal_components[slot]
+				if(!QDELETED(check_component) && check_component.integrity < check_component.max_integrity)
+					component = check_component
+					break
 
-				if(C)
+			// We've run out of components to fix.
+			if(!component)
+				to_chat(user, SPAN_NOTICE("Nothing to repair!"))
+				break
 
-					if(C.integrity < C.max_integrity)
-						while(C.integrity < C.max_integrity && NP && do_after(user, 1 SECOND, src))
-							if(NP.use(1))
-								C.adjust_integrity(10)
+			// Spend some time on the work.
+			if(!do_after(user, 1 SECOND, src))
+				break
 
-						to_chat(user, "<span class='notice'>You repair damage to \the [C].</span>")
+			// Something has destroyed us or the mech, or we're incapacitated or moved away.
+			if(QDELETED(user) || QDELETED(src) || QDELETED(component) || component.loc != src)
+				break
 
-			return
+			// Out of repair gel.
+			if(QDELETED(nanopaste) || !nanopaste.use(1))
+				to_chat(user, SPAN_WARNING("You're out of nanopaste!"))
+				break
 
-		else
-			to_chat(user, "<span class='notice'>You can't reach \the [src]'s internal components.</span>")
-			return
+			// Handle the actual repair.
+			component.adjust_integrity(10)
+			if(component.integrity >= component.max_integrity)
+				to_chat(user, SPAN_NOTICE("You repair the damage to \the [component]."))
+			else
+				to_chat(user, SPAN_NOTICE("You repair some of the damage to \the [component]."))
+
+			// Do another nanopaste check to avoid wasting a second on a do_after.
+			if(QDELETED(nanopaste) || !nanopaste.can_use(1))
+				to_chat(user, SPAN_WARNING("You're out of nanopaste!"))
+				break
+
+		return
 
 	else
 		call((proc_res["dynattackby"]||src), "dynattackby")(W,user)

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -479,12 +479,6 @@
 	radio.icon_state = icon_state
 	radio.subspace_transmission = 1
 
-/obj/mecha/proc/do_after(delay as num)
-	sleep(delay)
-	if(src)
-		return 1
-	return 0
-
 /obj/mecha/proc/enter_after(delay as num, var/mob/user as mob, var/numticks = 5)
 	var/delayfraction = delay/numticks
 
@@ -1641,7 +1635,7 @@
 			return
 
 		var/obj/item/stack/nanopaste/nanopaste = W
-		while(!QDELETED(user) && !QDELETED(src) && do_after(user, 1 SECOND, src))
+		while(!QDELETED(user) && !QDELETED(src))
 
 			// Get a component to attempt a repair on.
 			var/obj/item/mecha_parts/component/component
@@ -1656,12 +1650,8 @@
 				to_chat(user, SPAN_NOTICE("Nothing to repair!"))
 				break
 
-			// Spend some time on the work.
-			if(!do_after(user, 1 SECOND, src))
-				break
-
 			// Something has destroyed us or the mech, or we're incapacitated or moved away.
-			if(QDELETED(user) || QDELETED(src) || QDELETED(component) || component.loc != src)
+			if(QDELETED(user) || QDELETED(src) || QDELETED(component) || component.loc != src || !do_after(user, 1 SECOND, src))
 				break
 
 			// Out of repair gel.
@@ -2716,14 +2706,16 @@
 		src.occupant_message("Recalibrating coordination system.")
 		src.log_message("Recalibration of coordination system started.")
 		var/T = src.loc
-		if(do_after(100))
-			if(T == src.loc)
-				src.clearInternalDamage(MECHA_INT_CONTROL_LOST)
-				src.occupant_message("<font color='blue'>Recalibration successful.</font>")
-				src.log_message("Recalibration of coordination system finished with 0 errors.")
-			else
-				src.occupant_message("<font color='red'>Recalibration failed.</font>")
-				src.log_message("Recalibration of coordination system failed with 1 error.",1)
+		sleep(100)
+		if(QDELETED(src))
+			return
+		if(T == src.loc)
+			src.clearInternalDamage(MECHA_INT_CONTROL_LOST)
+			src.occupant_message("<font color='blue'>Recalibration successful.</font>")
+			src.log_message("Recalibration of coordination system finished with 0 errors.")
+		else
+			src.occupant_message("<font color='red'>Recalibration failed.</font>")
+			src.log_message("Recalibration of coordination system failed with 1 error.",1)
 	if(href_list["drop_from_cargo"])
 		var/obj/O = locate(href_list["drop_from_cargo"])
 		if(O && (O in src.cargo))

--- a/code/game/objects/items/bells.dm
+++ b/code/game/objects/items/bells.dm
@@ -88,7 +88,7 @@
 	if(!istype(W))
 		return
 	if(W.is_wrench() && isturf(loc))
-		if(do_after(5))
+		if(do_after(user, 5, src))
 			if(!src) return
 			to_chat(user, "<span class='notice'>You dissasemble the desk bell</span>")
 			new /obj/item/stack/material/steel(get_turf(src), 1)

--- a/code/modules/mob/living/bot/floorbot.dm
+++ b/code/modules/mob/living/bot/floorbot.dm
@@ -285,7 +285,7 @@
 			while(amount + 4 <= maxAmount)
 				busy = TRUE
 				update_icons()
-				if(do_after(5 SECONDS))
+				if(do_after(src, 5 SECONDS))
 					if(M)
 						M.use(1)
 						addTiles(4)


### PR DESCRIPTION
Fixes #9102.

Turns out mecha had an 11 year old do_after member function that shadowed the global and broke it. Likely responsible for a chunk (but not all) of the infinite loop behavior.