### PR TITLE
Tweaks the Head of Personnel's hat and locker contents

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -28,10 +28,11 @@
 		/obj/item/cartridge/hop,
 		/obj/item/radio/headset/heads/hop,
 		/obj/item/radio/headset/heads/hop/alt,
-		/obj/item/storage/box/ids = 2,
+		/obj/item/storage/box/ids,
 		/obj/item/gun/energy/gun,
 		/obj/item/gun/projectile/sec/flash,
-		/obj/item/flash)
+		/obj/item/flash
+	)
 
 /obj/structure/closet/secure_closet/hop2
 	name = "head of personnel's attire"
@@ -54,11 +55,12 @@
 		/obj/item/clothing/shoes/laceup/brown,
 		/obj/item/clothing/shoes/white,
 		/obj/item/clothing/under/rank/head_of_personnel_whimsy,
-		/obj/item/clothing/head/caphat/hop,
+		/obj/item/clothing/head/hop,
 		/obj/item/clothing/under/gimmick/rank/head_of_personnel/suit,
 		/obj/item/clothing/under/gimmick/rank/head_of_personnel/suit/skirt,
 		/obj/item/clothing/suit/storage/hooded/wintercoat/hop,
-		/obj/item/clothing/glasses/sunglasses)
+		/obj/item/clothing/glasses/sunglasses
+	)
 
 
 /obj/structure/closet/secure_closet/hos

--- a/code/modules/clothing/head/jobs.dm
+++ b/code/modules/clothing/head/jobs.dm
@@ -32,10 +32,11 @@
 	icon_state = "officercap"
 
 //HOP
-/obj/item/clothing/head/caphat/hop
-	name = "crew resource's hat"
-	desc = "A stylish hat that both protects you from enraged former-crewmembers and gives you a false sense of authority."
+/obj/item/clothing/head/hop
+	name = "head of personnel's cap"
+	desc = "A stylish cap that both protects you from enraged former-crewmembers and gives you a false sense of authority."
 	icon_state = "hopcap"
+	body_parts_covered = 0
 
 //Chaplain
 /obj/item/clothing/head/chaplain_hood


### PR DESCRIPTION
This originally started because I wanted to fix the grammar error in the naming of the hat and then just became a little cleanup.

- The Head of Personnel's cap is now /obj/item/clothing/head/hop rather than /obj/item/clothing/head/caphat/hop.
- Decreased the number of spare ID boxes in the Head of Personnel's locker from 2 -> 1. It was mostly extra clutter given these boxes are placed in multiple locations around the station anyway.
- Renamed the "crew resource's hat" to the "head of personnel's cap" for consistency with the rest of the HoP equipment.