### PR TITLE
Union Renovations 3

### DIFF
--- a/maps/cynosure/cynosure-1.dmm
+++ b/maps/cynosure/cynosure-1.dmm
@@ -7531,7 +7531,7 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/airlock/maintenance{
 	name = "Xenofauna Maintenance Access";
-	req_access = list(12, 67)
+	req_access = list(12,67)
 	},
 /turf/simulated/floor/plating,
 /area/surface/station/maintenance/medical/west)
@@ -8973,6 +8973,11 @@
 	},
 /turf/simulated/floor/tiled/old_cargo/gray,
 /area/surface/station/medical/morgue)
+"sr" = (
+/turf/simulated/wall/r_concrete{
+	desc = "You get the feeling you shouldn't mine around these."
+	},
+/area/surface/cave/explored/normal)
 "ss" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/borderfloor{
@@ -45481,8 +45486,8 @@ Kj
 Kj
 Kj
 Kj
-Fp
-Fp
+sr
+sr
 Kj
 Kj
 HE
@@ -45498,8 +45503,8 @@ HE
 HE
 HE
 HE
-Fp
-Fp
+HE
+HE
 HE
 HE
 HE
@@ -45739,7 +45744,7 @@ mV
 Kj
 HE
 Fp
-Fp
+sr
 Kj
 Kj
 Kj
@@ -45755,6 +45760,7 @@ HE
 HE
 HE
 HE
+HE
 Fp
 Fp
 HE
@@ -45786,9 +45792,8 @@ HE
 HE
 HE
 HE
-HE
-HE
-HE
+Fp
+Fp
 HE
 HE
 HE
@@ -46013,6 +46018,8 @@ HE
 HE
 HE
 HE
+Fp
+Fp
 HE
 HE
 HE
@@ -46042,10 +46049,8 @@ HE
 HE
 HE
 HE
-HE
-HE
-HE
-HE
+Fp
+Fp
 HE
 HE
 HE
@@ -50267,6 +50272,8 @@ HE
 HE
 HE
 HE
+Fp
+Fp
 HE
 HE
 HE
@@ -50283,10 +50290,8 @@ HE
 HE
 HE
 HE
-HE
-HE
-HE
-HE
+Fp
+Fp
 HE
 HE
 Kj
@@ -50524,6 +50529,8 @@ HE
 HE
 HE
 HE
+Fp
+Fp
 HE
 HE
 HE
@@ -50540,10 +50547,8 @@ HE
 HE
 HE
 HE
-HE
-HE
-HE
-HE
+Fp
+Fp
 HE
 HE
 HE
@@ -51667,6 +51672,8 @@ HE
 HE
 HE
 HE
+Fp
+Fp
 HE
 HE
 HE
@@ -51696,10 +51703,8 @@ HE
 HE
 HE
 HE
-HE
-HE
-HE
-HE
+Fp
+Fp
 HE
 HE
 HE
@@ -51924,6 +51929,8 @@ HE
 HE
 HE
 HE
+Fp
+Fp
 HE
 HE
 HE
@@ -51953,10 +51960,8 @@ HE
 HE
 HE
 HE
-HE
-HE
-HE
-HE
+Fp
+Fp
 HE
 HE
 HE
@@ -55009,8 +55014,8 @@ HE
 HE
 HE
 HE
-Fp
-Fp
+HE
+HE
 HE
 HE
 HE
@@ -55266,8 +55271,8 @@ HE
 HE
 HE
 HE
-Fp
-Fp
+HE
+HE
 HE
 HE
 HE
@@ -57064,6 +57069,8 @@ Kj
 HE
 HE
 HE
+Fp
+Fp
 HE
 HE
 HE
@@ -57093,10 +57100,8 @@ HE
 HE
 HE
 HE
-HE
-HE
-HE
-HE
+Fp
+Fp
 HE
 HE
 HE
@@ -57224,8 +57229,8 @@ HE
 HE
 HE
 HE
-HE
-HE
+Fp
+Fp
 HE
 HE
 HE
@@ -57321,6 +57326,8 @@ Kj
 Kj
 HE
 HE
+Fp
+Fp
 HE
 HE
 HE
@@ -57350,10 +57357,8 @@ HE
 HE
 HE
 HE
-HE
-HE
-HE
-HE
+Fp
+Fp
 HE
 HE
 HE
@@ -57481,8 +57486,8 @@ HE
 HE
 HE
 HE
-HE
-HE
+Fp
+Fp
 HE
 HE
 HE
@@ -61064,6 +61069,8 @@ HE
 HE
 HE
 HE
+Fp
+Fp
 HE
 HE
 HE
@@ -61077,10 +61084,8 @@ HE
 HE
 HE
 HE
-HE
-HE
-HE
-HE
+Fp
+Fp
 HE
 HE
 HE
@@ -61321,6 +61326,8 @@ HE
 HE
 HE
 HE
+Fp
+Fp
 HE
 HE
 HE
@@ -61334,10 +61341,8 @@ HE
 HE
 HE
 HE
-HE
-HE
-HE
-HE
+Fp
+Fp
 HE
 HE
 HE
@@ -62983,6 +62988,8 @@ HE
 HE
 HE
 HE
+Fp
+Fp
 HE
 HE
 HE
@@ -63004,10 +63011,8 @@ HE
 HE
 HE
 HE
-HE
-HE
-HE
-HE
+Fp
+Fp
 HE
 HE
 HE
@@ -63240,6 +63245,8 @@ HE
 HE
 HE
 HE
+Fp
+Fp
 HE
 HE
 HE
@@ -63261,10 +63268,8 @@ HE
 HE
 HE
 HE
-HE
-HE
-HE
-HE
+Fp
+Fp
 HE
 HE
 HE
@@ -70677,8 +70682,8 @@ HE
 HE
 HE
 WS
-HE
-HE
+Fp
+Fp
 HE
 HE
 HE
@@ -70934,8 +70939,8 @@ HE
 HE
 HE
 WS
-HE
-HE
+Fp
+Fp
 HE
 HE
 HE
@@ -74496,6 +74501,8 @@ HE
 Kj
 Kj
 HE
+Fp
+Fp
 HE
 HE
 HE
@@ -74515,10 +74522,8 @@ HE
 HE
 HE
 HE
-HE
-HE
-HE
-HE
+Fp
+Fp
 HE
 HE
 HE
@@ -74753,6 +74758,8 @@ HE
 Kj
 Kj
 HE
+Fp
+Fp
 HE
 HE
 HE
@@ -74772,10 +74779,8 @@ HE
 HE
 HE
 HE
-HE
-HE
-HE
-HE
+Fp
+Fp
 HE
 HE
 HE
@@ -80428,8 +80433,8 @@ HE
 HE
 HE
 HE
-HE
-HE
+Fp
+Fp
 HE
 HE
 HE
@@ -80685,8 +80690,8 @@ HE
 HE
 HE
 HE
-HE
-HE
+Fp
+Fp
 HE
 HE
 HE

--- a/maps/cynosure/cynosure-1.dmm
+++ b/maps/cynosure/cynosure-1.dmm
@@ -5216,7 +5216,7 @@
 	},
 /obj/machinery/door/airlock/research{
 	name = "Long Term Storage";
-	req_one_access = list(65)
+	req_one_access = list(47)
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/surface/outpost/research/xenoarcheology/longtermstorage)
@@ -23244,6 +23244,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/surface/station/maintenance/medical/west)
+"VV" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/airlock/research{
+	name = "Long Term Storage";
+	req_one_access = list(47)
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/surface/outpost/research/xenoarcheology/longtermstorage)
 "VW" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -54627,7 +54635,7 @@ iz
 Qw
 ux
 rw
-Hv
+VV
 jz
 Wc
 kL

--- a/maps/cynosure/cynosure-2.dmm
+++ b/maps/cynosure/cynosure-2.dmm
@@ -44876,8 +44876,6 @@
 /turf/simulated/floor/tiled,
 /area/surface/station/engineering/atmos)
 "tMk" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/flora/ausbushes/brflowers,
 /obj/machinery/light/spot{
 	dir = 1
 	},
@@ -44885,7 +44883,7 @@
 	dir = 1
 	},
 /obj/machinery/disposal,
-/turf/simulated/floor/grass,
+/turf/simulated/floor/tiled/hydro,
 /area/surface/station/park)
 "tMq" = (
 /obj/machinery/door/firedoor/glass,

--- a/maps/cynosure/cynosure-2.dmm
+++ b/maps/cynosure/cynosure-2.dmm
@@ -2120,6 +2120,24 @@
 /obj/effect/catwalk_plated/dark,
 /turf/simulated/floor/plating,
 /area/surface/station/maintenance/substation/cargo/gnd)
+"aXD" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/catwalk_plated,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/surface/station/hallway/primary/groundfloor/north)
 "aXH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -2601,10 +2619,6 @@
 	},
 /area/surface/outside/station/reactorpond)
 "bhP" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
@@ -2617,6 +2631,9 @@
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
+	},
+/obj/structure/disposalpipe/junction/yjunction{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/monofloor{
 	dir = 4
@@ -4643,6 +4660,7 @@
 /obj/effect/floor_decal/corner/green/bordercorner{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/surface/station/hallway/primary/groundfloor/west/elevator)
 "cdD" = (
@@ -8597,6 +8615,9 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/effect/catwalk_plated,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/surface/station/hallway/primary/groundfloor/north)
 "dRW" = (
@@ -12462,6 +12483,7 @@
 	pixel_x = 32
 	},
 /obj/item/gps/security,
+/obj/item/gps/security,
 /turf/simulated/floor/tiled/techmaint,
 /area/surface/station/security/lockerroom)
 "fAm" = (
@@ -13280,6 +13302,9 @@
 	dir = 4
 	},
 /obj/effect/catwalk_plated,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/surface/station/hallway/primary/groundfloor/north)
 "fRM" = (
@@ -13367,7 +13392,7 @@
 	input_tag = "o2_in";
 	name = "Oxygen Tank Control";
 	output_tag = "o2_out";
-	sensors = list("o2_sensor" = "Tank")
+	sensors = list("o2_sensor"="Tank")
 	},
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/blue/border,
@@ -14207,6 +14232,13 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/surface/station/ai/upload)
+"gqX" = (
+/obj/machinery/door/firedoor/glass,
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/surface/station/park)
 "grj" = (
 /obj/structure/table/reinforced,
 /obj/effect/floor_decal/borderfloorwhite{
@@ -16825,6 +16857,23 @@
 /obj/structure/railing,
 /turf/simulated/open,
 /area/surface/station/hallway/primary/groundfloor/east)
+"hBc" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/surface/station/hallway/primary/groundfloor/north)
 "hBh" = (
 /turf/simulated/floor/tiled/dark,
 /area/surface/station/hallway/primary/groundfloor/east)
@@ -20460,13 +20509,13 @@
 /turf/simulated/floor/tiled/freezer,
 /area/surface/station/crew_quarters/pool)
 "jsF" = (
-/obj/machinery/vending/fitness,
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/grey/border{
 	dir = 1
 	},
+/obj/item/banner/virgov,
 /turf/simulated/floor/tiled,
 /area/surface/station/crew_quarters/gym)
 "jtd" = (
@@ -21472,7 +21521,7 @@
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 1
 	},
-/obj/item/banner/virgov,
+/obj/item/banner/nt,
 /turf/simulated/floor/wood/sif,
 /area/surface/station/chapel/main)
 "jPo" = (
@@ -22717,6 +22766,7 @@
 /obj/effect/floor_decal/corner/paleblue/bordercorner2{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/white,
 /area/surface/station/medical/reception)
 "kkZ" = (
@@ -23842,6 +23892,8 @@
 /obj/effect/floor_decal/steeldecal/steel_decals_central7{
 	dir = 1
 	},
+/obj/structure/table/standard,
+/obj/item/storage/firstaid/regular,
 /turf/simulated/floor/tiled,
 /area/surface/station/crew_quarters/gym)
 "kLh" = (
@@ -28794,6 +28846,7 @@
 /obj/effect/floor_decal/corner/paleblue/bordercorner{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/white,
 /area/surface/station/medical/reception)
 "mRf" = (
@@ -29433,6 +29486,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/surface/station/hallway/primary/groundfloor/north)
 "neJ" = (
@@ -29488,14 +29545,13 @@
 /turf/simulated/floor/plating,
 /area/surface/station/maintenance/kitchen)
 "ngO" = (
-/obj/structure/table/standard,
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/grey/border{
 	dir = 1
 	},
-/obj/item/storage/firstaid/regular,
+/obj/machinery/vending/fitness,
 /turf/simulated/floor/tiled,
 /area/surface/station/crew_quarters/gym)
 "nhb" = (
@@ -31387,6 +31443,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/surface/station/hallway/primary/groundfloor/north)
 "nZD" = (
@@ -32461,6 +32520,7 @@
 	name = "Medbay";
 	req_access = list(5)
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/steel_grid,
 /area/surface/station/medical/reception)
 "otX" = (
@@ -34825,6 +34885,7 @@
 /obj/effect/landmark{
 	name = "lightsout"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/neutral,
 /area/surface/station/medical/reception)
 "ppO" = (
@@ -34859,6 +34920,10 @@
 /obj/structure/flora/ausbushes/palebush,
 /turf/simulated/floor/grass,
 /area/surface/station/park)
+"pqn" = (
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/white,
+/area/surface/station/medical/reception)
 "pqo" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 5
@@ -35962,6 +36027,16 @@
 	},
 /turf/simulated/floor/tiled,
 /area/surface/station/hallway/primary/groundfloor/east)
+"pQx" = (
+/obj/effect/floor_decal/corner_steel_grid{
+	dir = 5
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled,
+/area/surface/station/hallway/primary/groundfloor/north)
 "pQA" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -36329,6 +36404,24 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/surface/station/medical/chemistry)
+"qaH" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/surface/station/hallway/primary/groundfloor/north)
 "qaK" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -37969,7 +38062,7 @@
 	input_tag = "n2_in";
 	name = "Nitrogen Tank Control";
 	output_tag = "n2_out";
-	sensors = list("n2_sensor" = "Tank")
+	sensors = list("n2_sensor"="Tank")
 	},
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/red/border,
@@ -38532,9 +38625,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
+/obj/structure/disposalpipe/junction/yjunction{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
 /area/surface/station/medical/etc)
@@ -38997,7 +39089,7 @@
 	input_tag = "waste_in";
 	name = "Gas Mix Tank Control";
 	output_tag = "waste_out";
-	sensors = list("waste_sensor" = "Tank")
+	sensors = list("waste_sensor"="Tank")
 	},
 /turf/simulated/floor/tiled,
 /area/surface/station/engineering/atmos)
@@ -39569,6 +39661,7 @@
 /obj/effect/floor_decal/corner/paleblue/border{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/white,
 /area/surface/station/medical/reception)
 "rpI" = (
@@ -41724,6 +41817,13 @@
 	},
 /turf/simulated/floor/tiled,
 /area/surface/station/engineering/hallway)
+"stv" = (
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/surface/station/hallway/primary/groundfloor/west/elevator)
 "stD" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/green/border,
@@ -41771,7 +41871,7 @@
 	name = "Air Tank Control";
 	output_tag = "air_out";
 	pressure_setting = 2000;
-	sensors = list("air_sensor" = "Tank")
+	sensors = list("air_sensor"="Tank")
 	},
 /turf/simulated/floor/tiled,
 /area/surface/station/engineering/atmos)
@@ -44775,6 +44875,18 @@
 	},
 /turf/simulated/floor/tiled,
 /area/surface/station/engineering/atmos)
+"tMk" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/brflowers,
+/obj/machinery/light/spot{
+	dir = 1
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/machinery/disposal,
+/turf/simulated/floor/grass,
+/area/surface/station/park)
 "tMq" = (
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/airlock/glass_atmos{
@@ -45068,7 +45180,7 @@
 	input_tag = "co2_in";
 	name = "Carbon Dioxide Supply Control";
 	output_tag = "co2_out";
-	sensors = list("co2_sensor" = "Tank")
+	sensors = list("co2_sensor"="Tank")
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
@@ -46289,6 +46401,14 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/surface/station/medical/hallway/gnd)
+"uyX" = (
+/obj/effect/floor_decal/corner_steel_grid{
+	dir = 10
+	},
+/obj/effect/floor_decal/industrial/warning,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/white,
+/area/surface/station/medical/reception)
 "uzl" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 9
@@ -47311,7 +47431,7 @@
 	input_tag = "tox_in";
 	name = "Phoron Supply Control";
 	output_tag = "tox_out";
-	sensors = list("tox_sensor" = "Tank")
+	sensors = list("tox_sensor"="Tank")
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
@@ -49807,7 +49927,7 @@
 	input_tag = "n2o_in";
 	name = "Nitrous Oxide Supply Control";
 	output_tag = "n2o_out";
-	sensors = list("n2o_sensor" = "Tank")
+	sensors = list("n2o_sensor"="Tank")
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
@@ -50146,6 +50266,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/white,
 /area/surface/station/medical/reception)
 "wnd" = (
@@ -50287,6 +50408,18 @@
 	},
 /turf/simulated/floor/reinforced/airmix,
 /area/surface/station/engineering/atmos)
+"woX" = (
+/obj/machinery/door/firedoor/glass,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/door/blast/regular/open{
+	dir = 4;
+	id = "medbayquar";
+	layer = 3.3;
+	name = "Medbay Lockdown"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/techfloor,
+/area/surface/station/medical/reception)
 "woY" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -50375,6 +50508,7 @@
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/green/border,
 /obj/machinery/light,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/surface/station/hallway/primary/groundfloor/north)
 "wtw" = (
@@ -78951,7 +79085,7 @@ knS
 knS
 bhP
 ccZ
-lPO
+stv
 ord
 aqn
 wCG
@@ -86132,8 +86266,8 @@ oHA
 aLm
 neE
 wtk
-jgp
-gGO
+gqX
+tMk
 pts
 bql
 oqM
@@ -86901,7 +87035,7 @@ cAX
 kAK
 obP
 lGu
-rHb
+aXD
 vmK
 pfh
 oqM
@@ -87158,7 +87292,7 @@ vzn
 ydr
 obP
 lGu
-fCf
+hBc
 vmK
 eNB
 hlM
@@ -87415,7 +87549,7 @@ dTz
 wik
 bBs
 bzH
-fCf
+hBc
 vmK
 jgp
 hlM
@@ -87672,7 +87806,7 @@ tbv
 boy
 tLq
 dbY
-fCf
+hBc
 vmK
 eNB
 hlM
@@ -87929,7 +88063,7 @@ oZb
 kLG
 dfi
 dbY
-rHb
+aXD
 eWW
 pfh
 oqM
@@ -88186,7 +88320,7 @@ oZb
 kLG
 tLq
 dbY
-rHb
+aXD
 hWJ
 pfh
 eiv
@@ -88696,11 +88830,11 @@ kkG
 rpd
 mRb
 wnc
-oZb
-fId
-jgs
-qrK
-fCf
+pqn
+uyX
+woX
+pQx
+qaH
 iyI
 jgp
 gGO


### PR DESCRIPTION
Removes nationalism from chapel.
Adds nationalism to gym.
Adds additional GPS unit (1) to Security locker room. 
Painstakingly extracts concrete pillars sunk underneath the pool and gym. 
Lazily sinks some new concrete pillars fifty feet away. 
Also sinks a whole bunch more pillars around. These now delineate important structures, landing pads, etc. 
Adds additional disposal units to main garden and cargo hallway elevator.
Changes xenoarcheology artifact storage access to Research (general). North lab/storage door is still xeno-arch only.

All labour, union approved. Yada yada.
