### PR TITLE
Removed a space from the Moghesian Sea Delight type definition

### DIFF
--- a/code/modules/food/food/snacks.dm
+++ b/code/modules/food/food/snacks.dm
@@ -5325,7 +5325,7 @@
 	. = ..()
 	reagents.add_reagent("protein", 2, list("smoked sausage" = 2))
 
- /obj/item/reagent_containers/food/snacks/riztizkzi_sea
+/obj/item/reagent_containers/food/snacks/riztizkzi_sea
 	name = "moghesian sea delight"
 	desc = "Three raw eggs floating in a sea of blood. An authentic replication of an ancient Unathi delicacy."
 	icon = 'icons/obj/food_syn.dmi'


### PR DESCRIPTION
This is, presumably, going to fix issues with Moghesian Sea Delight not working properly as a recipe in-game currently. (It was spawning an invisible item named 'snack'.)

All I did was remove a space from code that was making a recipe go funky in-game and I am so scared but i assume Polaris will not explode from this