### PR TITLE
Yellow slimes won't try to shock non-mob food targets

### DIFF
--- a/code/modules/mob/living/simple_mob/subtypes/slime/xenobio/subtypes.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/slime/xenobio/subtypes.dm
@@ -149,6 +149,12 @@
 			/mob/living/simple_mob/slime/xenobio/orange
 		)
 
+
+/mob/living/simple_mob/slime/xenobio/yellow/ICheckRangedAttack(atom/A)
+	if (!ismob(A))
+		return FALSE
+	return ..()
+
 /mob/living/simple_mob/slime/xenobio/yellow/apply_melee_effects(atom/A)
 	..()
 	if(isliving(A))


### PR DESCRIPTION
#### purpose

yellow slimes distant from food or dirt on the ground won't try to actually go and eat it - instead they'll get trapped in a loop of shocking it with their ranged attack over and over

#### details

implements an override on the `xenobio/yellow` type to cause `ICheckRangedAttack` to return false if the target isn't a mob, and to run the base method if it is. this could also feasibly be put on the base slime type, if desired

#### testing

put an adult yellow slime in a pen with a blood splatter both before and after applying the changes. before, they get stuck shocking it; after, they do not, and will go over to normal adjacent distance and eat it.
