### PR TITLE
update vscode recommends & settings

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,7 +1,7 @@
 {
   "recommendations": [
-    "gbasood.byond-dm-language-support",
     "platymuus.dm-langclient",
-    "eamodio.gitlens"
+    "eamodio.gitlens",
+    "anturk.dmi-editor"
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -31,7 +31,7 @@
   },
 
   "workbench.editorAssociations": {
-    "*.dmi": "imagePreview.previewEditor"
+    "*.dmi": "dmiEditor.dmiEditor"
   },
 
   "debug.onTaskErrors": "abort",


### PR DESCRIPTION
Added gbasood.byond-dm-language-support when suite was rather younger, it is not aware of new syntax and has little value now.

anturk.dmi-editor provides limited manipulation of dmi states within vscode.