### PR TITLE
welders now update their icon upon refilling them.

### DIFF
--- a/code/game/objects/items/weapons/tools/weldingtool.dm
+++ b/code/game/objects/items/weapons/tools/weldingtool.dm
@@ -150,6 +150,7 @@
 			O.reagents.trans_to_obj(src, max_fuel)
 			to_chat(user, "<span class='notice'>Welder refueled</span>")
 			playsound(src, 'sound/effects/refill.ogg', 50, 1, -6)
+			update_icon()
 			return
 		else if(!welding)
 			to_chat(user, "<span class='notice'>[src] doesn't use fuel.</span>")


### PR DESCRIPTION
self-explanatory.
Welder sprite has a little gauge to show if it's full or not, so an empty welder will still look empty even upon refilling it.
This fixes that.