### PR TITLE
Drakes now have a preview icon.

### DIFF
--- a/code/game/jobs/job/civilian_chaplain.dm
+++ b/code/game/jobs/job/civilian_chaplain.dm
@@ -162,6 +162,6 @@
 	return 1
 
 /* If you uncomment this, every time the mob preview updates it makes a new PDA. It seems to work just fine and display without it, so why this exists, haven't a clue. -Hawk
-/datum/job/chaplain/equip_preview(var/mob/living/carbon/human/H, var/alt_title)
+/datum/job/chaplain/equip_preview(var/mob/living/carbon/human/H, var/alt_title, var/datum/preferences/prefs)
 	return equip(H, alt_title, FALSE)
 */

--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -92,7 +92,7 @@
 	to_chat(H, "<span class='notice'><b>Your account number is: [M.account_number], your account pin is: [M.remote_access_pin]</b></span>")
 
 // overrideable separately so AIs/borgs can have cardborg hats without unnecessary new()/qdel()
-/datum/job/proc/equip_preview(mob/living/carbon/human/H, var/alt_title)
+/datum/job/proc/equip_preview(mob/living/carbon/human/H, var/alt_title, var/datum/preferences/prefs)
 	var/decl/hierarchy/outfit/outfit = get_outfit(H, alt_title)
 	if(!outfit)
 		return FALSE
@@ -159,8 +159,8 @@
 
 /datum/job/proc/dress_mannequin(var/mob/living/carbon/human/dummy/mannequin/mannequin)
 	mannequin.delete_inventory(TRUE)
-	equip_preview(mannequin)
-	if(mannequin.back)
+	mannequin = equip_preview(mannequin)
+	if(istype(mannequin) && mannequin.back)
 		var/obj/O = mannequin.back
 		mannequin.drop_from_inventory(O)
 		qdel(O)

--- a/code/game/jobs/job/silicon.dm
+++ b/code/game/jobs/job/silicon.dm
@@ -32,7 +32,7 @@
 /datum/job/ai/is_position_available()
 	return (empty_playable_ai_cores.len != 0)
 
-/datum/job/ai/equip_preview(mob/living/carbon/human/H)
+/datum/job/ai/equip_preview(mob/living/carbon/human/H, var/alt_title, var/datum/preferences/prefs)
 	H.equip_to_slot_or_del(new /obj/item/clothing/suit/straight_jacket(H), slot_wear_suit)
 	H.equip_to_slot_or_del(new /obj/item/clothing/head/collectable/cardborg(H), slot_head)
 	return 1
@@ -85,7 +85,7 @@
 	if(!H)	return 0
 	return 1
 
-/datum/job/cyborg/equip_preview(mob/living/carbon/human/H)
+/datum/job/cyborg/equip_preview(mob/living/carbon/human/H, var/alt_title, var/datum/preferences/prefs)
 	H.equip_to_slot_or_del(new /obj/item/clothing/suit/costume/cardborg(H), slot_wear_suit)
 	H.equip_to_slot_or_del(new /obj/item/clothing/head/collectable/cardborg(H), slot_head)
 	return 1

--- a/code/game/objects/items/weapons/id cards/station_ids.dm
+++ b/code/game/objects/items/weapons/id cards/station_ids.dm
@@ -10,6 +10,7 @@
 
 	var/access = list()
 	var/registered_name = "Unknown" // The name registered_name on the card
+	var/registered_id_string = "ID Card"
 	slot_flags = SLOT_ID | SLOT_EARS
 
 	var/age = "\[UNSET\]"
@@ -53,12 +54,14 @@
 		ui.open()
 
 /obj/item/card/id/proc/update_name()
-	name = "[src.registered_name]'s ID Card ([src.assignment])"
+	name = "[src.registered_name]'s [registered_id_string] ([src.assignment])"
+
+/obj/item/card/id/proc/get_id_icon(mob/M)
+	M.ImmediateOverlayUpdate()
+	return getFlatIcon(M, defdir = SOUTH, no_anim = TRUE)
 
 /obj/item/card/id/proc/set_id_photo(mob/M)
-	M.ImmediateOverlayUpdate()
-	var/icon/F = getFlatIcon(M, defdir = SOUTH, no_anim = TRUE)
-	front = "'data:image/png;base64,[icon2base64(F)]'"
+	front = "'data:image/png;base64,[icon2base64(get_id_icon(M))]'"
 
 /mob/proc/set_id_info(var/obj/item/card/id/id_card)
 	id_card.age = 0

--- a/code/modules/mob/living/simple_mob/subtypes/animal/sif/grafadreka/grafadreka.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/sif/grafadreka/grafadreka.dm
@@ -471,23 +471,22 @@ You can eat glowing tree fruit to fuel your <b>ranged spitting attack</b> and <b
 	return FALSE
 
 
-/mob/living/simple_mob/animal/sif/grafadreka/proc/setup_colours()
+/mob/living/simple_mob/animal/sif/grafadreka/proc/setup_colours(var/force = FALSE)
 	var/static/list/fur_colours =  list(COLOR_SILVER, COLOR_WHITE, COLOR_GREEN_GRAY, COLOR_PALE_RED_GRAY, COLOR_BLUE_GRAY)
 	var/static/list/claw_colours = list(COLOR_GRAY, COLOR_SILVER, COLOR_WHITE, COLOR_GRAY15, COLOR_GRAY20, COLOR_GRAY40, COLOR_GRAY80)
 	var/static/list/glow_colours = list(COLOR_BLUE_LIGHT, COLOR_LIGHT_CYAN, COLOR_CYAN, COLOR_CYAN_BLUE)
 	var/static/list/base_colours = list("#608894", "#436974", "#7fa3ae")
 	var/static/list/eye_colours =  list(COLOR_WHITE, COLOR_SILVER)
-	if (!glow_colour)
+	if (!glow_colour || force)
 		glow_colour = pick(glow_colours)
-	if (!fur_colour)
+	if (!fur_colour || force)
 		fur_colour =  pick(fur_colours)
-	if (!claw_colour)
+	if (!claw_colour || force)
 		claw_colour = pick(claw_colours)
-	if (!base_colour)
+	if (!base_colour || force)
 		base_colour = pick(base_colours)
-	if (!eye_colour)
+	if (!eye_colour || force)
 		eye_colour =  pick(eye_colours)
-
 
 var/global/list/wounds_being_tended_by_drakes = list()
 

--- a/code/modules/mob/living/simple_mob/subtypes/animal/sif/grafadreka/grafadreka_misc.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/sif/grafadreka/grafadreka_misc.dm
@@ -105,7 +105,7 @@ Field studies suggest analytical abilities on par with some species of cepholapo
 	eyeblur = 2
 	fire_sound = 'sound/voice/drakes/hatchling_spit.ogg'
 
-/mob/living/simple_mob/animal/sif/grafadreka/rainbow/setup_colours()
+/mob/living/simple_mob/animal/sif/grafadreka/rainbow/setup_colours(var/force = FALSE)
 	glow_colour = get_random_colour(TRUE)
 	fur_colour =  get_random_colour(TRUE)
 	claw_colour = get_random_colour(TRUE)

--- a/code/modules/mob/new_player/preferences_setup.dm
+++ b/code/modules/mob/new_player/preferences_setup.dm
@@ -265,9 +265,8 @@
 	if(ishuman(mannequin))
 		mannequin.toggle_tail(setting = animations_toggle)
 		mannequin.toggle_wing(setting = animations_toggle)
-		mannequin.ImmediateOverlayUpdate()
-	if(isliving(mannequin))
-		update_character_previews(new /mutable_appearance(mannequin))
+	mannequin.ImmediateOverlayUpdate()
+	update_character_previews(new /mutable_appearance(mannequin))
 
 /datum/preferences/proc/get_highest_job()
 	var/datum/job/highJob

--- a/code/modules/mob/new_player/preferences_setup.dm
+++ b/code/modules/mob/new_player/preferences_setup.dm
@@ -252,19 +252,22 @@
 
 	if((equip_preview_mob & EQUIP_PREVIEW_JOB) && previewJob)
 		mannequin.job = previewJob.title
-		previewJob.equip_preview(mannequin, player_alt_titles[previewJob.title])
+		mannequin = previewJob.equip_preview(mannequin, player_alt_titles[previewJob.title], src)
+
+	return mannequin
 
 /datum/preferences/proc/update_preview_icon()
 	var/mob/living/carbon/human/dummy/mannequin/mannequin = get_mannequin(client_ckey)
 	if(!mannequin.dna) // Special handling for preview icons before SSAtoms has initialized.
 		mannequin.dna = new /datum/dna(null)
 	mannequin.delete_inventory(TRUE)
-	dress_preview_mob(mannequin)
-	mannequin.toggle_tail(setting = animations_toggle)
-	mannequin.toggle_wing(setting = animations_toggle)
-	mannequin.ImmediateOverlayUpdate()
-
-	update_character_previews(new /mutable_appearance(mannequin))
+	mannequin = dress_preview_mob(mannequin)
+	if(ishuman(mannequin))
+		mannequin.toggle_tail(setting = animations_toggle)
+		mannequin.toggle_wing(setting = animations_toggle)
+		mannequin.ImmediateOverlayUpdate()
+	if(isliving(mannequin))
+		update_character_previews(new /mutable_appearance(mannequin))
 
 /datum/preferences/proc/get_highest_job()
 	var/datum/job/highJob

--- a/maps/cynosure/cynosure_jobs.dm
+++ b/maps/cynosure/cynosure_jobs.dm
@@ -324,15 +324,18 @@ var/global/const/access_explorer = 43
 /datum/job/trained_animal/proc/apply_pref_colors_to_drake(var/mob/living/simple_mob/animal/sif/grafadreka/drake, var/datum/preferences/prefs)
 	// Protect against unset defaults creating a drake-shaped void.
 	drake.setup_colours(force = TRUE) // reset colors to defaults
-	var/col = rgb(prefs.r_eyes, prefs.g_eyes, prefs.b_eyes)
-	if(col != COLOR_BLACK)
-		drake.eye_colour = col
-	col = rgb(prefs.r_facial, prefs.g_facial, prefs.b_facial)
+	var/col = rgb(prefs.r_facial, prefs.g_facial, prefs.b_facial)
 	if(col != COLOR_BLACK)
 		drake.fur_colour = col
+	col = rgb(prefs.r_grad, prefs.g_grad, prefs.b_grad)
+	if(col != COLOR_BLACK)
+		drake.claw_colour = col
 	col = rgb(prefs.r_hair, prefs.g_hair, prefs.b_hair)
 	if(col != COLOR_BLACK)
 		drake.base_colour = col
+	col = rgb(prefs.r_eyes, prefs.g_eyes, prefs.b_eyes)
+	if(col != COLOR_BLACK)
+		drake.eye_colour = col
 	drake.update_icon()
 
 /datum/job/trained_animal/proc/prompt_rename(var/mob/player)

--- a/maps/cynosure/cynosure_jobs.dm
+++ b/maps/cynosure/cynosure_jobs.dm
@@ -215,7 +215,7 @@ var/global/const/access_explorer = 43
 	economic_modifier = 1
 	access = list()
 	minimal_access = list()
-	outfit_type = /decl/hierarchy/outfit/drake_preview
+	outfit_type = /decl/hierarchy/outfit/siffet
 	job_description = "A number of the bolder folks in Sif's anomalous region have partially domesticated some of the local wildlife as working animals."
 	assignable = FALSE
 	has_headset = FALSE
@@ -293,6 +293,21 @@ var/global/const/access_explorer = 43
 				var/obj/item/gps/gps = drake.harness.attached_items[drake.harness.ATTACHED_GPS]
 				if (gps)
 					gps.SetTag(drake.name)
+				var/obj/item/card/id/critter_card = drake.harness.attached_items[drake.harness.ATTACHED_ID]
+				if (critter_card)
+					critter_card.registered_name = critter.real_name
+					critter_card.assignment = istype(drake_setup) ? drake_setup.title : initial(drake_setup.title)
+					critter_card.sex = capitalize(critter.gender)
+					critter_card.update_name()
+
+					// Photo time
+					drake.sitting = TRUE
+					drake.resting = TRUE
+					drake.update_icon()
+					critter_card.set_id_photo(drake)
+					drake.sitting = FALSE
+					drake.resting = FALSE
+					drake.update_icon()
 
 		// Transfer over key.
 		if(player.mind)
@@ -340,11 +355,18 @@ var/global/const/access_explorer = 43
 
 /obj/item/card/id/drake_expedition
 	name = "animal access card"
+	registered_id_string = "Registration Card"
 	access = list(
 		access_explorer,
 		access_research,
 		access_xenofauna
 	)
+
+/obj/item/card/id/drake_expedition/get_id_icon(mob/M)
+	var/icon/mob_icon = ..()
+	if(istype(M, /mob/living/simple_mob/animal/sif/grafadreka))
+		mob_icon.Crop(16, 0, 48, 32)
+	return mob_icon
 
 /obj/item/storage/animal_harness/grafadreka/expedition
 	name = "expedition harness"

--- a/maps/cynosure/cynosure_jobs.dm
+++ b/maps/cynosure/cynosure_jobs.dm
@@ -215,7 +215,7 @@ var/global/const/access_explorer = 43
 	economic_modifier = 1
 	access = list()
 	minimal_access = list()
-	outfit_type = /decl/hierarchy/outfit/siffet
+	outfit_type = /decl/hierarchy/outfit/drake_preview
 	job_description = "A number of the bolder folks in Sif's anomalous region have partially domesticated some of the local wildlife as working animals."
 	assignable = FALSE
 	has_headset = FALSE
@@ -223,6 +223,7 @@ var/global/const/access_explorer = 43
 	offmap_spawn = TRUE
 	announce_arrival_and_despawn = FALSE
 	banned_job_species = null
+	var/list/secret_drakes = list()
 
 	alt_titles = list(
 		"Expedition Drake" = /datum/alt_title/drake/explorer_drake,
@@ -250,6 +251,21 @@ var/global/const/access_explorer = 43
 	title_blurb = "Wild grafadreka are not particularly good parents, and their hatchlings often wander away or are abandoned to their own devices."
 	drake_type = /mob/living/simple_mob/animal/sif/grafadreka/hatchling
 
+// Returns a drake mob instead of a human mob.
+/datum/job/trained_animal/equip_preview(mob/living/carbon/human/H, var/alt_title, var/datum/preferences/prefs)
+	if(!prefs)
+		return ..() // Equips a silly outfit.
+	var/datum/alt_title/drake/drake_setup = alt_titles[alt_title] || /datum/alt_title/drake
+	var/drake_type = istype(drake_setup) ? drake_setup.drake_type : initial(drake_setup.drake_type)
+	var/mob/living/simple_mob/animal/sif/grafadreka/secret_drake = secret_drakes[drake_type]
+	if(!secret_drake)
+		secret_drake = new drake_type
+		secret_drake.resting = TRUE
+		secret_drake.sitting = TRUE // So they fit inside the preview box in the east/west states.
+		secret_drakes[drake_type] = secret_drake
+	apply_pref_colors_to_drake(secret_drake, prefs)
+	return secret_drake
+
 /datum/job/trained_animal/handle_nonhuman_mob(var/mob/living/carbon/human/player, var/alt_title)
 
 	var/datum/alt_title/drake/drake_setup = alt_titles[alt_title] || /datum/alt_title/drake
@@ -269,22 +285,10 @@ var/global/const/access_explorer = 43
 			critter.real_name = critter.name
 
 		if(istype(critter, /mob/living/simple_mob/animal/sif/grafadreka))
+			apply_pref_colors_to_drake(critter, P)
 			var/mob/living/simple_mob/animal/sif/grafadreka/drake = critter
-			// Protect against unset defaults creating a drake-shaped void.
-			var/col = rgb(P.r_eyes, P.g_eyes, P.b_eyes)
-			if(col != COLOR_BLACK)
-				drake.eye_colour = col
-			col = rgb(P.r_facial, P.g_facial, P.b_facial)
-			if(col != COLOR_BLACK)
-				drake.fur_colour = col
-			col = rgb(P.r_hair, P.g_hair, P.b_hair)
-			if(col != COLOR_BLACK)
-				drake.base_colour = col
-			drake.update_icon()
-
 			for(var/language in P.alternate_languages)
 				LAZYDISTINCTADD(drake.understands_languages, language)
-
 			if (drake.harness?.attached_items)
 				var/obj/item/gps/gps = drake.harness.attached_items[drake.harness.ATTACHED_GPS]
 				if (gps)
@@ -302,6 +306,19 @@ var/global/const/access_explorer = 43
 		prompt_rename(critter)
 		return critter
 
+/datum/job/trained_animal/proc/apply_pref_colors_to_drake(var/mob/living/simple_mob/animal/sif/grafadreka/drake, var/datum/preferences/prefs)
+	// Protect against unset defaults creating a drake-shaped void.
+	drake.setup_colours(force = TRUE) // reset colors to defaults
+	var/col = rgb(prefs.r_eyes, prefs.g_eyes, prefs.b_eyes)
+	if(col != COLOR_BLACK)
+		drake.eye_colour = col
+	col = rgb(prefs.r_facial, prefs.g_facial, prefs.b_facial)
+	if(col != COLOR_BLACK)
+		drake.fur_colour = col
+	col = rgb(prefs.r_hair, prefs.g_hair, prefs.b_hair)
+	if(col != COLOR_BLACK)
+		drake.base_colour = col
+	drake.update_icon()
 
 /datum/job/trained_animal/proc/prompt_rename(var/mob/player)
 

--- a/maps/cynosure/job/outfits.dm
+++ b/maps/cynosure/job/outfits.dm
@@ -97,8 +97,35 @@ Keep outfits simple. Spawn with basic uniforms and minimal gear. Gear instead go
 	suit_store = /obj/item/tank/oxygen
 	mask = null
 
-// This is basically a joke for the service drake spawn alt title.
-/decl/hierarchy/outfit/siffet
+// Sort of a joke. Overrides the mob with a version of what their drake will most likely look like.
+/decl/hierarchy/outfit/drake_preview
 	name = OUTFIT_JOB_NAME("Siffet")
-	suit = /obj/item/clothing/suit/storage/hooded/costume/siffet
-	head = /obj/item/clothing/head/hood/siffet_hood
+	suit = /obj/item/clothing/suit/storage/hooded/costume/siffet/show_as_drake
+
+/obj/item/clothing/suit/storage/hooded/costume/siffet/show_as_drake
+	var/mob/living/simple_mob/animal/sif/grafadreka/secret_drake
+
+/obj/item/clothing/suit/storage/hooded/costume/siffet/show_as_drake/Initialize()
+	. = ..()
+	secret_drake = new
+
+/obj/item/clothing/suit/storage/hooded/costume/siffet/show_as_drake/Destroy()
+	QDEL_NULL(secret_drake)
+	return ..()
+
+/obj/item/clothing/suit/storage/hooded/costume/siffet/show_as_drake/get_worn_overlay(var/mob/living/wearer, var/body_type, var/slot_name, var/inhands, var/default_icon, var/default_layer, var/icon/clip_mask)
+	if(!ishuman(wearer))
+		return new /image
+	wearer.alpha = 0
+
+	var/mob/living/carbon/human/human_wearer = wearer
+	secret_drake.eye_colour  = rgb(human_wearer.r_eyes,   human_wearer.g_eyes,   human_wearer.b_eyes)
+	secret_drake.fur_colour  = rgb(human_wearer.r_facial, human_wearer.g_facial, human_wearer.b_facial)
+	secret_drake.base_colour = rgb(human_wearer.r_hair,   human_wearer.g_hair,   human_wearer.b_hair)
+	secret_drake.update_icon()
+
+	var/image/standing = new /image
+	standing.appearance = secret_drake
+	standing.pixel_x = -16
+	standing.appearance_flags |= RESET_ALPHA
+	return standing

--- a/maps/cynosure/job/outfits.dm
+++ b/maps/cynosure/job/outfits.dm
@@ -97,35 +97,8 @@ Keep outfits simple. Spawn with basic uniforms and minimal gear. Gear instead go
 	suit_store = /obj/item/tank/oxygen
 	mask = null
 
-// Sort of a joke. Overrides the mob with a version of what their drake will most likely look like.
-/decl/hierarchy/outfit/drake_preview
+// This is basically a joke for the service drake spawn alt title.
+/decl/hierarchy/outfit/siffet
 	name = OUTFIT_JOB_NAME("Siffet")
-	suit = /obj/item/clothing/suit/storage/hooded/costume/siffet/show_as_drake
-
-/obj/item/clothing/suit/storage/hooded/costume/siffet/show_as_drake
-	var/mob/living/simple_mob/animal/sif/grafadreka/secret_drake
-
-/obj/item/clothing/suit/storage/hooded/costume/siffet/show_as_drake/Initialize()
-	. = ..()
-	secret_drake = new
-
-/obj/item/clothing/suit/storage/hooded/costume/siffet/show_as_drake/Destroy()
-	QDEL_NULL(secret_drake)
-	return ..()
-
-/obj/item/clothing/suit/storage/hooded/costume/siffet/show_as_drake/get_worn_overlay(var/mob/living/wearer, var/body_type, var/slot_name, var/inhands, var/default_icon, var/default_layer, var/icon/clip_mask)
-	if(!ishuman(wearer))
-		return new /image
-	wearer.alpha = 0
-
-	var/mob/living/carbon/human/human_wearer = wearer
-	secret_drake.eye_colour  = rgb(human_wearer.r_eyes,   human_wearer.g_eyes,   human_wearer.b_eyes)
-	secret_drake.fur_colour  = rgb(human_wearer.r_facial, human_wearer.g_facial, human_wearer.b_facial)
-	secret_drake.base_colour = rgb(human_wearer.r_hair,   human_wearer.g_hair,   human_wearer.b_hair)
-	secret_drake.update_icon()
-
-	var/image/standing = new /image
-	standing.appearance = secret_drake
-	standing.pixel_x = -16
-	standing.appearance_flags |= RESET_ALPHA
-	return standing
+	suit = /obj/item/clothing/suit/storage/hooded/costume/siffet
+	head = /obj/item/clothing/head/hood/siffet_hood


### PR DESCRIPTION
- `equip_preview()` can now return a different mob to the input.
- `equip_preview()` now takes a preferences object as an argument.
- The drake job will return a drake customized to the preferences supplied to the preview proc.
- Trained drakes will populate their IDs with a photo and some fields.

Can't work out how to extend or realign the preview objects, but being able to see your eye, body and spines colour at all is an improvement on the old code, so whatever.

![image-1](https://github.com/PolarisSS13/Polaris/assets/2468979/03cb9237-9587-4143-93ad-1400ffc21344)

![image](https://github.com/PolarisSS13/Polaris/assets/2468979/7076f510-42b1-4238-936a-239c41762804)
