### PR TITLE
Adds a volume channel for system sounds (roundstart, votes, etc)

### DIFF
--- a/code/__defines/misc.dm
+++ b/code/__defines/misc.dm
@@ -335,6 +335,7 @@ var/global/list/##LIST_NAME = list();\
 #define VOLUME_CHANNEL_AMBIENCE "Ambience"
 #define VOLUME_CHANNEL_ALARMS "Alarms"
 #define VOLUME_CHANNEL_DOORS "Doors"
+#define VOLUME_CHANNEL_SYSTEM "System"
 
 // Make sure you update this or clients won't be able to adjust the channel
 GLOBAL_LIST_INIT(all_volume_channels, list(
@@ -342,6 +343,7 @@ GLOBAL_LIST_INIT(all_volume_channels, list(
 	VOLUME_CHANNEL_AMBIENCE,
 	VOLUME_CHANNEL_ALARMS,
 	VOLUME_CHANNEL_DOORS,
+	VOLUME_CHANNEL_SYSTEM,
 ))
 
 /*

--- a/code/controllers/subsystems/ticker.dm
+++ b/code/controllers/subsystems/ticker.dm
@@ -79,7 +79,8 @@ var/global/datum/controller/subsystem/ticker/ticker
 /datum/controller/subsystem/ticker/proc/pregame_welcome()
 	to_world("<span class='boldannounce notice'><em>Welcome to the pregame lobby!</em></span>")
 	to_world("<span class='boldannounce notice'>Please set up your character and select ready. The round will start in [pregame_timeleft] seconds.</span>")
-	world << sound('sound/misc/server-ready.ogg', volume = 100)
+	for (var/mob/M in player_list)
+		M.playsound_local(null, 'sound/misc/server-ready.ogg', 100, FALSE, is_global = TRUE, volume_channel = VOLUME_CHANNEL_SYSTEM)
 
 // Called during GAME_STATE_PREGAME (RUNLEVEL_LOBBY)
 /datum/controller/subsystem/ticker/proc/pregame_tick()
@@ -185,7 +186,8 @@ var/global/datum/controller/subsystem/ticker/ticker
 			if (S.name != "AI")
 				qdel(S)
 		to_world("<span class='boldannounce notice'><em>Enjoy the game!</em></span>")
-		world << sound('sound/AI/welcome.ogg') // Skie
+		for (var/mob/M in player_list)
+			M.playsound_local(null, 'sound/AI/welcome.ogg', 100, FALSE, is_global = TRUE, volume_channel = VOLUME_CHANNEL_SYSTEM)
 		//Holiday Round-start stuff	~Carn
 		Holiday_Game_Start()
 

--- a/code/controllers/subsystems/vote.dm
+++ b/code/controllers/subsystems/vote.dm
@@ -255,7 +255,8 @@ SUBSYSTEM_DEF(vote)
 
 		to_world("<font color='purple'><b>[text]</b>\nType <b>vote</b> or click <a href='?src=\ref[src]'>here</a> to place your votes.\nYou have [config.vote_period / 10] seconds to vote.</font>")
 		if(vote_type == VOTE_CREW_TRANSFER || vote_type == VOTE_GAMEMODE || vote_type == VOTE_CUSTOM)
-			world << sound('sound/ambience/alarm4.ogg', repeat = 0, wait = 0, volume = 50, channel = 3)
+			for (var/mob/M in player_list)
+				M.playsound_local(null, 'sound/ambience/alarm4.ogg', 50, FALSE, is_global = TRUE, channel = 3, volume_channel = VOLUME_CHANNEL_SYSTEM)
 
 		if(mode == VOTE_GAMEMODE && round_progressing)
 			gamemode_vote_called = TRUE


### PR DESCRIPTION
#### purpose

I've found always found the roundstart sound to be uncomfortably loud, and this is generally because most sounds in the game use 50 volume as a baseline and that one, like almost all global sounds, uses 100 volume - double that of most sounds use.

#### details

adds a new volume channel, System, to the volume menu. roundstart sounds, pregame lobby sounds, and vote start sounds are all tied to this channel, and its volume can be controlled like any other channel, allowing them to be made quieter

this is just one way of doing it - it's also possible to adjust the default or to skip the extra channel in favor of just reducing the default volume, but as a stickler for customization I liked the idea of letting folks have fine-grained control over what is purely a clientside thing

byond appears to cap sound volume at 100, so the roundstart sound (mercifully) cannot be made any louder - just quieter

#### testing

started a buncha rounds on my local server using various settings on the slider. the default should sound unchanged from the current version, but it can be changed in either direction now. I also tried with a guest account having it muted and another account having it normally to make sure the sounds played correctly, but admittedly I don't really have a way of testing it on a large scale, sadly

#### media

100% volume, the current default:

https://github.com/PolarisSS13/Polaris/assets/47678781/aeb40b56-680c-484a-9778-be9b300920c7

50% volume:

https://github.com/PolarisSS13/Polaris/assets/47678781/0b7f9721-708d-4f1d-8493-240912522db4
