### PR TITLE
POI - Remaps the Xenohive 

### DIFF
--- a/maps/submaps/surface_submaps/wilderness/xenohive.dmm
+++ b/maps/submaps/surface_submaps/wilderness/xenohive.dmm
@@ -1,120 +1,1275 @@
-"av" = (/obj/structure/table/steel_reinforced,/obj/structure/salvageable/personal,/obj/effect/alien/weeds,/turf/simulated/floor/tiled/steel_dirty,/area/submap/XenoHive)
-"aS" = (/mob/living/simple_mob/animal/space/alien,/obj/effect/alien/weeds/node,/obj/effect/alien/weeds,/turf/simulated/floor,/area/submap/XenoHive)
-"bq" = (/obj/effect/alien/weeds,/obj/random/maintenance/medical,/obj/random/maintenance/medical,/obj/random/maintenance/engineering,/obj/random/plushie,/obj/item/organ/internal/augment/armmounted,/obj/item/organ/internal/intestine,/obj/structure/safe,/obj/random/projectile/scrapped_laser,/obj/random/contraband,/turf/simulated/floor/outdoors/dirt{outdoors = 0},/area/submap/XenoHive)
-"bO" = (/obj/effect/alien/weeds,/obj/structure/simple_door/resin,/turf/simulated/floor/outdoors/rocks{outdoors = 0},/area/submap/XenoHive)
-"co" = (/obj/effect/alien/weeds,/obj/effect/decal/cleanable/dirt,/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/outdoors/rocks{outdoors = 0},/area/submap/XenoHive)
-"dk" = (/mob/living/simple_mob/animal/space/alien,/obj/effect/alien/weeds,/obj/structure/loot_pile/maint/technical,/turf/simulated/floor/outdoors/dirt{outdoors = 0},/area/submap/XenoHive)
-"dm" = (/obj/effect/alien/weeds,/obj/machinery/portable_atmospherics/powered/reagent_distillery/industrial,/turf/simulated/floor/outdoors/rocks{outdoors = 0},/area/submap/XenoHive)
-"dn" = (/obj/effect/alien/weeds,/turf/simulated/floor/outdoors/dirt{outdoors = 0},/area/submap/XenoHive)
-"eM" = (/obj/structure/loot_pile/surface/bones,/turf/simulated/floor/outdoors/dirt,/area/template_noop)
-"fw" = (/turf/template_noop,/area/submap/XenoHive)
-"fG" = (/obj/effect/alien/weeds,/turf/simulated/floor/tiled/steel_dirty,/area/submap/XenoHive)
-"fW" = (/obj/effect/decal/cleanable/dirt,/obj/effect/decal/cleanable/dirt,/obj/effect/decal/cleanable/dirt,/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/outdoors/dirt,/area/submap/XenoHive)
-"gl" = (/obj/effect/alien/weeds,/obj/random/toolbox/anom,/turf/simulated/floor/outdoors/dirt{outdoors = 0},/area/submap/XenoHive)
-"gO" = (/obj/effect/alien/weeds,/obj/item/organ/internal/heart,/obj/item/organ/internal/kidneys/vox,/obj/structure/safe,/obj/random/multiple/gun/projectile/shotgun,/obj/random/contraband/anom,/turf/simulated/floor,/area/submap/XenoHive)
-"gS" = (/obj/effect/alien/resin/wall,/turf/simulated/mineral/ignore_mapgen,/area/template_noop)
-"hx" = (/obj/effect/alien/weeds,/obj/machinery/telecomms/broadcaster,/obj/effect/decal/cleanable/dirt,/turf/simulated/floor,/area/submap/XenoHive)
-"il" = (/obj/effect/alien/weeds,/obj/effect/decal/cleanable/dirt,/obj/effect/landmark/corpse/hedberg/merc,/turf/simulated/floor/tiled/steel_dirty,/area/submap/XenoHive)
-"im" = (/obj/effect/alien/weeds,/obj/structure/table/rack,/obj/item/clothing/suit/armor/pcarrier/tan/tactical,/turf/simulated/floor/outdoors/rocks{outdoors = 0},/area/submap/XenoHive)
-"iF" = (/obj/structure/bed/chair{dir = 8},/obj/effect/alien/weeds,/obj/effect/spawner/gibs/human,/turf/simulated/floor/tiled/steel_dirty,/area/submap/XenoHive)
-"iJ" = (/obj/effect/alien/weeds,/obj/effect/alien/weeds,/obj/machinery/light/small/emergency/flicker{dir = 1},/obj/item/ore/magmellite,/turf/simulated/floor,/area/submap/XenoHive)
-"jY" = (/mob/living/simple_mob/animal/space/alien/queen/empress,/obj/effect/alien/weeds,/turf/simulated/floor,/area/submap/XenoHive)
-"kl" = (/obj/effect/alien/weeds,/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/outdoors/dirt{outdoors = 0},/area/submap/XenoHive)
-"lb" = (/turf/template_noop,/area/template_noop)
-"mE" = (/obj/effect/alien/weeds,/obj/random/junk,/turf/simulated/floor,/area/submap/XenoHive)
-"nd" = (/obj/structure/salvageable/server,/obj/effect/alien/weeds,/obj/effect/alien/weeds,/turf/simulated/floor/tiled/techfloor/grid,/area/submap/XenoHive)
-"oo" = (/mob/living/simple_mob/animal/space/alien/drone,/obj/effect/alien/weeds,/turf/simulated/floor/tiled/steel_dirty,/area/submap/XenoHive)
-"ps" = (/obj/effect/alien/weeds,/obj/structure/loot_pile/maint/technical,/turf/simulated/floor/outdoors/rocks{outdoors = 0},/area/submap/XenoHive)
-"qz" = (/mob/living/simple_mob/animal/space/alien,/obj/effect/alien/weeds,/turf/simulated/floor,/area/submap/XenoHive)
-"qI" = (/obj/effect/alien/weeds/node,/obj/effect/decal/cleanable/dirt,/obj/random/junk,/turf/simulated/floor,/area/submap/XenoHive)
-"rL" = (/obj/effect/alien/weeds,/turf/simulated/floor/outdoors/dirt,/area/submap/XenoHive)
-"sp" = (/obj/effect/alien/weeds/node,/obj/effect/decal/cleanable/dirt,/obj/effect/decal/cleanable/dirt,/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/outdoors/dirt{outdoors = 0},/area/submap/XenoHive)
-"sy" = (/turf/simulated/mineral/ignore_mapgen,/area/template_noop)
-"sX" = (/obj/effect/alien/weeds,/obj/effect/decal/cleanable/dirt,/obj/random/junk,/turf/simulated/floor,/area/submap/XenoHive)
-"tz" = (/obj/effect/alien/weeds,/obj/structure/loot_pile/maint/technical,/turf/simulated/floor/outdoors/dirt{outdoors = 0},/area/submap/XenoHive)
-"tA" = (/obj/effect/alien/weeds,/obj/effect/decal/cleanable/dirt,/obj/effect/landmark/corpse/hedberg,/turf/simulated/floor/tiled/steel_dirty,/area/submap/XenoHive)
-"uJ" = (/obj/structure/sign/biohazard,/turf/simulated/wall/skipjack,/area/submap/XenoHive)
-"va" = (/obj/effect/alien/weeds,/turf/simulated/floor/outdoors/rocks{outdoors = 0},/area/submap/XenoHive)
-"vu" = (/obj/effect/alien/weeds,/obj/structure/bed/nest,/turf/simulated/floor/outdoors/dirt{outdoors = 0},/area/submap/XenoHive)
-"wH" = (/obj/effect/alien/weeds,/obj/structure/loot_pile/mecha/durand,/turf/simulated/floor/outdoors/dirt{outdoors = 0},/area/submap/XenoHive)
-"xB" = (/turf/simulated/wall/skipjack,/area/submap/XenoHive)
-"xQ" = (/obj/effect/decal/cleanable/dirt,/obj/effect/alien/weeds,/turf/simulated/floor/outdoors/dirt{outdoors = 0},/area/submap/XenoHive)
-"yb" = (/obj/effect/alien/weeds,/obj/effect/landmark/corpse/hedberg/merc,/turf/simulated/floor,/area/submap/XenoHive)
-"yx" = (/mob/living/simple_mob/animal/space/alien,/obj/effect/alien/weeds,/obj/effect/alien/weeds,/turf/simulated/floor/outdoors/dirt,/area/submap/XenoHive)
-"yS" = (/obj/structure/table/steel_reinforced,/obj/effect/alien/weeds,/obj/item/toy/plushie/face_hugger,/obj/effect/decal/cleanable/dirt,/turf/simulated/floor,/area/submap/XenoHive)
-"zU" = (/obj/structure/salvageable/autolathe,/obj/effect/alien/weeds,/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/tiled/steel_dirty,/area/submap/XenoHive)
-"zV" = (/obj/effect/alien/weeds,/obj/item/ore/magmellite,/turf/simulated/floor/outdoors/dirt{outdoors = 0},/area/submap/XenoHive)
-"Ak" = (/obj/effect/alien/weeds,/obj/item/ore/magmellite,/turf/simulated/floor/outdoors/rocks{outdoors = 0},/area/submap/XenoHive)
-"AA" = (/obj/effect/alien/resin/wall,/obj/effect/alien/weeds,/turf/simulated/mineral/ignore_mapgen,/area/submap/XenoHive)
-"AB" = (/obj/effect/alien/resin/wall,/turf/simulated/mineral/ignore_mapgen,/area/submap/XenoHive)
-"BD" = (/obj/effect/alien/resin/membrane,/obj/effect/alien/weeds,/turf/simulated/floor/outdoors/dirt{outdoors = 0},/area/submap/XenoHive)
-"Cb" = (/obj/structure/bed/chair,/obj/effect/alien/weeds,/obj/effect/spawner/gibs/human,/turf/simulated/floor/tiled/steel_dirty,/area/submap/XenoHive)
-"Ce" = (/obj/effect/alien/weeds,/obj/random/maintenance/security,/obj/random/maintenance/security,/obj/random/maintenance/security,/obj/item/organ/internal/eyes/replicant,/obj/structure/safe,/obj/random/multiple/gun/projectile/rifle,/obj/random/contraband,/turf/simulated/floor,/area/submap/XenoHive)
-"CR" = (/obj/effect/alien/resin/wall,/turf/simulated/floor/outdoors/dirt,/area/template_noop)
-"De" = (/obj/effect/alien/weeds,/obj/effect/spawner/gibs/human,/turf/simulated/floor/outdoors/dirt{outdoors = 0},/area/submap/XenoHive)
-"Dh" = (/obj/effect/alien/weeds,/obj/random/medical/anom,/turf/simulated/floor/outdoors/dirt{outdoors = 0},/area/submap/XenoHive)
-"DN" = (/obj/effect/alien/weeds,/obj/random/maintenance/anom,/turf/simulated/floor/outdoors/dirt{outdoors = 0},/area/submap/XenoHive)
-"Et" = (/turf/simulated/mineral/ignore_mapgen,/area/submap/XenoHive)
-"FE" = (/mob/living/simple_mob/animal/space/alien/drone,/obj/effect/alien/weeds,/turf/simulated/floor,/area/submap/XenoHive)
-"Gw" = (/obj/structure/table,/obj/effect/alien/weeds,/obj/item/stack/material/phoron{amount = 10},/turf/simulated/floor,/area/submap/XenoHive)
-"Gy" = (/mob/living/simple_mob/animal/space/alien,/obj/effect/alien/weeds,/turf/simulated/floor/tiled/steel_dirty,/area/submap/XenoHive)
-"GN" = (/obj/effect/alien/weeds,/obj/effect/alien/resin/membrane,/turf/simulated/floor/outdoors/dirt{outdoors = 0},/area/submap/XenoHive)
-"Hr" = (/turf/simulated/floor/outdoors/dirt,/area/template_noop)
-"Hu" = (/obj/effect/alien/weeds,/obj/effect/decal/cleanable/blood/skathari,/turf/simulated/floor,/area/submap/XenoHive)
-"Hx" = (/obj/item/portable_destructive_analyzer,/obj/effect/alien/weeds,/turf/simulated/floor/outdoors/dirt{outdoors = 0},/area/submap/XenoHive)
-"Hz" = (/obj/effect/alien/weeds,/obj/structure/simple_door/resin,/turf/simulated/floor/outdoors/dirt{outdoors = 0},/area/submap/XenoHive)
-"HI" = (/obj/effect/alien/weeds,/obj/structure/prop/blackbox/quarantined_shuttle,/turf/simulated/floor/tiled/techfloor/grid,/area/submap/XenoHive)
-"HJ" = (/obj/effect/alien/weeds,/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/outdoors/rocks{outdoors = 0},/area/submap/XenoHive)
-"HO" = (/obj/structure/table,/obj/effect/alien/weeds,/obj/effect/decal/cleanable/dirt,/obj/item/storage/backpack/holding,/turf/simulated/floor,/area/submap/XenoHive)
-"Ir" = (/obj/effect/alien/weeds,/obj/structure/bed/nest,/turf/simulated/floor,/area/submap/XenoHive)
-"Is" = (/obj/effect/alien/weeds,/obj/structure/loot_pile/maint/boxfort,/turf/simulated/floor/outdoors/rocks{outdoors = 0},/area/submap/XenoHive)
-"IY" = (/obj/effect/alien/weeds,/obj/effect/alien/weeds,/obj/structure/bed/nest,/turf/simulated/floor/tiled/steel_dirty,/area/submap/XenoHive)
-"Jj" = (/obj/effect/alien/weeds,/obj/item/stack/material/phoron{amount = 10},/turf/simulated/floor/tiled/steel_dirty,/area/submap/XenoHive)
-"JV" = (/obj/effect/alien/weeds,/obj/structure/simple_door/resin,/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/outdoors/dirt{outdoors = 0},/area/submap/XenoHive)
-"LB" = (/obj/effect/alien/weeds,/obj/effect/decal/cleanable/dirt,/turf/simulated/floor,/area/submap/XenoHive)
-"Mx" = (/obj/machinery/door/airlock/vault,/turf/simulated/floor/tiled/techfloor,/area/submap/XenoHive)
-"MJ" = (/obj/structure/loot_pile/surface/bones,/turf/simulated/floor/outdoors/dirt,/area/submap/XenoHive)
-"MZ" = (/obj/effect/alien/weeds,/obj/structure/loot_pile/maint/boxfort,/turf/simulated/floor/outdoors/dirt{outdoors = 0},/area/submap/XenoHive)
-"Or" = (/obj/effect/alien/weeds,/obj/effect/alien/weeds,/obj/effect/decal/cleanable/dirt,/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/outdoors/rocks{outdoors = 0},/area/submap/XenoHive)
-"Pe" = (/obj/effect/alien/weeds,/obj/effect/alien/weeds,/obj/machinery/telecomms/receiver,/turf/simulated/floor/tiled/steel_dirty,/area/submap/XenoHive)
-"Pq" = (/obj/structure/simple_door/resin,/obj/effect/decal/cleanable/dirt,/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/outdoors/dirt{outdoors = 0},/area/submap/XenoHive)
-"Pv" = (/mob/living/simple_mob/animal/space/alien,/obj/effect/alien/weeds,/turf/simulated/floor/outdoors/dirt{outdoors = 0},/area/submap/XenoHive)
-"PX" = (/obj/effect/decal/cleanable/dirt,/obj/structure/loot_pile/mecha/gygax/dark/adv,/turf/template_noop,/area/submap/XenoHive)
-"QC" = (/obj/effect/alien/weeds,/obj/item/organ/internal/intestine/xeno,/obj/structure/safe,/obj/random/multiple/gun/projectile/handgun,/obj/random/contraband,/turf/simulated/floor/outdoors/rocks{outdoors = 0},/area/submap/XenoHive)
-"QG" = (/obj/effect/alien/weeds,/obj/effect/alien/weeds,/turf/simulated/floor,/area/submap/XenoHive)
-"Rr" = (/obj/structure/noticeboard/anomaly,/turf/simulated/wall/skipjack,/area/submap/XenoHive)
-"Sl" = (/obj/structure/salvageable/bliss,/obj/effect/alien/weeds,/turf/simulated/floor,/area/submap/XenoHive)
-"SO" = (/obj/effect/alien/weeds,/obj/effect/decal/cleanable/dirt,/obj/item/ore/magmellite,/turf/simulated/floor/tiled/steel_dirty,/area/submap/XenoHive)
-"Tb" = (/obj/effect/alien/weeds,/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/tiled/steel_dirty,/area/submap/XenoHive)
-"Tq" = (/mob/living/simple_mob/animal/space/alien,/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/outdoors/dirt{outdoors = 0},/area/submap/XenoHive)
-"Tv" = (/mob/living/simple_mob/animal/space/alien,/obj/effect/alien/weeds,/obj/structure/bed/nest,/turf/simulated/floor/outdoors/rocks{outdoors = 0},/area/submap/XenoHive)
-"Vg" = (/obj/effect/alien/weeds,/obj/structure/prop/transmitter,/obj/effect/decal/cleanable/dirt,/turf/simulated/floor,/area/submap/XenoHive)
-"Vj" = (/turf/simulated/floor/outdoors/dirt,/area/submap/XenoHive)
-"Vu" = (/obj/effect/alien/weeds/node,/obj/effect/decal/cleanable/dirt,/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/outdoors/dirt{outdoors = 0},/area/submap/XenoHive)
-"VA" = (/obj/effect/alien/weeds/node,/obj/effect/decal/cleanable/dirt,/obj/effect/decal/cleanable/dirt,/obj/random/junk,/turf/simulated/floor/outdoors/dirt{outdoors = 0},/area/submap/XenoHive)
-"WD" = (/obj/effect/alien/weeds,/obj/effect/decal/cleanable/dirt,/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/outdoors/dirt{outdoors = 0},/area/submap/XenoHive)
-"WE" = (/obj/effect/alien/weeds,/obj/structure/mopbucket,/turf/simulated/floor/outdoors/dirt{outdoors = 0},/area/submap/XenoHive)
-"Xa" = (/obj/effect/alien/weeds,/obj/structure/prop/nest{creature_types = list(/mob/living/simple_mob/animal/space/alien/drone); desc = "An underground nest of Skathari."; icon = 'icons/mob/alien.dmi'; icon_state = "nest"; interaction_message = "<span class='warning'>You feel like you shouldn't be sticking your nose into this thing.</span>"; name = "skathari nest"; total_creature_max = 10},/turf/simulated/floor,/area/submap/XenoHive)
-"Xy" = (/obj/structure/table/steel_reinforced,/obj/effect/alien/weeds,/obj/machinery/light/small/emergency/flicker{dir = 8},/obj/item/reagent_containers/food/snacks/truffle/random,/turf/simulated/floor,/area/submap/XenoHive)
-"YG" = (/obj/effect/alien/weeds,/obj/effect/landmark/corpse/hedberg/merc,/turf/simulated/floor/tiled/steel_dirty,/area/submap/XenoHive)
-"YL" = (/obj/effect/decal/cleanable/dirt,/obj/effect/decal/cleanable/dirt,/obj/effect/landmark/corpse/sifguard,/turf/simulated/floor/outdoors/dirt,/area/submap/XenoHive)
-"Zc" = (/obj/effect/alien/weeds,/obj/effect/decal/cleanable/dirt,/obj/effect/decal/cleanable/dirt,/obj/random/junk,/turf/simulated/floor/outdoors/dirt{outdoors = 0},/area/submap/XenoHive)
-"Zx" = (/obj/effect/alien/weeds,/obj/effect/decal/cleanable/dirt,/obj/effect/decal/cleanable/dirt,/obj/effect/landmark/corpse/hedberg,/turf/simulated/floor/outdoors/dirt{outdoors = 0},/area/submap/XenoHive)
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"ct" = (
+/obj/structure/girder/reinforced,
+/obj/item/stack/material/steel,
+/obj/item/stack/material/steel,
+/turf/simulated/floor/plating,
+/area/submap/XenoHive)
+"cJ" = (
+/turf/simulated/floor/tiled/techfloor,
+/area/submap/XenoHive)
+"cP" = (
+/obj/machinery/optable,
+/obj/effect/decal/cleanable/blood,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/submap/XenoHive)
+"dG" = (
+/obj/effect/floor_decal/rust,
+/obj/structure/loot_pile/mecha/gygax/dark/adv,
+/turf/simulated/floor/tiled/milspec/dark,
+/area/submap/XenoHive)
+"ec" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/mob/living/simple_mob/animal/space/alien/drone,
+/turf/simulated/floor/tiled/milspec/dark,
+/area/submap/XenoHive)
+"ee" = (
+/obj/item/material/shard,
+/obj/structure/grille/broken,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/submap/XenoHive)
+"eB" = (
+/obj/effect/alien/weeds,
+/obj/effect/landmark/corpse/hedberg,
+/obj/random/maintenance/security,
+/obj/random/projectile/sec,
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/tiled/milspec,
+/area/submap/XenoHive)
+"eY" = (
+/obj/effect/alien/weeds,
+/obj/structure/simple_door/resin,
+/turf/simulated/floor/tiled/milspec/dark,
+/area/submap/XenoHive)
+"fz" = (
+/obj/effect/alien/weeds,
+/obj/structure/loot_pile/mecha/durand,
+/turf/simulated/floor/plating,
+/area/submap/XenoHive)
+"fC" = (
+/obj/structure/simple_door/resin,
+/obj/effect/alien/weeds,
+/turf/simulated/floor/tiled/milspec/dark,
+/area/submap/XenoHive)
+"fM" = (
+/turf/simulated/floor/outdoors/dirt,
+/area/submap/XenoHive)
+"fT" = (
+/obj/effect/alien/weeds,
+/turf/simulated/floor/tiled/milspec,
+/area/submap/XenoHive)
+"fX" = (
+/turf/simulated/floor/tiled/milspec,
+/area/submap/XenoHive)
+"go" = (
+/turf/simulated/floor/outdoors/dirt,
+/area/template_noop)
+"gu" = (
+/obj/item/bodybag,
+/turf/simulated/floor/tiled/milspec/dark,
+/area/submap/XenoHive)
+"hL" = (
+/obj/effect/alien/weeds,
+/obj/structure/loot_pile/maint/technical,
+/turf/simulated/floor/tiled/milspec/dark,
+/area/submap/XenoHive)
+"hQ" = (
+/obj/structure/salvageable/bliss,
+/turf/simulated/floor/tiled/milspec/raised,
+/area/submap/XenoHive)
+"iv" = (
+/obj/random/junk,
+/turf/simulated/floor/tiled/milspec/dark,
+/area/submap/XenoHive)
+"jr" = (
+/obj/machinery/light/small,
+/turf/simulated/floor/tiled/milspec/dark,
+/area/submap/XenoHive)
+"jK" = (
+/obj/effect/floor_decal/milspec/box,
+/obj/machinery/telecomms/receiver,
+/turf/simulated/floor/tiled/milspec/raised,
+/area/submap/XenoHive)
+"kg" = (
+/obj/effect/alien/weeds,
+/obj/item/ore/magmellite,
+/turf/simulated/floor/tiled/milspec/dark,
+/area/submap/XenoHive)
+"km" = (
+/obj/effect/alien/weeds,
+/obj/effect/alien/weeds,
+/turf/simulated/floor/tiled/milspec,
+/area/submap/XenoHive)
+"kK" = (
+/obj/structure/table/steel_reinforced,
+/obj/effect/alien/weeds,
+/obj/machinery/portable_atmospherics/powered/reagent_distillery/industrial,
+/turf/simulated/floor/tiled/milspec/dark,
+/area/submap/XenoHive)
+"lb" = (
+/obj/effect/alien/weeds,
+/obj/structure/bed/nest,
+/turf/simulated/floor/tiled/white,
+/area/submap/XenoHive)
+"lD" = (
+/mob/living/simple_mob/animal/space/alien/queen/empress,
+/obj/effect/alien/weeds,
+/turf/simulated/floor/tiled/techfloor,
+/area/submap/XenoHive)
+"lH" = (
+/obj/effect/alien/resin/wall,
+/obj/effect/alien/resin/wall,
+/turf/simulated/wall/r_wall,
+/area/submap/XenoHive)
+"mf" = (
+/obj/effect/alien/weeds,
+/mob/living/simple_mob/animal/space/alien/drone,
+/turf/simulated/floor/tiled/white,
+/area/submap/XenoHive)
+"mV" = (
+/obj/structure/salvageable/autolathe,
+/turf/simulated/floor/tiled/milspec/dark,
+/area/submap/XenoHive)
+"mW" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/submap/XenoHive)
+"nd" = (
+/obj/effect/landmark/corpse/hedberg/merc,
+/obj/random/maintenance/security,
+/obj/random/contraband,
+/obj/random/multiple/gun/projectile/rifle,
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/tiled/white,
+/area/submap/XenoHive)
+"nG" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/milspec/dark,
+/area/submap/XenoHive)
+"nK" = (
+/obj/effect/alien/weeds,
+/obj/structure/simple_door/resin,
+/obj/effect/decal/cleanable/blood/drip,
+/turf/space,
+/area/submap/XenoHive)
+"nV" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/turf/simulated/floor/tiled/white,
+/area/submap/XenoHive)
+"oC" = (
+/obj/machinery/light/small,
+/obj/structure/table/steel_reinforced,
+/turf/simulated/floor/tiled/milspec/dark,
+/area/submap/XenoHive)
+"oY" = (
+/obj/effect/landmark/corpse/sifguard,
+/turf/simulated/floor/tiled/milspec/dark,
+/area/submap/XenoHive)
+"pk" = (
+/obj/machinery/floodlight,
+/turf/simulated/floor/tiled/milspec/dark,
+/area/submap/XenoHive)
+"qe" = (
+/obj/structure/sign/warning/secure_area,
+/turf/simulated/wall/r_wall,
+/area/submap/XenoHive)
+"rg" = (
+/obj/structure/girder/displaced,
+/turf/simulated/floor/plating,
+/area/submap/XenoHive)
+"rp" = (
+/turf/simulated/mineral/ignore_mapgen,
+/area/submap/XenoHive)
+"rB" = (
+/mob/living/simple_mob/animal/space/alien/drone,
+/turf/simulated/floor/tiled/white,
+/area/submap/XenoHive)
+"rW" = (
+/obj/effect/alien/weeds,
+/obj/effect/landmark/corpse/hedberg,
+/obj/random/maintenance/security,
+/obj/random/projectile/sec,
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/tiled/milspec/raised,
+/area/submap/XenoHive)
+"tS" = (
+/obj/structure/table/steel_reinforced,
+/obj/random/maintenance/anom,
+/obj/structure/noticeboard/anomaly,
+/turf/simulated/floor/tiled/white,
+/area/submap/XenoHive)
+"ut" = (
+/obj/effect/alien/weeds,
+/obj/structure/bed/nest,
+/turf/simulated/floor/tiled/techfloor,
+/area/submap/XenoHive)
+"uH" = (
+/obj/effect/alien/weeds,
+/obj/structure/table,
+/turf/simulated/floor/tiled/white,
+/area/submap/XenoHive)
+"uI" = (
+/obj/structure/salvageable/server,
+/turf/simulated/floor/tiled/milspec/raised,
+/area/submap/XenoHive)
+"vG" = (
+/obj/machinery/door/airlock/highsecurity,
+/turf/simulated/floor/tiled/dark,
+/area/submap/XenoHive)
+"vU" = (
+/obj/item/clothing/suit/armor/pcarrier/tan/tactical,
+/obj/effect/alien/weeds,
+/turf/simulated/floor/tiled/milspec/dark,
+/area/submap/XenoHive)
+"wT" = (
+/obj/structure/table/steel_reinforced,
+/obj/structure/salvageable/personal,
+/turf/simulated/floor/tiled/white,
+/area/submap/XenoHive)
+"ym" = (
+/obj/effect/alien/weeds,
+/obj/effect/landmark/corpse/hedberg,
+/obj/random/maintenance/security,
+/obj/random/projectile/scrapped_shotgun,
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/tiled/white,
+/area/submap/XenoHive)
+"yq" = (
+/obj/effect/alien/weeds,
+/obj/effect/alien/weeds,
+/turf/simulated/floor/tiled/milspec/dark,
+/area/submap/XenoHive)
+"yE" = (
+/obj/structure/simple_door/resin,
+/obj/effect/alien/weeds,
+/turf/simulated/floor/plating,
+/area/submap/XenoHive)
+"AC" = (
+/obj/effect/alien/resin/wall,
+/turf/simulated/floor/tiled/milspec,
+/area/submap/XenoHive)
+"AK" = (
+/obj/structure/table/steel_reinforced,
+/obj/item/storage/firstaid/surgery/simple,
+/obj/item/autopsy_scanner,
+/turf/simulated/floor/tiled/white,
+/area/submap/XenoHive)
+"Bf" = (
+/mob/living/simple_mob/animal/space/alien/drone,
+/turf/simulated/floor/tiled/techfloor,
+/area/submap/XenoHive)
+"Bk" = (
+/obj/structure/bed/chair/office/dark{
+	dir = 8
+	},
+/obj/structure/loot_pile/surface/bones,
+/turf/simulated/floor/tiled/milspec/dark,
+/area/submap/XenoHive)
+"Bv" = (
+/obj/random/obstruction,
+/turf/simulated/floor/outdoors/dirt,
+/area/submap/XenoHive)
+"BQ" = (
+/obj/structure/prop/blackbox/quarantined_shuttle,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/submap/XenoHive)
+"BT" = (
+/obj/effect/alien/weeds,
+/turf/simulated/floor/tiled/milspec/dark,
+/area/submap/XenoHive)
+"Cx" = (
+/obj/effect/alien/weeds,
+/obj/structure/table/steel_reinforced,
+/obj/fiftyspawner/phoron,
+/turf/simulated/floor/tiled/milspec/dark,
+/area/submap/XenoHive)
+"Cy" = (
+/obj/effect/alien/weeds,
+/turf/simulated/floor/tiled/techfloor,
+/area/submap/XenoHive)
+"CF" = (
+/obj/effect/alien/weeds,
+/obj/effect/alien/weeds,
+/obj/structure/simple_door/resin,
+/turf/simulated/floor/tiled/milspec/dark,
+/area/submap/XenoHive)
+"El" = (
+/obj/effect/alien/weeds,
+/obj/structure/table/steel_reinforced,
+/turf/simulated/floor/tiled/milspec/dark,
+/area/submap/XenoHive)
+"Fc" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/effect/alien/weeds,
+/turf/simulated/floor/tiled/milspec/dark,
+/area/submap/XenoHive)
+"FQ" = (
+/turf/simulated/wall/skipjack,
+/area/submap/XenoHive)
+"Gt" = (
+/obj/structure/grille,
+/obj/effect/alien/weeds,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/submap/XenoHive)
+"GO" = (
+/obj/structure/bed/chair/office/dark{
+	dir = 1
+	},
+/obj/structure/loot_pile/surface/bones,
+/turf/simulated/floor/tiled/white,
+/area/submap/XenoHive)
+"GV" = (
+/obj/structure/table/steel_reinforced,
+/obj/effect/alien/weeds,
+/obj/item/reagent_containers/food/snacks/truffle/random,
+/turf/simulated/floor/tiled/white,
+/area/submap/XenoHive)
+"Hb" = (
+/obj/structure/safe,
+/obj/item/organ/internal/augment/armmounted,
+/obj/item/organ/internal/kidneys/vox,
+/obj/item/organ/internal/eyes/replicant,
+/obj/effect/alien/weeds,
+/turf/simulated/floor/tiled/white,
+/area/submap/XenoHive)
+"Hg" = (
+/obj/effect/alien/weeds,
+/obj/effect/landmark/corpse/hedberg/merc,
+/obj/random/contraband,
+/obj/random/maintenance/security,
+/obj/random/projectile/scrapped_bulldog,
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/tiled/techfloor,
+/area/submap/XenoHive)
+"Ii" = (
+/obj/structure/table/rack,
+/obj/random/medical/anom,
+/turf/simulated/floor/tiled/milspec,
+/area/submap/XenoHive)
+"Iu" = (
+/obj/effect/floor_decal/milspec/box,
+/obj/machinery/telecomms/broadcaster,
+/turf/simulated/floor/tiled/milspec/raised,
+/area/submap/XenoHive)
+"Jn" = (
+/obj/structure/table/steel_reinforced,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/item/storage/backpack/holding,
+/turf/simulated/floor/tiled/white,
+/area/submap/XenoHive)
+"JL" = (
+/obj/effect/alien/weeds,
+/obj/structure/bed/nest,
+/turf/simulated/floor/plating,
+/area/submap/XenoHive)
+"KL" = (
+/obj/effect/alien/weeds,
+/obj/structure/bed/nest,
+/turf/simulated/floor/tiled/milspec,
+/area/submap/XenoHive)
+"KM" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/submap/XenoHive)
+"Lc" = (
+/obj/effect/floor_decal/milspec/box,
+/obj/structure/prop/transmitter,
+/turf/simulated/floor/tiled/milspec/raised,
+/area/submap/XenoHive)
+"Lg" = (
+/obj/effect/alien/weeds,
+/obj/item/ore/magmellite,
+/turf/simulated/floor/plating,
+/area/submap/XenoHive)
+"Ln" = (
+/obj/effect/alien/resin/wall,
+/turf/simulated/wall/r_wall,
+/area/submap/XenoHive)
+"Lq" = (
+/obj/effect/alien/resin/wall,
+/turf/simulated/wall/skipjack,
+/area/submap/XenoHive)
+"LD" = (
+/obj/effect/spawner/gibs/human,
+/turf/simulated/floor/tiled/milspec/dark,
+/area/submap/XenoHive)
+"LR" = (
+/obj/random/toolbox/anom,
+/turf/simulated/floor/tiled/milspec/dark,
+/area/submap/XenoHive)
+"LX" = (
+/obj/structure/foamedmetal,
+/turf/simulated/floor/outdoors/dirt,
+/area/submap/XenoHive)
+"Mt" = (
+/turf/simulated/floor/tiled/milspec/dark,
+/area/submap/XenoHive)
+"MN" = (
+/obj/effect/alien/weeds,
+/mob/living/simple_mob/animal/space/alien,
+/turf/simulated/floor/tiled/techfloor,
+/area/submap/XenoHive)
+"Nw" = (
+/mob/living/simple_mob/animal/space/alien,
+/turf/simulated/floor/tiled/milspec,
+/area/submap/XenoHive)
+"Nz" = (
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor/tiled/milspec/dark,
+/area/submap/XenoHive)
+"NK" = (
+/obj/effect/decal/cleanable/blood/drip,
+/turf/simulated/floor/tiled/milspec/dark,
+/area/submap/XenoHive)
+"Oc" = (
+/obj/structure/table/rack/shelf,
+/obj/random/tech_supply,
+/turf/simulated/floor/tiled/milspec/dark,
+/area/submap/XenoHive)
+"Ot" = (
+/obj/effect/alien/weeds,
+/obj/effect/alien/weeds,
+/obj/structure/bed/nest,
+/turf/simulated/floor/tiled/white,
+/area/submap/XenoHive)
+"Ov" = (
+/obj/structure/table/steel_reinforced,
+/obj/item/portable_destructive_analyzer,
+/turf/simulated/floor/tiled/milspec/dark,
+/area/submap/XenoHive)
+"Pd" = (
+/obj/effect/alien/weeds,
+/turf/simulated/floor/tiled/white,
+/area/submap/XenoHive)
+"Qn" = (
+/obj/effect/alien/weeds,
+/obj/structure/table/steel_reinforced,
+/turf/simulated/floor/tiled/white,
+/area/submap/XenoHive)
+"QO" = (
+/obj/structure/table/steel_reinforced,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/random/maintenance/medical,
+/turf/simulated/floor/tiled/white,
+/area/submap/XenoHive)
+"Ri" = (
+/obj/effect/spawner/gibs/human,
+/obj/structure/grille/broken,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/submap/XenoHive)
+"Rj" = (
+/turf/simulated/wall/r_wall,
+/area/submap/XenoHive)
+"Rp" = (
+/obj/effect/alien/resin/membrane,
+/turf/simulated/floor/plating,
+/area/submap/XenoHive)
+"RA" = (
+/obj/effect/decal/cleanable/blood/drip,
+/turf/simulated/floor/outdoors/dirt,
+/area/submap/XenoHive)
+"RG" = (
+/obj/structure/table/rack/shelf,
+/obj/random/maintenance/engineering,
+/turf/simulated/floor/tiled/milspec/dark,
+/area/submap/XenoHive)
+"SB" = (
+/obj/effect/alien/weeds,
+/mob/living/simple_mob/animal/space/alien/queen/empress,
+/turf/simulated/floor/tiled/techfloor,
+/area/submap/XenoHive)
+"ST" = (
+/obj/structure/salvageable/server,
+/obj/effect/alien/weeds,
+/turf/simulated/floor/tiled/milspec/raised,
+/area/submap/XenoHive)
+"SU" = (
+/mob/living/simple_mob/animal/space/alien,
+/turf/simulated/floor/tiled/milspec/dark,
+/area/submap/XenoHive)
+"TZ" = (
+/obj/effect/alien/weeds,
+/obj/structure/loot_pile/surface/bones,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/submap/XenoHive)
+"UJ" = (
+/obj/machinery/light/small/emergency{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/milspec/dark,
+/area/submap/XenoHive)
+"UR" = (
+/turf/template_noop,
+/area/template_noop)
+"UV" = (
+/obj/effect/landmark/corpse/hedberg,
+/obj/structure/bed/roller,
+/obj/effect/decal/cleanable/blood,
+/obj/random/projectile/scrapped_gun,
+/turf/simulated/floor/tiled/milspec,
+/area/submap/XenoHive)
+"VG" = (
+/obj/item/organ/internal/intestine,
+/obj/item/organ/internal/kidneys,
+/obj/structure/closet/crate/freezer,
+/turf/simulated/floor/tiled/white,
+/area/submap/XenoHive)
+"VK" = (
+/turf/simulated/floor/tiled/white,
+/area/submap/XenoHive)
+"VS" = (
+/obj/structure/table/rack/shelf,
+/obj/random/powercell,
+/turf/simulated/floor/tiled/milspec/dark,
+/area/submap/XenoHive)
+"Wi" = (
+/obj/effect/alien/weeds,
+/obj/item/ore/magmellite,
+/mob/living/simple_mob/animal/space/alien,
+/turf/simulated/floor/tiled/milspec/dark,
+/area/submap/XenoHive)
+"WG" = (
+/obj/effect/alien/weeds,
+/obj/item/ore/magmellite,
+/turf/simulated/floor/tiled/white,
+/area/submap/XenoHive)
+"WR" = (
+/obj/effect/alien/weeds,
+/mob/living/simple_mob/animal/space/alien,
+/turf/simulated/floor/plating,
+/area/submap/XenoHive)
+"WU" = (
+/obj/effect/alien/weeds,
+/obj/structure/bed/nest,
+/turf/simulated/floor/tiled/milspec/dark,
+/area/submap/XenoHive)
+"Xc" = (
+/obj/effect/alien/weeds,
+/obj/structure/bed/chair/office/dark{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/milspec/dark,
+/area/submap/XenoHive)
+"Xr" = (
+/obj/structure/simple_door/resin,
+/obj/effect/alien/weeds,
+/turf/simulated/floor/tiled/white,
+/area/submap/XenoHive)
+"Xs" = (
+/obj/effect/alien/weeds,
+/obj/structure/loot_pile/surface/bones,
+/turf/simulated/floor/tiled/white,
+/area/submap/XenoHive)
+"XW" = (
+/obj/effect/alien/weeds,
+/turf/simulated/floor/plating,
+/area/submap/XenoHive)
+"Yp" = (
+/obj/effect/alien/weeds,
+/obj/effect/spawner/gibs/human,
+/turf/simulated/floor/tiled/techfloor,
+/area/submap/XenoHive)
+"Yt" = (
+/mob/living/simple_mob/animal/space/alien/drone,
+/turf/simulated/floor/tiled/milspec,
+/area/submap/XenoHive)
+"ZA" = (
+/obj/effect/decal/cleanable/vomit,
+/turf/simulated/floor/tiled/milspec,
+/area/submap/XenoHive)
 
 (1,1,1) = {"
-lblblbsysysysysysylblblbHrsyeMlblblblbHrlblbsysylb
-lbsysyABABABABABABsysysyrLABrLHrsysysyrLrLABsysylb
-lbsyxBxBIsvuvaimRrxBxBEtdndndnEtEtEtEtEtyxrLMJfwlb
-syABxBHIndqzGwaviJgOxBABEtdkEtEtABEtABEtEtEtVjfwlb
-syABTvfGooqItAiFjYIrbqABEtEtEtEtPvdnDhMZABEtEtEtlb
-syABHxSlilhxVgPeYGIYQCABEtEtABwHdnDeVuklHzPvABEtsy
-syABdmJjsXfGTbmEFECexBABABABWEklZcZxklzVBDxQxQEtsy
-syABpsHOTbCbLBHuABABxBtzcoJVdnklPvdnABEtEtxQspzVsy
-syABxBySSOybzUuJxBxBxBWDOrBDDNABABEtEtEtEtABPqPqCR
-lbsyxBXyfGaSLBMxGyGNHJVAAkAAABEtEtEtEtEtEtEtTqfWeM
-lbsyxBABABXafGMxQGbOklABABABEtEttzdnPvglEtEtABYLlb
-lbsyEtEtxBxBxBxBxBABABABEtEtEtdnPvdnABrLrLEtEtPXlb
-lblblbsysysysysysysysysylblbMJrLsygSsysyMJVjEtEtlb
-lblblblblblbsysysysylblblblblbsysysysysysylblbsylb
-lblblblblblblblblblblblblblblblblblblblblblblblblb
+UR
+UR
+UR
+UR
+UR
+UR
+UR
+UR
+UR
+UR
+UR
+UR
+UR
+UR
+UR
+UR
+UR
+UR
+UR
+UR
+UR
+UR
+UR
+UR
+UR
+"}
+(2,1,1) = {"
+UR
+UR
+UR
+rp
+rp
+rp
+rp
+rp
+rp
+rp
+rp
+rp
+UR
+UR
+rp
+rp
+rp
+rp
+rp
+rp
+rp
+UR
+UR
+UR
+UR
+"}
+(3,1,1) = {"
+UR
+UR
+rp
+rp
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+rp
+rp
+rp
+Rj
+Rj
+Rj
+Ln
+Ln
+rp
+rp
+rp
+UR
+UR
+"}
+(4,1,1) = {"
+UR
+rp
+rp
+Rj
+Rj
+Lq
+Lq
+Lq
+Lq
+Lq
+Lq
+Lq
+Rj
+rp
+Rj
+Rj
+AK
+cP
+uH
+Ln
+Ln
+rp
+rp
+UR
+UR
+"}
+(5,1,1) = {"
+UR
+rp
+rp
+Rj
+Lq
+Lq
+ut
+ut
+ut
+ut
+ut
+Lq
+Lq
+Ln
+Ln
+VG
+VK
+Pd
+lb
+Hb
+Ln
+Ln
+rp
+rp
+UR
+"}
+(6,1,1) = {"
+UR
+rp
+rp
+Rj
+Lq
+ut
+Yp
+Cy
+lD
+Cy
+SB
+ut
+Lq
+fz
+Ln
+nV
+Ot
+Pd
+mf
+Pd
+lb
+Ln
+rp
+rp
+UR
+"}
+(7,1,1) = {"
+UR
+rp
+rp
+Rj
+Lq
+Cy
+MN
+Iu
+Lc
+jK
+Hg
+Cy
+Lq
+XW
+WU
+lb
+mf
+Pd
+Pd
+Pd
+lb
+Ln
+rp
+rp
+UR
+"}
+(8,1,1) = {"
+UR
+rp
+rp
+Rj
+Lq
+ut
+Cy
+Cy
+cJ
+Bf
+Cy
+ut
+Lq
+XW
+XW
+Pd
+Pd
+Pd
+lb
+WG
+Xs
+Ln
+rp
+rp
+UR
+"}
+(9,1,1) = {"
+UR
+rp
+rp
+Rj
+FQ
+FQ
+mW
+ee
+Ri
+TZ
+Gt
+Rp
+Lq
+XW
+JL
+fT
+Ln
+km
+KL
+eB
+AC
+Ln
+rp
+rp
+UR
+"}
+(10,1,1) = {"
+UR
+rp
+rp
+Rj
+FQ
+Jn
+QO
+QO
+KM
+Pd
+Qn
+GV
+Lq
+XW
+Lg
+BT
+BT
+yq
+BT
+WU
+BT
+Ln
+rp
+rp
+UR
+"}
+(11,1,1) = {"
+UR
+rp
+rp
+Rj
+FQ
+tS
+rB
+nd
+VK
+VK
+Pd
+Pd
+yE
+XW
+JL
+El
+BT
+WU
+Xc
+BT
+Ov
+Rj
+rp
+rp
+UR
+"}
+(12,1,1) = {"
+UR
+rp
+rp
+Rj
+FQ
+wT
+GO
+VK
+lb
+Pd
+Pd
+lb
+Lq
+XW
+Ln
+El
+BT
+Cx
+kK
+iv
+oC
+Rj
+rp
+rp
+UR
+"}
+(13,1,1) = {"
+UR
+rp
+rp
+Rj
+Rj
+FQ
+BQ
+Pd
+Pd
+ym
+lb
+Lq
+Lq
+XW
+lH
+hL
+BT
+BT
+Mt
+Mt
+mV
+Rj
+rp
+fM
+UR
+"}
+(14,1,1) = {"
+UR
+rp
+rp
+Rj
+Rj
+Rj
+Lq
+Lq
+Xr
+Lq
+Ln
+Lq
+WR
+XW
+Ln
+Ln
+Ln
+CF
+Rj
+Rj
+Rj
+Rj
+rp
+fM
+UR
+"}
+(15,1,1) = {"
+UR
+UR
+rp
+rp
+rp
+Rj
+Ln
+BT
+BT
+Wi
+Ln
+Ln
+XW
+Ln
+Ln
+Rj
+Mt
+BT
+BT
+Ln
+Ln
+rp
+fM
+UR
+UR
+"}
+(16,1,1) = {"
+UR
+rp
+rp
+rp
+Rj
+Rj
+nG
+Mt
+BT
+BT
+BT
+Ln
+fC
+Ln
+Rj
+UJ
+Mt
+Mt
+BT
+BT
+Ln
+Ln
+rp
+UR
+UR
+"}
+(17,1,1) = {"
+UR
+rp
+rp
+Rj
+Rj
+uI
+Mt
+uI
+Mt
+ST
+BT
+rW
+kg
+Ln
+pk
+Mt
+Nw
+ZA
+fX
+BT
+BT
+Ln
+qe
+rp
+UR
+"}
+(18,1,1) = {"
+UR
+rp
+rp
+Rj
+uI
+LR
+SU
+uI
+Mt
+uI
+BT
+BT
+BT
+eY
+Mt
+NK
+UV
+Rj
+KL
+BT
+BT
+vG
+RA
+fM
+UR
+"}
+(19,1,1) = {"
+UR
+rp
+rp
+Rj
+hQ
+Bk
+Mt
+uI
+LD
+uI
+Mt
+BT
+BT
+nK
+Mt
+Mt
+Ii
+Rj
+Yt
+BT
+BT
+vG
+fM
+RA
+go
+"}
+(20,1,1) = {"
+UR
+rp
+rp
+Rj
+Rj
+uI
+Mt
+uI
+Mt
+uI
+Mt
+uI
+ST
+Rj
+BT
+BT
+fX
+fX
+fX
+Mt
+BT
+Ln
+qe
+fM
+go
+"}
+(21,1,1) = {"
+UR
+rp
+rp
+rp
+Rj
+Rj
+ec
+Mt
+Mt
+Mt
+jr
+Rj
+Ln
+Ln
+Rj
+vU
+Nz
+oY
+Mt
+Fc
+Ln
+Ln
+rp
+rp
+UR
+"}
+(22,1,1) = {"
+UR
+UR
+rp
+rp
+rp
+Rj
+Rj
+Oc
+RG
+VS
+Rj
+Rj
+rp
+rp
+ct
+rg
+dG
+Nz
+gu
+Rj
+Ln
+rp
+rp
+rp
+UR
+"}
+(23,1,1) = {"
+UR
+UR
+UR
+rp
+rp
+rp
+Rj
+Rj
+Rj
+Rj
+Rj
+rp
+rp
+Bv
+LX
+Rj
+Rj
+Rj
+Rj
+Rj
+rp
+rp
+rp
+rp
+UR
+"}
+(24,1,1) = {"
+UR
+UR
+UR
+UR
+rp
+rp
+rp
+rp
+rp
+rp
+rp
+rp
+fM
+fM
+rp
+rp
+rp
+fM
+rp
+rp
+rp
+rp
+UR
+UR
+UR
+"}
+(25,1,1) = {"
+UR
+UR
+UR
+UR
+UR
+UR
+UR
+UR
+UR
+UR
+UR
+UR
+UR
+UR
+UR
+UR
+UR
+UR
+UR
+UR
+UR
+UR
+UR
+UR
+UR
 "}


### PR DESCRIPTION
I've seen frequent complaints from survivalists and explorers that the 'xenohive' POI (ie, the deep wilderness one with the Skathari) is too disruptive because it spawns 5 soldiers on its outskirts, who proceed to wander all over the map and cause unseemly deaths. While I think some wandering monsters spice things up, even a single Skathari soldier is definitely as dangerous as its lore implies and can bitterly end the lives of survivalists who just so happen to get too close to the river while exploring naturally. 

This PR not only rectifies that but also give the POI a bit of a facelift, as it's currently a narrow tunnel divided into a series of chambers that are full of various 'high end' items, which feels a bit odd.

- Increases map size to 25 x 25
- Remodels the map to look more like a blacksite science lab that was unwisely trying to contain Skathari (as its lore suggests)
- Removes Skathari from the exterior of the POI
- Shuffle loot out of the end room safes and disperse it around the area
- Adds a few more bodies and some broken weaponry to go along with them
- Replaces or removes several soldier Skathari (replaced with a smattering of workers)
- Generally changes the layout to favor the Skathari (oftentimes they'd just get caught on things)

Tested; spawns, functions, and plays as roughly intended. The front entry should be more than sufficient to indicate the dangers within, and the first room generally will not kill so long as a player focuses on running when a giant space bug comes to greet them. Difficulty increases the closer to the final chamber one gets, requiring more sound tactics than opening the door and charging forward.

![image](https://github.com/PolarisSS13/Polaris/assets/11377530/fe763918-117b-4199-9412-4bb756e1ce5a)


