### PR TITLE
Weapon Rebalance Part I: Energy Weapons

### DIFF
--- a/code/datums/supplypacks/munitions.dm
+++ b/code/datums/supplypacks/munitions.dm
@@ -74,7 +74,7 @@
 	containertype = /obj/structure/closet/crate/secure/weapon
 	containername = "Shotgun crate"
 	access = access_armory
-	
+
 /datum/supply_pack/munitions/shotgunsemi
 	name = "Weapons - Semi-Automatic Shotgun crate"
 	contains = list(
@@ -96,11 +96,11 @@
 	access = access_armory
 
 /datum/supply_pack/munitions/burstlaser
-	name = "Weapons - Burst laser"
+	name = "Weapons - Burst Energy Gun"
 	contains = list(/obj/item/gun/energy/gun/burst = 2)
 	cost = 50
 	containertype = /obj/structure/closet/crate/secure/lawson
-	containername = "Burst laser crate"
+	containername = "Burst Energy Gun crate"
 	access = access_armory
 
 /datum/supply_pack/munitions/ionweapons

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -6,7 +6,7 @@
 	icon_state = "laser"
 	item_state = "laser"
 	wielded_item_state = "laser-wielded"
-	fire_delay = 8
+	fire_delay = 0.8 SECONDS
 	slot_flags = SLOT_BELT|SLOT_BACK
 	w_class = ITEMSIZE_LARGE
 	force = 10
@@ -16,16 +16,16 @@
 	one_handed_penalty = 30
 
 	firemodes = list(
-		list(mode_name="normal", fire_delay=8, projectile_type=/obj/item/projectile/beam/midlaser, charge_cost = 240),
-		list(mode_name="suppressive", fire_delay=5, projectile_type=/obj/item/projectile/beam/weaklaser, charge_cost = 60),
-		)
+		list(mode_name = "normal", projectile_type = /obj/item/projectile/beam/midlaser, charge_cost = 240),
+		list(mode_name = "suppressive", fire_delay = 0.6 SECONDS, projectile_type = /obj/item/projectile/beam/weaklaser, charge_cost = 60),
+	)
 
 /obj/item/gun/energy/laser/empty
 	cell_type = null
 
 /obj/item/gun/energy/laser/mounted
-	self_recharge = 1
-	use_external_power = 1
+	self_recharge = TRUE
+	use_external_power = TRUE
 	one_handed_penalty = 0 // Not sure if two-handing gets checked for mounted weapons, but better safe than sorry.
 
 /obj/item/gun/energy/laser/mounted/augment
@@ -49,9 +49,9 @@
 	cell_type = /obj/item/cell/device
 
 	firemodes = list(
-		list(mode_name="normal", projectile_type=/obj/item/projectile/beam/practice, charge_cost = 48),
-		list(mode_name="suppressive", projectile_type=/obj/item/projectile/beam/practice, charge_cost = 12),
-		)
+		list(mode_name = "normal", projectile_type = /obj/item/projectile/beam/practice, charge_cost = 48),
+		list(mode_name = "suppressive", projectile_type = /obj/item/projectile/beam/practice, charge_cost = 12),
+	)
 
 //Functionally identical, but slightly higher tech due to rarer.
 /obj/item/gun/energy/laser/sleek
@@ -71,7 +71,7 @@
 	icon_state = "mininglaser"
 	item_state = "laser"
 	wielded_item_state = "laser-wielded"
-	fire_delay = 8
+	fire_delay = 0.8 SECONDS
 	slot_flags = SLOT_BELT|SLOT_BACK
 	w_class = ITEMSIZE_LARGE
 	force = 15
@@ -81,9 +81,9 @@
 	one_handed_penalty = 30
 
 	firemodes = list(
-		list(mode_name="mining", fire_delay=8, projectile_type=/obj/item/projectile/beam/mininglaser, charge_cost = 200),
-		list(mode_name="deter", fire_delay=5, projectile_type=/obj/item/projectile/beam/weaklaser, charge_cost = 80),
-		)
+		list(mode_name = "mining", projectile_type = /obj/item/projectile/beam/mininglaser, charge_cost = 200),
+		list(mode_name = "deter", fire_delay = 0.6 SECONDS, projectile_type=/obj/item/projectile/beam/weaklaser, charge_cost = 80),
+	)
 
 /obj/item/gun/energy/retro
 	name = "retro laser"
@@ -93,11 +93,11 @@
 	slot_flags = SLOT_BELT
 	w_class = ITEMSIZE_NORMAL
 	projectile_type = /obj/item/projectile/beam
-	fire_delay = 10 //old technology
+	fire_delay = 1 SECOND //old technology
 
 /obj/item/gun/energy/retro/mounted
-	self_recharge = 1
-	use_external_power = 1
+	self_recharge = TRUE
+	use_external_power = TRUE
 
 /obj/item/gun/energy/retro/empty
 	icon_state = "retro"
@@ -138,7 +138,7 @@
 	catalogue_data = list(/datum/category_item/catalogue/anomalous/precursor_a/alien_pistol)
 	icon_state = "alienpistol"
 	item_state = "alienpistol"
-	fire_delay = 10 // Handguns should be inferior to two-handed weapons. Even alien ones I suppose.
+	fire_delay = 1 SECOND // Handguns should be inferior to two-handed weapons. Even alien ones I suppose.
 	charge_cost = 480 // Five shots.
 
 	projectile_type = /obj/item/projectile/beam/cyan
@@ -160,7 +160,7 @@
 	w_class = ITEMSIZE_NORMAL
 	projectile_type = /obj/item/projectile/beam
 	origin_tech = null
-	fire_delay = 10		//Old pistol
+	fire_delay = 1 SECOND	//Old pistol
 	charge_cost = 480	//to compensate a bit for self-recharging
 	cell_type = /obj/item/cell/device/weapon/recharge/captain
 	battery_lock = 1
@@ -176,22 +176,21 @@
 	slot_flags = SLOT_BELT|SLOT_BACK
 	projectile_type = /obj/item/projectile/beam/heavylaser/cannon
 	battery_lock = 1
-	fire_delay = 20
+	fire_delay = 2 SECONDS
 	w_class = ITEMSIZE_LARGE
 	one_handed_penalty = 90 // The thing's heavy and huge.
 	accuracy = 45
 	charge_cost = 600
+	recharge_time = 1 SECOND
 
 /obj/item/gun/energy/lasercannon/mounted
 	name = "mounted laser cannon"
-	self_recharge = 1
-	use_external_power = 1
-	recharge_time = 10
+	self_recharge = TRUE
+	use_external_power = TRUE
 	accuracy = 0 // Mounted cannons are just fine the way they are.
 	one_handed_penalty = 0 // Not sure if two-handing gets checked for mounted weapons, but better safe than sorry.
 	projectile_type = /obj/item/projectile/beam/heavylaser
 	charge_cost = 400
-	fire_delay = 20
 
 /obj/item/gun/energy/xray
 	name = "xray laser gun"
@@ -202,6 +201,7 @@
 	origin_tech = list(TECH_COMBAT = 5, TECH_MATERIAL = 3, TECH_MAGNET = 2)
 	projectile_type = /obj/item/projectile/beam/xray
 	charge_cost = 200
+	fire_delay = 0.8 SECONDS
 
 /obj/item/gun/energy/sniperrifle
 	name = "marksman energy rifle"
@@ -218,11 +218,11 @@
 	action_button_name = "Use Scope"
 	battery_lock = 1
 	charge_cost = 600
-	fire_delay = 35
+	fire_delay = 3.5 SECONDS
 	force = 10
 	w_class = ITEMSIZE_HUGE // So it can't fit in a backpack.
 	accuracy = -45 //shooting at the hip
-	scoped_accuracy = 50
+	scoped_accuracy = 75
 	one_handed_penalty = 60 // The weapon itself is heavy, and the long barrel makes it hard to hold steady with just one hand.
 
 /obj/item/gun/energy/sniperrifle/ui_action_click()
@@ -246,7 +246,7 @@
 	slot_flags = SLOT_BACK
 	action_button_name = "Aim Down Sights"
 	charge_cost = 1300
-	fire_delay = 20
+	fire_delay = 2 SECONDS
 	force = 8
 	w_class = ITEMSIZE_LARGE
 	accuracy = 10

--- a/code/modules/projectiles/guns/energy/nuclear.dm
+++ b/code/modules/projectiles/guns/energy/nuclear.dm
@@ -4,7 +4,7 @@
 	description_fluff = "Lawson Arms is Hephaestus Industries’ main personal-energy-weapon branding, often sold alongside MarsTech projectile weapons to security and law enforcement agencies."
 	icon_state = "energystun100"
 	item_state = null	//so the human update icon uses the icon_state instead.
-	fire_delay = 10 // Handguns should be inferior to two-handed weapons.
+	fire_delay = 1 SECOND // Handguns should be inferior to two-handed weapons.
 
 	projectile_type = /obj/item/projectile/beam/stun/med
 	origin_tech = list(TECH_COMBAT = 3, TECH_MAGNET = 2)
@@ -13,16 +13,16 @@
 	firemodes = list(
 		list(mode_name="stun", projectile_type=/obj/item/projectile/beam/stun/med, modifystate="energystun", charge_cost = 240),
 		list(mode_name="lethal", projectile_type=/obj/item/projectile/beam, modifystate="energykill", charge_cost = 480),
-		)
+	)
 
 
 /obj/item/gun/energy/gun/mounted
 	name = "mounted energy gun"
-	self_recharge = 1
-	use_external_power = 1
+	self_recharge = TRUE
+	use_external_power = TRUE
 
 /obj/item/gun/energy/gun/burst
-	name = "burst laser"
+	name = "burst energy gun"
 	desc = "The Lawson Arms FM-2t is a versatile energy based weapon, capable of switching between stun or kill with a three round burst option for both settings."
 	description_fluff = "Lawson Arms is Hephaestus Industries’ main personal-energy-weapon branding, often sold alongside MarsTech projectile weapons to security and law enforcement agencies."
 	icon_state = "riflestun100"
@@ -30,7 +30,7 @@
 	charge_cost = 100
 	force = 8
 	w_class = ITEMSIZE_LARGE	//Probably gonna make it a rifle sooner or later
-	fire_delay = 6
+	fire_delay = 0.8 SECONDS
 
 	projectile_type = /obj/item/projectile/beam/stun/weak
 	origin_tech = list(TECH_COMBAT = 4, TECH_MAGNET = 2, TECH_ILLEGAL = 3)
@@ -40,11 +40,22 @@
 //	one_handed_penalty = 30
 
 	firemodes = list(
-		list(mode_name="stun", burst=1, projectile_type=/obj/item/projectile/beam/stun/weak, modifystate="riflestun", charge_cost = 100),
-		list(mode_name="stun burst", burst=3, fire_delay=null, move_delay=4, burst_accuracy=list(0,0,0), dispersion=list(0.0, 0.2, 0.5), projectile_type=/obj/item/projectile/beam/stun/weak, modifystate="riflestun"),
-		list(mode_name="lethal", burst=1, projectile_type=/obj/item/projectile/beam/burstlaser, modifystate="riflekill", charge_cost = 200),
-		list(mode_name="lethal burst", burst=3, fire_delay=null, move_delay=4, burst_accuracy=list(0,0,0), dispersion=list(0.0, 0.2, 0.5), projectile_type=/obj/item/projectile/beam/burstlaser, modifystate="riflekill"),
-		)
+		list(mode_name = "stun", burst = 1, projectile_type = /obj/item/projectile/beam/stun/weak,
+			modifystate = "riflestun"
+		),
+		list(mode_name = "stun burst", burst = 3, fire_delay = 1 SECOND, move_delay = 4,
+			burst_accuracy = list(0,0,0), dispersion = list(0.0, 0.2, 0.5),
+			projectile_type = /obj/item/projectile/beam/stun/weak, modifystate = "riflestun"
+		),
+		list(mode_name = "lethal", burst = 1, projectile_type = /obj/item/projectile/beam/burstlaser,
+			modifystate = "riflekill", charge_cost = 200
+		),
+		list(mode_name = "lethal burst", burst = 3, fire_delay = 1 SECOND, move_delay = 4,
+			burst_accuracy = list(0,0,0), dispersion = list(0.0, 0.2, 0.5),
+			projectile_type = /obj/item/projectile/beam/burstlaser, modifystate = "riflekill",
+			charge_cost = 200
+		),
+	)
 
 /obj/item/gun/energy/gun/nuclear
 	name = "advanced energy gun"
@@ -55,7 +66,7 @@
 	slot_flags = SLOT_BELT
 	force = 8 //looks heavier than a pistol
 	w_class = ITEMSIZE_LARGE	//Looks bigger than a pistol, too.
-	fire_delay = 6	//This one's not a handgun, it should have the same fire delay as everything else
+	fire_delay = 0.8 SECONDS	//This one's not a handgun, it should have the same fire delay as everything else
 	cell_type = /obj/item/cell/device/weapon/recharge
 	battery_lock = 1
 	modifystate = null
@@ -64,9 +75,9 @@
 //	one_handed_penalty = 15 // It's rather bulky, so holding it in one hand is a little harder than with two, however it's not 'required'.
 
 	firemodes = list(
-		list(mode_name="stun", projectile_type=/obj/item/projectile/beam/stun, modifystate="nucgunstun", charge_cost = 240),
-		list(mode_name="lethal", projectile_type=/obj/item/projectile/beam, modifystate="nucgunkill", charge_cost = 480),
-		)
+		list(mode_name = "stun", projectile_type = /obj/item/projectile/beam/stun, modifystate = "nucgunstun", charge_cost = 240),
+		list(mode_name = "lethal", projectile_type = /obj/item/projectile/beam, modifystate = "nucgunkill", charge_cost = 480),
+	)
 
 //Functionally a Perun, but flavoured.
 /obj/item/gun/energy/gun/compact
@@ -80,9 +91,9 @@
 	modifystate = "PDWstun"
 
 	firemodes = list(
-		list(mode_name="stun", projectile_type=/obj/item/projectile/beam/stun/med, modifystate="PDWstun", charge_cost = 240),
-		list(mode_name="lethal", projectile_type=/obj/item/projectile/beam, modifystate="PDWkill", charge_cost = 480),
-		)
+		list(mode_name = "stun", projectile_type = /obj/item/projectile/beam/stun/med, modifystate = "PDWstun", charge_cost = 240),
+		list(mode_name = "lethal", projectile_type = /obj/item/projectile/beam, modifystate = "PDWkill", charge_cost = 480),
+	)
 
 //What if we went smaller?
 /obj/item/gun/energy/gun/pocket
@@ -95,6 +106,6 @@
 
 	modifystate = "egunstun"
 	firemodes = list(
-		list(mode_name="stun", projectile_type=/obj/item/projectile/beam/stun/med, modifystate="egunstun", charge_cost = 240),
-		list(mode_name="lethal", projectile_type=/obj/item/projectile/beam, modifystate="egunkill", charge_cost = 480),
-		)
+		list(mode_name = "stun", projectile_type = /obj/item/projectile/beam/stun/med, modifystate = "egunstun", charge_cost = 240),
+		list(mode_name = "lethal", projectile_type = /obj/item/projectile/beam, modifystate = "egunkill", charge_cost = 480),
+	)

--- a/code/modules/projectiles/guns/energy/phase.dm
+++ b/code/modules/projectiles/guns/energy/phase.dm
@@ -36,13 +36,13 @@
 	one_handed_penalty = 0
 
 /obj/item/gun/energy/phasegun/mounted
-	self_recharge = 1
-	use_external_power = 1
+	self_recharge = TRUE
+	use_external_power = TRUE
 	one_handed_penalty = 0
 
 /obj/item/gun/energy/phasegun/mounted/cyborg
 	charge_cost = 400
-	recharge_time = 7
+	recharge_time = 0.6 SECONDS
 
 /obj/item/gun/energy/phasegun/pistol
 	name = "phase pistol"
@@ -57,12 +57,12 @@
 
 /obj/item/gun/energy/phasegun/pistol/mounted
 	name = "mounted phase pistol"
-	self_recharge = 1
-	use_external_power = 1
+	self_recharge = TRUE
+	use_external_power = TRUE
 
 /obj/item/gun/energy/phasegun/pistol/mounted/cyborg
 	charge_cost = 400
-	recharge_time = 7
+	recharge_time = 0.6 SECONDS
 
 /obj/item/gun/energy/phasegun/rifle
 	name = "phase rifle"

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -10,6 +10,7 @@
 	force = 10
 	slot_flags = SLOT_BACK
 	projectile_type = /obj/item/projectile/ion
+	fire_delay = 0.8 SECONDS
 
 /obj/item/gun/energy/ionrifle/emp_act(severity)
 	..(max(severity, 4)) //so it doesn't EMP itself, I guess
@@ -27,6 +28,7 @@
 	slot_flags = SLOT_BELT|SLOT_HOLSTER
 	charge_cost = 480
 	projectile_type = /obj/item/projectile/ion/pistol
+	fire_delay = 1 SECOND
 
 /obj/item/gun/energy/decloner
 	name = "biological demolecularisor"

--- a/code/modules/projectiles/guns/energy/stun.dm
+++ b/code/modules/projectiles/guns/energy/stun.dm
@@ -6,22 +6,23 @@
 	item_state = null	//so the human update icon uses the icon_state instead.
 	projectile_type = /obj/item/projectile/beam/stun
 	charge_cost = 480
+	fire_delay = 0.8 SECONDS
 
 /obj/item/gun/energy/taser/mounted
 	name = "mounted taser gun"
-	self_recharge = 1
-	use_external_power = 1
+	self_recharge = TRUE
+	use_external_power = TRUE
 
 /obj/item/gun/energy/taser/mounted/augment
-	self_recharge = 1
-	use_external_power = 0
+	self_recharge = TRUE
+	use_external_power = FALSE
 	use_organic_power = TRUE
 	canremove = FALSE
 
 /obj/item/gun/energy/taser/mounted/cyborg
 	name = "taser gun"
-	charge_cost = 400
-	recharge_time = 7 //Time it takes for shots to recharge (in ticks)
+	charge_cost = 480
+	recharge_time = 0.6 SECONDS
 
 /obj/item/gun/energy/taser/disabler
 	name = "disabler"
@@ -75,7 +76,7 @@
 	icon_state = "plasma_stun"
 	item_state = "plasma_stun"
 	origin_tech = list(TECH_COMBAT = 2, TECH_MATERIAL = 2, TECH_POWER = 3)
-	fire_delay = 20
+	fire_delay = 2 SECONDS
 	charge_cost = 600
 	projectile_type = /obj/item/projectile/energy/plasmastun
 
@@ -93,6 +94,7 @@
 	item_state = "stunrevolver"
 	origin_tech = list(TECH_COMBAT = 3, TECH_MATERIAL = 3, TECH_POWER = 2)
 	projectile_type = /obj/item/projectile/energy/electrode/strong
+	fire_delay = 0.8 SECONDS
 	charge_cost = 300
 
 /obj/item/gun/energy/stunrevolver/vintage
@@ -105,7 +107,6 @@
 	their own variants of the Stun Revolver."
 	icon_state = "vinstunrevolver"
 	item_state = "stunrevolver"
-	origin_tech = list(TECH_COMBAT = 3, TECH_MATERIAL = 3, TECH_POWER = 2)
 
 /obj/item/gun/energy/stunrevolver/snubnose
 	name = "snub stun revolver"
@@ -118,4 +119,3 @@
 	icon_state = "snubstunrevolver"
 	item_state = "stunrevolver"
 	w_class = ITEMSIZE_SMALL
-	origin_tech = list(TECH_COMBAT = 3, TECH_MATERIAL = 3, TECH_POWER = 2)

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -131,8 +131,8 @@
 	impact_type = /obj/effect/projectile/impact/laser_em
 
 /obj/item/projectile/beam/heavylaser/cannon
-	damage = 80
-	armor_penetration = 50
+	damage = 75
+	armor_penetration = 40
 	light_color = "#FF0D00"
 	hud_state = "laser_overcharge"
 
@@ -140,8 +140,8 @@
 	name = "xray beam"
 	icon_state = "xray"
 	fire_sound = 'sound/weapons/eluger.ogg'
-	damage = 25
-	armor_penetration = 50
+	damage = 35
+	armor_penetration = 60
 	light_color = "#00CC33"
 	hud_state = "laser_sniper"
 
@@ -265,8 +265,8 @@
 	name = "sniper beam"
 	icon_state = "xray"
 	fire_sound = 'sound/weapons/gauss_shoot.ogg'
-	damage = 50
-	armor_penetration = 10
+	damage = 45
+	armor_penetration = 20
 	light_color = "#00CC33"
 	hud_state = "laser_sniper"
 

--- a/code/modules/xenobio/items/weapons.dm
+++ b/code/modules/xenobio/items/weapons.dm
@@ -55,9 +55,8 @@
 	slime-based xeno lifeforms at a distance.  It is ineffective at stunning non-slimy lifeforms such as humanoids."
 
 /obj/item/gun/energy/taser/xeno/robot // Borg version
-	self_recharge = 1
-	use_external_power = 1
-	recharge_time = 3
+	self_recharge = TRUE
+	use_external_power = TRUE
 
 /obj/item/gun/energy/taser/xeno/sec //NT's corner-cutting option for their on-station security.
 	desc = "An NT Mk30 NL retrofitted to fire beams for subduing non-humanoid slimy xeno life forms."
@@ -69,9 +68,8 @@
 	description_fluff = "An NT Mk30 NL retrofitted after the events that occurred aboard the NRS Prometheus."
 
 /obj/item/gun/energy/taser/xeno/sec/robot //Cyborg variant of the security xeno-taser.
-	self_recharge = 1
-	use_external_power = 1
-	recharge_time = 3
+	self_recharge = TRUE
+	use_external_power = TRUE
 
 /obj/item/projectile/beam/stun/xeno
 	icon_state = "omni"


### PR DESCRIPTION
The (hopefully) first part of my series of weapon (and later armour) rebalances in an attempt to make things more fun, more impactful and less spam-click-until-horizontal.

These changes aim to give individual weapons more of a specific niche, and just generally improve some that are underperforming. A notable example is the Laser Cannon vs the X-Ray Laser Gun. X-Rays are designed to be armour piercing, yet its functionality was superseded by the Laser Cannon just being better at _everything._ The Marksman Energy Rifle also needed a little tune-up to fix the awful accuracy, while lowering the damage and upping the armour penetration to make it less of a 'miss every shot' or 'get killed from off screen without being able to respond' kind of weapon.

Additionally, this PR looks to generally set a floor of 0.6 seconds fire delay for any weapon, with most non-lethal or larger weapons preferring 0.8 seconds or higher where necessary. This is to ensure that firing a weapon is more impactful of a decision than just spam-click emptying a clip into someone and preventing fun from happening.

Finally, the burst laser and associated objects have been renamed to the "burst energy gun", because that's basically what it is and it irked me that it was called a burst _laser_ even though it had stun settings.

More details on the adjusted values are listed below.

**Tasers:**
- **All Taser weapons:** fire delay 0.6 seconds -> 0.8 seconds.
- **Cyborg Taser:** shot recharge time 0.7 seconds -> 0.6 seconds, power per shot 400W -> 480W.

**Xeno Tasers:**
- **All Xeno Taser weapons:** fire delay 0.6 seconds -> 0.8 seconds.
- **All Cyborg Xeno Taser weapons:** shot recharge time 0.3 seconds -> 0.4 seconds.

**Disablers:**
- **Disabler:** fire delay 0.6 seconds -> 0.8 seconds.
- **Swarm Disabler:** fire delay 0.6 seconds -> 0.8 seconds.

**Phase Weapons:**
- **Cyborg Phase Carbine:** shot recharge time 0.7 seconds -> 0.6 seconds.
- **Cyborg Phase Pistol:** shot recharge time 0.7 seconds -> 0.6 seconds.

**Lasers**
- **Advanced Energy Gun:** fire delay 0.6 seconds -> 0.8 seconds.
- **Burst Laser:** renamed to **Burst Energy Gun**, semi-automatic fire delay 0.6 seconds -> 0.8 seconds, burst fire delay 0.8 seconds -> 1 second, kill burst power per shot 100W -> 200W.
- **Laser Rifle:** suppressive fire delay 0.5 seconds -> 0.6 seconds.
- **Mounted Laser Rifle:** suppressive fire delay 0.5 seconds -> 0.6 seconds.
- **Augment Laser Rifle:** suppressive fire delay 0.5 seconds -> 0.6 seconds.
- **LR1 Shishi:** suppressive fire delay 0.5 seconds -> 0.6 seconds.
- **Mining Laser Rifle:** deter fire delay 0.5 seconds -> 0.6 seconds.
- **Laser Cannon:** damage 80 -> 75, armour penetration 50 -> 40, shot recharge time 0.4 seconds -> 1 second.
- **Marksman Energy Rifle:** accuracy (scoped) 50 -> 75, damage 50 -> 45, armour penetration 10 -> 20.
- **Laser Scattergun:** fire delay 0.6 seconds -> 0.8 seconds.
- **X-Ray Laser Gun:** damage 25 -> 35, armour penetration 50 -> 60, fire delay 0.6 seconds -> 0.8 seconds.
- **Suppression Gun:** armour penetration 75 -> 50, fire delay 0.6 seconds -> 0.8 seconds.

**Ionic Weapons:**
- **Ion Rifle:** fire delay 0.6 seconds -> 0.8 seconds.
- **Ion Pistol:** fire delay 0.6 seconds -> 1 second.