### PR TITLE
Teshari agility toggle

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/teshari.dm
+++ b/code/modules/mob/living/carbon/human/species/station/teshari.dm
@@ -134,8 +134,9 @@
 
 	inherent_verbs = list(
 		/mob/living/carbon/human/proc/sonar_ping,
-		/mob/living/proc/hide
-		)
+		/mob/living/proc/hide,
+		/mob/living/proc/toggle_pass_table
+	)
 
 	descriptors = list(
 		/datum/mob_descriptor/height = -3,

--- a/code/modules/mob/living/living_powers.dm
+++ b/code/modules/mob/living/living_powers.dm
@@ -25,3 +25,10 @@
 
 	to_chat(usr, "<span class='notice'>You will [allow_self_surgery ? "now" : "no longer"] attempt to operate upon yourself.</span>")
 	log_admin("DEBUG \[[world.timeofday]\]: [src.ckey ? "[src.name]:([src.ckey])" : "[src.name]"] has [allow_self_surgery ? "Enabled" : "Disabled"] self surgery.")
+
+/mob/living/proc/toggle_pass_table()
+	set name = "Toggle Agility"
+	set desc = "Allows you to start/stop hopping over things such as hydroponics trays, tables, and railings."
+	set category = "Abilities"
+	pass_flags ^= PASSTABLE
+	to_chat(src, "You [pass_flags & PASSTABLE ? "will" : "will NOT"] move over tables/railings/trays!")


### PR DESCRIPTION
Ports the ability for teshari to toggle their agility from downstream, through a button in the abilities tab, when pressed, this toggles their PASSTABLE flag off and on.