### PR TITLE
only /item archeology finds try to set origin tech

### DIFF
--- a/code/modules/xenoarcheaology/finds/find_spawning.dm
+++ b/code/modules/xenoarcheaology/finds/find_spawning.dm
@@ -706,12 +706,14 @@
 	if(!desc)
 		desc = "This item is completely [pick("alien","bizarre")]."
 
+	var/is_item = istype(new_item, /obj/item)
+
 	//icon and icon_state should have already been set
 	if(new_item)
 		new_item.name = name
 		new_item.desc = src.desc
 
-		if(talkative)
+		if(talkative && is_item)
 			new_item.talking_atom = new(new_item)
 			LAZYINITLIST(new_item.origin_tech)
 			new_item.origin_tech[TECH_ARCANE] += 1
@@ -726,7 +728,7 @@
 
 		qdel(src)
 
-	else if(talkative)
+	else if(talkative && is_item)
 		src.talking_atom = new(src)
 		LAZYINITLIST(origin_tech)
 		origin_tech[TECH_ARCANE] += 1


### PR DESCRIPTION
fixes a sporadic unit test fail, eg https://github.com/PolarisSS13/Polaris/actions/runs/7518767896/job/20466495839

presumably also fixes half initialized archeology finds