### PR TITLE
Mapfix - Medbay Disposals Junction

### DIFF
--- a/maps/cynosure/cynosure-2.dmm
+++ b/maps/cynosure/cynosure-2.dmm
@@ -38607,8 +38607,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/junction/yjunction{
-	dir = 8
+/obj/structure/disposalpipe/junction{
+	dir = 1;
+	icon_state = "pipe-j2"
 	},
 /turf/simulated/floor/tiled/white,
 /area/surface/station/medical/etc)


### PR DESCRIPTION
Swaps the medbay disposals pipe that joins the park disposals pipe so that garbarge from those respective bins doesn't end up in the opposite place.

Tested on loccal, confirmed that garbage now appropriately ends up in cargo's disposal processing.