### PR TITLE
POI - Frost Oasis Remap

### DIFF
--- a/maps/submaps/surface_submaps/wilderness/frostoasis.dmm
+++ b/maps/submaps/surface_submaps/wilderness/frostoasis.dmm
@@ -1,85 +1,183 @@
-"am" = (/obj/random/obstruction,/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/wood/broken,/area/submap/FrostOasis)
-"bB" = (/obj/structure/closet/cabinet,/obj/item/storage/belt/holding,/turf/simulated/floor/wood,/area/submap/FrostOasis)
+"am" = (/obj/structure/flora/ausbushes/ywflowers,/turf/simulated/floor/outdoors/grass/sif,/area/submap/FrostOasis)
+"bc" = (/obj/effect/decal/cleanable/dirt,/obj/random/obstruction,/turf/simulated/floor/outdoors/dirt,/area/submap/FrostOasis)
+"bB" = (/obj/structure/fence/door/opened,/turf/simulated/floor/outdoors/dirt,/area/submap/FrostOasis)
+"bC" = (/obj/structure/table/sifwoodentable,/obj/item/material/knife/butch,/obj/random/meat,/turf/simulated/floor/outdoors/dirt{outdoors = 0},/area/submap/FrostOasis)
+"bX" = (/obj/structure/closet/cabinet,/obj/random/maintenance/cargo,/obj/item/reagent_containers/food/snacks/driedfish,/obj/item/reagent_containers/food/snacks/driedfish,/obj/random/maintenance,/turf/simulated/floor/wood,/area/submap/FrostOasis)
 "cm" = (/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/outdoors/dirt,/area/submap/FrostOasis)
 "co" = (/turf/simulated/mineral/ignore_mapgen,/area/submap/FrostOasis)
+"ct" = (/obj/structure/table/sifwoodentable,/obj/item/a_gift,/obj/machinery/light/small{dir = 8},/turf/simulated/floor/wood,/area/submap/FrostOasis)
+"cA" = (/obj/structure/fireplace,/obj/effect/decal/cleanable/dirt,/obj/structure/sign/christmas/wreath,/turf/simulated/floor/wood,/area/submap/FrostOasis)
+"do" = (/obj/effect/decal/cleanable/dirt,/obj/item/trash/driedfish,/turf/simulated/floor/wood,/area/submap/FrostOasis)
 "dD" = (/obj/structure/loot_pile/maint/boxfort,/turf/simulated/floor/outdoors/dirt{outdoors = 0},/area/submap/FrostOasis)
+"dF" = (/obj/structure/simple_door/sifwood,/turf/simulated/floor/wood,/area/submap/FrostOasis)
 "fh" = (/mob/living/simple_mob/animal/sif/glitterfly{faction = "diyaab"},/turf/simulated/floor/outdoors/dirt,/area/template_noop)
 "fj" = (/turf/simulated/floor/outdoors/ice,/area/submap/FrostOasis)
-"go" = (/mob/living/simple_mob/animal/sif/glitterfly{faction = "diyaab"},/obj/effect/landmark/snowy_turf,/turf/template_noop,/area/submap/FrostOasis)
+"fH" = (/obj/effect/decal/cleanable/dirt,/obj/structure/simple_door/sifwood,/obj/structure/barricade,/turf/simulated/floor/wood/broken,/area/submap/FrostOasis)
+"fU" = (/obj/structure/sink{pixel_y = 17},/turf/simulated/floor/wood,/area/submap/FrostOasis)
+"gl" = (/obj/machinery/shower{dir = 1},/obj/effect/decal/remains/mummy2,/obj/machinery/light/small,/obj/effect/decal/cleanable/dirt,/obj/random/gun/random/anomalous,/turf/simulated/floor/wood,/area/submap/FrostOasis)
+"go" = (/obj/effect/decal/cleanable/dirt,/obj/machinery/light{dir = 4; icon_state = "tube1"},/turf/simulated/floor/wood,/area/submap/FrostOasis)
 "gF" = (/obj/structure/loot_pile/maint/junk,/turf/simulated/floor/outdoors/dirt{outdoors = 0},/area/submap/FrostOasis)
-"iC" = (/obj/structure/table/bench/sifwooden,/obj/item/flame/candle/candelabra/everburn{pixel_y = 7},/turf/simulated/floor/wood/broken,/area/submap/FrostOasis)
-"jN" = (/mob/living/simple_mob/animal/sif/glitterfly{faction = "diyaab"},/obj/structure/flora/ausbushes/brflowers,/obj/effect/landmark/snowy_turf,/turf/template_noop,/area/submap/FrostOasis)
-"kr" = (/obj/item/a_gift,/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/wood,/area/submap/FrostOasis)
-"ll" = (/obj/random/obstruction,/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/outdoors/dirt{outdoors = 0},/area/submap/FrostOasis)
-"lo" = (/obj/structure/flora/ausbushes/brflowers,/obj/effect/landmark/snowy_turf,/turf/template_noop,/area/submap/FrostOasis)
-"ls" = (/obj/structure/table/standard,/obj/item/a_gift,/obj/item/a_gift,/obj/random/material/anom,/obj/random/mug/anom,/turf/simulated/floor/wood,/area/submap/FrostOasis)
-"me" = (/obj/effect/decal/cleanable/dirt,/obj/effect/landmark/snowy_turf,/turf/template_noop,/area/submap/FrostOasis)
+"hf" = (/obj/structure/table/rack,/obj/item/clothing/suit/storage/hooded/wintercoat/ratvar,/turf/simulated/floor/wood,/area/submap/FrostOasis)
+"hz" = (/obj/structure/stasis_cage,/turf/simulated/floor/wood,/area/submap/FrostOasis)
+"hV" = (/obj/effect/landmark/snowy_turf,/turf/simulated/floor/outdoors/dirt,/area/submap/FrostOasis)
+"iv" = (/obj/effect/decal/cleanable/dirt,/obj/item/toy/xmastree,/turf/simulated/floor/wood,/area/submap/FrostOasis)
+"iC" = (/obj/effect/decal/cleanable/dirt,/obj/item/a_gift,/turf/simulated/floor/wood/broken,/area/submap/FrostOasis)
+"iW" = (/obj/structure/flora/ausbushes/ppflowers,/obj/effect/landmark/snowy_turf,/turf/simulated/floor/outdoors/grass/sif,/area/submap/FrostOasis)
+"jb" = (/obj/item/beartrap{deployed = 1; anchored = 1},/turf/simulated/floor/wood/broken,/area/submap/FrostOasis)
+"jj" = (/obj/structure/bed/chair/wood{dir = 8},/turf/simulated/floor/wood,/area/submap/FrostOasis)
+"jw" = (/obj/effect/decal/cleanable/dirt,/obj/effect/spider/stickyweb,/obj/random/mob/spider,/turf/simulated/floor/wood,/area/submap/FrostOasis)
+"jA" = (/obj/structure/fence/cut/large,/turf/simulated/floor/outdoors/dirt,/area/submap/FrostOasis)
+"jD" = (/obj/effect/landmark/snowy_turf,/turf/simulated/floor/outdoors/dirt{outdoors = 0},/area/submap/FrostOasis)
+"jI" = (/obj/structure/flora/grass/brown,/turf/simulated/floor/outdoors/grass/sif,/area/submap/FrostOasis)
+"jN" = (/obj/effect/spider/stickyweb,/turf/simulated/floor/outdoors/dirt{outdoors = 0},/area/submap/FrostOasis)
+"kr" = (/obj/item/reagent_containers/glass/bucket/wood,/turf/simulated/floor/outdoors/dirt,/area/submap/FrostOasis)
+"ll" = (/obj/structure/flora/ausbushes/ywflowers,/obj/effect/landmark/snowy_turf,/turf/simulated/floor/outdoors/grass/sif,/area/submap/FrostOasis)
+"lo" = (/obj/effect/decal/cleanable/blood/drip,/turf/simulated/floor/outdoors/dirt{outdoors = 0},/area/submap/FrostOasis)
+"ls" = (/obj/effect/landmark/snowy_turf,/obj/random/humanoidremains,/obj/random/projectile/scrapped_gun,/turf/simulated/floor/outdoors/grass/sif,/area/submap/FrostOasis)
+"lX" = (/obj/effect/landmark/snowy_turf,/obj/structure/flora/tree/pine,/turf/template_noop,/area/submap/FrostOasis)
+"me" = (/obj/effect/landmark/snowy_turf,/obj/structure/flora/tree/pine,/turf/simulated/floor/outdoors/grass/sif,/area/submap/FrostOasis)
+"mg" = (/obj/effect/decal/cleanable/dirt,/obj/machinery/light/small{dir = 1},/turf/simulated/floor/wood,/area/submap/FrostOasis)
 "mh" = (/turf/simulated/floor/outdoors/dirt,/area/submap/FrostOasis)
+"ml" = (/mob/living/simple_mob/animal/sif/diyaab,/turf/template_noop,/area/submap/FrostOasis)
 "mw" = (/obj/effect/decal/cleanable/dirt,/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/outdoors/dirt{outdoors = 0},/area/submap/FrostOasis)
-"mD" = (/obj/structure/flora/grass/both,/mob/living/simple_mob/animal/sif/shantak{faction = "diyaab"},/obj/effect/landmark/snowy_turf,/turf/template_noop,/area/submap/FrostOasis)
-"mH" = (/obj/random/obstruction,/obj/random/obstruction,/obj/effect/decal/cleanable/dirt,/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/outdoors/dirt{outdoors = 0},/area/submap/FrostOasis)
-"nB" = (/obj/structure/closet/grave,/obj/structure/gravemarker,/obj/random/multiple/voidsuit,/obj/random/gun/random/anomalous,/obj/effect/landmark/snowy_turf,/turf/template_noop,/area/submap/FrostOasis)
-"ou" = (/mob/living/simple_mob/animal/giant_spider/webslinger{faction = "diyaab"},/obj/effect/landmark/snowy_turf,/turf/template_noop,/area/submap/FrostOasis)
+"mD" = (/obj/structure/flora/grass/both,/turf/simulated/floor/outdoors/grass/sif,/area/submap/FrostOasis)
+"mH" = (/obj/structure/flora/grass/green,/turf/simulated/floor/outdoors/grass/sif,/area/submap/FrostOasis)
+"mY" = (/obj/effect/decal/cleanable/dirt,/obj/structure/dogbed,/obj/item/trash/driedfish,/turf/simulated/floor/wood,/area/submap/FrostOasis)
+"np" = (/obj/effect/decal/cleanable/dirt,/turf/simulated/mineral/ignore_mapgen,/area/submap/FrostOasis)
+"nB" = (/obj/structure/animal_den,/obj/effect/spider/stickyweb/dark,/turf/simulated/floor/outdoors/dirt{outdoors = 0},/area/submap/FrostOasis)
+"ok" = (/obj/structure/toilet{dir = 1},/obj/effect/decal/cleanable/filth,/obj/machinery/light/small,/obj/effect/spresent,/turf/simulated/floor/wood,/area/submap/FrostOasis)
+"om" = (/obj/random/multiple/voidsuit,/obj/random/humanoidremains,/obj/item/material/twohanded/spear,/turf/simulated/floor/wood,/area/submap/FrostOasis)
+"op" = (/obj/effect/landmark/snowy_turf,/obj/item/storage/backpack/dufflebag/syndie/ammo,/turf/simulated/floor/outdoors/grass/sif,/area/submap/FrostOasis)
+"ou" = (/turf/simulated/floor/outdoors/grass/sif,/area/submap/FrostOasis)
 "oA" = (/obj/effect/decal/cleanable/dirt,/obj/effect/decal/cleanable/dirt,/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/outdoors/dirt{outdoors = 0},/area/submap/FrostOasis)
 "oB" = (/obj/effect/landmark/snowy_turf,/turf/template_noop,/area/submap/FrostOasis)
-"pE" = (/obj/structure/flora/grass/green,/obj/effect/landmark/snowy_turf,/turf/template_noop,/area/submap/FrostOasis)
+"oV" = (/obj/structure/tanning_rack,/turf/simulated/floor/wood,/area/submap/FrostOasis)
+"pB" = (/obj/effect/decal/cleanable/dirt,/obj/random/trash,/turf/simulated/floor/wood,/area/submap/FrostOasis)
+"pE" = (/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/wood,/area/submap/FrostOasis)
+"pH" = (/obj/effect/spider/stickyweb/dark,/obj/structure/table/standard,/obj/random/mug/anom,/turf/simulated/floor/wood,/area/submap/FrostOasis)
+"pW" = (/obj/structure/table/sifwoodentable,/turf/simulated/floor/wood,/area/submap/FrostOasis)
+"pX" = (/obj/effect/decal/cleanable/dirt,/obj/item/cell/device/weapon,/obj/random/projectile/scrapped_laser,/obj/effect/decal/remains/mummy1,/turf/simulated/floor/wood,/area/submap/FrostOasis)
+"qY" = (/obj/structure/loot_pile/maint/boxfort,/turf/simulated/floor/outdoors/dirt,/area/submap/FrostOasis)
+"rE" = (/obj/structure/flora/ausbushes/brflowers,/obj/effect/landmark/snowy_turf,/turf/simulated/floor/outdoors/grass/sif,/area/submap/FrostOasis)
+"rF" = (/obj/structure/simple_door/sifwood,/obj/structure/sign/christmas/wreath,/turf/simulated/floor/wood,/area/submap/FrostOasis)
+"rG" = (/obj/structure/fence/door/opened{dir = 4},/turf/simulated/floor/outdoors/dirt,/area/submap/FrostOasis)
+"rQ" = (/obj/structure/table/sifwoodentable,/obj/random/mug/anom,/turf/simulated/floor/wood,/area/submap/FrostOasis)
 "st" = (/turf/simulated/floor/outdoors/dirt,/area/template_noop)
-"sU" = (/mob/living/simple_mob/animal/giant_spider/frost/sif{faction = "diyaab"},/obj/structure/flora/ausbushes/ywflowers,/obj/effect/landmark/snowy_turf,/turf/template_noop,/area/submap/FrostOasis)
-"tv" = (/obj/item/a_gift,/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/wood/broken,/area/submap/FrostOasis)
+"sU" = (/obj/effect/decal/cleanable/dirt,/obj/effect/decal/remains/mummy1,/obj/machinery/light/small{dir = 1},/turf/simulated/floor/wood,/area/submap/FrostOasis)
+"tr" = (/obj/effect/decal/cleanable/dirt,/obj/item/a_gift,/turf/simulated/floor/wood,/area/submap/FrostOasis)
+"tv" = (/obj/structure/fence,/turf/simulated/floor/outdoors/dirt,/area/submap/FrostOasis)
 "tT" = (/mob/living/simple_mob/animal/sif/glitterfly{faction = "diyaab"},/turf/simulated/floor/outdoors/dirt{outdoors = 0},/area/submap/FrostOasis)
-"uX" = (/mob/living/simple_mob/animal/giant_spider/frost/sif{faction = "diyaab"},/obj/effect/landmark/snowy_turf,/turf/template_noop,/area/submap/FrostOasis)
-"vb" = (/obj/structure/bed/double/padded,/obj/item/bedsheet/rddouble,/obj/effect/spresent,/turf/simulated/floor/wood,/area/submap/FrostOasis)
-"vK" = (/obj/item/a_gift,/obj/item/clothing/ears/earring/dangle/glass,/turf/simulated/floor/wood,/area/submap/FrostOasis)
+"tV" = (/obj/item/beartrap{deployed = 1; anchored = 1},/turf/simulated/floor/wood,/area/submap/FrostOasis)
+"tY" = (/obj/effect/decal/cleanable/blood/drip,/turf/simulated/floor/outdoors/dirt,/area/submap/FrostOasis)
+"uj" = (/obj/structure/table/sifwoodentable,/obj/item/a_gift,/turf/simulated/floor/wood,/area/submap/FrostOasis)
+"uX" = (/obj/random/trash,/turf/simulated/floor/wood,/area/submap/FrostOasis)
+"vb" = (/obj/structure/window/basic/full,/turf/simulated/floor/wood,/area/submap/FrostOasis)
+"vj" = (/obj/machinery/light/small{dir = 4},/turf/simulated/floor/wood,/area/submap/FrostOasis)
+"vk" = (/obj/structure/flora/grass/green,/obj/effect/landmark/snowy_turf,/turf/simulated/floor/outdoors/grass/sif,/area/submap/FrostOasis)
+"vJ" = (/obj/effect/decal/cleanable/dirt,/obj/effect/decal/cleanable/dirt,/obj/random/obstruction,/turf/simulated/floor/outdoors/dirt{outdoors = 0},/area/submap/FrostOasis)
+"vK" = (/obj/structure/loot_pile/maint/trash,/turf/simulated/floor/outdoors/dirt,/area/submap/FrostOasis)
+"vL" = (/obj/item/toy/xmastree,/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/wood,/area/submap/FrostOasis)
+"wC" = (/obj/structure/animal_den,/turf/simulated/floor/outdoors/dirt,/area/submap/FrostOasis)
+"wH" = (/obj/structure/table/bench/sifwooden/padded,/turf/simulated/floor/wood,/area/submap/FrostOasis)
+"xA" = (/obj/random/soap/anom,/turf/simulated/floor/wood,/area/submap/FrostOasis)
 "xI" = (/turf/simulated/floor/outdoors/dirt{outdoors = 0},/area/submap/FrostOasis)
-"zm" = (/obj/structure/flora/grass/both,/obj/effect/landmark/snowy_turf,/turf/template_noop,/area/submap/FrostOasis)
+"yd" = (/obj/structure/flora/tree/dead,/obj/effect/landmark/snowy_turf,/turf/simulated/floor/outdoors/grass/sif,/area/submap/FrostOasis)
+"yi" = (/obj/structure/closet/grave,/obj/structure/gravemarker{dir = 1},/obj/random/humanoidremains,/turf/template_noop,/area/submap/FrostOasis)
+"yX" = (/mob/living/simple_mob/animal/passive/penguin{faction = "diyaab"},/obj/item/reagent_containers/food/snacks/driedfish,/turf/simulated/floor/wood,/area/submap/FrostOasis)
+"zh" = (/obj/structure/table/sifwoodentable,/obj/item/towel/random,/obj/machinery/light/small{dir = 1},/turf/simulated/floor/wood,/area/submap/FrostOasis)
+"zm" = (/obj/structure/fence/door/locked,/turf/simulated/floor/outdoors/dirt,/area/submap/FrostOasis)
+"zq" = (/obj/structure/table/sifwoodentable,/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/wood,/area/submap/FrostOasis)
 "zI" = (/turf/simulated/wall/sifwood,/area/submap/FrostOasis)
-"Aj" = (/mob/living/simple_mob/animal/sif/savik{faction = "diyaab"},/obj/effect/landmark/snowy_turf,/turf/template_noop,/area/submap/FrostOasis)
-"AM" = (/obj/structure/flora/ausbushes/ywflowers,/obj/effect/landmark/snowy_turf,/turf/template_noop,/area/submap/FrostOasis)
-"Bt" = (/obj/structure/flora/ausbushes/ppflowers,/obj/effect/landmark/snowy_turf,/turf/template_noop,/area/submap/FrostOasis)
-"BF" = (/mob/living/simple_mob/animal/sif/diyaab,/obj/effect/landmark/snowy_turf,/turf/template_noop,/area/submap/FrostOasis)
-"EW" = (/obj/structure/table/standard,/obj/item/gift,/obj/item/gun/energy/temperature,/turf/simulated/floor/wood/broken,/area/submap/FrostOasis)
-"Fl" = (/obj/structure/curtain/open/bed,/obj/item/storage/fancy/blackcandle_box{start_anomalous = 1},/obj/random/soap,/obj/random/maintenance,/obj/random/maintenance,/obj/random/maintenance/cargo,/obj/random/maintenance/cargo,/obj/random/maintenance/medical,/obj/random/maintenance/engineering,/obj/random/maintenance/engineering,/obj/structure/window/reinforced/tinted/frosted{dir = 4},/obj/structure/table/rack,/turf/simulated/floor/wood/broken,/area/submap/FrostOasis)
+"Aj" = (/obj/structure/bed/double/padded,/obj/item/bedsheet/rddouble,/turf/simulated/floor/wood,/area/submap/FrostOasis)
+"AD" = (/obj/structure/prop/nest,/turf/simulated/floor/outdoors/dirt,/area/submap/FrostOasis)
+"AM" = (/obj/item/stack/animalhide,/turf/simulated/floor/outdoors/dirt{outdoors = 0},/area/submap/FrostOasis)
+"Bc" = (/obj/structure/table/sifwoodentable,/obj/item/whetstone,/turf/simulated/floor/wood,/area/submap/FrostOasis)
+"Bt" = (/obj/structure/flora/ausbushes/brflowers,/turf/simulated/floor/outdoors/grass/sif,/area/submap/FrostOasis)
+"BF" = (/obj/structure/flora/sif/frostbelle,/turf/simulated/floor/outdoors/grass/sif,/area/submap/FrostOasis)
+"CD" = (/obj/effect/decal/cleanable/dirt,/obj/effect/decal/cleanable/dirt,/mob/living/simple_mob/animal/space/bear{faction = "diyaab"},/turf/simulated/floor/wood,/area/submap/FrostOasis)
+"Da" = (/obj/structure/bed/padded,/obj/item/bedsheet/brown,/obj/effect/spawner/gibs/human,/turf/simulated/floor/wood,/area/submap/FrostOasis)
+"Ds" = (/obj/structure/gravemarker{dir = 1},/obj/structure/closet/grave,/obj/random/humanoidremains,/turf/template_noop,/area/submap/FrostOasis)
+"EW" = (/mob/living/simple_mob/animal/sif/shantak{faction = "diyaab"},/turf/simulated/floor/outdoors/dirt,/area/submap/FrostOasis)
+"EZ" = (/obj/structure/window/basic/full,/obj/structure/curtain/black,/turf/simulated/floor/wood,/area/submap/FrostOasis)
+"Fa" = (/obj/structure/flora/tree/dead,/turf/simulated/floor/outdoors/grass/sif,/area/submap/FrostOasis)
+"Ff" = (/obj/structure/prop/rock/waterflat,/turf/simulated/floor/beach/water/ocean,/area/submap/FrostOasis)
+"Fl" = (/obj/structure/fence/cut/large{dir = 8; icon_state = "straight_cut3"},/turf/simulated/floor/outdoors/dirt,/area/submap/FrostOasis)
+"FD" = (/obj/structure/simple_door/sifwood,/obj/structure/sign/christmas/wreath,/obj/structure/barricade,/turf/simulated/floor/wood,/area/submap/FrostOasis)
+"GB" = (/obj/structure/table/sifwoodentable,/obj/item/flame/candle/candelabra/everburn{pixel_y = 7},/turf/simulated/floor/wood,/area/submap/FrostOasis)
+"GN" = (/obj/structure/bed/chair/wood{dir = 4},/turf/simulated/floor/wood,/area/submap/FrostOasis)
+"Ia" = (/obj/structure/tanning_rack,/obj/item/stack/wetleather,/turf/simulated/floor/wood,/area/submap/FrostOasis)
 "It" = (/obj/effect/decal/cleanable/dirt,/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/outdoors/dirt,/area/template_noop)
 "IF" = (/turf/simulated/floor/beach/water/ocean,/area/submap/FrostOasis)
-"Ji" = (/obj/item/a_gift,/obj/random/junk,/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/wood,/area/submap/FrostOasis)
+"Ji" = (/obj/effect/spider/stickyweb,/turf/simulated/floor/wood,/area/submap/FrostOasis)
+"Jj" = (/mob/living/simple_mob/animal/sif/shantak{faction = "diyaab"},/turf/simulated/floor/outdoors/grass/sif,/area/submap/FrostOasis)
+"Jz" = (/obj/structure/window/basic/full,/obj/structure/barricade,/turf/simulated/floor/wood,/area/submap/FrostOasis)
 "JY" = (/obj/random/obstruction,/obj/effect/decal/cleanable/dirt,/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/outdoors/dirt{outdoors = 0},/area/submap/FrostOasis)
-"Ka" = (/obj/random/obstruction,/turf/simulated/floor/outdoors/dirt{outdoors = 0},/area/submap/FrostOasis)
+"Ka" = (/obj/structure/bed/chair/wood{dir = 4},/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/wood,/area/submap/FrostOasis)
 "Kq" = (/obj/structure/flora/tree/dead,/obj/effect/landmark/snowy_turf,/turf/template_noop,/area/submap/FrostOasis)
 "KW" = (/mob/living/simple_mob/animal/sif/glitterfly{faction = "diyaab"},/turf/simulated/floor/outdoors/dirt,/area/submap/FrostOasis)
-"Lt" = (/obj/structure/flora/ausbushes/ywflowers,/mob/living/simple_mob/animal/space/bear{faction = "diyaab"},/obj/effect/landmark/snowy_turf,/turf/template_noop,/area/submap/FrostOasis)
+"Lt" = (/obj/structure/flora/tree/pine,/obj/effect/landmark/snowy_turf,/turf/simulated/floor/outdoors/grass/sif,/area/submap/FrostOasis)
+"Ly" = (/obj/structure/kitchenspike,/obj/effect/decal/cleanable/blood,/turf/simulated/floor/outdoors/dirt{outdoors = 0},/area/submap/FrostOasis)
+"Ma" = (/obj/structure/flora/tree/pine,/turf/simulated/floor/outdoors/grass/sif,/area/submap/FrostOasis)
+"Mn" = (/obj/structure/kitchenspike,/obj/effect/decal/cleanable/blood,/obj/item/reagent_containers/food/snacks/meat,/turf/simulated/floor/outdoors/dirt{outdoors = 0},/area/submap/FrostOasis)
 "MA" = (/obj/effect/decal/cleanable/dirt,/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/outdoors/dirt,/area/submap/FrostOasis)
 "Nc" = (/obj/random/outcrop,/turf/simulated/floor/outdoors/dirt{outdoors = 0},/area/submap/FrostOasis)
 "Nd" = (/turf/simulated/mineral/ignore_mapgen,/area/template_noop)
-"Ni" = (/obj/effect/decal/cleanable/dirt,/turf/template_noop,/area/template_noop)
+"Ni" = (/obj/effect/decal/cleanable/dirt,/turf/template_noop,/area/submap/FrostOasis)
+"NY" = (/obj/structure/closet/cabinet,/obj/random/maintenance/medical,/obj/random/maintenance/engineering,/obj/random/maintenance/clean,/turf/simulated/floor/wood,/area/submap/FrostOasis)
+"OU" = (/obj/structure/closet/cabinet,/obj/item/clothing/suit/storage/toggle/labcoat,/obj/item/clothing/ears/earring/dangle/glass,/obj/random/maintenance/medical,/obj/item/clothing/under/dress/darkred,/obj/random/contraband/anom,/obj/effect/spider/stickyweb/dark,/obj/random/cash/huge,/obj/random/maintenance/security,/turf/simulated/floor/wood,/area/submap/FrostOasis)
 "OX" = (/turf/template_noop,/area/submap/FrostOasis)
+"Pt" = (/obj/effect/decal/cleanable/dirt,/obj/structure/table/bench/padded,/turf/simulated/floor/wood,/area/submap/FrostOasis)
+"PR" = (/obj/structure/table/bench/sifwooden/padded,/obj/machinery/light/small{dir = 1},/turf/simulated/floor/wood,/area/submap/FrostOasis)
+"PX" = (/obj/structure/mirror,/turf/simulated/wall/sifwood,/area/submap/FrostOasis)
 "Qn" = (/turf/template_noop,/area/template_noop)
-"Se" = (/obj/structure/table/bench/padded,/obj/random/junk,/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/wood,/area/submap/FrostOasis)
-"TZ" = (/mob/living/simple_mob/animal/sif/shantak{faction = "diyaab"},/obj/effect/landmark/snowy_turf,/turf/template_noop,/area/submap/FrostOasis)
-"Vz" = (/obj/random/obstruction,/turf/simulated/floor/wood/broken,/area/submap/FrostOasis)
+"Qu" = (/obj/item/trash/driedfish,/obj/machinery/light,/turf/simulated/floor/wood,/area/submap/FrostOasis)
+"QJ" = (/obj/effect/spider/stickyweb/dark,/turf/simulated/floor/wood,/area/submap/FrostOasis)
+"QR" = (/obj/effect/decal/cleanable/dirt,/obj/structure/closet/cabinet,/obj/item/reagent_containers/food/drinks/bottle/vodka,/obj/item/storage/box/glasses/cocktail,/obj/random/maintenance/medical,/obj/random/maintenance/medical,/turf/simulated/floor/wood,/area/submap/FrostOasis)
+"Se" = (/obj/structure/table/sifwoodentable,/obj/random/drinkbottle,/turf/simulated/floor/wood,/area/submap/FrostOasis)
+"TJ" = (/obj/effect/decal/cleanable/dirt,/obj/structure/table/standard,/obj/item/a_gift,/turf/simulated/floor/wood,/area/submap/FrostOasis)
+"TZ" = (/obj/structure/table/sifwoodentable,/obj/random/drinkbottle/anom,/turf/simulated/floor/wood,/area/submap/FrostOasis)
+"Uo" = (/obj/random/obstruction,/turf/simulated/floor/outdoors/dirt,/area/submap/FrostOasis)
+"Vz" = (/obj/effect/landmark/snowy_turf,/turf/simulated/floor/outdoors/grass/sif,/area/submap/FrostOasis)
+"Wl" = (/obj/effect/decal/cleanable/dirt,/obj/item/beartrap{deployed = 1; anchored = 1},/turf/simulated/floor/wood,/area/submap/FrostOasis)
+"WK" = (/obj/effect/spider/stickyweb,/obj/structure/girder,/turf/simulated/floor/outdoors/dirt{outdoors = 0},/area/submap/FrostOasis)
 "Xf" = (/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/outdoors/dirt{outdoors = 0},/area/submap/FrostOasis)
-"Yc" = (/mob/living/simple_mob/animal/passive/penguin{faction = "diyaab"},/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/wood/broken,/area/submap/FrostOasis)
-"ZD" = (/obj/structure/flora/grass/brown,/obj/effect/landmark/snowy_turf,/turf/template_noop,/area/submap/FrostOasis)
-"ZQ" = (/obj/structure/prop/nest,/obj/effect/landmark/snowy_turf,/turf/template_noop,/area/submap/FrostOasis)
+"Xq" = (/obj/structure/bed/chair/wood{dir = 8},/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/wood,/area/submap/FrostOasis)
+"XY" = (/obj/structure/bed/padded,/obj/effect/decal/cleanable/dirt,/obj/effect/spider/stickyweb,/obj/random/mob/spider/mutant,/turf/simulated/floor/wood,/area/submap/FrostOasis)
+"Yc" = (/obj/structure/fence{dir = 8; icon_state = "straight"},/turf/simulated/floor/outdoors/dirt,/area/submap/FrostOasis)
+"Zx" = (/mob/living/simple_mob/animal/sif/savik{faction = "diyaab"},/turf/simulated/floor/outdoors/dirt,/area/submap/FrostOasis)
+"ZD" = (/obj/effect/landmark/snowy_turf,/obj/structure/flora/grass/both,/turf/template_noop,/area/submap/FrostOasis)
+"ZQ" = (/turf/simulated/floor/wood,/area/submap/FrostOasis)
+"ZX" = (/obj/structure/table/standard,/obj/item/storage/fancy/blackcandle_box{start_anomalous = 1},/turf/simulated/floor/wood,/area/submap/FrostOasis)
 
 (1,1,1) = {"
-QnQnQnQnQnQnstQnQnQnQnQnQnQnstItfhQnQnQn
-QnQnNdNdststQnQnNdQnQnQnQnQncoMAcoOXQnQn
-QnNdNdNdxImhOXcococoOXOXcococoJYcocoQnQn
-QnQnmhxItTdDcocoZQcococococollmHKacoQnQn
-QnQnOXmhxIcococooBcococoTZxIXfXfxIcoQnQn
-QnQnmhOXcococooBZDouoBoBzmmeAjXfNccoNdQn
-QnQnOXcococomDKqLtBtlosUloBFoBoBcocoNdQn
-QnQnNdcocooBoBjNlofjIFBtgoZDoBpEcocoQnQn
-QnQnNdcozmBFpEuXAMIFfjBtouoBoBzmcocoQnQn
-QnNdNdcoxIoBoBoBAMloLtzmnBKqoBoBcocoNdQn
-QnNdNdcoNcXfcooBoBBFAMuXcocooBXfdDcoNdQn
-QnNdNdcoxImwcoTZoBZDoBcocococoamVzcoNdNd
-QnQnNdcoxIoAcocooBoBoBcozIzIzIXfxIzINdNd
-QnNdcocoXfmwcococozmAjcozIbBFlYctvzINdNd
-NdcocoKaJYmwcocococococozISekrJiiCzINdQn
-NdcomhKaKacococococococozIlsEWvKvbzINdQn
-QnmhmhcmcococogFxImhcocozIzIzIzIzIzINdQn
-QnOXKWcmcocomhxItTOXOXcoNdNdNdNdNdNdNdNd
-QnQnNistQnQnQnstNdstQnQnQnNdNdNdQnQnNdNd
-QnQnQnQnQnQnstNdNdQnQnQnQnQnQnQnQnQnQnQn
+QnQnQnQnQnstQnQnQnNdNdNdNdQnQnQnQnNdNdQnQnQnQnQnstItfhQnQnQn
+QncocomhmhOXOXOXcocococococococococococoOXOXcocomhMAcoOXOXQn
+NdcocoxImhOXcocococozIzIzIzIcocococococococococoUoJYcococoQn
+QnmhxItTdDcococozIzIzIcAcAzIzIzIcocococococomhcocmXfcocoOXQn
+QnOXmhxIcococozIzIvLmgpEpEsUiCzIzIzIPXzIPXzIxIxIXfXfNccocoQn
+QnmhOXcococozIzIpXuXGNSepWXqpEivQRzIfUzhfUzImhnpcoXfxIcocoQn
+QnOXcocococozIzqpEZQKaGBBcjjpEtrpBfHxAtVpEzImhyicococoxIcoQn
+QncococococozIctjbZQGNrQTZXquXpEvjzIdFzIdFzImhOXOXDscoxIcoNd
+QncococococozIzqzqpEZQZQZQZQtVZQujzIokzIglzIhVmhmhmhmhoucoNd
+QnOXcococoqYzIvbvbzIzIWljbzIzIvbJzzIzIzIzIzIOXmhmecocococoNd
+QnOXcocoOXmhjAoBoBzIzIrFFDzIzIhVhVoBOXKqoBmhmhmhcococococoNd
+QncococomhmhtvlXmhwHPRZQZQPRwHmhmhmhoBoBmhmhoBzIzIzIzIzIcoNd
+NdcocoADmlmhrGmhmhZQZQomZQZQZQmhouLtEWmhmDmhoBEZTJPthzzIcoQn
+QncococoOXOXtvmhmhzIZQoVIaZQzImHLtVzvkOXOXmhmhdFpECDgozIcoQn
+QncococoOXOXtvmhmDouFajIllfjfjfjfjfjBFLtoumDmhzINYpEDazIcoNd
+QncocococococomhZDouamllfjIFIFIFIFIFfjfjllBtmhzIzIzIzIzIcoNd
+QnOXcocococomDmhLtBtrEfjIFIFIFFfIFIFIFfjiWmhjImhcococococoNd
+QnOXcococoLtmhoBVzxIvkfjIFIFIFIFIFIFfjVziWJjmhcocococococoNd
+QnOXcocomDmhmHxILyMnVzamfjIFIFIFIFfjmHopmDmhzIzIzIzIzIcocoNd
+QncococoxIcocoydAMlobCrEfjfjfjfjfjBFlsouMaouEZpHJiJiWKcocoNd
+QncococoxInpxIxIloxIxIouamMaBtamouVzVzmDVzmhdFQJJijwjNcocoQn
+QncococoxImhxIcoxIxIjDVzoumDouamVzjDxIxImhmhzIOUjwXYjNnBcoQn
+QnOXcocoxIoAcocoxIloxIxIxIxIouxIxIcozIzIdFEZzIzIzIzIzIcocoQn
+QncococobcvJcocoYczmYczIYcbBFlYccocozIbXdohfzIcocococococoQn
+NdcocoxImwmwcokrmhtYmhtvmhmhkrmhcocozIyXZQmYzIcocococococoQn
+NdcomhxIxIcocovKOXmhZxjAmhOXEWvKcocozIAjQuZXzIcocococococoNd
+QnmhmhcmcocoOXmhZxmhOXtvOXOXOXcococozIzIzIzIzIcococogFxIwCNd
+QnOXKWcmcococoOXOXOXOXcocococococococococococococomhxItTOXQn
+QnOXNimhOXcococococococoOXcococoOXOXcococococococoOXmhcomhQn
+QnQnQnQnQnQnNdNdNdNdQnQnQnQnQnQnQnQnQnQnQnNdNdQnQnstNdNdQnQn
 "}


### PR DESCRIPTION
Pretty much a total facelift for the frostoasis POI, which suffered from being cramped and chock full of hostile mobs that basically required corner cheesing or simply drilling into the goodie room to receive a reward for. That said, I did like the inexplicable nature of several of Sif's hostile creatures working together - is it because of some quirk of their nature, or the SAR's anomalous properties? Keep the SAR weird!

- Overall flavor changed to befit an illegal safari lodge that went terribly wrong - the wildlife was clearly being harshly exploited here
- Made the map bigger by ~10 units, both tall and wide
- Spread out monsters a bit and reduced their numbers, made spiders part of their own faction again but sequestered them off to one side. 
- Changed entry points to prevent immediate aggro from mobs, as well as create tension even when bottlenecking
- Perhaps controversial: removed the bluespace backpack and belt of holding, replaced them with a tactical belt and syndie duffelbag spawn. Having cutting edge research laying around felt weird, especially without any implied reasoning, but I wanted to preserve the spot being a good hit for storage options. Naturally also removed the temp gun, replaced it with a few additional weapon spawns.

Before:
![2023-09-19_12 14 37](https://github.com/PolarisSS13/Polaris/assets/11377530/e5b686ee-4cd8-43c9-a767-50019b882ef8)

After:
![2023-09-19 23 21 09](https://github.com/PolarisSS13/Polaris/assets/11377530/c250c013-d6f8-490b-8933-ec109b1c280a)

