### PR TITLE
Revised Sivian Fauna Lists

### DIFF
--- a/code/game/objects/random/mob.dm
+++ b/code/game/objects/random/mob.dm
@@ -73,16 +73,17 @@
 	mob_wander_distance = 10
 
 /obj/random/mob/sif/item_to_spawn()
-	return pick(prob(30);/mob/living/simple_mob/animal/sif/diyaab,
+	return pick(prob(25);/mob/living/simple_mob/animal/sif/diyaab,
 				prob(20);/mob/living/simple_mob/animal/passive/hare,
-				prob(15);/mob/living/simple_mob/animal/passive/crab,
-				prob(15);/mob/living/simple_mob/animal/passive/penguin,
-				prob(15);/mob/living/simple_mob/animal/passive/mouse,
-				prob(15);/mob/living/simple_mob/animal/passive/dog/tamaskan,
-				prob(10);/mob/living/simple_mob/animal/sif/siffet,
+				prob(15);/mob/living/simple_mob/animal/sif/duck,
+				prob(10);/mob/living/simple_mob/animal/sif/glitterfly,
+				prob(10);/mob/living/simple_mob/animal/sif/sakimm,
+				prob(10);/mob/living/simple_mob/animal/sif/shantak,
+				prob(5);/mob/living/simple_mob/animal/sif/savik,
+				prob(5);/mob/living/simple_mob/animal/passive/mouse,
+				prob(5);/mob/living/simple_mob/animal/sif/hooligan_crab,
 				prob(2);/mob/living/simple_mob/animal/giant_spider/frost,
-				prob(1);/mob/living/simple_mob/animal/space/goose,
-				prob(20);/mob/living/simple_mob/animal/passive/crab)
+				prob(1);/mob/living/simple_mob/animal/sif/glitterfly/rare)
 
 
 /obj/random/mob/sif/peaceful

--- a/code/game/objects/random/mob.dm
+++ b/code/game/objects/random/mob.dm
@@ -311,7 +311,7 @@
 				prob(15);/mob/living/simple_mob/animal/passive/fish/javelin,
 				prob(20);/mob/living/simple_mob/animal/passive/fish/rockfish,
 				prob(5);/mob/living/simple_mob/animal/passive/fish/solarfish,
-				prob(10);/mob/living/simple_mob/animal/passive/crab,
+				prob(10);/mob/living/simple_mob/animal/passive/crab/sif,
 				prob(1);/mob/living/simple_mob/animal/sif/hooligan_crab)
 
 /obj/random/mob/bird

--- a/code/game/objects/random/mob.dm
+++ b/code/game/objects/random/mob.dm
@@ -91,16 +91,31 @@
 	icon_state = "animal_passive"
 
 	mob_returns_home = 1
-	mob_wander_distance = 12
+	mob_wander_distance = 10
 
 /obj/random/mob/sif/peaceful/item_to_spawn()
 	return pick(prob(30);/mob/living/simple_mob/animal/sif/diyaab,
 				prob(20);/mob/living/simple_mob/animal/passive/hare,
-				prob(15);/mob/living/simple_mob/animal/passive/crab,
-				prob(15);/mob/living/simple_mob/animal/passive/penguin,
-				prob(15);/mob/living/simple_mob/animal/passive/mouse,
-				prob(15);/mob/living/simple_mob/animal/passive/dog/tamaskan,
-				prob(20);/mob/living/simple_mob/animal/sif/hooligan_crab)
+				prob(10);/mob/living/simple_mob/animal/sif/glitterfly,
+				prob(10);/mob/living/simple_mob/animal/sif/shantak/retaliate,
+				prob(10);/mob/living/simple_mob/animal/sif/sakimm,
+				prob(5);/mob/living/simple_mob/animal/passive/mouse,
+				prob(1);/mob/living/simple_mob/animal/sif/glitterfly/rare)
+				
+/obj/random/mob/sif/aquatic
+	name = "Random Aquatic Sif Animal"
+	desc = "This is a random aquatic animal that can be found on Sivian shores."
+	icon_state = "animal"
+
+	mob_returns_home = 1
+	mob_wander_distance = 10
+
+/obj/random/mob/sif/aquatic/item_to_spawn()
+	return pick(prob(30);/mob/living/simple_mob/animal/passive/crab/sif,
+				prob(25);/mob/living/simple_mob/animal/sif/duck,
+				prob(15);/mob/living/simple_mob/animal/sif/diyaab,
+				prob(5);/mob/living/simple_mob/animal/sif/hooligan_crab,
+				prob(1);/mob/living/simple_mob/animal/passive/karik)
 
 /obj/random/mob/sif/hostile
 	name = "Random Hostile Sif Animal"

--- a/maps/submaps/surface_submaps/plains/swampy_den.dmm
+++ b/maps/submaps/surface_submaps/plains/swampy_den.dmm
@@ -19,7 +19,7 @@
 /area/submap/swampy_den)
 "o" = (
 /obj/structure/animal_den,
-/obj/random/mob/sif/peaceful,
+/obj/random/mob/sif/aquatic,
 /turf/simulated/floor/outdoors/dirt,
 /area/submap/swampy_den)
 "s" = (


### PR DESCRIPTION
- Audits the Sivian creature tables and removes some of the more inappropriate entries like normal crabs, geese, and tamaskans, swapping them with more relevant creatures like the Sivian shelf crab, sakiim, or frostducks.
- Makes a new spawn pool for aquatic creatures for PoIs so that mappers can prevent shelf crabs from spawning far inland, also implements this in the Swamp Den PoI.
- Also normalizes the wander distance, setting it to 10 for the peaceful creatures to prevent them from getting too far away from their dens.

Siffets would've made it onto these lists but their ability to retaliate against non-small aggressors seems to be currently broken.
Karik could also probably use the ability to retaliate but I was unable to fix this with the limited knowledge I have.