### PR TITLE
Non-antag vox nerfs.

### DIFF
--- a/code/game/objects/items/weapons/material/shards.dm
+++ b/code/game/objects/items/weapons/material/shards.dm
@@ -116,7 +116,7 @@
 		if(ishuman(M))
 			var/mob/living/carbon/human/H = M
 
-			if(H.species.siemens_coefficient<0.5) //Thick skin.
+			if(H.species.get_siemens_coefficient(H) < 0.5) //Thick skin.
 				return
 
 			if( H.shoes || ( H.wear_suit && (H.wear_suit.body_parts_covered & FEET) ) )

--- a/code/game/objects/items/weapons/traps.dm
+++ b/code/game/objects/items/weapons/traps.dm
@@ -357,7 +357,7 @@
 	if(ishuman(L))
 		var/mob/living/carbon/human/H = L
 
-		if(H.species.siemens_coefficient<0.5) //Thick skin.
+		if(H.species.get_siemens_coefficient(H) < 0.5) //Thick skin.
 			return
 
 		if( H.shoes || ( H.wear_suit && (H.wear_suit.body_parts_covered & FEET) ) )

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -310,7 +310,7 @@
 	if (!def_zone)
 		def_zone = pick("l_hand", "r_hand")
 
-	if(species.siemens_coefficient == -1)
+	if(species.get_siemens_coefficient(src) == -1)
 		if(stored_shock_by_ref["\ref[src]"])
 			stored_shock_by_ref["\ref[src]"] += shock_damage
 		else

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -126,7 +126,7 @@ emp_act
 	if (!def_zone)
 		return 1.0
 
-	var/siemens_coefficient = max(species.siemens_coefficient,0)
+	var/siemens_coefficient = max(species.get_siemens_coefficient(src),0)
 
 	var/list/clothing_items = list(head, wear_mask, wear_suit, w_uniform, gloves, shoes) // What all are we checking?
 	for(var/obj/item/clothing/C in clothing_items)

--- a/code/modules/mob/living/carbon/human/species/outsider/event.dm
+++ b/code/modules/mob/living/carbon/human/species/outsider/event.dm
@@ -91,7 +91,7 @@ Variables you may want to make use of are:
 	flash_mod = 0.9
 	sound_mod = 0.9
 	chemOD_mod = 0.9
-	siemens_coefficient = 0.9
+	shock_vulnerability = 0.9
 
 	spawn_flags = SPECIES_IS_RESTRICTED
 	appearance_flags = HAS_SKIN_TONE | HAS_EYE_COLOR
@@ -199,7 +199,7 @@ Variables you may want to make use of are:
 
 /datum/species/event1/proc/toggle_cloning()
 	flags ^= NO_SCAN
-	
+
 /datum/species/event1/proc/toggle_defibbing()
 	flags ^= NO_DEFIB
 

--- a/code/modules/mob/living/carbon/human/species/outsider/replicant.dm
+++ b/code/modules/mob/living/carbon/human/species/outsider/replicant.dm
@@ -35,7 +35,7 @@
 	radiation_mod = 0.9
 	flash_mod = 0.9
 	sound_mod = 0.9
-	siemens_coefficient = 0.9
+	shock_vulnerability = 0.9
 
 	spawn_flags = SPECIES_IS_RESTRICTED
 	appearance_flags = HAS_SKIN_COLOR | HAS_EYE_COLOR | HAS_HAIR_COLOR | HAS_UNDERWEAR

--- a/code/modules/mob/living/carbon/human/species/outsider/shadow.dm
+++ b/code/modules/mob/living/carbon/human/species/outsider/shadow.dm
@@ -10,7 +10,7 @@
 	light_dam = 2
 	darksight = 8
 	has_organ = list()
-	siemens_coefficient = 0
+	shock_vulnerability = 0
 
 	blood_color = "#CCCCCC"
 	flesh_color = "#AAAAAA"

--- a/code/modules/mob/living/carbon/human/species/outsider/skeleton.dm
+++ b/code/modules/mob/living/carbon/human/species/outsider/skeleton.dm
@@ -32,7 +32,7 @@
 	flash_mod =     0
 	chemOD_mod =	0
 
-	siemens_coefficient = 0
+	shock_vulnerability = 0
 
 	death_message = "falls over and stops moving!"
 	knockout_message = "falls over and stops moving!"

--- a/code/modules/mob/living/carbon/human/species/outsider/vox.dm
+++ b/code/modules/mob/living/carbon/human/species/outsider/vox.dm
@@ -55,7 +55,7 @@
 
 	breath_type = "nitrogen"
 	poison_type = "oxygen"
-	siemens_coefficient = 0.2
+	shock_vulnerability = 0.2
 
 	flags = NO_SCAN
 	spawn_flags = SPECIES_CAN_JOIN | SPECIES_IS_WHITELISTED

--- a/code/modules/mob/living/carbon/human/species/outsider/vox.dm
+++ b/code/modules/mob/living/carbon/human/species/outsider/vox.dm
@@ -210,3 +210,15 @@
 				"datum" = body_marking_styles_list["Vox Claws"]
 			)
 	return TRUE
+
+// Nerfs some vox aspects if you aren't an antag (ie. raider, merc)
+// TODO: raider/non-raider voxforms, if there's some way to do that nicely...
+/datum/species/vox/can_shred(mob/living/carbon/human/H, ignore_intent)
+	if(H.mind && player_is_antag(H.mind))
+		return ..()
+	return FALSE
+
+/datum/species/vox/get_siemens_coefficient(var/mob/living/carbon/human/H)
+	if(H.mind && player_is_antag(H.mind))
+		return ..()
+	return 0.65 // resistant, but still able to be tased/shocked to an extent

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -195,7 +195,7 @@
 	// Body/form vars.
 	var/list/inherent_verbs = list()									// Species-specific verbs.
 	var/has_fine_manipulation = 1							// Can use small items.
-	var/siemens_coefficient = 1								// The lower, the thicker the skin and better the insulation.
+	var/shock_vulnerability = 1								// Used as Siemen's coefficient. The lower, the thicker the skin and better the insulation.
 	var/darksight = 2										// Native darksight distance.
 	var/flags = 0											// Various specific features.
 	var/appearance_flags = 0								// Appearance/display related features.

--- a/code/modules/mob/living/carbon/human/species/species_getters.dm
+++ b/code/modules/mob/living/carbon/human/species/species_getters.dm
@@ -131,3 +131,6 @@
 
 /datum/species/proc/get_slowdown(var/mob/living/carbon/human/H)
 	return slowdown
+
+/datum/species/proc/get_siemens_coefficient(var/mob/living/carbon/human/H)
+	return shock_vulnerability

--- a/code/modules/mob/living/carbon/human/species/station/golem.dm
+++ b/code/modules/mob/living/carbon/human/species/station/golem.dm
@@ -9,7 +9,7 @@
 	unarmed_types = list(/datum/unarmed_attack/stomp, /datum/unarmed_attack/kick, /datum/unarmed_attack/punch)
 	flags = NO_PAIN | NO_SCAN | NO_POISON | NO_MINOR_CUT | NO_DEFIB
 	spawn_flags = SPECIES_IS_RESTRICTED
-	siemens_coefficient = 0
+	shock_vulnerability = 0
 
 	assisted_langs = list()
 

--- a/code/modules/mob/living/carbon/human/species/station/prometheans.dm
+++ b/code/modules/mob/living/carbon/human/species/station/prometheans.dm
@@ -71,7 +71,7 @@ var/global/datum/species/shapeshifter/promethean/prometheans
 	body_temperature = T20C	// Room temperature
 
 	rarity_value = 5
-	siemens_coefficient = 0.8
+	shock_vulnerability = 0.8
 
 	water_resistance = 0
 	water_damage_mod = 0.3

--- a/code/modules/mob/living/carbon/human/species/station/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station.dm
@@ -507,7 +507,7 @@
 	water_movement = -4	//Ignore shallow water
 	rarity_value = 3
 	hud_type = /datum/hud_data/diona
-	siemens_coefficient = 0.3
+	shock_vulnerability = 0.3
 	show_ssd = "completely quiescent"
 	health_hud_intensity = 2.5
 	item_slowdown_mod = 0.1

--- a/code/modules/mob/living/carbon/human/species/xenomorphs/alien_species.dm
+++ b/code/modules/mob/living/carbon/human/species/xenomorphs/alien_species.dm
@@ -11,7 +11,7 @@
 	rarity_value = 3
 
 	has_fine_manipulation = 0
-	siemens_coefficient = 0
+	shock_vulnerability = 0
 	gluttonous = GLUT_SMALLER
 
 	brute_mod = 0.5 // Hardened carapace.

--- a/code/modules/mob/living/simple_mob/subtypes/slime/xenobio/combat.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/slime/xenobio/combat.dm
@@ -12,7 +12,7 @@
 
 				if(ishuman(L))
 					var/mob/living/carbon/human/H = L
-					stun_power *= max(H.species.siemens_coefficient, 0)
+					stun_power *= max(H.species.get_siemens_coefficient(H), 0)
 
 				if(prob(stun_power * 10)) // Try an electric shock.
 					power_charge = max(0, power_charge - 3)

--- a/code/modules/power/power.dm
+++ b/code/modules/power/power.dm
@@ -304,7 +304,7 @@
 		PN.trigger_warning(5)
 	if(istype(M,/mob/living/carbon/human))
 		var/mob/living/carbon/human/H = M
-		if(H.species.siemens_coefficient <= 0)
+		if(H.species.get_siemens_coefficient(H) <= 0)
 			return
 		if(H.gloves)
 			var/obj/item/clothing/gloves/G = H.gloves


### PR DESCRIPTION
- Species shock vulnerability is handled with a getter.
- Non-antag vox do not get shredding behavior (unarmed damage to windows and grills, APCs, mechs, very fast cuff resists).
- Non-antag vox have 35% shock resistance (electrocution/tasers) instead of 80%.