### PR TITLE
POI - Shelter Remap

### DIFF
--- a/code/game/objects/random/mob.dm
+++ b/code/game/objects/random/mob.dm
@@ -238,6 +238,29 @@
 				prob(5);/mob/living/simple_mob/mechanical/hivebot/ranged_damage/laser,
 				prob(5);/mob/living/simple_mob/mechanical/hivebot/ranged_damage/strong,
 				prob(5);/mob/living/simple_mob/mechanical/hivebot/ranged_damage/strong/guard)
+				
+/obj/random/mob/robotic/hivebot/melee
+	name = "Random Lesser Melee Hivebot"
+	desc = "This is a random hivebot that engages in melee but has no special ability."
+	icon_state = "robot"
+
+	mob_faction = "hivebot"
+
+/obj/random/mob/robotic/hivebot/melee/item_to_spawn()
+	return pick(prob(10);/mob/living/simple_mob/mechanical/hivebot,
+				prob(5);/mob/living/simple_mob/mechanical/hivebot/swarm)
+				
+/obj/random/mob/robotic/hivebot/laser
+	name = "Random Laser Hivebot"
+	desc = "This is a random hivebot that can shoot through obstacles and does burn damage."
+	icon_state = "robot"
+
+	mob_faction = "hivebot"
+
+/obj/random/mob/robotic/hivebot/laser/item_to_spawn()
+	return pick(prob(30);/mob/living/simple_mob/mechanical/hivebot/ranged_damage/laser,
+				prob(5);/mob/living/simple_mob/mechanical/hivebot/ranged_damage/backline
+				prob(5);/mob/living/simple_mob/mechanical/hivebot/ranged_damage/rapid)
 
 //Mice
 

--- a/code/game/objects/random/mob.dm
+++ b/code/game/objects/random/mob.dm
@@ -259,8 +259,7 @@
 
 /obj/random/mob/robotic/hivebot/laser/item_to_spawn()
 	return pick(prob(30);/mob/living/simple_mob/mechanical/hivebot/ranged_damage/laser,
-				prob(5);/mob/living/simple_mob/mechanical/hivebot/ranged_damage/backline
-				prob(5);/mob/living/simple_mob/mechanical/hivebot/ranged_damage/rapid)
+				prob(5);/mob/living/simple_mob/mechanical/hivebot/ranged_damage/backline)
 
 //Mice
 

--- a/maps/submaps/surface_submaps/wilderness/Shelter.dmm
+++ b/maps/submaps/surface_submaps/wilderness/Shelter.dmm
@@ -36,6 +36,9 @@
 /obj/item/radio{
 	start_anomalous = 1
 	},
+/obj/machinery/light/small{
+	dir = 1
+	},
 /turf/simulated/floor/wood/sif,
 /area/submap/Shelter1)
 "hd" = (
@@ -69,6 +72,12 @@
 "mc" = (
 /obj/structure/toilet,
 /turf/simulated/floor/tiled/neutral,
+/area/submap/Shelter1)
+"mw" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/wood/sif,
 /area/submap/Shelter1)
 "sh" = (
 /obj/item/stack/material/wood/sif,
@@ -104,6 +113,9 @@
 "xq" = (
 /obj/item/stack/material/wood/sif,
 /obj/random/mob/robotic/hivebot/melee,
+/obj/machinery/light/small{
+	dir = 1
+	},
 /turf/simulated/floor/wood/sif/broken,
 /area/submap/Shelter1)
 "xv" = (
@@ -188,6 +200,9 @@
 /obj/random/soap,
 /obj/random/medical,
 /obj/item/stock_parts/spring,
+/obj/machinery/light/small{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/neutral,
 /area/submap/Shelter1)
 "Jp" = (
@@ -260,6 +275,9 @@
 /area/submap/Shelter1)
 "Vv" = (
 /obj/item/stack/material/steel,
+/obj/machinery/light/small{
+	dir = 8
+	},
 /turf/simulated/floor/wood/sif/broken,
 /area/submap/Shelter1)
 "WG" = (
@@ -388,7 +406,7 @@ xq
 WI
 iC
 IT
-PS
+mw
 LB
 eM
 Fp

--- a/maps/submaps/surface_submaps/wilderness/Shelter.dmm
+++ b/maps/submaps/surface_submaps/wilderness/Shelter.dmm
@@ -1,33 +1,549 @@
-"a" = (/turf/simulated/floor/outdoors/grass/sif,/area/template_noop)
-"b" = (/turf/simulated/floor/outdoors/grass/sif/forest,/area/template_noop)
-"c" = (/obj/effect/landmark/snowy_turf,/turf/template_noop,/area/template_noop)
-"d" = (/turf/simulated/floor/outdoors/grass/sif/forest,/area/submap/Shelter1)
-"e" = (/turf/simulated/floor/outdoors/grass/sif,/area/submap/Shelter1)
-"f" = (/obj/effect/landmark/snowy_turf,/turf/template_noop,/area/submap/Shelter1)
-"g" = (/turf/simulated/wall/log_sif,/area/submap/Shelter1)
-"h" = (/obj/random/obstruction,/turf/simulated/floor/outdoors/rocks/caves,/area/submap/Shelter1)
-"i" = (/turf/simulated/floor/outdoors/rocks/caves,/area/submap/Shelter1)
-"j" = (/obj/structure/bonfire/sifwood,/turf/simulated/floor/outdoors/rocks/caves,/area/submap/Shelter1)
-"k" = (/obj/random/mob/robotic,/turf/simulated/floor/outdoors/rocks/caves,/area/submap/Shelter1)
-"l" = (/obj/structure/bed/roller/adv,/obj/random/humanoidremains,/obj/random/cash,/obj/random/cigarettes,/obj/item/clothing/under/explorer,/obj/item/clothing/shoes/boots/winter/explorer,/obj/item/clothing/mask/gas/explorer,/obj/item/clothing/accessory/medal/permit/gun/planetside,/obj/item/clothing/suit/armor/pcarrier/light/nt,/obj/random/projectile/scrapped_smg,/obj/random/projectile/scrapped_pistol,/turf/simulated/floor/outdoors/rocks/caves,/area/submap/Shelter1)
-"m" = (/obj/random/medical/lite,/obj/random/toolbox,/obj/random/trash,/obj/random/technology_scanner/anom,/obj/random/tool/anom,/turf/simulated/floor/outdoors/rocks/caves,/area/submap/Shelter1)
-"n" = (/obj/structure/fence/corner{dir = 1; icon_state = "corner"},/obj/effect/landmark/snowy_turf,/turf/template_noop,/area/submap/Shelter1)
-"o" = (/obj/structure/fence/door/locked{dir = 1; icon_state = "door_closed"},/obj/effect/landmark/snowy_turf,/turf/template_noop,/area/submap/Shelter1)
-"p" = (/obj/structure/fence/post{dir = 8; icon_state = "post"},/obj/effect/landmark/snowy_turf,/turf/template_noop,/area/submap/Shelter1)
-"q" = (/obj/structure/fence{dir = 8; icon_state = "straight"},/obj/effect/landmark/snowy_turf,/turf/template_noop,/area/submap/Shelter1)
-"r" = (/obj/structure/fence/cut/large{dir = 8; icon_state = "straight_cut3"},/obj/effect/landmark/snowy_turf,/turf/template_noop,/area/submap/Shelter1)
-"s" = (/obj/structure/fence/corner,/obj/effect/landmark/snowy_turf,/turf/template_noop,/area/submap/Shelter1)
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"bH" = (
+/turf/simulated/floor/outdoors/rocks/caves,
+/area/submap/Shelter1)
+"cu" = (
+/obj/item/material/shard/shrapnel,
+/turf/simulated/floor/wood/sif,
+/area/submap/Shelter1)
+"dO" = (
+/obj/structure/table/sifwoodentable,
+/obj/item/flashlight/lamp/green,
+/obj/random/cigarettes,
+/obj/item/flame/lighter/random,
+/turf/simulated/floor/wood/sif,
+/area/submap/Shelter1)
+"dZ" = (
+/obj/structure/girder,
+/obj/item/stack/material/wood/sif,
+/turf/simulated/floor/plating,
+/area/submap/Shelter1)
+"ee" = (
+/obj/item/stack/material/wood/sif,
+/obj/item/stack/rods,
+/obj/item/material/shard/shrapnel,
+/turf/simulated/floor/plating,
+/area/submap/Shelter1)
+"eM" = (
+/turf/simulated/wall/log_sif,
+/area/submap/Shelter1)
+"eT" = (
+/obj/random/junk,
+/turf/simulated/floor/wood/sif/broken,
+/area/submap/Shelter1)
+"gc" = (
+/obj/structure/loot_pile/surface/bones,
+/obj/item/radio{
+	start_anomalous = 1
+	},
+/turf/simulated/floor/wood/sif,
+/area/submap/Shelter1)
+"hd" = (
+/obj/structure/table/sifwoodentable,
+/obj/item/binoculars/spyglass,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/wood/sif,
+/area/submap/Shelter1)
+"hl" = (
+/obj/structure/flora/grass/both,
+/turf/simulated/floor/outdoors/grass/sif,
+/area/submap/Shelter1)
+"iC" = (
+/obj/structure/girder,
+/turf/simulated/floor/plating,
+/area/submap/Shelter1)
+"jd" = (
+/obj/structure/table/sifwoodentable,
+/obj/random/mug,
+/turf/simulated/floor/wood/sif,
+/area/submap/Shelter1)
+"lg" = (
+/turf/template_noop,
+/area/template_noop)
+"lO" = (
+/obj/structure/closet/secure_closet/freezer/fridge,
+/turf/simulated/floor/wood/sif,
+/area/submap/Shelter1)
+"mc" = (
+/obj/structure/toilet,
+/turf/simulated/floor/tiled/neutral,
+/area/submap/Shelter1)
+"sh" = (
+/obj/item/stack/material/wood/sif,
+/turf/simulated/floor/wood/sif/broken,
+/area/submap/Shelter1)
+"sv" = (
+/obj/structure/fence,
+/turf/simulated/floor/outdoors/dirt,
+/area/submap/Shelter1)
+"sI" = (
+/obj/structure/fence{
+	dir = 8;
+	icon_state = "straight"
+	},
+/turf/simulated/floor/outdoors/grass/sif,
+/area/submap/Shelter1)
+"uf" = (
+/obj/structure/table/sifwoodentable,
+/obj/machinery/microwave,
+/turf/simulated/floor/wood/sif,
+/area/submap/Shelter1)
+"uZ" = (
+/obj/item/material/shard/shrapnel,
+/obj/item/stack/material/steel,
+/turf/simulated/floor/plating,
+/area/submap/Shelter1)
+"wc" = (
+/obj/structure/fence/door{
+	dir = 1
+	},
+/turf/simulated/floor/outdoors/dirt,
+/area/submap/Shelter1)
+"xq" = (
+/obj/item/stack/material/wood/sif,
+/obj/random/mob/robotic/hivebot/melee,
+/turf/simulated/floor/wood/sif/broken,
+/area/submap/Shelter1)
+"xv" = (
+/turf/simulated/floor/tiled/neutral,
+/area/submap/Shelter1)
+"xQ" = (
+/obj/structure/flora/grass/brown,
+/turf/simulated/floor/outdoors/grass/sif,
+/area/submap/Shelter1)
+"ye" = (
+/obj/effect/decal/cleanable/blood/oil,
+/obj/item/stack/material/steel,
+/turf/simulated/floor/tiled/neutral,
+/area/submap/Shelter1)
+"yg" = (
+/turf/simulated/floor/outdoors/grass/sif,
+/area/submap/Shelter1)
+"yr" = (
+/obj/effect/decal/remains/human,
+/turf/simulated/floor/outdoors/dirt,
+/area/submap/Shelter1)
+"yD" = (
+/obj/structure/fireplace,
+/turf/simulated/floor/wood/sif,
+/area/submap/Shelter1)
+"zh" = (
+/obj/effect/decal/cleanable/blood/oil,
+/obj/effect/spawner/gibs/robot,
+/turf/simulated/floor/reinforced,
+/area/submap/Shelter1)
+"zv" = (
+/obj/structure/fence/cut/large,
+/turf/simulated/floor/outdoors/dirt,
+/area/submap/Shelter1)
+"zz" = (
+/obj/effect/spawner/gibs/robot,
+/turf/simulated/floor/reinforced,
+/area/submap/Shelter1)
+"zX" = (
+/obj/fiftyspawner/log/sif,
+/turf/simulated/floor/wood/sif,
+/area/submap/Shelter1)
+"AT" = (
+/obj/structure/simple_door/sifwood,
+/turf/simulated/floor/wood/sif,
+/area/submap/Shelter1)
+"AU" = (
+/obj/random/mob/robotic/hivebot/laser,
+/turf/simulated/floor/wood/sif,
+/area/submap/Shelter1)
+"BJ" = (
+/obj/structure/window/basic/full,
+/obj/structure/curtain/black,
+/turf/simulated/floor/wood/sif,
+/area/submap/Shelter1)
+"Fa" = (
+/turf/simulated/wall/titanium,
+/area/submap/Shelter1)
+"Fp" = (
+/turf/template_noop,
+/area/submap/Shelter1)
+"HH" = (
+/turf/simulated/floor/wood/sif/broken,
+/area/submap/Shelter1)
+"HT" = (
+/obj/structure/table/sifwoodentable,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/random/coin/anom,
+/turf/simulated/floor/wood/sif,
+/area/submap/Shelter1)
+"IT" = (
+/obj/random/projectile/scrapped_shotgun,
+/obj/random/toolbox,
+/obj/effect/spawner/gibs/human,
+/turf/simulated/floor/wood/sif,
+/area/submap/Shelter1)
+"Je" = (
+/obj/structure/closet/cabinet,
+/obj/item/mop,
+/obj/random/soap,
+/obj/random/medical,
+/obj/item/stock_parts/spring,
+/turf/simulated/floor/tiled/neutral,
+/area/submap/Shelter1)
+"Jp" = (
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/outdoors/dirt,
+/area/submap/Shelter1)
+"JD" = (
+/obj/structure/closet/cabinet,
+/obj/item/clothing/accessory/medal/permit/gun/planetside,
+/obj/item/clothing/suit/armor/pcarrier/light,
+/obj/item/clothing/mask/gas/half,
+/obj/item/clothing/shoes/boots/winter,
+/obj/item/material/knife/machete,
+/obj/item/storage/wallet/random,
+/turf/simulated/floor/wood/sif,
+/area/submap/Shelter1)
+"JR" = (
+/turf/simulated/floor/outdoors/dirt,
+/area/submap/Shelter1)
+"Kf" = (
+/obj/structure/fence,
+/turf/simulated/floor/outdoors/rocks/caves,
+/area/submap/Shelter1)
+"Lp" = (
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/outdoors/rocks/caves,
+/area/submap/Shelter1)
+"LB" = (
+/obj/random/trash,
+/obj/random/junk,
+/obj/random/mob/robotic/hivebot/melee,
+/turf/simulated/floor/wood/sif,
+/area/submap/Shelter1)
+"Mw" = (
+/obj/structure/loot_pile/maint/trash,
+/turf/simulated/floor/outdoors/dirt,
+/area/submap/Shelter1)
+"MR" = (
+/obj/structure/girder/displaced,
+/turf/simulated/floor/plating,
+/area/submap/Shelter1)
+"Nx" = (
+/obj/structure/fence/corner{
+	dir = 4
+	},
+/turf/simulated/floor/outdoors/grass/sif,
+/area/submap/Shelter1)
+"OO" = (
+/obj/structure/loot_pile/maint/junk,
+/turf/simulated/floor/outdoors/dirt,
+/area/submap/Shelter1)
+"Pg" = (
+/turf/simulated/floor/outdoors/dirt,
+/area/template_noop)
+"PS" = (
+/turf/simulated/floor/wood/sif,
+/area/submap/Shelter1)
+"Ro" = (
+/obj/structure/sink{
+	pixel_y = 17
+	},
+/obj/structure/mirror{
+	pixel_y = 32
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/submap/Shelter1)
+"RV" = (
+/obj/item/material/shard/shrapnel,
+/turf/simulated/floor/reinforced,
+/area/submap/Shelter1)
+"Vv" = (
+/obj/item/stack/material/steel,
+/turf/simulated/floor/wood/sif/broken,
+/area/submap/Shelter1)
+"WG" = (
+/obj/item/stack/material/wood/sif,
+/obj/item/material/shard/shrapnel,
+/turf/simulated/floor/outdoors/rocks/caves,
+/area/submap/Shelter1)
+"WI" = (
+/turf/simulated/floor/reinforced,
+/area/submap/Shelter1)
+"Xl" = (
+/obj/structure/fence,
+/turf/simulated/floor/outdoors/grass/sif,
+/area/submap/Shelter1)
+"YM" = (
+/obj/structure/flora/ausbushes/brflowers,
+/turf/simulated/floor/outdoors/grass/sif,
+/area/submap/Shelter1)
+"YV" = (
+/obj/item/stack/material/steel,
+/turf/simulated/floor/wood/sif,
+/area/submap/Shelter1)
+"Zb" = (
+/obj/structure/bed/chair/comfy/brown,
+/turf/simulated/floor/wood/sif,
+/area/submap/Shelter1)
+"Zj" = (
+/obj/structure/bed/double/padded,
+/obj/item/bedsheet/mimedouble,
+/turf/simulated/floor/wood/sif,
+/area/submap/Shelter1)
 
 (1,1,1) = {"
-addeddddfec
-efeefffdeee
-eeeffffffee
-fdgggggggef
-ddghijikgfe
-ffgkiiiigfe
-ffgihlmhgfe
-ffnopqprsee
-edfffffffdf
-fedfffffddd
-bffeeddddfb
+lg
+lg
+lg
+lg
+lg
+lg
+lg
+lg
+lg
+lg
+lg
+lg
+lg
+lg
+lg
+"}
+(2,1,1) = {"
+lg
+eM
+eM
+BJ
+eM
+eM
+yg
+hl
+yg
+Fp
+Fp
+xQ
+yg
+Fp
+lg
+"}
+(3,1,1) = {"
+lg
+eM
+gc
+Zb
+dO
+eM
+eM
+eM
+eM
+BJ
+BJ
+BJ
+eM
+Fp
+lg
+"}
+(4,1,1) = {"
+lg
+BJ
+PS
+cu
+PS
+eM
+hd
+HT
+eM
+uf
+lO
+jd
+eM
+yg
+lg
+"}
+(5,1,1) = {"
+lg
+eM
+JD
+Zj
+AU
+AT
+PS
+sh
+PS
+PS
+cu
+PS
+eM
+Fp
+lg
+"}
+(6,1,1) = {"
+lg
+eM
+eM
+eM
+ee
+eM
+xq
+WI
+iC
+IT
+PS
+LB
+eM
+Fp
+lg
+"}
+(7,1,1) = {"
+lg
+Fp
+eM
+Ro
+xv
+MR
+Fa
+RV
+Fa
+eM
+eM
+PS
+eM
+yg
+lg
+"}
+(8,1,1) = {"
+lg
+OO
+eM
+mc
+ye
+Fa
+Fa
+zz
+Fa
+Fa
+Vv
+cu
+BJ
+YM
+Pg
+"}
+(9,1,1) = {"
+Pg
+Mw
+eM
+Je
+WI
+WI
+zz
+zh
+WI
+WI
+WI
+YV
+AT
+JR
+lg
+"}
+(10,1,1) = {"
+Pg
+JR
+eM
+dZ
+bH
+Fa
+Fa
+zz
+MR
+Fa
+sh
+PS
+BJ
+YM
+lg
+"}
+(11,1,1) = {"
+lg
+JR
+wc
+Jp
+JR
+WG
+iC
+WI
+dZ
+eT
+PS
+PS
+eM
+yg
+lg
+"}
+(12,1,1) = {"
+lg
+hl
+sI
+Fp
+yr
+JR
+Lp
+WI
+uZ
+HH
+yD
+zX
+eM
+yg
+lg
+"}
+(13,1,1) = {"
+lg
+Fp
+Nx
+Xl
+Xl
+sv
+zv
+Kf
+eM
+BJ
+eM
+BJ
+eM
+Fp
+lg
+"}
+(14,1,1) = {"
+lg
+Fp
+Fp
+Fp
+Fp
+Fp
+JR
+JR
+xQ
+yg
+yg
+Fp
+Fp
+Fp
+lg
+"}
+(15,1,1) = {"
+lg
+lg
+lg
+lg
+lg
+lg
+lg
+lg
+lg
+lg
+lg
+lg
+lg
+lg
+lg
 "}

--- a/maps/submaps/surface_submaps/wilderness/wilderness.dm
+++ b/maps/submaps/surface_submaps/wilderness/wilderness.dm
@@ -286,7 +286,7 @@
 
 /datum/map_template/surface/wilderness/normal/Shelter1
 	name = "Shelter 1"
-	desc = "The remains of a resourceful, but prideful explorer."
+	desc = "The bitter end of a house after a drop pod crashed into it."
 	mappath = 'maps/submaps/surface_submaps/wilderness/Shelter.dmm'
 	cost = 10
 


### PR DESCRIPTION
Remaps the Shelter PoI. Some artistic liberty here: previously it was a tiny shack in fuck-all nowhere with some drones in it, I changed it to be more like a house that had a stray drop pod crash into it.

- Overall content is more like a small, once-cozy house
- Makes the primary enemy hivebots because combat drones are a massive pain for this level of content
- Shrapnel (makes glass sounds when stepped on), blood, and fencing provides signposting
- Removes one gun spawn, replaces it with a machete and a spyglass
- Overall scrubs the idea of this belonging to 'an explorer', and instead simply just some rugged folks who used to live out here
- A few more potential anomaly spawns

Importantly, this PR adds two new subgroups to the random hivebot spawn group: lesser melee and laser, to be expanded in a different PR.
- 'Lesser melee' is the base hivebot and swarmbot, specifically excluding the tank variants.
- 'Laser' is the stock laser hivebot with a small chance to spawn the backline hivebot.

The overall goal was to get finer control over the robotic enemies spawning here to avoid ballistics (which would be incredibly lethal for this tier of PoI) but still take advantage of leashing behavior.

Tested on local, runs as anticipated.

Before:
![2023-10-27 11 32 11](https://github.com/PolarisSS13/Polaris/assets/11377530/917b030a-6cc6-45a1-9e3e-0f9f04f6896f)

After:
![2023-10-27 11 52 24](https://github.com/PolarisSS13/Polaris/assets/11377530/16caa76c-26fd-4543-ae29-46fb66aebece)
