### PR TITLE
fix automatic changelog generation

### DIFF
--- a/.github/workflows/autochangelog.yml
+++ b/.github/workflows/autochangelog.yml
@@ -14,6 +14,8 @@ jobs:
     name: Autochangelog
     runs-on: ubuntu-20.04
     if: github.event.pull_request.merged == true
+    permissions:
+      contents: write
     steps:
       - uses: /actions/checkout@v3
         with:


### PR DESCRIPTION
🆑
bugfix: If you can read this, fixed automatic changelog generation.
/🆑

per <https://github.com/stefanzweifel/git-auto-commit-action/tree/v4/#usage>

Polaris enabled the `Require a pull request before merging` protection on master in 2021 without accounting for this action; elevating the job's permissions to write will hopefully allow it to commit directly again.

An alternative would be to run under bot account credentials by creating and adding one to the `Allow specified actors to bypass required pull requests` list or by giving it repo admin (scary), but if this works it's preferable.