### PR TITLE
nerfs nanopaste

### DIFF
--- a/code/game/objects/items/stacks/nanopaste.dm
+++ b/code/game/objects/items/stacks/nanopaste.dm
@@ -51,8 +51,10 @@
 				if(S.open >= 2)
 					if(do_after(user,5 * toolspeed))
 						S.heal_damage(20, 20, robo_repair = 1)
+						M.adjustToxLoss(5)
 				else if(do_after(user,5 * toolspeed))
 					S.heal_damage(10,10, robo_repair =1)
+					M.adjustToxLoss(5) // to prevent spamming
 				H.updatehealth()
 				use(1)
 				user.visible_message("<span class='notice'>\The [user] applies some nanite paste on [user != M ? "[M]'s [S.name]" : "[S]"] with [src].</span>",\


### PR DESCRIPTION
Using nanopaste now adds 5 instability. This should not impede using nanopaste to pick yourself up after a fight or untrained characters using nanopaste to repair prosthetics but does force damaged FBPs to return to the station to charge. Numbers derived from out of my ass.