### PR TITLE
Vox are defibbable.

### DIFF
--- a/code/modules/mob/living/carbon/human/species/outsider/vox.dm
+++ b/code/modules/mob/living/carbon/human/species/outsider/vox.dm
@@ -57,7 +57,7 @@
 	poison_type = "oxygen"
 	siemens_coefficient = 0.2
 
-	flags = NO_SCAN | NO_DEFIB
+	flags = NO_SCAN
 	spawn_flags = SPECIES_CAN_JOIN | SPECIES_IS_WHITELISTED
 	appearance_flags = HAS_SKIN_COLOR | HAS_EYE_COLOR | HAS_HAIR_COLOR
 	limb_blend = ICON_MULTIPLY


### PR DESCRIPTION
Vox predate defibs, when defibs were added apparently it used NO_SCAN which vox have due to not having DNA/not being clonable, it is very harsh to make them completely unrecoverable when they can join as non-antags.