### PR TITLE
Revert "SSmachines instancing PR (#9080)"

### DIFF
--- a/code/ATMOSPHERICS/datum_pipe_network.dm
+++ b/code/ATMOSPHERICS/datum_pipe_network.dm
@@ -14,7 +14,7 @@ var/global/list/datum/pipe_network/pipe_networks = list()	// TODO - Move into SS
 	//var/datum/gas_mixture/air_transient = null
 
 /datum/pipe_network/Destroy()
-	STOP_PROCESSING_MACHINERY(src, SSMACHINES_PIPENETS_LIST)
+	STOP_PROCESSING_PIPENET(src)
 	for(var/datum/pipeline/line_member in line_members)
 		line_member.network = null
 	for(var/obj/machinery/atmospherics/normal_member in normal_members)
@@ -48,7 +48,7 @@ var/global/list/datum/pipe_network/pipe_networks = list()	// TODO - Move into SS
 	update_network_gases()
 
 	if((normal_members.len>0)||(line_members.len>0))
-		START_PROCESSING_MACHINERY(src, SSMACHINES_PIPENETS_LIST)
+		START_PROCESSING_PIPENET(src)
 	else
 		qdel(src)
 

--- a/code/ATMOSPHERICS/pipes/pipe_base.dm
+++ b/code/ATMOSPHERICS/pipes/pipe_base.dm
@@ -35,9 +35,9 @@
 /obj/machinery/atmospherics/pipe/proc/set_leaking(var/new_leaking)
 	if(new_leaking && !leaking)
 		if(!speed_process)
-			begin_processing()
+			START_MACHINE_PROCESSING(src)
 		else
-			begin_speed_processing()
+			START_PROCESSING(SSfastprocess, src)
 		leaking = TRUE
 		if(parent)
 			parent.leaks |= src
@@ -45,9 +45,9 @@
 				parent.network.leaks |= src
 	else if (!new_leaking && leaking)
 		if(!speed_process)
-			end_processing()
+			STOP_MACHINE_PROCESSING(src)
 		else
-			end_speed_processing()
+			STOP_PROCESSING(SSfastprocess, src)
 		leaking = FALSE
 		if(parent)
 			parent.leaks -= src

--- a/code/__defines/machinery.dm
+++ b/code/__defines/machinery.dm
@@ -17,11 +17,6 @@ var/global/defer_powernet_rebuild = 0      // True if net rebuild will be called
 #define USE_POWER_IDLE   1	// Machine is using power at its idle power level
 #define USE_POWER_ACTIVE 2	// Machine is using power at its active power level
 
-/// Bitflags for a machine's preferences on when it should start processing. For use with machinery's `processing_flags` var.
-#define START_PROCESSING_ON_INIT (1<<0) /// Indicates the machine will automatically start processing right after it's `Initialize()` is ran.
-#define START_PROCESSING_MANUALLY (1<<1) /// Machines with this flag will not start processing when it's spawned. Use this if you want to manually control when a machine starts processing.
-
-
 // Channel numbers for power.
 #define CURRENT_CHANNEL -1 // Passed as an argument this means "use whatever current channel is"
 #define EQUIP   1
@@ -144,22 +139,30 @@ var/global/list/restricted_camera_networks = list(NETWORK_ERT,NETWORK_MERCENARY,
 #define SUPERMATTER_EMERGENCY 5		// Integrity < 25%
 #define SUPERMATTER_DELAMINATING 6	// Pretty obvious.
 
-// SSmachines categories
-#define SSMACHINES_MACHINERY_LIST	0 // The default, most things processed by SSmachines are the machinery type
-#define SSMACHINES_POWERNETS_LIST	1 // Powernets to be processed
-#define SSMACHINES_POWEROBJS_LIST	2 // Power objects to be processed (only powersinks atm)
-#define SSMACHINES_PIPENETS_LIST	3 // Pipenets to be worked through
+//wIP - PORT ALL OF THESE TO SUBSYSTEMS AND GET RID OF THE WHOLE LIST PROCESS THING
+// Fancy-pants START/STOP_PROCESSING() macros that lets us custom define what the list is.
+#define START_PROCESSING_IN_LIST(DATUM, LIST) \
+if (!(DATUM.datum_flags & DF_ISPROCESSING)) {\
+	LIST += DATUM;\
+	DATUM.datum_flags |= DF_ISPROCESSING\
+}
 
-/// Takes a datum and optionally a flag (`SSMACHINES_MACHINERY_LIST` (default), `SSMACHINES_POWERNETS_LIST`, `SSMACHINES_POWEROJBS_LIST`, `SSMACHINES_PIPENETS_LIST`) and adds that datum
-/// to SSmachines
-#define START_PROCESSING_MACHINERY(Datum, List) if (!(Datum.datum_flags & DF_ISPROCESSING)) {Datum.datum_flags |= DF_ISPROCESSING;SSmachines.start_processing(Datum, List)}
-#define STOP_PROCESSING_MACHINERY(Datum, List) Datum.datum_flags &= ~DF_ISPROCESSING;SSmachines.stop_processing(Datum, List)
-/// Takes a datum and optionally a flag (`SSMACHINES_MACHINERY_LIST` (default), `SSMACHINES_POWERNETS_LIST`, `SSMACHINES_POWEROJBS_LIST`, `SSMACHINES_PIPENETS_LIST`) and removes that datum
-/// from SSmachines
-#define START_SPEED_PROCESSING(Datum) if (!(Datum.datum_flags & DF_ISPROCESSING)) {Datum.datum_flags |= DF_ISPROCESSING;SSfastprocess.processing += Datum}
-#define STOP_SPEED_PROCESSING(Datum) Datum.datum_flags &= ~DF_ISPROCESSING;SSfastprocess.processing -= Datum
+#define STOP_PROCESSING_IN_LIST(DATUM, LIST) LIST.Remove(DATUM);DATUM.datum_flags &= ~DF_ISPROCESSING
+
+// Note - I would prefer these be defined machines.dm, but some are used prior in file order. ~Leshana
+#define START_MACHINE_PROCESSING(Datum) START_PROCESSING_IN_LIST(Datum, global.processing_machines)
+#define STOP_MACHINE_PROCESSING(Datum) STOP_PROCESSING_IN_LIST(Datum, global.processing_machines)
+
+#define START_PROCESSING_PIPENET(Datum) START_PROCESSING_IN_LIST(Datum, global.pipe_networks)
+#define STOP_PROCESSING_PIPENET(Datum) STOP_PROCESSING_IN_LIST(Datum, global.pipe_networks)
+
+#define START_PROCESSING_POWERNET(Datum) START_PROCESSING_IN_LIST(Datum, global.powernets)
+#define STOP_PROCESSING_POWERNET(Datum) STOP_PROCESSING_IN_LIST(Datum, global.powernets)
+
+#define START_PROCESSING_POWER_OBJECT(Datum) START_PROCESSING_IN_LIST(Datum, global.processing_power_items)
+#define STOP_PROCESSING_POWER_OBJECT(Datum) STOP_PROCESSING_IN_LIST(Datum, global.processing_power_items)
 
 // Computer login types
 #define LOGIN_TYPE_NORMAL 1
 #define LOGIN_TYPE_AI 2
-#define LOGIN_TYPE_ROBOT 3
+#define LOGIN_TYPE_ROBOT 3 

--- a/code/controllers/subsystems/machines.dm
+++ b/code/controllers/subsystems/machines.dm
@@ -1,7 +1,14 @@
 #define SSMACHINES_PIPENETS      1
 #define SSMACHINES_MACHINERY     2
 #define SSMACHINES_POWERNETS     3
-#define SSMACHINES_POWER_ITEMS	 4
+#define SSMACHINES_POWER_OBJECTS 4
+
+//
+// SSmachines subsystem - Processing machines, pipenets, and powernets!
+//
+// Implementation Plan:
+// PHASE 1 - Add subsystem using the existing global list vars
+// PHASE 2 - Move the global list vars into the subsystem.
 
 SUBSYSTEM_DEF(machines)
 	name = "Machines"
@@ -12,17 +19,18 @@ SUBSYSTEM_DEF(machines)
 
 	var/current_step = SSMACHINES_PIPENETS
 
-	var/cost_pipenets       = 0
-	var/cost_machinery      = 0
-	var/cost_powernets      = 0
-	var/cost_power_objects  = 0
+	var/cost_pipenets      = 0
+	var/cost_machinery     = 0
+	var/cost_powernets     = 0
+	var/cost_power_objects = 0
 
-	var/list/pipenets       = list()
-	var/list/machinery      = list()
-	var/list/powernets      = list()
-	var/list/power_objects	= list()
+	// TODO - PHASE 2 - Switch these from globals to instance vars
+	// var/list/pipenets      = list()
+	// var/list/machinery     = list()
+	// var/list/powernets     = list()
+	// var/list/power_objects = list()
 
-	var/list/current_run 	= list()
+	var/list/current_run = list()
 
 /datum/controller/subsystem/machines/Initialize(timeofday)
 	makepowernets()
@@ -33,10 +41,10 @@ SUBSYSTEM_DEF(machines)
 /datum/controller/subsystem/machines/fire(resumed, no_mc_tick)
 	var/timer = TICK_USAGE
 
-	INTERNAL_PROCESS_STEP(SSMACHINES_POWER_ITEMS,FALSE,process_power_objects,cost_power_objects,SSMACHINES_PIPENETS) // Higher priority, damnit
+	INTERNAL_PROCESS_STEP(SSMACHINES_POWER_OBJECTS,FALSE,process_power_objects,cost_power_objects,SSMACHINES_PIPENETS) // Higher priority, damnit
 	INTERNAL_PROCESS_STEP(SSMACHINES_PIPENETS,TRUE,process_pipenets,cost_pipenets,SSMACHINES_MACHINERY)
 	INTERNAL_PROCESS_STEP(SSMACHINES_MACHINERY,FALSE,process_machinery,cost_machinery,SSMACHINES_POWERNETS)
-	INTERNAL_PROCESS_STEP(SSMACHINES_POWERNETS,FALSE,process_powernets,cost_powernets,SSMACHINES_POWER_ITEMS)
+	INTERNAL_PROCESS_STEP(SSMACHINES_POWERNETS,FALSE,process_powernets,cost_powernets,SSMACHINES_POWER_OBJECTS)
 
 // rebuild all power networks from scratch - only called at world creation or by the admin verb
 // The above is a lie. Turbolifts also call this proc.
@@ -80,16 +88,16 @@ SUBSYSTEM_DEF(machines)
 	msg += "PN:[round(cost_powernets,1)]|"
 	msg += "PO:[round(cost_power_objects,1)]"
 	msg += "} "
-	msg += "PI:[pipe_networks.len]|"
-	msg += "MC:[machinery.len]|"
-	msg += "PN:[powernets.len]|"
-	msg += "PO:[power_objects.len]|"
-	msg += "MC/MS:[round((cost ? machinery.len/cost_machinery : 0),0.1)]"
+	msg += "PI:[global.pipe_networks.len]|"
+	msg += "MC:[global.processing_machines.len]|"
+	msg += "PN:[global.powernets.len]|"
+	msg += "PO:[global.processing_power_items.len]|"
+	msg += "MC/MS:[round((cost ? global.processing_machines.len/cost_machinery : 0),0.1)]"
 	..(jointext(msg, null))
 
 /datum/controller/subsystem/machines/proc/process_pipenets(resumed = 0)
 	if (!resumed)
-		src.current_run = pipe_networks.Copy()
+		src.current_run = global.pipe_networks.Copy()
 	//cache for sanic speed (lists are references anyways)
 	var/list/current_run = src.current_run
 	while(current_run.len)
@@ -98,7 +106,7 @@ SUBSYSTEM_DEF(machines)
 		if(istype(PN) && !QDELETED(PN))
 			PN.process(wait)
 		else
-			pipe_networks.Remove(PN)
+			global.pipe_networks.Remove(PN)
 			if(!QDELETED(PN))
 				DISABLE_BITFIELD(PN.datum_flags, DF_ISPROCESSING)
 		if(MC_TICK_CHECK)
@@ -106,7 +114,7 @@ SUBSYSTEM_DEF(machines)
 
 /datum/controller/subsystem/machines/proc/process_machinery(resumed = 0)
 	if (!resumed)
-		src.current_run = machines.Copy()
+		src.current_run = global.processing_machines.Copy()
 
 	var/list/current_run = src.current_run
 	while(current_run.len)
@@ -114,7 +122,7 @@ SUBSYSTEM_DEF(machines)
 		current_run.len--
 
 		if(!istype(M) || QDELETED(M) || (M.process(wait) == PROCESS_KILL))
-			machines.Remove(M)
+			global.processing_machines.Remove(M)
 			if(!QDELETED(M))
 				DISABLE_BITFIELD(M.datum_flags, DF_ISPROCESSING)
 		if(MC_TICK_CHECK)
@@ -122,7 +130,7 @@ SUBSYSTEM_DEF(machines)
 
 /datum/controller/subsystem/machines/proc/process_powernets(resumed = 0)
 	if (!resumed)
-		src.current_run = powernets.Copy()
+		src.current_run = global.powernets.Copy()
 
 	var/list/current_run = src.current_run
 	while(current_run.len)
@@ -131,7 +139,7 @@ SUBSYSTEM_DEF(machines)
 		if(istype(PN) && !QDELETED(PN))
 			PN.reset(wait)
 		else
-			powernets.Remove(PN)
+			global.powernets.Remove(PN)
 			if(!QDELETED(PN))
 				DISABLE_BITFIELD(PN.datum_flags, DF_ISPROCESSING)
 		if(MC_TICK_CHECK)
@@ -141,44 +149,19 @@ SUBSYSTEM_DEF(machines)
 // Currently only used by powersinks. These items get priority processed before machinery
 /datum/controller/subsystem/machines/proc/process_power_objects(resumed = 0)
 	if (!resumed)
-		src.current_run = power_objects.Copy()
+		src.current_run = global.processing_power_items.Copy()
 
 	var/list/current_run = src.current_run
 	while(current_run.len)
 		var/obj/item/I = current_run[current_run.len]
 		current_run.len--
 		if(!I.pwr_drain(wait)) // 0 = Process Kill, remove from processing list.
-			power_objects.Remove(I)
+			global.processing_power_items.Remove(I)
 			DISABLE_BITFIELD(I.datum_flags, DF_ISPROCESSING)
 		if(MC_TICK_CHECK)
 			return
 
-/** Adds a datum to this subsystem
-  *
-  * `dat` - datum to be added
-  *
-  * `list = SSMACHINES_MACHINERY_LIST` - list to be added to, defaults to machines
-  */
-/datum/controller/subsystem/machines/proc/start_processing(dat, list = SSMACHINES_MACHINERY_LIST)
-	switch(list)
-		if(SSMACHINES_MACHINERY_LIST) machinery += dat
-		if(SSMACHINES_POWERNETS_LIST) powernets += dat
-		if(SSMACHINES_POWEROBJS_LIST) power_objects += dat
-		if(SSMACHINES_PIPENETS_LIST)  pipenets += dat
-
-/** Removes a datum from this subsystem
-  *
-  * ```dat``` - datum to be removed
-  *
-  *```list``` = SSMACHINES_MACHINERY_LIST` - list to be removed from, defaults to machines
-  */
-/datum/controller/subsystem/machines/proc/stop_processing(dat, list = SSMACHINES_MACHINERY_LIST)
-	switch(list)
-		if(SSMACHINES_MACHINERY_LIST) machinery -= dat
-		if(SSMACHINES_POWERNETS_LIST) powernets -= dat
-		if(SSMACHINES_POWEROBJS_LIST) power_objects -= dat
-		if(SSMACHINES_PIPENETS_LIST)  pipenets -= dat
 
 #undef SSMACHINES_PIPENETS
 #undef SSMACHINES_MACHINERY
-#undef SSMACHINES_POWER_ITEMS
+#undef SSMACHINES_POWER_OBJECTS

--- a/code/controllers/subsystems/processing/fastprocess.dm
+++ b/code/controllers/subsystems/processing/fastprocess.dm
@@ -4,7 +4,6 @@ PROCESSING_SUBSYSTEM_DEF(fastprocess)
 	name = "Fast Processing"
 	wait = 0.2 SECONDS
 	stat_tag = "FP"
-	var/list/machinery = list()
 
 /datum/controller/subsystem/processing/fastprocess/Recover()
 	log_debug("[name] subsystem Recover().")

--- a/code/game/machinery/camera/presets.dm
+++ b/code/game/machinery/camera/presets.dm
@@ -171,9 +171,9 @@ var/global/list/engineering_networks = list(
 	var/list/my_area = by_area[A.name]
 	my_area += src
 	var/number = my_area.len
-
+	
 	c_tag = "[A.name] #[number]"
-
+	
 /obj/machinery/camera/autoname/Destroy()
 	var/area/A = get_area(src)
 	if(!A || !by_area || !by_area[A.name])
@@ -215,7 +215,7 @@ var/global/list/engineering_networks = list(
 		return //nooooo
 	assembly.upgrades.Add(new /obj/item/assembly/prox_sensor(assembly))
 	setPowerUsage()
-	begin_processing()
+	START_MACHINE_PROCESSING(src)
 	sense_proximity(callback = /atom/proc/HasProximity)
 	update_coverage()
 

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -643,7 +643,7 @@ About the new airlock wires panel:
 		backup_power_lost_until = world.time + SecondsToTicks(10)
 
 	if(main_power_lost_until > 0 || backup_power_lost_until > 0)
-		begin_processing()
+		START_MACHINE_PROCESSING(src)
 
 	// Disable electricity if required
 	if(electrified_until && isAllPowerLoss())
@@ -655,7 +655,7 @@ About the new airlock wires panel:
 	backup_power_lost_until = backupPowerCablesCut() ? -1 : world.time + SecondsToTicks(60)
 
 	if(backup_power_lost_until > 0)
-		begin_processing()
+		START_MACHINE_PROCESSING(src)
 
 	// Disable electricity if required
 	if(electrified_until && isAllPowerLoss())
@@ -700,7 +700,7 @@ About the new airlock wires panel:
 		src.electrified_until = duration == -1 ? -1 : world.time + SecondsToTicks(duration)
 
 	if(electrified_until > 0)
-		begin_processing()
+		START_MACHINE_PROCESSING(src)
 
 	if(feedback && message)
 		to_chat(usr,message)

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -113,56 +113,32 @@ Class Procs:
 	var/obj/item/circuitboard/circuit = null
 	var/list/materials = list() //Exclusively used for machines that take materials - lathes, fabricators etc. Honestly overdue for a whole lathe/fab refactor at some point.
 
-	// Use the fastprocess subsystem instead of SSMachines?
-	var/speed_process = FALSE
-	// The subsystem we will be using
-	var/subsystem_type = /datum/controller/subsystem/machines
+	var/speed_process = FALSE			//If false, SSmachines. If true, SSfastprocess.
 
 	required_dexterity = MOB_DEXTERITY_TOUCHSCREENS
 
-/// Helper proc for telling a machine to start processing with the subsystem type that is located in its `subsystem_type` var.
-/obj/machinery/proc/begin_processing()
-	START_PROCESSING_MACHINERY(src, SSMACHINES_MACHINERY_LIST)
 
-/// Helper proc for telling a machine to stop processing with the subsystem type that is located in its `subsystem_type` var.
-/obj/machinery/proc/end_processing()
-	STOP_PROCESSING_MACHINERY(src, SSMACHINES_MACHINERY_LIST)
-
-/// Helper proc for telling a machine to start processing with the subsystem type that is located in its `subsystem_type` var.
-/obj/machinery/proc/begin_speed_processing()
-	end_processing()
-	START_SPEED_PROCESSING(src)
-
-/// Helper proc for telling a machine to stop processing with the subsystem type that is located in its `subsystem_type` var.
-/obj/machinery/proc/end_speed_processing()
-	STOP_SPEED_PROCESSING(src)
-	begin_processing()
-
-
-
-/obj/machinery/Initialize(var/ml, direction=0)
+/obj/machinery/Initialize(var/ml, d=0)
 	. = ..()
-
-	if(direction)
-		set_dir(direction)
-
+	if(d)
+		set_dir(d)
 	if(ispath(circuit))
 		circuit = new circuit(src)
 	global.machines += src
 	if(ispath(circuit))
 		circuit = new circuit(src)
 	if(!speed_process)
-		START_PROCESSING_MACHINERY(src, SSMACHINES_MACHINERY_LIST)
+		START_MACHINE_PROCESSING(src)
 	else
-		begin_speed_processing()
+		START_PROCESSING(SSfastprocess, src)
 	if(!ml)
 		power_change()
 
 /obj/machinery/Destroy()
 	if(!speed_process)
-		STOP_PROCESSING_MACHINERY(src, SSMACHINES_MACHINERY_LIST)
+		STOP_MACHINE_PROCESSING(src)
 	else
-		end_speed_processing()
+		STOP_PROCESSING(SSfastprocess, src)
 	global.machines -= src
 	if(component_parts)
 		for(var/atom/A in component_parts)

--- a/code/game/machinery/syndicatebeacon.dm
+++ b/code/game/machinery/syndicatebeacon.dm
@@ -95,7 +95,7 @@
 			singulo.target = src
 	icon_state = "[icontype]1"
 	active = 1
-	begin_processing()
+	START_MACHINE_PROCESSING(src)
 	if(user)
 		to_chat(user, "<span class='notice'>You activate the beacon.</span>")
 

--- a/code/modules/mining/machinery/machine_processing.dm
+++ b/code/modules/mining/machinery/machine_processing.dm
@@ -215,11 +215,11 @@
 	else
 		speed_process = !speed_process // switching gears
 	if(speed_process) // high gear
-		end_processing()
-		begin_speed_processing()
+		STOP_MACHINE_PROCESSING(src)
+		START_PROCESSING(SSfastprocess, src)
 	else // low gear
-		end_speed_processing()
-		begin_processing()
+		STOP_PROCESSING(SSfastprocess, src)
+		START_MACHINE_PROCESSING(src)
 	for(var/obj/machinery/mineral/unloading_machine/unloader in refinery_area.contents)
 		unloader.toggle_speed()
 	for(var/obj/machinery/conveyor_switch/cswitch in refinery_area.contents)

--- a/code/modules/mining/machinery/machine_stacking.dm
+++ b/code/modules/mining/machinery/machine_stacking.dm
@@ -109,11 +109,11 @@
 	else
 		speed_process = !speed_process // switching gears
 	if(speed_process) // high gear
-		end_processing()
-		begin_speed_processing()
+		STOP_MACHINE_PROCESSING(src)
+		START_PROCESSING(SSfastprocess, src)
 	else // low gear
-		end_speed_processing()
-		begin_processing()
+		STOP_PROCESSING(SSfastprocess, src)
+		START_MACHINE_PROCESSING(src)
 
 /obj/machinery/mineral/stacking_machine/process()
 	if (src.output && src.input)

--- a/code/modules/mining/machinery/machine_unloading.dm
+++ b/code/modules/mining/machinery/machine_unloading.dm
@@ -27,11 +27,11 @@
 	else
 		speed_process = !speed_process // switching gears
 	if(speed_process) // high gear
-		end_processing()
-		begin_speed_processing()
+		STOP_MACHINE_PROCESSING(src)
+		START_PROCESSING(SSfastprocess, src)
 	else // low gear
-		end_speed_processing()
-		begin_processing()
+		STOP_PROCESSING(SSfastprocess, src)
+		START_MACHINE_PROCESSING(src)
 
 /obj/machinery/mineral/unloading_machine/process()
 	if (src.output && src.input)

--- a/code/modules/power/antimatter/shielding.dm
+++ b/code/modules/power/antimatter/shielding.dm
@@ -147,7 +147,7 @@
 
 /obj/machinery/am_shielding/proc/setup_core()
 	processing = 1
-	begin_processing()
+	START_MACHINE_PROCESSING(src)
 	if(!control_unit)	return
 	control_unit.linked_cores.Add(src)
 	control_unit.reported_core_efficiency += efficiency

--- a/code/modules/power/powernet.dm
+++ b/code/modules/power/powernet.dm
@@ -21,7 +21,7 @@
 	var/problem = 0				// If this is not 0 there is some sort of issue in the powernet. Monitors will display warnings.
 
 /datum/powernet/New()
-	START_PROCESSING_MACHINERY(src, SSMACHINES_POWERNETS_LIST)
+	START_PROCESSING_POWERNET(src)
 	..()
 
 /datum/powernet/Destroy()
@@ -31,7 +31,7 @@
 	for(var/obj/machinery/power/M in nodes)
 		nodes -= M
 		M.powernet = null
-	STOP_PROCESSING_MACHINERY(src, SSMACHINES_POWERNETS_LIST)
+	STOP_PROCESSING_POWERNET(src)
 	return ..()
 
 //Returns the amount of excess power (before refunding to SMESs) from last tick.

--- a/code/modules/recycling/conveyor2.dm
+++ b/code/modules/recycling/conveyor2.dm
@@ -46,11 +46,11 @@
 	else
 		speed_process = !speed_process // switching gears
 	if(speed_process) // high gear
-		end_processing()
-		begin_speed_processing()
+		STOP_MACHINE_PROCESSING(src)
+		START_PROCESSING(SSfastprocess, src)
 	else // low gear
-		end_speed_processing()
-		begin_processing()
+		STOP_PROCESSING(SSfastprocess, src)
+		START_MACHINE_PROCESSING(src)
 
 /obj/machinery/conveyor/proc/setmove()
 	if(operating == FORWARDS)

--- a/code/modules/xenobio/machinery/processor.dm
+++ b/code/modules/xenobio/machinery/processor.dm
@@ -24,7 +24,7 @@
 		return
 	if(to_be_processed.len)
 		spawn(1)
-			start_processing()
+			begin_processing()
 	else
 		to_chat(user, "<span class='warning'>The processor is empty.</span>")
 		playsound(src, 'sound/machines/buzz-sigh.ogg', 50, 1)
@@ -60,7 +60,7 @@
 	AM.forceMove(src)
 	visible_message("<span class='notice'>\the [user] places [AM] inside \the [src].</span>")
 
-/obj/machinery/processor/proc/start_processing()
+/obj/machinery/processor/proc/begin_processing()
 	if(processing)
 		return // Already doing it.
 	processing = TRUE


### PR DESCRIPTION
Atmos pipes aren't processing. Someone was reportedly able to fill a pipe using a passive vent, but pumps filters, etc are doing nothing. Looking at the stat of the machinery subsystem, it doesn't think there's any pipe objects. This is flagrantly wrong.

SB: ![image](https://puu.sh/JM4jj/10025a744f.png)
IS: ![image](https://puu.sh/JM4kj/62f7f55879.png)
* Of note is the second PI entry, it lists the number of pipe objects being processed by SSMachines: it's 0 in master, and 282 on my locally-compiled code dating to a few months ago

I hypothesize that the reported performance improvement was seen because it was not processing atmospherics.
This is a pretty major regression, so I'm not waiting for a forwards fix.

This reverts commit 4889b33cea75b2de1367aa0150393c4f8d13f5c4.