### PR TITLE
Tweaks the Head of Security's locker and office layout

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -71,7 +71,7 @@
 
 	starts_with = list(
 		/obj/item/clothing/head/helmet/HoS,
-		/obj/item/clothing/head/helmet/HoS/hat,
+		/obj/item/clothing/head/helmet/HoS/cap,
 		/obj/item/clothing/suit/storage/vest/hos,
 		/obj/item/clothing/under/rank/head_of_security/jensen,
 		/obj/item/clothing/under/rank/head_of_security/corp,

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -102,7 +102,8 @@
 		/obj/item/clothing/shoes/boots/winter/security,
 		/obj/item/flashlight/maglight,
 		/obj/item/clothing/mask/gas/half,
-		/obj/item/clothing/mask/gas/sechailer/swat/hos
+		/obj/item/clothing/mask/gas/sechailer/swat/hos,
+		/obj/item/clothing/accessory/storage/black_vest
 	)
 
 /obj/structure/closet/secure_closet/hos/Initialize()

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -83,7 +83,6 @@
 		/obj/item/radio/headset/heads/hos/alt,
 		/obj/item/clothing/glasses/sunglasses/sechud,
 		/obj/item/taperoll/police,
-		/obj/item/shield/riot,
 		/obj/item/shield/riot/tele,
 		/obj/item/storage/box/holobadge/hos,
 		/obj/item/clothing/accessory/medal/badge/holo/hos,
@@ -99,12 +98,12 @@
 		/obj/item/clothing/accessory/holster/waist,
 		/obj/item/melee/telebaton,
 		/obj/item/clothing/head/beret/sec/corporate/hos,
-		/obj/item/clothing/suit/storage/hooded/wintercoat/security,
 		/obj/item/clothing/suit/storage/hooded/wintercoat/security/hos,
 		/obj/item/clothing/shoes/boots/winter/security,
 		/obj/item/flashlight/maglight,
 		/obj/item/clothing/mask/gas/half,
-		/obj/item/clothing/mask/gas/sechailer/swat/hos)
+		/obj/item/clothing/mask/gas/sechailer/swat/hos
+	)
 
 /obj/structure/closet/secure_closet/hos/Initialize()
 	if(prob(50))

--- a/code/modules/clothing/head/jobs.dm
+++ b/code/modules/clothing/head/jobs.dm
@@ -84,7 +84,7 @@
 	item_state_slots = list(slot_r_hand_str = "beret_navy", slot_l_hand_str = "beret_navy")
 
 /obj/item/clothing/head/beret/sec/navy/hos
-	name = "Head of Security beret"
+	name = "head of security beret"
 	desc = "A navy blue beret with a Head of Security's rank emblem. For officers that are more inclined towards style than safety."
 	icon_state = "beret_navy_hos"
 	item_state_slots = list(slot_r_hand_str = "beret_navy", slot_l_hand_str = "beret_navy")
@@ -102,7 +102,7 @@
 	item_state_slots = list(slot_r_hand_str = "beret_black", slot_l_hand_str = "beret_black")
 
 /obj/item/clothing/head/beret/sec/corporate/hos
-	name = "Head of Security beret"
+	name = "head of security beret"
 	desc = "A corporate black beret with a Head of Security's rank emblem. For officers that are more inclined towards style than safety."
 	icon_state = "beret_corporate_hos"
 	item_state_slots = list(slot_r_hand_str = "beret_black", slot_l_hand_str = "beret_black")
@@ -124,17 +124,17 @@
 	valid_accessory_slots = null
 
 /obj/item/clothing/head/helmet/HoS
-	name = "Head of Security helmet"
-	desc = "Standard Head of Security gear. Protects the head from impacts."
+	name = "head of security's helmet"
+	desc = "Standard gear for the Head of Security. Protects the head from impacts."
 
-/obj/item/clothing/head/helmet/HoS/hat
-	name = "Head of Security Hat"
-	desc = "The hat of the Head of Security. For showing the officers who's in charge."
+/obj/item/clothing/head/helmet/HoS/cap
+	name = "head of security's cap"
+	desc = "The cap of the Head of Security. For showing the officers who's in charge."
 	icon_state = "hoscap"
 	valid_accessory_slots = null
 
 /obj/item/clothing/head/helmet/dermal
-	name = "Dermal Armour Patch"
+	name = "dermal armour patch"
 	desc = "You're not quite sure how you manage to take it on and off, but it implants nicely in your head."
 	icon_state = "dermal"
 	item_state_slots = list(slot_r_hand_str = "", slot_l_hand_str = "")

--- a/maps/cynosure/cynosure-2.dmm
+++ b/maps/cynosure/cynosure-2.dmm
@@ -7126,9 +7126,6 @@
 /obj/machinery/recharger/wallcharger{
 	pixel_y = -28
 	},
-/obj/item/cassette_tape/random,
-/obj/item/taperecorder,
-/obj/item/megaphone,
 /obj/structure/closet/secure_closet/hos/cynosure,
 /turf/simulated/floor/tiled/dark,
 /area/surface/station/crew_quarters/heads/hos)
@@ -8244,9 +8241,7 @@
 /turf/simulated/floor/tiled,
 /area/surface/station/engineering/atmos)
 "dJA" = (
-/obj/structure/railing/grey{
-	dir = 2
-	},
+/obj/structure/railing/grey,
 /obj/structure/railing/grey{
 	dir = 4
 	},
@@ -21049,9 +21044,7 @@
 /turf/simulated/floor/tiled/monotile,
 /area/surface/station/park)
 "jDZ" = (
-/obj/structure/railing/grey{
-	dir = 2
-	},
+/obj/structure/railing/grey,
 /turf/simulated/open,
 /area/surface/outside/plains/station)
 "jEc" = (
@@ -21214,7 +21207,8 @@
 	icon_state = "2-8"
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 4
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/surface/station/crew_quarters/heads/hos)
@@ -21483,9 +21477,6 @@
 "jOp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /turf/simulated/floor/carpet,
 /area/surface/station/crew_quarters/heads/hos)
@@ -29001,9 +28992,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/simulated/floor/carpet,
 /area/surface/station/crew_quarters/heads/hos)
 "mTi" = (
@@ -30364,11 +30352,14 @@
 "nBA" = (
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/corner/blue/border,
-/obj/structure/filingcabinet,
 /obj/item/storage/secure/safe{
 	pixel_x = 5;
 	pixel_y = -26
 	},
+/obj/structure/table/reinforced,
+/obj/item/cassette_tape/random,
+/obj/item/taperecorder,
+/obj/item/megaphone,
 /turf/simulated/floor/tiled/dark,
 /area/surface/station/crew_quarters/heads/hos)
 "nCe" = (
@@ -34720,9 +34711,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/simulated/floor/tiled/dark,
 /area/surface/station/crew_quarters/heads/hos)
 "pnA" = (
@@ -35056,9 +35044,7 @@
 /turf/simulated/floor/tiled/white,
 /area/surface/station/medical/surgery)
 "psE" = (
-/obj/structure/railing/grey{
-	dir = 2
-	},
+/obj/structure/railing/grey,
 /turf/simulated/floor/outdoors/mask,
 /area/surface/outside/plains/plateau)
 "psJ" = (
@@ -37982,9 +37968,7 @@
 /obj/structure/railing/grey{
 	dir = 4
 	},
-/obj/structure/railing/grey{
-	dir = 2
-	},
+/obj/structure/railing/grey,
 /turf/simulated/open,
 /area/surface/outside/plains/station)
 "qEU" = (
@@ -38299,10 +38283,6 @@
 	dir = 4
 	},
 /obj/machinery/papershredder,
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = 24
@@ -40000,9 +39980,7 @@
 /turf/simulated/floor/plating,
 /area/surface/station/engineering/reactor_smes)
 "ryn" = (
-/obj/structure/railing/grey{
-	dir = 2
-	},
+/obj/structure/railing/grey,
 /obj/structure/railing/grey{
 	dir = 8
 	},
@@ -44536,9 +44514,7 @@
 /obj/structure/railing/grey{
 	dir = 8
 	},
-/obj/structure/railing/grey{
-	dir = 2
-	},
+/obj/structure/railing/grey,
 /turf/simulated/open,
 /area/surface/outside/plains/station)
 "tFB" = (
@@ -44959,6 +44935,8 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk,
 /turf/simulated/floor/tiled/dark,
 /area/surface/station/crew_quarters/heads/hos)
 "tMQ" = (
@@ -51238,8 +51216,7 @@
 /obj/effect/floor_decal/corner/blue/bordercorner2{
 	dir = 4
 	},
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk,
+/obj/structure/filingcabinet,
 /turf/simulated/floor/tiled/dark,
 /area/surface/station/crew_quarters/heads/hos)
 "wMa" = (

--- a/maps/cynosure/structures/closets/security.dm
+++ b/maps/cynosure/structures/closets/security.dm
@@ -18,7 +18,6 @@
 		/obj/item/radio/headset/heads/hos/alt,
 		/obj/item/clothing/glasses/sunglasses/sechud,
 		/obj/item/taperoll/police,
-		/obj/item/shield/riot,
 		/obj/item/shield/riot/tele,
 		/obj/item/storage/box/holobadge/hos,
 		/obj/item/clothing/accessory/medal/badge/holo/hos,
@@ -33,11 +32,12 @@
 		/obj/item/clothing/accessory/holster/waist,
 		/obj/item/melee/telebaton,
 		/obj/item/clothing/head/beret/sec/corporate/hos,
-		/obj/item/clothing/suit/storage/hooded/wintercoat/security,
+		/obj/item/clothing/suit/storage/hooded/wintercoat/security/hos,
 		/obj/item/clothing/shoes/boots/winter/security,
 		/obj/item/flashlight/maglight,
 		/obj/item/clothing/mask/gas/half,
-		/obj/item/clothing/mask/gas/sechailer/swat/hos)
+		/obj/item/clothing/mask/gas/sechailer/swat/hos
+	)
 
 /obj/structure/closet/secure_closet/hos/Initialize()
 	if(prob(50))

--- a/maps/cynosure/structures/closets/security.dm
+++ b/maps/cynosure/structures/closets/security.dm
@@ -6,7 +6,7 @@
 
 	starts_with = list(
 		/obj/item/clothing/head/helmet/HoS,
-		/obj/item/clothing/head/helmet/HoS/hat,
+		/obj/item/clothing/head/helmet/HoS/cap,
 		/obj/item/clothing/suit/armor/pcarrier/light/nt/cynosure,
 		/obj/item/clothing/under/rank/head_of_security/jensen,
 		/obj/item/clothing/under/rank/head_of_security/corp,

--- a/maps/cynosure/structures/closets/security.dm
+++ b/maps/cynosure/structures/closets/security.dm
@@ -36,7 +36,8 @@
 		/obj/item/clothing/shoes/boots/winter/security,
 		/obj/item/flashlight/maglight,
 		/obj/item/clothing/mask/gas/half,
-		/obj/item/clothing/mask/gas/sechailer/swat/hos
+		/obj/item/clothing/mask/gas/sechailer/swat/hos,
+		/obj/item/clothing/accessory/storage/black_vest
 	)
 
 /obj/structure/closet/secure_closet/hos/Initialize()


### PR DESCRIPTION
Just a few little tweaks to clean things up. Very similar to the changes I made for the Head of Personnel previously.

Removes from the head of security's locker:
- The standard riot shield.
- The standard security winter coat.
(Replaces the standard security winter coat with the specific head of security variant where appropriate.)

Adds a simple black standard-issue security webbing to the head of security's locker.

Adjusts the naming of many head of security equipment items for consistency:
- Lowercases 'head of security beret' and 'dermal armour patch'.
- Renames 'Head of Security helmet' to 'head of security's helmet'.
- Renames 'Head of Security hat' to 'head of security's cap'.
(Also re-paths /obj/item/clothing/head/helmet/HoS/hat to /obj/item/clothing/head/helmet/HoS/cap for consistency.)

Adjusts the head of security's office layout:
- Moves the disposal unit from the east corner to the west corner.
- Moves the filing cabinet to the tile previously occupied by the disposal unit.
- Adds a table with the megaphone, universal recorder and cassette tape to the tile previously occupied by the filing cabinet.
- Removes the megaphone, universal recorder and cassette tape from the head of security's locker.

Changelog stuff just in case it got fixed:
🆑
tweak: Adjusted the layout of the Head of Security's Office. Many items that were just shoved into the locker have been distributed around the room.
tweak: The names of many of the Head of Security's equipment items have been adjusted for consistency.
tweak: The contents of the Head of Security's locker have been adjusted, including the addition of a Head of Security-variant winter coat, black webbing, and the removal of some unused items. Heads of Security rejoice!
/🆑