### PR TITLE
Improves the dark mode color of some languages

### DIFF
--- a/code/modules/vchat/css/ss13styles.css
+++ b/code/modules/vchat/css/ss13styles.css
@@ -149,7 +149,8 @@ h1.alert, h2.alert		{color: #000000;}
 
 /* Languages */
 
-.alien					{color: #543354;}
+.alien					{color: #ae41ae;}
+.inverted .alien					{color: #b982b9;}
 .tajaran				{color: #803B56;}
 .tajaran_signlang		{color: #941C1C;}
 .akhani					{color: #AC398C;}
@@ -158,6 +159,7 @@ h1.alert, h2.alert		{color: #000000;}
 .skrellfar				{color: #70FCFF;}
 .soghun					{color: #50BA6C;}
 .solcom					{color: #22228B;}
+.inverted .solcom					{color: #4343ed;}
 .changeling				{color: #800080;}
 .sergal					{color: #0077FF; font-family: "Comic Sans MS";}
 .birdsongc				{color: #CC9900;}
@@ -169,6 +171,7 @@ h1.alert, h2.alert		{color: #000000;}
 .promethean				{color: #5A5A5A; font-family:"Comic Sans MS","Comic Sans",cursive;}
 .inverted .promethean			{color: #A5A5A5; font-family:"Comic Sans MS","Comic Sans",cursive;}
 .zaddat					{color: #941C1C;}
+.inverted .zaddat					{color: #fa3838;}
 .rough					{font-family: "Trebuchet MS", cursive, sans-serif;}
 .say_quote				{font-family: Georgia, Verdana, sans-serif;}
 .terminus				{font-family: "Times New Roman", Times, serif, sans-serif}

--- a/code/stylesheet.dm
+++ b/code/stylesheet.dm
@@ -90,7 +90,7 @@ h1.alert, h2.alert		{color: #000000;}
 
 /* Languages */
 
-.alien					{color: #543354;}
+.alien					{color: #ae41ae;}
 .tajaran				{color: #803B56;}
 .tajaran_signlang		{color: #941C1C;}
 .akhani					{color: #AC398C;}


### PR DESCRIPTION
Improves the dark mode readability of Schechi, Sol common, and Vedahq. Also adjusts the light mode color of Schechi to appear more pink-purple.
![image](https://github.com/PolarisSS13/Polaris/assets/33647525/7244cdb2-6e6d-47ca-bf15-538853e7c6b8)
