### PR TITLE
remove usages of /tmp/

### DIFF
--- a/code/ZAS/Airflow.dm
+++ b/code/ZAS/Airflow.dm
@@ -2,7 +2,7 @@
 Contains helper procs for airflow, handled in /connection_group.
 */
 
-/mob/var/tmp/last_airflow_stun = 0
+/mob/var/last_airflow_stun = 0
 /mob/proc/airflow_stun()
 	if(stat == 2)
 		return 0
@@ -64,10 +64,10 @@ Contains helper procs for airflow, handled in /connection_group.
 		else
 			if(n < vsc.airflow_dense_pressure) return 0
 
-/atom/movable/var/tmp/turf/airflow_dest
-/atom/movable/var/tmp/airflow_speed = 0
-/atom/movable/var/tmp/airflow_time = 0
-/atom/movable/var/tmp/last_airflow = 0
+/atom/movable/var/turf/airflow_dest
+/atom/movable/var/airflow_speed = 0
+/atom/movable/var/airflow_time = 0
+/atom/movable/var/last_airflow = 0
 
 /atom/movable/proc/AirflowCanMove(n)
 	return 1

--- a/code/ZAS/ConnectionManager.dm
+++ b/code/ZAS/ConnectionManager.dm
@@ -34,7 +34,7 @@ Macros:
 // macro-ized to cut down on proc calls
 #define check(c) (c && c.valid())
 
-/turf/var/tmp/connection_manager/connections
+/turf/var/connection_manager/connections
 
 /connection_manager/var/connection/N
 /connection_manager/var/connection/S

--- a/code/ZAS/Debug.dm
+++ b/code/ZAS/Debug.dm
@@ -9,7 +9,7 @@ var/global/image/mark = image('icons/Testing/Zone.dmi', icon_state = "mark")
 
 /connection_edge/var/dbg_out = 0
 
-/turf/var/tmp/dbg_img
+/turf/var/dbg_img
 /turf/proc/dbg(image/img, d = 0)
 	if(d > 0) img.dir = d
 	cut_overlay(dbg_img)

--- a/code/controllers/subsystems/ai.dm
+++ b/code/controllers/subsystems/ai.dm
@@ -6,10 +6,10 @@ SUBSYSTEM_DEF(ai)
 	wait = 2 SECONDS
 
 	/// The list of AI datums to be processed.
-	var/static/tmp/list/queue = list()
+	var/static/list/queue = list()
 
 	/// The list of AI datums currently being processed.
-	var/static/tmp/list/current = list()
+	var/static/list/current = list()
 
 
 /datum/controller/subsystem/ai/stat_entry(msg_prefix)

--- a/code/controllers/subsystems/aifast.dm
+++ b/code/controllers/subsystems/aifast.dm
@@ -6,10 +6,10 @@ SUBSYSTEM_DEF(aifast)
 	wait = 0.25 SECONDS
 
 	/// The list of AI datums to be processed.
-	var/static/tmp/list/queue = list()
+	var/static/list/queue = list()
 
 	/// The list of AI datums currently being processed.
-	var/static/tmp/list/current = list()
+	var/static/list/current = list()
 
 
 /datum/controller/subsystem/aifast/stat_entry(msg_prefix)

--- a/code/controllers/subsystems/airflow.dm
+++ b/code/controllers/subsystems/airflow.dm
@@ -101,11 +101,11 @@ SUBSYSTEM_DEF(airflow)
 #undef CLEAR_OBJECT
 
 /atom/movable
-	var/tmp/airflow_xo
-	var/tmp/airflow_yo
-	var/tmp/airflow_od
-	var/tmp/airflow_process_delay
-	var/tmp/airflow_skip_speedcheck
+	var/airflow_xo
+	var/airflow_yo
+	var/airflow_od
+	var/airflow_process_delay
+	var/airflow_skip_speedcheck
 
 /atom/movable/proc/prepare_airflow(n)
 	if (!airflow_dest || airflow_speed < 0 || last_airflow > world.time - vsc.airflow_delay)

--- a/code/controllers/subsystems/alarm.dm
+++ b/code/controllers/subsystems/alarm.dm
@@ -5,13 +5,13 @@ SUBSYSTEM_DEF(alarm)
 	init_order = INIT_ORDER_ALARM
 
 	/// The list of alarm handlers this subsystem processes
-	var/static/tmp/list/datum/alarm_handler/handlers
+	var/static/list/datum/alarm_handler/handlers
 
 	/// The list of alarm handlers currently being processed
-	var/static/tmp/list/current = list()
+	var/static/list/current = list()
 
 	/// The list of active alarms
-	var/static/tmp/list/active = list()
+	var/static/list/active = list()
 
 
 /datum/controller/subsystem/alarm/Initialize(timeofday)

--- a/code/controllers/subsystems/events.dm
+++ b/code/controllers/subsystems/events.dm
@@ -2,7 +2,7 @@ SUBSYSTEM_DEF(events)
 	name = "Events (Legacy)"
 	wait = 2 SECONDS
 
-	var/tmp/list/currentrun = null
+	var/list/currentrun = null
 
 	var/list/datum/event/active_events = list()
 	var/list/datum/event/finished_events = list()

--- a/code/controllers/subsystems/inactivity.dm
+++ b/code/controllers/subsystems/inactivity.dm
@@ -2,7 +2,7 @@ SUBSYSTEM_DEF(inactivity)
 	name = "Inactivity"
 	wait = 60 SECONDS
 	flags = SS_NO_INIT | SS_BACKGROUND
-	var/tmp/list/client_list
+	var/list/client_list
 	var/number_kicked = 0
 
 /datum/controller/subsystem/inactivity/fire(resumed, no_mc_tick)

--- a/code/controllers/subsystems/overlays.dm
+++ b/code/controllers/subsystems/overlays.dm
@@ -6,16 +6,16 @@ SUBSYSTEM_DEF(overlays)
 	init_order = INIT_ORDER_OVERLAY
 
 	/// The queue of atoms that need overlay updates.
-	var/static/tmp/list/queue = list()
+	var/static/list/queue = list()
 
 	/// A list([icon] = list([state] = [appearance], ...), ...) cache of appearances.
-	var/static/tmp/list/state_cache = list()
+	var/static/list/state_cache = list()
 
 	/// A list([icon] = [appearance], ...) cache of appearances.
-	var/static/tmp/list/icon_cache = list()
+	var/static/list/icon_cache = list()
 
 	/// The number of appearances currently cached.
-	var/static/tmp/cache_size = 0
+	var/static/cache_size = 0
 
 
 /datum/controller/subsystem/overlays/Recover()

--- a/code/controllers/subsystems/radiation.dm
+++ b/code/controllers/subsystems/radiation.dm
@@ -7,9 +7,9 @@ SUBSYSTEM_DEF(radiation)
 	var/list/sources_assoc = list()		// Sources indexed by turf for de-duplication.
 	var/list/resistance_cache = list()	// Cache of turf's radiation resistance.
 
-	var/tmp/list/current_sources   = list()
-	var/tmp/list/current_res_cache = list()
-	var/tmp/list/listeners         = list()
+	var/list/current_sources   = list()
+	var/list/current_res_cache = list()
+	var/list/listeners         = list()
 
 /datum/controller/subsystem/radiation/fire(resumed, no_mc_tick)
 	if (!resumed)

--- a/code/controllers/subsystems/shuttles.dm
+++ b/code/controllers/subsystems/shuttles.dm
@@ -33,7 +33,7 @@ SUBSYSTEM_DEF(shuttles)
 	var/list/sectors_to_initialize                 // Used to find all sector objects at the appropriate time.
 	var/block_init_queue = TRUE                    // Block initialization of new shuttles/sectors
 
-	var/tmp/list/current_run                       // Shuttles remaining to process this fire() tick
+	var/list/current_run                       // Shuttles remaining to process this fire() tick
 
 /datum/controller/subsystem/shuttles/OnNew()
 	global.shuttle_controller = src // TODO - Remove this! Change everything to point at SSshuttles instead

--- a/code/controllers/subsystems/tgui.dm
+++ b/code/controllers/subsystems/tgui.dm
@@ -6,16 +6,16 @@ SUBSYSTEM_DEF(tgui)
 	runlevels = RUNLEVEL_LOBBY | RUNLEVELS_DEFAULT
 
 	/// The current queue of UIs to be processed
-	var/static/tmp/list/current = list()
+	var/static/list/current = list()
 
 	/// The whole set of open UIs
-	var/static/tmp/list/open_uis = list()
+	var/static/list/open_uis = list()
 
 	/// The whole set of open UIs as ("\ref[owner]" = /datum/tgui?)
-	var/static/tmp/list/open_uis_by_src = list()
+	var/static/list/open_uis_by_src = list()
 
 	/// The template document used by all tgui instances
-	var/static/tmp/base_html
+	var/static/base_html
 
 
 /datum/controller/subsystem/tgui/Recover()

--- a/code/datums/datum.dm
+++ b/code/datums/datum.dm
@@ -14,8 +14,8 @@
 	var/datum_flags = EMPTY_BITFIELD
 
 #ifdef TESTING
-	var/tmp/running_find_references
-	var/tmp/last_find_references = 0
+	var/running_find_references
+	var/last_find_references = 0
 #endif
 
 // Default implementation of clean-up code.

--- a/code/game/objects/effects/overlays.dm
+++ b/code/game/objects/effects/overlays.dm
@@ -7,7 +7,7 @@
 	name="beam"
 	icon='icons/effects/beam.dmi'
 	icon_state="b_beam"
-	var/tmp/atom/BeamSource
+	var/atom/BeamSource
 
 /obj/effect/overlay/beam/Initialize()
 	. = ..()
@@ -111,7 +111,7 @@
 	pixel_x = -32
 	pixel_y = -32
 
-// For skathari empress' telegrab warning, could replace down the line. 
+// For skathari empress' telegrab warning, could replace down the line.
 /obj/effect/overlay/skathari_telegrab
 	name = "bluespace displacement"
 	desc = "An eerie field of bluespace energy, you might want to run!"
@@ -119,7 +119,7 @@
 	icon_state = "emfield_s3"
 	alpha = 100
 	pixel_x = -32
-	pixel_y = -16 /// Line up with the big sprite that spawns it! 
+	pixel_y = -16 /// Line up with the big sprite that spawns it!
 	plane = MOB_PLANE
 	layer = BELOW_MOB_LAYER
 

--- a/code/game/periodic_news.dm
+++ b/code/game/periodic_news.dm
@@ -107,7 +107,7 @@ var/global/list/newscaster_standard_feeds = list(/datum/news_announcement/bluesp
 /proc/process_newscaster()
 	check_for_newscaster_updates(ticker.mode.newscaster_announcements)
 
-var/global/tmp/announced_news_types = list()
+var/global/announced_news_types = list()
 /proc/check_for_newscaster_updates(type)
 	for(var/subtype in typesof(type)-type)
 		var/datum/news_announcement/news = new subtype()

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -34,7 +34,7 @@
 	var/block_tele = FALSE      // If true, most forms of teleporting to or from this turf tile will fail.
 	var/can_build_into_floor = FALSE // Used for things like RCDs (and maybe lattices/floor tiles in the future), to see if a floor should replace it.
 	var/list/dangerous_objects // List of 'dangerous' objs that the turf holds that can cause something bad to happen when stepped on, used for AI mobs.
-	var/tmp/changing_turf
+	var/changing_turf
 
 /turf/Initialize(mapload)
 	. = ..()

--- a/code/modules/clothing/under/accessories/xeno/teshari.dm
+++ b/code/modules/clothing/under/accessories/xeno/teshari.dm
@@ -32,9 +32,9 @@
 		'sound/misc/dingaling3.ogg',
 		'sound/misc/dingaling4.ogg'
 	)
-	var/tmp/dingaling_volume = 260
-	var/tmp/dingaling_chance = 30
-	var/tmp/dingaling_vary = FALSE
+	var/dingaling_volume = 260
+	var/dingaling_chance = 30
+	var/dingaling_vary = FALSE
 
 /obj/item/clothing/accessory/teshtail/bells/is_mob_movement_sensitive()
 	return TRUE

--- a/code/modules/events/electrical_storm.dm
+++ b/code/modules/events/electrical_storm.dm
@@ -3,8 +3,8 @@
 	startWhen = 30			// 1 minute
 	endWhen = 60			// Set in setup()
 	has_skybox_image = TRUE
-	var/tmp/lightning_color
-	var/tmp/list/valid_apcs		// List of valid APCs.
+	var/lightning_color
+	var/list/valid_apcs		// List of valid APCs.
 
 /datum/event/electrical_storm/get_skybox_image()
 	if(!lightning_color)

--- a/code/modules/food/kitchen/cooking_machines/_appliance.dm
+++ b/code/modules/food/kitchen/cooking_machines/_appliance.dm
@@ -2,7 +2,7 @@
 
 // Tracks precooked food to stop deep fried baked grilled grilled grilled Diona nymph cereal.
 /obj/item/reagent_containers/food/snacks
-	var/tmp/list/cooked = list()
+	var/list/cooked = list()
 
 // Root type for cooking machines. See following files for specific implementations.
 /obj/machinery/appliance

--- a/code/modules/lighting/lighting_source.dm
+++ b/code/modules/lighting/lighting_source.dm
@@ -17,9 +17,9 @@ var/global/total_lighting_sources = 0
 	var/lum_b
 
 	// The lumcount values used to apply the light.
-	var/tmp/applied_lum_r
-	var/tmp/applied_lum_g
-	var/tmp/applied_lum_b
+	var/applied_lum_r
+	var/applied_lum_g
+	var/applied_lum_b
 
 	var/list/datum/lighting_corner/effect_str     // List used to store how much we're affecting corners.
 	var/list/turf/affecting_turfs

--- a/code/modules/lighting/lighting_turf.dm
+++ b/code/modules/lighting/lighting_turf.dm
@@ -2,12 +2,12 @@
 	var/dynamic_lighting = TRUE    // Does the turf use dynamic lighting?
 	luminosity           = 1
 
-	var/tmp/lighting_corners_initialised = FALSE
+	var/lighting_corners_initialised = FALSE
 
-	var/tmp/list/datum/light_source/affecting_lights       // List of light sources affecting this turf.
-	var/tmp/atom/movable/lighting_overlay/lighting_overlay // Our lighting overlay.
-	var/tmp/list/datum/lighting_corner/corners
-	var/tmp/has_opaque_atom = FALSE // Not to be confused with opacity, this will be TRUE if there's any opaque atom on the tile.
+	var/list/datum/light_source/affecting_lights       // List of light sources affecting this turf.
+	var/atom/movable/lighting_overlay/lighting_overlay // Our lighting overlay.
+	var/list/datum/lighting_corner/corners
+	var/has_opaque_atom = FALSE // Not to be confused with opacity, this will be TRUE if there's any opaque atom on the tile.
 
 // Causes any affecting light sources to be queued for a visibility update, for example a door got opened.
 /turf/proc/reconsider_lights()

--- a/code/modules/maps/swapmaps.dm
+++ b/code/modules/maps/swapmaps.dm
@@ -134,8 +134,8 @@ swapmap
 	var/x2		// maximum x,y,z coords (also used as width,height,depth until positioned)
 	var/y2
 	var/z2
-	var/tmp/locked	// don't move anyone to this map; it's saving or loading
-	var/tmp/mode	// save as text-mode
+	var/locked	// don't move anyone to this map; it's saving or loading
+	var/mode	// save as text-mode
 	var/ischunk		// tells the load routine to load to the specified location
 
 	New(_id,x,y,z)

--- a/code/modules/mob/living/silicon/robot/subtypes/thinktank/_thinktank.dm
+++ b/code/modules/mob/living/silicon/robot/subtypes/thinktank/_thinktank.dm
@@ -24,10 +24,10 @@
 	var/has_had_player = FALSE
 	var/const/platform_respawn_time = 3 MINUTES
 
-	var/tmp/last_recharge_state =     FALSE
-	var/tmp/recharge_complete =       FALSE
-	var/tmp/recharger_charge_amount = 10 KILOWATTS
-	var/tmp/recharger_tick_cost =     80 KILOWATTS
+	var/last_recharge_state =     FALSE
+	var/recharge_complete =       FALSE
+	var/recharger_charge_amount = 10 KILOWATTS
+	var/recharger_tick_cost =     80 KILOWATTS
 	var/weakref/recharging
 
 /mob/living/silicon/robot/platform/Login()

--- a/code/modules/mob/living/simple_mob/subtypes/animal/sif/grafadreka/grafadreka.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/sif/grafadreka/grafadreka.dm
@@ -73,12 +73,12 @@ You can eat glowing tree fruit to fuel your <b>ranged spitting attack</b> and <b
 	var/attacking_with_claws = TRUE
 
 	// Set during initialize and used to generate overlays.
-	var/tmp/current_icon_state // used to track our 'actual' icon state due to overlay nonsense in update_icon
-	var/tmp/fur_colour
-	var/tmp/claw_colour
-	var/tmp/glow_colour
-	var/tmp/base_colour
-	var/tmp/eye_colour
+	var/current_icon_state // used to track our 'actual' icon state due to overlay nonsense in update_icon
+	var/fur_colour
+	var/claw_colour
+	var/glow_colour
+	var/base_colour
+	var/eye_colour
 
 	var/offset_compiled_icon = -16
 	var/is_baby = FALSE

--- a/code/modules/organs/wound.dm
+++ b/code/modules/organs/wound.dm
@@ -50,8 +50,8 @@
 
 
 	// helper lists
-	var/tmp/list/desc_list = list()
-	var/tmp/list/damage_list = list()
+	var/list/desc_list = list()
+	var/list/damage_list = list()
 
 /datum/wound/New(var/damage)
 

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -85,10 +85,10 @@
 	var/keep_aim = 1 	//1 for keep shooting until aim is lowered
 						//0 for one bullet after tarrget moves and aim is lowered
 	var/multi_aim = 0 //Used to determine if you can target multiple people.
-	var/tmp/list/mob/living/aim_targets //List of who yer targeting.
-	var/tmp/mob/living/last_moved_mob //Used to fire faster at more than one person.
-	var/tmp/told_cant_shoot = 0 //So that it doesn't spam them with the fact they cannot hit them.
-	var/tmp/lock_time = -100
+	var/list/mob/living/aim_targets //List of who yer targeting.
+	var/mob/living/last_moved_mob //Used to fire faster at more than one person.
+	var/told_cant_shoot = 0 //So that it doesn't spam them with the fact they cannot hit them.
+	var/lock_time = -100
 
 	var/dna_lock = 0				//whether or not the gun is locked to dna
 	var/obj/item/dnalockingchip/attached_lock

--- a/code/modules/scripting/AST/AST Nodes.dm
+++ b/code/modules/scripting/AST/AST Nodes.dm
@@ -65,8 +65,8 @@ var/global/const/OOP_GROUP   = OOP_UNARY		+ 1   //()
 */
 /node/expression/operator
 	var/node/expression/exp
-	var/tmp/name
-	var/tmp/precedence
+	var/name
+	var/precedence
 
 /node/expression/operator/New()
 	.=..()

--- a/code/modules/shuttles/shuttle.dm
+++ b/code/modules/shuttles/shuttle.dm
@@ -8,7 +8,7 @@
 	var/list/shuttle_area // Initial value can be either a single area type or a list of area types
 	var/obj/effect/shuttle_landmark/current_location //This variable is type-abused initially: specify the landmark_tag, not the actual landmark.
 
-	var/tmp/arrive_time = 0	//the time at which the shuttle arrives when long jumping
+	var/arrive_time = 0	//the time at which the shuttle arrives when long jumping
 	var/flags = SHUTTLE_FLAGS_NONE
 	var/process_state = IDLE_STATE // Used with SHUTTLE_FLAGS_PROCESS, as well as to store current state.
 	var/category = /datum/shuttle
@@ -28,7 +28,7 @@
 	var/mothershuttle //tag of mothershuttle
 	var/motherdock    //tag of mothershuttle landmark, defaults to starting location
 
-	var/tmp/depart_time = 0 //Similar to above, set when the shuttle leaves when long jumping. Used for progress bars.
+	var/depart_time = 0 //Similar to above, set when the shuttle leaves when long jumping. Used for progress bars.
 
 	var/debug_logging = FALSE // If set to true, the shuttle will start broadcasting its debug messages to admins
 

--- a/code/modules/shuttles/shuttle_autodock.dm
+++ b/code/modules/shuttles/shuttle_autodock.dm
@@ -10,7 +10,7 @@
 	var/datum/embedded_program/docking/shuttle_docking_controller // Controller on the shuttle (the one in use)
 	var/docking_codes
 
-	var/tmp/obj/effect/shuttle_landmark/next_location  //This is only used internally.
+	var/obj/effect/shuttle_landmark/next_location  //This is only used internally.
 	var/datum/embedded_program/docking/active_docking_controller // Controller we are docked with (or trying to)
 
 	var/obj/effect/shuttle_landmark/landmark_transition  //This variable is type-abused initially: specify the landmark_tag, not the actual landmark.

--- a/code/modules/turbolift/turbolift.dm
+++ b/code/modules/turbolift/turbolift.dm
@@ -10,9 +10,9 @@
 	var/obj/structure/lift/panel/control_panel_interior // Lift control panel.
 	var/doors_closing = 0								// Whether doors are in the process of closing
 
-	var/tmp/moving_upwards
-	var/tmp/busy_state									// Used for controller processing.
-	var/tmp/next_process								// world.time process() should next do something
+	var/moving_upwards
+	var/busy_state									// Used for controller processing.
+	var/next_process								// world.time process() should next do something
 
 /datum/turbolift/proc/emergency_stop()
 	queued_floors.Cut()


### PR DESCRIPTION
/tmp/ is a var path sugar that causes the value of datum member vars to not be saved, should that datum be serialized to a byond savefile. It's irrelevant in these removed uses, which is all of them. It's doubly irrelevant in the handful of global uses. Destroy /tmp/.

Will conflict with #9300 because this touches a file the other deletes. Handling order isn't important.
