### PR TITLE
POI - Tape House

### DIFF
--- a/code/game/objects/effects/map_effects/sound_emitter.dm
+++ b/code/game/objects/effects/map_effects/sound_emitter.dm
@@ -52,6 +52,7 @@
 	sounds_to_play = list("thunder")
 	interval_lower_bound = 10 SECONDS
 	interval_upper_bound = 15 SECONDS
+	
 
 /obj/effect/map_effect/interval/sound_emitter/geiger
 	sounds_to_play = list('sound/items/geiger/low1.ogg', 'sound/items/geiger/low2.ogg', 'sound/items/geiger/low3.ogg', 'sound/items/geiger/low4.ogg')
@@ -117,3 +118,15 @@
 	sounds_to_play = list('sound/items/bikehorn.ogg')
 	interval_lower_bound = 5
 	interval_upper_bound = 1 SECOND
+	
+/obj/effect/map_effect/interval/sound_emitter/creepy
+	sounds_to_play = list('sound/hallucinations/serithi/creepy3.ogg','sound/hallucinations/serithi/creepy2.ogg')
+	interval_lower_bound = 30 SECONDS
+	interval_upper_bound = 40 SECONDS
+	sound_volume = 40
+	sound_ignore_walls = FALSE
+	
+/obj/effect/map_effect/interval/sound_emitter/footsteps_wood
+	sounds_to_play = list('sound/effects/footstep/wood1.ogg','sound/effects/footstep/wood5.ogg','sound/effects/footstep/floor1.ogg','sound/effects/footstep/floor5.ogg')
+	interval_lower_bound = 5 SECONDS
+	interval_upper_bound = 30 SECONDS

--- a/code/game/objects/items/poi_items.dm
+++ b/code/game/objects/items/poi_items.dm
@@ -121,3 +121,31 @@
 	name = "Simeon"
 	real_name = name
 	desc = "This lab monkey has a certain glint in their eye."
+	
+/obj/item/paper/bittersweet_transcript
+	name = "bittersweet transcript"
+	
+/obj/item/paper/bittersweet_transcript/Initialize()	
+	. = ..()
+	info = {"<b>Transcript:</b><br><br>\[00:00] Recording started.<br>\[00:12] "Say what you want about them, and I sure have a lot to say, but H-H set me up with a beautiful plot to retire to."<br>\[00:26] "There's plenty of space, plenty of windows to look out into the nearby forest and watch the wildlife. They told us it's pretty safe for this part of the frontier, though I'm still glad they let me keep some surplus armor."<br>\[00:38] "The fridge is full, the tables are all set, and I even started growing lillies. They help keep the boredom away."<br>\[00:41] (Unrecognized sound) <br>\[01:02] "It doesn't stop her side of the bed from being any less cold and empty, though."<br>\[01:03] Recording stopped."}
+
+/obj/item/paper/uneasey_transcript
+	name = "uneasy transcript"
+
+/obj/item/paper/uneasey_transcript/Initialize()
+	. = ..()
+	info = {"<b>Transcript:</b><br><br>\[00:00] Recording started.<br>\[00:06] "Well, it`s been a few months."<br>\[00:17] "Everything`s great, really, I`ve been recording these short little logs to give me something to do."<br>\[00:23] "I feel less insane talking to myself if it`s into a little blinking red light, anyway, haha."<br>\[00:27] (Unrecognized sound) <br>\[00:40] "There it is, though. I don`t know if this thing picked it up, but it sounds like there`s ... pacing. I thought it was just the house settling the first few times but..."<br>\[00:48] "Looking back at other transcripts, apparently it doesn`t like anything else other than talking."<br>\[00:57] "This place feels like an enclosure sometimes. All these windows feel like they have eyes, and every tree outside has become a hiding place."<br>\[01:12] "... I think I'm losing it."<br>\[01:14] Recording stopped."}
+
+/obj/item/paper/determined_transcript
+	name = "determined transcript"
+
+/obj/item/paper/determined_transcript/Initialize()
+	. = ..()
+	info = {"<b>Transcript:</b><br><br>\[00:00] Recording started.<br>\[00:12] "It`s coming from inside the closet, but I think I get it now."<br>\[00:13] (Unrecognized sound)<br>\[00:19] "It won`t stop unless I make it."<br>\[00:29] "I`ll take a light and the recorder with me so I can have a record of what happens."<br>\[00:31] (Unrecognized sound)<br>\[00:42] "And I guess if it`s bad..."<br>\[00:45] "Lilly, I`ll see you soon."<br>\[00:59] Recording stopped."}
+
+/obj/item/paper/crumpled/crumpled_transcript
+	name = "crumpled transcript"
+
+/obj/item/paper/crumpled/crumpled_transcript/Initialize()
+	. = ..()
+	info = {"<b>Transcript:</b><br><br>\[00:00] Recording started.<br>\[00:02] (Unrecognized sound)<br>\[00:02] (Unrecognized sound)<br>\[00:07] (Unrecognized sound)<br>\[00:12] "WHAT ARE Y-"<br>\[00:12] (Unrecognized sound)<br>\[00:13] (Unrecognized sound)<br>\[00:17] (Unrecognized sound)<br>\[15:06] (Unrecognized sound)<br>\[15:06] Recording stopped."}

--- a/maps/submaps/surface_submaps/plains/TapeHouse.dmm
+++ b/maps/submaps/surface_submaps/plains/TapeHouse.dmm
@@ -78,7 +78,7 @@
 /obj/item/gun/projectile/shotgun/doublebarrel/sawn,
 /obj/item/paper/crumpled{
 	name = "Crumpled Transcript";
-	info = <b>Transcript:</b><br><br>[00:00] Recording started.<br>[00:02] (Unrecognized sound)<br>[00:02] (Unrecognized sound)<br>[00:07] (Unrecognized sound)<br>[00:12] "WHAT ARE Y-"<br>[00:12] (Unrecognized sound)<br>[00:13] (Unrecognized sound)<br>[00:17] (Unrecognized sound)<br>[15:06] (Unrecognized sound)<br>[15:06] Recording stopped.
+	info = '<b>Transcript:</b><br><br>[00:00] Recording started.<br>[00:02] (Unrecognized sound)<br>[00:02] (Unrecognized sound)<br>[00:07] (Unrecognized sound)<br>[00:12] "WHAT ARE Y-"<br>[00:12] (Unrecognized sound)<br>[00:13] (Unrecognized sound)<br>[00:17] (Unrecognized sound)<br>[15:06] (Unrecognized sound)<br>[15:06] Recording stopped.'
 	},
 /turf/simulated/floor/wood/sif,
 /area/submap/TapeHouse)
@@ -105,7 +105,7 @@
 	},
 /obj/item/paper{
 	name = "Bittersweet Transcript";
-	info = <b>Transcript:</b><br><br>[00:00] Recording started.<br>[00:12] "Say what you want about them, and I sure have a lot to say, but H-H set me up with a beautiful plot to retire to."<br>[00:26] "There's plenty of space, plenty of windows to look out into the nearby forest and watch the wildlife. They told us it's pretty safe for this part of the frontier, though I'm still glad they let me keep some surplus armor."<br>[00:38] "The fridge is full, the tables are all set, and I even started growing lillies. They help keep the boredom away."<br>[00:41] (Unrecognized sound) <br>[01:02] "It doesn't stop her side of the bed from being any less cold and empty, though."<br>[01:03] Recording stopped.
+	info = '<b>Transcript:</b><br><br>[00:00] Recording started.<br>[00:12] "Say what you want about them, and I sure have a lot to say, but H-H set me up with a beautiful plot to retire to."<br>[00:26] "There's plenty of space, plenty of windows to look out into the nearby forest and watch the wildlife. They told us it's pretty safe for this part of the frontier, though I'm still glad they let me keep some surplus armor."<br>[00:38] "The fridge is full, the tables are all set, and I even started growing lillies. They help keep the boredom away."<br>[00:41] (Unrecognized sound) <br>[01:02] "It doesn't stop her side of the bed from being any less cold and empty, though."<br>[01:03] Recording stopped.'
 	},
 /turf/simulated/floor/carpet,
 /area/submap/TapeHouse)
@@ -126,7 +126,7 @@
 /obj/item/trash/candle,
 /obj/item/paper{
 	name = "Determined Transcript";
-	info = <b>Transcript:</b><br><br>[00:00] Recording started.<br>[00:12] "It's coming from inside the closet, but I think I get it now."<br>[00:13] (Unrecognized sound)<br>[00:19] "It won't stop unless I make it."<br>[00:29] "I'll take a light and the recorder with me so I can have a record of what happens."<br>[00:31] (Unrecognized sound)<br>[00:42] "And I guess if it's bad..."<br>[00:45] "Lilly, I'll see you soon."<br>[00:59] Recording stopped.
+	info = '<b>Transcript:</b><br><br>[00:00] Recording started.<br>[00:12] "It's coming from inside the closet, but I think I get it now."<br>[00:13] (Unrecognized sound)<br>[00:19] "It won't stop unless I make it."<br>[00:29] "I'll take a light and the recorder with me so I can have a record of what happens."<br>[00:31] (Unrecognized sound)<br>[00:42] "And I guess if it's bad..."<br>[00:45] "Lilly, I'll see you soon."<br>[00:59] Recording stopped.'
 	},
 /turf/simulated/floor/wood/sif,
 /area/submap/TapeHouse)
@@ -565,7 +565,7 @@
 /obj/structure/table/wooden_reinforced,
 /obj/item/paper{
 	name = "Uneasy Transcript";
-	info = <b>Transcript:</b><br><br>[00:00] Recording started.<br>[00:06] "Well, it's been a few months."<br>[00:17] "Everything's great, really, I've been recording these short little logs to give me something to do.<br>[00:23] "I feel less insane talking to myself if it's into a little blinking red light, anyway, haha."<br>[00:27] (Unrecognized sound) <br>[00:40] "There it is, though. I don't know if this thing picked it up, but it sounds like there's ... pacing. I thought it was just the house settling the first few times but..."<br>[00:48] "Looking back at other transcripts, apparently it doesn't like anything else other than talking."<br>[00:57] "This place feels like an enclosure sometimes. All these windows feel like they have eyes, and every tree outside has become a hiding place."<br>[01:12] "... I think I'm losing it."<br>[01:14] Recording stopped.
+	info = '<b>Transcript:</b><br><br>[00:00] Recording started.<br>[00:06] "Well, it's been a few months."<br>[00:17] "Everything's great, really, I've been recording these short little logs to give me something to do.<br>[00:23] "I feel less insane talking to myself if it's into a little blinking red light, anyway, haha."<br>[00:27] (Unrecognized sound) <br>[00:40] "There it is, though. I don't know if this thing picked it up, but it sounds like there's ... pacing. I thought it was just the house settling the first few times but..."<br>[00:48] "Looking back at other transcripts, apparently it doesn't like anything else other than talking."<br>[00:57] "This place feels like an enclosure sometimes. All these windows feel like they have eyes, and every tree outside has become a hiding place."<br>[01:12] "... I think I'm losing it."<br>[01:14] Recording stopped.'
 	},
 /obj/random/cigarettes,
 /turf/simulated/floor/wood/sif,

--- a/maps/submaps/surface_submaps/plains/TapeHouse.dmm
+++ b/maps/submaps/surface_submaps/plains/TapeHouse.dmm
@@ -1,0 +1,1092 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"ak" = (
+/obj/structure/table/rack/shelf,
+/obj/item/reagent_containers/food/condiment/spacespice,
+/obj/item/reagent_containers/food/drinks/jar,
+/turf/simulated/floor/wood/sif,
+/area/submap/TapeHouse)
+"ba" = (
+/obj/structure/bookcase,
+/turf/simulated/floor/wood/sif,
+/area/submap/TapeHouse)
+"bP" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/template_noop,
+/area/submap/TapeHouse)
+"cI" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/template_noop,
+/area/submap/TapeHouse)
+"dv" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/flora/grass/brown,
+/turf/simulated/floor/outdoors/grass/sif,
+/area/submap/TapeHouse)
+"dV" = (
+/obj/structure/coatrack,
+/turf/simulated/floor/carpet/bcarpet,
+/area/submap/TapeHouse)
+"ej" = (
+/obj/structure/bed/chair/wood{
+	dir = 4
+	},
+/turf/simulated/floor/wood/sif,
+/area/submap/TapeHouse)
+"eq" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/table/bench/sifwooden,
+/turf/simulated/floor/wood/sif,
+/area/submap/TapeHouse)
+"eB" = (
+/obj/effect/floor_decal/spline/plain,
+/turf/simulated/floor/wood/sif/broken,
+/area/submap/TapeHouse)
+"eV" = (
+/turf/template_noop,
+/area/submap/TapeHouse)
+"fU" = (
+/obj/effect/floor_decal/spline/plain{
+	dir = 8
+	},
+/turf/simulated/floor/wood/sif{
+	outdoors = 0
+	},
+/area/submap/TapeHouse)
+"gb" = (
+/obj/structure/table/reinforced,
+/obj/effect/floor_decal/spline/plain,
+/obj/item/trash/candle,
+/turf/simulated/floor/tiled/hydro,
+/area/submap/TapeHouse)
+"gz" = (
+/obj/effect/map_effect/interval/sound_emitter/creepy,
+/obj/effect/decal/cleanable/filth,
+/obj/item/taperecorder,
+/obj/item/clothing/shoes/boots/winter,
+/obj/item/clothing/under/dress/vneck,
+/obj/item/flashlight/empty{
+	start_anomalous = 1
+	},
+/obj/item/gun/projectile/shotgun/doublebarrel/sawn,
+/obj/item/paper/crumpled{
+	name = "Crumpled Transcript";
+	info = <b>Transcript:</b><br><br>[00:00] Recording started.<br>[00:02] (Unrecognized sound)<br>[00:02] (Unrecognized sound)<br>[00:07] (Unrecognized sound)<br>[00:12] "WHAT ARE Y-"<br>[00:12] (Unrecognized sound)<br>[00:13] (Unrecognized sound)<br>[00:17] (Unrecognized sound)<br>[15:06] (Unrecognized sound)<br>[15:06] Recording stopped.
+	},
+/turf/simulated/floor/wood/sif,
+/area/submap/TapeHouse)
+"gP" = (
+/obj/structure/bed/chair/sofa/black/corner{
+	dir = 4
+	},
+/obj/effect/floor_decal/carpet,
+/turf/simulated/floor/carpet,
+/area/submap/TapeHouse)
+"gR" = (
+/obj/machinery/light/flamp,
+/turf/simulated/floor/wood/sif,
+/area/submap/TapeHouse)
+"hE" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/bcarpet,
+/area/submap/TapeHouse)
+"jC" = (
+/obj/structure/bed/chair/sofa/black{
+	dir = 4
+	},
+/obj/item/paper{
+	name = "Bittersweet Transcript";
+	info = <b>Transcript:</b><br><br>[00:00] Recording started.<br>[00:12] "Say what you want about them, and I sure have a lot to say, but H-H set me up with a beautiful plot to retire to."<br>[00:26] "There's plenty of space, plenty of windows to look out into the nearby forest and watch the wildlife. They told us it's pretty safe for this part of the frontier, though I'm still glad they let me keep some surplus armor."<br>[00:38] "The fridge is full, the tables are all set, and I even started growing lillies. They help keep the boredom away."<br>[00:41] (Unrecognized sound) <br>[01:02] "It doesn't stop her side of the bed from being any less cold and empty, though."<br>[01:03] Recording stopped.
+	},
+/turf/simulated/floor/carpet,
+/area/submap/TapeHouse)
+"jI" = (
+/obj/effect/floor_decal/carpet{
+	dir = 8
+	},
+/obj/effect/floor_decal/carpet{
+	dir = 1
+	},
+/obj/effect/floor_decal/carpet{
+	dir = 9
+	},
+/turf/simulated/floor/carpet,
+/area/submap/TapeHouse)
+"jM" = (
+/obj/structure/table/woodentable,
+/obj/item/trash/candle,
+/obj/item/paper{
+	name = "Determined Transcript";
+	info = <b>Transcript:</b><br><br>[00:00] Recording started.<br>[00:12] "It's coming from inside the closet, but I think I get it now."<br>[00:13] (Unrecognized sound)<br>[00:19] "It won't stop unless I make it."<br>[00:29] "I'll take a light and the recorder with me so I can have a record of what happens."<br>[00:31] (Unrecognized sound)<br>[00:42] "And I guess if it's bad..."<br>[00:45] "Lilly, I'll see you soon."<br>[00:59] Recording stopped.
+	},
+/turf/simulated/floor/wood/sif,
+/area/submap/TapeHouse)
+"kt" = (
+/obj/machinery/light_switch,
+/turf/simulated/wall/sifwood,
+/area/submap/TapeHouse)
+"kz" = (
+/obj/item/stool/barstool/padded{
+	dir = 1
+	},
+/turf/simulated/floor/wood/sif,
+/area/submap/TapeHouse)
+"kJ" = (
+/obj/structure/window/reinforced,
+/obj/structure/flora/ausbushes/sunnybush,
+/turf/simulated/floor/outdoors/grass/sif,
+/area/submap/TapeHouse)
+"lk" = (
+/obj/effect/floor_decal/corner/white/diagonal,
+/obj/structure/toilet{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/submap/TapeHouse)
+"lt" = (
+/obj/structure/table/rack/shelf,
+/obj/item/reagent_containers/food/condiment/carton/flour/rustic,
+/obj/item/material/sharpeningkit,
+/turf/simulated/floor/wood/sif,
+/area/submap/TapeHouse)
+"mZ" = (
+/obj/structure/bed/chair/sofa/black/corner{
+	dir = 1
+	},
+/obj/effect/floor_decal/carpet{
+	dir = 1
+	},
+/turf/simulated/floor/carpet,
+/area/submap/TapeHouse)
+"nk" = (
+/obj/effect/floor_decal/carpet{
+	dir = 4
+	},
+/obj/structure/table/bench/glass,
+/obj/item/storage/photo_album{
+	name = "worn photo album";
+	desc = "Despite this photo album's apparent use, half of the pictures seem to have been pulled from their pockets, while those that remain are blurry and faded."
+	},
+/turf/simulated/floor/carpet,
+/area/submap/TapeHouse)
+"ov" = (
+/obj/structure/table/rack/shelf,
+/obj/item/storage/box/condimentbottles,
+/obj/item/extinguisher,
+/turf/simulated/floor/wood/sif,
+/area/submap/TapeHouse)
+"pT" = (
+/obj/machinery/shower{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/white/diagonal,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	dir = 9
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	dir = 10
+	},
+/obj/structure/curtain/open/shower,
+/obj/item/clothing/under/bathrobe,
+/turf/simulated/floor/tiled/eris,
+/area/submap/TapeHouse)
+"qs" = (
+/obj/structure/flora/tree/sif,
+/turf/template_noop,
+/area/submap/TapeHouse)
+"ru" = (
+/obj/structure/simple_door/sifwood,
+/turf/simulated/floor/wood/sif,
+/area/submap/TapeHouse)
+"sp" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/flora/ausbushes/grassybush,
+/turf/simulated/floor/outdoors/grass/sif,
+/area/submap/TapeHouse)
+"sv" = (
+/obj/effect/floor_decal/corner/white/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/submap/TapeHouse)
+"sw" = (
+/obj/structure/window/reinforced,
+/obj/structure/table/wooden_reinforced,
+/obj/item/pen/fountain5,
+/obj/item/paper_bin,
+/turf/simulated/floor/wood/sif,
+/area/submap/TapeHouse)
+"sx" = (
+/obj/effect/floor_decal/spline/plain{
+	dir = 1
+	},
+/obj/structure/table/rack,
+/obj/item/material/kitchen/utensil/spoon{
+	pixel_x = 2
+	},
+/obj/item/material/kitchen/utensil/spoon{
+	pixel_x = 2
+	},
+/obj/item/material/kitchen/utensil/fork,
+/obj/item/material/kitchen/utensil/fork,
+/obj/item/storage/box/glasses/square{
+	pixel_y = -2
+	},
+/obj/item/reagent_containers/glass/rag,
+/turf/simulated/floor/tiled/hydro,
+/area/submap/TapeHouse)
+"sF" = (
+/turf/simulated/floor/outdoors/dirt,
+/area/submap/TapeHouse)
+"sS" = (
+/obj/structure/table/wooden_reinforced,
+/obj/item/clothing/accessory/medal/silver/valor,
+/turf/simulated/floor/wood/sif,
+/area/submap/TapeHouse)
+"sV" = (
+/turf/simulated/floor/carpet/bcarpet,
+/area/submap/TapeHouse)
+"tI" = (
+/obj/structure/window/reinforced,
+/obj/structure/table/wooden_reinforced,
+/turf/simulated/floor/wood/sif,
+/area/submap/TapeHouse)
+"uX" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/table/woodentable,
+/obj/item/flame/candle,
+/obj/item/camera,
+/turf/simulated/floor/wood/sif,
+/area/submap/TapeHouse)
+"vh" = (
+/obj/effect/floor_decal/corner/white/diagonal,
+/obj/structure/mirror{
+	pixel_x = 28
+	},
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 12
+	},
+/obj/item/towel/random,
+/obj/random/medical/lite,
+/turf/simulated/floor/tiled/white,
+/area/submap/TapeHouse)
+"vD" = (
+/obj/structure/table/reinforced,
+/obj/effect/floor_decal/spline/plain,
+/obj/random/junk,
+/turf/simulated/floor/tiled/hydro,
+/area/submap/TapeHouse)
+"vI" = (
+/turf/simulated/floor/tiled/hydro,
+/area/submap/TapeHouse)
+"vM" = (
+/obj/structure/table/rack/shelf,
+/obj/structure/curtain/black,
+/obj/item/toy/plushie/marble_fox,
+/obj/item/ammo_magazine/clip/c12g/pellet,
+/turf/simulated/floor/wood/sif,
+/area/submap/TapeHouse)
+"wz" = (
+/obj/effect/floor_decal/spline/plain{
+	dir = 8
+	},
+/obj/structure/flora/pottedplant/unusual,
+/turf/simulated/floor/wood/sif{
+	outdoors = 0
+	},
+/area/submap/TapeHouse)
+"wJ" = (
+/obj/item/clothing/under/dress/red_swept_dress,
+/obj/structure/curtain/black,
+/obj/structure/table/rack/shelf,
+/obj/random/maintenance/security,
+/turf/simulated/floor/wood/sif,
+/area/submap/TapeHouse)
+"xd" = (
+/obj/effect/floor_decal/carpet{
+	dir = 8
+	},
+/turf/simulated/floor/carpet,
+/area/submap/TapeHouse)
+"xp" = (
+/obj/structure/bed/chair/wood,
+/turf/simulated/floor/wood/sif,
+/area/submap/TapeHouse)
+"xq" = (
+/obj/structure/loot_pile/maint/trash,
+/obj/effect/decal/cleanable/filth,
+/turf/simulated/floor/outdoors/dirt,
+/area/submap/TapeHouse)
+"xs" = (
+/obj/structure/closet/secure_closet/freezer/fridge,
+/obj/effect/floor_decal/spline/plain{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/hydro,
+/area/submap/TapeHouse)
+"xG" = (
+/obj/effect/map_effect/interval/sound_emitter/footsteps_wood,
+/turf/simulated/wall/sifwood,
+/area/submap/TapeHouse)
+"yH" = (
+/obj/effect/floor_decal/carpet{
+	dir = 4
+	},
+/obj/effect/floor_decal/carpet{
+	dir = 1
+	},
+/obj/effect/floor_decal/carpet{
+	dir = 5
+	},
+/turf/simulated/floor/carpet,
+/area/submap/TapeHouse)
+"zf" = (
+/obj/structure/table/reinforced,
+/obj/machinery/microwave,
+/obj/effect/floor_decal/spline/plain{
+	dir = 1
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/hydro,
+/area/submap/TapeHouse)
+"zD" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/flora/grass/both,
+/turf/simulated/floor/outdoors/grass/sif,
+/area/submap/TapeHouse)
+"Ae" = (
+/obj/structure/window/reinforced,
+/turf/template_noop,
+/area/submap/TapeHouse)
+"Cq" = (
+/turf/simulated/floor/wood/sif,
+/area/submap/TapeHouse)
+"Cy" = (
+/obj/effect/floor_decal/corner/white/diagonal,
+/obj/item/soap/nanotrasen,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/submap/TapeHouse)
+"Cz" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/bed/chair/wood{
+	dir = 4
+	},
+/turf/simulated/floor/wood/sif,
+/area/submap/TapeHouse)
+"CA" = (
+/obj/structure/table/rack/shelf,
+/obj/item/clothing/under/suit_jacket/charcoal,
+/obj/item/clothing/shoes/dress,
+/obj/item/clothing/under/frontier,
+/obj/structure/curtain/black,
+/obj/random/maintenance/cargo,
+/turf/simulated/floor/wood/sif,
+/area/submap/TapeHouse)
+"CJ" = (
+/obj/structure/table/rack/shelf,
+/obj/item/reagent_containers/food/condiment/yeast,
+/turf/simulated/floor/wood/sif,
+/area/submap/TapeHouse)
+"DF" = (
+/obj/structure/closet,
+/obj/item/clothing/suit/storage/hooded/wintercoat,
+/obj/item/cane,
+/obj/item/storage/wallet/random,
+/obj/item/flashlight/flare,
+/obj/random/contraband,
+/turf/simulated/floor/wood/sif,
+/area/submap/TapeHouse)
+"DJ" = (
+/obj/structure/flora/pottedplant/dead,
+/turf/simulated/floor/wood/sif,
+/area/submap/TapeHouse)
+"DL" = (
+/obj/machinery/media/jukebox,
+/turf/simulated/floor/wood/sif,
+/area/submap/TapeHouse)
+"EE" = (
+/obj/structure/bed/double/padded,
+/obj/item/bedsheet/hosdouble,
+/turf/simulated/floor/wood/sif,
+/area/submap/TapeHouse)
+"Hc" = (
+/obj/machinery/appliance/cooker/oven,
+/turf/simulated/floor/tiled/hydro,
+/area/submap/TapeHouse)
+"HM" = (
+/obj/structure/grille/rustic,
+/obj/structure/window/reinforced/full,
+/obj/structure/curtain/black,
+/turf/simulated/floor/wood/sif,
+/area/submap/TapeHouse)
+"IE" = (
+/obj/structure/table/rack/shelf,
+/obj/item/mop,
+/obj/item/flashlight/lantern,
+/turf/simulated/floor/wood/sif,
+/area/submap/TapeHouse)
+"IW" = (
+/obj/structure/table/rack/shelf,
+/obj/item/reagent_containers/food/condiment/carton/sugar/rustic,
+/obj/item/reagent_containers/food/drinks/jar,
+/turf/simulated/floor/wood/sif,
+/area/submap/TapeHouse)
+"JE" = (
+/obj/effect/floor_decal/carpet,
+/obj/effect/floor_decal/carpet{
+	dir = 4
+	},
+/obj/effect/floor_decal/carpet{
+	dir = 6
+	},
+/turf/simulated/floor/carpet,
+/area/submap/TapeHouse)
+"JU" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/space_heater,
+/turf/simulated/floor/wood/sif,
+/area/submap/TapeHouse)
+"Ky" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/wood/sif,
+/area/submap/TapeHouse)
+"Mr" = (
+/obj/effect/floor_decal/spline/plain,
+/turf/simulated/floor/tiled/hydro,
+/area/submap/TapeHouse)
+"My" = (
+/turf/simulated/wall/sifwood,
+/area/submap/TapeHouse)
+"MU" = (
+/obj/structure/window/reinforced,
+/obj/structure/flora/ausbushes/leafybush,
+/turf/simulated/floor/outdoors/grass/sif,
+/area/submap/TapeHouse)
+"Nv" = (
+/obj/structure/window/reinforced,
+/obj/structure/flora/ausbushes/grassybush,
+/turf/simulated/floor/outdoors/grass/sif,
+/area/submap/TapeHouse)
+"On" = (
+/obj/structure/table/wooden_reinforced,
+/obj/item/material/harpoon,
+/turf/simulated/floor/wood/sif,
+/area/submap/TapeHouse)
+"OQ" = (
+/obj/structure/table/reinforced,
+/obj/effect/floor_decal/spline/plain,
+/turf/simulated/floor/tiled/hydro,
+/area/submap/TapeHouse)
+"PA" = (
+/obj/structure/table/wooden_reinforced,
+/obj/item/trash/small_bowl,
+/obj/item/material/kitchen/utensil/spoon,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/simulated/floor/wood/sif,
+/area/submap/TapeHouse)
+"PV" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/wood/sif,
+/area/submap/TapeHouse)
+"Rm" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/bed/chair/wood{
+	dir = 1
+	},
+/turf/simulated/floor/wood/sif,
+/area/submap/TapeHouse)
+"RK" = (
+/obj/effect/floor_decal/spline/plain{
+	dir = 4
+	},
+/obj/structure/bed/chair/wood/wings,
+/turf/simulated/floor/wood/sif/broken,
+/area/submap/TapeHouse)
+"Sh" = (
+/obj/structure/window/reinforced,
+/turf/simulated/floor/wood/sif,
+/area/submap/TapeHouse)
+"Sp" = (
+/obj/effect/floor_decal/spline/plain{
+	dir = 4
+	},
+/turf/simulated/floor/wood/sif{
+	outdoors = 0
+	},
+/area/submap/TapeHouse)
+"TD" = (
+/obj/structure/table/wooden_reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/item/trash/candle,
+/turf/simulated/floor/wood/sif,
+/area/submap/TapeHouse)
+"TQ" = (
+/obj/structure/grille/rustic,
+/obj/structure/window/reinforced/full,
+/turf/simulated/floor/wood/sif,
+/area/submap/TapeHouse)
+"TR" = (
+/obj/structure/table/wooden_reinforced,
+/obj/item/paper{
+	name = "Uneasy Transcript";
+	info = <b>Transcript:</b><br><br>[00:00] Recording started.<br>[00:06] "Well, it's been a few months."<br>[00:17] "Everything's great, really, I've been recording these short little logs to give me something to do.<br>[00:23] "I feel less insane talking to myself if it's into a little blinking red light, anyway, haha."<br>[00:27] (Unrecognized sound) <br>[00:40] "There it is, though. I don't know if this thing picked it up, but it sounds like there's ... pacing. I thought it was just the house settling the first few times but..."<br>[00:48] "Looking back at other transcripts, apparently it doesn't like anything else other than talking."<br>[00:57] "This place feels like an enclosure sometimes. All these windows feel like they have eyes, and every tree outside has become a hiding place."<br>[01:12] "... I think I'm losing it."<br>[01:14] Recording stopped.
+	},
+/obj/random/cigarettes,
+/turf/simulated/floor/wood/sif,
+/area/submap/TapeHouse)
+"TY" = (
+/obj/structure/bed/chair/wood,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/simulated/floor/wood/sif,
+/area/submap/TapeHouse)
+"Ur" = (
+/obj/structure/sink/kitchen{
+	dir = 4;
+	pixel_x = -12
+	},
+/turf/simulated/floor/tiled/hydro,
+/area/submap/TapeHouse)
+"UL" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/bed/chair/wood{
+	dir = 8;
+	icon_state = "wooden_chair"
+	},
+/turf/simulated/floor/wood/sif,
+/area/submap/TapeHouse)
+"UM" = (
+/obj/effect/floor_decal/spline/plain{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/hydro,
+/area/submap/TapeHouse)
+"Vg" = (
+/obj/machinery/computer/security/telescreen/entertainment{
+	icon_state = "frame";
+	pixel_x = 32
+	},
+/turf/simulated/floor/wood/sif,
+/area/submap/TapeHouse)
+"VU" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/wood/sif,
+/area/submap/TapeHouse)
+"Wo" = (
+/obj/structure/table/rack,
+/turf/simulated/floor/carpet/bcarpet,
+/area/submap/TapeHouse)
+"Wy" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/flora/pottedplant/dead,
+/turf/simulated/floor/wood/sif,
+/area/submap/TapeHouse)
+"WR" = (
+/turf/simulated/floor/wood/sif{
+	outdoors = 0
+	},
+/area/submap/TapeHouse)
+"Xr" = (
+/obj/effect/floor_decal/carpet,
+/obj/effect/floor_decal/carpet{
+	dir = 8
+	},
+/obj/effect/floor_decal/carpet{
+	dir = 10
+	},
+/turf/simulated/floor/carpet,
+/area/submap/TapeHouse)
+"XW" = (
+/obj/item/clothing/under/utility/grey,
+/obj/item/clothing/shoes/black,
+/obj/item/flame/lighter/random,
+/obj/item/clothing/suit/storage/vest/solgov/hedberg,
+/obj/structure/table/rack/shelf,
+/obj/structure/curtain/black,
+/turf/simulated/floor/wood/sif,
+/area/submap/TapeHouse)
+
+(1,1,1) = {"
+eV
+eV
+eV
+eV
+eV
+eV
+eV
+eV
+eV
+eV
+eV
+eV
+eV
+eV
+eV
+eV
+eV
+eV
+eV
+"}
+(2,1,1) = {"
+eV
+eV
+sF
+eV
+qs
+eV
+eV
+eV
+eV
+eV
+My
+My
+bP
+bP
+bP
+bP
+My
+My
+eV
+"}
+(3,1,1) = {"
+qs
+eV
+eV
+sF
+xq
+My
+My
+My
+My
+My
+My
+My
+TY
+TD
+PA
+Rm
+My
+My
+eV
+"}
+(4,1,1) = {"
+eV
+My
+My
+ru
+My
+My
+xs
+Hc
+Ur
+vD
+kz
+Cq
+Cq
+jI
+xd
+Xr
+Sh
+cI
+eV
+"}
+(5,1,1) = {"
+eV
+My
+ak
+Cq
+Cq
+ru
+UM
+vI
+vI
+OQ
+kz
+Cq
+My
+mZ
+jC
+gP
+Sh
+cI
+eV
+"}
+(6,1,1) = {"
+eV
+My
+lt
+Cq
+CJ
+My
+sx
+vI
+vI
+gb
+kz
+Cq
+My
+yH
+nk
+JE
+Sh
+cI
+eV
+"}
+(7,1,1) = {"
+eV
+My
+ov
+PV
+IW
+My
+zf
+vI
+vI
+Mr
+Cq
+Cq
+Cq
+PV
+Vg
+Cq
+My
+My
+eV
+"}
+(8,1,1) = {"
+eV
+My
+My
+My
+My
+My
+My
+My
+My
+xG
+DL
+Cq
+My
+My
+My
+My
+My
+My
+eV
+"}
+(9,1,1) = {"
+eV
+Ae
+eq
+Cq
+Cq
+My
+DJ
+Cq
+ba
+My
+VU
+Cq
+Cq
+sw
+cI
+eV
+eV
+eV
+eV
+"}
+(10,1,1) = {"
+qs
+Ae
+eq
+Cq
+Cq
+ru
+Cq
+Cq
+Cq
+Cq
+Cq
+Cq
+xp
+tI
+dv
+eV
+eV
+eV
+eV
+"}
+(11,1,1) = {"
+eV
+My
+My
+JU
+Cq
+My
+TR
+On
+sS
+My
+DJ
+Cq
+Cq
+tI
+sp
+eV
+eV
+qs
+eV
+"}
+(12,1,1) = {"
+eV
+My
+My
+My
+ru
+My
+My
+My
+My
+My
+My
+Cq
+kt
+My
+My
+eV
+eV
+eV
+eV
+"}
+(13,1,1) = {"
+eV
+eV
+My
+My
+Cq
+ru
+sv
+pT
+My
+IE
+My
+sV
+dV
+Wo
+TQ
+wz
+fU
+My
+eV
+"}
+(14,1,1) = {"
+eV
+eV
+Nv
+Cz
+Cq
+My
+Cy
+lk
+My
+VU
+ru
+sV
+hE
+sV
+ru
+WR
+WR
+eB
+eV
+"}
+(15,1,1) = {"
+eV
+eV
+Ae
+uX
+Cq
+My
+sv
+vh
+My
+DF
+My
+My
+My
+My
+My
+RK
+Sp
+My
+eV
+"}
+(16,1,1) = {"
+eV
+qs
+kJ
+UL
+Cq
+My
+ru
+My
+My
+My
+My
+CA
+vM
+My
+My
+eV
+eV
+eV
+eV
+"}
+(17,1,1) = {"
+eV
+eV
+MU
+Wy
+Cq
+My
+Cq
+Cq
+Cq
+ru
+Cq
+Cq
+Cq
+gz
+My
+eV
+eV
+eV
+eV
+"}
+(18,1,1) = {"
+eV
+eV
+My
+My
+VU
+ru
+Cq
+Cq
+ej
+kt
+My
+wJ
+XW
+My
+My
+eV
+eV
+eV
+qs
+"}
+(19,1,1) = {"
+eV
+eV
+My
+My
+Ky
+My
+gR
+EE
+jM
+My
+My
+My
+My
+My
+eV
+eV
+eV
+eV
+eV
+"}
+(20,1,1) = {"
+qs
+eV
+eV
+My
+zD
+My
+HM
+HM
+HM
+My
+eV
+eV
+eV
+eV
+eV
+eV
+qs
+eV
+eV
+"}
+(21,1,1) = {"
+eV
+eV
+eV
+eV
+eV
+eV
+eV
+eV
+eV
+eV
+eV
+qs
+eV
+eV
+eV
+eV
+eV
+eV
+eV
+"}

--- a/maps/submaps/surface_submaps/plains/TapeHouse.dmm
+++ b/maps/submaps/surface_submaps/plains/TapeHouse.dmm
@@ -76,10 +76,7 @@
 	start_anomalous = 1
 	},
 /obj/item/gun/projectile/shotgun/doublebarrel/sawn,
-/obj/item/paper/crumpled{
-	name = "Crumpled Transcript";
-	info = "<b>Transcript:</b><br><br>[00:00] Recording started.<br>[00:02] (Unrecognized sound)<br>[00:02] (Unrecognized sound)<br>[00:07] (Unrecognized sound)<br>[00:12] ''WHAT ARE Y-''<br>[00:12] (Unrecognized sound)<br>[00:13] (Unrecognized sound)<br>[00:17] (Unrecognized sound)<br>[15:06] (Unrecognized sound)<br>[15:06] Recording stopped."
-	},
+/obj/item/paper/crumpled/crumpled_transcript,
 /turf/simulated/floor/wood/sif,
 /area/submap/TapeHouse)
 "gP" = (
@@ -103,10 +100,7 @@
 /obj/structure/bed/chair/sofa/black{
 	dir = 4
 	},
-/obj/item/paper{
-	name = "Bittersweet Transcript";
-	info = "<b>Transcript:</b><br><br>[00:00] Recording started.<br>[00:12] ''Say what you want about them, and I sure have a lot to say, but H-H set me up with a beautiful plot to retire to.''<br>[00:26] ''There's plenty of space, plenty of windows to look out into the nearby forest and watch the wildlife. They told us it's pretty safe for this part of the frontier, though I'm still glad they let me keep some surplus armor.''<br>[00:38] ''The fridge is full, the tables are all set, and I even started growing lillies. They help keep the boredom away.''<br>[00:41] (Unrecognized sound) <br>[01:02] ''It doesn't stop her side of the bed from being any less cold and empty, though."<br>[01:03] Recording stopped."
-	},
+/obj/item/paper/bittersweet_transcript,
 /turf/simulated/floor/carpet,
 /area/submap/TapeHouse)
 "jI" = (
@@ -124,10 +118,7 @@
 "jM" = (
 /obj/structure/table/woodentable,
 /obj/item/trash/candle,
-/obj/item/paper{
-	name = "Determined Transcript";
-	info = "<b>Transcript:</b><br><br>[00:00] Recording started.<br>[00:12] ''It's coming from inside the closet, but I think I get it now.''<br>[00:13] (Unrecognized sound)<br>[00:19] ''It won't stop unless I make it.''<br>[00:29] ''I'll take a light and the recorder with me so I can have a record of what happens.''<br>[00:31] (Unrecognized sound)<br>[00:42] ''And I guess if it's bad...''<br>[00:45] ''Lilly, I'll see you soon.''<br>[00:59] Recording stopped."
-	},
+/obj/item/paper/determined_transcript,
 /turf/simulated/floor/wood/sif,
 /area/submap/TapeHouse)
 "kt" = (
@@ -296,9 +287,9 @@
 /area/submap/TapeHouse)
 "vM" = (
 /obj/structure/table/rack/shelf,
-/obj/structure/curtain/black,
 /obj/item/toy/plushie/marble_fox,
 /obj/item/ammo_magazine/clip/c12g/pellet,
+/obj/structure/curtain/black,
 /turf/simulated/floor/wood/sif,
 /area/submap/TapeHouse)
 "wz" = (
@@ -312,9 +303,9 @@
 /area/submap/TapeHouse)
 "wJ" = (
 /obj/item/clothing/under/dress/red_swept_dress,
-/obj/structure/curtain/black,
 /obj/structure/table/rack/shelf,
 /obj/random/maintenance/security,
+/obj/structure/curtain/black,
 /turf/simulated/floor/wood/sif,
 /area/submap/TapeHouse)
 "xd" = (
@@ -402,8 +393,8 @@
 /obj/item/clothing/under/suit_jacket/charcoal,
 /obj/item/clothing/shoes/dress,
 /obj/item/clothing/under/frontier,
-/obj/structure/curtain/black,
 /obj/random/maintenance/cargo,
+/obj/structure/curtain/black,
 /turf/simulated/floor/wood/sif,
 /area/submap/TapeHouse)
 "CJ" = (
@@ -418,6 +409,7 @@
 /obj/item/storage/wallet/random,
 /obj/item/flashlight/flare,
 /obj/random/contraband,
+/obj/item/ammo_magazine/clip/c12g/pellet,
 /turf/simulated/floor/wood/sif,
 /area/submap/TapeHouse)
 "DJ" = (
@@ -563,10 +555,7 @@
 /area/submap/TapeHouse)
 "TR" = (
 /obj/structure/table/wooden_reinforced,
-/obj/item/paper{
-	name = "Uneasy Transcript";
-	info = "<b>Transcript:</b><br><br>[00:00] Recording started.<br>[00:06] ''Well, it's been a few months.''<br>[00:17] ''Everything's great, really, I've been recording these short little logs to give me something to do.''<br>[00:23] ''I feel less insane talking to myself if it's into a little blinking red light, anyway, haha.''<br>[00:27] (Unrecognized sound) <br>[00:40] ''There it is, though. I don't know if this thing picked it up, but it sounds like there's ... pacing. I thought it was just the house settling the first few times but...''<br>[00:48] ''Looking back at other transcripts, apparently it doesn't like anything else other than talking.''<br>[00:57] ''This place feels like an enclosure sometimes. All these windows feel like they have eyes, and every tree outside has become a hiding place.''<br>[01:12] ''... I think I'm losing it.''<br>[01:14] Recording stopped."
-	},
+/obj/item/paper/uneasey_transcript,
 /obj/random/cigarettes,
 /turf/simulated/floor/wood/sif,
 /area/submap/TapeHouse)

--- a/maps/submaps/surface_submaps/plains/TapeHouse.dmm
+++ b/maps/submaps/surface_submaps/plains/TapeHouse.dmm
@@ -78,7 +78,7 @@
 /obj/item/gun/projectile/shotgun/doublebarrel/sawn,
 /obj/item/paper/crumpled{
 	name = "Crumpled Transcript";
-	info = '<b>Transcript:</b><br><br>[00:00] Recording started.<br>[00:02] (Unrecognized sound)<br>[00:02] (Unrecognized sound)<br>[00:07] (Unrecognized sound)<br>[00:12] "WHAT ARE Y-"<br>[00:12] (Unrecognized sound)<br>[00:13] (Unrecognized sound)<br>[00:17] (Unrecognized sound)<br>[15:06] (Unrecognized sound)<br>[15:06] Recording stopped.'
+	info = "<b>Transcript:</b><br><br>[00:00] Recording started.<br>[00:02] (Unrecognized sound)<br>[00:02] (Unrecognized sound)<br>[00:07] (Unrecognized sound)<br>[00:12] ''WHAT ARE Y-''<br>[00:12] (Unrecognized sound)<br>[00:13] (Unrecognized sound)<br>[00:17] (Unrecognized sound)<br>[15:06] (Unrecognized sound)<br>[15:06] Recording stopped."
 	},
 /turf/simulated/floor/wood/sif,
 /area/submap/TapeHouse)
@@ -105,7 +105,7 @@
 	},
 /obj/item/paper{
 	name = "Bittersweet Transcript";
-	info = '<b>Transcript:</b><br><br>[00:00] Recording started.<br>[00:12] "Say what you want about them, and I sure have a lot to say, but H-H set me up with a beautiful plot to retire to."<br>[00:26] "There's plenty of space, plenty of windows to look out into the nearby forest and watch the wildlife. They told us it's pretty safe for this part of the frontier, though I'm still glad they let me keep some surplus armor."<br>[00:38] "The fridge is full, the tables are all set, and I even started growing lillies. They help keep the boredom away."<br>[00:41] (Unrecognized sound) <br>[01:02] "It doesn't stop her side of the bed from being any less cold and empty, though."<br>[01:03] Recording stopped.'
+	info = "<b>Transcript:</b><br><br>[00:00] Recording started.<br>[00:12] ''Say what you want about them, and I sure have a lot to say, but H-H set me up with a beautiful plot to retire to.''<br>[00:26] ''There's plenty of space, plenty of windows to look out into the nearby forest and watch the wildlife. They told us it's pretty safe for this part of the frontier, though I'm still glad they let me keep some surplus armor.''<br>[00:38] ''The fridge is full, the tables are all set, and I even started growing lillies. They help keep the boredom away.''<br>[00:41] (Unrecognized sound) <br>[01:02] ''It doesn't stop her side of the bed from being any less cold and empty, though."<br>[01:03] Recording stopped."
 	},
 /turf/simulated/floor/carpet,
 /area/submap/TapeHouse)
@@ -126,7 +126,7 @@
 /obj/item/trash/candle,
 /obj/item/paper{
 	name = "Determined Transcript";
-	info = '<b>Transcript:</b><br><br>[00:00] Recording started.<br>[00:12] "It's coming from inside the closet, but I think I get it now."<br>[00:13] (Unrecognized sound)<br>[00:19] "It won't stop unless I make it."<br>[00:29] "I'll take a light and the recorder with me so I can have a record of what happens."<br>[00:31] (Unrecognized sound)<br>[00:42] "And I guess if it's bad..."<br>[00:45] "Lilly, I'll see you soon."<br>[00:59] Recording stopped.'
+	info = "<b>Transcript:</b><br><br>[00:00] Recording started.<br>[00:12] ''It's coming from inside the closet, but I think I get it now.''<br>[00:13] (Unrecognized sound)<br>[00:19] ''It won't stop unless I make it.''<br>[00:29] ''I'll take a light and the recorder with me so I can have a record of what happens.''<br>[00:31] (Unrecognized sound)<br>[00:42] ''And I guess if it's bad...''<br>[00:45] ''Lilly, I'll see you soon.''<br>[00:59] Recording stopped."
 	},
 /turf/simulated/floor/wood/sif,
 /area/submap/TapeHouse)
@@ -565,7 +565,7 @@
 /obj/structure/table/wooden_reinforced,
 /obj/item/paper{
 	name = "Uneasy Transcript";
-	info = '<b>Transcript:</b><br><br>[00:00] Recording started.<br>[00:06] "Well, it's been a few months."<br>[00:17] "Everything's great, really, I've been recording these short little logs to give me something to do.<br>[00:23] "I feel less insane talking to myself if it's into a little blinking red light, anyway, haha."<br>[00:27] (Unrecognized sound) <br>[00:40] "There it is, though. I don't know if this thing picked it up, but it sounds like there's ... pacing. I thought it was just the house settling the first few times but..."<br>[00:48] "Looking back at other transcripts, apparently it doesn't like anything else other than talking."<br>[00:57] "This place feels like an enclosure sometimes. All these windows feel like they have eyes, and every tree outside has become a hiding place."<br>[01:12] "... I think I'm losing it."<br>[01:14] Recording stopped.'
+	info = "<b>Transcript:</b><br><br>[00:00] Recording started.<br>[00:06] ''Well, it's been a few months.''<br>[00:17] ''Everything's great, really, I've been recording these short little logs to give me something to do.''<br>[00:23] ''I feel less insane talking to myself if it's into a little blinking red light, anyway, haha.''<br>[00:27] (Unrecognized sound) <br>[00:40] ''There it is, though. I don't know if this thing picked it up, but it sounds like there's ... pacing. I thought it was just the house settling the first few times but...''<br>[00:48] ''Looking back at other transcripts, apparently it doesn't like anything else other than talking.''<br>[00:57] ''This place feels like an enclosure sometimes. All these windows feel like they have eyes, and every tree outside has become a hiding place.''<br>[01:12] ''... I think I'm losing it.''<br>[01:14] Recording stopped."
 	},
 /obj/random/cigarettes,
 /turf/simulated/floor/wood/sif,

--- a/maps/submaps/surface_submaps/plains/plains.dm
+++ b/maps/submaps/surface_submaps/plains/plains.dm
@@ -44,6 +44,7 @@
 #include "plainsdrake_den.dmm"
 #include "pondside_den.dmm"
 #include "swampy_den.dmm"
+#include "TapeHouse.dmm"
 #endif
 
 
@@ -330,3 +331,9 @@
 	desc = "A muddy animal den."
 	mappath = 'maps/submaps/surface_submaps/plains/swampy_den.dmm'
 	cost = 5
+
+/datum/map_template/surface/plains/TapeHouse
+	name = "Tape House"
+	desc = "An eerie and untouched abandoned home."
+	mappath = 'maps/submaps/surface_submaps/plains/TapeHouse.dmm'
+	cost = 15

--- a/maps/submaps/surface_submaps/plains/plains_areas.dm
+++ b/maps/submaps/surface_submaps/plains/plains_areas.dm
@@ -161,3 +161,7 @@
 	name = "POI - Swamp Den"
 	ambience = AMBIENCE_SIF
 	
+/area/submap/TapeHouse
+	name = "POI - Tape House"
+	ambience = AMBIENCE_FOREBODING
+	


### PR DESCRIPTION
Intended to be the haunted house counterpart to the bloody home that Felix is sometimes found in, this PoI started with the idea of scattering about playable tapes with eerie narration, but quickly I found that I didn't really have the knowledge to make it work. A tape recorder still plays a big part in the form of printed transcripts that are scattered about that fill the same role.

Features
- Two new sound emitters, tweaked to make sure they're not too loud or frequent: disembodied footsteps in the central area and eerie ambience at ground zero of whatever became of the former inhabitant.
- Lots of blind corners and windows for atmosphere!
- Fake transcripts (that were a labor of love!!!) and some environmental storytelling.
- A few guaranteed lootables: a whetstone, double barrel with a 12g clip, a decent armor vest, and 1 anomalous item.

Costs 15 spawn points.

![image](https://github.com/PolarisSS13/Polaris/assets/11377530/1076d24f-6912-45c5-8e12-c8584205bdfe)
